### PR TITLE
Crash reporting

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -43,6 +43,7 @@ tasks:
             - queue:scheduler-id:${scheduler_id}
             - queue:create-task:highest:aws-provisioner-v1/${build_worker_type}
             - project:mobile:fenix:releng:signing:format:autograph_apk
+            - secrets:get:project/mobile/fenix/sentry
             - $if: is_mozilla_mobile_repo
               then:
                 - queue:create-task:highest:scriptworker-prov-v1/mobile-signing-v1

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,6 +45,10 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
+    lintOptions {
+        lintConfig file("lint.xml")
+    }
 }
 
 android.applicationVariants.all { variant ->
@@ -93,6 +97,8 @@ dependencies {
     implementation Deps.anko_appcompat
     implementation Deps.anko_constraintlayout
 
+    implementation Deps.sentry
+
     implementation Deps.mozilla_concept_engine
     implementation Deps.mozilla_concept_storage
     implementation Deps.mozilla_concept_toolbar
@@ -110,7 +116,10 @@ dependencies {
     implementation Deps.mozilla_feature_session
     implementation Deps.mozilla_feature_toolbar
     implementation Deps.mozilla_feature_tabs
+
     implementation Deps.mozilla_support_ktx
+
+    implementation Deps.mozilla_lib_crash
 
     testImplementation Deps.junit
     androidTestImplementation Deps.tools_test_runner
@@ -120,4 +129,22 @@ dependencies {
     x86Implementation Deps.geckoview_nightly_x86
     implementation Deps.androidx_legacy
     implementation Deps.android_arch_navigation
+}
+
+
+android.applicationVariants.all { variant ->
+    // Reading sentry token from local file (if it exists). In a release task on taskcluster it will be available.
+    try {
+        def token = new File("${rootDir}/.sentry_token").text.trim()
+        buildConfigField 'String', 'SENTRY_TOKEN', '"' + token + '"'
+    } catch (FileNotFoundException ignored) {
+        buildConfigField 'String', 'SENTRY_TOKEN', 'null'
+    }
+
+    // Activating crash reporting only if command line parameter was provided (in automation)
+    if (project.hasProperty("crashReports") && project.property("crashReports") == "true") {
+        buildConfigField 'boolean', 'CRASH_REPORTING', 'true'
+    } else {
+        buildConfigField 'boolean', 'CRASH_REPORTING', 'false'
+    }
 }

--- a/app/lint.xml
+++ b/app/lint.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<lint>
+    <issue id="InvalidPackage">
+        <!-- The Sentry SDK is compiled against parts of the Java SDK that are not available in the Android SDK.
+             Let's just ignore issues in the Sentry code since that is a third-party dependency anyways. -->
+        <ignore path="**/sentry*.jar" />
+    </issue>
+</lint>
+

--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -9,4 +9,24 @@ import org.mozilla.fenix.components.Components
 
 class FenixApplication : Application() {
     val components by lazy { Components(this) }
+
+    override fun onCreate() {
+        super.onCreate()
+
+        setupCrashReporting()
+    }
+
+    private fun setupCrashReporting() {
+        @Suppress("ConstantConditionIf")
+        if (!BuildConfig.CRASH_REPORTING || BuildConfig.BUILD_TYPE != "release") {
+            // Only enable crash reporting if this is a release build and if crash reporting was explicitly enabled
+            // via a Gradle command line flag.
+            return
+        }
+
+        components
+            .analytics
+            .crashReporter
+            .install(this)
+    }
 }

--- a/app/src/main/java/org/mozilla/fenix/components/Analytics.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Analytics.kt
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.components
+
+import android.content.Context
+import mozilla.components.lib.crash.CrashReporter
+import mozilla.components.lib.crash.service.MozillaSocorroService
+import mozilla.components.lib.crash.service.SentryService
+import org.mozilla.fenix.BuildConfig
+import org.mozilla.fenix.R
+import org.mozilla.geckoview.BuildConfig.MOZ_APP_BUILDID
+import org.mozilla.geckoview.BuildConfig.MOZ_APP_VERSION
+
+/**
+ * Component group for all functionality related to analytics e.g. crash reporting and telemetry.
+ */
+class Analytics(
+    private val context: Context
+) {
+    val crashReporter: CrashReporter by lazy {
+        val sentryService = SentryService(
+            context,
+            BuildConfig.SENTRY_TOKEN,
+            tags = mapOf("geckoview" to "$MOZ_APP_VERSION-$MOZ_APP_BUILDID"),
+            sendEventForNativeCrashes = true
+        )
+
+        val socorroService = MozillaSocorroService(context, "Fenix")
+
+        CrashReporter(
+            services = listOf(sentryService, socorroService),
+            shouldPrompt = CrashReporter.Prompt.ALWAYS,
+            promptConfiguration = CrashReporter.PromptConfiguration(
+                appName = context.getString(R.string.app_name),
+                organizationName = "Mozilla"
+            ),
+            enabled = true
+        )
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/components/Components.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Components.kt
@@ -22,4 +22,5 @@ class Components(private val context: Context) {
         )
     }
     val utils by lazy { Utilities(context, core.sessionManager, useCases.sessionUseCases, useCases.searchUseCases) }
+    val analytics by lazy { Analytics(context) }
 }

--- a/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -16,6 +16,9 @@ import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
 import mozilla.components.feature.session.HistoryDelegate
+import mozilla.components.lib.crash.handler.CrashHandlerService
+import org.mozilla.geckoview.GeckoRuntime
+import org.mozilla.geckoview.GeckoRuntimeSettings
 import java.util.concurrent.TimeUnit
 
 /**
@@ -36,7 +39,14 @@ class Core(private val context: Context) {
             trackingProtectionPolicy = createTrackingProtectionPolicy(prefs),
             historyTrackingDelegate = HistoryDelegate(historyStorage)
         )
-        GeckoEngine(context, defaultSettings)
+
+        val runtimeSettings = GeckoRuntimeSettings.Builder()
+            .crashHandler(CrashHandlerService::class.java)
+            .build()
+
+        val runtime = GeckoRuntime.create(context, runtimeSettings)
+
+        GeckoEngine(context, defaultSettings, runtime)
     }
 
     /**

--- a/automation/taskcluster/decision_task_nightly.py
+++ b/automation/taskcluster/decision_task_nightly.py
@@ -40,12 +40,18 @@ def generate_build_task(apks, is_staging):
     return taskcluster.slugId(), BUILDER.build_task(
         name="(Fenix) Build task",
         description="Build Fenix from source code.",
-        command='cd .. && {} && ./gradlew --no-daemon clean test assembleRelease'.format(checkout),
+        command=('cd .. && ' + checkout +
+            ' && python automation/taskcluster/helper/get-secret.py'
+            ' -s project/mobile/fenix/sentry -k dsn -f .sentry_token'
+            ' && ./gradlew --no-daemon -PcrashReports=true clean test assembleRelease'),
         features={
             "chainOfTrust": True
         },
         artifacts=artifacts,
         worker_type='android-components-g' if is_staging else 'gecko-focus',
+        scopes=[
+            "secrets:get:project/mobile/fenix/sentry"
+        ]
     )
 
 

--- a/automation/taskcluster/helper/get-secret.py
+++ b/automation/taskcluster/helper/get-secret.py
@@ -1,0 +1,42 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import argparse
+import base64
+import os
+import taskcluster
+
+def write_secret_to_file(path, data, key, base64decode=False, append=False, prefix=''):
+    path = os.path.join(os.path.dirname(__file__), '../../../' + path)
+    with open(path, 'a' if append else 'w') as f:
+        value = data['secret'][key]
+        if base64decode:
+            value = base64.b64decode(value)
+        f.write(prefix + value)
+
+
+def fetch_secret_from_taskcluster(name):
+    secrets = taskcluster.Secrets({'baseUrl': 'http://taskcluster/secrets/v1'})
+    return secrets.get(name)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Fetch a taskcluster secret value and save it to a file.')
+
+    parser.add_argument('-s', dest="secret", action="store", help="name of the secret")
+    parser.add_argument('-k', dest='key', action="store", help='key of the secret')
+    parser.add_argument('-f', dest="path", action="store", help='file to save secret to')
+    parser.add_argument('--decode', dest="decode", action="store_true", default=False, help='base64 decode secret before saving to file')
+    parser.add_argument('--append', dest="append", action="store_true", default=False, help='append secret to existing file')
+    parser.add_argument('--prefix', dest="prefix", action="store", default="", help='add prefix when writing secret to file')
+
+    result = parser.parse_args()
+
+    secret = fetch_secret_from_taskcluster(result.secret)
+    write_secret_to_file(result.path, secret, result.key, result.decode, result.append, result.prefix)
+
+
+if __name__ == "__main__":
+    main()

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -9,6 +9,7 @@ private object Versions {
     const val rxAndroid = "2.1.0"
     const val rxKotlin = "2.3.0"
     const val anko = "0.10.8"
+    const val sentry = "1.7.10"
 
     const val androidx_appcompat = "1.0.2"
     const val androidx_constraint_layout = "2.0.0-alpha3"
@@ -72,7 +73,11 @@ object Deps {
     const val mozilla_feature_prompts = "org.mozilla.components:feature-prompts:${Versions.mozilla_android_components}"
     const val mozilla_feature_toolbar = "org.mozilla.components:feature-toolbar:${Versions.mozilla_android_components}"
 
+    const val mozilla_lib_crash = "org.mozilla.components:lib-crash:${Versions.mozilla_android_components}"
+
     const val mozilla_support_ktx = "org.mozilla.components:support-ktx:${Versions.mozilla_android_components}"
+
+    const val sentry = "io.sentry:sentry-android:${Versions.sentry}"
 
     const val junit = "junit:junit:${Versions.junit}"
     const val tools_test_runner = "com.android.support.test:runner:${Versions.test_tools}"


### PR DESCRIPTION
This PR:
* integrates the `lib-crash` components
* sets up crash reporting via Socorro (native crash) and Sentry (uncaught exceptions)
* sets up the release/nightly task to fetch the sentry token and enable crash reporting