### PR TITLE
Don't use glean's not-really-public EventMetricType directly

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
@@ -4,7 +4,6 @@
 package org.mozilla.fenix.components.metrics
 
 import android.content.Context
-import mozilla.components.service.glean.metrics.EventMetricType
 import mozilla.components.service.glean.Glean
 import mozilla.components.support.utils.Browsers
 import org.mozilla.fenix.BuildConfig
@@ -13,8 +12,8 @@ import org.mozilla.fenix.GleanMetrics.Metrics
 import org.mozilla.fenix.GleanMetrics.Events
 
 private class EventWrapper<T : Enum<T>>(
-    private val event: EventMetricType<T>,
-    private val keyMapper: ((String) -> T)? = null
+    private val recorder: ((Map<T, String>?) -> Unit),
+    private val keyMapper: ((String) -> T)?
 ) {
     private val String.asCamelCase: String
         get() = this.split("_").reduceIndexed { index, acc, s ->
@@ -29,16 +28,28 @@ private class EventWrapper<T : Enum<T>>(
             null
         }
 
-        this.event.record(extras)
+        this.recorder(extras)
     }
 }
 
 private val Event.wrapper
     get() = when (this) {
-        is Event.OpenedApp -> EventWrapper(Events.appOpened) { Events.appOpenedKeys.valueOf(it) }
-        is Event.SearchBarTapped -> EventWrapper(Events.searchBarTapped) { Events.searchBarTappedKeys.valueOf(it) }
-        is Event.EnteredUrl -> EventWrapper(Events.enteredUrl) { Events.enteredUrlKeys.valueOf(it) }
-        is Event.PerformedSearch -> EventWrapper(Events.performedSearch) { Events.performedSearchKeys.valueOf(it) }
+        is Event.OpenedApp -> EventWrapper(
+            { Events.appOpened.record(it) },
+            { Events.appOpenedKeys.valueOf(it) }
+        )
+        is Event.SearchBarTapped -> EventWrapper(
+            { Events.searchBarTapped.record(it) },
+            { Events.searchBarTappedKeys.valueOf(it) }
+        )
+        is Event.EnteredUrl -> EventWrapper(
+            { Events.enteredUrl.record(it) },
+            { Events.enteredUrlKeys.valueOf(it) }
+        )
+        is Event.PerformedSearch -> EventWrapper(
+            { Events.performedSearch.record(it) },
+            { Events.performedSearchKeys.valueOf(it) }
+        )
         else -> null
     }
 


### PR DESCRIPTION
This fixes a usage of glean so that `EventMetricType` isn't used directly.

The classes in `mozilla.components.service.glean.metrics` are technically public because the generated metrics API needs to use them from the application's package namespace.  However, these aren't really part of the public API and we don't intend for them to be used directly by end users.  This is sort of the glean team's bad because we didn't do a good enough job communicating this.

Once this PR is merged as we are no longer at risk of breaking Fenix, we will probably rename these classes or do some other form of tomfoolery to make it more obvious that they shouldn't be used directly.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
