### PR TITLE
Closes #1172: Make RadioButton in RadioButtonPreference non focusable.

### DIFF
--- a/app/src/main/res/layout/preference_widget_radiobutton.xml
+++ b/app/src/main/res/layout/preference_widget_radiobutton.xml
@@ -28,6 +28,7 @@
                 android:layout_gravity="start"
                 android:button="@null"
                 android:clickable="false"
+                android:focusable="false"
                 android:drawableStart="?android:attr/listChoiceIndicatorSingle"
                 android:drawablePadding="@dimen/radio_button_preference_drawable_padding"/>
 


### PR DESCRIPTION
This tells TalkBack not to land on the button individually, but instead
to land on the parent View. TalkBack users will get both the button
state and the textual description. Double tapping should work too.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
