### PR TITLE
History UI limits: visit type & time

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryComponent.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryComponent.kt
@@ -10,21 +10,8 @@ import org.mozilla.fenix.mvi.ActionBusFactory
 import org.mozilla.fenix.mvi.Change
 import org.mozilla.fenix.mvi.UIComponent
 import org.mozilla.fenix.mvi.ViewState
-import java.net.URL
 
-data class HistoryItem(val id: Int, val url: String, val visitedAt: Long) {
-    val title: String
-        get() = siteTitle()
-
-    @SuppressWarnings("TooGenericExceptionCaught")
-    private fun siteTitle(): String {
-        return try {
-            URL(url).host
-        } catch (e: Exception) {
-            url
-        }
-    }
-}
+data class HistoryItem(val id: Int, val title: String, val url: String, val visitedAt: Long)
 
 @Mockable
 class HistoryComponent(

--- a/app/src/test/java/org/mozilla/fenix/library/history/HistoryComponentTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/history/HistoryComponentTest.kt
@@ -40,7 +40,7 @@ class HistoryComponentTest {
 
     @Test
     fun `add and remove one history item normally`() {
-        val historyItem = HistoryItem(123, "http://mozilla.org", 0)
+        val historyItem = HistoryItem(123, "Mozilla", "http://mozilla.org", 0)
 
         emitter.onNext(HistoryChange.Change(listOf(historyItem)))
         emitter.onNext(HistoryChange.EnterEditMode(historyItem))
@@ -62,8 +62,8 @@ class HistoryComponentTest {
     @Test
     fun `try making changes when not in edit mode`() {
         val historyItems = listOf(
-            HistoryItem(1337, "http://reddit.com", 0),
-            HistoryItem(31337, "http://leethaxor.com", 0)
+            HistoryItem(1337, "Reddit", "http://reddit.com", 0),
+            HistoryItem(31337, "Haxor", "http://leethaxor.com", 0)
         )
 
         emitter.onNext(HistoryChange.Change(historyItems))


### PR DESCRIPTION
These are temporary limitations to make History UI somewhat functional,
until we get relevant UI and API changes in place.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
  - None of this UI code seems to be tested; longer term, these restrictions/filtering will be done at the library level anyway.
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
