### PR TITLE
Closes #2340. Set navigation icon color on library screen.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/LibraryFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/LibraryFragment.kt
@@ -4,6 +4,8 @@
 
 package org.mozilla.fenix.library
 
+import android.graphics.PorterDuff
+import android.graphics.PorterDuffColorFilter
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.Menu
@@ -78,7 +80,13 @@ class LibraryFragment : Fragment() {
 
     private fun setToolbarColor() {
         val toolbar = (activity as AppCompatActivity).findViewById<Toolbar>(R.id.navigationToolbar)
-        toolbar.setBackgroundColor(R.attr.foundation.getColorFromAttr(context!!))
-        toolbar.setTitleTextColor(R.attr.primaryText.getColorFromAttr(context!!))
+
+        val backgroundColor = R.attr.foundation.getColorFromAttr(context!!)
+        val foregroundColor = R.attr.primaryText.getColorFromAttr(context!!)
+
+        toolbar.setBackgroundColor(backgroundColor)
+        toolbar.setTitleTextColor(foregroundColor)
+        toolbar.navigationIcon?.colorFilter =
+                PorterDuffColorFilter(foregroundColor, PorterDuff.Mode.SRC_IN)
     }
 }


### PR DESCRIPTION
Applying color filter to `toolbar.navigationIcon` in `LibraryFragment` fixes this issue. However I would prefer solutions that involve proper theming. Programmatic-way chosen because of:

  - Applying styling to toolbar will increase regression scope drastically.
  - Applying styling will require small refactoring because setting toolbar colors is quite widespread in application's codebase.

**Tests**: issue can't be tested with espresso in black-box testing style. Something like [Screenshot testing](https://facebook.github.io/screenshot-tests-for-android/) is more appropriate for this. Thus, tests are not included.


### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
