### PR TITLE
Closes #270: Integrate browser-storage-sync

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -90,6 +90,7 @@ dependencies {
     implementation Deps.mozilla_browser_domains
     implementation Deps.mozilla_browser_engine_gecko_nightly
     implementation Deps.mozilla_browser_session
+    implementation Deps.mozilla_browser_storage_sync
     implementation Deps.mozilla_browser_toolbar
 
     implementation Deps.mozilla_feature_awesomebar

--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -52,7 +52,8 @@ class BrowserFragment : Fragment() {
             ToolbarIntegration(
                 requireContext(),
                 toolbar,
-                requireComponents.toolbar.shippedDomainsProvider
+                requireComponents.toolbar.shippedDomainsProvider,
+                requireComponents.core.historyStorage
             )
         )
 

--- a/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -11,9 +11,11 @@ import mozilla.components.browser.engine.gecko.GeckoEngine
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.session.storage.SessionStorage
+import mozilla.components.browser.storage.sync.PlacesHistoryStorage
 import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
+import mozilla.components.feature.session.HistoryDelegate
 import java.util.concurrent.TimeUnit
 
 /**
@@ -31,7 +33,8 @@ class Core(private val context: Context) {
         val defaultSettings = DefaultSettings(
             remoteDebuggingEnabled = false,
             testingModeEnabled = false,
-            trackingProtectionPolicy = createTrackingProtectionPolicy(prefs)
+            trackingProtectionPolicy = createTrackingProtectionPolicy(prefs),
+            historyTrackingDelegate = HistoryDelegate(historyStorage)
         )
         GeckoEngine(context, defaultSettings)
     }
@@ -59,6 +62,12 @@ class Core(private val context: Context) {
                 .whenSessionsChange()
         }
     }
+
+    /**
+     * The storage component to persist browsing history (with the exception of
+     * private sessions).
+     */
+    val historyStorage by lazy { PlacesHistoryStorage(context) }
 
     /**
      * Constructs a [TrackingProtectionPolicy] based on current preferences.

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarIntegration.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarIntegration.kt
@@ -13,6 +13,7 @@ import androidx.navigation.Navigation
 import androidx.navigation.fragment.FragmentNavigator
 import mozilla.components.browser.domains.autocomplete.DomainAutocompleteProvider
 import mozilla.components.browser.toolbar.BrowserToolbar
+import mozilla.components.concept.storage.HistoryStorage
 import mozilla.components.feature.toolbar.ToolbarAutocompleteFeature
 import mozilla.components.feature.toolbar.ToolbarFeature
 import org.mozilla.fenix.R
@@ -23,6 +24,7 @@ class ToolbarIntegration(
     context: Context,
     toolbar: BrowserToolbar,
     domainAutocompleteProvider: DomainAutocompleteProvider,
+    historyStorage: HistoryStorage,
     sessionId: String? = null
 ) : LifecycleObserver {
     init {
@@ -50,6 +52,7 @@ class ToolbarIntegration(
 
         ToolbarAutocompleteFeature(toolbar).apply {
             addDomainProvider(domainAutocompleteProvider)
+            addHistoryStorageProvider(historyStorage)
         }
     }
 

--- a/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
@@ -48,7 +48,9 @@ class SearchFragment : Fragment() {
             ToolbarIntegration(
             requireContext(),
             toolbar,
-            ShippedDomainsProvider().also { it.initialize(requireContext()) })
+            ShippedDomainsProvider().also { it.initialize(requireContext()) },
+            requireComponents.core.historyStorage
+        )
         )
 
         awesomeBarFeature = AwesomeBarFeature(awesomeBar, toolbar, null, onEditComplete = ::userDidSearch)


### PR DESCRIPTION
This adds support for persisting history and providing toolbar url autocomplete suggestions via `browser-storage-sync` component.

Underneath, this is powered by a [Rust version of places](https://github.com/mozilla/application-services/tree/master/components/places).

You can poke at the sqlite database this creates over at `/data/data/org.mozilla.fenix.debug/files/places.sqlite`.

Once we integrate FxA, feature-sync and upcoming SyncManager components, this component will also power history sync.