### PR TITLE
Remove Quick Actions Sheet contentDescription

### DIFF
--- a/app/src/main/res/layout/layout_quick_action_sheet.xml
+++ b/app/src/main/res/layout/layout_quick_action_sheet.xml
@@ -9,7 +9,6 @@
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:contentDescription="@string/quick_action_sheet"
     android:background="?attr/toolbarColor">
 
     <androidx.appcompat.widget.AppCompatImageButton

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -177,8 +177,6 @@
     <string name="quick_action_bookmark">Bookmark</string>
     <!-- Option in Quick Action Sheet in the browser to put the the current page in reader mode -->
     <string name="quick_action_read">Read</string>
-    <!-- Content description (not visible, for screen readers etc.): Quick action sheet-->
-    <string name="quick_action_sheet">Quick action sheet</string>
     <!-- Content description (not visible, for screen readers etc.): Quick action sheet handle -->
     <string name="quick_action_sheet_handle">Quick actions</string>
 


### PR DESCRIPTION
Oops, I missed this in the initial pass of quick actions sheet accessibility

This is not needed for screen reader usability, and introduces an
useless intermediate node that TalkBack lands on.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
