### PR TITLE
No issue: Sets up observers for tab collection changes

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/collections/CreateCollectionFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/collections/CreateCollectionFragment.kt
@@ -5,14 +5,12 @@ package org.mozilla.fenix.collections
    file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import android.app.Dialog
-import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.ViewModelProviders
-import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.fragment_create_collection.view.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -20,8 +18,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import org.mozilla.fenix.FenixViewModelProvider
 import org.mozilla.fenix.R
-import org.mozilla.fenix.components.FenixSnackbar
-import org.mozilla.fenix.ext.getRootView
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.home.sessioncontrol.toSessionBundle
 import org.mozilla.fenix.mvi.ActionBusFactory
@@ -129,7 +125,6 @@ class CreateCollectionFragment : DialogFragment(), CoroutineScope {
                 )
                 is CollectionCreationAction.BackPressed -> handleBackPress(backPressFrom = it.backPressFrom)
                 is CollectionCreationAction.SaveCollectionName -> {
-                    showSavedSnackbar(it.tabs.size)
                     dismiss()
 
                     context?.let { context ->
@@ -140,7 +135,6 @@ class CreateCollectionFragment : DialogFragment(), CoroutineScope {
                     }
                 }
                 is CollectionCreationAction.SelectCollection -> {
-                    showSavedSnackbar(it.tabs.size)
                     dismiss()
                     context?.let { context ->
                         val sessionBundle = it.tabs.toList().toSessionBundle(context)
@@ -151,39 +145,11 @@ class CreateCollectionFragment : DialogFragment(), CoroutineScope {
                     }
                 }
                 is CollectionCreationAction.RenameCollection -> {
-                    showRenamedSnackbar()
                     dismiss()
                     launch(Dispatchers.IO) {
                         requireComponents.core.tabCollectionStorage.renameCollection(it.collection, it.name)
                     }
                 }
-            }
-        }
-    }
-
-    private fun showRenamedSnackbar() {
-        context?.let { context: Context ->
-            val rootView = context.getRootView()
-            rootView?.let { view: View ->
-                val string = context.getString(R.string.snackbar_collection_renamed)
-                FenixSnackbar.make(view, Snackbar.LENGTH_LONG).setText(string)
-                    .show()
-            }
-        }
-    }
-
-    private fun showSavedSnackbar(tabSize: Int) {
-        context?.let { context: Context ->
-            val rootView = context.getRootView()
-            rootView?.let { view: View ->
-                val string =
-                    if (tabSize > 1) context.getString(R.string.create_collection_tabs_saved) else
-                        context.getString(R.string.create_collection_tab_saved)
-                val snackbar = FenixSnackbar.make(view, Snackbar.LENGTH_LONG).setText(string)
-                viewModel.snackbarAnchorView?.let {
-                    snackbar.setAnchorView(it)
-                }
-                snackbar.show()
             }
         }
     }


### PR DESCRIPTION
This is the beginning of investigating emitting collections changes more efficiently and whether we can add an animation when collection changes happen. This will be required for any investigation/work for #2899

As a nice side effect of this work the snackbars for collections changes are now swipable :)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
