### PR TITLE
Handle listener state bugs as onViewCreated isn't always called

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -103,18 +103,6 @@ class BrowserFragment : Fragment(), BackHandler {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        getAutoDisposeObservable<SearchAction>()
-            .subscribe {
-                when (it) {
-                    is SearchAction.ToolbarTapped -> Navigation.findNavController(toolbar)
-                        .navigate(BrowserFragmentDirections.actionBrowserFragmentToSearchFragment(
-                            requireComponents.core.sessionManager.selectedSession?.id,
-                            (activity as HomeActivity).browsingModeManager.isPrivate
-                        ))
-                    is SearchAction.ToolbarMenuItemTapped -> handleToolbarItemInteraction(it)
-                }
-            }
-
         sessionId = BrowserFragmentArgs.fromBundle(arguments!!).sessionId
 
         (activity as AppCompatActivity).supportActionBar?.hide()
@@ -182,6 +170,23 @@ class BrowserFragment : Fragment(), BackHandler {
             feature = (toolbarComponent.uiView as ToolbarUIView).toolbarIntegration,
             owner = this,
             view = view)
+    }
+
+    override fun onStart() {
+        super.onStart()
+        getAutoDisposeObservable<SearchAction>()
+            .subscribe {
+                when (it) {
+                    is SearchAction.ToolbarTapped -> Navigation.findNavController(toolbar)
+                        .navigate(
+                            BrowserFragmentDirections.actionBrowserFragmentToSearchFragment(
+                                requireComponents.core.sessionManager.selectedSession?.id,
+                                (activity as HomeActivity).browsingModeManager.isPrivate
+                            )
+                        )
+                    is SearchAction.ToolbarMenuItemTapped -> handleToolbarItemInteraction(it)
+                }
+            }
     }
 
     @SuppressWarnings("ReturnCount")

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragment.kt
@@ -79,6 +79,18 @@ class HistoryFragment : Fragment(), CoroutineScope, BackHandler {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        launch(Dispatchers.IO) {
+            val items = requireComponents.core.historyStorage.getVisited()
+                .mapIndexed { id, item -> HistoryItem(id, item) }
+
+            launch(Dispatchers.Main) {
+                getManagedEmitter<HistoryChange>().onNext(HistoryChange.Change(items))
+            }
+        }
+    }
+
+    override fun onStart() {
+        super.onStart()
         getAutoDisposeObservable<HistoryAction>()
             .subscribe {
                 when (it) {
@@ -93,15 +105,6 @@ class HistoryFragment : Fragment(), CoroutineScope, BackHandler {
                         .onNext(HistoryChange.ExitEditMode)
                 }
             }
-
-        launch(Dispatchers.IO) {
-            val items = requireComponents.core.historyStorage.getVisited()
-                .mapIndexed { id, item -> HistoryItem(id, item) }
-
-            launch(Dispatchers.Main) {
-                getManagedEmitter<HistoryChange>().onNext(HistoryChange.Change(items))
-            }
-        }
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
@@ -63,7 +63,10 @@ class SearchFragment : Fragment() {
         lifecycle.addObserver((toolbarComponent.uiView as ToolbarUIView).toolbarIntegration)
 
         view.toolbar_wrapper.clipToOutline = false
+    }
 
+    override fun onStart() {
+        super.onStart()
         getAutoDisposeObservable<SearchAction>()
             .subscribe {
                 when (it) {


### PR DESCRIPTION
It seems the reason we had some odd listener state bugs is because onCreateView/onViewCreated isn't called consistently. onCreate/onStart/onResume, on the other hand, are called every time.