### PR TITLE
For #1375 - Suppress history suggestions in awesome bar via setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - #1170: Allow user to add a new site exception to site permissions
 - #1430 - Adds the Fenix Snackbar
 - #1397 - Adds favicons to the history view
+- #1375 - Added setting for turning off history suggestions
 
 >>>>>>> For #1397 - Updates changelog
 ### Changed

--- a/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarUIView.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarUIView.kt
@@ -155,9 +155,12 @@ class AwesomeBarUIView(
             view.addProviders(searchSuggestionProvider!!)
         }
 
+        if (Settings.getInstance(container.context).shouldShowVisitedSitesBookmarks) {
+            view.addProviders(historyStorageProvider!!)
+        }
+
         view.addProviders(
             clipboardSuggestionProvider!!,
-            historyStorageProvider!!,
             sessionProvider!!
         )
     }

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -61,6 +61,12 @@ class Settings private constructor(context: Context) {
             false
         )
 
+    val shouldShowVisitedSitesBookmarks: Boolean
+        get() = preferences.getBoolean(
+            appContext.getPreferenceKey(R.string.pref_key_show_visited_sites_bookmarks),
+            true
+        )
+
     val shouldUseDarkTheme: Boolean
         get() = preferences.getBoolean(
             appContext.getPreferenceKey(R.string.pref_key_dark_theme),

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -37,7 +37,8 @@
     <!-- Search Settings -->
     <string name="pref_key_show_search_suggestions" translatable="false">pref_key_show_search_suggestions</string>
 
-    <string name = "pref_key_bounce_quick_action" translatable="false">pref_key_bounce_quick_action</string>
+    <string name="pref_key_bounce_quick_action" translatable="false">pref_key_bounce_quick_action</string>
+    <string name="pref_key_show_visited_sites_bookmarks" translatable="false">pref_key_show_visited_sites_bookmarks</string>
     <!-- Site Permissions Settings -->
     <string name="pref_key_optimize" translatable="false">pref_key_optimize</string>
     <string name="pref_key_show_site_exceptions" translatable="false">pref_key_show_site_exceptions</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -89,6 +89,8 @@
     <string name="preferences_category_about">About</string>
     <!-- Preference for settings related to changing the default search engine -->
     <string name="preferences_search_engine">Search engine</string>
+    <!-- Preference for showing visited sites and bookmarks in awesomebar -->
+    <string name="preference_show_visited_sites_bookmarks">Show visited sites and bookmarks</string>
     <!-- Preference linking to help about Fenix -->
     <string name="preferences_help">Help</string>
     <!-- Preference link to rating Fenix on the Play Store -->

--- a/app/src/main/res/xml/search_engine_preferences.xml
+++ b/app/src/main/res/xml/search_engine_preferences.xml
@@ -11,4 +11,9 @@
         android:key="@string/pref_key_show_search_suggestions"
         android:title="@string/preferences_show_search_suggestions"
         app:iconSpaceReserved="false" />
+    <SwitchPreference
+        android:defaultValue="true"
+        android:key="@string/pref_key_show_visited_sites_bookmarks"
+        android:title='@string/preference_show_visited_sites_bookmarks'
+        app:iconSpaceReserved="false" />
 </PreferenceScreen>


### PR DESCRIPTION
We don't actually have bookmark suggestion provider hooked up yet, but this should allow a user to turn off the history suggestions. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
