### PR TITLE
For #1719: tracking protection icon in quick settings is almost invis…

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsUIView.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsUIView.kt
@@ -108,8 +108,6 @@ class QuickSettingsUIView(
             context
         ) else DefaultThemeManager.resolveAttribute(R.attr.neutral, context)
         val icon = AppCompatResources.getDrawable(context, drawableId)
-        val resolvedColor = ContextCompat.getColor(context, drawableTint)
-        icon?.setTint(resolvedColor)
         trackingProtectionSwitch.setCompoundDrawablesWithIntrinsicBounds(icon, null, null, null)
         trackingProtectionSwitch.isChecked = isTrackingProtectionOn
 


### PR DESCRIPTION
…ible

There was already a fix for the text color, but the icon is also affected.