### PR TITLE
For #423: Add release build type for raptor perf. testing

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,11 +30,17 @@ android {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         manifestPlaceholders.isRaptorEnabled = "false"
     }
+
     buildTypes {
         release {
             shrinkResources true
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+        releaseRaptor {
+            initWith release
+            manifestPlaceholders.isRaptorEnabled = "true"
+            matchingFallbacks = ['release']
         }
         debug {
             shrinkResources false


### PR DESCRIPTION
We have limited Raptor to debug/special builds in https://github.com/mozilla-mobile/fenix/pull/670

The PI team needs to test release builds with Raptor, so this brings in a raptor build type based on release. Once https://github.com/mozilla-mobile/fenix/pull/1220 lands, all builds will be exposed on TC and can be consumed by the PI team.

Any suggestions for a different buildtype name are very welcome? :) Maybe releaseTest?
