### PR TITLE
No issue: Refactor dialogs to use nav graph

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -58,7 +58,6 @@ import org.mozilla.fenix.DefaultThemeManager
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.IntentReceiverActivity
 import org.mozilla.fenix.R
-import org.mozilla.fenix.collections.CreateCollectionFragment
 import org.mozilla.fenix.collections.CreateCollectionViewModel
 import org.mozilla.fenix.collections.SaveCollectionStep
 import org.mozilla.fenix.components.FenixSnackbar
@@ -85,7 +84,6 @@ import org.mozilla.fenix.quickactionsheet.QuickActionAction
 import org.mozilla.fenix.quickactionsheet.QuickActionChange
 import org.mozilla.fenix.quickactionsheet.QuickActionComponent
 import org.mozilla.fenix.quickactionsheet.QuickActionState
-import org.mozilla.fenix.settings.quicksettings.QuickSettingsSheetDialogFragment
 import org.mozilla.fenix.utils.ItsNotBrokenSnack
 import org.mozilla.fenix.utils.Settings
 import kotlin.coroutines.CoroutineContext
@@ -641,11 +639,10 @@ class BrowserFragment : Fragment(), BackHandler, CoroutineScope,
             val selectedSet = setOf(tabs)
             viewModel?.selectedTabs = selectedSet
             viewModel?.saveCollectionStep = SaveCollectionStep.SelectCollection
-            CreateCollectionFragment()
-                .show(
-                    requireActivity().supportFragmentManager,
-                    CreateCollectionFragment.createCollectionTag
-                )
+            view?.let {
+                val directions = BrowserFragmentDirections.actionBrowserFragmentToCreateCollectionFragment()
+                Navigation.findNavController(it).navigate(directions)
+            }
         }
     }
 
@@ -668,18 +665,16 @@ class BrowserFragment : Fragment(), BackHandler, CoroutineScope,
             val sitePermissions: SitePermissions? = storage.findSitePermissionsBy(host)
 
             launch(Main) {
-                val quickSettingsSheet = QuickSettingsSheetDialogFragment.newInstance(
-                    url = session.url,
-                    isSecured = session.securityInfo.secure,
-                    isTrackingProtectionOn = session.trackerBlockingEnabled,
-                    sitePermissions = sitePermissions,
-                    gravity = getAppropriateLayoutGravity()
-                )
-                quickSettingsSheet.sitePermissions = sitePermissions
-                quickSettingsSheet.show(
-                    requireFragmentManager(),
-                    QuickSettingsSheetDialogFragment.FRAGMENT_TAG
-                )
+                view?.let {
+                    val directions = BrowserFragmentDirections.actionBrowserFragmentToQuickSettingsSheetDialogFragment(
+                        url = session.url,
+                        isSecured = session.securityInfo.secure,
+                        isTrackingProtectionOn = session.trackerBlockingEnabled,
+                        sitePermissions = sitePermissions,
+                        gravity = getAppropriateLayoutGravity()
+                    )
+                    Navigation.findNavController(it).navigate(directions)
+                }
             }
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/collections/CreateCollectionFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/collections/CreateCollectionFragment.kt
@@ -129,8 +129,4 @@ class CreateCollectionFragment : DialogFragment() {
             }
         }
     }
-
-    companion object {
-        const val createCollectionTag = "createCollection"
-    }
 }

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -35,7 +35,6 @@ import org.mozilla.fenix.BrowsingModeManager
 import org.mozilla.fenix.DefaultThemeManager
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
-import org.mozilla.fenix.collections.CreateCollectionFragment
 import org.mozilla.fenix.collections.CreateCollectionViewModel
 import org.mozilla.fenix.collections.SaveCollectionStep
 import org.mozilla.fenix.components.metrics.Event
@@ -494,16 +493,9 @@ class HomeFragment : Fragment(), CoroutineScope {
         viewModel?.selectedTabs = selectedSet
         viewModel?.saveCollectionStep = SaveCollectionStep.SelectTabs
 
-        CreateCollectionFragment().also {
-            it.onCollectionSaved = {
-                storedCollections.add(it)
-                emitCollectionChange()
-            }
-
-            it.show(
-                requireActivity().supportFragmentManager,
-                CreateCollectionFragment.createCollectionTag
-            )
+        view?.let {
+            val directions = HomeFragmentDirections.actionHomeFragmentToCreateCollectionFragment()
+            Navigation.findNavController(it).navigate(directions)
         }
     }
 

--- a/app/src/main/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsSheetDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsSheetDialogFragment.kt
@@ -38,28 +38,21 @@ import java.net.MalformedURLException
 import java.net.URL
 import kotlin.coroutines.CoroutineContext
 
-private const val KEY_URL = "KEY_URL"
-private const val KEY_IS_SECURED = "KEY_IS_SECURED"
-private const val KEY_SITE_PERMISSIONS = "KEY_SITE_PERMISSIONS"
-private const val KEY_IS_TP_ON = "KEY_IS_TP_ON"
-private const val KEY_DIALOG_GRAVITY = "KEY_DIALOG_GRAVITY"
 private const val REQUEST_CODE_QUICK_SETTINGS_PERMISSIONS = 4
 
 @SuppressWarnings("TooManyFunctions")
 class QuickSettingsSheetDialogFragment : AppCompatDialogFragment(), CoroutineScope {
     private val safeArguments get() = requireNotNull(arguments)
-    private val url: String by lazy { safeArguments.getString(KEY_URL) }
-    private val isSecured: Boolean by lazy { safeArguments.getBoolean(KEY_IS_SECURED) }
-    private val isTrackingProtectionOn: Boolean by lazy { safeArguments.getBoolean(KEY_IS_TP_ON) }
-    private val promptGravity: Int by lazy { safeArguments.getInt(KEY_DIALOG_GRAVITY) }
+    private val url: String by lazy { QuickSettingsSheetDialogFragmentArgs.fromBundle(safeArguments).url }
+    private val isSecured: Boolean by lazy { QuickSettingsSheetDialogFragmentArgs.fromBundle(safeArguments).isSecured }
+    private val isTrackingProtectionOn: Boolean by lazy {
+        QuickSettingsSheetDialogFragmentArgs.fromBundle(safeArguments).isTrackingProtectionOn
+    }
+    private val promptGravity: Int by lazy { QuickSettingsSheetDialogFragmentArgs.fromBundle(safeArguments).gravity }
     private lateinit var quickSettingsComponent: QuickSettingsComponent
     private lateinit var job: Job
 
-    var sitePermissions: SitePermissions?
-        get() = safeArguments.getParcelable(KEY_SITE_PERMISSIONS)
-        set(value) {
-            safeArguments.putParcelable(KEY_SITE_PERMISSIONS, value)
-        }
+    private var sitePermissions: SitePermissions? = null
 
     override val coroutineContext: CoroutineContext get() = Dispatchers.IO + job
 
@@ -73,6 +66,7 @@ class QuickSettingsSheetDialogFragment : AppCompatDialogFragment(), CoroutineSco
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
+        sitePermissions = QuickSettingsSheetDialogFragmentArgs.fromBundle(safeArguments).sitePermissions
         val rootView = inflateRootView(container)
         quickSettingsComponent = QuickSettingsComponent(
             rootView as NestedScrollView, this, ActionBusFactory.get(this),
@@ -125,32 +119,6 @@ class QuickSettingsSheetDialogFragment : AppCompatDialogFragment(), CoroutineSco
             setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
         }
         return this
-    }
-
-    companion object {
-        const val FRAGMENT_TAG = "QUICK_SETTINGS_FRAGMENT_TAG"
-
-        fun newInstance(
-            url: String,
-            isSecured: Boolean,
-            isTrackingProtectionOn: Boolean,
-            sitePermissions: SitePermissions?,
-            gravity: Int = BOTTOM
-        ): QuickSettingsSheetDialogFragment {
-
-            val fragment = QuickSettingsSheetDialogFragment()
-            val arguments = fragment.arguments ?: Bundle()
-
-            with(arguments) {
-                putString(KEY_URL, url)
-                putBoolean(KEY_IS_SECURED, isSecured)
-                putBoolean(KEY_IS_TP_ON, isTrackingProtectionOn)
-                putParcelable(KEY_SITE_PERMISSIONS, sitePermissions)
-                putInt(KEY_DIALOG_GRAVITY, gravity)
-            }
-            fragment.arguments = arguments
-            return fragment
-        }
     }
 
     override fun onRequestPermissionsResult(

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -32,6 +32,9 @@
         <action
             android:id="@+id/action_homeFragment_to_settingsFragment"
             app:destination="@id/settingsFragment" />
+        <action
+            android:id="@+id/action_homeFragment_to_createCollectionFragment"
+            app:destination="@id/createCollectionFragment" />
     </fragment>
 
     <fragment
@@ -116,6 +119,12 @@
         <action
             android:id="@+id/action_browserFragment_to_bookmarkEditFragment"
             app:destination="@id/bookmarkEditFragment" />
+        <action
+            android:id="@+id/action_browserFragment_to_createCollectionFragment"
+            app:destination="@id/createCollectionFragment" />
+        <action
+            android:id="@+id/action_browserFragment_to_quickSettingsSheetDialogFragment"
+            app:destination="@id/quickSettingsSheetDialogFragment" />
     </fragment>
 
     <fragment
@@ -300,4 +309,31 @@
         android:id="@+id/exceptionsFragment"
         android:name="org.mozilla.fenix.exceptions.ExceptionsFragment"
         android:label="ExceptionsFragment" />
+    <dialog
+        android:id="@+id/createCollectionFragment"
+        android:name="org.mozilla.fenix.collections.CreateCollectionFragment"
+        android:label="fragment_create_collection"
+        tools:layout="@layout/fragment_create_collection" />
+    <dialog
+        android:id="@+id/quickSettingsSheetDialogFragment"
+        android:name="org.mozilla.fenix.settings.quicksettings.QuickSettingsSheetDialogFragment"
+        android:label="QuickSettingsSheetDialogFragment" >
+        <argument
+            android:name="url"
+            app:argType="string" />
+        <argument
+            android:name="isSecured"
+            app:argType="boolean" />
+        <argument
+            android:name="isTrackingProtectionOn"
+            app:argType="boolean" />
+        <argument
+            android:name="sitePermissions"
+            app:argType="mozilla.components.feature.sitepermissions.SitePermissions"
+            app:nullable="true" />
+        <argument
+            android:name="gravity"
+            app:argType="integer"
+            android:defaultValue="80" />
+    </dialog>
 </navigation>


### PR DESCRIPTION
Nav graphs now support dialog fragments so we can clean up these transactions a bit.
 
Tagging @Amejia481 for review because I had to refactor a bit of `QuickSettingsSheetDialogFragment` and I want to make sure this looks right to you!

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
