### PR TITLE
DO NOT LAND - Do `org.mozilla.appservices` work "by hand".

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,17 +8,6 @@ apply plugin: 'kotlin-android-extensions'
 apply from: "$project.rootDir/automation/gradle/versionCode.gradle"
 apply plugin: 'androidx.navigation.safeargs.kotlin'
 
-apply plugin: 'org.mozilla.appservices'
-
-appservices {
-    defaultConfig {
-        megazord = 'fenix'
-        // Necessary to allow for local dependency substitutions.
-        // See https://github.com/mozilla-mobile/reference-browser/pull/356#issuecomment-449190236
-        unitTestingEnabled = false
-    }
-}
-
 android {
     compileSdkVersion 28
     defaultConfig {
@@ -357,7 +346,7 @@ dependencies {
     }
 
     androidTestImplementation Deps.espresso_idling_resources
-    
+
     androidTestImplementation Deps.tools_test_runner
     androidTestImplementation Deps.tools_test_rules
     androidTestUtil Deps.orchestrator
@@ -399,3 +388,35 @@ task printBuildVariants {
 // Normally this should use the same version as the glean dependency. But since we are currently using AC snapshots we
 // can't reference a git tag with a specific version here. So we are just using "master" and hoping for the best.
 apply from: 'https://github.com/mozilla-mobile/android-components/raw/master/components/service/glean/scripts/sdk_generator.gradle'
+
+// Internal, but stable and convenient.
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
+
+// This is the equivalent of what the `org.mozilla.appservices` Gradle plugin
+// achieves, minus asserting that the versions of all the megazord components
+// agree.  This could be added if required.
+afterEvaluate {
+    def megazord = DefaultModuleIdentifier.newId('org.mozilla.appservices', 'fenix-megazord')
+    def megazordComponents = [
+        DefaultModuleIdentifier.newId('org.mozilla.appservices', 'fxaclient'),
+        DefaultModuleIdentifier.newId('org.mozilla.appservices', 'places'),
+        DefaultModuleIdentifier.newId('org.mozilla.appservices', 'push'),
+        DefaultModuleIdentifier.newId('org.mozilla.appservices', 'rustlog'),
+        DefaultModuleIdentifier.newId('org.mozilla.appservices', 'viaduct')
+    ]
+
+    configurations.each { configuration ->
+        configuration.resolutionStrategy.dependencySubstitution.all { dependency ->
+            if (dependency.requested instanceof ModuleComponentSelector) {
+                def moduleIdentifier = ((ModuleComponentSelector) dependency.requested).moduleIdentifier
+                if (megazordComponents.contains(moduleIdentifier)) {
+                    def megazordVersion = Deps.mozilla_appservices
+                    def substitution = "${megazord.group}:${megazord.name}:${megazordVersion}"
+                    logger.lifecycle("In ${configuration}: substituting megazord module '$substitution' for component module" +
+                                     " '${moduleIdentifier.group}:${moduleIdentifier.name}:${dependency.requested.version}'")
+                    dependency.useTarget(substitution)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.Deferred
+import mozilla.appservices.FenixMegazord
 import mozilla.components.concept.fetch.Client
 import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
 import mozilla.components.service.fretboard.Fretboard

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,6 @@ buildscript {
     dependencies {
         classpath Deps.tools_androidgradle
         classpath Deps.tools_kotlingradle
-        classpath Deps.tools_appservicesgradle
         classpath Deps.androidx_safeargs
         classpath Deps.allopen
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -24,7 +24,6 @@ private object Versions {
     const val androidx_navigation = "2.1.0-alpha02"
     const val androidx_recyclerview = "1.1.0-alpha04"
 
-    const val appservices_gradle_plugin = "0.4.4"
     const val mozilla_android_components = "0.51.0-SNAPSHOT"
     const val mozilla_appservices = "0.25.2"
 
@@ -52,7 +51,6 @@ private object Versions {
 object Deps {
     const val tools_androidgradle = "com.android.tools.build:gradle:${Versions.android_gradle_plugin}"
     const val tools_kotlingradle = "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.kotlin}"
-    const val tools_appservicesgradle = "org.mozilla.appservices:gradle-plugin:${Versions.appservices_gradle_plugin}"
     const val kotlin_stdlib = "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${Versions.kotlin}"
     const val kotlin_coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.coroutines}"
 
@@ -102,6 +100,7 @@ object Deps {
     const val mozilla_feature_session_bundling = "org.mozilla.components:feature-session-bundling:${Versions.mozilla_android_components}"
     const val mozilla_feature_site_permissions = "org.mozilla.components:feature-sitepermissions:${Versions.mozilla_android_components}"
 
+    const val mozilla_appservices = Versions.mozilla_appservices
     const val mozilla_places = "org.mozilla.appservices:places:${Versions.mozilla_appservices}"
 
     const val mozilla_service_firefox_accounts = "org.mozilla.components:service-firefox-accounts:${Versions.mozilla_android_components}"


### PR DESCRIPTION
**DO NOT LAND: THIS IS A PoC ONLY.**

This shows how to manually do the megazord substitution that the
`org.mozilla.appservices` plugin does by hand.  It could be factored
into a standalone Gradle file and generalized in a variety of
directions, avoiding the existing plugin, which has proved brittle and
opaque.

There's additional work required order to land this.  I made
`FenixApplication` explicitly depend on the megazord class to verify
that it's doing the right thing; that should be removed.  In fact, we
should make the substitution process for a-s megazord-aware instead
and get rid of the introspection entirely, but that's a separate
problem.

This is basically what https://github.com/mozilla/application-services/pull/921 asks for.