### PR TITLE
Sync on foreground, improve send tab notifications

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/BackgroundServices.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/BackgroundServices.kt
@@ -20,6 +20,7 @@ import mozilla.components.feature.sync.GlobalSyncableStoreProvider
 import mozilla.components.service.fxa.Config
 import mozilla.components.service.fxa.manager.DeviceTuple
 import mozilla.components.service.fxa.manager.FxaAccountManager
+import mozilla.components.support.base.log.logger.Logger
 import org.mozilla.fenix.R
 import org.mozilla.fenix.test.Mockable
 
@@ -58,7 +59,9 @@ class BackgroundServices(
     }
 
     private val deviceEventObserver = object : DeviceEventsObserver {
+        private val logger = Logger("DeviceEventsObserver")
         override fun onEvents(events: List<DeviceEvent>) {
+            logger.info("Received ${events.size} device event(s)")
             events.filter { it is DeviceEvent.TabReceived }.forEach {
                 notificationManager.showReceivedTabs(it as DeviceEvent.TabReceived)
             }


### PR DESCRIPTION
First patch adds the following to a foreground event:
- kicks off a sync (if we're logged in)
- refreshes device state (including polling for events like send tab).

Second patch makes it more likely that our "send tab" notifications show up as "heads up" notifications.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
