### PR TITLE
Requires a prefixed "v" when parsing git tag name

### DIFF
--- a/automation/taskcluster/decision_task.py
+++ b/automation/taskcluster/decision_task.py
@@ -170,10 +170,11 @@ if __name__ == "__main__":
         formatted_date = datetime.datetime.now().strftime('%y%V')
         ordered_groups_of_tasks = release('nightly', result.staging, '1.0.{}'.format(formatted_date))
     elif command == 'beta':
-        semver = re.compile(r'^\d+\.\d+\.\d+-beta\.\d+$')
+        semver = re.compile(r'^v\d+\.\d+\.\d+-beta\.\d+$')
         if not semver.match(result.tag):
-            raise ValueError('Github tag must be in beta semver format, e.g.: "1.0.0-beta.0')
-        ordered_groups_of_tasks = release('beta', False, result.tag)
+            raise ValueError('Github tag must be in beta semver format and prefixed with a "v", e.g.: "v1.0.0-beta.0"')
+        version = result.tag[1:]  # remove prefixed "v"
+        ordered_groups_of_tasks = release('beta', False, version)
     else:
         raise Exception('Unsupported command "{}"'.format(command))
 


### PR DESCRIPTION
Fixes #3162

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### Merge checklist
- [ ] Update [wiki](https://github.com/mozilla-mobile/fenix/wiki/Release-Process) to recommend a prefixed "v"