### PR TITLE
For #2435 - fixed placement of overflow menu icons in library

### DIFF
--- a/app/src/main/res/layout/bookmark_row.xml
+++ b/app/src/main/res/layout/bookmark_row.xml
@@ -14,7 +14,7 @@
     android:paddingTop="8dp"
     android:paddingBottom="8dp"
     android:paddingStart="16dp"
-    android:paddingEnd="16dp"
+    android:paddingEnd="0dp"
     android:background="?android:attr/selectableItemBackground">
 
     <ImageView
@@ -47,16 +47,15 @@
         app:layout_constraintTop_toTopOf="parent"
         tools:text="Internet" />
 
-    <ImageView
+    <ImageButton
         android:id="@+id/bookmark_overflow"
-        android:layout_width="24dp"
-        android:layout_height="wrap_content"
-        android:layout_margin="10dp"
+        android:layout_width="@dimen/glyph_button_width"
+        android:layout_height="@dimen/glyph_button_height"
+        android:background="?android:attr/selectableItemBackgroundBorderless"
         android:contentDescription="@string/bookmark_menu_content_description"
         android:src="@drawable/ic_menu"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/bookmark_title"
         app:layout_constraintTop_toTopOf="parent" />
     
     <View

--- a/app/src/main/res/layout/history_list_item.xml
+++ b/app/src/main/res/layout/history_list_item.xml
@@ -11,7 +11,8 @@
     android:clickable="true"
     android:focusable="true"
     android:padding="4dp"
-    android:paddingStart="20dp">
+    android:paddingStart="20dp"
+    android:paddingEnd="0dp">
 
     <ImageButton
         android:id="@+id/history_item_overflow"


### PR DESCRIPTION
Before:

![before](https://user-images.githubusercontent.com/1100614/57807473-88abbc00-7761-11e9-8f06-012f65ec7c24.png)

After:

![after](https://user-images.githubusercontent.com/1100614/57807487-8c3f4300-7761-11e9-8a1b-6e2b108b9f34.png)
