### PR TITLE
Remove deprecated success path for Firefox Accounts login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - #1139 - Resolved a 170ms delay on cold start
 - #176 - Added a swipe to delete gesture on home screen
 - #1539 - Added bookmarks multi-select related features
+- #1603 - Remove deprecated success path for Firefox Accounts login
 
 ### Changed
 - #1429 - Updated site permissions ui for MVP

--- a/app/src/main/java/org/mozilla/fenix/components/BackgroundServices.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/BackgroundServices.kt
@@ -25,7 +25,6 @@ class BackgroundServices(
     companion object {
         const val CLIENT_ID = "a2270f727f45f648"
         const val REDIRECT_URL = "https://accounts.firefox.com/oauth/success/$CLIENT_ID"
-        const val SUCCESS_PATH = "connect_another_device?showSuccessMessage=true"
     }
 
     // This is slightly messy - here we need to know the union of all "scopes"

--- a/app/src/main/java/org/mozilla/fenix/components/Services.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Services.kt
@@ -19,8 +19,7 @@ class Services(
         FirefoxAccountsAuthFeature(
             accountManager,
             tabsUseCases,
-            redirectUrl = BackgroundServices.REDIRECT_URL,
-            successPath = BackgroundServices.SUCCESS_PATH
+            redirectUrl = BackgroundServices.REDIRECT_URL
         )
     }
 }


### PR DESCRIPTION
Requires https://github.com/mozilla-mobile/android-components/pull/2678 SNAPSHOT
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
