### PR TITLE
Closes #1902: Remove direct appservices dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -255,8 +255,6 @@ dependencies {
 
     implementation Deps.leanplum
 
-    implementation Deps.mozilla_places
-
     implementation Deps.mozilla_concept_engine
     implementation Deps.mozilla_concept_storage
     implementation Deps.mozilla_concept_toolbar

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -26,7 +26,6 @@ private object Versions {
 
     const val appservices_gradle_plugin = "0.4.4"
     const val mozilla_android_components = "0.51.0-SNAPSHOT"
-    const val mozilla_appservices = "0.26.0"
 
     const val autodispose = "1.1.0"
     const val adjust = "4.11.4"
@@ -102,8 +101,6 @@ object Deps {
     const val mozilla_feature_findinpage = "org.mozilla.components:feature-findinpage:${Versions.mozilla_android_components}"
     const val mozilla_feature_session_bundling = "org.mozilla.components:feature-session-bundling:${Versions.mozilla_android_components}"
     const val mozilla_feature_site_permissions = "org.mozilla.components:feature-sitepermissions:${Versions.mozilla_android_components}"
-
-    const val mozilla_places = "org.mozilla.appservices:places:${Versions.mozilla_appservices}"
 
     const val mozilla_service_firefox_accounts = "org.mozilla.components:service-firefox-accounts:${Versions.mozilla_android_components}"
     const val mozilla_service_fretboard = "org.mozilla.components:service-fretboard:${Versions.mozilla_android_components}"


### PR DESCRIPTION
Our big dependency - android-components - is tightly integrated
against a certain version of appservices. Having a direct dependency
at the Fenix level is a foot-gun: it allows Fenix to consume an API-incompatible
version of appservices, breaking parts of android-components. Due to
how gradle dependency resolution works, this breakage is "silent": there are
no compile time warnings. A recent example of this is broken history sync,
and buggy FxA experience in Fenix.

This patch removes a direct dependency, letting android-components dictate
which appservices version should be used Fenix builds.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
