### PR TITLE
Migrates "raptor" build type to work for chrome-perf-testing, too

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,7 +21,8 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments clearPackageData: 'true'
         manifestPlaceholders.isRaptorEnabled = "false"
-        resValue "bool", "IS_DEBUG", "true"
+        resValue "bool", "IS_DEBUG", "false"
+        buildConfigField "boolean", "USE_RELEASE_VERSIONING", "false"
     }
 
     def releaseTemplate = {
@@ -37,17 +38,19 @@ android {
             minifyEnabled false
             applicationIdSuffix ".debug"
             manifestPlaceholders.isRaptorEnabled = "true"
+            resValue "bool", "IS_DEBUG", "true"
         }
-        raptor releaseTemplate >> { // the ">>" concatenates the raptor-specific options with the template
+        forPerformanceTest releaseTemplate >> { // the ">>" concatenates the raptor-specific options with the template
             manifestPlaceholders.isRaptorEnabled = "true"
-            applicationIdSuffix ".raptor"
+            applicationIdSuffix ".performancetest"
+            debuggable true
         }
         nightly releaseTemplate >> {
-            resValue "bool", "IS_DEBUG", "false"
+            buildConfigField "boolean", "USE_RELEASE_VERSIONING", "true"
         }
         beta releaseTemplate >> {
             applicationIdSuffix ".beta"
-            resValue "bool", "IS_DEBUG", "false"
+            buildConfigField "boolean", "USE_RELEASE_VERSIONING", "true"
         }
     }
 
@@ -119,10 +122,10 @@ android.applicationVariants.all { variant ->
 
     def buildType = variant.buildType.name
     def versionCode = null
-    def releaseChannels = ["nightly", "beta", "release"]
-    def isReleased = releaseChannels.contains(buildType)
+    def isDebug = variant.buildType.resValues['IS_DEBUG']?.value ?: false
+    def useReleaseVersioning = variant.buildType.buildConfigFields['USE_RELEASE_VERSIONING']?.value ?: false
 
-    if (isReleased) {
+    if (useReleaseVersioning) {
         versionCode = generatedVersionCode
 
         // The Google Play Store does not allow multiple APKs for the same app that all have the
@@ -163,32 +166,29 @@ android.applicationVariants.all { variant ->
     }
 
     println("----------------------------------------------")
-    println("Variant name: " + variant.name)
-    println("Build type:   " + variant.buildType.name)
-    println("Flavor:       " + variant.flavorName)
-    println("Version code: " + (versionCode ?: variant.mergedFlavor.versionCode))
+    println("Variant name:      " + variant.name)
+    println("Build type:        " + variant.buildType.name)
+    println("Flavor:            " + variant.flavorName)
+    println("Version code:      " + (versionCode ?: variant.mergedFlavor.versionCode))
+    println("Telemetry enabled: " + !isDebug)
 
 // -------------------------------------------------------------------------------------------------
 // BuildConfig: Set variables for Sentry, Crash Reporting, and Telemetry
 // -------------------------------------------------------------------------------------------------
 
-    // Reading sentry token from local file (if it exists). In a release task on taskcluster it will be available.
-    try {
-        def token = new File("${rootDir}/.sentry_token").text.trim()
-        buildConfigField 'String', 'SENTRY_TOKEN', '"' + token + '"'
-    } catch (FileNotFoundException ignored) {
-        buildConfigField 'String', 'SENTRY_TOKEN', 'null'
-    }
-
-    // Activating crash reporting only if command line parameter was provided (in automation)
-    if (project.hasProperty("crashReports") && project.property("crashReports") == "true") {
+    buildConfigField 'String', 'SENTRY_TOKEN', 'null'
+    if (!isDebug) {
         buildConfigField 'boolean', 'CRASH_REPORTING', 'true'
+        // Reading sentry token from local file (if it exists). In a release task on taskcluster it will be available.
+        try {
+            def token = new File("${rootDir}/.sentry_token").text.trim()
+            buildConfigField 'String', 'SENTRY_TOKEN', '"' + token + '"'
+        } catch (FileNotFoundException ignored) {}
     } else {
         buildConfigField 'boolean', 'CRASH_REPORTING', 'false'
     }
 
-    // Activating telemetry only if command line parameter was provided (in automation)
-    if (project.hasProperty("telemetry") && project.property("telemetry") == "true") {
+    if (!isDebug) {
         buildConfigField 'boolean', 'TELEMETRY', 'true'
     } else {
         buildConfigField 'boolean', 'TELEMETRY', 'false'
@@ -205,7 +205,7 @@ android.applicationVariants.all { variant ->
 
     print("Adjust token: ")
 
-    if (isReleased) {
+    if (!isDebug) {
         try {
             def token = new File("${rootDir}/.adjust_token").text.trim()
             buildConfigField 'String', 'ADJUST_TOKEN', '"' + token + '"'
@@ -241,7 +241,7 @@ android.applicationVariants.all { variant ->
 // -------------------------------------------------------------------------------------------------
 // Feature build flags
 // -------------------------------------------------------------------------------------------------
-    buildConfigField 'Boolean', 'SEND_TAB_ENABLED', (buildType == "nightly" || !isReleased).toString()
+    buildConfigField 'Boolean', 'SEND_TAB_ENABLED', (buildType == "nightly" || isDebug).toString()
 }
 
 androidExtensions {
@@ -382,10 +382,6 @@ dependencies {
 
     debugImplementation Deps.flipper
     debugImplementation Deps.soLoader
-}
-
-if (project.hasProperty("raptor")) {
-    android.defaultConfig.manifestPlaceholders.isRaptorEnabled = "true"
 }
 
 // -------------------------------------------------------------------------------------------------

--- a/app/src/main/java/org/mozilla/fenix/Config.kt
+++ b/app/src/main/java/org/mozilla/fenix/Config.kt
@@ -5,20 +5,21 @@
 package org.mozilla.fenix
 
 enum class ReleaseChannel {
-    Debug, Nightly, Beta, Release;
+    Debug, Nightly, Beta, Production;
 
     val isReleased: Boolean
         get() = when (this) {
-            Release, Beta, Nightly -> true
-            else -> false
+            Debug -> false
+            else -> true
         }
 }
 
 object Config {
     val channel = when (BuildConfig.BUILD_TYPE) {
-        "release" -> ReleaseChannel.Release
+        "production" -> ReleaseChannel.Production
         "beta" -> ReleaseChannel.Beta
         "nightly" -> ReleaseChannel.Nightly
-        else -> ReleaseChannel.Debug
+        "debug" -> ReleaseChannel.Debug
+        else -> ReleaseChannel.Production // Performance-test builds should test production behaviour
     }
 }

--- a/automation/taskcluster/decision_task.py
+++ b/automation/taskcluster/decision_task.py
@@ -89,9 +89,9 @@ def raptor(is_staging):
     mozharness_task_id = fetch_mozharness_task_id(geckoview_nightly_version)
     gecko_revision = taskcluster.Queue().task(mozharness_task_id)['payload']['env']['GECKO_HEAD_REV']
 
-    for variant in [Variant.from_values(abi, False, 'raptor') for abi in ('aarch64', 'arm')]:
+    for variant in [Variant.from_values(abi, False, 'forPerformanceTest') for abi in ('aarch64', 'arm')]:
         assemble_task_id = taskcluster.slugId()
-        build_tasks[assemble_task_id] = BUILDER.craft_assemble_task(variant)
+        build_tasks[assemble_task_id] = BUILDER.craft_assemble_raptor_task(variant)
         signing_task_id = taskcluster.slugId()
         signing_tasks[signing_task_id] = BUILDER.craft_raptor_signing_task(assemble_task_id, variant, is_staging)
 


### PR DESCRIPTION
Fixes #2523.

Migrates 
`index.project.mobile.fenix.v2.raptor.latest.{abi}` 
to
`index.project.mobile.fenix.v2.performance-test.latest.{abi}`

Performance test builds are now debuggable, and have telemetry enabled.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
- [x] [This task group is green](https://tools.taskcluster.net/groups/O9aFfD76Rj-wo6Gv1qtvYg)
- [x] [There's an associated approved patch to update in-tree raptor configuration (since the application id changed)](https://phabricator.services.mozilla.com/D33150)