### PR TITLE
Issue #309: Add proguard rule for FenixMegazord

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -35,3 +35,9 @@
 -keepclassmembernames class kotlinx.** {
     volatile <fields>;
 }
+
+####################################################################################################
+# Mozilla Application Services
+####################################################################################################
+
+-keep class mozilla.appservices.FenixMegazord  { *; }


### PR DESCRIPTION
Unfortunately, today's nightly/release build is crashing because the `init` method of `FenixMegazord` got proguarded. I've added an exclusion here to fix that.

Once merged, we should publish a new Nightly.