### PR TITLE
Closes #1743: Align Scan and Shortcut buttons with search logo.

### DIFF
--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -66,7 +66,7 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        android:paddingStart="16dp"
+        android:paddingStart="20dp"
         android:paddingEnd="16dp"
         android:paddingTop="4dp"
         android:paddingBottom="4dp"


### PR DESCRIPTION
(I wasn't sure whether to add "Closes #1743" here or not, since this is only a partial fix, the rest of it being in mozilla-mobile/android-components#2953…)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
  No code changes, but I ran `detekt` anyway, and it passed. 🙂
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
  Padding-only change, which I don't _think_ we test? I'm happy to fix the test if it fails!
- [X] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
  Polish change, so I don't think it needs a changelog entry.
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
  No accessibility features were changed.