### PR TITLE
Update GV architectures to nightly

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -306,9 +306,9 @@ dependencies {
 
     implementation Deps.mozilla_lib_fetch_httpurlconnection
 
-    armImplementation Gecko.geckoview_beta_arm
-    x86Implementation Gecko.geckoview_beta_x86
-    aarch64Implementation Gecko.geckoview_beta_aarch64
+    armImplementation Gecko.geckoview_nightly_arm
+    x86Implementation Gecko.geckoview_nightly_x86
+    aarch64Implementation Gecko.geckoview_nightly_aarch64
 
     implementation Deps.androidx_legacy
     implementation Deps.androidx_preference


### PR DESCRIPTION
This was a missing requirement.