### PR TITLE
Fixes decision task issue preventing apks for raptor from being published

### DIFF
--- a/automation/taskcluster/lib/tasks.py
+++ b/automation/taskcluster/lib/tasks.py
@@ -332,12 +332,13 @@ class TaskBuilder(object):
         self, assemble_task_id, variant
     ):
         architecture, build_type = get_architecture_and_build_type_from_variant(variant)
+        build_type = convert_camel_case_into_kebab_case(build_type)
         routes = [
             'index.project.mobile.fenix.v2.branch.master.revision.{}.{}.{}'.format(
                 self.commit, build_type, architecture
             ),
-            'index.project.mobile.fenix.v2.branch.master.latest.{}.{}.{}'.format(
-                product, build_type, architecture
+            'index.project.mobile.fenix.v2.branch.master.latest.{}.{}'.format(
+                build_type, architecture
             ),
             'index.project.mobile.fenix.v2.branch.master.pushdate.{}.{}.{}.revision.{}.{}.{}'.format(
                 self.date.year, self.date.month, self.date.day, self.commit,
@@ -483,6 +484,7 @@ def get_architecture_and_build_type_from_variant(variant):
         )
 
     build_type = variant[len(architecture):]
+    build_type = lower_case_first_letter(build_type)
     return architecture, build_type
 
 


### PR DESCRIPTION
Due to the change to `get_architecture_and_...()`, `build_type` was being capitalized in a different way than expected.
This PR resolves this issue, as well as an index-formatting problem

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
