### PR TITLE
Closes #832 & For #222: Adds basic custom tab integration

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -49,6 +49,7 @@ import org.mozilla.fenix.components.toolbar.ToolbarComponent
 import org.mozilla.fenix.components.toolbar.ToolbarIntegration
 import org.mozilla.fenix.components.toolbar.ToolbarMenu
 import org.mozilla.fenix.components.toolbar.ToolbarUIView
+import org.mozilla.fenix.customtabs.CustomTabsIntegration
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.share
@@ -68,6 +69,8 @@ class BrowserFragment : Fragment(), BackHandler, ComponentCallbacks2 {
     private val sitePermissionsFeature = ViewBoundFeatureWrapper<SitePermissionsFeature>()
     private val fullScreenFeature = ViewBoundFeatureWrapper<FullScreenFeature>()
     private val thumbnailsFeature = ViewBoundFeatureWrapper<ThumbnailsFeature>()
+    private val customTabsIntegration = ViewBoundFeatureWrapper<CustomTabsIntegration>()
+
     var sessionId: String? = null
 
     override fun onCreateView(
@@ -216,6 +219,22 @@ class BrowserFragment : Fragment(), BackHandler, ComponentCallbacks2 {
             owner = this,
             view = view
         )
+
+        val actionEmitter = ActionBusFactory.get(this).getManagedEmitter(SearchAction::class.java)
+        sessionId?.let { id ->
+            customTabsIntegration.set(
+                feature = CustomTabsIntegration(
+                    requireContext(),
+                    requireComponents.core.sessionManager,
+                    toolbar,
+                    id,
+                    requireActivity(),
+                    onItemTapped = { actionEmitter.onNext(SearchAction.ToolbarMenuItemTapped(it)) }
+                ),
+                owner = this,
+                view = view
+            )
+        }
     }
 
     override fun onResume() {

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -46,7 +46,7 @@ object Deps {
     const val tools_appservicesgradle = "org.mozilla.appservices:gradle-plugin:${Versions.appservices_gradle_plugin}"
     const val kotlin_stdlib = "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${Versions.kotlin}"
 
-    const val allopen =  "org.jetbrains.kotlin:kotlin-allopen:${Versions.kotlin}"
+    const val allopen = "org.jetbrains.kotlin:kotlin-allopen:${Versions.kotlin}"
 
     const val rxKotlin = "io.reactivex.rxjava2:rxkotlin:${Versions.rxKotlin}"
     const val rxAndroid = "io.reactivex.rxjava2:rxandroid:${Versions.rxAndroid}"
@@ -147,4 +147,3 @@ object Deps {
     const val glide = "com.github.bumptech.glide:glide:${Versions.glide}"
     const val glideAnnotationProcessor = "com.github.bumptech.glide:compiler:${Versions.glide}"
 }
-


### PR DESCRIPTION
I recognize this PR leads to a bit of code duplication. This is actually how Reference Browser has it implemented as well, as it's possible we _want_ the entire toolbar to look different. This PR effectively moves our little bit of duplication to a new class so it's at least logically separated. 

I wonder if there's a way for us to make at least `menuToolbar` shared between them?