### PR TITLE
Closes #875: Adds shortcuts

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -16,6 +16,7 @@ import androidx.appcompat.widget.Toolbar
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.NavigationUI
+import mozilla.components.browser.search.SearchEngine
 import mozilla.components.browser.session.Session
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.feature.intent.IntentProcessor
@@ -148,9 +149,14 @@ open class HomeActivity : AppCompatActivity() {
         openToBrowser(SafeIntent(intent).getStringExtra(IntentProcessor.ACTIVE_SESSION_ID), BrowserDirection.FromGlobal)
     }
 
-    fun openToBrowserAndLoad(text: String, sessionId: String? = null, from: BrowserDirection) {
+    fun openToBrowserAndLoad(
+        text: String,
+        sessionId: String? = null,
+        engine: SearchEngine? = null,
+        from: BrowserDirection
+    ) {
         openToBrowser(sessionId, from)
-        load(text, sessionId)
+        load(text, sessionId, engine)
     }
 
     fun openToBrowser(sessionId: String?, from: BrowserDirection) {
@@ -165,7 +171,7 @@ open class HomeActivity : AppCompatActivity() {
         navHost.navController.navigate(directions)
     }
 
-    private fun load(text: String, sessionId: String?) {
+    private fun load(text: String, sessionId: String?, engine: SearchEngine?) {
         val isPrivate = this.browsingModeManager.isPrivate
 
         val loadUrlUseCase = if (sessionId == null) {
@@ -179,8 +185,8 @@ open class HomeActivity : AppCompatActivity() {
         val searchUseCase: (String) -> Unit = { searchTerms ->
             if (sessionId == null) {
                 components.useCases.searchUseCases.newTabSearch
-                    .invoke(searchTerms, Session.Source.USER_ENTERED, true, isPrivate)
-            } else components.useCases.searchUseCases.defaultSearch.invoke(searchTerms)
+                    .invoke(searchTerms, Session.Source.USER_ENTERED, true, isPrivate, searchEngine = engine)
+            } else components.useCases.searchUseCases.defaultSearch.invoke(searchTerms, engine)
         }
 
         if (text.isUrl()) {

--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -21,6 +21,7 @@ import androidx.navigation.Navigation
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.component_search.*
 import kotlinx.android.synthetic.main.fragment_browser.view.*
+import kotlinx.android.synthetic.main.fragment_search.*
 import mozilla.components.browser.toolbar.behavior.BrowserToolbarBottomBehavior
 import mozilla.components.feature.contextmenu.ContextMenuCandidate
 import mozilla.components.feature.contextmenu.ContextMenuFeature
@@ -87,7 +88,8 @@ class BrowserFragment : Fragment(), BackHandler {
             view.browserLayout,
             ActionBusFactory.get(this), sessionId,
             (activity as HomeActivity).browsingModeManager.isPrivate,
-            SearchState("", isEditing = false)
+            SearchState("", isEditing = false),
+            search_engine_icon
         )
 
         toolbarComponent.uiView.view.apply {

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarUIView.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarUIView.kt
@@ -109,7 +109,7 @@ class ToolbarUIView(
     }
 
     private fun shouldUpdateEngineIcon(newState: SearchState): Boolean {
-        return (newState.isEditing && engineDidChange(newState))
+        return newState.isEditing && (engineDidChange(newState) || state == null)
     }
 
     private fun updateEngineIcon(newState: SearchState) {

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarUIView.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarUIView.kt
@@ -93,37 +93,61 @@ class ToolbarUIView(
     }
 
     override fun updateView() = Consumer<SearchState> {
-        with(view.context) {
-            if (it.isEditing) {
-                val defaultEngineIcon = components.search.searchEngineManager.defaultSearchEngine?.icon
-                val searchIcon = it.engine?.icon ?: defaultEngineIcon
-                val draw = BitmapDrawable(searchIcon)
-                val iconSize =
-                    containerView?.context!!.resources.getDimension(R.dimen.preference_icon_drawable_size).toInt()
-                draw.setBounds(0, 0, iconSize, iconSize)
-                engineIconView?.backgroundDrawable = draw
-            }
+        if (shouldUpdateEngineIcon(it)) {
+            updateEngineIcon(it)
         }
 
         if (shouldClearSearchURL(it)) {
-            view.url = ""
-            view.editMode()
+            clearSearchURL()
         }
 
-        if (it.engine == state?.engine) {
-            if (it.isEditing) {
-                view.url = it.query
-                view.editMode()
-            } else {
-                view.displayMode()
-            }
+        if (shouldUpdateEditingState(it)) {
+            updateEditingState(it)
         }
 
         state = it
     }
 
+    private fun shouldUpdateEngineIcon(newState: SearchState): Boolean {
+        return (newState.isEditing && engineDidChange(newState))
+    }
+
+    private fun updateEngineIcon(newState: SearchState) {
+        with(view.context) {
+            val defaultEngineIcon = components.search.searchEngineManager.defaultSearchEngine?.icon
+            val searchIcon = newState.engine?.icon ?: defaultEngineIcon
+            val draw = BitmapDrawable(searchIcon)
+            val iconSize =
+                containerView?.context!!.resources.getDimension(R.dimen.preference_icon_drawable_size).toInt()
+            draw.setBounds(0, 0, iconSize, iconSize)
+            engineIconView?.backgroundDrawable = draw
+        }
+    }
+
     private fun shouldClearSearchURL(newState: SearchState): Boolean {
         return newState.engine != state?.engine && view.url == newState.query
+    }
+
+    private fun clearSearchURL() {
+        view.url = ""
+        view.editMode()
+    }
+
+    private fun shouldUpdateEditingState(newState: SearchState): Boolean {
+        return !engineDidChange(newState)
+    }
+
+    private fun updateEditingState(newState: SearchState) {
+        if (newState.isEditing) {
+            view.url = newState.query
+            view.editMode()
+        } else {
+            view.displayMode()
+        }
+    }
+
+    private fun engineDidChange(newState: SearchState): Boolean {
+        return newState.engine != state?.engine
     }
 
     companion object {

--- a/app/src/main/java/org/mozilla/fenix/search/SearchLayouts.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchLayouts.kt
@@ -63,10 +63,15 @@ internal fun SearchFragment.setOutOfExperimentConstraints(layout: ConstraintLayo
                 BOTTOM to TOP of UNSET
             )
         }
+        search_with_shortcuts {
+            connect(
+                TOP to BOTTOM of toolbar_wrapper
+            )
+        }
         awesomeBar {
             connect(
                 TOP to TOP of UNSET,
-                TOP to BOTTOM of toolbar_wrapper,
+                TOP to BOTTOM of search_with_shortcuts,
                 BOTTOM to TOP of pill_wrapper
             )
         }

--- a/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarComponent.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarComponent.kt
@@ -12,27 +12,38 @@ import org.mozilla.fenix.mvi.Reducer
 import org.mozilla.fenix.mvi.UIComponent
 import org.mozilla.fenix.mvi.ViewState
 
-data class AwesomeBarState(val query: String) : ViewState
+data class AwesomeBarState(
+    val query: String,
+    val showShortcutEnginePicker: Boolean,
+    val suggestionEngine: SearchEngine? = null
+) : ViewState
 
 sealed class AwesomeBarAction : Action {
     data class URLTapped(val url: String) : AwesomeBarAction()
-    data class SearchTermsTapped(val searchTerms: String, val engine: SearchEngine?) : AwesomeBarAction()
+    data class SearchTermsTapped(val searchTerms: String, val engine: SearchEngine? = null) : AwesomeBarAction()
+    data class SearchShortcutEngineSelected(val engine: SearchEngine) : AwesomeBarAction()
 }
 
 sealed class AwesomeBarChange : Change {
+    data class SearchShortcutEngineSelected(val engine: SearchEngine) : AwesomeBarChange()
+    data class SearchShortcutEnginePicker(val show: Boolean) : AwesomeBarChange()
     data class UpdateQuery(val query: String) : AwesomeBarChange()
 }
 
 class AwesomeBarComponent(
     private val container: ViewGroup,
     bus: ActionBusFactory,
-    override var initialState: AwesomeBarState = AwesomeBarState("")
+    override var initialState: AwesomeBarState = AwesomeBarState("", false)
 ) : UIComponent<AwesomeBarState, AwesomeBarAction, AwesomeBarChange>(
     bus.getManagedEmitter(AwesomeBarAction::class.java),
     bus.getSafeManagedObservable(AwesomeBarChange::class.java)
 ) {
     override val reducer: Reducer<AwesomeBarState, AwesomeBarChange> = { state, change ->
         when (change) {
+            is AwesomeBarChange.SearchShortcutEngineSelected ->
+                state.copy(suggestionEngine = change.engine, showShortcutEnginePicker = false)
+            is AwesomeBarChange.SearchShortcutEnginePicker ->
+                state.copy(showShortcutEnginePicker = change.show)
             is AwesomeBarChange.UpdateQuery -> state.copy(query = change.query)
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarUIView.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarUIView.kt
@@ -30,6 +30,7 @@ import org.mozilla.fenix.mvi.UIView
 import org.mozilla.fenix.search.SearchFragmentDirections
 import org.mozilla.fenix.utils.Settings
 
+@SuppressWarnings("TooManyFunctions")
 class AwesomeBarUIView(
     private val container: ViewGroup,
     actionEmitter: Observer<AwesomeBarAction>,
@@ -109,8 +110,8 @@ class AwesomeBarUIView(
                         searchUseCase = searchUseCase,
                         fetchClient = components.core.client,
                         mode = SearchSuggestionProvider.Mode.MULTIPLE_SUGGESTIONS,
-                        limit = 3
-                        // TODO icon = draw?.toBitmap()
+                        limit = 3,
+                        icon = draw?.toBitmap()
                     )
             }
 
@@ -175,8 +176,8 @@ class AwesomeBarUIView(
                 components.search.searchEngineManager.getDefaultSearchEngine(this, engine.name),
                 shortcutSearchUseCase,
                 components.core.client,
-                mode = SearchSuggestionProvider.Mode.MULTIPLE_SUGGESTIONS
-                // TODO icon = draw?.toBitmap()
+                mode = SearchSuggestionProvider.Mode.MULTIPLE_SUGGESTIONS,
+                icon = draw?.toBitmap()
             )
         }
     }
@@ -198,18 +199,17 @@ class AwesomeBarUIView(
     }
 
     override fun updateView() = Consumer<AwesomeBarState> {
-        it.suggestionEngine?.let { newEngine ->
-            if (state?.suggestionEngine != newEngine) {
+        if (engineDidChange(it)) {
+            it.suggestionEngine?.let { newEngine ->
                 setShortcutEngine(newEngine)
             }
         }
 
-        when (it.showShortcutEnginePicker) {
-            true -> {
+        if (shouldUpdateShortcutEnginePickerVisibility(it)) {
+            if (it.showShortcutEnginePicker) {
                 showShortcutEnginePicker()
                 updateSearchWithVisibility(true)
-            }
-            false -> {
+            } else {
                 hideShortcutEnginePicker()
                 updateSearchWithVisibility(false)
                 it.suggestionEngine?.also { showSearchSuggestionProvider() } ?: showSuggestionProviders()
@@ -218,5 +218,13 @@ class AwesomeBarUIView(
 
         view.onInputChanged(it.query)
         state = it
+    }
+
+    private fun engineDidChange(newState: AwesomeBarState): Boolean {
+        return state?.suggestionEngine != newState.suggestionEngine
+    }
+
+    private fun shouldUpdateShortcutEnginePickerVisibility(newState: AwesomeBarState): Boolean {
+        return state?.showShortcutEnginePicker != newState.showShortcutEnginePicker
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarUIView.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarUIView.kt
@@ -65,13 +65,13 @@ class AwesomeBarUIView(
         }
     }
 
-    val searchUseCase = object : SearchUseCases.SearchUseCase {
+    private val searchUseCase = object : SearchUseCases.SearchUseCase {
         override fun invoke(searchTerms: String, searchEngine: SearchEngine?) {
             actionEmitter.onNext(AwesomeBarAction.SearchTermsTapped(searchTerms, searchEngine))
         }
     }
 
-    val shortcutSearchUseCase = object : SearchUseCases.SearchUseCase {
+    private val shortcutSearchUseCase = object : SearchUseCases.SearchUseCase {
         override fun invoke(searchTerms: String, searchEngine: SearchEngine?) {
             actionEmitter.onNext(AwesomeBarAction.SearchTermsTapped(searchTerms, state?.suggestionEngine))
         }
@@ -192,10 +192,7 @@ class AwesomeBarUIView(
     }
 
     private fun updateSearchWithVisibility(visible: Boolean) {
-        search_with_shortcuts.visibility = when (visible) {
-            true -> View.VISIBLE
-            false -> View.GONE
-        }
+        search_with_shortcuts.visibility = if (visible) View.VISIBLE else View.GONE
     }
 
     override fun updateView() = Consumer<AwesomeBarState> {

--- a/app/src/main/java/org/mozilla/fenix/search/awesomebar/ShortcutEngineManager.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/awesomebar/ShortcutEngineManager.kt
@@ -1,0 +1,100 @@
+package org.mozilla.fenix.search.awesomebar
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+   License, v. 2.0. If a copy of the MPL was not distributed with this
+   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import android.view.View
+import androidx.core.content.ContextCompat
+import androidx.navigation.Navigation
+import io.reactivex.Observer
+import kotlinx.android.synthetic.main.fragment_search.*
+import mozilla.components.browser.search.SearchEngine
+import org.jetbrains.anko.textColor
+import org.mozilla.fenix.DefaultThemeManager
+import org.mozilla.fenix.R
+import org.mozilla.fenix.search.SearchFragmentDirections
+
+class ShortcutEngineManager(
+    private val awesomeBarUIView: AwesomeBarUIView,
+    private val actionEmitter: Observer<AwesomeBarAction>,
+    private val setShortcutEngine: (newEngine: SearchEngine) -> Unit,
+    private val showSuggestionProviders: () -> Unit,
+    private val showSearchSuggestionProvider: () -> Unit
+) {
+
+    var shortcutsEnginePickerProvider: ShortcutsSuggestionProvider? = null
+    val context = awesomeBarUIView.containerView?.context!!
+
+    fun updateSelectedEngineIfNecessary(newState: AwesomeBarState) {
+        if (engineDidChange(newState)) {
+            newState.suggestionEngine?.let { newEngine ->
+                setShortcutEngine(newEngine)
+            }
+        }
+    }
+
+    fun updateEnginePickerVisibilityIfNecessary(newState: AwesomeBarState) {
+        if (shouldUpdateShortcutEnginePickerVisibility(newState)) {
+            if (newState.showShortcutEnginePicker) {
+                showShortcutEnginePicker()
+                updateSearchWithVisibility(true)
+            } else {
+                hideShortcutEnginePicker()
+                updateSearchWithVisibility(false)
+                newState.suggestionEngine?.also { showSearchSuggestionProvider() } ?: showSuggestionProviders()
+            }
+        }
+    }
+
+    fun selectShortcutEngine(engine: SearchEngine) {
+        actionEmitter.onNext(AwesomeBarAction.SearchShortcutEngineSelected(engine))
+    }
+
+    fun selectShortcutEngineSettings() {
+        val directions = SearchFragmentDirections.actionSearchFragmentToSearchEngineFragment()
+        Navigation.findNavController(awesomeBarUIView.view).navigate(directions)
+    }
+
+    private fun engineDidChange(newState: AwesomeBarState): Boolean {
+        return awesomeBarUIView.state?.suggestionEngine != newState.suggestionEngine
+    }
+
+    private fun shouldUpdateShortcutEnginePickerVisibility(newState: AwesomeBarState): Boolean {
+        return awesomeBarUIView.state?.showShortcutEnginePicker != newState.showShortcutEnginePicker
+    }
+
+    private fun showShortcutEnginePicker() {
+        with(context) {
+            awesomeBarUIView.search_shortcuts_button.background = getDrawable(R.drawable.search_pill_background)
+
+            awesomeBarUIView.search_shortcuts_button.compoundDrawables[0].setTint(ContextCompat.getColor(this,
+                DefaultThemeManager.resolveAttribute(R.attr.pillWrapperBackground, this)))
+
+            awesomeBarUIView.search_shortcuts_button.textColor = ContextCompat.getColor(this,
+                DefaultThemeManager.resolveAttribute(R.attr.pillWrapperBackground, this))
+
+            awesomeBarUIView.view.removeAllProviders()
+            awesomeBarUIView.view.addProviders(shortcutsEnginePickerProvider!!)
+        }
+    }
+
+    private fun hideShortcutEnginePicker() {
+        with(context) {
+            awesomeBarUIView.search_shortcuts_button.setBackgroundColor(ContextCompat.getColor(this,
+                DefaultThemeManager.resolveAttribute(R.attr.pillWrapperBackground, this)))
+
+            awesomeBarUIView.search_shortcuts_button.compoundDrawables[0].setTint(ContextCompat.getColor(this,
+                DefaultThemeManager.resolveAttribute(R.attr.searchShortcutsTextColor, this)))
+
+            awesomeBarUIView.search_shortcuts_button.textColor = ContextCompat.getColor(this,
+                DefaultThemeManager.resolveAttribute(R.attr.searchShortcutsTextColor, this))
+
+            awesomeBarUIView.view.removeProviders(shortcutsEnginePickerProvider!!)
+        }
+    }
+
+    private fun updateSearchWithVisibility(visible: Boolean) {
+        awesomeBarUIView.search_with_shortcuts.visibility = if (visible) View.VISIBLE else View.GONE
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/search/awesomebar/ShortcutsSuggestionProvider.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/awesomebar/ShortcutsSuggestionProvider.kt
@@ -1,0 +1,55 @@
+package org.mozilla.fenix.search.awesomebar
+
+import android.content.Context
+import mozilla.components.browser.search.SearchEngine
+import mozilla.components.browser.search.SearchEngineManager
+import mozilla.components.concept.awesomebar.AwesomeBar
+import mozilla.components.support.ktx.android.graphics.drawable.toBitmap
+import org.mozilla.fenix.R
+import java.util.UUID
+
+/**
+ * A [AwesomeBar.SuggestionProvider] implementation that provides search engine suggestions.
+ */
+class ShortcutsSuggestionProvider(
+    private val searchEngineManager: SearchEngineManager,
+    private val context: Context,
+    private val selectShortcutEngine: (engine: SearchEngine) -> Unit,
+    private val selectShortcutEngineSettings: () -> Unit
+) : AwesomeBar.SuggestionProvider {
+    override val id: String = UUID.randomUUID().toString()
+
+    override suspend fun onInputChanged(text: String): List<AwesomeBar.Suggestion> {
+        val suggestions = mutableListOf<AwesomeBar.Suggestion>()
+
+        searchEngineManager.getSearchEngines(context).forEach {
+            suggestions.add(
+                AwesomeBar.Suggestion(
+                    provider = this,
+                    id = id,
+                    icon = { _, _ ->
+                        it.icon
+                    },
+                    title = it.name,
+                    onSuggestionClicked = {
+                        selectShortcutEngine(it)
+                    })
+            )
+        }
+
+        suggestions.add(
+            AwesomeBar.Suggestion(
+                provider = this,
+                id = id,
+                icon = { _, _ ->
+                    context.getDrawable(R.drawable.ic_settings)?.toBitmap()
+                },
+                title = context.getString(R.string.search_shortcuts_engine_settings),
+                onSuggestionClicked = {
+                    // Open search engine settings
+                    selectShortcutEngineSettings()
+                })
+        )
+        return suggestions
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/search/awesomebar/ShortcutsSuggestionProvider.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/awesomebar/ShortcutsSuggestionProvider.kt
@@ -19,6 +19,9 @@ class ShortcutsSuggestionProvider(
 ) : AwesomeBar.SuggestionProvider {
     override val id: String = UUID.randomUUID().toString()
 
+    override val shouldClearSuggestions: Boolean
+        get() = false
+
     override suspend fun onInputChanged(text: String): List<AwesomeBar.Suggestion> {
         val suggestions = mutableListOf<AwesomeBar.Suggestion>()
 

--- a/app/src/main/java/org/mozilla/fenix/search/awesomebar/ShortcutsSuggestionProvider.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/awesomebar/ShortcutsSuggestionProvider.kt
@@ -46,7 +46,6 @@ class ShortcutsSuggestionProvider(
                 },
                 title = context.getString(R.string.search_shortcuts_engine_settings),
                 onSuggestionClicked = {
-                    // Open search engine settings
                     selectShortcutEngineSettings()
                 })
         )

--- a/app/src/main/res/drawable/search_pill_background.xml
+++ b/app/src/main/res/drawable/search_pill_background.xml
@@ -3,10 +3,10 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
-    <solid android:color="@color/searchPillBackground"/>
+    <solid android:color="?attr/pillWrapperSelectedBackground"/>
 
     <stroke android:width="1dp"
-            android:color="@color/searchPillPrimary"/>
+            android:color="?attr/pillWrapperSelectedBackground"/>
 
     <corners android:radius="16dp"/>
 </shape>

--- a/app/src/main/res/layout/component_awesomebar.xml
+++ b/app/src/main/res/layout/component_awesomebar.xml
@@ -10,7 +10,6 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:padding="4dp"
-        android:layout_marginTop="16dp"
         app:layout_constraintTop_toBottomOf="@id/toolbar_wrapper"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -43,7 +43,7 @@
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-    <androidx.appcompat.widget.AppCompatTextView
+    <TextView
             android:id="@+id/search_with_shortcuts"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -11,8 +11,6 @@
     android:id="@+id/search_layout"
     android:background="?attr/searchBackground">
 
-
-
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/toolbar_wrapper"
         android:layout_width="0dp"

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -47,7 +47,7 @@
             android:id="@+id/search_with_shortcuts"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="20dp"
+            android:layout_marginTop="15dp"
             android:visibility="gone"
             android:fontFamily="Inter UI"
             android:textAllCaps="true"

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -53,7 +53,7 @@
             android:textAllCaps="true"
             android:textStyle="bold"
             android:textSize="12sp"
-            android:textColor="@color/search_with_shortcut_text_color"
+            android:textColor="?attr/awesomeBarDescriptionTextColor"
             android:letterSpacing="0.15"
             android:text="@string/search_shortcuts_search_with"
             app:layout_constraintTop_toBottomOf="@id/toolbar_wrapper"

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -11,6 +11,8 @@
     android:id="@+id/search_layout"
     android:background="?attr/searchBackground">
 
+
+
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/toolbar_wrapper"
         android:layout_width="0dp"
@@ -40,7 +42,24 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toEndOf="@id/search_engine_icon"
             app:layout_constraintEnd_toEndOf="parent"/>
+
     </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/search_with_shortcuts"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:visibility="gone"
+            android:fontFamily="Inter UI"
+            android:textAllCaps="true"
+            android:textStyle="bold"
+            android:textSize="12sp"
+            android:textColor="@color/search_with_shortcut_text_color"
+            android:letterSpacing="0.15"
+            android:text="@string/search_shortcuts_search_with"
+            app:layout_constraintTop_toBottomOf="@id/toolbar_wrapper"
+            app:layout_constraintStart_toStartOf="@id/toolbar_wrapper"/>
 
     <LinearLayout
         android:id="@+id/pill_wrapper"
@@ -64,16 +83,14 @@
             android:drawableStart="@drawable/ic_qr"
             android:layout_marginEnd="8dp"
             android:textColor="?attr/searchShortcutsTextColor"
-            android:background="?attr/pillWrapperBackground"
-            android:drawableTint="?attr/searchShortcutsTextColor"/>
+            android:background="?attr/pillWrapperBackground"/>
 
         <Button
             style="@style/search_pill"
             android:id="@+id/search_shortcuts_button"
             android:text="@string/search_shortcuts_button"
-            android:drawableStart="@drawable/ic_shortcuts"
+            android:drawableStart="@drawable/ic_search"
             android:textColor="?attr/searchShortcutsTextColor"
-            android:background="?attr/pillWrapperBackground"
-            android:drawableTint="?attr/searchShortcutsTextColor"/>
+            android:background="?attr/pillWrapperBackground"/>
     </LinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -44,6 +44,8 @@
             app:destination="@id/browserFragment"
             app:popUpTo="@id/homeFragment" />
         <argument android:name="session_id" app:argType="string" app:nullable="true"/>
+        <action android:id="@+id/action_searchFragment_to_searchEngineFragment"
+                app:destination="@id/searchEngineFragment" app:popUpTo="@+id/searchFragment"/>
     </fragment>
 
     <fragment

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -30,10 +30,11 @@
     <attr name="sessionBorderColor" format="reference" />
 
     <!-- Search fragment -->
-    <attr name="searchBackground" format="reference" />
-    <attr name="searchShortcutsTextColor" format="reference" />
-    <attr name="pillWrapperBackground" format="reference" />
-    <attr name="suggestionBackground" format="reference" />
+    <attr name="searchBackground" format="reference"/>
+    <attr name="searchShortcutsTextColor" format="reference"/>
+    <attr name="pillWrapperBackground" format="reference"/>
+    <attr name="pillWrapperSelectedBackground" format="reference"/>
+    <attr name="suggestionBackground" format="reference"/>
 
     <!-- Browser fragment -->
     <attr name="browserUrlBarBackground" format="reference" />

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -48,8 +48,10 @@
     <color name="private_browsing_top_gradient">#242251</color>
     <color name="private_browsing_bottom_gradient">#393862</color>
 
-    <color name="searchPillBackground">#FAFAFC</color>
-    <color name="searchPillPrimary">#202340</color>
+    <color name="search_pill_background">#FAFAFC</color>
+    <color name="search_pill_selected_background">#2f2c61</color>
+    <color name="search_pill_private_selected_background">#080639</color>
+    <color name="search_pill_primary">#202340</color>
 
     <color name="library_sessions_icon_background">#B9F0FD</color>
     <color name="library_sessions_icon">#0E214A</color>
@@ -89,4 +91,6 @@
     <color name="quick_action_pull_tab">#2915141A</color>
 
     <color name="library_list_item_text_color_light_mode">#202340</color>
+
+    <color name="search_with_shortcut_text_color">#99202340</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -91,6 +91,4 @@
     <color name="quick_action_pull_tab">#2915141A</color>
 
     <color name="library_list_item_text_color_light_mode">#202340</color>
-
-    <color name="search_with_shortcut_text_color">#99202340</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -76,6 +76,10 @@
     <string name="search_scan_button">Scan</string>
     <!-- Button in the search view that lets a user search by using a shortcut -->
     <string name="search_shortcuts_button">Shortcuts</string>
+    <!-- Button in the search view when shortcuts are displayed that takes a user to the search engine settings -->
+    <string name="search_shortcuts_engine_settings">Search engine settings</string>
+    <!-- Header displayed when selecting a shortcut search engine -->
+    <string name="search_shortcuts_search_with">Search with</string>
     <!-- Button in the search view that lets a user navigate to the site in their clipboard -->
     <string name="awesomebar_clipboard_title">Fill link from clipboard</string>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -44,6 +44,7 @@
         <item name="searchBackground">@color/off_white</item>
         <item name="searchShortcutsTextColor">@color/awesome_bar_title_color</item>
         <item name="pillWrapperBackground">@color/off_white</item>
+        <item name="pillWrapperSelectedBackground">@color/search_pill_selected_background</item>
         <item name="awesomeBarTitleTextColor">@color/awesome_bar_title_color</item>
         <item name="awesomeBarDescriptionTextColor">@color/awesome_bar_description_color</item>
         <item name="suggestionBackground">@color/photonBlue50</item>
@@ -103,6 +104,7 @@
         <item name="searchBackground">@color/private_browsing_bottom_gradient</item>
         <item name="searchShortcutsTextColor">@color/off_white</item>
         <item name="pillWrapperBackground">@color/private_browsing_top_gradient</item>
+        <item name="pillWrapperSelectedBackground">@color/off_white</item>
         <item name="awesomeBarTitleTextColor">@color/off_white</item>
         <item name="awesomeBarDescriptionTextColor">@color/photonGrey40</item>
         <item name="suggestionBackground">@color/private_browsing_primary</item>
@@ -137,7 +139,7 @@
         <item name="android:layout_height">wrap_content</item>
         <item name="android:textAllCaps">false</item>
         <item name="android:textSize">14sp</item>
-        <item name="android:textColor">@color/searchPillPrimary</item>
+        <item name="android:textColor">@color/search_pill_primary</item>
         <item name="android:layout_gravity">center_vertical</item>
         <item name="android:gravity">center_vertical</item>
         <item name="android:singleLine">true</item>

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,6 @@ plugins {
 
 allprojects {
     repositories {
-        mavenLocal()
         google()
 
         // Currently the main repository where appservices artifacts are published.

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ plugins {
 
 allprojects {
     repositories {
+        mavenLocal()
         google()
 
         // Currently the main repository where appservices artifacts are published.


### PR DESCRIPTION
I'd love for this PR to be reviewed for its major content (since it's so large), and I can then change the two places with `TODO` once [this a-c change](https://github.com/mozilla-mobile/android-components/pull/2512) lands. Alternatively, we could merge without that change and fast-follow with it tomorrow.