### PR TITLE
Closes #1329: Raptor performance tests can no longer be executed

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -305,6 +305,8 @@ dependencies {
     debugImplementation Deps.leakcanary
     releaseImplementation Deps.leakcanary_noop
 
+    implementation Deps.mozilla_lib_fetch_httpurlconnection
+
     armImplementation Gecko.geckoview_beta_arm
     x86Implementation Gecko.geckoview_beta_x86
     aarch64Implementation Gecko.geckoview_beta_aarch64

--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -9,6 +9,7 @@ import android.app.Application
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
+import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
 import mozilla.components.service.fretboard.Fretboard
 import mozilla.components.service.fretboard.source.kinto.KintoExperimentSource
 import mozilla.components.service.fretboard.storage.flatfile.FlatFileExperimentStorage
@@ -72,7 +73,8 @@ open class FenixApplication : Application() {
             EXPERIMENTS_BASE_URL,
             EXPERIMENTS_BUCKET_NAME,
             EXPERIMENTS_COLLECTION_NAME,
-            components.core.client
+            // TODO Switch back to components.core.client (see https://github.com/mozilla-mobile/fenix/issues/1329)
+            HttpURLConnectionClient()
         )
         // TODO add ValueProvider to keep clientID in sync with Glean when ready
         fretboard = Fretboard(experimentSource, FlatFileExperimentStorage(experimentsFile))

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -103,6 +103,7 @@ object Deps {
     const val mozilla_ui_icons = "org.mozilla.components:ui-icons:${Versions.mozilla_android_components}"
 
     const val mozilla_lib_crash = "org.mozilla.components:lib-crash:${Versions.mozilla_android_components}"
+    const val mozilla_lib_fetch_httpurlconnection = "org.mozilla.components:lib-fetch-httpurlconnection:${Versions.mozilla_android_components}"
 
     const val mozilla_support_base = "org.mozilla.components:support-base:${Versions.mozilla_android_components}"
     const val mozilla_support_ktx = "org.mozilla.components:support-ktx:${Versions.mozilla_android_components}"


### PR DESCRIPTION
We definitely want to use Gecko fetch for this, but it will get the performance team unstuck until we have a better way of launching Raptor. 