### PR TITLE
Declare appservices repository dependency explicitly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,14 @@ plugins {
 allprojects {
     repositories {
         google()
+
+        // Currently the main repository where appservices artifacts are published.
+        // This will eventually move to maven.mozilla.org
+        // See https://github.com/mozilla/application-services/issues/252
+        maven {
+            url "https://dl.bintray.com/mozilla-appservices/application-services"
+        }
+
         maven {
             url "https://snapshots.maven.mozilla.org/maven2"
         }


### PR DESCRIPTION
For now we've settled on where we're publishing appservices artifacts; let's declare that dependency in the project.