### PR TITLE
Release raptor rename

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,9 +48,9 @@ android {
             applicationIdSuffix ".debug"
             manifestPlaceholders.isRaptorEnabled = "true"
         }
-        // "releaseRaptor" is only used for performance testing, and isn't a real "release" type
-        releaseRaptor releaseTemplate >> { // the ">>" concatenates the releaseRaptor-specific options with the template
+        raptor releaseTemplate >> { // the ">>" concatenates the raptor-specific options with the template
             manifestPlaceholders.isRaptorEnabled = "true"
+            applicationIdSuffix ".raptor"
         }
         nightly releaseTemplate >> {
             buildConfigField "boolean", "IS_RELEASED", "true"

--- a/automation/taskcluster/decision_task.py
+++ b/automation/taskcluster/decision_task.py
@@ -72,12 +72,12 @@ def pr_or_push(is_push):
         # autophone only supports arm and aarch64, so only sign/perftest those builds
         if (
             is_push and
-            build_type == 'releaseRaptor' and
+            build_type == 'raptor' and
             architecture in ('arm', 'aarch64') and
             SHORT_HEAD_BRANCH == 'master'
         ):
             signing_task_id = taskcluster.slugId()
-            signing_tasks[signing_task_id] = BUILDER.craft_master_commit_signing_task(assemble_task_id, variant)
+            signing_tasks[signing_task_id] = BUILDER.craft_raptor_signing_task(assemble_task_id, variant)
 
             ALL_RAPTOR_CRAFT_FUNCTIONS = [
                 BUILDER.craft_raptor_tp6m_cold_task(for_suite=i)

--- a/automation/taskcluster/lib/tasks.py
+++ b/automation/taskcluster/lib/tasks.py
@@ -341,29 +341,31 @@ class TaskBuilder(object):
             },
         }
 
-    def craft_master_commit_signing_task(
+    def craft_raptor_signing_task(
         self, assemble_task_id, variant
     ):
-        architecture, build_type = get_architecture_and_build_type_from_variant(variant)
-        build_type = convert_camel_case_into_kebab_case(build_type)
-
+        architecture, _ = get_architecture_and_build_type_from_variant(variant)
         routes = []
         if self.repo_url == _OFFICIAL_REPO_URL:
-            routes = [
-                'index.project.mobile.fenix.v2.branch.master.revision.{}.{}.{}'.format(
-                    self.commit, build_type, architecture
-                ),
-                'index.project.mobile.fenix.v2.branch.master.latest.{}.{}'.format(
-                    build_type, architecture
-                ),
-                'index.project.mobile.fenix.v2.branch.master.pushdate.{}.{}.{}.revision.{}.{}.{}'.format(
-                    self.date.year, self.date.month, self.date.day, self.commit,
-                    build_type, architecture
-                ),
-                'index.project.mobile.fenix.v2.branch.master.pushdate.{}.{}.{}.latest.{}.{}'.format(
-                    self.date.year, self.date.month, self.date.day, build_type, architecture
-                ),
-            ]
+            def routes_from_build_type(build_type):
+                return [
+                    'index.project.mobile.fenix.v2.branch.master.revision.{}.{}.{}'.format(
+                        self.commit, build_type, architecture
+                    ),
+                    'index.project.mobile.fenix.v2.branch.master.latest.{}.{}'.format(
+                        build_type, architecture
+                    ),
+                    'index.project.mobile.fenix.v2.branch.master.pushdate.{}.{}.{}.revision.{}.{}.{}'.format(
+                        self.date.year, self.date.month, self.date.day, self.commit,
+                        build_type, architecture
+                    ),
+                    'index.project.mobile.fenix.v2.branch.master.pushdate.{}.{}.{}.latest.{}.{}'.format(
+                        self.date.year, self.date.month, self.date.day, build_type, architecture
+                    ),
+                ]
+
+            # For backwards-compat for the perf-testing team, we'll still create routes with the "release-raptor" value
+            routes = routes_from_build_type('raptor') + routes_from_build_type('release-raptor')
 
         return self._craft_signing_task(
             name='sign: {}'.format(variant),
@@ -525,7 +527,7 @@ class TaskBuilder(object):
                     "--test-packages-url={}/{}/artifacts/public/build/target.test_packages.json".format(_DEFAULT_TASK_URL, mozharness_task_id),
                     "--test={}".format(test_name),
                     "--app=fenix",
-                    "--binary=org.mozilla.fenix",
+                    "--binary=org.mozilla.fenix.raptor",
                     "--activity=GeckoViewActivity",
                     "--download-symbols=ondemand"
                 ] + extra_test_args,


### PR DESCRIPTION
Note: this changes:
* The `gradle` command from `./gradlew assembleReleaseRaptor` to `./gradlew assembleRaptor`
* The application ID changes from `org.mozilla.fenix` to `org.mozilla.fenix.raptor` (note: `--binary` is updated as part of this PR to use the new ID)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
