### PR TITLE
Closes #754 - Restore SearchFragment navigation logic

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
@@ -11,9 +11,13 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
+import androidx.navigation.Navigation
 import kotlinx.android.synthetic.main.fragment_search.view.*
+import mozilla.components.browser.session.Session
 import mozilla.components.feature.search.SearchUseCases
 import mozilla.components.feature.session.SessionUseCases
+import mozilla.components.support.ktx.kotlin.isUrl
+import mozilla.components.support.ktx.kotlin.toNormalizedUrl
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.toolbar.SearchAction
@@ -44,8 +48,8 @@ class SearchFragment : Fragment() {
         isPrivate = (activity as HomeActivity).browsingModeManager.isPrivate
         val view = inflater.inflate(R.layout.fragment_search, container, false)
         val url = sessionId?.let {
-            requireComponents.core.sessionManager.findSessionById(it)?.let {
-                    session -> session.url
+            requireComponents.core.sessionManager.findSessionById(it)?.let { session ->
+                session.url
             }
         } ?: ""
 
@@ -83,7 +87,8 @@ class SearchFragment : Fragment() {
                 when (it) {
                     is SearchAction.UrlCommitted -> {
                         if (it.url.isNotBlank()) {
-                            (activity as HomeActivity).openToBrowserAndLoad(it.url, it.session)
+                            transitionToBrowser()
+                            load(it.url)
                         }
                     }
                     is SearchAction.TextChanged -> {
@@ -97,20 +102,14 @@ class SearchFragment : Fragment() {
                 when (it) {
                     is AwesomeBarAction.URLTapped -> {
                         getSessionUseCase(requireContext(), sessionId == null).invoke(it.url)
-                        navigateToBrowser()
+                        transitionToBrowser()
                     }
                     is AwesomeBarAction.SearchTermsTapped -> {
                         getSearchUseCase(requireContext(), sessionId == null).invoke(it.searchTerms)
-                        navigateToBrowser()
+                        transitionToBrowser()
                     }
                 }
             }
-    }
-
-    private fun navigateToBrowser() {
-        requireComponents.core.sessionManager.selectedSession?.apply {
-            (activity as HomeActivity).openToBrowser(sessionId)
-        }
     }
 
     private fun getSearchUseCase(context: Context, useNewTab: Boolean): SearchUseCases.SearchUseCase {
@@ -133,5 +132,43 @@ class SearchFragment : Fragment() {
             true -> context.components.useCases.tabsUseCases.addPrivateTab
             false -> context.components.useCases.tabsUseCases.addTab
         }
+    }
+
+    // Issue: https://github.com/mozilla-mobile/fenix/issues/626
+    // Currently we were kind of forcing all this logic through the Toolbar Feature.
+    // But since we cannot actually load a page without an available GeckoSession
+    // we have to wait until after we navigate to call the use case.
+    // We should move this logic into a place that makes more sense.
+    private fun load(text: String) {
+        val sessionId = SearchFragmentArgs.fromBundle(arguments!!).sessionId
+        val isPrivate = (activity as HomeActivity).browsingModeManager.isPrivate
+
+        val loadUrlUseCase = if (sessionId == null) {
+            if (isPrivate) {
+                requireComponents.useCases.tabsUseCases.addPrivateTab
+            } else {
+                requireComponents.useCases.tabsUseCases.addTab
+            }
+        } else requireComponents.useCases.sessionUseCases.loadUrl
+
+        val searchUseCase: (String) -> Unit = { searchTerms ->
+            if (sessionId == null) {
+                requireComponents.useCases.searchUseCases.newTabSearch
+                    .invoke(searchTerms, Session.Source.USER_ENTERED, true, isPrivate)
+            } else requireComponents.useCases.searchUseCases.defaultSearch.invoke(searchTerms)
+        }
+
+        if (text.isUrl()) {
+            loadUrlUseCase.invoke(text.toNormalizedUrl())
+        } else {
+            searchUseCase.invoke(text)
+        }
+    }
+
+    private fun transitionToBrowser() {
+        val sessionId = SearchFragmentArgs.fromBundle(arguments!!).sessionId
+        val directions = SearchFragmentDirections.actionSearchFragmentToBrowserFragment(sessionId)
+
+        Navigation.findNavController(view!!.search_layout).navigate(directions)
     }
 }


### PR DESCRIPTION
I wanted to fix this issue, so I just took some functions from #667 that were deleted from SearchFragment. Happy for anyone else to move things around, but the root cause of this issue was updating to using the global browser logic for all of the search -> browser navigation.