### PR TITLE
Issue #391: ToolbarUIView: Do not bind toolbar integration to initially selected session.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -51,6 +51,9 @@ class BrowserFragment : Fragment(), BackHandler {
     private lateinit var toolbarComponent: ToolbarComponent
     private lateinit var customTabsToolbarFeature: CustomTabsToolbarFeature
 
+    private val sessionId: String?
+        get() = arguments?.getString(SESSION_ID)
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -60,7 +63,7 @@ class BrowserFragment : Fragment(), BackHandler {
         toolbarComponent = ToolbarComponent(
             view.browserLayout,
             ActionBusFactory.get(this),
-            SearchState("", isEditing = false)
+            SearchState("", isEditing = false, sessionId = sessionId)
         )
 
         toolbarComponent.uiView.view.apply {
@@ -99,8 +102,6 @@ class BrowserFragment : Fragment(), BackHandler {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
-        val sessionId = arguments?.getString(SESSION_ID)
 
         val sessionManager = requireComponents.core.sessionManager
 

--- a/app/src/main/java/org/mozilla/fenix/search/toolbar/ToolbarComponent.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/toolbar/ToolbarComponent.kt
@@ -28,13 +28,13 @@ class ToolbarComponent(
         }
     }
 
-    override fun initView() = ToolbarUIView(container, actionEmitter, changesObservable)
+    override fun initView() = ToolbarUIView(container, actionEmitter, changesObservable, initialState.sessionId)
     init {
         render(reducer)
     }
 }
 
-data class SearchState(val query: String, val isEditing: Boolean) : ViewState
+data class SearchState(val query: String, val isEditing: Boolean, val sessionId: String? = null) : ViewState
 
 sealed class SearchAction : Action {
     data class UrlCommitted(val url: String) : SearchAction()

--- a/app/src/main/java/org/mozilla/fenix/search/toolbar/ToolbarIntegration.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/toolbar/ToolbarIntegration.kt
@@ -11,7 +11,6 @@ import androidx.lifecycle.OnLifecycleEvent
 import androidx.navigation.Navigation
 import mozilla.components.browser.domains.autocomplete.DomainAutocompleteProvider
 import mozilla.components.browser.session.SessionManager
-import mozilla.components.browser.session.runWithSession
 import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.concept.storage.HistoryStorage
 import mozilla.components.feature.toolbar.ToolbarAutocompleteFeature
@@ -35,7 +34,13 @@ class ToolbarIntegration(
         val home = BrowserToolbar.Button(
             context.resources.getDrawable(R.drawable.ic_home, context.application.theme),
             context.getString(R.string.browser_home_button),
-            visible = { sessionManager.runWithSession(sessionId) { it.isCustomTabSession().not() } }
+            visible = {
+                if (sessionId == null) {
+                    true
+                } else {
+                    sessionManager.findSessionById(sessionId)?.isCustomTabSession()?.not() ?: true
+                }
+            }
         ) {
             Navigation.findNavController(toolbar).navigate(R.id.action_browserFragment_to_homeFragment)
         }

--- a/app/src/main/java/org/mozilla/fenix/search/toolbar/ToolbarUIView.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/toolbar/ToolbarUIView.kt
@@ -20,7 +20,8 @@ import org.mozilla.fenix.mvi.UIView
 class ToolbarUIView(
     container: ViewGroup,
     actionEmitter: Observer<SearchAction>,
-    changesObservable: Observable<SearchChange>
+    changesObservable: Observable<SearchChange>,
+    sessionId: String? = null
 ) :
     UIView<SearchState, SearchAction, SearchChange>(container, actionEmitter, changesObservable) {
 
@@ -71,7 +72,7 @@ class ToolbarUIView(
                 ShippedDomainsProvider().also { it.initialize(this) },
                 components.core.historyStorage,
                 components.core.sessionManager,
-                components.core.sessionManager.selectedSession?.id
+                sessionId
             )
         }
     }


### PR DESCRIPTION
Closes #408

Instead either use static session id (e.g. in a custom tab) or dynamically follow selected session.

Using a static session id caused the toolbar feature not reacting to changes. For example with the following STR the toolbar wouldn't show the data of the new selected session:

* Load a website
* Long press a link to show the context menu
* Select "Open in new tab"
* Click "switch" on the appearing snackbar

Expected: Browser displays new tab and toolbar shows URL of new tab.
Actual: Browser display new tab but still shows the URL of the previous tab.

To get a potential session id to the integration I pass it into the `SearchState`. Is that okay?

