### PR TITLE
Upgrade to A-C 0.52.0-SNAPSHOT, GV 68.0.20190429095544 and Kotlin 1.3.30

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 private object Versions {
-    const val kotlin = "1.3.21"
+    const val kotlin = "1.3.30"
     const val coroutines = "1.2.0-alpha-2"
     const val android_gradle_plugin = "3.3.2"
     const val rxAndroid = "2.1.0"
@@ -25,7 +25,7 @@ private object Versions {
     const val androidx_recyclerview = "1.1.0-alpha04"
 
     const val appservices_gradle_plugin = "0.4.4"
-    const val mozilla_android_components = "0.51.0-SNAPSHOT"
+    const val mozilla_android_components = "0.52.0-SNAPSHOT"
 
     const val autodispose = "1.1.0"
     const val adjust = "4.11.4"

--- a/buildSrc/src/main/java/Gecko.kt
+++ b/buildSrc/src/main/java/Gecko.kt
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object GeckoVersions {
-    const val nightly_version = "68.0.20190422094240"
+    const val nightly_version = "68.0.20190429095544"
     const val beta_version = "67.0.20190415085659"
     const val release_version = "66.0.20190322021635"
 }


### PR DESCRIPTION
Sending along some upgrades for the latest A-C snapshots. We are working on reader view integration which needs the latest. ⏫ ⏫ 