### PR TITLE
Fixes #1498 - Ignores missing translation lint

### DIFF
--- a/app/lint.xml
+++ b/app/lint.xml
@@ -8,5 +8,6 @@
              Let's just ignore issues in the Sentry code since that is a third-party dependency anyways. -->
         <ignore path="**/sentry*.jar" />
     </issue>
+    <issue id="MissingTranslation" severity="ignore" />
 </lint>
 


### PR DESCRIPTION
We need to ignore this lint rule for l10n