### PR TITLE
Closes #3091 - Hide Pull to Refresh under flag

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -250,6 +250,7 @@ android.applicationVariants.all { variant ->
 // Feature build flags
 // -------------------------------------------------------------------------------------------------
     buildConfigField 'Boolean', 'SEND_TAB_ENABLED', (buildType == "nightly" || isDebug).toString()
+    buildConfigField 'Boolean', 'PULL_TO_REFRESH_ENABLED', (false).toString()
 }
 
 androidExtensions {

--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -56,6 +56,7 @@ import mozilla.components.support.ktx.android.view.enterToImmersiveMode
 import mozilla.components.support.ktx.android.view.exitImmersiveModeIfNeeded
 import mozilla.components.support.ktx.kotlin.toUri
 import org.mozilla.fenix.BrowsingModeManager
+import org.mozilla.fenix.BuildConfig
 import org.mozilla.fenix.FenixViewModelProvider
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.IntentReceiverActivity
@@ -185,7 +186,7 @@ class BrowserFragment : Fragment(), BackHandler, CoroutineScope {
         return view
     }
 
-    @Suppress("LongMethod")
+    @Suppress("LongMethod", "ComplexMethod")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
@@ -334,18 +335,23 @@ class BrowserFragment : Fragment(), BackHandler, CoroutineScope {
             view = view
         )
 
-        val primaryTextColor = ThemeManager.resolveAttribute(R.attr.primaryText, requireContext())
-        view.swipeRefresh.setColorSchemeColors(primaryTextColor)
-        swipeRefreshFeature.set(
-            feature = SwipeRefreshFeature(
-                requireComponents.core.sessionManager,
-                requireComponents.useCases.sessionUseCases.reload,
-                view.swipeRefresh,
-                customTabSessionId
-            ),
-            owner = this,
-            view = view
-        )
+        if (BuildConfig.PULL_TO_REFRESH_ENABLED) {
+            val primaryTextColor = ThemeManager.resolveAttribute(R.attr.primaryText, requireContext())
+            view.swipeRefresh.setColorSchemeColors(primaryTextColor)
+            swipeRefreshFeature.set(
+                feature = SwipeRefreshFeature(
+                    requireComponents.core.sessionManager,
+                    requireComponents.useCases.sessionUseCases.reload,
+                    view.swipeRefresh,
+                    customTabSessionId
+                ),
+                owner = this,
+                view = view
+            )
+        } else {
+            // Disable pull to refresh
+            view.swipeRefresh.setOnChildScrollUpCallback { _, _ -> true }
+        }
 
         readerViewFeature.set(
             feature = ReaderViewFeature(


### PR DESCRIPTION
This was merged in after feature freeze so we're pulling it out for now. Pull to refresh will continue to work in debug mode under a flag so that the design can be iterated on easily.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
