### PR TITLE
Fix #2612: Force PG to keep kotlinx coroutines

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -30,8 +30,8 @@
 # Kotlinx
 ####################################################################################################
 
--keepnames class kotlinx.coroutines.internal.MainDispatcherFactory {}
--keepnames class kotlinx.coroutines.CoroutineExceptionHandler {}
+-keep class kotlinx.coroutines.internal.MainDispatcherFactory {}
+-keep class kotlinx.coroutines.CoroutineExceptionHandler {}
 -keepclassmembernames class kotlinx.** {
     volatile <fields>;
 }


### PR DESCRIPTION
This PR forces ProGuard to keep the kotlinx coroutine library. I have a/b tested that, upon application of this patch, we can update to GV nightly (version 68.0.20190517093040).