### PR TITLE
For #3283 fix crash on renaming a collection

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/collections/CollectionCreationUIView.kt
+++ b/app/src/main/java/org/mozilla/fenix/collections/CollectionCreationUIView.kt
@@ -65,6 +65,7 @@ class CollectionCreationUIView(
     private val transition = AutoTransition()
 
     init {
+        job = Job()
         transition.duration = TRANSITION_DURATION
 
         selectTabsConstraints.clone(collection_constraint_layout)


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features



lateinit property job was never initialised and this is the reason why the app was crashing