### PR TITLE
Make sure we use 'Turn on Sync' instead of 'Sign In'

### DIFF
--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -11,7 +11,7 @@
         android:key="@string/pref_key_sign_in"
         android:layout="@layout/sign_in_preference"
         android:summary="@string/preferences_sign_in_description"
-        android:title="@string/preferences_sign_in" />
+        android:title="@string/preferences_sync" />
 
     <androidx.preference.PreferenceCategory
         android:key="@string/pref_key_account_category"

--- a/app/src/main/res/xml/turn_on_sync_preferences.xml
+++ b/app/src/main/res/xml/turn_on_sync_preferences.xml
@@ -11,7 +11,7 @@
         android:icon="@drawable/ic_qr" />
     <androidx.preference.Preference
         android:key="@string/pref_key_sync_sign_in"
-        android:title="@string/preferences_sync_sign_in"
+        android:title="@string/preferences_sync"
         android:icon="@drawable/ic_sign_in" />
     <androidx.preference.Preference
         android:key="@string/pref_key_sync_create_account"


### PR DESCRIPTION
This was brought up in an app-services bughunt by @ryanfeeley. Thankfully we already had a correct string in the tree.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
