### PR TITLE
TaskBuilder.build_task(): Add scopes parameter.

### DIFF
--- a/automation/taskcluster/lib/tasks.py
+++ b/automation/taskcluster/lib/tasks.py
@@ -14,7 +14,7 @@ class TaskBuilder(object):
         self.source = source
         self.scheduler_id = scheduler_id
 
-    def build_task(self, name, description, command, artifacts, features, worker_type):
+    def build_task(self, name, description, command, artifacts, features, worker_type, scopes=[]):
         created = datetime.datetime.now()
         expires = taskcluster.fromNow('1 year')
         deadline = taskcluster.fromNow('1 day')
@@ -31,7 +31,7 @@ class TaskBuilder(object):
             "deadline": taskcluster.stringDate(deadline),
             "dependencies": [self.task_id],
             "routes": [],
-            "scopes": [],
+            "scopes": scopes,
             "requires": "all-completed",
             "payload": {
                 "features": features,


### PR DESCRIPTION
I assumed the `TaskBuilder` class would be the same as in the reference browser repository. But that is not the case. We need the `scopes` parameter now that the build task needs an additional scope for getting the Sentry token.