### PR TITLE
Closes #1414: Fixed site permissions settings getting reset in Android 6.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,4 +45,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - #1429 - Updated site permissions ui for MVP
 - #1599 - Fixed a crash creating a bookmark for a custom tab
+- #1414 - Fixed site permissions settings getting reset in Android 6.
 ### Removed

--- a/app/src/main/java/org/mozilla/fenix/settings/Extensions.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/Extensions.kt
@@ -6,10 +6,13 @@ package org.mozilla.fenix.settings
 
 import android.content.Context
 import android.view.View
+import android.widget.RadioButton
 import android.widget.TextView
+import androidx.core.content.ContextCompat
 import androidx.core.text.HtmlCompat
 import mozilla.components.feature.sitepermissions.SitePermissions
 import mozilla.components.feature.sitepermissions.SitePermissionsRules
+import org.mozilla.fenix.DefaultThemeManager
 import org.mozilla.fenix.R
 
 internal fun SitePermissionsRules.Action.toString(context: Context): String {
@@ -93,6 +96,19 @@ fun PhoneFeature.getPreferenceKey(context: Context): String {
         PhoneFeature.MICROPHONE -> context.getString(R.string.pref_key_phone_feature_microphone)
         PhoneFeature.NOTIFICATION -> context.getString(R.string.pref_key_phone_feature_notification)
     }
+}
+
+/* In devices with Android 6, when we use android:button="@null" android:drawableStart doesn't work via xml
+* as a result we have to apply it programmatically. More info about this issue https://github.com/mozilla-mobile/fenix/issues/1414
+*/
+fun RadioButton.setStartCheckedIndicator() {
+    val attr =
+        DefaultThemeManager.resolveAttribute(android.R.attr.listChoiceIndicatorSingle, context)
+    val buttonDrawable = ContextCompat.getDrawable(context, attr)
+    buttonDrawable.apply {
+        this?.setBounds(0, 0, this.intrinsicWidth, this.intrinsicHeight)
+    }
+    this.setCompoundDrawables(buttonDrawable, null, null, null)
 }
 
 fun initBlockedByAndroidView(phoneFeature: PhoneFeature, blockedByAndroidView: View) {

--- a/app/src/main/java/org/mozilla/fenix/settings/SitePermissionsManageExceptionsPhoneFeatureFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SitePermissionsManageExceptionsPhoneFeatureFragment.kt
@@ -99,6 +99,7 @@ class SitePermissionsManageExceptionsPhoneFeatureFragment : Fragment(), Coroutin
     private fun RadioButton.restoreState(status: SitePermissions.Status) {
         if (phoneFeature.getStatus(sitePermissions) == status) {
             this.isChecked = true
+            this.setStartCheckedIndicator()
         }
     }
 

--- a/app/src/main/java/org/mozilla/fenix/settings/SitePermissionsManagePhoneFeatureFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SitePermissionsManagePhoneFeatureFragment.kt
@@ -94,6 +94,7 @@ class SitePermissionsManagePhoneFeatureFragment : Fragment() {
     private fun RadioButton.restoreState(action: SitePermissionsRules.Action) {
         if (phoneFeature.action == action) {
             this.isChecked = true
+            this.setStartCheckedIndicator()
         }
     }
 


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
