### PR TITLE
For #2785 - Adds back item animator session control

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -128,7 +128,14 @@ class HomeFragment : Fragment(), CoroutineScope, AccountObserver {
                 this,
                 SessionControlViewModel::class.java
             ) {
-                SessionControlViewModel(SessionControlState(listOf(), setOf(), listOf(), mode))
+                SessionControlViewModel(
+                    SessionControlState(
+                        getListOfTabs(requireComponents.core.sessionManager),
+                        setOf(),
+                        requireComponents.core.tabCollectionStorage.cachedTabCollections,
+                        mode
+                    )
+                )
             }
         )
 
@@ -269,10 +276,14 @@ class HomeFragment : Fragment(), CoroutineScope, AccountObserver {
                 }
         }
 
-        val mode = currentMode()
-        getManagedEmitter<SessionControlChange>().onNext(SessionControlChange.ModeChange(mode))
+        getManagedEmitter<SessionControlChange>().onNext(
+            SessionControlChange.Change(
+                tabs = getListOfTabs(sessionManager = requireComponents.core.sessionManager),
+                mode = currentMode(),
+                collections = requireComponents.core.tabCollectionStorage.cachedTabCollections
+            )
+        )
 
-        emitSessionChanges()
         sessionObserver.onStart()
         tabCollectionObserver = subscribeToTabCollections()
     }
@@ -586,25 +597,28 @@ class HomeFragment : Fragment(), CoroutineScope, AccountObserver {
     }
 
     private fun emitSessionChanges() {
-        val sessionManager = requireComponents.core.sessionManager
-
+        val sessionManager = context?.components?.core?.sessionManager ?: return
         getManagedEmitter<SessionControlChange>().onNext(
             SessionControlChange.TabsChange(
-                sessionManager.sessions
-                    .filter { (activity as HomeActivity).browsingModeManager.isPrivate == it.private }
-                    .map {
-                        val selected = it == sessionManager.selectedSession
-                        Tab(
-                            it.id,
-                            it.url,
-                            it.url.urlToTrimmedHost(),
-                            it.title,
-                            selected,
-                            it.thumbnail
-                        )
-                    }
+                getListOfTabs(sessionManager)
             )
         )
+    }
+
+    private fun getListOfTabs(sessionManager: SessionManager): List<Tab> {
+        return sessionManager.sessions
+            .filter { (activity as HomeActivity).browsingModeManager.isPrivate == it.private }
+            .map {
+                val selected = it == sessionManager.selectedSession
+                Tab(
+                    it.id,
+                    it.url,
+                    it.url.urlToTrimmedHost(),
+                    it.title,
+                    selected,
+                    it.thumbnail
+                )
+            }
     }
 
     private fun emitAccountChanges() {

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlComponent.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlComponent.kt
@@ -139,6 +139,8 @@ fun Observer<SessionControlAction>.onNext(onboardingAction: OnboardingAction) {
 }
 
 sealed class SessionControlChange : Change {
+    data class Change(val tabs: List<Tab>, val mode: Mode, val collections: List<TabCollection>) :
+        SessionControlChange()
     data class TabsChange(val tabs: List<Tab>) : SessionControlChange()
     data class ModeChange(val mode: Mode) : SessionControlChange()
     data class CollectionsChange(val collections: List<TabCollection>) : SessionControlChange()
@@ -165,6 +167,11 @@ class SessionControlViewModel(
 
                     state.copy(expandedCollections = newExpandedCollection)
                 }
+                is SessionControlChange.Change -> state.copy(
+                    tabs = change.tabs,
+                    mode = change.mode,
+                    collections = change.collections
+                )
             }
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlUIView.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlUIView.kt
@@ -139,7 +139,6 @@ class SessionControlUIView(
         view.apply {
             adapter = sessionControlAdapter
             layoutManager = LinearLayoutManager(container.context)
-            itemAnimator = null // TODO #2785: Remove this line
             val itemTouchHelper =
                 ItemTouchHelper(
                     SwipeToDeleteCallback(


### PR DESCRIPTION
Trying to reduce the amount of changes we emit in onStart. Still on fresh start, will be called many times as all the pieces are loaded and ready at different points (first mode, then tabs, then sessions). Open to suggestions about helping this... But should improve when BrowserFragment is resumed.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
