### PR TITLE
Closes #2555: Remove appservices gradle plugin, perform megazord substitution by hand.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,18 +8,7 @@ apply plugin: 'kotlin-android-extensions'
 apply from: "$project.rootDir/automation/gradle/versionCode.gradle"
 apply plugin: 'androidx.navigation.safeargs.kotlin'
 
-apply plugin: 'org.mozilla.appservices'
-
 import com.android.build.gradle.internal.tasks.AppPreBuildTask
-
-appservices {
-    defaultConfig {
-        megazord = 'fenix'
-        // Necessary to allow for local dependency substitutions.
-        // See https://github.com/mozilla-mobile/reference-browser/pull/356#issuecomment-449190236
-        unitTestingEnabled = false
-    }
-}
 
 android {
     compileSdkVersion 28
@@ -376,7 +365,6 @@ dependencies {
     testImplementation Deps.junit
     testImplementation Deps.robolectric
     implementation Deps.fragment_testing
-    testImplementation Deps.megazord_forUnitTests
     testImplementation Deps.places_forUnitTests
 
     testImplementation Deps.mockito_core
@@ -415,3 +403,43 @@ task printGeckoviewVersions {
 // Normally this should use the same version as the glean dependency. But since we are currently using AC snapshots we
 // can't reference a git tag with a specific version here. So we are just using "master" and hoping for the best.
 apply from: 'https://github.com/mozilla-mobile/android-components/raw/master/components/service/glean/scripts/sdk_generator.gradle'
+
+// For production builds, the native code for all `org.mozilla.appservices` dependencies gets compiled together
+// into a single "megazord" build, and different megazords are published for different subsets of features.
+// Ref https://mozilla.github.io/application-services/docs/applications/consuming-megazord-libraries.html
+// Substitute all appservices dependencies with an appropriate megazord.
+afterEvaluate {
+    def megazord = "fenix-megazord"
+    def appServicesGroup = "org.mozilla.appservices"
+    def appServicesVersion = null
+    configurations.each { configuration ->
+        configuration.resolutionStrategy.eachDependency { DependencyResolveDetails dependency ->
+            if (dependency.requested.group == appServicesGroup) {
+                // Ensure that we only depend on a single, consistent version of appservices.
+                if (appServicesVersion == null) {
+                  appServicesVersion = dependency.requested.version
+                } else {
+                    if (dependency.requested.version != appServicesVersion) {
+                        logger.lifecycle("In ${configuration}: mismatched '${appServicesGroup}` dependency version:" +
+                                         " '${dependency.requested.group}:${dependency.requested.name}:${dependency.requested.version}'" +
+                                         " does not have expected version ${appServicesVersion}")
+                        throw new RuntimeException("mismatched '${appServicesGroup}` dependency version")
+                    }
+                }
+                // Check whether it was already megazorded.
+                if (! dependency.requested.name.endsWith("-withoutLib")) {
+                    // Use either the -forUnitTests megazord, or the default one.
+                    def substitution
+                    if (dependency.requested.name.endsWith("-forUnitTests")) {
+                      substitution = "org.mozilla.appservices:${megazord}-forUnitTests:${appServicesVersion}"
+                    } else {
+                      substitution = "org.mozilla.appservices:${megazord}:${appServicesVersion}"
+                    }
+                    logger.lifecycle("In ${configuration}: substituting megazord module '$substitution' for component module" +
+                                     " '${dependency.requested.group}:${dependency.requested.name}:${dependency.requested.version}'")
+                    dependency.useTarget(substitution)
+                }
+            }
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,6 @@ buildscript {
     dependencies {
         classpath Deps.tools_androidgradle
         classpath Deps.tools_kotlingradle
-        classpath Deps.tools_appservicesgradle
         classpath Deps.androidx_safeargs
         classpath Deps.allopen
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -28,9 +28,13 @@ private object Versions {
     const val androidx_core = "1.2.0-alpha01"
     const val androidx_transition = "1.1.0-rc01"
 
-    const val appservices_gradle_plugin = "0.4.4"
     const val mozilla_android_components = "0.54.0-SNAPSHOT"
-    const val mozilla_appservices = "0.27.0"
+    // Note that android-components also depends on application-services,
+    // and in fact is our main source of appservices-related functionality.
+    // The version number below tracks the application-services version
+    // that we depend on directly for tests, and it's important that it
+    // be kept in sync with the version used by android-components above.
+    const val mozilla_appservices = "0.28.1"
 
     const val autodispose = "1.1.0"
     const val adjust = "4.11.4"
@@ -58,7 +62,6 @@ private object Versions {
 object Deps {
     const val tools_androidgradle = "com.android.tools.build:gradle:${Versions.android_gradle_plugin}"
     const val tools_kotlingradle = "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.kotlin}"
-    const val tools_appservicesgradle = "org.mozilla.appservices:gradle-plugin:${Versions.appservices_gradle_plugin}"
     const val kotlin_stdlib = "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${Versions.kotlin}"
     const val kotlin_coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.coroutines}"
 
@@ -175,7 +178,6 @@ object Deps {
     const val uiautomator = "com.android.support.test.uiautomator:uiautomator-v18:${Versions.uiautomator}"
     const val robolectric = "org.robolectric:robolectric:${Versions.robolectric}"
     const val fragment_testing = "androidx.fragment:fragment-testing:${Versions.androidx_testing}"
-    const val megazord_forUnitTests = "org.mozilla.appservices:fenix-megazord-forUnitTests:${Versions.mozilla_appservices}"
     const val places_forUnitTests = "org.mozilla.appservices:places-forUnitTests:${Versions.mozilla_appservices}"
 
     const val google_ads_id = "com.google.android.gms:play-services-ads-identifier:${Versions.google_ads_id_version}"


### PR DESCRIPTION
Here's my current take on doing appservices megazord substitution by hand, ref https://github.com/mozilla-mobile/fenix/issues/2555.

Unlike the approach in https://github.com/mozilla-mobile/fenix/pull/1787, this doesn't explicitly list out all the individual appservices dependencies that should be replaced. Instead is assumes that **all** dependencies under `org.mozilla.appservices` should be replaced by the configured all-in-one megazord.

This seems to me both simpler, and more likely to fail early and noisily if something goes wrong. For example, if this project takes a new (possibly transitive) dependency on another appservices component but we forget to add it to the `fenix-megazord` build, then the approach here will result in a build failure; I tested this by trying to build with `lockbox-megazord` instead. That might be jarring for the developer who introduced the new dependency and gets an unexpected build failure, but seems better than accidentally shipping a mix of megazorded and non-megazorded appservices components.

With this change, I have had some tentative success in doing a local composite build and substituting in local versions of appservices components, but I think there are still a few bugs to shake out on that front, so won't make any promises just yet. But it should be a good step in that direction.

/cc @ncalexan @colintheshots @thomcc 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] ~~**Tests**: This PR includes thorough tests or an explanation of why it does not~~
  - I couldn't think of a way to test this other than confirming that existing tests still work
- [ ] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one~~
  - I didn't add one because it seemed like the existing entries were user-facing changes rather than infrastructural things, but I'm happy to add one.
- [ ] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~
    - No user-facing features
