### PR TITLE
Revert "For #689: Adds fade animation to Android <9.0"

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -7,7 +7,6 @@ package org.mozilla.fenix
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
-import android.os.Build
 import android.os.Bundle
 import android.preference.PreferenceManager
 import android.util.AttributeSet
@@ -46,14 +45,7 @@ open class HomeActivity : AppCompatActivity() {
     val themeManager = DefaultThemeManager().also {
         it.onThemeChange = { theme ->
             setTheme(theme)
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
-                // Older versions of android do not support window animation style, so we use a transition instead
-                finish()
-                overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
-                startActivity(intent)
-            } else {
-                recreate()
-            }
+            recreate()
         }
     }
 


### PR DESCRIPTION
Reverts mozilla-mobile/fenix#1520
This is causing issues because the state is not preserved when we finish and start the activity instead of recreating See #1633
Reverting this will cause no animation to be shown for older devices