### PR TITLE
Fix for 2428 from a-c

### DIFF
--- a/app/src/main/res/layout/mozac_ui_tabcounter_layout.xml
+++ b/app/src/main/res/layout/mozac_ui_tabcounter_layout.xml
@@ -19,7 +19,7 @@
             android:id="@+id/counter_box"
             android:layout_width="24dp"
             android:layout_height="24dp"
-            android:contentDescription="@string/mozac_ui_tabcounter_description"
+            android:importantForAccessibility="no"
             android:src="@drawable/mozac_ui_tabcounter_box"/>
 
         <!-- This text size auto adjusts based on num digits in `TabCounter` -->


### PR DESCRIPTION
In 2428 from android-components, they removed part of
the tab layout XML for localization/usability and fenix
copied that file directly. Fenix needs to make the
equivalent change. This patch does that.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
