### PR TITLE
Bump app-services gradle plugin version

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -22,7 +22,7 @@ private object Versions {
     const val androidx_fragment = "1.1.0-alpha05"
     const val androidx_navigation = "2.0.0"
 
-    const val appservices_gradle_plugin = "0.3.1"
+    const val appservices_gradle_plugin = "0.4.2"
     const val mozilla_android_components = "0.47.0-SNAPSHOT"
 
     const val test_tools = "1.0.2"


### PR DESCRIPTION
This is required for consumers of 0.20.2 application-services libraries. A-c updated to 0.20.2, so Fenix should as well. See https://github.com/mozilla-mobile/android-components/pull/2376.