### PR TITLE
Enforce unidirectional arch better

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -8,7 +8,6 @@ import android.content.Context
 import android.content.SharedPreferences
 import android.preference.PreferenceManager
 import mozilla.components.browser.engine.gecko.GeckoEngine
-import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.session.storage.SessionStorage
 import mozilla.components.browser.storage.sync.PlacesHistoryStorage
@@ -19,7 +18,6 @@ import mozilla.components.feature.session.HistoryDelegate
 import mozilla.components.lib.crash.handler.CrashHandlerService
 import org.mozilla.geckoview.GeckoRuntime
 import org.mozilla.geckoview.GeckoRuntimeSettings
-import java.util.concurrent.TimeUnit
 
 /**
  * Component group for all core browser functionality.

--- a/app/src/main/java/org/mozilla/fenix/home/sessions/SessionsComponent.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessions/SessionsComponent.kt
@@ -4,10 +4,8 @@
 
 package org.mozilla.fenix.home.sessions
 
-import android.annotation.SuppressLint
 import android.view.ViewGroup
 import mozilla.components.browser.session.Session
-import mozilla.components.support.base.log.logger.Logger
 import org.mozilla.fenix.mvi.Action
 import org.mozilla.fenix.mvi.ActionBusFactory
 import org.mozilla.fenix.mvi.Change
@@ -16,10 +14,13 @@ import org.mozilla.fenix.mvi.ViewState
 
 class SessionsComponent(
     private val container: ViewGroup,
-    override val bus: ActionBusFactory,
+    bus: ActionBusFactory,
     override var initialState: SessionsState = SessionsState(emptyList())
 ) :
-    UIComponent<SessionsState, SessionsAction, SessionsChange>(bus) {
+    UIComponent<SessionsState, SessionsAction, SessionsChange>(
+        bus.getManagedEmitter(SessionsAction::class.java),
+        bus.getSafeManagedObservable(SessionsChange::class.java)
+    ) {
 
     override val reducer: (SessionsState, SessionsChange) -> SessionsState = { state, change ->
         when (change) {
@@ -27,20 +28,10 @@ class SessionsComponent(
         }
     }
 
-    override fun initView() = SessionsUIView(container, bus)
+    override fun initView() = SessionsUIView(container, actionEmitter, changesObservable)
 
     init {
-        setup()
-    }
-
-    @SuppressLint("CheckResult")
-    fun setup(): SessionsComponent {
         render(reducer)
-        getUserInteractionEvents<SessionsAction>()
-            .subscribe {
-                Logger("SessionsComponent").debug(it.toString())
-            }
-        return this
     }
 }
 

--- a/app/src/main/java/org/mozilla/fenix/home/sessions/SessionsUIView.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessions/SessionsUIView.kt
@@ -8,13 +8,18 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import io.reactivex.Observable
+import io.reactivex.Observer
 import io.reactivex.functions.Consumer
 import org.mozilla.fenix.R
-import org.mozilla.fenix.mvi.ActionBusFactory
 import org.mozilla.fenix.mvi.UIView
 
-class SessionsUIView(container: ViewGroup, bus: ActionBusFactory) :
-    UIView<SessionsState>(container, bus) {
+class SessionsUIView(
+    container: ViewGroup,
+    actionEmitter: Observer<SessionsAction>,
+    changesObservable: Observable<SessionsChange>
+) :
+    UIView<SessionsState, SessionsAction, SessionsChange>(container, actionEmitter, changesObservable) {
 
     override val view: RecyclerView = LayoutInflater.from(container.context)
         .inflate(R.layout.component_sessions, container, true)

--- a/app/src/main/java/org/mozilla/fenix/mvi/ActionBusFactory.kt
+++ b/app/src/main/java/org/mozilla/fenix/mvi/ActionBusFactory.kt
@@ -27,6 +27,7 @@ import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.OnLifecycleEvent
 import io.reactivex.Observable
+import io.reactivex.Observer
 import io.reactivex.rxkotlin.merge
 import io.reactivex.subjects.PublishSubject
 import io.reactivex.subjects.Subject
@@ -102,6 +103,10 @@ class ActionBusFactory private constructor(val owner: LifecycleOwner) {
         return if (map[clazz] != null) map[clazz] as Observable<T> else create(clazz)
     }
 
+    fun <T : Action> getManagedEmitter(clazz: Class<T>): Observer<T> {
+        return if (map[clazz] != null) map[clazz] as Observer<T> else create(clazz)
+    }
+
     fun logMergedObservables() {
         // TODO make this observe new items in the map and combine them
         map.values.merge().compose(logState()).subscribe()
@@ -130,6 +135,9 @@ inline fun <reified T : Action> LifecycleOwner.emit(event: T) =
  */
 inline fun <reified T : Action> LifecycleOwner.getSafeManagedObservable(): Observable<T> =
     ActionBusFactory.get(this).getSafeManagedObservable(T::class.java)
+
+inline fun <reified T : Action> LifecycleOwner.getManagedEmitter(): Observer<T> =
+    ActionBusFactory.get(this).getManagedEmitter(T::class.java)
 
 /**
  * This method returns a destroy observable that can be passed to [org.mozilla.fenix.mvi.UIView]s as needed.

--- a/app/src/main/java/org/mozilla/fenix/mvi/UIView.kt
+++ b/app/src/main/java/org/mozilla/fenix/mvi/UIView.kt
@@ -7,12 +7,15 @@ package org.mozilla.fenix.mvi
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.IdRes
+import io.reactivex.Observable
+import io.reactivex.Observer
 import io.reactivex.functions.Consumer
 import kotlinx.android.extensions.LayoutContainer
 
-abstract class UIView<S : ViewState>(
+abstract class UIView<S : ViewState, A : Action, C : Change>(
     private val container: ViewGroup,
-    val bus: ActionBusFactory
+    protected val actionEmitter: Observer<A>,
+    protected val changesObservable: Observable<C>
 ) : LayoutContainer {
 
     abstract val view: View

--- a/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarComponent.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarComponent.kt
@@ -4,32 +4,38 @@ package org.mozilla.fenix.search.awesomebar
    file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import android.view.ViewGroup
-import org.mozilla.fenix.mvi.*
+import org.mozilla.fenix.mvi.Action
+import org.mozilla.fenix.mvi.ActionBusFactory
+import org.mozilla.fenix.mvi.Change
+import org.mozilla.fenix.mvi.Reducer
+import org.mozilla.fenix.mvi.UIComponent
+import org.mozilla.fenix.mvi.ViewState
 
-data class AwesomeBarState(val query: String) : ViewState {
-    fun updateQuery(query: String) = AwesomeBarState(query)
-}
+data class AwesomeBarState(val query: String) : ViewState
 
-sealed class AwesomeBarAction: Action {
-    object ItemSelected: AwesomeBarAction()
+sealed class AwesomeBarAction : Action {
+    object ItemSelected : AwesomeBarAction()
 }
 
 sealed class AwesomeBarChange : Change {
-    data class UpdateQuery(val query: String): AwesomeBarChange()
+    data class UpdateQuery(val query: String) : AwesomeBarChange()
 }
 
 class AwesomeBarComponent(
     private val container: ViewGroup,
-    override val bus: ActionBusFactory,
+    bus: ActionBusFactory,
     override var initialState: AwesomeBarState = AwesomeBarState("")
-) : UIComponent<AwesomeBarState, AwesomeBarAction, AwesomeBarChange>(bus) {
+) : UIComponent<AwesomeBarState, AwesomeBarAction, AwesomeBarChange>(
+    bus.getManagedEmitter(AwesomeBarAction::class.java),
+    bus.getSafeManagedObservable(AwesomeBarChange::class.java)
+) {
     override val reducer: Reducer<AwesomeBarState, AwesomeBarChange> = { state, change ->
         when (change) {
-            is AwesomeBarChange.UpdateQuery -> state.updateQuery(change.query)
+            is AwesomeBarChange.UpdateQuery -> state.copy(query = change.query)
         }
     }
 
-    override fun initView() = AwesomeBarUIView(container, bus)
+    override fun initView() = AwesomeBarUIView(container, actionEmitter, changesObservable)
 
     init {
         render(reducer)


### PR DESCRIPTION
This splits the bus into an `Observer<Action>` and `Observable<Change>` so Changes come from outside as input and Actions come from the internals as output.