### PR TITLE
glean: 1542709: Write dependencies out as an artifact.

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -155,7 +155,6 @@ tasks:
               - {$eval: 'default_task_definition'}
               - scopes:
                   - ${assume_scope_prefix}:branch:${short_head_branch}
-                  - ${assume_scope_prefix}:pull-request
                 payload:
                   command:
                     - >-

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -155,6 +155,7 @@ tasks:
               - {$eval: 'default_task_definition'}
               - scopes:
                   - ${assume_scope_prefix}:branch:${short_head_branch}
+                  - ${assume_scope_prefix}:pull-request
                 payload:
                   command:
                     - >-

--- a/automation/taskcluster/decision_task.py
+++ b/automation/taskcluster/decision_task.py
@@ -72,6 +72,8 @@ def pr_or_push(is_push):
         build_tasks[taskcluster.slugId()] = BUILDER.craft_test_task(variant)
 
     if is_push and SHORT_HEAD_BRANCH == 'master':
+        other_tasks[taskcluster.slugId()] = BUILDER.craft_dependencies_task()
+
         for variant in ('armRaptor', 'aarch64Raptor'):
             assemble_task_id = taskcluster.slugId()
             build_tasks[assemble_task_id] = BUILDER.craft_assemble_task(variant)
@@ -91,7 +93,6 @@ def pr_or_push(is_push):
         BUILDER.craft_ktlint_task,
         BUILDER.craft_lint_task,
         BUILDER.craft_compare_locales_task,
-        BUILDER.craft_dependencies_task,
     ):
         other_tasks[taskcluster.slugId()] = craft_function()
 

--- a/automation/taskcluster/decision_task.py
+++ b/automation/taskcluster/decision_task.py
@@ -91,6 +91,7 @@ def pr_or_push(is_push):
         BUILDER.craft_ktlint_task,
         BUILDER.craft_lint_task,
         BUILDER.craft_compare_locales_task,
+        BUILDER.craft_dependencies_task,
     ):
         other_tasks[taskcluster.slugId()] = craft_function()
 

--- a/automation/taskcluster/lib/tasks.py
+++ b/automation/taskcluster/lib/tasks.py
@@ -207,13 +207,14 @@ class TaskBuilder(object):
                 'symbol': 'dependencies',
                 'tier': 1,
             },
+            routes=['index.project.mobile.fenix.v2.branch.master.latest'],
             artifacts={
                 'public/dependencies.txt': {
                     "type": 'file',
                     "path": '/opt/fenix/dependencies.txt',
                     "expires": taskcluster.stringDate(taskcluster.fromNow(DEFAULT_EXPIRES_IN)),
                 }
-            }
+            },
         )
 
     def _craft_clean_gradle_task(

--- a/automation/taskcluster/lib/tasks.py
+++ b/automation/taskcluster/lib/tasks.py
@@ -207,7 +207,9 @@ class TaskBuilder(object):
                 'symbol': 'dependencies',
                 'tier': 1,
             },
-            routes=['index.project.mobile.fenix.v2.branch.master.latest'],
+            routes=[
+                'index.project.mobile.fenix.v2.branch.master.revision.{}'.format(self.commit)
+            ],
             artifacts={
                 'public/dependencies.txt': {
                     "type": 'file',

--- a/automation/taskcluster/lib/tasks.py
+++ b/automation/taskcluster/lib/tasks.py
@@ -190,6 +190,32 @@ class TaskBuilder(object):
             },
         )
 
+    def craft_dependencies_task(self):
+        # Output the dependencies to an artifact.  This is used by the
+        # telemetry probe scraper to determine all of the metrics that
+        # Fenix might send (both from itself and any of its dependent
+        # libraries that use Glean).
+        return self._craft_clean_gradle_task(
+            name='dependencies',
+            description='Write dependencies to a build artifact',
+            gradle_task='app:dependencies --configuration implementation > dependencies.txt',
+            treeherder={
+                'jobKind': 'test',
+                'machine': {
+                    'platform': 'lint',
+                },
+                'symbol': 'dependencies',
+                'tier': 1,
+            },
+            artifacts={
+                'public/dependencies.txt': {
+                    "type": 'file',
+                    "path": '/opt/fenix/dependencies.txt',
+                    "expires": taskcluster.stringDate(taskcluster.fromNow(DEFAULT_EXPIRES_IN)),
+                }
+            }
+        )
+
     def _craft_clean_gradle_task(
         self, name, description, gradle_task, artifacts=None, routes=None, treeherder=None
     ):


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1542709 for background.

The purpose of this PR is to support the [probe_scraper](https://github.com/mozilla/probe-scraper), which provides an index of all the metrics in a given product.  To find all of the metrics in Fenix, it needs to load its `metrics.yaml` file, but also the `metrics.yaml` file of Glean itself, as well as the `metrics.yaml` files defined in any dependencies of Glean.  To make it easier to walk the tree of dependencies, this PR creates an artifact with the output of `./gradlew app:dependencies` (basically having gradle do the tree walking for us), which `probe_scraper` will later look at and parse, and merge all of the `metrics.yaml` content together.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
