### PR TITLE
Closes #1083. Don't print sensitive data to logs in the production app.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/ext/Log.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/Log.kt
@@ -1,0 +1,44 @@
+package org.mozilla.fenix.ext
+
+import android.util.Log
+import org.mozilla.fenix.BuildConfig
+
+/**
+ * Will print to `Log.d()` only when [BuildConfig.DEBUG] is enabled.
+ *
+ * Meant to be used for logs that should not be visible in the production app.
+ */
+@Suppress("NOTHING_TO_INLINE")
+inline fun logDebug(tag: String, message: String) {
+    if (BuildConfig.DEBUG) Log.d(tag, message)
+}
+
+/**
+ * Will print to `Log.w()` only when [BuildConfig.DEBUG] is enabled.
+ *
+ * Meant to be used for logs that should not be visible in the production app.
+ */
+@Suppress("NOTHING_TO_INLINE")
+inline fun logWarn(tag: String, message: String) {
+    if (BuildConfig.DEBUG) Log.w(tag, message)
+}
+
+/**
+ * Will print to `Log.w()` only when [BuildConfig.DEBUG] is enabled.
+ *
+ * Meant to be used for logs that should not be visible in the production app.
+ */
+@Suppress("NOTHING_TO_INLINE")
+inline fun logWarn(tag: String, message: String, err: Throwable) {
+    if (BuildConfig.DEBUG) Log.w(tag, message, err)
+}
+
+/**
+ * Will print to `Log.e()` only when [BuildConfig.DEBUG] is enabled.
+ *
+ * Meant to be used for logs that should not be visible in the production app.
+ */
+@Suppress("NOTHING_TO_INLINE")
+inline fun logErr(tag: String, message: String, err: Throwable) {
+    if (BuildConfig.DEBUG) Log.e(tag, message, err)
+}

--- a/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarComponent.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarComponent.kt
@@ -4,7 +4,6 @@ package org.mozilla.fenix.search.awesomebar
    License, v. 2.0. If a copy of the MPL was not distributed with this
    file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import android.util.Log
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModel
@@ -12,6 +11,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProviders
 import io.reactivex.Observable
 import mozilla.components.browser.search.SearchEngine
+import org.mozilla.fenix.ext.logDebug
 import org.mozilla.fenix.mvi.Action
 import org.mozilla.fenix.mvi.ActionBusFactory
 import org.mozilla.fenix.mvi.Change
@@ -77,7 +77,7 @@ class AwesomeBarViewModel(initialState: AwesomeBarState, changesObservable: Obse
 
     companion object {
         val reducer: Reducer<AwesomeBarState, AwesomeBarChange> = { state, change ->
-            Log.d("IN_REDUCER", change.toString())
+            logDebug("IN_REDUCER", change.toString())
             when (change) {
                 is AwesomeBarChange.SearchShortcutEngineSelected ->
                     state.copy(suggestionEngine = change.engine, showShortcutEnginePicker = false)


### PR DESCRIPTION
**Issue**: #1083 

I would rather use [Timber](https://github.com/JakeWharton/timber) but as I see logging isn't (yet?) widespread in this project.

**Tests**: absent. It'll be quite tricky to test inline functions.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
