### PR TITLE
Try to fix build bustage from #1321.

### DIFF
--- a/automation/taskcluster/lib/tasks.py
+++ b/automation/taskcluster/lib/tasks.py
@@ -271,7 +271,7 @@ class TaskBuilder(object):
         }
 
         return self._craft_default_task_definition(
-            worker_type='mobile-signing-dep-v1' if signing_format == 'dep' else 'mobile-signing-v1',
+            worker_type='mobile-signing-dep-v1' if signing_type == 'dep-signing' else 'mobile-signing-v1',
             provisioner_id='scriptworker-prov-v1',
             dependencies=[assemble_task_id],
             routes=routes,


### PR DESCRIPTION
This just looks wrong.  I'm concerned that this was green as a PR,
because it suggests that we were signing with an incorrect
`worker_type` there; but here we are -- let's see if it addresses the
issue.  If not, we'll back the whole of #1321 out.

This is basically untested, 'cuz it's not really possible/worth the effort to test except on `master`.