### PR TITLE
Fixes #2739. Update sign-in preference visibility when screen is resumed.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
@@ -52,7 +52,7 @@ import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.utils.ItsNotBrokenSnack
 import kotlin.coroutines.CoroutineContext
 
-@SuppressWarnings("TooManyFunctions")
+@SuppressWarnings("TooManyFunctions", "LargeClass")
 class SettingsFragment : PreferenceFragmentCompat(), CoroutineScope, AccountObserver {
     private lateinit var job: Job
     override val coroutineContext: CoroutineContext
@@ -61,7 +61,6 @@ class SettingsFragment : PreferenceFragmentCompat(), CoroutineScope, AccountObse
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         job = Job()
-        updateSignInVisibility()
 
         preferenceManager.sharedPreferences.registerOnSharedPreferenceChangeListener { sharedPreferences, key ->
             try {
@@ -118,6 +117,7 @@ class SettingsFragment : PreferenceFragmentCompat(), CoroutineScope, AccountObse
 
         setupPreferences()
         setupAccountUI()
+        updateSignInVisibility()
     }
 
     @Suppress("ComplexMethod")
@@ -283,6 +283,7 @@ class SettingsFragment : PreferenceFragmentCompat(), CoroutineScope, AccountObse
 
     override fun onAuthenticated(account: OAuthAccount) {
         updateAuthState(account)
+        updateSignInVisibility()
     }
 
     override fun onError(error: Exception) {


### PR DESCRIPTION
Update sign-in item visibility on each screen resuming, not just when fragment was created.

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~
