### PR TITLE
Use UpdateTrackingProtectionUseCase

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/Components.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Components.kt
@@ -16,7 +16,7 @@ class Components(private val context: Context) {
     val services by lazy { Services(backgroundServices.accountManager, useCases.tabsUseCases) }
     val core by lazy { Core(context) }
     val search by lazy { Search(context) }
-    val useCases by lazy { UseCases(context, core.sessionManager, search.searchEngineManager) }
+    val useCases by lazy { UseCases(context, core.sessionManager, core.engine.settings, search.searchEngineManager) }
     val utils by lazy { Utilities(context, core.sessionManager, useCases.sessionUseCases, useCases.searchUseCases) }
     val analytics by lazy { Analytics(context) }
 }

--- a/app/src/main/java/org/mozilla/fenix/components/UseCases.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/UseCases.kt
@@ -7,8 +7,10 @@ package org.mozilla.fenix.components
 import android.content.Context
 import mozilla.components.browser.search.SearchEngineManager
 import mozilla.components.browser.session.SessionManager
+import mozilla.components.concept.engine.Settings
 import mozilla.components.feature.search.SearchUseCases
 import mozilla.components.feature.session.SessionUseCases
+import mozilla.components.feature.session.SettingsUseCases
 import mozilla.components.feature.tabs.TabsUseCases
 import org.mozilla.fenix.test.Mockable
 
@@ -20,6 +22,7 @@ import org.mozilla.fenix.test.Mockable
 class UseCases(
     private val context: Context,
     private val sessionManager: SessionManager,
+    private val engineSettings: Settings,
     private val searchEngineManager: SearchEngineManager
 ) {
     /**
@@ -36,4 +39,9 @@ class UseCases(
      * Use cases that provide search engine integration.
      */
     val searchUseCases by lazy { SearchUseCases(context, searchEngineManager, sessionManager) }
+
+    /**
+     * Use cases that provide settings management.
+     */
+    val settingsUseCases by lazy { SettingsUseCases(engineSettings, sessionManager) }
 }

--- a/app/src/test/java/org/mozilla/fenix/components/TestComponents.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/TestComponents.kt
@@ -10,7 +10,7 @@ class TestComponents(private val context: Context) : Components(context) {
     override val services by lazy { Services(backgroundServices.accountManager, useCases.tabsUseCases) }
     override val core by lazy { TestCore(context) }
     override val search by lazy { Search(context) }
-    override val useCases by lazy { UseCases(context, core.sessionManager, search.searchEngineManager) }
+    override val useCases by lazy { UseCases(context, core.sessionManager, core.engine.settings, search.searchEngineManager) }
     override val utils by lazy {
         Utilities(
             context,


### PR DESCRIPTION
mozilla-mobile/android-components#2746 extracted the tracking protection code into a reusable use case.

`.enableTrackingProtection(policy)` is equivalent to `.disableTrackingProtection()` when certain flags on the policy are set. As a result, using only `enableTrackingProtection` works fine and its what android-components and reference-browser do.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
