### PR TITLE
For #747. Fix possible memory leak on `HomeActivity`.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -88,6 +88,7 @@ open class HomeActivity : AppCompatActivity() {
     }
 
     override fun onDestroy() {
+        themeManager.onThemeChange = null
         sessionObserver?.let { components.core.sessionManager.unregister(it) }
         super.onDestroy()
     }


### PR DESCRIPTION
**Issue**: #474.

**Problem description**:
User change between normal/private theme ⟶ `themeManager.onThemeChange()` is called ⟶ new `HomeActivity` [is created](https://github.com/mozilla-mobile/fenix/blob/e4b4934f5320e8bbd3fe73aaa216b0f74f9db8cc/app/src/main/java/org/mozilla/fenix/HomeActivity.kt#L45) ⟶ old `HomeActivity` is leaked.

**Fix**:
Unsubscribe from `themeManager.onThemeChange` in `HomeActivity.onDestroy()` to let GC collect obsolete instances of `HomeActivity` and `DefaultThemeManager`.

### Pull Request checklist
- [+] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [-] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [-] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [-] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
