### PR TITLE
Update A-C to 0.42.0-SNAPSHOT

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -98,7 +98,8 @@ class BrowserFragment : Fragment(), BackHandler {
             ContextMenuCandidate.defaultCandidates(
                 requireContext(),
                 requireComponents.useCases.tabsUseCases,
-                view))
+                view),
+            view.engineView)
 
         downloadsFeature = DownloadsFeature(
             requireContext(),

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -5,7 +5,7 @@
 private object Versions {
     const val kotlin = "1.3.11"
     const val android_gradle_plugin = "3.2.1"
-    const val geckoNightly = "67.0.20190130001444"
+    const val geckoNightly = "67.0.20190204092937"
     const val rxAndroid = "2.1.0"
     const val rxKotlin = "2.3.0"
     const val anko = "0.10.8"

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -18,7 +18,7 @@ private object Versions {
     const val androidx_annotation = "1.0.1"
     const val androidx_lifecycle = "2.0.0"
 
-    const val mozilla_android_components = "0.41.0-SNAPSHOT"
+    const val mozilla_android_components = "0.42.0-SNAPSHOT"
 
     const val junit = "4.12"
     const val test_tools = "1.0.2"


### PR DESCRIPTION
This patch updates A-C to 0.42.0-SNAPSHOT. Do not land yet, it seems the 0.42 build has not kicked off yet.