### PR TITLE
For #3138: Fix white background on search bar

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
@@ -94,7 +94,10 @@ class SearchFragment : Fragment(), BackHandler {
             ) {
                 ToolbarViewModel(SearchState(url, session?.searchTerms ?: "", isEditing = true))
             }
-        )
+        ).also {
+            // Remove background from toolbar view since it conflicts with the search UI.
+            it.uiView.view.background = null
+        }
 
         awesomeBarComponent = AwesomeBarComponent(
             view.search_layout,


### PR DESCRIPTION
The fix for this is simple. Remove the `toolbar_background` drawable. However, what's confusing is that during the refactor, this was taken from [the original code](https://github.com/mozilla-mobile/fenix/blob/209b50016e1300ba4446f50fc8d6019feffc1c9d/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt#L159) where it was always being set in Kotlin and moved to the layout file.

I'm not sure why this was originally added in that case or if it added an additional purpose that I may have overseen.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
