### PR TITLE
Closes #2900: Fix crash when trying to show the site info panel with a null session.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -699,7 +699,7 @@ class BrowserFragment : Fragment(), BackHandler, CoroutineScope {
     }
 
     private fun showQuickSettingsDialog() {
-        val session = requireNotNull(getSessionById())
+        val session = getSessionById() ?: return
         launch {
             val host = session.url.toUri()?.host
             val sitePermissions: SitePermissions? = host?.let {


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
