### PR TITLE
Pass concept-fetch Client implementation to SearchSuggestionProvider.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarUIView.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarUIView.kt
@@ -59,6 +59,7 @@ class AwesomeBarUIView(
                     if (useNewTab) {
                         components.useCases.searchUseCases.newTabSearch
                     } else components.useCases.searchUseCases.defaultSearch,
+                    components.core.client,
                     SearchSuggestionProvider.Mode.MULTIPLE_SUGGESTIONS
                 )
             )


### PR DESCRIPTION
This is an API change in AC. The `AwesomeBar` now uses a `Client` from `concept-fetch` for HTTP requests. In apps that are using `GeckoView` it's preferable to use the `GeckoViewFetchClient` implementation.