### PR TITLE
Ensures that fenix team is also notified of automation changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,5 +18,5 @@
 # By default the Android Components team will be the owner for everything in
 # the repo. Unless a later match takes precedence.
 * @mozilla-mobile/fenix
-/automation @mozilla-mobile/releng
-/.github @mozilla-mobile/releng
+/automation/ @mozilla-mobile/releng @mozilla-mobile/fenix
+/.github/ @mozilla-mobile/releng @mozilla-mobile/fenix


### PR DESCRIPTION
The wildcard assignment is overridden by follow-up directives, so I explicitly added `@mozilla-mobile/fenix` as an owner too, so we in releng don't block any PRs :)