### PR TITLE
Integrate BackgroundSyncManager, enable history sync

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -248,6 +248,7 @@ dependencies {
     implementation Deps.mozilla_concept_engine
     implementation Deps.mozilla_concept_storage
     implementation Deps.mozilla_concept_toolbar
+    implementation Deps.mozilla_concept_sync
 
     implementation Deps.mozilla_browser_awesomebar
     implementation Deps.mozilla_feature_downloads
@@ -266,6 +267,7 @@ dependencies {
     implementation Deps.mozilla_feature_intent
     implementation Deps.mozilla_feature_prompts
     implementation Deps.mozilla_feature_session
+    implementation Deps.mozilla_feature_sync
     implementation Deps.mozilla_feature_toolbar
     implementation Deps.mozilla_feature_tabs
     implementation Deps.mozilla_feature_findinpage

--- a/app/src/main/java/org/mozilla/fenix/components/Components.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Components.kt
@@ -10,7 +10,7 @@ import android.content.Context
  * Provides access to all components.
  */
 class Components(private val context: Context) {
-    val backgroundServices by lazy { BackgroundServices(context) }
+    val backgroundServices by lazy { BackgroundServices(context, core.historyStorage) }
     val services by lazy { Services(backgroundServices.accountManager, useCases.tabsUseCases) }
     val core by lazy { Core(context) }
     val search by lazy { Search(context) }

--- a/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarUIView.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarUIView.kt
@@ -54,7 +54,7 @@ class AwesomeBarUIView(
             view.addProviders(ClipboardSuggestionProvider(
                 this,
                 loadUrlUseCase,
-                getDrawable(R.drawable.ic_link).toBitmap(),
+                getDrawable(R.drawable.ic_link)!!.toBitmap(),
                 getString(R.string.awesomebar_clipboard_title)
                 )
             )

--- a/app/src/main/java/org/mozilla/fenix/settings/AccountSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/AccountSettingsFragment.kt
@@ -4,7 +4,9 @@
 
 package org.mozilla.fenix.settings
 
+import android.content.Context
 import android.os.Bundle
+import android.text.format.DateUtils
 import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.Navigation
 import androidx.preference.Preference
@@ -13,9 +15,12 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import mozilla.components.concept.sync.SyncStatusObserver
+import mozilla.components.feature.sync.getLastSynced
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.getPreferenceKey
 import org.mozilla.fenix.ext.requireComponents
+import java.lang.Exception
 import kotlin.coroutines.CoroutineContext
 
 class AccountSettingsFragment : PreferenceFragmentCompat(), CoroutineScope {
@@ -38,9 +43,28 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), CoroutineScope {
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         setPreferencesFromResource(R.xml.account_settings_preferences, rootKey)
 
-        val signIn = context?.getPreferenceKey(R.string.pref_key_sign_out)
-        val preferenceSignOut = findPreference<Preference>(signIn)
+        // Sign out
+        val signOut = context?.getPreferenceKey(R.string.pref_key_sign_out)
+        val preferenceSignOut = findPreference<Preference>(signOut)
         preferenceSignOut.onPreferenceClickListener = getClickListenerForSignOut()
+
+        // Sync now
+        val syncNow = context?.getPreferenceKey(R.string.pref_key_sync_now)
+        val preferenceSyncNow = findPreference<Preference>(syncNow)
+        preferenceSyncNow.onPreferenceClickListener = getClickListenerForSyncNow()
+
+        // Current sync state
+        updateLastSyncedTimePref(context!!, preferenceSyncNow)
+        if (requireComponents.backgroundServices.syncManager.isSyncRunning()) {
+            preferenceSyncNow.title = getString(R.string.sync_syncing)
+            preferenceSyncNow.isEnabled = false
+        } else {
+            preferenceSyncNow.isEnabled = true
+        }
+
+        // NB: ObserverRegistry will take care of cleaning up internal references to 'observer' and
+        // 'owner' when appropriate.
+        requireComponents.backgroundServices.syncManager.register(syncStatusObserver, owner = this, autoPause = true)
     }
 
     private fun getClickListenerForSignOut(): Preference.OnPreferenceClickListener {
@@ -50,6 +74,68 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), CoroutineScope {
                 Navigation.findNavController(view!!).popBackStack()
             }
             true
+        }
+    }
+
+    private fun getClickListenerForSyncNow(): Preference.OnPreferenceClickListener {
+        return Preference.OnPreferenceClickListener {
+            requireComponents.backgroundServices.syncManager.syncNow()
+            true
+        }
+    }
+
+    private val syncStatusObserver = object : SyncStatusObserver {
+        override fun onStarted() {
+            CoroutineScope(Dispatchers.Main).launch {
+                val pref = findPreference<Preference>(context?.getPreferenceKey(R.string.pref_key_sync_now))
+
+                pref.title = getString(R.string.sync_syncing)
+                pref.isEnabled = false
+            }
+        }
+
+        // Sync stopped successfully.
+        override fun onIdle() {
+            CoroutineScope(Dispatchers.Main).launch {
+                val pref = findPreference<Preference>(context?.getPreferenceKey(R.string.pref_key_sync_now))
+                pref.title = getString(R.string.preferences_sync_now)
+                pref.isEnabled = true
+                updateLastSyncedTimePref(context!!, pref, failed = false)
+            }
+        }
+
+        // Sync stopped after encountering a problem.
+        override fun onError(error: Exception?) {
+            CoroutineScope(Dispatchers.Main).launch {
+                val pref = findPreference<Preference>(context?.getPreferenceKey(R.string.pref_key_sync_now))
+                pref.title = getString(R.string.preferences_sync_now)
+                pref.isEnabled = true
+                updateLastSyncedTimePref(context!!, pref, failed = true)
+            }
+        }
+    }
+
+    fun updateLastSyncedTimePref(context: Context, pref: Preference, failed: Boolean = false) {
+        val lastSyncTime = getLastSynced(context)
+
+        pref.summary = if (!failed && lastSyncTime == 0L) {
+            // Never tried to sync.
+            getString(R.string.sync_never_synced_summary)
+        } else if (failed && lastSyncTime == 0L) {
+            // Failed to sync, never succeeded before.
+            getString(R.string.sync_failed_never_synced_summary)
+        } else if (!failed && lastSyncTime != 0L) {
+            // Successfully synced.
+            getString(
+                R.string.sync_last_synced_summary,
+                DateUtils.getRelativeTimeSpanString(lastSyncTime)
+            )
+        } else {
+            // Failed to sync, succeeded before.
+            getString(
+                R.string.sync_failed_summary,
+                DateUtils.getRelativeTimeSpanString(lastSyncTime)
+            )
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -127,6 +127,16 @@
     <string name="preferences_sync_history">History</string>
     <!-- Preference for signing out -->
     <string name="preferences_sign_out">Sign out</string>
+    <!-- Label indicating that sync is in progress -->
+    <string name="sync_syncing">Syncing</string>
+    <!-- Label summary indicating that sync failed along with last time it succeeded -->
+    <string name="sync_failed_summary">Sync failed. Last success: %s</string>
+    <!-- Label summary showing never synced -->
+    <string name="sync_failed_never_synced_summary">Sync failed. Last synced: never</string>
+    <!-- Label summary showing last time synced -->
+    <string name="sync_last_synced_summary">Last synced: %s</string>
+    <!-- Label summary showing never synced -->
+    <string name="sync_never_synced_summary">Last synced: never</string>
 
     <!-- Advanced Preferences -->
     <!-- Preference switch for Telemetry -->

--- a/app/src/main/res/xml/account_settings_preferences.xml
+++ b/app/src/main/res/xml/account_settings_preferences.xml
@@ -6,8 +6,7 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
     <androidx.preference.Preference
             android:key="@string/pref_key_sync_now"
-            android:title="@string/preferences_sync_now"
-            android:enabled = "false" />
+            android:title="@string/preferences_sync_now" />
 
     <PreferenceCategory
             android:title="@string/preferences_sync_category">

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -64,6 +64,7 @@ object Deps {
     const val mozilla_concept_tabstray = "org.mozilla.components:concept-tabstray:${Versions.mozilla_android_components}"
     const val mozilla_concept_toolbar = "org.mozilla.components:concept-toolbar:${Versions.mozilla_android_components}"
     const val mozilla_concept_storage = "org.mozilla.components:concept-storage:${Versions.mozilla_android_components}"
+    const val mozilla_concept_sync = "org.mozilla.components:concept-sync:${Versions.mozilla_android_components}"
 
     const val mozilla_browser_awesomebar = "org.mozilla.components:browser-awesomebar:${Versions.mozilla_android_components}"
     const val mozilla_browser_engine_gecko_nightly = "org.mozilla.components:browser-engine-gecko-nightly:${Versions.mozilla_android_components}"


### PR DESCRIPTION
This patch integrates the new a-c BackgroundSyncManager, which is the
main entry point for interacting with Sync. Behind the scenes, it uses
WorkManager in order to sync configured syncable stores.

Current behaviour:
- sync runs on start, with a slight delay
- sync runs on a schedule few times a day, to lessen the startup sync burden

Also included is a basic UI integration in order to allow user to synchronize
on demand, and monitor sync state.