### PR TITLE
Adds Metrics for Crash reporter and browser menu items

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -101,6 +101,33 @@ events:
     - telemetry-client-dev@mozilla.com
     expires: "2020-03-01"
 
+crash_reporter:
+    opened:
+      type: event
+      description: >
+        The crash reporter was displayed
+      bugs:
+      - 1040
+      data_reviews:
+      - TBD
+      notification_emails:
+      - telemetry-client-dev@mozilla.com
+      expires: "2020-03-01"
+    closed:
+      type: event
+      description: >
+        The crash reporter was closed
+      extra_keys:
+        crash_submitted:
+          description: "A boolean that tells us whether or not the user submitted a crash report"
+      bugs:
+      - 1040
+      data_reviews:
+      - TBD
+      notification_emails:
+      - telemetry-client-dev@mozilla.com
+      expires: "2020-03-01"
+
 context_menu:
   item_tapped:
     type: event

--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -64,6 +64,23 @@ events:
     notification_emails:
     - telemetry-client-dev@mozilla.com
     expires: "2020-03-01"
+  browser_menu_action:
+    type: event
+    description: >
+      A browser menu item was tapped
+    extra_keys:
+      item:
+        description: >
+          A string containing the name of the item the user tapped. These items include:
+          Settings, Your library, Help, Desktop Site toggle on/off, Find in Page, New Tab,
+          Private Tab, Share, Report Site Issue, Back/Forward button, Reload Button
+    bugs:
+    - 1024
+    data_reviews:
+    - TBD
+    notification_emails:
+    - telemetry-client-dev@mozilla.com
+    expires: "2020-03-01"
   ss_menu_opened:
     type: event
     description: >

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
@@ -8,7 +8,10 @@ import mozilla.components.service.glean.Glean
 import mozilla.components.service.glean.metrics.NoExtraKeys
 import mozilla.components.support.utils.Browsers
 import org.mozilla.fenix.BuildConfig
-import org.mozilla.fenix.GleanMetrics.*
+import org.mozilla.fenix.GleanMetrics.CrashReporter
+import org.mozilla.fenix.GleanMetrics.Events
+import org.mozilla.fenix.GleanMetrics.FindInPage
+import org.mozilla.fenix.GleanMetrics.ContextMenu
 import org.mozilla.fenix.GleanMetrics.Metrics
 import org.mozilla.fenix.utils.Settings
 
@@ -35,7 +38,6 @@ private class EventWrapper<T : Enum<T>>(
 
 private val Event.wrapper
     get() = when (this) {
-
         is Event.OpenedApp -> EventWrapper(
             { Events.appOpened.record(it) },
             { Events.appOpenedKeys.valueOf(it) }
@@ -77,6 +79,10 @@ private val Event.wrapper
         is Event.CrashReporterClosed -> EventWrapper(
             { CrashReporter.closed },
             { CrashReporter.closedKeys.valueOf(it) }
+        )
+        is Event.BrowserMenuItemTapped -> EventWrapper(
+            { Events.browserMenuAction },
+            { Events.browserMenuActionKeys.valueOf(it) }
         )
 
         // Don't track other events with Glean

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
@@ -8,11 +8,9 @@ import mozilla.components.service.glean.Glean
 import mozilla.components.service.glean.metrics.NoExtraKeys
 import mozilla.components.support.utils.Browsers
 import org.mozilla.fenix.BuildConfig
-import org.mozilla.fenix.GleanMetrics.ContextMenu
-import org.mozilla.fenix.utils.Settings
+import org.mozilla.fenix.GleanMetrics.*
 import org.mozilla.fenix.GleanMetrics.Metrics
-import org.mozilla.fenix.GleanMetrics.Events
-import org.mozilla.fenix.GleanMetrics.FindInPage
+import org.mozilla.fenix.utils.Settings
 
 private class EventWrapper<T : Enum<T>>(
     private val recorder: ((Map<T, String>?) -> Unit),
@@ -37,6 +35,7 @@ private class EventWrapper<T : Enum<T>>(
 
 private val Event.wrapper
     get() = when (this) {
+
         is Event.OpenedApp -> EventWrapper(
             { Events.appOpened.record(it) },
             { Events.appOpenedKeys.valueOf(it) }
@@ -72,6 +71,14 @@ private val Event.wrapper
             { ContextMenu.itemTapped.record(it) },
             { ContextMenu.itemTappedKeys.valueOf(it) }
         )
+        is Event.CrashReporterOpened -> EventWrapper<NoExtraKeys>(
+            { CrashReporter.opened }
+        )
+        is Event.CrashReporterClosed -> EventWrapper(
+            { CrashReporter.closed },
+            { CrashReporter.closedKeys.valueOf(it) }
+        )
+
         // Don't track other events with Glean
         else -> null
     }

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/Metrics.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/Metrics.kt
@@ -99,6 +99,12 @@ sealed class Event {
         }
     }
 
+    object CrashReporterOpened : Event()
+    data class CrashReporterClosed(val crashSubmitted: Boolean) : Event() {
+        override val extras: Map<String, String>?
+            get() = mapOf("crash_submitted" to crashSubmitted.toString())
+    }
+
     open val extras: Map<String, String>?
         get() = null
 }

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/Metrics.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/Metrics.kt
@@ -105,6 +105,16 @@ sealed class Event {
             get() = mapOf("crash_submitted" to crashSubmitted.toString())
     }
 
+    data class BrowserMenuItemTapped(val item: Item) : Event() {
+        enum class Item {
+            SETTINGS, LIBRARY, HELP, DESKTOP_VIEW_ON, DESKTOP_VIEW_OFF, FIND_IN_PAGE, NEW_TAB,
+            NEW_PRIVATE_TAB, SHARE, REPORT_SITE_ISSUE, BACK, FORWARD, RELOAD, STOP, OPEN_IN_FENIX
+        }
+
+        override val extras: Map<String, String>?
+            get() = mapOf("item" to item.toString().toLowerCase())
+    }
+
     open val extras: Map<String, String>?
         get() = null
 }


### PR DESCRIPTION
# Request for data collection review form

**All questions are mandatory. You must receive review from a data steward peer on your responses to these questions before shipping new data collection.**

1) **What questions will you answer with this data?**

Crash Reporter
- Define stability
- How often the crash page shows up per user/per day etc
- Understand if/how often users feel like sharing this data with us

Browser Menu Items
- What are the most common uses cases for users to open the 
- How often is "Request Desktop Site"?

2) **Why does Mozilla need to answer these questions?  Are there benefits for users? Do we need this information to address product or business requirements?**

* One of the measurements of tracking the stability of the app is to collect telemetry on the crash reporting page
* We need to understand how users are navigating through the browser, including also these events into Amplitude let's us create funnels and improve user flow

3) **What alternative methods did you consider to answer these questions? Why were they not sufficient?**

* N/A (These are baseline metrics)

4) **Can current instrumentation answer these questions?**

* Currently no, as these are some of the first metrics we're recording

5) **List all proposed measurements and indicate the category of data collection for each measurement, using the Firefox [data c](https://wiki.mozilla.org/Firefox/Data_Collection)[ollection ](https://wiki.mozilla.org/Firefox/Data_Collection)[categories](https://wiki.mozilla.org/Firefox/Data_Collection) on the found on the Mozilla wiki.**

* All data is Category 2.

6) **How long will this data be collected?**

Until 03/01/2020

7) **What populations will you measure?**

* All release, beta, and nightly users with telemetry enabled.

8) **Please provide a general description of how you will analyze this data.**

* Glean/ Amplitude

9) **Where do you intend to share the results of your analysis?**

* Only on Glean, Amplitude and with mobile teams.