### PR TITLE
Add application id suffix for debug builds.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,6 +18,9 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+        debug {
+            applicationIdSuffix ".debug"
+        }
     }
 
     flavorDimensions "abi"


### PR DESCRIPTION
This makes it a bit more pleasant to work with devices that also have the Nightly builds installed.