### PR TITLE
AwesomeBar: Limit number of search engine suggestions.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarUIView.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarUIView.kt
@@ -65,7 +65,8 @@ class AwesomeBarUIView(
                         searchEngine = components.search.searchEngineManager.getDefaultSearchEngine(this),
                         searchUseCase = searchUseCase,
                         fetchClient = components.core.client,
-                        mode = SearchSuggestionProvider.Mode.MULTIPLE_SUGGESTIONS
+                        mode = SearchSuggestionProvider.Mode.MULTIPLE_SUGGESTIONS,
+                        limit = 3
                     )
                 )
             }


### PR DESCRIPTION
From Slack

> i think shorlander said that they were revisiting the awesomebar results. but maybe short term to make the nightly a bit more usable,  we can just limit the results to like 2 or 3 items until we have a new design?