### PR TITLE
Closes #749: Adds coloring to destructive history option

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryItemMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryItemMenu.kt
@@ -22,7 +22,8 @@ class HistoryItemMenu(
     private val menuItems by lazy {
         listOf(
             SimpleBrowserMenuItem(
-                context.getString(R.string.history_delete_item)
+                context.getString(R.string.history_delete_item),
+                R.color.photonRed60
             ) {
                 onItemTapped.invoke(Item.Delete)
             }


### PR DESCRIPTION
## Screenshot
![screenshot_20190228-133242_fenix](https://user-images.githubusercontent.com/4400286/53600076-8328d780-3b5d-11e9-81ce-bfd482c81b41.jpg)
