### PR TITLE
Issue #267: Enable taskcluster proxy feature for build task.

### DIFF
--- a/automation/taskcluster/decision_task_nightly.py
+++ b/automation/taskcluster/decision_task_nightly.py
@@ -45,7 +45,8 @@ def generate_build_task(apks, is_staging):
             ' -s project/mobile/fenix/sentry -k dsn -f .sentry_token'
             ' && ./gradlew --no-daemon -PcrashReports=true clean test assembleRelease'),
         features={
-            "chainOfTrust": True
+            "chainOfTrust": True,
+            "taskClusterProxy": True
         },
         artifacts=artifacts,
         worker_type='android-components-g' if is_staging else 'gecko-focus',


### PR DESCRIPTION
This is needed so that the build task can connect to the secrets service in
order to receive the Sentry token.