### PR TITLE
1551700: Enable custom pings from debug dashboard

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
@@ -14,6 +14,7 @@ import org.mozilla.fenix.GleanMetrics.CustomTab
 import org.mozilla.fenix.GleanMetrics.Events
 import org.mozilla.fenix.GleanMetrics.FindInPage
 import org.mozilla.fenix.GleanMetrics.Metrics
+import org.mozilla.fenix.GleanMetrics.Pings
 import org.mozilla.fenix.GleanMetrics.QuickActionSheet
 import org.mozilla.fenix.GleanMetrics.SearchDefaultEngine
 import org.mozilla.fenix.ext.components
@@ -174,12 +175,13 @@ class GleanMetricsService(private val context: Context) : MetricsService {
     private val activationPing = ActivationPing(context)
 
     override fun start() {
+        Glean.setUploadEnabled(true)
 
         if (initialized) return
         initialized = true
 
         starter = CoroutineScope(Dispatchers.Default).launch {
-            Glean.setUploadEnabled(true)
+            Glean.registerPings(Pings)
             Glean.initialize(context)
 
             Metrics.apply {


### PR DESCRIPTION
Custom pings need to be explicitly registered with Glean so it knows how to send them from its `adb` debugging hook.

Additionally, this fixes an issue where disabling and re-enabling telemetry in the same process wouldn't actually re-enable the telemetry.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
