### PR TITLE
For #2435 - adds URL to bookmarks in library

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkAdapter.kt
@@ -260,8 +260,10 @@ class BookmarkAdapter(val emptyView: View, val actionEmitter: Observer<BookmarkA
 
             val constraintSet = ConstraintSet()
             constraintSet.clone(bookmark_layout)
-            constraintSet.connect(bookmark_title.id, ConstraintSet.BOTTOM, ConstraintSet.PARENT_ID, ConstraintSet.BOTTOM);
-            constraintSet.applyTo(bookmark_layout);
+            constraintSet.connect(
+                bookmark_title.id, ConstraintSet.BOTTOM, ConstraintSet.PARENT_ID, ConstraintSet.BOTTOM
+            )
+            constraintSet.applyTo(bookmark_layout)
 
             bookmark_favicon.setImageResource(R.drawable.ic_folder_icon)
             bookmark_favicon.visibility = View.VISIBLE

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkAdapter.kt
@@ -135,11 +135,11 @@ class BookmarkAdapter(val emptyView: View, val actionEmitter: Observer<BookmarkA
         @Suppress("ComplexMethod")
         override fun bind(item: BookmarkNode, mode: BookmarkState.Mode, selected: Boolean) {
 
-            val shiftThreeDp = TypedValue.applyDimension(
-                TypedValue.COMPLEX_UNIT_DIP, TWO_DIGIT_PADDING, containerView!!.context.resources.displayMetrics
+            val shiftTwoDp = TypedValue.applyDimension(
+                TypedValue.COMPLEX_UNIT_DIP, TWO_DIGIT_MARGIN, containerView!!.context.resources.displayMetrics
             ).toInt()
             val params = bookmark_title.getLayoutParams() as ViewGroup.MarginLayoutParams
-            params.topMargin = shiftThreeDp
+            params.topMargin = shiftTwoDp
             bookmark_title.setLayoutParams(params)
 
             bookmark_favicon.visibility = View.VISIBLE
@@ -242,7 +242,7 @@ class BookmarkAdapter(val emptyView: View, val actionEmitter: Observer<BookmarkA
         }
 
         companion object {
-            internal const val TWO_DIGIT_PADDING = 2F
+            internal const val TWO_DIGIT_MARGIN = 2F
 
             val viewType = ViewType.ITEM
         }

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkAdapter.kt
@@ -4,9 +4,11 @@
 
 package org.mozilla.fenix.library.bookmarks
 
+import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.constraintlayout.widget.ConstraintSet
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import io.reactivex.Observer
@@ -133,8 +135,16 @@ class BookmarkAdapter(val emptyView: View, val actionEmitter: Observer<BookmarkA
         @Suppress("ComplexMethod")
         override fun bind(item: BookmarkNode, mode: BookmarkState.Mode, selected: Boolean) {
 
+            val shiftThreeDp = TypedValue.applyDimension(
+                TypedValue.COMPLEX_UNIT_DIP, TWO_DIGIT_PADDING, containerView!!.context.resources.displayMetrics
+            ).toInt()
+            val params = bookmark_title.getLayoutParams() as ViewGroup.MarginLayoutParams
+            params.topMargin = shiftThreeDp
+            bookmark_title.setLayoutParams(params)
+
             bookmark_favicon.visibility = View.VISIBLE
             bookmark_title.visibility = View.VISIBLE
+            bookmark_url.visibility = View.VISIBLE
             bookmark_overflow.visibility = View.VISIBLE
             bookmark_separator.visibility = View.GONE
             bookmark_layout.isClickable = true
@@ -173,6 +183,7 @@ class BookmarkAdapter(val emptyView: View, val actionEmitter: Observer<BookmarkA
                 )
             }
             bookmark_title.text = if (item.title.isNullOrBlank()) item.url else item.title
+            bookmark_url.text = item.url
             updateUrl(item, mode, selected)
         }
 
@@ -231,6 +242,8 @@ class BookmarkAdapter(val emptyView: View, val actionEmitter: Observer<BookmarkA
         }
 
         companion object {
+            internal const val TWO_DIGIT_PADDING = 2F
+
             val viewType = ViewType.ITEM
         }
     }
@@ -245,9 +258,15 @@ class BookmarkAdapter(val emptyView: View, val actionEmitter: Observer<BookmarkA
 
         override fun bind(item: BookmarkNode, mode: BookmarkState.Mode, selected: Boolean) {
 
+            val constraintSet = ConstraintSet()
+            constraintSet.clone(bookmark_layout)
+            constraintSet.connect(bookmark_title.id, ConstraintSet.BOTTOM, ConstraintSet.PARENT_ID, ConstraintSet.BOTTOM);
+            constraintSet.applyTo(bookmark_layout);
+
             bookmark_favicon.setImageResource(R.drawable.ic_folder_icon)
             bookmark_favicon.visibility = View.VISIBLE
             bookmark_title.visibility = View.VISIBLE
+            bookmark_url.visibility = View.GONE
             bookmark_overflow.visibility = View.VISIBLE
             bookmark_separator.visibility = View.GONE
             bookmark_layout.isClickable = true
@@ -343,6 +362,7 @@ class BookmarkAdapter(val emptyView: View, val actionEmitter: Observer<BookmarkA
 
             bookmark_favicon.visibility = View.GONE
             bookmark_title.visibility = View.GONE
+            bookmark_url.visibility = View.GONE
             bookmark_overflow.increaseTapArea(bookmarkOverflowExtraDips)
             bookmark_overflow.visibility = View.VISIBLE
             bookmark_separator.visibility = View.VISIBLE

--- a/app/src/main/res/layout/bookmark_row.xml
+++ b/app/src/main/res/layout/bookmark_row.xml
@@ -11,41 +11,52 @@
     android:layout_height="56dp"
     android:clickable="true"
     android:focusable="true"
-    android:paddingTop="8dp"
-    android:paddingBottom="8dp"
-    android:paddingStart="16dp"
+    android:padding="4dp"
+    android:paddingStart="20dp"
     android:paddingEnd="0dp"
     android:background="?android:attr/selectableItemBackground">
 
     <ImageView
         android:id="@+id/bookmark_favicon"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
         android:background="@drawable/favicon_background"
         android:importantForAccessibility="no"
         android:padding="10dp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintDimensionRatio="1:1"
         tools:src="@drawable/ic_folder_icon" />
 
     <TextView
         android:id="@+id/bookmark_title"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginEnd="8dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
         android:ellipsize="end"
-        android:lines="1"
-        android:textSize="16sp"
+        android:singleLine="true"
+        android:textAlignment="viewStart"
+        android:textSize="18sp"
         android:textColor="?primaryText"
-        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/bookmark_overflow"
-        app:layout_constraintHorizontal_bias="0"
         app:layout_constraintStart_toEndOf="@id/bookmark_favicon"
         app:layout_constraintTop_toTopOf="parent"
         tools:text="Internet" />
+
+    <TextView
+        android:id="@+id/bookmark_url"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:ellipsize="end"
+        android:singleLine="true"
+        android:textAlignment="viewStart"
+        android:textColor="?secondaryText"
+        android:textSize="12sp"
+        app:layout_constraintEnd_toStartOf="@id/bookmark_overflow"
+        app:layout_constraintStart_toEndOf="@id/bookmark_favicon"
+        app:layout_constraintTop_toBottomOf="@id/bookmark_title" />
 
     <ImageButton
         android:id="@+id/bookmark_overflow"


### PR DESCRIPTION
I added the URL to the bookmarks in the library for the following reasons:

* it's an useful information
* it's consistent with the history
* Fennec does this
* Google Chrome does this

I also made the font size of the title and the spacing between the favicon and the title the same as in the history. The spacing between the title and the URL is the same as in the history when #2580 will get merged.

(But if you prefer the smaller font size it can be changed back and also be changed in the history, either in this PR or as a follow-up. I wanted to be consistent but it's not clear which one is preferred.)

![bookmarks](https://user-images.githubusercontent.com/1100614/57968040-b3666200-7965-11e9-9c57-5e1100216bc8.png)

Let me know what do you think.