### PR TITLE
No issue: Use GeckoView fetch implementation for A-S libs (megazord)

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -164,8 +164,7 @@ open class FenixApplication : Application() {
         return try {
             val megazordClass = Class.forName("mozilla.appservices.FenixMegazord")
             val megazordInitMethod = megazordClass.getDeclaredMethod("init", Lazy::class.java)
-            // https://github.com/mozilla-mobile/android-components/issues/2715
-            val client: Lazy<Client> = lazy { HttpURLConnectionClient() }
+            val client: Lazy<Client> = lazy { components.core.client }
             megazordInitMethod.invoke(megazordClass, client)
             true
         } catch (e: ClassNotFoundException) {


### PR DESCRIPTION
This should work now after https://github.com/mozilla-mobile/fenix/pull/1900 landed.

The underlying problem in GV described in https://github.com/mozilla-mobile/android-components/issues/2715 is fixed now.

cc @thomcc 