### PR TITLE
Default to LeakCanary being off

### DIFF
--- a/app/src/debug/java/org/mozilla/fenix/DebugFenixApplication.kt
+++ b/app/src/debug/java/org/mozilla/fenix/DebugFenixApplication.kt
@@ -36,8 +36,8 @@ class DebugFenixApplication : FenixApplication() {
         context: Context,
         private val defaultDumper: HeapDumper
     ) : HeapDumper {
-        var prefs: SharedPreferences? = PreferenceManager.getDefaultSharedPreferences(context)
-        var enabled = prefs?.getBoolean(context.getPreferenceKey(pref_key_leakcanary), true) ?: true
+        var prefs: SharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
+        var enabled = prefs.getBoolean(context.getPreferenceKey(pref_key_leakcanary), false)
         override fun dumpHeap(): File? = if (enabled) defaultDumper.dumpHeap() else HeapDumper.RETRY_LATER
     }
 }

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -67,7 +67,8 @@
         <androidx.preference.SwitchPreference
             android:icon="@drawable/ic_about"
             android:key="@string/pref_key_leakcanary"
-            android:title="@string/preference_leakcanary" />
+            android:title="@string/preference_leakcanary"
+            android:defaultValue="false" />
     </androidx.preference.PreferenceCategory>
 
     <androidx.preference.PreferenceCategory


### PR DESCRIPTION
This is so we can test our changes without being slowed down by waiting for leak dumps. Integration tests will enable LeakCanary and developers can enable it through Settings.