### PR TITLE
Fixes #706: Adds launchMode singleInstance

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
             android:usesCleartextTraffic="true"
             tools:ignore="UnusedAttribute">
         <activity android:name=".HomeActivity"
+                  android:launchMode="singleInstance"
                   android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>

--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -6,6 +6,7 @@ package org.mozilla.fenix
 
 import android.app.Activity
 import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import android.util.AttributeSet
 import android.view.View
@@ -24,6 +25,7 @@ import mozilla.components.support.ktx.kotlin.toNormalizedUrl
 import mozilla.components.support.utils.SafeIntent
 import org.mozilla.fenix.ext.components
 
+@SuppressWarnings("TooManyFunctions")
 open class HomeActivity : AppCompatActivity() {
     val themeManager = DefaultThemeManager().also {
         it.onThemeChange = { theme ->
@@ -51,9 +53,12 @@ open class HomeActivity : AppCompatActivity() {
         setSupportActionBar(navigationToolbar)
         NavigationUI.setupWithNavController(navigationToolbar, hostNavController, appBarConfiguration)
 
-        if (intent?.extras?.getBoolean(OPEN_TO_BROWSER) == true) {
-            handleOpenedFromExternalSource()
-        }
+        handleOpenedFromExternalSourceIfNecessary()
+    }
+
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        handleOpenedFromExternalSourceIfNecessary()
     }
 
     override fun onCreateView(
@@ -87,6 +92,12 @@ open class HomeActivity : AppCompatActivity() {
             currentFocus?.also {
                 this.hideSoftInputFromWindow(it.windowToken, 0)
             }
+        }
+    }
+
+    private fun handleOpenedFromExternalSourceIfNecessary() {
+        if (intent?.extras?.getBoolean(OPEN_TO_BROWSER) == true) {
+            handleOpenedFromExternalSource()
         }
     }
 


### PR DESCRIPTION
I paired with @boek for a bit. Turns out we needed to make our activity a `singleInstance`

Basically when we were launching from outside the app, a new HomeActivity was created while still keeping the old one around, which meant bad memory states could happen leading to crashes. 

More info [here](https://developer.android.com/guide/components/activities/tasks-and-back-stack).