### PR TITLE
For #3004 - Do not restore motionlayout state in ReloadData

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -250,18 +250,7 @@ class HomeFragment : Fragment(), CoroutineScope, AccountObserver {
                         is SessionControlAction.Tab -> handleTabAction(it.action)
                         is SessionControlAction.Collection -> handleCollectionAction(it.action)
                         is SessionControlAction.Onboarding -> handleOnboardingAction(it.action)
-                        is SessionControlAction.ReloadData -> {
-                            val homeViewModel = activity?.run {
-                                ViewModelProviders.of(this).get(HomeScreenViewModel::class.java)
-                            }
-                            homeViewModel?.layoutManagerState?.also { parcelable ->
-                                sessionControlComponent.view.layoutManager?.onRestoreInstanceState(parcelable)
-                            }
-                            val progress = homeViewModel?.motionLayoutProgress
-                            homeLayout?.progress =
-                                if (progress ?: 0F > MOTION_LAYOUT_PROGRESS_ROUND_POINT) 1.0f else 0f
-                            homeViewModel?.layoutManagerState = null
-                        }
+                        is SessionControlAction.ReloadData -> { }
                     }
                 }
         }


### PR DESCRIPTION
Without this, the motion layout does not restore in onResume, but we need to figure out a better place to put this logic. Maybe we can figure out a way to get a callback to know if the updating list adapter data doesn't have a diff that way when we restore, it won't get all wonky.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
