### PR TITLE
For #1287 - Create animation for opening and closing tab from home

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -73,6 +73,7 @@ open class HomeActivity : AppCompatActivity() {
         val navigationToolbar = findViewById<Toolbar>(R.id.navigationToolbar)
         setSupportActionBar(navigationToolbar)
         NavigationUI.setupWithNavController(navigationToolbar, navHost.navController, appBarConfiguration)
+        supportActionBar?.hide()
 
         intent
             ?.let { SafeIntent(it) }

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarIntegration.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarIntegration.kt
@@ -57,7 +57,7 @@ class ToolbarIntegration(
                     {
                         toolbar.hideKeyboard()
                         // We need to dynamically add the options here because if you do it in XML it overwrites
-                        val options = NavOptions.Builder().setPopUpTo(R.id.browserFragment, false)
+                        val options = NavOptions.Builder().setPopUpTo(R.id.homeFragment, true)
                             .setEnterAnim(R.anim.fade_in).setExitAnim(R.anim.fade_out).build()
                         val extras =
                             FragmentNavigator.Extras.Builder()
@@ -66,8 +66,10 @@ class ToolbarIntegration(
                                     "$TAB_ITEM_TRANSITION_NAME${sessionManager.selectedSession?.id}"
                                 )
                                 .build()
-                        Navigation.findNavController(toolbar)
-                            .navigate(R.id.action_browserFragment_to_homeFragment, null, options, extras)
+                        val navController = Navigation.findNavController(toolbar)
+                        if (!navController.popBackStack(R.id.homeFragment, false)) {
+                            navController.navigate(R.id.action_browserFragment_to_homeFragment, null, options, extras)
+                        }
                     },
                     isPrivate
                 )

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarUIView.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarUIView.kt
@@ -108,6 +108,7 @@ class ToolbarUIView(
             toolbarIntegration = ToolbarIntegration(
                 this,
                 view,
+                container,
                 menuToolbar,
                 ShippedDomainsProvider().also { it.initialize(this) },
                 components.core.historyStorage,

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -50,7 +50,6 @@ import org.mozilla.fenix.collections.CreateCollectionViewModel
 import org.mozilla.fenix.collections.SaveCollectionStep
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.allowUndo
-import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.urlToTrimmedHost
 import org.mozilla.fenix.home.sessioncontrol.CollectionAction

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -246,8 +246,9 @@ class HomeFragment : Fragment(), CoroutineScope, AccountObserver {
                             homeViewModel?.layoutManagerState?.also { parcelable ->
                                 sessionControlComponent.view.layoutManager?.onRestoreInstanceState(parcelable)
                             }
+                            val progress = homeViewModel?.motionLayoutProgress
                             homeLayout?.progress =
-                                if (homeViewModel?.motionLayoutProgress ?: 0F > MOTION_LAYOUT_PROGRESS_ROUND_POINT) 1.0f else 0f
+                                if (progress ?: 0F > MOTION_LAYOUT_PROGRESS_ROUND_POINT) 1.0f else 0f
                             homeViewModel?.layoutManagerState = null
                         }
                     }

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -48,8 +48,8 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.collections.CreateCollectionViewModel
 import org.mozilla.fenix.collections.SaveCollectionStep
 import org.mozilla.fenix.components.metrics.Event
-import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.allowUndo
+import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.urlToTrimmedHost
 import org.mozilla.fenix.home.sessioncontrol.CollectionAction
@@ -220,14 +220,6 @@ class HomeFragment : Fragment(), CoroutineScope, AccountObserver {
 
     override fun onResume() {
         super.onResume()
-        val homeViewModel = activity?.run {
-            ViewModelProviders.of(this).get(HomeScreenViewModel::class.java)
-        }
-        homeViewModel?.layoutManagerState?.also { parcelable ->
-            sessionControlComponent.view.layoutManager?.onRestoreInstanceState(parcelable)
-        }
-        homeLayout?.progress =
-            if (homeViewModel?.motionLayoutProgress ?: 0F > MOTION_LAYOUT_PROGRESS_ROUND_POINT) 1.0f else 0f
         (activity as AppCompatActivity).supportActionBar?.hide()
 
         requireComponents.backgroundServices.accountManager.register(this, owner = this)

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlComponent.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlComponent.kt
@@ -7,6 +7,7 @@ package org.mozilla.fenix.home.sessioncontrol
 import android.content.Context
 import android.graphics.Bitmap
 import android.os.Parcelable
+import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import io.reactivex.Observer
@@ -97,7 +98,7 @@ sealed class TabAction : Action {
     object Add : TabAction()
     object ShareTabs : TabAction()
     data class CloseAll(val private: Boolean) : TabAction()
-    data class Select(val sessionId: String) : TabAction()
+    data class Select(val tabView: View, val sessionId: String) : TabAction()
     data class Close(val sessionId: String) : TabAction()
     data class Share(val sessionId: String) : TabAction()
     object PrivateBrowsingLearnMore : TabAction()

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/TabViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/TabViewHolder.kt
@@ -53,7 +53,7 @@ class TabViewHolder(
 
         close_tab_button.increaseTapArea(buttonIncreaseDps)
         item_tab.setOnClickListener {
-            actionEmitter.onNext(TabAction.Select(tab?.sessionId!!))
+            actionEmitter.onNext(TabAction.Select(it, tab?.sessionId!!))
         }
 
         item_tab.setOnLongClickListener {
@@ -85,6 +85,7 @@ class TabViewHolder(
     fun bindSession(tab: Tab) {
         this.tab = tab
         updateTabUI(tab)
+        item_tab.transitionName = "$TAB_ITEM_TRANSITION_NAME${tab.sessionId}"
         updateSelected(tab.selected ?: false)
     }
 
@@ -105,6 +106,7 @@ class TabViewHolder(
     }
 
     companion object {
+        private const val TAB_ITEM_TRANSITION_NAME = "tab_item"
         const val LAYOUT_ID = R.layout.tab_list_row
         const val buttonIncreaseDps = 12
         const val favIconBorderRadiusInPx = 8

--- a/app/src/main/res/layout/component_session_control.xml
+++ b/app/src/main/res/layout/component_session_control.xml
@@ -3,11 +3,12 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
-<androidx.recyclerview.widget.RecyclerView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.recyclerview.widget.RecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/home_component"
     android:layout_width="0dp"
     android:layout_height="0dp"
+    android:clipChildren="false"
+    android:clipToPadding="false"
     android:padding="16dp"
     android:scrollbars="none"
-    android:clipToPadding="false" />
+    android:transitionGroup="false" />

--- a/app/src/main/res/layout/fragment_browser.xml
+++ b/app/src/main/res/layout/fragment_browser.xml
@@ -24,7 +24,7 @@
         android:clipToPadding="true"
         app:behavior_hideable="true"
         app:behavior_peekHeight="12dp"
-        app:layout_behavior="org.mozilla.fenix.quickactionsheet.QuickActionSheetBehavior"/>
+        app:layout_behavior="org.mozilla.fenix.quickactionsheet.QuickActionSheetBehavior" />
 
     <mozilla.components.feature.findinpage.view.FindInPageBar
         android:id="@+id/findInPageView"
@@ -41,11 +41,11 @@
 
     <mozilla.components.feature.readerview.view.ReaderViewControlsBar
         android:id="@+id/readerViewControlsBar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom"
         android:background="?foundation"
         android:elevation="24dp"
-        android:visibility="gone"
-        android:layout_gravity="bottom"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+        android:visibility="gone" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -13,7 +13,6 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="?homeBackground"
-        android:clipChildren="false"
         app:layoutDescription="@xml/home_scene"
         tools:context=".home.HomeFragment">
         <ImageButton

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -13,6 +13,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="?homeBackground"
+        android:clipChildren="false"
         app:layoutDescription="@xml/home_scene"
         tools:context=".home.HomeFragment">
         <ImageButton

--- a/app/src/main/res/layout/tab_list_row.xml
+++ b/app/src/main/res/layout/tab_list_row.xml
@@ -12,6 +12,7 @@
     android:clipToPadding="false"
     android:focusable="true"
     android:foreground="?android:attr/selectableItemBackground"
+    android:transitionGroup="true"
     app:cardBackgroundColor="?above"
     app:cardCornerRadius="@dimen/tab_corner_radius"
     app:cardElevation="5dp">

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -28,7 +28,9 @@
             app:destination="@id/searchFragment" />
         <action
             android:id="@+id/action_homeFragment_to_browserFragment"
-            app:destination="@id/browserFragment" />
+            app:destination="@id/browserFragment"
+            app:enterAnim="@anim/fade_in"
+            app:exitAnim="@anim/fade_out" />
         <action
             android:id="@+id/action_homeFragment_to_libraryFragment"
             app:destination="@id/libraryFragment" />
@@ -113,9 +115,7 @@
         tools:layout="@layout/fragment_browser">
         <action
             android:id="@+id/action_browserFragment_to_homeFragment"
-            app:destination="@id/homeFragment"
-            app:popUpTo="@+id/nav_graph"
-            app:popUpToInclusive="true" />
+            app:destination="@id/homeFragment" />
         <action
             android:id="@+id/action_browserFragment_to_searchFragment"
             app:destination="@id/searchFragment" />

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -29,7 +29,9 @@
             android:id="@+id/action_homeFragment_to_browserFragment"
             app:destination="@id/browserFragment"
             app:enterAnim="@anim/fade_in"
-            app:exitAnim="@anim/fade_out" />
+            app:exitAnim="@anim/fade_out"
+            app:popEnterAnim="@anim/fade_in"
+            app:popExitAnim="@anim/fade_out" />
         <action
             android:id="@+id/action_homeFragment_to_libraryFragment"
             app:destination="@id/libraryFragment" />

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -18,7 +18,6 @@
     <fragment
         android:id="@+id/homeFragment"
         android:name="org.mozilla.fenix.home.HomeFragment"
-        android:label="fragment_home"
         tools:layout="@layout/fragment_home">
         <action
             android:id="@+id/action_homeFragment_to_turnOnSyncFragment"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -6,6 +6,7 @@
 
     <style name="NormalThemeBase" parent="Theme.AppCompat.DayNight.NoActionBar">
         <!-- Android system styling -->
+        <item name="android:windowContentTransitions">true</item>
         <item name="android:windowAnimationStyle">@style/WindowAnimationTransition</item>
         <item name="android:progressBarStyleHorizontal">@style/progressBarStyleHorizontal</item>
         <item name="android:statusBarColor">@color/foundation_normal_theme</item>
@@ -58,6 +59,7 @@
 
     <style name="PrivateThemeBase" parent="Theme.AppCompat.NoActionBar">
         <!-- Android system styling -->
+        <item name="android:windowContentTransitions">true</item>
         <item name="android:windowAnimationStyle">@style/WindowAnimationTransition</item>
         <item name="android:progressBarStyleHorizontal">@style/progressBarStyleHorizontal</item>
         <item name="android:statusBarColor">@color/foundation_private_theme</item>


### PR DESCRIPTION
I'm wondering if there is a way to see if there's a pending shared transition so that we don't have to block any animation on the IDs being set in HomeFragment. Let's test it and make a follow up ticket if we need to

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
