### PR TITLE
No issue: Register observers with owner view

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -248,7 +248,7 @@ open class HomeActivity : AppCompatActivity() {
 
             override fun onSessionAdded(session: Session) {
                 super.onSessionAdded(session)
-                session.register(singleSessionObserver)
+                session.register(singleSessionObserver, this@HomeActivity)
             }
 
             override fun onSessionRemoved(session: Session) {
@@ -259,10 +259,10 @@ open class HomeActivity : AppCompatActivity() {
             override fun onSessionsRestored() {
                 super.onSessionsRestored()
                 components.core.sessionManager.sessions.forEach {
-                    it.register(singleSessionObserver)
+                    it.register(singleSessionObserver, this@HomeActivity)
                 }
             }
-        }.also { components.core.sessionManager.register(it) }
+        }.also { components.core.sessionManager.register(it, this) }
     }
 
     companion object {

--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -739,7 +739,7 @@ class BrowserFragment : Fragment(), BackHandler, CoroutineScope {
                 super.onLoadingStateChanged(session, loading)
             }
         }
-        getSessionById()?.register(observer)
+        getSessionById()?.register(observer, this)
         return observer
     }
 
@@ -749,7 +749,7 @@ class BrowserFragment : Fragment(), BackHandler, CoroutineScope {
                 super.onSessionSelected(session)
                 (activity as HomeActivity).updateThemeForSession(session)
             }
-        }.also { requireComponents.core.sessionManager.register(it) }
+        }.also { requireComponents.core.sessionManager.register(it, this) }
     }
 
     private fun findBookmarkedURL(session: Session?): Boolean {

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -540,7 +540,7 @@ class HomeFragment : Fragment(), CoroutineScope, AccountObserver {
                 emitSessionChanges()
             }
         }
-        requireComponents.core.sessionManager.register(observer)
+        requireComponents.core.sessionManager.register(observer, this)
         return observer
     }
 


### PR DESCRIPTION
We do unregister, but this seems like a good idea to add 
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
