### PR TITLE
No issue: Fix build breakage on erroneous lint warnings for WrongCons…

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -138,6 +138,8 @@ open class FenixApplication : Application() {
         }
     }
 
+    @SuppressLint("WrongConstant")
+    // Suppressing erroneous lint warning about using MODE_NIGHT_AUTO_BATTERY, a likely library bug
     private fun setDayNightTheme() {
         when {
             Settings.getInstance(this).shouldUseLightTheme -> {

--- a/app/src/main/java/org/mozilla/fenix/settings/ThemeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/ThemeFragment.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.fenix.settings
 
+import android.annotation.SuppressLint
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
@@ -69,6 +70,8 @@ class ThemeFragment : PreferenceFragmentCompat() {
         }
     }
 
+    @SuppressLint("WrongConstant")
+    // Suppressing erroneous lint warning about using MODE_NIGHT_AUTO_BATTERY, a likely library bug
     private fun bindAutoBatteryTheme() {
         val keyBatteryTheme = getString(R.string.pref_key_auto_battery_theme)
         radioAutoBatteryTheme = requireNotNull(findPreference(keyBatteryTheme))


### PR DESCRIPTION
…tant: MODE_NIGHT_AUTO_BATTERY



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
