### PR TITLE
Doesn't print gecko emoji on android ver < 7 (android N)

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/AboutFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/AboutFragment.kt
@@ -27,10 +27,15 @@ class AboutFragment : Fragment() {
 
         val appName = requireContext().resources.getString(R.string.app_name)
         (activity as AppCompatActivity).title = getString(R.string.preferences_about, appName)
-
+        
+        
+        var maybeGecko = " \uD83E\uDD8E "
+        if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.N) {
+            maybegecko = " "
+        }
         val aboutText = try {
             val packageInfo = requireContext().packageManager.getPackageInfo(requireContext().packageName, 0)
-            val geckoVersion = PackageInfoCompat.getLongVersionCode(packageInfo).toString() + " \uD83E\uDD8E " +
+            val geckoVersion = PackageInfoCompat.getLongVersionCode(packageInfo).toString() + maybeGecko +
                     GeckoViewBuildConfig.MOZ_APP_VERSION + "-" + GeckoViewBuildConfig.MOZ_APP_BUILDID
             String.format(
                 "%s (Build #%s)",

--- a/app/src/main/java/org/mozilla/fenix/settings/AboutFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/AboutFragment.kt
@@ -31,7 +31,7 @@ class AboutFragment : Fragment() {
         
         var maybeGecko = " \uD83E\uDD8E "
         if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.N) {
-            maybegecko = " "
+            maybeGecko = " "
         }
         val aboutText = try {
             val packageInfo = requireContext().packageManager.getPackageInfo(requireContext().packageName, 0)

--- a/app/src/main/java/org/mozilla/fenix/settings/AboutFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/AboutFragment.kt
@@ -27,12 +27,11 @@ class AboutFragment : Fragment() {
 
         val appName = requireContext().resources.getString(R.string.app_name)
         (activity as AppCompatActivity).title = getString(R.string.preferences_about, appName)
-        
-        
         var maybeGecko = " \uD83E\uDD8E "
         if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.N) {
-            maybeGecko = " "
+            maybeGecko = "GV: "
         }
+
         val aboutText = try {
             val packageInfo = requireContext().packageManager.getPackageInfo(requireContext().packageName, 0)
             val geckoVersion = PackageInfoCompat.getLongVersionCode(packageInfo).toString() + maybeGecko +


### PR DESCRIPTION
Introduces a check for the android version. Since android didn't have the gecko emoji before version 7, I made it so that it just prints a space in its stead.