### PR TITLE
Closes #264: Integrate feature-contextmenu component 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -112,6 +112,7 @@ dependencies {
     implementation Deps.mozilla_browser_toolbar
 
     implementation Deps.mozilla_feature_awesomebar
+    implementation Deps.mozilla_feature_contextmenu
     implementation Deps.mozilla_feature_downloads
     implementation Deps.mozilla_feature_intent
     implementation Deps.mozilla_feature_prompts

--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -16,6 +16,8 @@ import android.view.accessibility.AccessibilityManager
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.fragment.app.Fragment
 import kotlinx.android.synthetic.main.fragment_browser.*
+import mozilla.components.feature.contextmenu.ContextMenuCandidate
+import mozilla.components.feature.contextmenu.ContextMenuFeature
 import mozilla.components.feature.downloads.DownloadsFeature
 import mozilla.components.feature.session.SessionFeature
 import mozilla.components.feature.session.SessionUseCases
@@ -27,6 +29,7 @@ import mozilla.components.feature.prompts.PromptFeature
 
 class BrowserFragment : Fragment() {
 
+    private lateinit var contextMenuFeature: ContextMenuFeature
     private lateinit var downloadsFeature: DownloadsFeature
     private lateinit var promptsFeature: PromptFeature
     private lateinit var sessionFeature: SessionFeature
@@ -50,6 +53,14 @@ class BrowserFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         val sessionManager = requireComponents.core.sessionManager
+
+        contextMenuFeature = ContextMenuFeature(
+            requireFragmentManager(),
+            sessionManager,
+            ContextMenuCandidate.defaultCandidates(
+                requireContext(),
+                requireComponents.useCases.tabsUseCases,
+                view))
 
         downloadsFeature = DownloadsFeature(
             requireContext(),
@@ -83,6 +94,7 @@ class BrowserFragment : Fragment() {
         }
 
         lifecycle.addObservers(
+            contextMenuFeature,
             downloadsFeature,
             promptsFeature,
             sessionFeature,

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -5,7 +5,7 @@
 private object Versions {
     const val kotlin = "1.3.11"
     const val android_gradle_plugin = "3.2.1"
-    const val geckoNightly = "66.0.20190128092811"
+    const val geckoNightly = "67.0.20190130001444"
     const val rxAndroid = "2.1.0"
     const val rxKotlin = "2.3.0"
     const val anko = "0.10.8"


### PR DESCRIPTION
This brings in context menus shown for long presses (e.g. on links, images, etc.). The tabs functionality isn't integrated in Fenix yet, but the menus will display with various other useful default options.

This also required updating GV to the latest nightly. I've added a separate commit for this here (same version as A-C).