### PR TITLE
Fix stray HTML tag in about.html

### DIFF
--- a/app/src/main/res/raw/about.html
+++ b/app/src/main/res/raw/about.html
@@ -2,6 +2,7 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this file,
    - You can obtain one at http://mozilla.org/MPL/2.0/.  -->
+<html>
 <head>
     <meta
             name="viewport"
@@ -40,13 +41,12 @@ img#wordmark {
     }
     </style>
 </head>
-<html>
-    <body class="about">
-        <br>
-        <img src="%wordmark%" id="wordmark"/>
-        <br>
-        <p class="subtitle">%about-version%</p>
-        %about-content%
-        <p class="subtitle">Built on: %build-date%</p>
-    </body>
+<body class="about">
+    <br>
+    <img src="%wordmark%" id="wordmark"/>
+    <br>
+    <p class="subtitle">%about-version%</p>
+    %about-content%
+    <p class="subtitle">Built on: %build-date%</p>
+</body>
 </html>


### PR DESCRIPTION
Just moving the `html` tag to the beginning (to be the parent of the `head`, rather than its next-sibling).

I'm also deindenting `body` and its contents so that the indentation is consistent. (Alternately, we could increase the indentation of `head` and all of its contents, but that seems unnecessary, and it would probably force the `img#wordmark` /**/ comment to wrap to 3 lines. Seems simpler to just have html/body/head all at the same level of indentation, which is a somewhat common practice to save on indentation.)

This fixes #901.