### PR TITLE
Use support-ktx for Lifecycle.addObservers

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -79,6 +79,8 @@ dependencies {
     implementation Deps.mozilla_feature_intent
     implementation Deps.mozilla_feature_session
 
+    implementation Deps.mozilla_support_ktx
+
     testImplementation Deps.junit
     androidTestImplementation Deps.tools_test_runner
     androidTestImplementation Deps.tools_espresso_core

--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -9,13 +9,10 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleObserver
 import kotlinx.android.synthetic.main.fragment_browser.*
-import mozilla.components.feature.intent.IntentProcessor
 import mozilla.components.feature.session.SessionFeature
 import mozilla.components.feature.session.SessionUseCases
-import mozilla.components.support.utils.SafeIntent
+import mozilla.components.support.ktx.android.arch.lifecycle.addObservers
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 
@@ -52,5 +49,3 @@ class BrowserFragment : Fragment() {
         lifecycle.addObservers(sessionFeature)
     }
 }
-
-private fun Lifecycle.addObservers(vararg observers: LifecycleObserver) = observers.forEach { addObserver(it) }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -44,6 +44,8 @@ object Deps {
     const val mozilla_feature_session = "org.mozilla.components:feature-session:${Versions.mozilla_android_components}"
     const val mozilla_feature_storage = "org.mozilla.components:feature-storage:${Versions.mozilla_android_components}"
 
+    const val mozilla_support_ktx = "org.mozilla.components:support-ktx:${Versions.mozilla_android_components}"
+
     const val junit = "junit:junit:${Versions.junit}"
     const val tools_test_runner = "com.android.support.test:runner:${Versions.test_tools}"
     const val tools_espresso_core = "com.android.support.test.espresso:espresso-core:${Versions.espresso_core}"


### PR DESCRIPTION
This was a leftover extension in r-b that was moved to support-ktx.