### PR TITLE
Update Android Components to 0.39-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,9 @@ allprojects {
     repositories {
         google()
         maven {
+            url "https://snapshots.maven.mozilla.org/maven2"
+        }
+        maven {
             url "https://maven.mozilla.org/maven2"
         }
         jcenter()

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -10,7 +10,7 @@ private object Versions {
     const val androidx_appcompat = "1.0.2"
     const val androidx_constraint_layout = "2.0.0-alpha3"
 
-    const val mozilla_android_components = "0.37.0"
+    const val mozilla_android_components = "0.39.0-SNAPSHOT"
 
     const val junit = "4.12"
     const val test_tools = "1.0.2"
@@ -42,3 +42,4 @@ object Deps {
     const val androidx_legacy = "androidx.legacy:legacy-support-v4:${Versions.androidx_legacy}"
     const val android_arch_navigation = "android.arch.navigation:navigation-fragment:${Versions.android_arch_navigation}"
 }
+


### PR DESCRIPTION
This updates Fenix to use the most recent A-C (snapshot) release.