### PR TITLE
Update AC, GV and switch to GV beta.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -286,7 +286,7 @@ dependencies {
     implementation Deps.mozilla_feature_downloads
     implementation Deps.mozilla_browser_domains
     implementation Deps.mozilla_browser_icons
-    implementation Deps.mozilla_browser_engine_gecko_nightly
+    implementation Deps.mozilla_browser_engine_gecko_beta
     implementation Deps.mozilla_browser_session
     implementation Deps.mozilla_browser_storage_sync
     implementation Deps.mozilla_browser_toolbar
@@ -324,9 +324,9 @@ dependencies {
 
     implementation Deps.mozilla_lib_fetch_httpurlconnection
 
-    armImplementation Gecko.geckoview_nightly_arm
-    x86Implementation Gecko.geckoview_nightly_x86
-    aarch64Implementation Gecko.geckoview_nightly_aarch64
+    armImplementation Gecko.geckoview_beta_arm
+    x86Implementation Gecko.geckoview_beta_x86
+    aarch64Implementation Gecko.geckoview_beta_aarch64
 
     implementation Deps.androidx_legacy
     implementation Deps.androidx_preference

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -29,7 +29,7 @@ private object Versions {
     const val androidx_transition = "1.1.0-rc01"
 
     const val appservices_gradle_plugin = "0.4.4"
-    const val mozilla_android_components = "0.53.0-SNAPSHOT"
+    const val mozilla_android_components = "0.54.0-SNAPSHOT"
     const val mozilla_appservices = "0.27.0"
 
     const val autodispose = "1.1.0"

--- a/buildSrc/src/main/java/Gecko.kt
+++ b/buildSrc/src/main/java/Gecko.kt
@@ -3,9 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object GeckoVersions {
-    const val nightly_version = "68.0.20190508111321"
-    const val beta_version = "67.0.20190430135507"
-    const val release_version = "66.0.20190322021635"
+    const val nightly_version = "69.0.20190522093426"
+    const val beta_version = "68.0.20190520141152"
+    const val release_version = "67.0.20190521210220"
 }
 
 @Suppress("MaxLineLength")


### PR DESCRIPTION
* Android Components: 0.48.0-SNAPSHOT
* Updates GeckoView versions
* Switches to GeckoView Beta / browser-engine-gecko-beta (68.0).

May depend on #2716.