### PR TITLE
Fixes #654 - Update refresh/stop toolbar buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,5 +55,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - #1599 - Fixed a crash creating a bookmark for a custom tab
 - #1414 - Fixed site permissions settings getting reset in Android 6.
 - #1994 - Made app state persist better when rotating the screen
+- #654 - Updated Refresh button to turn into Stop button while menu is open.
 - [AC #2725](https://github.com/mozilla-mobile/android-components/issues/2725) Updated tracking protectionPolicy to [recommend](https://github.com/mozilla-mobile/android-components/blob/master/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt#L156)
 ### Removed

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/MenuPresenter.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/MenuPresenter.kt
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+   License, v. 2.0. If a copy of the MPL was not distributed with this
+   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.components.toolbar
+
+import mozilla.components.browser.session.SelectionAwareSessionObserver
+import mozilla.components.browser.session.Session
+import mozilla.components.browser.session.SessionManager
+import mozilla.components.browser.toolbar.BrowserToolbar
+
+class MenuPresenter(
+    private val menuToolbar: BrowserToolbar,
+    sessionManager: SessionManager,
+    private val sessionId: String? = null
+) : SelectionAwareSessionObserver(sessionManager) {
+
+    fun start() {
+        observeIdOrSelected(sessionId)
+    }
+
+    /** Redraw the refresh/stop button */
+    override fun onLoadingStateChanged(session: Session, loading: Boolean) {
+        menuToolbar.invalidateActions()
+    }
+
+    /** Redraw the back and forward buttons */
+    override fun onNavigationStateChanged(session: Session, canGoBack: Boolean, canGoForward: Boolean) {
+        menuToolbar.invalidateActions()
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarIntegration.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarIntegration.kt
@@ -77,12 +77,15 @@ class ToolbarIntegration(
         ToolbarFeature.UrlRenderConfiguration(PublicSuffixList(context),
             DefaultThemeManager.resolveAttribute(R.attr.primaryText, context), renderStyle = renderStyle)
     )
+    private var menuPresenter = MenuPresenter(toolbar, context.components.core.sessionManager, sessionId)
 
     override fun start() {
+        menuPresenter.start()
         toolbarPresenter.start()
     }
 
     override fun stop() {
+        menuPresenter.stop()
         toolbarPresenter.stop()
     }
 }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -29,7 +29,7 @@ private object Versions {
     const val androidx_transition = "1.1.0-rc01"
 
     const val appservices_gradle_plugin = "0.4.4"
-    const val mozilla_android_components = "0.53.0-SNAPSHOT"
+    const val mozilla_android_components = "0.54.0-SNAPSHOT"
     const val mozilla_appservices = "0.27.0"
 
     const val autodispose = "1.1.0"


### PR DESCRIPTION
Refresh/stop, back, and forward buttons will now update while the browser-menu is open.

Requires mozilla-mobile/android-components#3022 ~to be merged into the A-C snapshot tomorrow~ which is now in the 0.54.0 snapshot.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
