### PR TITLE
Upgrade to GV 68.0.20190508111321 and fixes for latest A-C 0.52.0

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/BackgroundServices.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/BackgroundServices.kt
@@ -10,10 +10,12 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import mozilla.components.browser.storage.sync.PlacesBookmarksStorage
 import mozilla.components.browser.storage.sync.PlacesHistoryStorage
+import mozilla.components.concept.sync.DeviceType
 import mozilla.components.feature.sync.BackgroundSyncManager
 import mozilla.components.feature.sync.GlobalSyncableStoreProvider
 import mozilla.components.service.fxa.Config
-import mozilla.components.service.fxa.FxaAccountManager
+import mozilla.components.service.fxa.manager.DeviceTuple
+import mozilla.components.service.fxa.manager.FxaAccountManager
 import org.mozilla.fenix.test.Mockable
 
 /**
@@ -49,7 +51,13 @@ class BackgroundServices(
         it.addStore("bookmarks")
     }
 
-    val accountManager = FxaAccountManager(context, config, scopes, syncManager).also {
+    val accountManager = FxaAccountManager(
+        context,
+        config,
+        scopes,
+        DeviceTuple("Fenix", DeviceType.MOBILE, emptyList()),
+        syncManager
+    ).also {
         CoroutineScope(Dispatchers.Main).launch { it.initAsync().await() }
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/components/Services.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Services.kt
@@ -6,7 +6,7 @@ package org.mozilla.fenix.components
 
 import mozilla.components.feature.accounts.FirefoxAccountsAuthFeature
 import mozilla.components.feature.tabs.TabsUseCases
-import mozilla.components.service.fxa.FxaAccountManager
+import mozilla.components.service.fxa.manager.FxaAccountManager
 import org.mozilla.fenix.test.Mockable
 
 /**

--- a/buildSrc/src/main/java/Gecko.kt
+++ b/buildSrc/src/main/java/Gecko.kt
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object GeckoVersions {
-    const val nightly_version = "68.0.20190503041749"
+    const val nightly_version = "68.0.20190508111321"
     const val beta_version = "67.0.20190430135507"
     const val release_version = "66.0.20190322021635"
 }


### PR DESCRIPTION
Closes #2342, Closes #2297

A-C has upgraded GV to 68.0.20190508111321 which fixes a few crashes that were introduced last week. Latest A-C also needs a minor API change, which is included here.
