### PR TITLE
Passes gradle variants without parsing

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -392,10 +392,13 @@ if (project.hasProperty("raptor")) {
 // -------------------------------------------------------------------------------------------------
 task printBuildVariants {
     doLast {
-        def buildVariants = android.applicationVariants.collect { variant ->
-            variant.name
-        }
-        println "variants: " + groovy.json.JsonOutput.toJson(buildVariants)
+        def variantData = android.applicationVariants.collect { variant -> [
+            name: variant.name,
+            buildType: variant.buildType.name,
+            abi: variant.productFlavors.find { it.dimension == 'abi' }.name,
+            isSigned: variant.signingReady,
+        ]}
+        println "variants: " + groovy.json.JsonOutput.toJson(variantData)
     }
 }
 

--- a/automation/taskcluster/lib/gradle.py
+++ b/automation/taskcluster/lib/gradle.py
@@ -6,8 +6,10 @@ from __future__ import print_function
 import json
 import subprocess
 
+from lib.variant import Variant
 
-def get_build_variants():
+
+def get_debug_variants():
     print("Fetching build variants from gradle")
     output = _run_gradle_process('printBuildVariants')
     content = _extract_content_from_command_output(output, prefix='variants: ')
@@ -16,9 +18,10 @@ def get_build_variants():
     if len(variants) == 0:
         raise ValueError("Could not get build variants from gradle")
 
-    print("Got variants: {}".format(' '.join(variants)))
-
-    return variants
+    print("Got variants: {}".format(variants))
+    return [Variant(variant_dict['name'], variant_dict['abi'], variant_dict['isSigned'], variant_dict['buildType'])
+            for variant_dict in variants
+            if variant_dict['buildType'] == 'debug']
 
 
 def get_geckoview_versions():

--- a/automation/taskcluster/lib/variant.py
+++ b/automation/taskcluster/lib/variant.py
@@ -1,0 +1,20 @@
+class Variant:
+    def __init__(self, raw, abi, is_signed, build_type):
+        self.raw = raw
+        self.abi = abi
+        self.build_type = build_type
+        self._is_signed = is_signed
+        self.for_gradle_command = raw[:1].upper() + raw[1:]
+        self.platform = 'android-{}-{}'.format(self.abi, self.build_type)
+
+    def apk_absolute_path(self):
+        return '/opt/fenix/app/build/outputs/apk/{abi}/{build_type}/app-{abi}-{build_type}{unsigned}.apk'.format(
+            build_type=self.build_type,
+            abi=self.abi,
+            unsigned='' if self._is_signed else '-unsigned',
+        )
+
+    @staticmethod
+    def from_values(abi, is_signed, build_type):
+        raw = abi + build_type[:1].upper() + build_type[1:]
+        return Variant(raw, abi, is_signed, build_type)


### PR DESCRIPTION
[Test build](https://taskcluster-web.netlify.com/tasks/groups/PpgCz5XrTN-zzCfBGlGs3Q)

Rather than receiving variant names from `gradle`, then parsing them, this PR has `gradle` provide all relevant variant data to automation directly, so we don't need to have as many assumptions in-automation

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
- [x] [This staging nightly release graph is green](https://taskcluster-ui.herokuapp.com/tasks/groups/ZDyObOeVTYmue5TKRUJXCQ)
- [x] [This master-push graph is green](https://tools.taskcluster.net/groups/bBJk6BG5S0ao4gLeN7syqA)