### PR TITLE
Bump A-C snapshot version to 0.48

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -162,7 +162,9 @@ class BrowserFragment : Fragment(), BackHandler {
             view = view)
 
         findInPageIntegration.set(
-            feature = FindInPageIntegration(requireComponents.core.sessionManager, view.findInPageView),
+            feature = FindInPageIntegration(
+                requireComponents.core.sessionManager, view.findInPageView, view.engineView
+            ),
             owner = this,
             view = view)
 

--- a/app/src/main/java/org/mozilla/fenix/components/FindInPageIntegration.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/FindInPageIntegration.kt
@@ -10,6 +10,7 @@ import android.view.View
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.toolbar.BrowserToolbar
+import mozilla.components.concept.engine.EngineView
 import mozilla.components.feature.findinpage.FindInPageFeature
 import mozilla.components.feature.findinpage.view.FindInPageBar
 import mozilla.components.feature.findinpage.view.FindInPageView
@@ -18,9 +19,10 @@ import mozilla.components.support.base.feature.LifecycleAwareFeature
 
 class FindInPageIntegration(
     private val sessionManager: SessionManager,
-    private val view: FindInPageView
+    private val view: FindInPageView,
+    engineView: EngineView
 ) : LifecycleAwareFeature, BackHandler {
-    private val feature = FindInPageFeature(sessionManager, view, ::onClose)
+    private val feature = FindInPageFeature(sessionManager, view, engineView, ::onClose)
 
     override fun start() {
         feature.start()

--- a/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarUIView.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarUIView.kt
@@ -62,10 +62,10 @@ class AwesomeBarUIView(
             if (Settings.getInstance(container.context).showSearchSuggestions()) {
                 view.addProviders(
                     SearchSuggestionProvider(
-                        components.search.searchEngineManager.getDefaultSearchEngine(this),
-                        searchUseCase,
-                        components.core.client,
-                        SearchSuggestionProvider.Mode.MULTIPLE_SUGGESTIONS
+                        searchEngine = components.search.searchEngineManager.getDefaultSearchEngine(this),
+                        searchUseCase = searchUseCase,
+                        fetchClient = components.core.client,
+                        mode = SearchSuggestionProvider.Mode.MULTIPLE_SUGGESTIONS
                     )
                 )
             }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -22,8 +22,8 @@ private object Versions {
     const val androidx_fragment = "1.1.0-alpha05"
     const val androidx_navigation = "2.1.0-alpha01"
 
-    const val appservices_gradle_plugin = "0.3.1"
-    const val mozilla_android_components = "0.47.0-SNAPSHOT"
+    const val appservices_gradle_plugin = "0.4.2"
+    const val mozilla_android_components = "0.48.0-SNAPSHOT"
 
     const val test_tools = "1.0.2"
     const val espresso_core = "2.2.2"


### PR DESCRIPTION
This is necessary to pick up an application-services dependency bump, and unbreak master.

AwesomeBarUIView changes are needed because, evidently, a new parameter was introduced, and
not at the end.

The newest 0.48 snapshot is currently in the process of being published; it's necessary for these changes to work.