### PR TITLE
Issue #1077: Switch to GeckoView Beta (67.0).

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -254,7 +254,7 @@ dependencies {
     implementation Deps.mozilla_feature_downloads
     implementation Deps.mozilla_browser_domains
     implementation Deps.mozilla_browser_icons
-    implementation Deps.mozilla_browser_engine_gecko_nightly
+    implementation Deps.mozilla_browser_engine_gecko_beta
     implementation Deps.mozilla_browser_session
     implementation Deps.mozilla_browser_storage_sync
     implementation Deps.mozilla_browser_toolbar
@@ -288,9 +288,9 @@ dependencies {
     debugImplementation Deps.leakcanary
     releaseImplementation Deps.leakcanary_noop
 
-    armImplementation Deps.geckoview_nightly_arm
-    x86Implementation Deps.geckoview_nightly_x86
-    aarch64Implementation Deps.geckoview_nightly_aarch64
+    armImplementation Gecko.geckoview_beta_arm
+    x86Implementation Gecko.geckoview_beta_x86
+    aarch64Implementation Gecko.geckoview_beta_aarch64
 
     implementation Deps.androidx_legacy
     implementation Deps.androidx_preference

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -5,7 +5,6 @@
 private object Versions {
     const val kotlin = "1.3.11"
     const val android_gradle_plugin = "3.3.2"
-    const val geckoNightly = "67.0.20190312095443"
     const val rxAndroid = "2.1.0"
     const val rxKotlin = "2.3.0"
     const val anko = "0.10.8"
@@ -55,10 +54,6 @@ object Deps {
     const val anko_appcompat = "org.jetbrains.anko:anko-appcompat-v7:${Versions.anko}"
     const val anko_constraintlayout = "org.jetbrains.anko:anko-constraint-layout:${Versions.anko}"
 
-    const val geckoview_nightly_arm = "org.mozilla.geckoview:geckoview-nightly-armeabi-v7a:${Versions.geckoNightly}"
-    const val geckoview_nightly_x86 = "org.mozilla.geckoview:geckoview-nightly-x86:${Versions.geckoNightly}"
-    const val geckoview_nightly_aarch64 = "org.mozilla.geckoview:geckoview-nightly-arm64-v8a:${Versions.geckoNightly}"
-
     const val mozilla_concept_engine = "org.mozilla.components:concept-engine:${Versions.mozilla_android_components}"
     const val mozilla_concept_tabstray = "org.mozilla.components:concept-tabstray:${Versions.mozilla_android_components}"
     const val mozilla_concept_toolbar = "org.mozilla.components:concept-toolbar:${Versions.mozilla_android_components}"
@@ -67,6 +62,7 @@ object Deps {
 
     const val mozilla_browser_awesomebar = "org.mozilla.components:browser-awesomebar:${Versions.mozilla_android_components}"
     const val mozilla_browser_engine_gecko_nightly = "org.mozilla.components:browser-engine-gecko-nightly:${Versions.mozilla_android_components}"
+    const val mozilla_browser_engine_gecko_beta = "org.mozilla.components:browser-engine-gecko-beta:${Versions.mozilla_android_components}"
     const val mozilla_browser_domains = "org.mozilla.components:browser-domains:${Versions.mozilla_android_components}"
     const val mozilla_browser_icons = "org.mozilla.components:browser-icons:${Versions.mozilla_android_components}"
     const val mozilla_browser_search = "org.mozilla.components:browser-search:${Versions.mozilla_android_components}"

--- a/buildSrc/src/main/java/Gecko.kt
+++ b/buildSrc/src/main/java/Gecko.kt
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+internal object GeckoVersions {
+    const val nightly_version = "68.0.20190321104132"
+    const val beta_version = "67.0.20190318154932"
+    const val release_version = "66.0.20190320150847"
+}
+
+@Suppress("MaxLineLength")
+object Gecko {
+    const val geckoview_nightly_arm = "org.mozilla.geckoview:geckoview-nightly-armeabi-v7a:${GeckoVersions.nightly_version}"
+    const val geckoview_nightly_x86 = "org.mozilla.geckoview:geckoview-nightly-x86:${GeckoVersions.nightly_version}"
+    const val geckoview_nightly_aarch64 = "org.mozilla.geckoview:geckoview-nightly-arm64-v8a:${GeckoVersions.nightly_version}"
+
+    const val geckoview_beta_arm = "org.mozilla.geckoview:geckoview-beta-armeabi-v7a:${GeckoVersions.beta_version}"
+    const val geckoview_beta_x86 = "org.mozilla.geckoview:geckoview-beta-x86:${GeckoVersions.beta_version}"
+    const val geckoview_beta_aarch64 = "org.mozilla.geckoview:geckoview-beta-arm64-v8a:${GeckoVersions.beta_version}"
+
+    const val geckoview_release_arm = "org.mozilla.geckoview:geckoview-armeabi-v7a:${GeckoVersions.release_version}"
+    const val geckoview_release_x86 = "org.mozilla.geckoview:geckoview-x86:${GeckoVersions.release_version}"
+    const val geckoview_release_aarch64 = "org.mozilla.geckoview:geckoview-arm64-v8a:${GeckoVersions.release_version}"
+}


### PR DESCRIPTION
Currently the plan is to ship with GeckoView 67.0. Version 67.0 just migrated from Nightly to the Beta channel. This patch replaces the nightly versions (GV and browser-engine-gecko-*) with the beta versions.

For now this is probably good enough. I think eventually we want to have build variants for the different GeckoView release channels. This will allow us to build features (behind flags) against Nightly and enable them later on once they are available in the release channel. Since Android Components wraps and abstracts the GeckoView API away this should work easily across channels. Anyhow, to not create a thousand more variants right now, it's just easier to only use Beta.