### PR TITLE
Initial view for the Sync Fragment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - #113 - Added QR code scanner
 - #975 - Added telemetry for preference switches
 - #1955 - Added a confirmation dialog for QR code and barcode searches
+- #1874 - Added a "Turn on Sync" fragment for Firefox Accounts login and sign up
 
 ### Changed
 - #1429 - Updated site permissions ui for MVP

--- a/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
@@ -188,15 +188,8 @@ class SettingsFragment : PreferenceFragmentCompat(), CoroutineScope, AccountObse
 
     private fun getClickListenerForSignIn(): OnPreferenceClickListener {
         return OnPreferenceClickListener {
-            requireComponents.services.accountsAuthFeature.beginAuthentication()
-            // TODO The sign-in web content populates session history,
-            // so pressing "back" after signing in won't take us back into the settings screen, but rather up the
-            // session history stack.
-            // We could auto-close this tab once we get to the end of the authentication process?
-            // Via an interceptor, perhaps.
-            view?.let {
-                (activity as HomeActivity).openToBrowser(BrowserDirection.FromSettings)
-            }
+            val directions = SettingsFragmentDirections.actionSettingsFragmentToSyncFragment()
+            Navigation.findNavController(view!!).navigate(directions)
             true
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/settings/TurnOnSyncFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/TurnOnSyncFragment.kt
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.settings
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.preference.Preference
+import androidx.preference.PreferenceFragmentCompat
+import org.mozilla.fenix.BrowserDirection
+import org.mozilla.fenix.HomeActivity
+import org.mozilla.fenix.R
+import org.mozilla.fenix.ext.getPreferenceKey
+import org.mozilla.fenix.ext.requireComponents
+
+class TurnOnSyncFragment : PreferenceFragmentCompat() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        (activity as AppCompatActivity).title = getString(R.string.preferences_sync)
+        (activity as AppCompatActivity).supportActionBar?.show()
+    }
+
+    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
+        setPreferencesFromResource(R.xml.turn_on_sync_preferences, rootKey)
+
+        val preferenceSignIn =
+            findPreference<Preference>(context!!.getPreferenceKey(R.string.pref_key_sync_sign_in))
+        val preferenceNewAccount =
+            findPreference<Preference>(context!!.getPreferenceKey(R.string.pref_key_sync_create_account))
+        preferenceSignIn?.onPreferenceClickListener = getClickListenerForSignIn()
+        preferenceNewAccount?.onPreferenceClickListener = getClickListenerForSignIn()
+    }
+
+    private fun getClickListenerForSignIn(): Preference.OnPreferenceClickListener {
+        return Preference.OnPreferenceClickListener {
+            requireComponents.services.accountsAuthFeature.beginAuthentication()
+            // TODO The sign-in web content populates session history,
+            // so pressing "back" after signing in won't take us back into the settings screen, but rather up the
+            // session history stack.
+            // We could auto-close this tab once we get to the end of the authentication process?
+            // Via an interceptor, perhaps.
+            view?.let {
+                (activity as HomeActivity).openToBrowser(BrowserDirection.FromSettings)
+            }
+            true
+        }
+    }
+}

--- a/app/src/main/res/drawable/ic_sign_in.xml
+++ b/app/src/main/res/drawable/ic_sign_in.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:pathData="M11.586,11l-1.293,-1.293a1,1 0,0 1,1.414 -1.414l3,3a1,1 0,0 1,0 1.414l-3,3a1,1 0,0 1,-1.414 -1.414L11.586,13H3a1,1 0,0 1,0 -2h8.586zM7,8a1,1 0,1 1,-2 0V6a4,4 0,0 1,4 -4h8a4,4 0,0 1,4 4v12a4,4 0,0 1,-4 4H9a4,4 0,0 1,-4 -4v-2a1,1 0,0 1,2 0v2a2,2 0,0 0,2 2h8a2,2 0,0 0,2 -2V6a2,2 0,0 0,-2 -2H9a2,2 0,0 0,-2 2v2z"
+        android:fillColor="?primaryText" />
+</vector>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -227,6 +227,9 @@
             android:id="@+id/action_settingsFragment_to_searchEngineFragment"
             app:destination="@id/searchEngineFragment" />
         <action
+            android:id="@+id/action_settingsFragment_to_syncFragment"
+            app:destination="@id/syncFragment" />
+        <action
             android:id="@+id/action_settingsFragment_to_aboutFragment"
             app:destination="@id/aboutFragment" />
         <action
@@ -260,6 +263,16 @@
         android:id="@+id/searchEngineFragment"
         android:name="org.mozilla.fenix.settings.SearchEngineFragment"
         android:label="SearchEngineFragment" />
+
+    <fragment
+        android:id="@+id/syncFragment"
+        android:name="org.mozilla.fenix.settings.TurnOnSyncFragment"
+        android:label="SyncFragment">
+        <action
+            android:id="@+id/action_settingsFragment_to_browserFragment"
+            app:destination="@id/browserFragment"
+            app:popUpTo="@+id/settingsFragment" />
+    </fragment>
 
     <fragment
         android:id="@+id/aboutFragment"

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -35,6 +35,8 @@
     <string name="pref_key_sync_bookmarks" translatable="false">pref_key_sync_bookmarks</string>
     <string name="pref_key_sign_out" translatable="false">pref_key_sign_out</string>
     <string name="pref_key_cached_account" translatable="false">pref_key_cached_account</string>
+    <string name="pref_key_sync_sign_in" translatable="false">pref_key_sync_sign_in</string>
+    <string name="pref_key_sync_create_account" translatable="false">pref_key_sync_create_account</string>
 
     <!-- Search Settings -->
     <string name="pref_key_show_search_suggestions" translatable="false">pref_key_show_search_suggestions</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -179,6 +179,14 @@
     <!-- Preference switch for app health report. The first parameter is the name of the application (For example: Fenix) -->
     <string name="preferences_fenix_health_report">%s health report</string>
 
+    <!-- Turn On Sync Preferences -->
+    <!-- Header of the Turn on Sync preference view -->
+    <string name="preferences_sync">Turn on Sync</string>
+    <!-- Preference for account login -->
+    <string name="preferences_sync_sign_in">Sign in</string>
+    <!-- Preference for account creation -->
+    <string name="preferences_sync_create_account">Create an account</string>
+
     <!-- Theme Preferences -->
     <!-- Preference for using light theme -->
     <string name="preference_light_theme">Light</string>

--- a/app/src/main/res/xml/turn_on_sync_preferences.xml
+++ b/app/src/main/res/xml/turn_on_sync_preferences.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<androidx.preference.PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <androidx.preference.Preference
+        android:key="@string/pref_key_sync_sign_in"
+        android:title="@string/preferences_sync_sign_in"
+        android:icon="@drawable/ic_sign_in" />
+    <androidx.preference.Preference
+        android:key="@string/pref_key_sync_create_account"
+        android:title="@string/preferences_sync_create_account"
+        android:icon="@drawable/ic_new" />
+</androidx.preference.PreferenceScreen>


### PR DESCRIPTION
UX: https://mozilla.invisionapp.com/share/QSR2F8UD4PN#/screens/357470308

@grigoryk this adds this screen: https://mozilla.invisionapp.com/share/QSR2F8UD4PN#/screens/357470308

We can land this first before the extra pairing button.

I need to figure out where to get the icons form @ryanfeeley 

![image](https://user-images.githubusercontent.com/128755/56479213-1c031180-6482-11e9-9e0c-a55784159231.png)



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
