### PR TITLE
For #1759 - Try to change copy URL to plainText

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -542,8 +542,7 @@ class BrowserFragment : Fragment(), BackHandler, CoroutineScope {
 
     private fun Session.copyUrl(context: Context) {
         val clipBoard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-        val uri = Uri.parse(url)
-        clipBoard.primaryClip = ClipData.newRawUri("Uri", uri)
+        clipBoard.primaryClip = ClipData.newPlainText(url, url)
     }
 
     private fun subscribeToSession(): Session.Observer {

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragment.kt
@@ -9,7 +9,6 @@ import android.content.ClipboardManager
 import android.content.Context
 import android.graphics.PorterDuff
 import android.graphics.PorterDuffColorFilter
-import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.Menu
@@ -397,7 +396,6 @@ class BookmarkFragment : Fragment(), CoroutineScope, BackHandler, AccountObserve
 
     private fun BookmarkNode.copyUrl(context: Context) {
         val clipBoard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-        val uri = Uri.parse(url)
-        clipBoard.primaryClip = ClipData.newRawUri("Uri", uri)
+        clipBoard.primaryClip = ClipData.newPlainText(url, url)
     }
 }


### PR DESCRIPTION
Not sure if this will fix the users problem, but seems like plain text would be fine for our clipboard use case? I checked and AC when copying a link to the clipboard (ie in ContextMenuCandidate) uses plainText

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
