### PR TITLE
Closes #736 & Closes #722: Adds delete session button to private browsing

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -68,6 +68,7 @@ class HomeFragment : Fragment() {
         tabsComponent = TabsComponent(
             view.homeContainer,
             bus,
+            (activity as HomeActivity).browsingModeManager.isPrivate,
             TabsState(sessionManager.sessions.map { it.toSessionViewState(it == sessionManager.selectedSession) })
         )
         sessionsComponent = SessionsComponent(view.homeContainer, bus)
@@ -164,6 +165,7 @@ class HomeFragment : Fragment() {
         (activity as AppCompatActivity).supportActionBar?.hide()
     }
 
+    @SuppressWarnings("ComplexMethod")
     override fun onStart() {
         super.onStart()
         if (isAdded) {
@@ -183,6 +185,9 @@ class HomeFragment : Fragment() {
                             requireComponents.core.sessionManager.findSessionById(it.sessionId)?.let { session ->
                                 requireComponents.core.sessionManager.remove(session)
                             }
+                        }
+                        is TabsAction.CloseAll -> {
+                            requireComponents.useCases.tabsUseCases.removeAllTabsOfType.invoke(it.private)
                         }
                     }
                 }

--- a/app/src/main/java/org/mozilla/fenix/home/tabs/TabsComponent.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/tabs/TabsComponent.kt
@@ -17,6 +17,7 @@ import org.mozilla.fenix.mvi.ViewState
 class TabsComponent(
     private val container: ViewGroup,
     bus: ActionBusFactory,
+    private val isPrivate: Boolean,
     override var initialState: TabsState = TabsState(listOf())
 ) :
     UIComponent<TabsState, TabsAction, TabsChange>(
@@ -30,7 +31,7 @@ class TabsComponent(
         }
     }
 
-    override fun initView() = TabsUIView(container, actionEmitter, changesObservable)
+    override fun initView() = TabsUIView(container, actionEmitter, changesObservable, isPrivate)
     val tabList: RecyclerView
         get() = uiView.view.tabs_list as RecyclerView
 
@@ -48,6 +49,7 @@ fun Session.toSessionViewState(selected: Boolean): SessionViewState {
 
 sealed class TabsAction : Action {
     object Archive : TabsAction()
+    data class CloseAll(val private: Boolean) : TabsAction()
     data class Select(val sessionId: String) : TabsAction()
     data class Close(val sessionId: String) : TabsAction()
 }

--- a/app/src/main/java/org/mozilla/fenix/home/tabs/TabsUIView.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/tabs/TabsUIView.kt
@@ -27,7 +27,8 @@ import org.mozilla.fenix.mvi.UIView
 class TabsUIView(
     container: ViewGroup,
     actionEmitter: Observer<TabsAction>,
-    changesObservable: Observable<TabsChange>
+    changesObservable: Observable<TabsChange>,
+    private val isPrivate: Boolean
 ) :
     UIView<TabsState, TabsAction, TabsChange>(container, actionEmitter, changesObservable) {
 
@@ -65,6 +66,10 @@ class TabsUIView(
                 this.setCompoundDrawablesWithIntrinsicBounds(drawable, null, null, null)
             }
 
+            delete_session_button.setOnClickListener {
+                actionEmitter.onNext(TabsAction.CloseAll(true))
+            }
+
             save_session_button.setOnClickListener {
                 actionEmitter.onNext(TabsAction.Archive)
             }
@@ -73,10 +78,11 @@ class TabsUIView(
 
     override fun updateView() = Consumer<TabsState> {
         tabsAdapter.sessions = it.sessions
+        val sessionButton = if (isPrivate) view.delete_session_button else view.save_session_button
 
         (if (it.sessions.isEmpty()) View.GONE else View.VISIBLE).also { visibility ->
             view.tabs_header.visibility = visibility
-            view.save_session_button.visibility = visibility
+            sessionButton.visibility = visibility
         }
     }
 

--- a/app/src/main/res/drawable/ic_delete.xml
+++ b/app/src/main/res/drawable/ic_delete.xml
@@ -1,3 +1,7 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"

--- a/app/src/main/res/layout/component_tabs.xml
+++ b/app/src/main/res/layout/component_tabs.xml
@@ -81,4 +81,31 @@
             android:focusable="false"
             android:layout_gravity="center" />
     </FrameLayout>
+
+    <FrameLayout
+        android:id="@+id/delete_session_button"
+        android:foreground="?android:attr/selectableItemBackground"
+        android:background="@drawable/button_background"
+        android:backgroundTint="@color/delete_session_button_background"
+        android:layout_margin="16dp"
+        android:padding="6dp"
+        android:clickable="true"
+        android:focusable="true"
+        android:visibility="gone"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+        <TextView
+            android:id="@+id/delete_session_button_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/session_delete"
+            android:textColor="@color/color_primary_dark"
+            android:drawableStart="@drawable/ic_delete"
+            android:drawablePadding="8dp"
+            android:textSize="16sp"
+            android:gravity="center"
+            android:clickable="false"
+            android:focusable="false"
+            android:layout_gravity="center" />
+    </FrameLayout>
 </merge>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -34,6 +34,7 @@
     <color name="session_list_empty_fg">#544CD9</color>
     <color name="session_list_header">#6D6D6E</color>
     <color name="session_list_private_header">#4a4671</color>
+    <color name="delete_session_button_background">#e5e5ea</color>
 
     <color name="private_browsing_primary">#ad3bff</color>
     <color name="private_browsing_top_gradient">#242251</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,8 +23,6 @@
         Private Sessions tabs. While this doesn\'t make you anonymous to websites or your internet service provider,
         it makes it easier to keep what you do online private from anyone else who uses this device.\n\nCommon myths
         about private browsing</string>
-    <!-- Delete session button to erase your history in a private session -->
-    <string name="private_browsing_delete_session">Delete Session</string>
 
     <!-- Browser Fragment -->
     <!-- Content description (not visible, for screen readers etc.): Navigate home -->
@@ -172,6 +170,8 @@ people before profit. Our mission: keep the Internet open and accessible to all.
 
     <!-- Text for the button to save a session -->
     <string name="session_save">Save Session</string>
+    <!-- Text for the button to delete a session -->
+    <string name="session_delete">Delete Session</string>
 
     <!-- Text for the button to delete a single session -->
     <string name="session_item_delete">Delete</string>


### PR DESCRIPTION
Note: I also did a bit of work on a separate branch (found [here](https://github.com/mozilla-mobile/fenix/compare/master...sblatz:delete-session?expand=1) which we may need in the future if we decide to [use a floating button instead](https://github.com/mozilla-mobile/fenix/issues/739) of one that's appended to the end of the tabs list).