### PR TITLE
Fix usage of sentry token in staging

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -43,7 +43,6 @@ tasks:
             - queue:scheduler-id:${scheduler_id}
             - queue:create-task:highest:aws-provisioner-v1/${build_worker_type}
             - project:mobile:fenix:releng:signing:format:autograph_apk
-            - secrets:get:project/mobile/fenix/sentry
             - $if: is_mozilla_mobile_repo
               then:
                 - queue:create-task:highest:scriptworker-prov-v1/mobile-signing-v1
@@ -51,12 +50,14 @@ tasks:
                 - project:mobile:fenix:releng:signing:cert:release-signing
                 - project:mobile:fenix:releng:googleplay:product:fenix
                 - queue:route:index.project.mobile.fenix.signed-nightly.*
+                - secrets:get:project/mobile/fenix/sentry
               else:
                 - queue:create-task:highest:scriptworker-prov-v1/mobile-signing-dep-v1
                 - queue:create-task:highest:scriptworker-prov-v1/mobile-pushapk-dep-v1
                 - project:mobile:fenix:releng:signing:cert:dep-signing
                 - project:mobile:fenix:releng:googleplay:product:fenix:dep
                 - queue:route:index.project.mobile.fenix.staging-signed-nightly.*
+                - secrets:get:garbage/staging/project/mobile/fenix/sentry
         payload:
           maxRunTime: 600   # Decision should remain fast enough to schedule a handful of tasks
           image: mozillamobile/fenix:1.3

--- a/automation/taskcluster/decision_task_nightly.py
+++ b/automation/taskcluster/decision_task_nightly.py
@@ -36,13 +36,14 @@ def generate_build_task(apks, is_staging):
     } for apk in apks}
 
     checkout = 'git clone {} repository && cd repository'.format(GITHUB_HTTP_REPOSITORY)
+    sentry_secret = '{}project/mobile/fenix/sentry'.format('garbage/staging/' if is_staging else '')
 
     return taskcluster.slugId(), BUILDER.build_task(
         name="(Fenix) Build task",
         description="Build Fenix from source code.",
         command=('cd .. && ' + checkout +
             ' && python automation/taskcluster/helper/get-secret.py'
-            ' -s project/mobile/fenix/sentry -k dsn -f .sentry_token'
+            ' -s {} -k dsn -f .sentry_token'.format(sentry_secret) +
             ' && ./gradlew --no-daemon -PcrashReports=true clean test assembleRelease'),
         features={
             "chainOfTrust": True,
@@ -51,7 +52,7 @@ def generate_build_task(apks, is_staging):
         artifacts=artifacts,
         worker_type='android-components-g' if is_staging else 'gecko-focus',
         scopes=[
-            "secrets:get:project/mobile/fenix/sentry"
+            "secrets:get:{}".format(sentry_secret)
         ]
     )
 


### PR DESCRIPTION
Staging repository doesn't/shouldn't have access to production tokens