### PR TITLE
For #1366. Update toolbar search state when typing.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarComponent.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarComponent.kt
@@ -12,14 +12,14 @@ import mozilla.components.browser.search.SearchEngine
 import mozilla.components.browser.toolbar.BrowserToolbar
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ThemeManager
-import org.mozilla.fenix.mvi.ViewState
-import org.mozilla.fenix.mvi.Change
 import org.mozilla.fenix.mvi.Action
 import org.mozilla.fenix.mvi.ActionBusFactory
+import org.mozilla.fenix.mvi.Change
 import org.mozilla.fenix.mvi.Reducer
 import org.mozilla.fenix.mvi.UIComponent
 import org.mozilla.fenix.mvi.UIComponentViewModelBase
 import org.mozilla.fenix.mvi.UIComponentViewModelProvider
+import org.mozilla.fenix.mvi.ViewState
 
 class ToolbarComponent(
     private val container: ViewGroup,
@@ -74,7 +74,8 @@ data class SearchState(
     val searchTerm: String,
     val isEditing: Boolean,
     val engine: SearchEngine? = null,
-    val focused: Boolean = isEditing
+    val focused: Boolean = isEditing,
+    val isQueryUpdated: Boolean = false
 ) : ViewState
 
 sealed class SearchAction : Action {
@@ -87,6 +88,7 @@ sealed class SearchAction : Action {
 }
 
 sealed class SearchChange : Change {
+    data class QueryTextChanged(val query: String) : SearchChange()
     object ToolbarRequestedFocus : SearchChange()
     object ToolbarClearedFocus : SearchChange()
     data class SearchShortcutEngineSelected(val engine: SearchEngine) : SearchChange()
@@ -98,6 +100,7 @@ class ToolbarViewModel(initialState: SearchState) :
     companion object {
         val reducer: Reducer<SearchState, SearchChange> = { state, change ->
             when (change) {
+                is SearchChange.QueryTextChanged -> state.copy(query = change.query, isQueryUpdated = true)
                 is SearchChange.ToolbarClearedFocus -> state.copy(focused = false)
                 is SearchChange.ToolbarRequestedFocus -> state.copy(focused = true)
                 is SearchChange.SearchShortcutEngineSelected ->

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarUIView.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarUIView.kt
@@ -183,7 +183,9 @@ class ToolbarUIView(
         if (newState.isEditing) {
             view.setSearchTerms(newState.searchTerm)
             view.url = newState.query
-            view.editMode()
+            if (!newState.isQueryUpdated) {
+                view.editMode()
+            }
         } else {
             view.displayMode()
         }

--- a/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
@@ -244,6 +244,7 @@ class SearchFragment : Fragment(), BackHandler {
                         }
                     }
                     is SearchAction.TextChanged -> {
+                        getManagedEmitter<SearchChange>().onNext(SearchChange.QueryTextChanged(it.query))
                         getManagedEmitter<AwesomeBarChange>().onNext(AwesomeBarChange.UpdateQuery(it.query))
                     }
                     is SearchAction.EditingCanceled -> {


### PR DESCRIPTION
### Issue: #1366

This is only part of the solution. There is still another case when activity is killed and recreated and whole state isn't saved.

### What was fixed?

`SearchState.query` was used but not updated at all. So when we are hiding fragment - subscriptions to state are disposed. When fragment is show - we are subscribing to toolbar state again, but since `query` wasn't updated anywhere - we are receiving it in initial state.

To fix this we can update query in `SearchState` when it is updated in `AwesomeBar`.

Proposed solution is quite lightweight, it is based on some compromises (since there is no single source of the truth: Toolbar and AwesomeBar has some overlapping state-semantics but they are treated separately). The point I'm __not completely happy with__ is that we need to use `isQueryUpdated` flag to indicate that we don't need to reenable edit mode in `updateEditingState()` to avoid cursor jumping.

As a (better!) alternative to this we can add something like `BrowserToolbar.isInEditMode()` into `android-components`. I suggest to use this option.

__Ideas and thoughts are more than welcomed!__

### Test

_TBD_

### Pull Request checklist

- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~