### PR TITLE
Closes #698: Create product flavors for Fennec transition.

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -89,9 +89,9 @@ tasks:
                 --track ${track} \
                 --commit \
                 --output /opt/fenix/app/build/outputs/apk \
-                --apk arm/release/app-arm-release-unsigned.apk \
-                --apk x86/release/app-x86-release-unsigned.apk \
-                --apk aarch64/release/app-aarch64-release-unsigned.apk \
+                --apk armGreenfield/release/app-arm-greenfield-release-unsigned.apk \
+                --apk x86Greenfield/release/app-x86-greenfield-release-unsigned.apk \
+                --apk aarch64Greenfield/release/app-aarch64-greenfield-release-unsigned.apk \
                 --date ${now}
           artifacts:
             public/task-graph.json:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,10 +33,11 @@ android {
         }
     }
 
-    flavorDimensions "abi"
+    flavorDimensions "abi", "channel"
 
     productFlavors {
-        // Processor architectures
+        // Processor architectures (abi dimension)
+
         arm {
             dimension "abi"
             ndk {
@@ -54,6 +55,32 @@ android {
             ndk {
                 abiFilter "arm64-v8a"
             }
+        }
+
+        // Product channels (channel dimension)
+
+        // "Greenfield" is our clean version of Fenix without any of the "Fennec transition" code.
+        greenfield {
+            dimension "channel"
+        }
+        firefoxNightly {
+            dimension "channel"
+
+            // Aurora was a channel between nightly builds and beta versions. Aurora builds were published on Google
+            // Play. When the Aurora channel was shutdown in April 2017 the decision was made to instead ship Nightly
+            // builds to Google Play using the existing application id. Previously Nightly builds were not available
+            // on Google Play. Since then our Nightly package name is "fennec_aurora" instead of "fennec_nightly".
+            applicationId "org.mozilla.fennec_aurora"
+        }
+        firefoxBeta {
+            dimension "channel"
+
+            applicationId "org.mozilla.firefox_beta"
+        }
+        firefoxRelease {
+            dimension "channel"
+
+            applicationId "org.mozilla.firefox"
         }
     }
 

--- a/config/pre-push-recommended.sh
+++ b/config/pre-push-recommended.sh
@@ -3,4 +3,4 @@
 ./gradlew -q \
         ktlint \
         detekt \
-        app:assembleX86Debug
+        app:assembleX86GreenfieldDebug


### PR DESCRIPTION
Creates product flavors for Fennec transition:
* greenfield (pure Fenix without anything added)
* firefoxNightly (To replace Firefox Nightly)
* firefoxBeta (To replace Firefox Beta)
* firefoxRelease (To replace Firefox Release)

For now it will be a bit annoying to have all those flavors. But once the transition has been
successfully completed we can start to tear them down again.

Once GeckoView universal builds are available we can get rid of the "abi" dimension too.

If this is going to slow down the CI process then I might look into parallelizing the build
or potentially introducing a taskcluster CI setup (if that makes sense).

Also closes #702.