### PR TITLE
Add notification for failed nightly decision task.

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -65,6 +65,8 @@ tasks:
                 - queue:route:index.project.mobile.fenix.staging-signed-nightly.*
                 - secrets:get:garbage/staging/project/mobile/fenix/sentry
                 - secrets:get:garbage/staging/project/mobile/fenix/leanplum
+        routes:
+          - notify.email.fenix-eng-notifications@mozilla.com.on-failed
         payload:
           maxRunTime: 600   # Decision should remain fast enough to schedule a handful of tasks
           image: mozillamobile/fenix:1.3


### PR DESCRIPTION
The cron job task notifies the Fenix team in case of failure (neccesary route present under https://tools.taskcluster.net/hooks/project-mobile/fenix-nightly) but the nightly decision task itself doesn't (e.g. https://tools.taskcluster.net/groups/EfMlLQPoQMG0diSNN8v6Gw/tasks/EfMlLQPoQMG0diSNN8v6Gw/details). This adds that route there as well.