### PR TITLE
No issue: ClipboardProvider no longer needs to be added/removed based on input

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarUIView.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarUIView.kt
@@ -169,20 +169,15 @@ class AwesomeBarUIView(
             view.addProviders(historyStorageProvider!!)
         }
 
-        view.addProviders(sessionProvider!!)
+        view.addProviders(
+            clipboardSuggestionProvider!!,
+            sessionProvider!!
+        )
     }
 
     private fun showSearchSuggestionProvider() {
         if (Settings.getInstance(container.context).showSearchSuggestions()) {
             view.addProviders(searchSuggestionProvider!!)
-        }
-    }
-
-    private fun updateLinkVisibility() {
-        if (state?.query?.isEmpty() == true) {
-            view.addProviders(clipboardSuggestionProvider!!)
-        } else {
-            view.removeProviders(clipboardSuggestionProvider!!)
         }
     }
 
@@ -213,7 +208,5 @@ class AwesomeBarUIView(
 
         view.onInputChanged(it.query)
         state = it
-
-        updateLinkVisibility()
     }
 }


### PR DESCRIPTION
This basically reverts https://github.com/mozilla-mobile/fenix/commit/11918d45f4ce97f9c64273fcbe6f7df1d6fd4365#diff-e68bc3f7a2e6f8d0a48238b79105867a, as it's no longer needed. It's the default behaviour of `ClipboardSuggestionProvider` now to **only** return a suggestion if the input text is empty (in the latest 0.55.0-SNAPSHOTS).

So, we no longer need to add/remove the provider based on the input text.

Adding/Removing providers on every input change is not cheap, plus there was a problem here, where the provider may be added multiple times. A-C is now failing (with more details) if the latter happens, to get to the bottom of https://github.com/mozilla-mobile/fenix/issues/2932.