### PR TITLE
For #2228 - Update Bookmark Status in onUrlChanged

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -736,6 +736,12 @@ class BrowserFragment : Fragment(), BackHandler, CoroutineScope {
 
                 super.onLoadingStateChanged(session, loading)
             }
+
+            override fun onUrlChanged(session: Session, url: String) {
+                super.onUrlChanged(session, url)
+                updateBookmarkState(session)
+
+            }
         }
         getSessionById()?.register(observer)
         return observer

--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -108,6 +108,7 @@ class BrowserFragment : Fragment(), BackHandler, CoroutineScope {
     private val fullScreenFeature = ViewBoundFeatureWrapper<FullScreenFeature>()
     private val thumbnailsFeature = ViewBoundFeatureWrapper<ThumbnailsFeature>()
     private val customTabsIntegration = ViewBoundFeatureWrapper<CustomTabsIntegration>()
+    private var findBookmarkJob: Job? = null
     private lateinit var job: Job
 
     var customTabSessionId: String? = null
@@ -740,7 +741,6 @@ class BrowserFragment : Fragment(), BackHandler, CoroutineScope {
             override fun onUrlChanged(session: Session, url: String) {
                 super.onUrlChanged(session, url)
                 updateBookmarkState(session)
-
             }
         }
         getSessionById()?.register(observer)
@@ -767,7 +767,8 @@ class BrowserFragment : Fragment(), BackHandler, CoroutineScope {
     }
 
     private fun updateBookmarkState(session: Session) {
-        launch {
+        if (findBookmarkJob?.isActive == true) findBookmarkJob?.cancel()
+        findBookmarkJob = launch {
             val found = findBookmarkedURL(session)
             launch(Main) {
                 getManagedEmitter<QuickActionChange>()


### PR DESCRIPTION
Some sites like youtube don't trigger onLoadingState changed when you click a video so let's also check for if the title changed. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
