### PR TITLE
For #2490 - Update Dockerfile with UI test deps

### DIFF
--- a/automation/docker/Dockerfile
+++ b/automation/docker/Dockerfile
@@ -5,9 +5,13 @@
 # Inspired by:
 # https://hub.docker.com/r/runmymind/docker-android-sdk/~/dockerfile/
 
-FROM ubuntu:17.10
+FROM ubuntu:18.04
 
 MAINTAINER Sebastian Kaspari "skaspari@mozilla.com"
+
+# -- Configuration ----------------------------------------------------------------------
+
+ENV GOOGLE_SDK_VERSION 233
 
 # -- System -----------------------------------------------------------------------------
 
@@ -15,6 +19,7 @@ RUN apt-get update -qq
 
 RUN apt-get install -y openjdk-8-jdk \
 					   curl \
+					   wget \
 					   git \
 					   python \
 					   python-pip \
@@ -49,11 +54,32 @@ RUN sdkmanager --verbose "platform-tools" \
     "extras;google;m2repository"
 
 # Checkout source code
-RUN git clone https://github.com/mozilla-mobile/fenix.git
+#RUN git clone https://github.com/mozilla-mobile/fenix.git
+RUN git clone https://github.com/rpappalax/fenix.git -b dockerfile-add-test-deps --single-branch
 
 # Build project and run gradle tasks once to pull all dependencies
 WORKDIR /opt/fenix
-RUN ./gradlew --no-daemon assemble test lint
+RUN ./gradlew -PversionName=0.0 --no-daemon assemble test lint
+
+# -- Test tools -------------------------------------------------------------------------
+
+RUN mkdir -p /build/test-tools
+
+WORKDIR /build
+
+ENV TEST_TOOLS /build/test-tools
+ENV GOOGLE_SDK_DOWNLOAD ./gcloud.tar.gz
+ENV PATH ${PATH}:${TEST_TOOLS}:${TEST_TOOLS}/google-cloud-sdk/bin
+
+RUN curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GOOGLE_SDK_VERSION}.0.0-linux-x86_64.tar.gz --output ${GOOGLE_SDK_DOWNLOAD} \
+    && tar -xvf ${GOOGLE_SDK_DOWNLOAD} -C ${TEST_TOOLS} \
+    && rm -f ${GOOGLE_SDK_DOWNLOAD} \
+    && ${TEST_TOOLS}/google-cloud-sdk/install.sh --quiet \
+    && ${TEST_TOOLS}/google-cloud-sdk/bin/gcloud --quiet components update
+
+RUN URL_FLANK_BIN=$(curl -s "https://api.github.com/repos/TestArmada/flank/releases/latest" | grep "browser_download_url*" | sed -r "s/\"//g" | cut -d ":" -f3) \
+    && wget "https:${URL_FLANK_BIN}" -O ${TEST_TOOLS}/flank.jar \
+    && chmod +x ${TEST_TOOLS}/flank.jar
 
 # -- Post setup -------------------------------------------------------------------------
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,3 +18,4 @@ android.enableJetifier=true
 android.enableR8=true
 android.enableR8.fullMode=true
 android.enableUnitTestBinaryResources=true
+org.gradle.parallel=false


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

For running automated UI tests in Fenix, we'll first need to land some dependencies in the Dockerfile (as we did recently w/ A-C: https://github.com/mozilla-mobile/android-components/issues/2796).

NOTE:
The version of Ubuntu 17.10 currently being used by master throws the following error:
```
docker build .
Sending build context to Docker daemon  4.096kB
Step 1/22 : FROM ubuntu:17.10
 ---> e211a66937c6
Step 2/22 : MAINTAINER Sebastian Kaspari "skaspari@mozilla.com"
 ---> Running in a9bcbd965781
Removing intermediate container a9bcbd965781
 ---> 1de1e5752d44
Step 3/22 : RUN apt-get update -qq
 ---> Running in b987913a7c8a
E: The repository 'http://security.ubuntu.com/ubuntu artful-security Release' does not have a Release file.
E: The repository 'http://archive.ubuntu.com/ubuntu artful Release' does not have a Release file.
E: The repository 'http://archive.ubuntu.com/ubuntu artful-updates Release' does not have a Release file.
E: The repository 'http://archive.ubuntu.com/ubuntu artful-backports Release' does not have a Release file.
The command '/bin/sh -c apt-get update -qq' returned a non-zero code: 100
```

I've upgraded to Ubuntu 18.04 which solves that problem, but get a different error:
```
> Task :architecture:processReleaseManifest
> Task :app:preAarch64BetaBuild FAILED
FAILURE: Build failed with an exception.
* Where:
Build file '/opt/fenix/app/build.gradle' line: 1726 actionable tasks: 6 executed

* What went wrong:
Execution failed for task ':app:preAarch64BetaBuild'.
> Release builds require the 'versionName' property, e.g.: './gradlew -PversionName=<...> assembleNightly'
```
@pocmo I assume this is an error caused by me trying to build this locally rather than on taskcluster (hence, OK)?