### PR TITLE
Hide tabs list when no session is selected

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/tabs/TabsUIView.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/tabs/TabsUIView.kt
@@ -79,6 +79,7 @@ class TabsUIView(
         (if (it.sessions.isEmpty()) View.GONE else View.VISIBLE).also { visibility ->
             view.tabs_header.visibility = visibility
             sessionButton.visibility = visibility
+            view.tabs_list.visibility = visibility
         }
     }
 }


### PR DESCRIPTION
The empty tabs list is visible to TalkBack when it is empty. Settings it to View.GONE also removes some extra padding pixels that it uses, and generally looks better. If this is wrong, it can be set to View.INVISIBLE, this will achieve the desired effect with TalkBack and will keep the current layout.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
