### PR TITLE
Issue #418: Add account settings page and sign out functionality

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/AccountSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/AccountSettingsFragment.kt
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.settings
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.navigation.Navigation
+import androidx.preference.Preference
+import androidx.preference.PreferenceFragmentCompat
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import org.mozilla.fenix.R
+import org.mozilla.fenix.ext.getPreferenceKey
+import org.mozilla.fenix.ext.requireComponents
+import kotlin.coroutines.CoroutineContext
+
+class AccountSettingsFragment : PreferenceFragmentCompat(), CoroutineScope {
+    private lateinit var job: Job
+    override val coroutineContext: CoroutineContext
+        get() = Dispatchers.Main + job
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        job = Job()
+        (activity as AppCompatActivity).title = getString(R.string.preferences_account_settings)
+        (activity as AppCompatActivity).supportActionBar?.show()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        job.cancel()
+    }
+
+    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        setPreferencesFromResource(R.xml.account_settings_preferences, rootKey)
+
+        val signIn = context?.getPreferenceKey(R.string.pref_key_sign_out)
+        val preferenceSignOut = findPreference<Preference>(signIn)
+        preferenceSignOut.onPreferenceClickListener = getClickListenerForSignOut()
+    }
+
+    private fun getClickListenerForSignOut(): Preference.OnPreferenceClickListener {
+        return Preference.OnPreferenceClickListener {
+            launch {
+                requireComponents.backgroundServices.accountManager.logout().await()
+                Navigation.findNavController(view!!).popBackStack()
+            }
+            true
+        }
+    }
+}

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -98,6 +98,8 @@
                 app:destination="@id/sitePermissionsFragment"/>
         <action android:id="@+id/action_settingsFragment_to_accessibilityFragment"
                 app:destination="@id/accessibilityFragment"/>
+        <action android:id="@+id/action_settingsFragment_to_accountSettingsFragment"
+                app:destination="@id/accountSettingsFragment"/>
     </fragment>
     <fragment android:id="@+id/dataChoicesFragment" android:name="org.mozilla.fenix.settings.DataChoicesFragment"
               android:label="DataChoicesFragment"/>
@@ -106,4 +108,6 @@
               android:label="SitePermissionsFragment"/>
     <fragment android:id="@+id/accessibilityFragment" android:name="org.mozilla.fenix.settings.AccessibilityFragment"
               android:label="AccessibilityFragment"/>
+    <fragment android:id="@+id/accountSettingsFragment" android:name="org.mozilla.fenix.settings.AccountSettingsFragment"
+              android:label="AccountSettingsFragment"/>
 </navigation>

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -26,5 +26,10 @@
     <string name="pref_key_mozilla_location_service" translatable="false">pref_key_mozilla_location_service</string>
     <string name="pref_key_fenix_health_report" translatable="false">pref_key_fenix_health_report</string>
 
+    <!-- Account Settings -->
+    <string name="pref_key_account_category" translatable="false">pref_key_account_category</string>
+    <string name="pref_key_sync_now" translatable="false">pref_key_sync_now</string>
+    <string name="pref_key_sync_history" translatable="false">pref_key_sync_history</string>
+    <string name="pref_key_sign_out" translatable="false">pref_key_sign_out</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -110,6 +110,18 @@
     <string name="preferences_data_choices">Data choices</string>
     <!-- Preference for developers -->
     <string name="preference_leakcanary">Leak Canary</string>
+    <!-- Preference for account settings -->
+    <string name="preferences_account_settings">Account Settings</string>
+
+    <!-- Account Preferences -->
+    <!-- Preference for triggering sync -->
+    <string name="preferences_sync_now">Sync now</string>
+    <!-- Preference category for sync -->
+    <string name="preferences_sync_category">Choose what to sync</string>
+    <!-- Preference for syncing history -->
+    <string name="preferences_sync_history">History</string>
+    <!-- Preference for signing out -->
+    <string name="preferences_sign_out">Sign out</string>
 
     <!-- Advanced Preferences -->
     <!-- Preference switch for Telemetry -->

--- a/app/src/main/res/xml/account_settings_preferences.xml
+++ b/app/src/main/res/xml/account_settings_preferences.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+    <androidx.preference.Preference
+            android:key="@string/pref_key_sync_now"
+            android:title="@string/preferences_sync_now"
+            android:enabled = "false" />
+
+    <PreferenceCategory
+            android:title="@string/preferences_sync_category">
+
+        <CheckBoxPreference
+                android:key="@string/pref_key_sync_history"
+                android:defaultValue="true"
+                android:enabled="false"
+                android:title="@string/preferences_sync_history" />
+    </PreferenceCategory>
+
+    <androidx.preference.Preference
+            android:key="@string/pref_key_sign_out"
+            android:title="@string/preferences_sign_out" />
+</PreferenceScreen>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -13,8 +13,11 @@
         android:title="@string/preferences_sign_in" />
 
     <androidx.preference.PreferenceCategory
+        android:key = "@string/pref_key_account_category"
         android:title="@string/preferences_category_account"
-        app:iconSpaceReserved="false">
+        app:iconSpaceReserved="false"
+        app:isPreferenceVisible="false">
+
         <androidx.preference.Preference
             android:icon="@drawable/ic_shortcuts"
             android:key="@string/pref_key_account"


### PR DESCRIPTION
This brings in the nested account settings page which can be used to logout (and later to configure and trigger sync), plus some minor cleanup.

Update/Summary:
- Account is now clickable and takes the user to the account settings page
- Sign out is working
- This also removes the awkward initial animation for the account setting preference group when it shouldn't be visible
- Further, this fixes the problem that the settings page doesn't properly display the profile when the app is restarted and the user authenticated (this was due to `updateAccountProfile` running on the wrong thread)

