### PR TITLE
Configures pushapk to verify beta APK with beta certificate

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -45,7 +45,7 @@ tasks:
 
     trust_level:
       # Pull requests on main repository can't be trusted because anybody can open a PR on it, without a review
-      $if: 'tasks_for in ["github-push", "github-release", "cron"] && event.repository.html_url == "https://github.com/mozilla-mobile/fenix"'
+      $if: 'tasks_for in ["github-push", "github-release", "cron"] && event.repository.html_url == "https://github.com/mitchhentges/fenix"'
       then: 3
       else: 1
   in:

--- a/automation/taskcluster/lib/tasks.py
+++ b/automation/taskcluster/lib/tasks.py
@@ -423,6 +423,7 @@ class TaskBuilder(object):
         payload = {
             "commit": True,
             "google_play_track": track,
+            "certificate_alias": 'fenix' if is_staging else 'fenix-{}'.format(track),
             "upstreamArtifacts": [
                 {
                     "paths": apks,


### PR DESCRIPTION
Is required for Fenix beta to be pushed to the Google Play Store.
Requires [this PR](https://github.com/mozilla-releng/build-puppet/pull/472)


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
