### PR TITLE
For #2277 - Clean up threading for session control with undo

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/ext/CoroutineScope.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/CoroutineScope.kt
@@ -6,7 +6,6 @@ package org.mozilla.fenix.ext
 
 import android.view.View
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.Dispatchers.Main
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -19,7 +18,7 @@ fun CoroutineScope.allowUndo(
     onCancel: suspend () -> Unit = {},
     operation: suspend () -> Unit
 ) {
-    val undoJob = launch(IO) {
+    val undoJob = launch(Main) {
         delay(UNDO_DELAY)
         operation.invoke()
     }


### PR DESCRIPTION
This will fix weird behavior when deleting multiple tabs. Do you have an idea for a fragment lifecycle that I should also call the pending delete job? I tried in onStop but it doesn't seem to help the case of 
1. Delete Tab
2. Navigate to Settings 
3. Press Back

The deleted tab appears and then deletes when the timeout occurs

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
