### PR TITLE
No issue: Only set the engine's theme when it is instantiated

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -65,7 +65,6 @@ open class HomeActivity : AppCompatActivity() {
         DefaultThemeManager.applyStatusBarTheme(window, themeManager, this)
         browsingModeManager = DefaultBrowsingModeManager(this)
 
-        components.core.setEnginePreferredColorScheme()
         setContentView(R.layout.activity_home)
 
         val appBarConfiguration = AppBarConfiguration.Builder(setOf(R.id.libraryFragment)).build()

--- a/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -62,7 +62,8 @@ class Core(private val context: Context) {
             remoteDebuggingEnabled = Settings.getInstance(context).isRemoteDebuggingEnabled,
             testingModeEnabled = false,
             trackingProtectionPolicy = createTrackingProtectionPolicy(),
-            historyTrackingDelegate = HistoryDelegate(historyStorage)
+            historyTrackingDelegate = HistoryDelegate(historyStorage),
+            preferredColorScheme = getPreferredColorScheme()
         )
 
         GeckoEngine(context, defaultSettings, runtime)
@@ -153,11 +154,11 @@ class Core(private val context: Context) {
     /**
      * Sets Preferred Color scheme based on Dark/Light Theme Settings or Current Configuration
      */
-    fun setEnginePreferredColorScheme() {
+    fun getPreferredColorScheme(): PreferredColorScheme {
         val inDark =
             (context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) ==
                     Configuration.UI_MODE_NIGHT_YES
-        engine.settings.preferredColorScheme = when {
+        return when {
             Settings.getInstance(context).shouldUseDarkTheme -> PreferredColorScheme.Dark
             Settings.getInstance(context).shouldUseLightTheme -> PreferredColorScheme.Light
             inDark -> PreferredColorScheme.Dark

--- a/app/src/main/java/org/mozilla/fenix/settings/ThemeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/ThemeFragment.kt
@@ -100,6 +100,9 @@ class ThemeFragment : PreferenceFragmentCompat() {
     private fun setNewTheme(mode: Int) {
         AppCompatDelegate.setDefaultNightMode(mode)
         activity?.recreate()
+        with(requireComponents.core) {
+            engine.settings.preferredColorScheme = getPreferredColorScheme()
+        }
         requireComponents.useCases.sessionUseCases.reload.invoke()
     }
 }


### PR DESCRIPTION
CC @hawkinsw - does this work for you?
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
