### PR TITLE
Closes #2713: Weave in "onboarding state" and split adapter items acc…

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -55,6 +55,7 @@ import org.mozilla.fenix.home.sessioncontrol.SessionControlViewModel
 import org.mozilla.fenix.home.sessioncontrol.Tab
 import org.mozilla.fenix.home.sessioncontrol.TabAction
 import org.mozilla.fenix.home.sessioncontrol.TabCollection
+import org.mozilla.fenix.home.sessioncontrol.OnboardingState
 import org.mozilla.fenix.lib.Do
 import org.mozilla.fenix.mvi.ActionBusFactory
 import org.mozilla.fenix.mvi.getAutoDisposeObservable
@@ -612,7 +613,13 @@ class HomeFragment : Fragment(), CoroutineScope {
     }
 
     private fun currentMode(): Mode = if (!onboarding.userHasBeenOnboarded()) {
-        Mode.Onboarding
+        // TODO monitor account state changes somewhere in this class via AccountObserver + `accountManager.register()`.
+        val account = requireComponents.backgroundServices.accountManager.authenticatedAccount()
+        if (account == null) {
+            Mode.Onboarding(OnboardingState.SignedOut)
+        } else {
+            Mode.Onboarding(OnboardingState.ManuallySignedIn)
+        }
     } else if ((activity as HomeActivity).browsingModeManager.isPrivate) {
         Mode.Private
     } else {

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -26,6 +26,9 @@ import kotlinx.coroutines.runBlocking
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
+import mozilla.components.concept.sync.AccountObserver
+import mozilla.components.concept.sync.OAuthAccount
+import mozilla.components.concept.sync.Profile
 import org.jetbrains.anko.constraint.layout.ConstraintSetBuilder.Side.BOTTOM
 import org.jetbrains.anko.constraint.layout.ConstraintSetBuilder.Side.END
 import org.jetbrains.anko.constraint.layout.ConstraintSetBuilder.Side.START
@@ -67,7 +70,7 @@ import kotlin.coroutines.CoroutineContext
 import kotlin.math.roundToInt
 
 @SuppressWarnings("TooManyFunctions", "LargeClass")
-class HomeFragment : Fragment(), CoroutineScope {
+class HomeFragment : Fragment(), CoroutineScope, AccountObserver {
     private val bus = ActionBusFactory.get(this)
     private var sessionObserver: SessionManager.Observer? = null
     private var tabCollectionObserver: Observer<List<TabCollection>>? = null
@@ -208,6 +211,8 @@ class HomeFragment : Fragment(), CoroutineScope {
         homeLayout?.progress =
             if (homeViewModel?.motionLayoutProgress ?: 0F > MOTION_LAYOUT_PROGRESS_ROUND_POINT) 1.0f else 0f
         (activity as AppCompatActivity).supportActionBar?.hide()
+
+        requireComponents.backgroundServices.accountManager.register(this, owner = this)
     }
 
     @SuppressWarnings("ComplexMethod")
@@ -587,6 +592,11 @@ class HomeFragment : Fragment(), CoroutineScope {
         )
     }
 
+    private fun emitAccountChanges() {
+        val mode = currentMode()
+        getManagedEmitter<SessionControlChange>().onNext(SessionControlChange.ModeChange(mode))
+    }
+
     private fun showCollectionCreationFragment(
         selectedTabId: String? = null,
         selectedTabCollection: TabCollection? = null,
@@ -613,7 +623,6 @@ class HomeFragment : Fragment(), CoroutineScope {
     }
 
     private fun currentMode(): Mode = if (!onboarding.userHasBeenOnboarded()) {
-        // TODO monitor account state changes somewhere in this class via AccountObserver + `accountManager.register()`.
         val account = requireComponents.backgroundServices.accountManager.authenticatedAccount()
         if (account == null) {
             Mode.Onboarding(OnboardingState.SignedOut)
@@ -625,6 +634,11 @@ class HomeFragment : Fragment(), CoroutineScope {
     } else {
         Mode.Normal
     }
+
+    override fun onAuthenticated(account: OAuthAccount) { emitAccountChanges() }
+    override fun onError(error: Exception) { emitAccountChanges() }
+    override fun onLoggedOut() { emitAccountChanges() }
+    override fun onProfileUpdated(profile: Profile) { emitAccountChanges() }
 
     companion object {
         private const val toolbarPaddingDp = 12f

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlAdapter.kt
@@ -51,7 +51,7 @@ sealed class AdapterItem {
 
     object OnboardingHeader : AdapterItem()
     data class OnboardingSectionHeader(val labelBuilder: (Context) -> String) : AdapterItem()
-    object OnboardingFirefoxAccount : AdapterItem()
+    data class OnboardingFirefoxAccount(val state: OnboardingState) : AdapterItem()
     object OnboardingThemePicker : AdapterItem()
     object OnboardingTrackingProtection : AdapterItem()
     object OnboardingPrivateBrowsing : AdapterItem()
@@ -72,7 +72,7 @@ sealed class AdapterItem {
             is TabInCollectionItem -> TabInCollectionViewHolder.LAYOUT_ID
             OnboardingHeader -> OnboardingHeaderViewHolder.LAYOUT_ID
             is OnboardingSectionHeader -> OnboardingSectionHeaderViewHolder.LAYOUT_ID
-            OnboardingFirefoxAccount -> OnboardingFirefoxAccountViewHolder.LAYOUT_ID
+            is OnboardingFirefoxAccount -> OnboardingFirefoxAccountViewHolder.LAYOUT_ID
             OnboardingThemePicker -> OnboardingThemePickerViewHolder.LAYOUT_ID
             OnboardingTrackingProtection -> OnboardingTrackingProtectionViewHolder.LAYOUT_ID
             OnboardingPrivateBrowsing -> OnboardingPrivateBrowsingViewHolder.LAYOUT_ID
@@ -155,6 +155,9 @@ class SessionControlAdapter(
             }
             is OnboardingSectionHeaderViewHolder -> holder.bind(
                 (items[position] as AdapterItem.OnboardingSectionHeader).labelBuilder
+            )
+            is OnboardingFirefoxAccountViewHolder -> holder.bind(
+                (items[position] as AdapterItem.OnboardingFirefoxAccount).state == OnboardingState.AutoSignedIn
             )
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlComponent.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlComponent.kt
@@ -69,11 +69,11 @@ fun List<Tab>.toSessionBundle(context: Context): MutableList<Session> {
  * Describes various onboarding states.
  */
 enum class OnboardingState {
-    // signed out, no account carried over from Fennec.
+    // Signed out, no account carried over from Fennec.
     SignedOut,
-    // auto-signed in, via a Fennec account.
+    // Auto-signed in, via a Fennec account.
     AutoSignedIn,
-    // manually signed in while in onboarding.
+    // Manually signed in while in onboarding.
     ManuallySignedIn
 }
 

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlComponent.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlComponent.kt
@@ -64,10 +64,23 @@ fun List<Tab>.toSessionBundle(context: Context): MutableList<Session> {
 
     return sessionBundle
 }
+
+/**
+ * Describes various onboarding states.
+ */
+enum class OnboardingState {
+    // signed out, no account carried over from Fennec.
+    SignedOut,
+    // auto-signed in, via a Fennec account.
+    AutoSignedIn,
+    // manually signed in while in onboarding.
+    ManuallySignedIn
+}
+
 sealed class Mode {
     object Normal : Mode()
     object Private : Mode()
-    object Onboarding : Mode()
+    data class Onboarding(val state: OnboardingState) : Mode()
 }
 
 data class SessionControlState(

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlUIView.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlUIView.kt
@@ -70,21 +70,15 @@ private fun onboardingAdapterItems(onboardingState: OnboardingState): List<Adapt
         OnboardingState.SignedOut -> {
             listOf(
                 AdapterItem.OnboardingSectionHeader { it.getString(R.string.onboarding_fxa_section_header) },
-                AdapterItem.OnboardingFirefoxAccount
+                AdapterItem.OnboardingFirefoxAccount(onboardingState)
             )
         }
         OnboardingState.AutoSignedIn -> {
             listOf(
-                AdapterItem.OnboardingSectionHeader { it.getString(R.string.onboarding_fxa_section_header) },
-                AdapterItem.OnboardingFirefoxAccount
+                AdapterItem.OnboardingFirefoxAccount(onboardingState)
             )
         }
-        OnboardingState.ManuallySignedIn -> {
-            listOf(
-                AdapterItem.OnboardingSectionHeader { it.getString(R.string.onboarding_fxa_section_header) },
-                AdapterItem.OnboardingFirefoxAccount
-            )
-        }
+        else -> listOf()
     })
 
     items.addAll(listOf(

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlUIView.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlUIView.kt
@@ -64,7 +64,6 @@ private fun privateModeAdapterItems(tabs: List<Tab>): List<AdapterItem> {
 private fun onboardingAdapterItems(onboardingState: OnboardingState): List<AdapterItem> {
     val items: MutableList<AdapterItem> = mutableListOf(AdapterItem.OnboardingHeader)
 
-    // TODO customize the UI based on different account states.
     // Customize FxA items based on where we are with the account state:
     items.addAll(when (onboardingState) {
         OnboardingState.SignedOut -> {

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlUIView.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlUIView.kt
@@ -61,25 +61,51 @@ private fun privateModeAdapterItems(tabs: List<Tab>): List<AdapterItem> {
     return items
 }
 
-private fun onboardingAdapterItems(): List<AdapterItem> = listOf(
-    AdapterItem.OnboardingHeader,
-    AdapterItem.OnboardingSectionHeader() { it.getString(R.string.onboarding_fxa_section_header) },
-    AdapterItem.OnboardingFirefoxAccount,
-    AdapterItem.OnboardingSectionHeader() {
-        val appName = it.getString(R.string.app_name)
-        it.getString(R.string.onboarding_feature_section_header, appName)
-    },
-    AdapterItem.OnboardingThemePicker,
-    AdapterItem.OnboardingTrackingProtection,
-    AdapterItem.OnboardingPrivateBrowsing,
-    AdapterItem.OnboardingPrivacyNotice,
-    AdapterItem.OnboardingFinish
-)
+private fun onboardingAdapterItems(onboardingState: OnboardingState): List<AdapterItem> {
+    val items: MutableList<AdapterItem> = mutableListOf(AdapterItem.OnboardingHeader)
+
+    // TODO customize the UI based on different account states.
+    // Customize FxA items based on where we are with the account state:
+    items.addAll(when (onboardingState) {
+        OnboardingState.SignedOut -> {
+            listOf(
+                AdapterItem.OnboardingSectionHeader { it.getString(R.string.onboarding_fxa_section_header) },
+                AdapterItem.OnboardingFirefoxAccount
+            )
+        }
+        OnboardingState.AutoSignedIn -> {
+            listOf(
+                AdapterItem.OnboardingSectionHeader { it.getString(R.string.onboarding_fxa_section_header) },
+                AdapterItem.OnboardingFirefoxAccount
+            )
+        }
+        OnboardingState.ManuallySignedIn -> {
+            listOf(
+                AdapterItem.OnboardingSectionHeader { it.getString(R.string.onboarding_fxa_section_header) },
+                AdapterItem.OnboardingFirefoxAccount
+            )
+        }
+    })
+
+    items.addAll(listOf(
+        AdapterItem.OnboardingSectionHeader {
+            val appName = it.getString(R.string.app_name)
+            it.getString(R.string.onboarding_feature_section_header, appName)
+        },
+        AdapterItem.OnboardingThemePicker,
+        AdapterItem.OnboardingTrackingProtection,
+        AdapterItem.OnboardingPrivateBrowsing,
+        AdapterItem.OnboardingPrivacyNotice,
+        AdapterItem.OnboardingFinish
+    ))
+
+    return items
+}
 
 private fun SessionControlState.toAdapterList(): List<AdapterItem> = when (mode) {
     is Mode.Normal -> normalModeAdapterItems(tabs, collections, expandedCollections)
     is Mode.Private -> privateModeAdapterItems(tabs)
-    is Mode.Onboarding -> onboardingAdapterItems()
+    is Mode.Onboarding -> onboardingAdapterItems(mode.state)
 }
 
 private fun collectionTabItems(collection: TabCollection) = collection.tabs.mapIndexed { index, tab ->

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingFirefoxAccountViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingFirefoxAccountViewHolder.kt
@@ -20,6 +20,17 @@ class OnboardingFirefoxAccountViewHolder(private val view: View) : RecyclerView.
     }
 
     fun bind(autoSignedIn: Boolean) {
+        updateHeaderText(autoSignedIn)
+        updateButtonVisibility(autoSignedIn)
+    }
+
+    private fun updateButtonVisibility(autoSignedIn: Boolean) {
+        view.turn_on_sync_button.visibility = if (autoSignedIn) View.GONE else View.VISIBLE
+        view.stay_signed_in_button.visibility = if (autoSignedIn) View.VISIBLE else View.GONE
+        view.sign_out_button.visibility = if (autoSignedIn) View.VISIBLE else View.GONE
+    }
+
+    private fun updateHeaderText(autoSignedIn: Boolean) {
         val appName = view.context.getString(R.string.app_name)
 
         val icon =
@@ -30,10 +41,6 @@ class OnboardingFirefoxAccountViewHolder(private val view: View) : RecyclerView.
         view.header_text.text =
             if (!autoSignedIn) view.context.getString(R.string.onboarding_firefox_account_auto_signin_header)
             else view.context.getString(R.string.onboarding_firefox_account_header, appName)
-
-        view.turn_on_sync_button.visibility = if (autoSignedIn) View.GONE else View.VISIBLE
-        view.stay_signed_in_button.visibility = if (autoSignedIn) View.VISIBLE else View.GONE
-        view.sign_out_button.visibility = if (autoSignedIn) View.VISIBLE else View.GONE
     }
 
     companion object {

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingFirefoxAccountViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingFirefoxAccountViewHolder.kt
@@ -11,16 +11,29 @@ import kotlinx.android.synthetic.main.onboarding_firefox_account.view.*
 import org.mozilla.fenix.R
 import org.mozilla.fenix.home.HomeFragmentDirections
 
-class OnboardingFirefoxAccountViewHolder(view: View) : RecyclerView.ViewHolder(view) {
-
+class OnboardingFirefoxAccountViewHolder(private val view: View) : RecyclerView.ViewHolder(view) {
     init {
-        val appName = view.context.getString(R.string.app_name)
-        view.header_text.text = view.context.getString(R.string.onboarding_firefox_account_header, appName)
-
         view.turn_on_sync_button.setOnClickListener {
             val directions = HomeFragmentDirections.actionHomeFragmentToTurnOnSyncFragment()
             Navigation.findNavController(view).navigate(directions)
         }
+    }
+
+    fun bind(autoSignedIn: Boolean) {
+        val appName = view.context.getString(R.string.app_name)
+
+        val icon =
+            if (autoSignedIn) view.context.getDrawable(R.drawable.ic_onboarding_avatar_anonymous)
+            else view.context.getDrawable(R.drawable.ic_onboarding_firefox_accounts)
+
+        view.header_text.setCompoundDrawablesRelativeWithIntrinsicBounds(icon, null, null, null)
+        view.header_text.text =
+            if (!autoSignedIn) view.context.getString(R.string.onboarding_firefox_account_auto_signin_header)
+            else view.context.getString(R.string.onboarding_firefox_account_header, appName)
+
+        view.turn_on_sync_button.visibility = if (autoSignedIn) View.GONE else View.VISIBLE
+        view.stay_signed_in_button.visibility = if (autoSignedIn) View.VISIBLE else View.GONE
+        view.sign_out_button.visibility = if (autoSignedIn) View.VISIBLE else View.GONE
     }
 
     companion object {

--- a/app/src/main/res/drawable/ic_onboarding_avatar_anonymous.xml
+++ b/app/src/main/res/drawable/ic_onboarding_avatar_anonymous.xml
@@ -1,0 +1,47 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M17.6655,14.2092C16.1843,12.4998 14.1333,14.8 11.9997,14.8C9.8675,14.8 7.8151,12.4998 6.3339,14.2092C5.9139,14.6936 5.8803,15.3992 6.2401,15.9284C7.4959,17.7764 9.5959,19 11.9997,19C14.4035,19 16.5035,17.7764 17.7593,15.9284C18.1205,15.3992 18.0855,14.6936 17.6655,14.2092M16.25,9.25C16.25,6.9026 14.3474,5 12,5C9.6526,5 7.75,6.9026 7.75,9.25C7.75,11.5974 9.6526,13.5 12,13.5C14.3474,13.5 16.25,11.5974 16.25,9.25Z"
+      android:strokeWidth="1"
+      android:fillType="nonZero"
+      android:strokeColor="#00000000">
+    <aapt:attr name="android:fillColor">
+      <gradient 
+          android:startY="21.265238"
+          android:startX="10.078417"
+          android:endY="-6.155523"
+          android:endX="18.457676"
+          android:type="linear">
+        <item android:offset="0" android:color="#FF00B3F4"/>
+        <item android:offset="0.16" android:color="#FF07B8ED"/>
+        <item android:offset="0.41" android:color="#FF1AC6D8"/>
+        <item android:offset="0.7" android:color="#FF39DCB7"/>
+        <item android:offset="0.76" android:color="#FF3FE1B0"/>
+      </gradient>
+    </aapt:attr>
+  </path>
+  <path
+      android:pathData="M12,22C6.4772,22 2,17.5228 2,12C2,6.4772 6.4772,2 12,2C17.5228,2 22,6.4772 22,12C21.9939,17.5203 17.5203,21.9939 12,22L12,22ZM12,4C7.5817,4 4,7.5817 4,12C4,16.4183 7.5817,20 12,20C16.4183,20 20,16.4183 20,12C19.995,7.5838 16.4162,4.005 12,4Z"
+      android:strokeWidth="1"
+      android:fillType="nonZero"
+      android:strokeColor="#00000000">
+    <aapt:attr name="android:fillColor">
+      <gradient 
+          android:startY="25.236055"
+          android:startX="7.735972"
+          android:endY="-13.936461"
+          android:endX="26.325832"
+          android:type="linear">
+        <item android:offset="0" android:color="#FF00B3F4"/>
+        <item android:offset="0.16" android:color="#FF07B8ED"/>
+        <item android:offset="0.41" android:color="#FF1AC6D8"/>
+        <item android:offset="0.7" android:color="#FF39DCB7"/>
+        <item android:offset="0.76" android:color="#FF3FE1B0"/>
+      </gradient>
+    </aapt:attr>
+  </path>
+</vector>

--- a/app/src/main/res/layout/onboarding_firefox_account.xml
+++ b/app/src/main/res/layout/onboarding_firefox_account.xml
@@ -42,4 +42,49 @@
             android:textColor="?neutral"
             android:textSize="14sp" />
     </FrameLayout>
+    <FrameLayout
+        android:id="@+id/stay_signed_in_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:background="@drawable/button_background"
+        android:backgroundTint="@color/onboarding_card_button_background_dark"
+        android:clickable="true"
+        android:focusable="true"
+        android:foreground="?android:attr/selectableItemBackground"
+        android:padding="10dp"
+        android:visibility="gone">
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:clickable="false"
+            android:focusable="false"
+            android:textStyle="bold"
+            android:gravity="center"
+            android:text="@string/onboarding_firefox_account_stay_signed_in"
+            android:textColor="?neutral"
+            android:textSize="14sp" />
+    </FrameLayout>
+    <FrameLayout
+        android:id="@+id/sign_out_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:clickable="true"
+        android:focusable="true"
+        android:foreground="?android:attr/selectableItemBackground"
+        android:padding="10dp"
+        android:visibility="gone">
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:clickable="false"
+            android:focusable="false"
+            android:gravity="center"
+            android:text="@string/onboarding_firefox_account_sign_out"
+            android:textColor="?neutral"
+            android:textSize="12sp" />
+    </FrameLayout>
 </LinearLayout>

--- a/app/src/main/res/values/static_strings.xml
+++ b/app/src/main/res/values/static_strings.xml
@@ -34,8 +34,15 @@
     <!-- text for the firefox account onboarding card header
     The first parameter is the name of the app defined in app_name (for example: Firefox Preview) -->
     <string name="onboarding_firefox_account_header" translatable="false">Get the most out of %s.</string>
-    <!-- text for the button to sign into your Firefox account -->
+    <!-- text for the firefox account onboarding card header when we detect you're already signed in to
+        another Firefox browser. (The word `Firefox` should not be translated -->
+    <string name="onboarding_firefox_account_auto_signin_header" translatable="false">You are signed in to another Firefox browser on this phone.</string>
+    <!-- text for the button to sign into your Firefox account. The word "Firefox" should not be translated -->
     <string name="onboarding_firefox_account_sign_in">Sign in to Firefox</string>
+    <!-- text for the button to stay signed into your Firefox account. -->
+    <string name="onboarding_firefox_account_stay_signed_in">Stay signed in</string>
+    <!-- text for the button to sign out of your Firefox account. -->
+    <string name="onboarding_firefox_account_sign_out">Sign out</string>
     <!-- text for the tracking protection onboarding card header -->
     <string name="onboarding_tracking_protection_header" translatable="false">Protect yourself</string>
     <!-- text for the tracking protection card description


### PR DESCRIPTION
Missing UI customizations, probably will need new strings, and missing an account observer listener impl (to live in HomeFragment, I think).

cc @boek 


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
