### PR TITLE
Gradle: Ignore non-greenfield build variants.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -101,6 +101,15 @@ android {
         }
     }
 
+    variantFilter { variant ->
+        def flavors = variant.flavors*.name.toString().toLowerCase()
+
+        if (!flavors.contains("greenfield")) {
+            // For now everything that isn't a "greenfield" build isn't used. So let's ignore those variants.
+            setIgnore(true)
+        }
+    }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
For now the other variants are not in-use (and may never be). Let's ignore them until we know for sure.