### PR TITLE
Use abiFilter in product flavour definitions to filter for the supported architectures

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,8 +26,19 @@ android {
     flavorDimensions "abi"
     productFlavors {
         // replace the libraries with 64-bit versions when they're ready
-        arm { dimension "abi" }
-        x86 { dimension "abi" }
+        // Processor architectures
+        arm {
+            dimension "abi"
+            ndk {
+                abiFilter "armeabi-v7a"
+            }
+        }
+        x86 {
+            dimension "abi"
+            ndk {
+                abiFilter "x86"
+            }
+        }
     }
 
     compileOptions {


### PR DESCRIPTION
This fixes a regression from https://github.com/mozilla-mobile/fenix/pull/294.

That patch adds a dependency which loads some native libraries. Those native libs are
shipped for a variety of architectures. Specifically, there are versions of aarch64 and armv7.
What seems to happen is that since those libraries are loaded first (GV is lazily initialized
after history stuff), and since aarch64 versions of these libs is chosen by the native loader,
consequent native loads select for the same abi type. aarch64 version of libmozglue isn't there,
loader fails to find it and we crash.

Being explicit with the abiFilter in the product flavour definitions strips out aarch64 app-services
libs from the apk. When they're loaded first, armv7 versions are picked (since we don't have any other
ones), and everything works correctly afterwards.

Another way to achieve the same result would be to exclude arm64 libs via packagignOptions directive:
`packagingOptions { exclude "lib/arm64-v8a/**" }`

... but that's a less flexible approach in the longer term.

Quoting @ncalexan:
> This will get a little more consistent with https://bugzilla.mozilla.org/show_bug.cgi?id=1522581 and the a-c side ticket https://github.com/mozilla-mobile/android-components/issues/1447