### PR TITLE
Closes #266 - Integrate feature-downloads component

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -93,6 +93,7 @@ dependencies {
     implementation Deps.mozilla_browser_toolbar
 
     implementation Deps.mozilla_feature_awesomebar
+    implementation Deps.mozilla_feature_downloads
     implementation Deps.mozilla_feature_intent
     implementation Deps.mozilla_feature_session
     implementation Deps.mozilla_feature_toolbar

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="org.mozilla.fenix">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+
     <application
             android:allowBackup="true"
             android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -12,6 +12,7 @@ import android.view.ViewGroup
 import android.view.accessibility.AccessibilityManager
 import androidx.fragment.app.Fragment
 import kotlinx.android.synthetic.main.fragment_browser.*
+import mozilla.components.feature.downloads.DownloadsFeature
 import mozilla.components.feature.session.SessionFeature
 import mozilla.components.feature.session.SessionUseCases
 import mozilla.components.support.ktx.android.arch.lifecycle.addObservers
@@ -22,6 +23,7 @@ import androidx.coordinatorlayout.widget.CoordinatorLayout
 
 class BrowserFragment : Fragment() {
 
+    private lateinit var downloadsFeature: DownloadsFeature
     private lateinit var sessionFeature: SessionFeature
 
     override fun onCreateView(
@@ -41,6 +43,15 @@ class BrowserFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         val sessionManager = requireComponents.core.sessionManager
+
+        downloadsFeature = DownloadsFeature(
+            requireContext(),
+            sessionManager = sessionManager,
+            fragmentManager = childFragmentManager,
+            onNeedToRequestPermissions = { permissions ->
+                requestPermissions(permissions, REQUEST_CODE_DOWNLOAD_PERMISSIONS)
+            }
+        )
 
         sessionFeature = SessionFeature(
             sessionManager,
@@ -64,5 +75,20 @@ class BrowserFragment : Fragment() {
             val layoutParams = toolbar.layoutParams as CoordinatorLayout.LayoutParams
             layoutParams.behavior = null
         }
+
+        lifecycle.addObservers(
+            downloadsFeature,
+            sessionFeature
+        )
+    }
+
+    override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<String>, grantResults: IntArray) {
+        when (requestCode) {
+            REQUEST_CODE_DOWNLOAD_PERMISSIONS -> downloadsFeature.onPermissionsResult(permissions, grantResults)
+        }
+    }
+
+    companion object {
+        private const val REQUEST_CODE_DOWNLOAD_PERMISSIONS = 1
     }
 }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -13,7 +13,7 @@ private object Versions {
     const val androidx_appcompat = "1.0.2"
     const val androidx_constraint_layout = "2.0.0-alpha3"
 
-    const val mozilla_android_components = "0.40.0-SNAPSHOT"
+    const val mozilla_android_components = "0.41.0-SNAPSHOT"
 
     const val junit = "4.12"
     const val test_tools = "1.0.2"


### PR DESCRIPTION
This will allow Fenix to download files via Android's download manager. Note that cleartext traffic is not permitted in Fenix right now so when testing HTTPS will need to be used. If you want to enable cleartext traffic, let me know, and I will add a commit.

The download dialog is customizable should we want to do that later.

This also depends on 0.41.0-SNAPSHOT: https://github.com/mozilla-mobile/fenix/pull/274

