### PR TITLE
Closes #537: Refactors private sessions

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -89,7 +89,7 @@ open class HomeActivity : AppCompatActivity() {
     private fun openToBrowser() {
         val sessionId = SafeIntent(intent).getStringExtra(IntentProcessor.ACTIVE_SESSION_ID)
         val host = supportFragmentManager.findFragmentById(R.id.container) as NavHostFragment
-        val directions = NavGraphDirections.actionGlobalBrowser(sessionId, browsingModeManager.isPrivate)
+        val directions = NavGraphDirections.actionGlobalBrowser(sessionId)
         host.navController.navigate(directions)
     }
 

--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -54,7 +54,6 @@ class BrowserFragment : Fragment(), BackHandler {
     private val findInPageIntegration = ViewBoundFeatureWrapper<FindInPageIntegration>()
     private val customTabsToolbarFeature = ViewBoundFeatureWrapper<CustomTabsToolbarFeature>()
     private val toolbarIntegration = ViewBoundFeatureWrapper<ToolbarIntegration>()
-    private var isPrivate = false
     var sessionId: String? = null
 
     override fun onCreateView(
@@ -64,14 +63,13 @@ class BrowserFragment : Fragment(), BackHandler {
     ): View? {
         require(arguments != null)
         sessionId = BrowserFragmentArgs.fromBundle(arguments!!).sessionId
-        isPrivate = BrowserFragmentArgs.fromBundle(arguments!!).isPrivateTab
 
         val view = inflater.inflate(R.layout.fragment_browser, container, false)
 
         toolbarComponent = ToolbarComponent(
             view.browserLayout,
             ActionBusFactory.get(this), sessionId,
-            isPrivate,
+            (activity as HomeActivity).browsingModeManager.isPrivate,
             SearchState("", isEditing = false)
         )
 
@@ -179,9 +177,7 @@ class BrowserFragment : Fragment(), BackHandler {
                     is SearchAction.ToolbarTapped -> Navigation.findNavController(toolbarComponent.getView())
                         .navigate(
                             BrowserFragmentDirections.actionBrowserFragmentToSearchFragment(
-                                requireComponents.core.sessionManager.selectedSession?.id,
-                                (activity as HomeActivity).browsingModeManager.isPrivate
-                            )
+                                requireComponents.core.sessionManager.selectedSession?.id)
                         )
                     is SearchAction.ToolbarMenuItemTapped -> handleToolbarItemInteraction(it)
                 }
@@ -229,8 +225,7 @@ class BrowserFragment : Fragment(), BackHandler {
                 .selectedSession?.url?.apply { requireContext().share(this) }
             ToolbarMenu.Item.NewPrivateTab -> {
                 val directions = BrowserFragmentDirections
-                    .actionBrowserFragmentToSearchFragment(requireComponents.core.sessionManager.selectedSession?.id,
-                        (activity as HomeActivity).browsingModeManager.isPrivate)
+                    .actionBrowserFragmentToSearchFragment(requireComponents.core.sessionManager.selectedSession?.id)
                 Navigation.findNavController(view!!).navigate(directions)
                 (activity as HomeActivity).browsingModeManager.mode = BrowsingModeManager.Mode.Private
             }
@@ -245,8 +240,7 @@ class BrowserFragment : Fragment(), BackHandler {
             }
             ToolbarMenu.Item.NewTab -> {
                 val directions = BrowserFragmentDirections
-                    .actionBrowserFragmentToSearchFragment(null,
-                        (activity as HomeActivity).browsingModeManager.isPrivate)
+                    .actionBrowserFragmentToSearchFragment(null)
                 Navigation.findNavController(view!!).navigate(directions)
                 (activity as HomeActivity).browsingModeManager.mode = BrowsingModeManager.Mode.Normal
             }

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -79,8 +79,7 @@ class HomeFragment : Fragment() {
         val roundToInt = (toolbarPaddingDp * Resources.getSystem().displayMetrics.density).roundToInt()
         view.toolbar.compoundDrawablePadding = roundToInt
         view.toolbar.setOnClickListener {
-            val directions = HomeFragmentDirections.actionHomeFragmentToSearchFragment(null,
-                (activity as HomeActivity).browsingModeManager.isPrivate)
+            val directions = HomeFragmentDirections.actionHomeFragmentToSearchFragment(null)
             Navigation.findNavController(it).navigate(directions)
         }
 
@@ -112,10 +111,7 @@ class HomeFragment : Fragment() {
             override fun onTransitionCompleted(p0: MotionLayout?, p1: Int) { }
         })
 
-        view.toolbar_wrapper.isPrivateModeEnabled = (requireActivity() as HomeActivity)
-            .themeManager
-            .currentTheme
-            .isPrivate()
+        view.toolbar_wrapper.isPrivateModeEnabled = (activity as HomeActivity).browsingModeManager.isPrivate
 
         privateBrowsingButton.setOnClickListener {
             val browsingModeManager = (activity as HomeActivity).browsingModeManager
@@ -135,10 +131,7 @@ class HomeFragment : Fragment() {
                         is TabsAction.Select -> {
                             val session = requireComponents.core.sessionManager.findSessionById(it.sessionId)
                             requireComponents.core.sessionManager.select(session!!)
-                            val directions = HomeFragmentDirections.actionHomeFragmentToBrowserFragment(
-                                it.sessionId,
-                                (activity as HomeActivity).browsingModeManager.isPrivate
-                            )
+                            val directions = HomeFragmentDirections.actionHomeFragmentToBrowserFragment(it.sessionId)
                             Navigation.findNavController(view!!).navigate(directions)
                         }
                         is TabsAction.Close -> {

--- a/app/src/main/java/org/mozilla/fenix/home/tabs/TabsUIView.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/tabs/TabsUIView.kt
@@ -51,8 +51,7 @@ class TabsUIView(
         }
         header.add_tab_button.increaseTapArea(HomeFragment.addTabButtonIncreaseDps)
         header.add_tab_button.setOnClickListener {
-            val directions = HomeFragmentDirections.actionHomeFragmentToSearchFragment(null,
-                isPrivate)
+            val directions = HomeFragmentDirections.actionHomeFragmentToSearchFragment(null)
             Navigation.findNavController(it).navigate(directions)
         }
         header.tabs_overflow_button.increaseTapArea(HomeFragment.overflowButtonIncreaseDps)

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragment.kt
@@ -21,7 +21,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import mozilla.components.support.base.feature.BackHandler
-import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.mvi.ActionBusFactory
@@ -58,8 +57,7 @@ class HistoryFragment : Fragment(), CoroutineScope, BackHandler {
     private fun selectItem(item: HistoryItem) {
         Navigation.findNavController(requireActivity(), R.id.container).apply {
             navigate(
-                HistoryFragmentDirections.actionGlobalBrowser(null,
-                    (activity as HomeActivity).browsingModeManager.isPrivate),
+                HistoryFragmentDirections.actionGlobalBrowser(null),
                 NavOptions.Builder().setPopUpTo(R.id.homeFragment, false).build()
             )
         }

--- a/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
@@ -40,7 +40,7 @@ class SearchFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         val sessionId = SearchFragmentArgs.fromBundle(arguments!!).sessionId
-        val isPrivate = SearchFragmentArgs.fromBundle(arguments!!).isPrivateTab
+        val isPrivate = (activity as HomeActivity).browsingModeManager.isPrivate
         val view = inflater.inflate(R.layout.fragment_search, container, false)
         val url = sessionId?.let {
             requireComponents.core.sessionManager.findSessionById(it)?.let {
@@ -105,7 +105,7 @@ class SearchFragment : Fragment() {
     // We should move this logic into a place that makes more sense.
     private fun load(text: String) {
         val sessionId = SearchFragmentArgs.fromBundle(arguments!!).sessionId
-        val isPrivate = SearchFragmentArgs.fromBundle(arguments!!).isPrivateTab
+        val isPrivate = (activity as HomeActivity).browsingModeManager.isPrivate
 
         val loadUrlUseCase = if (sessionId == null) {
             if (isPrivate) {
@@ -131,8 +131,7 @@ class SearchFragment : Fragment() {
 
     private fun transitionToBrowser() {
         val sessionId = SearchFragmentArgs.fromBundle(arguments!!).sessionId
-        val directions = SearchFragmentDirections.actionSearchFragmentToBrowserFragment(sessionId,
-            (activity as HomeActivity).browsingModeManager.isPrivate)
+        val directions = SearchFragmentDirections.actionSearchFragmentToBrowserFragment(sessionId)
 
         Navigation.findNavController(view!!.search_layout).navigate(directions)
     }

--- a/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
@@ -86,11 +86,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
             requireComponents.useCases.tabsUseCases.addTab.invoke(aboutURL, true)
             view?.let {
                 Navigation.findNavController(it)
-                    .navigate(
-                        SettingsFragmentDirections.actionGlobalBrowser(
-                            null, false
-                        )
-                    )
+                    .navigate(SettingsFragmentDirections.actionGlobalBrowser(null))
             }
             true
         }

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -38,7 +38,6 @@
             app:destination="@id/browserFragment"
             app:popUpTo="@id/homeFragment" />
         <argument android:name="session_id" app:argType="string" app:nullable="true"/>
-        <argument android:name="is_private_tab" app:argType="boolean"/>
     </fragment>
 
     <fragment
@@ -57,9 +56,6 @@
             android:name="session_id"
             app:argType="string"
             app:nullable="true" />
-        <argument
-            android:name="is_private_tab"
-            app:argType="boolean"/>
         <action
             android:id="@+id/action_browserFragment_to_settingsFragment"
             app:destination="@id/settingsFragment" />


### PR DESCRIPTION
This removes the need to pass around a variable that should be managed by just `browsingModeManager` and also means there are less dependencies on the activity (such as in HistoryFragment).