### PR TITLE
Fixes #1886: Applies theme to toolbar onResume of library fragment

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/LibraryFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/LibraryFragment.kt
@@ -12,11 +12,13 @@ import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.Fragment
 import androidx.navigation.Navigation
 import kotlinx.android.synthetic.main.fragment_library.*
 import mozilla.appservices.places.BookmarkRoot
 import org.mozilla.fenix.R
+import org.mozilla.fenix.ext.getColorFromAttr
 import org.mozilla.fenix.library.bookmarks.BookmarkFragmentArgs
 
 class LibraryFragment : Fragment() {
@@ -36,6 +38,8 @@ class LibraryFragment : Fragment() {
 
     override fun onResume() {
         super.onResume()
+
+        setToolbarColor()
         (activity as AppCompatActivity).title = getString(R.string.library_title)
         (activity as AppCompatActivity).supportActionBar?.show()
     }
@@ -68,5 +72,11 @@ class LibraryFragment : Fragment() {
             }
             else -> super.onOptionsItemSelected(item)
         }
+    }
+
+    private fun setToolbarColor() {
+        val toolbar = (activity as AppCompatActivity).findViewById<Toolbar>(R.id.navigationToolbar)
+        toolbar.setBackgroundColor(R.attr.foundation.getColorFromAttr(context!!))
+        toolbar.setTitleTextColor(R.attr.primaryText.getColorFromAttr(context!!))
     }
 }


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
