### PR TITLE
For #2736 - Fix Docker build error [WIP]

### DIFF
--- a/automation/docker/Dockerfile
+++ b/automation/docker/Dockerfile
@@ -54,12 +54,14 @@ RUN sdkmanager --verbose "platform-tools" \
     "extras;google;m2repository"
 
 # Checkout source code
-#RUN git clone https://github.com/mozilla-mobile/fenix.git
-RUN git clone https://github.com/rpappalax/fenix.git -b dockerfile-add-test-deps --single-branch
+RUN git clone https://github.com/mozilla-mobile/fenix.git
 
 # Build project and run gradle tasks once to pull all dependencies
 WORKDIR /opt/fenix
-RUN ./gradlew -PversionName=0.0 --no-daemon assemble test lint
+RUN ./gradlew clean
+RUN ./gradlew --stop 
+#RUN ./gradlew  --no-daemon assembleDebug test lint 
+RUN ./gradlew  -PversionName=0.0 --no-daemon assemble test lint 
 
 # -- Test tools -------------------------------------------------------------------------
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,8 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx2048m
+#org.gradle.jvmargs=-Xmx2048m -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap
+#org.gradle.jvmargs=-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
@@ -18,4 +20,3 @@ android.enableJetifier=true
 android.enableR8=true
 android.enableR8.fullMode=true
 android.enableUnitTestBinaryResources=true
-org.gradle.parallel=false


### PR DESCRIPTION
DO NOT MERGE

I believe I've fixed a memory issue that was causing a build failure, but looks like there's process error on glean_parser bootstrap...
@travis79 @Dexterp37 are there perhaps some missing args?

```
app:compileAarch64DebugRenderscript
> Task :app:checkAarch64DebugManifest
> Task :app:generateAarch64DebugBuildConfig
> Task :app:generateMetricsSourceForAarch64Debug FAILED

FAILURE: Build failed with an exception.

* Where:
Script 'https://github.com/mozilla-mobile/android-components/raw/master/components/service/glean/scripts/sdk_generator.gradle' line: 180

* What went wrong:
Execution failed for task ':app:generateMetricsSourceForAarch64Debug'.
> Process '[/root/.gradle/glean/bootstrap-4.5.11/Miniconda3/bin/python, -c,
  import importlib
  import subprocess
  import sys

  module_name = sys.argv[1]
  expected_version = sys.argv[2]

  try:
      module = importlib.import_module(module_name)
  except ImportError:
      found_version = None
  else:
      found_version = getattr(module, '__version__')

  if found_version != expected_version:
      subprocess.check_call([
          sys.executable,
          '-m',
          'pip',
          'install',
          '--upgrade',
          f'{module_name}=={expected_version}'
      ])

  subprocess.check_call([
      sys.executable,
      '-m',
      module_name
  ] + sys.argv[3:])
  , glean_parser, 0.27.1, translate, -f, kotlin, -o, /opt/fenix/app/build/generated/source/glean/aarch64/debug/kotlin, -s, namespace=org.mozilla.fenix.GleanMetrics, /opt/fenix/app/metrics.yaml, /opt/fenix/app/pings.yaml]' finished with non-zero exit value 1:

  ==============================================================================
  /opt/fenix/app/pings.yaml: On instance activation:
      __init__() missing 2 required positional arguments: 'bugs' and 'notification_emails'
  Traceback (most recent call last):
    File "<string>", line 30, in <module>
    File "/root/.gradle/glean/bootstrap-4.5.11/Miniconda3/lib/python3.7/subprocess.py", line 328, in check_call
      raise CalledProcessError(retcode, cmd)
  subprocess.CalledProcessError: Command '['/root/.gradle/glean/bootstrap-4.5.11/Miniconda3/bin/python', '-m', 'glean_parser', 'translate', '-f', 'kotlin', '-o', '/opt/fenix/app/build/generated/source/glean/aarch64/debug/kotlin', '-s', 'namespace=org.mozilla.fenix.GleanMetrics', '/opt/fenix/app/metrics.yaml', '/opt/fenix/app/pings.yaml']' returned non-zero exit status 1.


* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 4m 26s
9 actionable tasks: 9 executed
The command '/bin/sh -c ./gradlew --no-daemon assembleDebug test lint' returned a non-zero code: 1
```


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
