### PR TITLE
For #2815 - Use RootView for displaying snackbar in browserfragment

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -423,9 +423,11 @@ class BrowserFragment : Fragment(), BackHandler, CoroutineScope {
                     is SearchAction.ToolbarLongClicked -> {
                         getSessionById()?.let { session ->
                             session.copyUrl(requireContext())
-                            FenixSnackbar.make(view!!, Snackbar.LENGTH_LONG)
-                                .setText(resources.getString(R.string.url_copied))
-                                .show()
+                            view?.rootView?.let {
+                                FenixSnackbar.make(it, Snackbar.LENGTH_LONG)
+                                    .setText(resources.getString(R.string.url_copied))
+                                    .show()
+                            }
                         }
                     }
                 }
@@ -507,7 +509,7 @@ class BrowserFragment : Fragment(), BackHandler, CoroutineScope {
                         requireComponents.analytics.metrics.track(Event.AddBookmark)
                         view?.let {
                             FenixSnackbar.make(
-                                it,
+                                it.rootView,
                                 Snackbar.LENGTH_LONG
                             )
                                 .setAction(getString(R.string.edit_bookmark_snackbar_action)) {


### PR DESCRIPTION
It displays on top of the URL bar but I suppose this is better than not showing up at all.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
