### PR TITLE
For #2890: Sending tab from another device shows empty title

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/NotificationManager.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/NotificationManager.kt
@@ -15,6 +15,7 @@ import android.os.Build
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import mozilla.components.concept.sync.DeviceEvent
+import mozilla.components.concept.sync.TabData
 import org.mozilla.fenix.R
 
 /**
@@ -51,7 +52,7 @@ class NotificationManager(private val context: Context) {
 
             val builder = NotificationCompat.Builder(context, RECEIVE_TABS_CHANNEL_ID)
                 .setSmallIcon(R.drawable.ic_status_logo)
-                .setContentTitle(tab.title)
+                .setTitle(event, tab)
                 .setContentText(tab.url)
                 .setContentIntent(pendingIntent)
                 // Explicitly set a priority for <API25 devices.
@@ -83,5 +84,22 @@ class NotificationManager(private val context: Context) {
         val notificationManager: NotificationManager =
             context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
         notificationManager.createNotificationChannel(channel)
+    }
+
+    private fun NotificationCompat.Builder.setTitle(
+        event: DeviceEvent.TabReceived,
+        tab: TabData
+    ): NotificationCompat.Builder {
+        event.from?.let { device ->
+            setContentTitle(context.getString(R.string.fxa_tab_received_from_notification_name, device.displayName))
+            return this
+        }
+
+        if (tab.title.isEmpty()) {
+            setContentTitle(context.getString(R.string.fxa_tab_received_notification_name))
+        } else {
+            setContentTitle(tab.title)
+        }
+        return this
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -171,6 +171,12 @@
     <string name="fxa_received_tab_channel_name">Received tabs</string>
     <!-- Description of the "receive tabs" notification channel. Displayed in the "App notifications" system settings for the app -->
     <string name="fxa_received_tab_channel_description">Notifications for tabs received from other Firefox devices.</string>
+    <!--  The body for these is the URL of the tab received  -->
+    <string name="fxa_tab_received_notification_name">Tab Received</string>
+    <!-- When multiple tabs have been received -->
+    <string name="fxa_tabs_received_notification_name">Tabs Received</string>
+    <!-- %s is the device name -->
+    <string name="fxa_tab_received_from_notification_name">Tab from %s</string>
 
     <!-- Advanced Preferences -->
     <!-- Preference for tracking protection settings -->


### PR DESCRIPTION
When we have no device name or title from the app sending the tab, we should still have a title.

cc: @Pike & @Delphine , sorry about this error! There are these 3 strings that [already exist in desktop](https://hg.mozilla.org/l10n/gecko-strings/file/default/browser/chrome/browser/accounts.properties#l77) which also needed to be picked up here too. Hope it isn't too much of an inconvenience to add them.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
