### PR TITLE
Limit Raptor to debug and special builds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,6 +17,7 @@ android {
         versionCode Config.versionCode
         versionName Config.versionName + Config.generateVersionSuffix()
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        manifestPlaceholders.isRaptorEnabled = "false"
     }
     buildTypes {
         release {
@@ -28,6 +29,7 @@ android {
             shrinkResources false
             minifyEnabled false
             applicationIdSuffix ".debug"
+            manifestPlaceholders.isRaptorEnabled = "true"
         }
     }
 
@@ -215,6 +217,10 @@ android.applicationVariants.all { variant ->
 
     def buildDate = Config.generateBuildDate()
     buildConfigField 'String', 'BUILD_DATE', '"' + buildDate + '"'
+}
+
+if (project.hasProperty("raptor")) {
+    android.defaultConfig.manifestPlaceholders.isRaptorEnabled = "true"
 }
 
 // Normally this should use the same version as the glean dependency. But since we are currently using AC snapshots we

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -68,7 +68,8 @@
         </activity>
 
         <activity android:name=".browser.BrowserPerformanceTestActivity"
-                  android:exported="true"/>
+                  android:exported="${isRaptorEnabled}"
+                  android:enabled="${isRaptorEnabled}"/>
 
         <service
                 android:name=".customtabs.CustomTabsService"


### PR DESCRIPTION
Raptor's activity should be disabled in release builds.