### PR TITLE
Only set the engine's theme when it is instantiated

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -65,7 +65,6 @@ open class HomeActivity : AppCompatActivity() {
         DefaultThemeManager.applyStatusBarTheme(window, themeManager, this)
         browsingModeManager = DefaultBrowsingModeManager(this)
 
-        components.core.setEnginePreferredColorScheme()
         setContentView(R.layout.activity_home)
 
         val appBarConfiguration = AppBarConfiguration.Builder(setOf(R.id.libraryFragment)).build()

--- a/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -64,8 +64,19 @@ class Core(private val context: Context) {
             trackingProtectionPolicy = createTrackingProtectionPolicy(),
             historyTrackingDelegate = HistoryDelegate(historyStorage)
         )
+        val e = GeckoEngine(context, defaultSettings, runtime)
 
-        GeckoEngine(context, defaultSettings, runtime)
+        val inDark =
+            (context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) ==
+                    Configuration.UI_MODE_NIGHT_YES
+        e.settings.preferredColorScheme = when {
+            Settings.getInstance(context).shouldUseDarkTheme -> PreferredColorScheme.Dark
+            Settings.getInstance(context).shouldUseLightTheme -> PreferredColorScheme.Light
+            inDark -> PreferredColorScheme.Dark
+            else -> PreferredColorScheme.Light
+        }
+
+        e
     }
 
     /**
@@ -147,21 +158,6 @@ class Core(private val context: Context) {
             normalMode && !privateMode -> trackingProtectionPolicy.forRegularSessionsOnly()
             !normalMode && privateMode -> trackingProtectionPolicy.forPrivateSessionsOnly()
             else -> TrackingProtectionPolicy.none()
-        }
-    }
-
-    /**
-     * Sets Preferred Color scheme based on Dark/Light Theme Settings or Current Configuration
-     */
-    fun setEnginePreferredColorScheme() {
-        val inDark =
-            (context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) ==
-                    Configuration.UI_MODE_NIGHT_YES
-        engine.settings.preferredColorScheme = when {
-            Settings.getInstance(context).shouldUseDarkTheme -> PreferredColorScheme.Dark
-            Settings.getInstance(context).shouldUseLightTheme -> PreferredColorScheme.Light
-            inDark -> PreferredColorScheme.Dark
-            else -> PreferredColorScheme.Light
         }
     }
 }


### PR DESCRIPTION
Instead of instantiating the Gecko engine just to
set the theme, only set the theme when the engine
is actually instantiated.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
