### PR TITLE
Fixes 1689 - Custom tabs menus now reference sessions via sessionId.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -36,6 +36,7 @@ import mozilla.components.browser.session.SessionManager
 import mozilla.components.feature.contextmenu.ContextMenuCandidate
 import mozilla.components.feature.contextmenu.ContextMenuFeature
 import mozilla.components.feature.downloads.DownloadsFeature
+import mozilla.components.feature.intent.IntentProcessor
 import mozilla.components.feature.prompts.PromptFeature
 import mozilla.components.feature.session.FullScreenFeature
 import mozilla.components.feature.session.SessionFeature
@@ -115,7 +116,7 @@ class BrowserFragment : Fragment(), BackHandler, CoroutineScope,
         savedInstanceState: Bundle?
     ): View? {
         require(arguments != null)
-        customTabSessionId = BrowserFragmentArgs.fromBundle(arguments!!).customTabSessionId
+        customTabSessionId = arguments?.getString(IntentProcessor.ACTIVE_SESSION_ID)
 
         val view = inflater.inflate(R.layout.fragment_browser, container, false)
 
@@ -509,10 +510,10 @@ class BrowserFragment : Fragment(), BackHandler, CoroutineScope,
     private fun handleToolbarItemInteraction(action: SearchAction.ToolbarMenuItemTapped) {
         val sessionUseCases = requireComponents.useCases.sessionUseCases
         Do exhaustive when (action.item) {
-            ToolbarMenu.Item.Back -> sessionUseCases.goBack.invoke()
-            ToolbarMenu.Item.Forward -> sessionUseCases.goForward.invoke()
-            ToolbarMenu.Item.Reload -> sessionUseCases.reload.invoke()
-            ToolbarMenu.Item.Stop -> sessionUseCases.stopLoading.invoke()
+            ToolbarMenu.Item.Back -> sessionUseCases.goBack.invoke(getSessionById())
+            ToolbarMenu.Item.Forward -> sessionUseCases.goForward.invoke(getSessionById())
+            ToolbarMenu.Item.Reload -> sessionUseCases.reload.invoke(getSessionById())
+            ToolbarMenu.Item.Stop -> sessionUseCases.stopLoading.invoke(getSessionById())
             ToolbarMenu.Item.Settings -> Navigation.findNavController(toolbarComponent.getView())
                 .navigate(BrowserFragmentDirections.actionBrowserFragmentToSettingsFragment())
             ToolbarMenu.Item.Library -> Navigation.findNavController(toolbarComponent.getView())

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarUIView.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarUIView.kt
@@ -43,8 +43,9 @@ class ToolbarUIView(
         .inflate(R.layout.layout_url_background, container, false)
 
     init {
-        val session = sessionId?.let { view.context.components.core.sessionManager.findSessionById(sessionId) }
-            ?: view.context.components.core.sessionManager.selectedSession
+        val sessionManager = view.context.components.core.sessionManager
+        val session = sessionId?.let { sessionManager.findSessionById(it) }
+                ?: sessionManager.selectedSession
 
         view.apply {
             setOnUrlCommitListener {
@@ -88,7 +89,10 @@ class ToolbarUIView(
             val isCustom = session?.isCustomTabSession() ?: false
 
             val menuToolbar = if (isCustom) {
-                CustomTabToolbarMenu(this,
+                CustomTabToolbarMenu(
+                    this,
+                    sessionManager,
+                    sessionId,
                     onItemTapped = { actionEmitter.onNext(SearchAction.ToolbarMenuItemTapped(it)) }
                 )
             } else {

--- a/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabToolbarMenu.kt
@@ -10,6 +10,8 @@ import mozilla.components.browser.menu.item.BrowserMenuDivider
 import mozilla.components.browser.menu.item.BrowserMenuImageText
 import mozilla.components.browser.menu.item.BrowserMenuItemToolbar
 import mozilla.components.browser.menu.item.SimpleBrowserMenuItem
+import mozilla.components.browser.session.Session
+import mozilla.components.browser.session.SessionManager
 import org.mozilla.fenix.DefaultThemeManager
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.toolbar.ToolbarMenu
@@ -17,9 +19,14 @@ import org.mozilla.fenix.ext.components
 
 class CustomTabToolbarMenu(
     private val context: Context,
+    private val sessionManager: SessionManager,
+    private val sessionId: String?,
     private val onItemTapped: (ToolbarMenu.Item) -> Unit = {}
 ) : ToolbarMenu {
     override val menuBuilder by lazy { BrowserMenuBuilder(menuItems) }
+
+    private val session: Session?
+        get() = sessionId?.let { sessionManager.findSessionById(it) }
 
     override val menuToolbar by lazy {
         val back = BrowserMenuItemToolbar.TwoStateButton(
@@ -30,7 +37,7 @@ class CustomTabToolbarMenu(
                 context
             ),
             isInPrimaryState = {
-                context.components.core.sessionManager.selectedSession?.canGoBack ?: true
+                session?.canGoBack ?: true
             },
             secondaryImageTintResource = DefaultThemeManager.resolveAttribute(
                 R.attr.neutral,
@@ -49,7 +56,7 @@ class CustomTabToolbarMenu(
                 context
             ),
             isInPrimaryState = {
-                context.components.core.sessionManager.selectedSession?.canGoForward ?: true
+                session?.canGoForward ?: true
             },
             secondaryImageTintResource = DefaultThemeManager.resolveAttribute(
                 R.attr.neutral,
@@ -68,7 +75,7 @@ class CustomTabToolbarMenu(
                 context
             ),
             isInPrimaryState = {
-                val loading = context.components.core.sessionManager.selectedSession?.loading
+                val loading = session?.loading
                 loading == false
             },
             secondaryImageResource = mozilla.components.ui.icons.R.drawable.mozac_ic_stop,
@@ -79,7 +86,7 @@ class CustomTabToolbarMenu(
             ),
             disableInSecondaryState = false
         ) {
-            if (context.components.core.sessionManager.selectedSession?.loading == true) {
+            if (session?.loading == true) {
                 onItemTapped.invoke(ToolbarMenu.Item.Stop)
             } else {
                 onItemTapped.invoke(ToolbarMenu.Item.Reload)

--- a/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabsIntegration.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabsIntegration.kt
@@ -25,6 +25,8 @@ class CustomTabsIntegration(
     private val customTabToolbarMenu by lazy {
         CustomTabToolbarMenu(
             context,
+            sessionManager,
+            sessionId,
             onItemTapped = onItemTapped
         )
     }

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -104,7 +104,7 @@
             android:id="@+id/action_browserFragment_to_searchFragment"
             app:destination="@id/searchFragment" />
         <argument
-            android:name="custom_tab_session_id"
+            android:name="activeSessionId"
             app:argType="string"
             app:nullable="true" />
         <action


### PR DESCRIPTION
Fixes #1689.

This PR ensures that custom tabs menus that require the opened (not active) session can do so. This means that forward, back and refresh/stop work and are sensitive to the state of the session.

It also fixes a mismatch between the Android Components `IntentProcessor` and fenix's `BrowserFragment` to send the correct `sessionId`.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
