### PR TITLE
For #1290, For #1910 Init Toolbar with Display or Edit Mode, Animate Toolbar to Search

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -135,6 +135,7 @@ class BrowserFragment : Fragment(), BackHandler, CoroutineScope {
             view.browserLayout,
             ActionBusFactory.get(this), customTabSessionId,
             (activity as HomeActivity).browsingModeManager.isPrivate,
+            false,
             search_engine_icon,
             FenixViewModelProvider.create(
                 this,

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarComponent.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarComponent.kt
@@ -47,6 +47,7 @@ class ToolbarComponent(
     )
 
     init {
+        getView().transitionName = "toolbar_transition"
         bind()
         applyTheme()
     }

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarComponent.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarComponent.kt
@@ -26,7 +26,7 @@ class ToolbarComponent(
     bus: ActionBusFactory,
     private val sessionId: String?,
     private val isPrivate: Boolean,
-    private val inSearchFragment: Boolean,
+    private val startInEditMode: Boolean,
     private val engineIconView: ImageView? = null,
     viewModelProvider: UIComponentViewModelProvider<SearchState, SearchChange>
 ) :
@@ -41,7 +41,7 @@ class ToolbarComponent(
     override fun initView() = ToolbarUIView(
         sessionId,
         isPrivate,
-        inSearchFragment,
+        startInEditMode,
         container,
         actionEmitter,
         changesObservable,

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarComponent.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarComponent.kt
@@ -26,6 +26,7 @@ class ToolbarComponent(
     bus: ActionBusFactory,
     private val sessionId: String?,
     private val isPrivate: Boolean,
+    private val inSearchFragment: Boolean,
     private val engineIconView: ImageView? = null,
     viewModelProvider: UIComponentViewModelProvider<SearchState, SearchChange>
 ) :
@@ -40,6 +41,7 @@ class ToolbarComponent(
     override fun initView() = ToolbarUIView(
         sessionId,
         isPrivate,
+        inSearchFragment,
         container,
         actionEmitter,
         changesObservable,

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarComponent.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarComponent.kt
@@ -49,7 +49,6 @@ class ToolbarComponent(
     )
 
     init {
-        getView().transitionName = "toolbar_transition"
         bind()
         applyTheme()
     }

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarUIView.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarUIView.kt
@@ -24,6 +24,7 @@ import org.mozilla.fenix.mvi.UIView
 class ToolbarUIView(
     sessionId: String?,
     isPrivate: Boolean,
+    inSearchFragment: Boolean,
     container: ViewGroup,
     actionEmitter: Observer<SearchAction>,
     changesObservable: Observable<SearchChange>,
@@ -48,6 +49,10 @@ class ToolbarUIView(
             ?: sessionManager.selectedSession
 
         view.apply {
+            if (inSearchFragment) {
+                editMode()
+            }
+
             elevation = resources.pxToDp(TOOLBAR_ELEVATION).toFloat()
 
             setOnUrlCommitListener {

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarUIView.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarUIView.kt
@@ -24,7 +24,7 @@ import org.mozilla.fenix.mvi.UIView
 class ToolbarUIView(
     sessionId: String?,
     isPrivate: Boolean,
-    inSearchFragment: Boolean,
+    startInEditMode: Boolean,
     container: ViewGroup,
     actionEmitter: Observer<SearchAction>,
     changesObservable: Observable<SearchChange>,
@@ -49,7 +49,7 @@ class ToolbarUIView(
             ?: sessionManager.selectedSession
 
         view.apply {
-            if (inSearchFragment) {
+            if (startInEditMode) {
                 editMode()
             }
 

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -55,6 +55,7 @@ import org.mozilla.fenix.ext.urlToTrimmedHost
 import org.mozilla.fenix.home.sessioncontrol.CollectionAction
 import org.mozilla.fenix.home.sessioncontrol.Mode
 import org.mozilla.fenix.home.sessioncontrol.OnboardingAction
+import org.mozilla.fenix.home.sessioncontrol.OnboardingState
 import org.mozilla.fenix.home.sessioncontrol.SessionControlAction
 import org.mozilla.fenix.home.sessioncontrol.SessionControlChange
 import org.mozilla.fenix.home.sessioncontrol.SessionControlComponent
@@ -63,7 +64,6 @@ import org.mozilla.fenix.home.sessioncontrol.SessionControlViewModel
 import org.mozilla.fenix.home.sessioncontrol.Tab
 import org.mozilla.fenix.home.sessioncontrol.TabAction
 import org.mozilla.fenix.home.sessioncontrol.TabCollection
-import org.mozilla.fenix.home.sessioncontrol.OnboardingState
 import org.mozilla.fenix.lib.Do
 import org.mozilla.fenix.mvi.ActionBusFactory
 import org.mozilla.fenix.mvi.getAutoDisposeObservable
@@ -171,7 +171,7 @@ class HomeFragment : Fragment(), CoroutineScope, AccountObserver {
             searchIcon.setBounds(0, 0, iconSize, iconSize)
 
             runBlocking(Dispatchers.Main) {
-                view.toolbar.setCompoundDrawables(searchIcon, null, null, null)
+                search_engine_icon.setImageDrawable(searchIcon)
             }
         }
 
@@ -188,7 +188,13 @@ class HomeFragment : Fragment(), CoroutineScope, AccountObserver {
             invokePendingDeleteJobs()
             onboarding.finish()
             val directions = HomeFragmentDirections.actionHomeFragmentToSearchFragment(null)
-            Navigation.findNavController(it).navigate(directions)
+            val extras =
+                FragmentNavigator.Extras.Builder()
+                    .addSharedElement(it, "toolbar_transition")
+                    .addSharedElement(toolbar_wrapper, "toolbar_wrapper_transition")
+                    .addSharedElement(search_engine_icon, "toolbar_icon_transition")
+                    .build()
+            Navigation.findNavController(it).navigate(directions, extras)
 
             requireComponents.analytics.metrics.track(Event.SearchBarTapped(Event.SearchBarTapped.Source.HOME))
         }

--- a/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
@@ -19,6 +19,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.navigation.Navigation
+import androidx.transition.TransitionInflater
 import kotlinx.android.synthetic.main.fragment_search.*
 import kotlinx.android.synthetic.main.fragment_search.view.*
 import mozilla.components.browser.search.SearchEngine
@@ -58,6 +59,12 @@ class SearchFragment : Fragment(), BackHandler {
     private var isPrivate = false
     private val qrFeature = ViewBoundFeatureWrapper<QrFeature>()
     private var permissionDidUpdate = false
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        postponeEnterTransition()
+        sharedElementEnterTransition = TransitionInflater.from(context).inflateTransition(android.R.transition.move)
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -172,6 +179,8 @@ class SearchFragment : Fragment(), BackHandler {
                 requireComponents.analytics.metrics.track(Event.SearchShortcutMenuOpened)
             }
         }
+
+        startPostponedEnterTransition()
     }
 
     override fun onResume() {

--- a/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
@@ -83,6 +83,7 @@ class SearchFragment : Fragment(), BackHandler {
             ActionBusFactory.get(this),
             sessionId,
             isPrivate,
+            true,
             view.search_engine_icon,
             FenixViewModelProvider.create(
                 this,

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -50,6 +50,7 @@
 
         <org.mozilla.fenix.home.SearchView
             android:id="@+id/toolbar_wrapper"
+            android:transitionName="toolbar_wrapper_transition"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginEnd="16dp"
@@ -61,21 +62,26 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/wordmark">
 
+            <ImageView
+                android:id="@+id/search_engine_icon"
+                android:transitionName="toolbar_icon_transition"
+                android:layout_margin="12dp"
+                android:layout_width="24dp"
+                android:layout_height="24dp" />
+
             <TextView
+                android:transitionName="toolbar_transition"
                 android:id="@+id/toolbar"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:paddingStart="12sp"
-                android:paddingEnd="12sp"
-                android:paddingTop="16sp"
-                android:paddingBottom="16sp"
-                android:drawablePadding="12sp"
+                android:layout_height="match_parent"
+                android:layout_marginStart="47dp"
+                android:padding="12dp"
                 android:clickable="true"
                 android:focusable="true"
-                android:gravity="center_vertical"
+                android:layout_gravity="center_vertical"
                 android:text="@string/search_hint"
                 android:textColor="?primaryText"
-                android:textSize="14sp" />
+                android:textSize="15sp" />
         </org.mozilla.fenix.home.SearchView>
 
         <View

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -50,38 +50,38 @@
 
         <org.mozilla.fenix.home.SearchView
             android:id="@+id/toolbar_wrapper"
-            android:transitionName="toolbar_wrapper_transition"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="16dp"
-            android:layout_marginTop="64dp"
             android:layout_marginStart="16dp"
-            android:elevation="@dimen/toolbar_elevation"
+            android:layout_marginTop="64dp"
+            android:layout_marginEnd="16dp"
             android:background="@drawable/home_search_background_normal"
+            android:elevation="@dimen/toolbar_elevation"
+            android:transitionName="toolbar_wrapper_transition"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/wordmark">
 
             <ImageView
                 android:id="@+id/search_engine_icon"
-                android:transitionName="toolbar_icon_transition"
-                android:layout_margin="12dp"
                 android:layout_width="24dp"
-                android:layout_height="24dp" />
+                android:layout_height="24dp"
+                android:layout_margin="12dp"
+                android:transitionName="toolbar_icon_transition" />
 
             <TextView
-                android:transitionName="toolbar_transition"
                 android:id="@+id/toolbar"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
+                android:layout_gravity="center_vertical"
                 android:layout_marginStart="47dp"
-                android:padding="12dp"
                 android:clickable="true"
                 android:focusable="true"
-                android:layout_gravity="center_vertical"
+                android:padding="12dp"
                 android:text="@string/search_hint"
                 android:textColor="?primaryText"
-                android:textSize="15sp" />
+                android:textSize="15sp"
+                android:transitionName="toolbar_transition" />
         </org.mozilla.fenix.home.SearchView>
 
         <View

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -66,8 +66,7 @@
                 android:id="@+id/search_engine_icon"
                 android:layout_width="24dp"
                 android:layout_height="24dp"
-                android:layout_margin="12dp"
-                android:transitionName="toolbar_icon_transition" />
+                android:layout_margin="12dp" />
 
             <TextView
                 android:id="@+id/toolbar"
@@ -80,8 +79,7 @@
                 android:padding="12dp"
                 android:text="@string/search_hint"
                 android:textColor="?primaryText"
-                android:textSize="15sp"
-                android:transitionName="toolbar_transition" />
+                android:textSize="15sp" />
         </org.mozilla.fenix.home.SearchView>
 
         <View

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -13,6 +13,7 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/toolbar_wrapper"
+        android:transitionName="toolbar_wrapper_transition"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
@@ -25,6 +26,7 @@
         app:layout_constraintTop_toTopOf="parent">
         <ImageView
             android:id="@+id/search_engine_icon"
+            android:transitionName="toolbar_icon_transition"
             android:layout_margin="12dp"
             android:layout_width="24dp"
             android:layout_height="24dp"

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -30,7 +30,6 @@
             android:layout_width="24dp"
             android:layout_height="24dp"
             android:layout_margin="12dp"
-            android:transitionName="toolbar_icon_transition"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -5,15 +5,14 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/search_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".search.SearchFragment"
-    android:id="@+id/search_layout"
-    android:background="?above">
+    android:background="?above"
+    tools:context=".search.SearchFragment">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/toolbar_wrapper"
-        android:transitionName="toolbar_wrapper_transition"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
@@ -21,60 +20,63 @@
         android:layout_marginEnd="16dp"
         android:background="@drawable/search_url_background"
         android:outlineProvider="paddedBounds"
+        android:transitionName="toolbar_wrapper_transition"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
+
         <ImageView
             android:id="@+id/search_engine_icon"
-            android:transitionName="toolbar_icon_transition"
-            android:layout_margin="12dp"
             android:layout_width="24dp"
             android:layout_height="24dp"
-            app:layout_constraintTop_toTopOf="parent"
+            android:layout_margin="12dp"
+            android:transitionName="toolbar_icon_transition"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent" />
+            app:layout_constraintTop_toTopOf="parent" />
+
         <FrameLayout
             android:id="@+id/toolbar_component_wrapper"
-            android:layout_height="0dp"
             android:layout_width="0dp"
+            android:layout_height="0dp"
             android:layout_marginStart="12dp"
-            app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@id/search_engine_icon"
-            app:layout_constraintEnd_toEndOf="parent"/>
+            app:layout_constraintTop_toTopOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <TextView
-            android:id="@+id/search_with_shortcuts"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="15dp"
-            android:visibility="gone"
-            android:fontFamily="Inter UI"
-            android:textAllCaps="true"
-            android:textStyle="bold"
-            android:textSize="12sp"
-            android:textColor="?secondaryText"
-            android:letterSpacing="0.15"
-            android:text="@string/search_shortcuts_search_with"
-            app:layout_constraintTop_toBottomOf="@id/toolbar_wrapper"
-            app:layout_constraintStart_toStartOf="@id/toolbar_wrapper"/>
+        android:id="@+id/search_with_shortcuts"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="15dp"
+        android:fontFamily="Inter UI"
+        android:letterSpacing="0.15"
+        android:text="@string/search_shortcuts_search_with"
+        android:textAllCaps="true"
+        android:textColor="?secondaryText"
+        android:textSize="12sp"
+        android:textStyle="bold"
+        android:visibility="gone"
+        app:layout_constraintStart_toStartOf="@id/toolbar_wrapper"
+        app:layout_constraintTop_toBottomOf="@id/toolbar_wrapper" />
 
     <LinearLayout
         android:id="@+id/pill_wrapper"
-        android:background="?foundation"
-        android:elevation="10dp"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:background="?foundation"
+        android:elevation="10dp"
         android:orientation="horizontal"
         android:paddingStart="20dp"
-        android:paddingEnd="16dp"
         android:paddingTop="4dp"
+        android:paddingEnd="16dp"
         android:paddingBottom="4dp"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent">
+        app:layout_constraintStart_toStartOf="parent">
 
         <ToggleButton
             android:id="@+id/search_scan_button"

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -24,7 +24,11 @@
             app:destination="@+id/turnOnSyncFragment" />
         <action
             android:id="@+id/action_homeFragment_to_searchFragment"
-            app:destination="@id/searchFragment" />
+            app:destination="@id/searchFragment"
+            app:enterAnim="@anim/fade_in"
+            app:exitAnim="@anim/fade_out"
+            app:popEnterAnim="@anim/fade_in"
+            app:popExitAnim="@anim/fade_out" />
         <action
             android:id="@+id/action_homeFragment_to_browserFragment"
             app:destination="@id/browserFragment"


### PR DESCRIPTION
Tagging @boek for review because I know we worked on the toolbar integration working with search and home fragment, but I found that the initial state isn't happening fast enough to not see a flash of DisplayToolbar when you enter SearchFragment. The simple solution is to pass in whether we are using the toolbar in SearchFragment or not and enter editMode in init, but there may be a cleaner solution.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
