### PR TITLE
Run raptor nightly instead of per-commit

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -123,99 +123,128 @@ tasks:
             owner: ${user}@users.noreply.github.com
             source: ${repository}/raw/${head_rev}/.taskcluster.yml
       in:
-        - $if: 'tasks_for == "github-pull-request" && event["action"] in ["opened", "reopened", "synchronize"]'
-          then:
-            $let:
-              pull_request_title: ${event.pull_request.title}
-              pull_request_number: ${event.pull_request.number}
-              pull_request_url: ${event.pull_request.html_url}
-            in:
+        $flatten:
+          - $if: 'tasks_for == "github-pull-request" && event["action"] in ["opened", "reopened", "synchronize"]'
+            then:
+              $let:
+                pull_request_title: ${event.pull_request.title}
+                pull_request_number: ${event.pull_request.number}
+                pull_request_url: ${event.pull_request.html_url}
+              in:
+                $mergeDeep:
+                  - {$eval: 'default_task_definition'}
+                  - scopes:
+                      - ${assume_scope_prefix}:pull-request
+                    payload:
+                      command:
+                        - >-
+                          git fetch ${repository} ${head_branch}
+                          && git config advice.detachedHead false
+                          && git checkout FETCH_HEAD
+                          && python automation/taskcluster/decision_task.py pull-request
+                      env:
+                        GITHUB_PULL_TITLE: ${pull_request_title}
+                    extra:
+                      treeherder:
+                        symbol: D-PR
+                    metadata:
+                      name: 'Fenix - Decision task (Pull Request #${pull_request_number})'
+                      description: 'Building and testing the Fenix - triggered by [#${pull_request_number}](${pull_request_url})'
+          - $if: 'tasks_for == "github-push" && head_branch[:10] != "refs/tags/"'
+            then:
               $mergeDeep:
                 - {$eval: 'default_task_definition'}
                 - scopes:
-                    - ${assume_scope_prefix}:pull-request
+                    - ${assume_scope_prefix}:branch:${short_head_branch}
                   payload:
                     command:
                       - >-
                         git fetch ${repository} ${head_branch}
                         && git config advice.detachedHead false
                         && git checkout FETCH_HEAD
-                        && python automation/taskcluster/decision_task.py pull-request
-                    env:
-                      GITHUB_PULL_TITLE: ${pull_request_title}
+                        && python automation/taskcluster/decision_task.py push
                   extra:
                     treeherder:
-                      symbol: D-PR
+                      symbol: D
                   metadata:
-                    name: 'Fenix - Decision task (Pull Request #${pull_request_number})'
-                    description: 'Building and testing the Fenix - triggered by [#${pull_request_number}](${pull_request_url})'
-        - $if: 'tasks_for == "github-push" && head_branch[:10] != "refs/tags/"'
-          then:
-            $mergeDeep:
-              - {$eval: 'default_task_definition'}
-              - scopes:
-                  - ${assume_scope_prefix}:branch:${short_head_branch}
-                payload:
-                  command:
-                    - >-
-                      git fetch ${repository} ${head_branch}
-                      && git config advice.detachedHead false
-                      && git checkout FETCH_HEAD
-                      && python automation/taskcluster/decision_task.py push
-                extra:
-                  treeherder:
-                    symbol: D
-                metadata:
-                  name: Fenix - Decision task
-                  description: Schedules the build and test tasks for Fenix.
-        - $if: 'tasks_for == "github-release" && event["action"] == "published"'
-          then:
-            $mergeDeep:
-              - {$eval: 'default_task_definition'}
-              - scopes:
-                - ${assume_scope_prefix}:release
-                payload:
-                  command:
-                    - >-
-                      git fetch ${repository} refs/tags/${head_rev}
-                      && git config advice.detachedHead false
-                      && git checkout FETCH_HEAD
-                      && python automation/taskcluster/decision_task.py beta ${event.release.tag_name}
-                extra:
-                  treeherder:
-                    symbol: beta-D
-                metadata:
-                  name: Fenix Beta Decision Task
-                  description: Building and releasing Fenix to the beta channel - triggered by release ${event.release.tag_name}
-        - $if: 'tasks_for == "cron"'
-          then:
-            $mergeDeep:
-              - {$eval: 'default_task_definition'}
-              - scopes:
-                  - $if: 'trust_level == 3'
-                    then: assume:hook-id:project-mobile/fenix-nightly
-                    else: assume:hook-id:project-mobile/fenix-nightly-staging
-                routes:
-                  $if: 'trust_level == 3'
-                  then:
-                    - notify.email.fenix-eng-notifications@mozilla.com.on-failed
-                payload:
-                  $let:
-                    staging_flag:
-                      $if: 'trust_level == 3'
-                      then: ''
-                      else: '--staging'
-                  in:
+                    name: Fenix VCS-Push Decision task
+                    description: Schedules the build and test tasks for Fenix.
+          - $if: 'tasks_for == "github-release" && event["action"] == "published"'
+            then:
+              $mergeDeep:
+                - {$eval: 'default_task_definition'}
+                - scopes:
+                  - ${assume_scope_prefix}:release
+                  payload:
                     command:
                       - >-
-                        git fetch ${repository} ${head_branch}
+                        git fetch ${repository} refs/tags/${head_rev}
                         && git config advice.detachedHead false
                         && git checkout FETCH_HEAD
-                        && python automation/taskcluster/decision_task.py nightly ${staging_flag}
-                extra:
-                  cron: {$json: {$eval: 'cron'}}
-                  treeherder:
-                    symbol: nightly-D
-                metadata:
-                  name: Fenix Nightly Decision Task
-                  description: Decision task scheduled by cron task [${cron.task_id}](https://tools.taskcluster.net/tasks/${cron.task_id})
+                        && python automation/taskcluster/decision_task.py beta ${event.release.tag_name}
+                  extra:
+                    treeherder:
+                      symbol: beta-D
+                  metadata:
+                    name: Fenix Beta Decision Task
+                    description: Building and releasing Fenix to the beta channel - triggered by release ${event.release.tag_name}
+          - $if: 'tasks_for == "cron"'
+            then:
+              $let:
+                staging_flag:
+                  $if: 'trust_level == 3'
+                  then: ''
+                  else: '--staging'
+              in:
+              - $if: 'cron.name == "nightly"'
+                then:
+                  $mergeDeep:
+                    - {$eval: 'default_task_definition'}
+                    - scopes:
+                        - $if: 'trust_level == 3'
+                          then: assume:hook-id:project-mobile/fenix-nightly
+                          else: assume:hook-id:project-mobile/fenix-nightly-staging
+                      routes:
+                        $if: 'trust_level == 3'
+                        then:
+                          - notify.email.fenix-eng-notifications@mozilla.com.on-failed
+                      payload:
+                        command:
+                          - >-
+                            git fetch ${repository} ${head_branch}
+                            && git config advice.detachedHead false
+                            && git checkout FETCH_HEAD
+                            && python automation/taskcluster/decision_task.py nightly ${staging_flag}
+                      extra:
+                        cron: {$json: {$eval: 'cron'}}
+                        treeherder:
+                          symbol: nightly-D
+                      metadata:
+                        name: Fenix Nightly Decision Task
+                        description: Decision task scheduled by cron task [${cron.task_id}](https://tools.taskcluster.net/tasks/${cron.task_id})
+              - $if: 'cron.name == "raptor"'
+                then:
+                  $mergeDeep:
+                    - {$eval: 'default_task_definition'}
+                    - scopes:
+                        - $if: 'trust_level == 3'
+                          then: assume:hook-id:project-mobile/fenix-raptor
+                          else: assume:hook-id:project-mobile/fenix-raptor-staging
+                      routes:
+                        $if: 'trust_level == 3'
+                        then:
+                          - notify.email.fenix-eng-notifications@mozilla.com.on-failed
+                      payload:
+                        command:
+                          - >-
+                            git fetch ${repository} ${head_branch}
+                            && git config advice.detachedHead false
+                            && git checkout FETCH_HEAD
+                            && python automation/taskcluster/decision_task.py raptor ${staging_flag}
+                      extra:
+                        cron: {$json: {$eval: 'cron'}}
+                        treeherder:
+                          symbol: raptor-D
+                      metadata:
+                        name: Fenix Raptor Decision Task
+                        description: Decision task scheduled by cron task [${cron.task_id}](https://tools.taskcluster.net/tasks/${cron.task_id})

--- a/automation/taskcluster/lib/tasks.py
+++ b/automation/taskcluster/lib/tasks.py
@@ -375,24 +375,18 @@ class TaskBuilder(object):
         }
 
     def craft_raptor_signing_task(
-        self, assemble_task_id, variant
+        self, assemble_task_id, variant, is_staging,
     ):
-        routes = []
-        if self.repo_url == _OFFICIAL_REPO_URL:
-            routes = [
-                'index.project.mobile.fenix.v2.branch.master.revision.{}.raptor.{}'.format(
-                    self.commit, variant.abi
-                ),
-                'index.project.mobile.fenix.v2.branch.master.latest.raptor.{}'.format(
-                    variant.abi
-                ),
-                'index.project.mobile.fenix.v2.branch.master.pushdate.{}.{}.{}.revision.{}.raptor.{}'.format(
-                    self.date.year, self.date.month, self.date.day, self.commit, variant.abi
-                ),
-                'index.project.mobile.fenix.v2.branch.master.pushdate.{}.{}.{}.latest.raptor.{}'.format(
-                    self.date.year, self.date.month, self.date.day, variant.abi
-                ),
-            ]
+        staging_prefix = '.staging' if is_staging else ''
+        routes = [
+            "index.project.mobile.fenix.v2{}.raptor.{}.{}.{}.latest.{}".format(
+                staging_prefix, self.date.year, self.date.month, self.date.day, variant.abi
+            ),
+            "index.project.mobile.fenix.v2{}.raptor.{}.{}.{}.revision.{}.{}".format(
+                staging_prefix, self.date.year, self.date.month, self.date.day, self.commit, variant.abi
+            ),
+            "index.project.mobile.fenix.v2{}.raptor.latest.{}".format(staging_prefix, variant.abi),
+        ]
 
         return self._craft_signing_task(
             name='sign: {}'.format(variant.raw),
@@ -413,19 +407,19 @@ class TaskBuilder(object):
         )
 
     def craft_release_signing_task(
-        self, build_task_id, apk_paths, track, is_staging=False,
+        self, build_task_id, apk_paths, track, is_staging,
     ):
         capitalized_track = upper_case_first_letter(track)
-        index_release = 'staging.{}'.format(track) if is_staging else track
+        staging_prefix = '.staging' if is_staging else ''
 
         routes = [
-            "index.project.mobile.fenix.v2.{}.{}.{}.{}.latest".format(
-                index_release, self.date.year, self.date.month, self.date.day
+            "index.project.mobile.fenix.v2{}.{}.{}.{}.{}.latest".format(
+                staging_prefix, track, self.date.year, self.date.month, self.date.day
             ),
-            "index.project.mobile.fenix.v2.{}.{}.{}.{}.revision.{}".format(
-                index_release, self.date.year, self.date.month, self.date.day, self.commit
+            "index.project.mobile.fenix.v2{}.{}.{}.{}.{}.revision.{}".format(
+                staging_prefix, track, self.date.year, self.date.month, self.date.day, self.commit
             ),
-            "index.project.mobile.fenix.v2.{}.latest".format(index_release),
+            "index.project.mobile.fenix.v2{}.{}.latest".format(staging_prefix, track),
         ]
 
         return self._craft_signing_task(


### PR DESCRIPTION
Fixes #2218
Ping @tomprince, @escapewindow for review, since this adds new values into the taskcluster context (`cron.name`).

We now have two different cron jobs that use hooks to perform the jobs on a schedule:
* Daily: release Fenix nightly
* Daily (may change in the future): run raptor performance tests

This modifies automation to allow raptor jobs to be scheduled independently, while also adding logic to handle multiple different hooks scheduling different graphs

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
- [x] [This task group must be green](https://taskcluster-ui.herokuapp.com/tasks/groups/SJhN6lzxRAGOPr4SKw697w)
- [x] Johan has approved the PR

### After Merge checklist
- [ ] Update Fenix Nightly hooks to add `nightly` argument when calling `schedule_nightly_graph.py`
- [ ] Run `fenix-raptor` hook, enable cron schedule