### PR TITLE
Fix blank custom tabs following an NPE.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/IntentReceiverActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/IntentReceiverActivity.kt
@@ -18,6 +18,11 @@ class IntentReceiverActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        // The intent property is nullable, but the rest of the code below
+        // assumes it is not. If it's null, then we make a new one and open
+        // the HomeActivity.
+        val intent = intent?.let { Intent(intent) } ?: Intent()
+
         val isPrivate = PreferenceManager
             .getDefaultSharedPreferences(this).getBoolean(getString(R.string.pref_key_private_mode), false)
 
@@ -27,11 +32,7 @@ class IntentReceiverActivity : Activity() {
             components.utils.intentProcessor.process(intent)
         }
 
-        val openToBrowser: Boolean
-
-        val intent = Intent(intent)
-
-        openToBrowser = when {
+        val openToBrowser = when {
             CustomTabConfig.isCustomTabIntent(SafeIntent(intent)) -> {
                 intent.setClassName(applicationContext, CustomTabActivity::class.java.name)
                 true


### PR DESCRIPTION
Fixes #1771.

This PR protects against the initial `NullPointerException` ever happening.

This is a rare case, and we do not have anything to go on at this point, so we fallback to a new intent, and the user is routed to the home activity.