### PR TITLE
[Do Not Merge] For #747. Fix coroutines leaks in `HistoryFragment`.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/ext/String.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/String.kt
@@ -18,13 +18,14 @@ fun String.replace(pairs: Map<String, String>): String {
     return result
 }
 
-fun String?.urlToHost(): String {
-    return try {
-        val url = URL(this)
-        url.host
-    } catch (e: MalformedURLException) {
-        ""
-    }
+/**
+ * Try to parse and get host part if this [String] is valid URL.
+ * Returns **null** otherwise.
+ */
+fun String?.getHostFromUrl(): String? = try {
+    URL(this).host
+} catch (e: MalformedURLException) {
+    null
 }
 
 fun String?.urlToTrimmedHost(): String {
@@ -40,8 +41,8 @@ fun String?.urlToTrimmedHost(): String {
             else -> url.host
         }
     } catch (e: MalformedURLException) {
-        this.urlToHost()
+        this.getHostFromUrl() ?: ""
     } catch (e: StringIndexOutOfBoundsException) {
-        this.urlToHost()
+        this.getHostFromUrl() ?: ""
     }
 }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -4,7 +4,7 @@
 
 private object Versions {
     const val kotlin = "1.3.30"
-    const val coroutines = "1.2.0-alpha-2"
+    const val coroutines = "1.2.1"
     const val android_gradle_plugin = "3.3.2"
     const val rxAndroid = "2.1.0"
     const val rxKotlin = "2.3.0"
@@ -66,6 +66,7 @@ object Deps {
     const val tools_kotlingradle = "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.kotlin}"
     const val kotlin_stdlib = "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${Versions.kotlin}"
     const val kotlin_coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.coroutines}"
+    const val kotlin_coroutines_android = "org.jetbrains.kotlinx:kotlinx-coroutines-android:${Versions.coroutines}"
 
     const val allopen = "org.jetbrains.kotlin:kotlin-allopen:${Versions.kotlin}"
 


### PR DESCRIPTION
### Changes
  - Updated coroutines library to stable `1.2.1`.
  - Added `coroutines-android`.
  - _(first commit)_ Restructured coroutines scope on `HistoryFragment` to avoid memory leaks via global queue. (Check [commit separately](https://github.com/mozilla-mobile/fenix/commit/440ad6731d6d6ae35ae1ca60825e1cc8cd0bb022) to get idea more easily).
  - ~~Changed order of `filter` and `sorted` to actually get some profit from sequence. :)~~
  - _(second commit)_ Improved readability of `HistoryFragment` a bit. Hope you don't mind. [Highly recommended to look at it :smiley:](https://github.com/dector/fenix/blob/440ad6731d6d6ae35ae1ca60825e1cc8cd0bb022/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragment.kt)

P.S. There are some memory leaks on this screen left. Not for the whole fragment, but for some views. I suggest that further investigation requires deep diving into `HistoryComponent`.

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
