### PR TITLE
Update the deprecated BitmapDrawable constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - #975 - Added telemetry for preference switches
 - #1955 - Added a confirmation dialog for QR code and barcode searches
 - #1874 - Added a "Turn on Sync" fragment for Firefox Accounts login and sign up
+- #2308 - Update the deprecated BitmapDrawable constructor
 
 ### Changed
 - #1429 - Updated site permissions ui for MVP

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarUIView.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarUIView.kt
@@ -153,7 +153,7 @@ class ToolbarUIView(
         with(view.context) {
             val defaultEngineIcon = components.search.searchEngineManager.defaultSearchEngine?.icon
             val searchIcon = newState.engine?.icon ?: defaultEngineIcon
-            val draw = BitmapDrawable(searchIcon)
+            val draw = BitmapDrawable(resources, searchIcon)
             val iconSize =
                 containerView?.context!!.resources.getDimension(R.dimen.preference_icon_drawable_size).toInt()
             draw.setBounds(0, 0, iconSize, iconSize)


### PR DESCRIPTION
Fixes this 
![image](https://user-images.githubusercontent.com/128755/57255451-c30ab000-7021-11e9-94b2-b6733f4f9a4e.png)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
