### PR TITLE
Fixes #566: Clears search on new tab

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarUIView.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarUIView.kt
@@ -87,6 +87,7 @@ class ToolbarUIView(
 
     override fun updateView() = Consumer<SearchState> {
         if (it.isEditing) {
+            view.url = it.query
             view.editMode()
         } else {
             view.displayMode()

--- a/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
@@ -18,6 +18,7 @@ import org.mozilla.fenix.components.toolbar.SearchAction
 import org.mozilla.fenix.components.toolbar.SearchState
 import org.mozilla.fenix.components.toolbar.ToolbarComponent
 import org.mozilla.fenix.components.toolbar.ToolbarUIView
+import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.mvi.ActionBusFactory
 import org.mozilla.fenix.mvi.getAutoDisposeObservable
 import org.mozilla.fenix.mvi.getManagedEmitter
@@ -38,12 +39,18 @@ class SearchFragment : Fragment() {
         val sessionId = SearchFragmentArgs.fromBundle(arguments!!).sessionId
         val isPrivate = SearchFragmentArgs.fromBundle(arguments!!).isPrivateTab
         val view = inflater.inflate(R.layout.fragment_search, container, false)
+        val url = sessionId?.let {
+            requireComponents.core.sessionManager.findSessionById(it)?.let {
+                    session -> session.url
+            }
+        } ?: ""
+
         toolbarComponent = ToolbarComponent(
             view.toolbar_wrapper,
             ActionBusFactory.get(this),
             sessionId,
             isPrivate,
-            SearchState("", isEditing = true)
+            SearchState(url, isEditing = true)
         )
         awesomeBarComponent = AwesomeBarComponent(
             view.search_layout, ActionBusFactory.get(this),


### PR DESCRIPTION
Now setting the url based on the tab's query. This means that if it's a new tab, the query is empty, and if it a tab transitioning from BrowserFragment to SearchFragment it will properly be set.