### PR TITLE
Revert "Closes #811 - Clear stack after switching to private browsing"

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -16,7 +16,6 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
-import androidx.navigation.NavOptions
 import androidx.navigation.Navigation
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.component_search.*
@@ -271,13 +270,10 @@ class BrowserFragment : Fragment(), BackHandler {
             ToolbarMenu.Item.Share -> requireComponents.core.sessionManager
                 .selectedSession?.url?.apply { requireContext().share(this) }
             ToolbarMenu.Item.NewPrivateTab -> {
-                val navBuilder = NavOptions.Builder()
-                val navOptions = navBuilder.setPopUpTo(R.id.homeFragment, false).build()
                 val directions = BrowserFragmentDirections
                     .actionBrowserFragmentToSearchFragment(null)
-                Navigation.findNavController(view!!).navigate(directions, navOptions)
-                (activity as HomeActivity).browsingModeManager.mode =
-                    BrowsingModeManager.Mode.Private
+                Navigation.findNavController(view!!).navigate(directions)
+                (activity as HomeActivity).browsingModeManager.mode = BrowsingModeManager.Mode.Private
             }
             ToolbarMenu.Item.FindInPage -> FindInPageIntegration.launch?.invoke()
             ToolbarMenu.Item.ReportIssue -> requireComponents.core.sessionManager

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -83,7 +83,6 @@ class HomeFragment : Fragment() {
         return view
     }
 
-    @SuppressWarnings("ComplexMethod")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
@@ -163,9 +162,6 @@ class HomeFragment : Fragment() {
             browsingModeManager.mode = when (browsingModeManager.mode) {
                 BrowsingModeManager.Mode.Normal -> BrowsingModeManager.Mode.Private
                 BrowsingModeManager.Mode.Private -> BrowsingModeManager.Mode.Normal
-            }
-            Navigation.findNavController(it).apply {
-                popBackStack(R.id.nav_graph, false)
             }
         }
     }


### PR DESCRIPTION
This is causing issues (I believe #874) so reverting for now, will have to find a way to prevent #811 by separating private + normal modes
Reverts mozilla-mobile/fenix#841