### PR TITLE
No issue - make spacing in history view consistent with spacing on ta…

### DIFF
--- a/app/src/main/res/layout/history_list_item.xml
+++ b/app/src/main/res/layout/history_list_item.xml
@@ -45,7 +45,6 @@
         android:textAlignment="viewStart"
         android:textColor="?secondaryText"
         android:textSize="12sp"
-        android:layout_marginTop="4dp"
         app:layout_constraintEnd_toStartOf="@id/history_item_overflow"
         app:layout_constraintStart_toEndOf="@id/history_favicon"
         app:layout_constraintTop_toBottomOf="@id/history_title" />
@@ -61,6 +60,7 @@
         android:textAlignment="viewStart"
         android:textColor="?primaryText"
         android:textSize="18sp"
+        android:layout_marginTop="2dp"
         app:layout_constraintEnd_toStartOf="@id/history_item_overflow"
         app:layout_constraintStart_toEndOf="@id/history_favicon"
         app:layout_constraintTop_toTopOf="parent" />


### PR DESCRIPTION
…bs view

I made the spacing between page title and url in the history view consistent with the spacing between host and page title in the tabs view on the home screen.

![spacing](https://user-images.githubusercontent.com/1100614/57885009-4601e680-782a-11e9-8648-7827a2eeba00.png)
