### PR TITLE
Fixes #575: Crash "IllegalStateException: Display already acquired"

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/ThemeManager.kt
+++ b/app/src/main/java/org/mozilla/fenix/ThemeManager.kt
@@ -39,9 +39,11 @@ class DefaultThemeManager : ThemeManager {
         get() = temporaryThemeManagerStorage
 
     override fun setTheme(theme: ThemeManager.Theme) {
-        temporaryThemeManagerStorage = theme
+        if (temporaryThemeManagerStorage != theme) {
+            temporaryThemeManagerStorage = theme
 
-        onThemeChange?.invoke(currentTheme)
+            onThemeChange?.invoke(currentTheme)
+        }
     }
 
     companion object {


### PR DESCRIPTION
The crash occurs because we recreate HomeActivity and CustomTabsActivity when starting them. When we're loading Custom Tabs, we end up recreating the activity with the same session id while the page is already loading. This fix is the minimal set of changes to avoid the crash by not recreating the activity if the default theme is already correct.