### PR TITLE
For #3073 'Open in Firefox Preview' no longer opens in app

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -576,7 +576,11 @@ class BrowserFragment : Fragment(), BackHandler, CoroutineScope {
 
     override fun onViewStateRestored(savedInstanceState: Bundle?) {
         super.onViewStateRestored(savedInstanceState)
-        customTabSessionId = savedInstanceState?.getString(KEY_CUSTOM_TAB_SESSION_ID)
+        savedInstanceState?.getString(KEY_CUSTOM_TAB_SESSION_ID)?.let {
+            if (requireComponents.core.sessionManager.findSessionById(it)?.customTabConfig != null) {
+                customTabSessionId = it
+            }
+        }
     }
 
     override fun onStop() {


### PR DESCRIPTION
Saving and restoring the custom tab session ID fixed one problem while causing another. I added code to only restore the ID if the session has a customTabConfig associated.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
