### PR TITLE
Closes #699: Firefox flavors: Re-use sharedUserId.

### DIFF
--- a/app/src/firefoxBeta/AndroidManifest.xml
+++ b/app/src/firefoxBeta/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  sharedUserId: This flavor is meant to replace Firefox (Beta channel) and therefore needs to inherit
+                its sharedUserId for all eternity. Shipping an app update without sharedUserId can have
+                fatal consequences. For example see:
+                - https://issuetracker.google.com/issues/36924841
+                - https://issuetracker.google.com/issues/36905922
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+      android:sharedUserId="org.mozilla.firefox.sharedID">
+</manifest>

--- a/app/src/firefoxNightly/AndroidManifest.xml
+++ b/app/src/firefoxNightly/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  sharedUserId: This flavor is meant to replace Firefox (Nightly channel) and therefore needs to inherit
+                its sharedUserId for all eternity. Shipping an app update without sharedUserId can have
+                fatal consequences. For example see:
+                - https://issuetracker.google.com/issues/36924841
+                - https://issuetracker.google.com/issues/36905922
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+      android:sharedUserId="org.mozilla.fennec.sharedID">
+</manifest>

--- a/app/src/firefoxRelease/AndroidManifest.xml
+++ b/app/src/firefoxRelease/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  sharedUserId: This flavor is meant to replace Firefox (Release channel) and therefore needs to inherit
+                its sharedUserId for all eternity. Shipping an app update without sharedUserId can have
+                fatal consequences. For example see:
+                - https://issuetracker.google.com/issues/36924841
+                - https://issuetracker.google.com/issues/36905922
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+      android:sharedUserId="org.mozilla.firefox.sharedID">
+</manifest>


### PR DESCRIPTION
I wanted to add a little "sanity check" unit test for this (to avoid regressing this accidentally), but this might require changing the setup, @colintheshots what do you recommend?

* For a local unit test (`test`) I would need to add Robolectric since that would require the Android system parts to actually get access to the manifest from code.

* With an on-device unit test (`androidTest`) that should just work but they don't get run in automation yet. And once we run them in automation we may not run them for every PR so it's more likely for something to slip through.

Happy to address that in a follow-up PR.