### PR TITLE
[FIXES BUILD] Use `Drawable.toBitmap()` from androidx-ktx.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -352,6 +352,7 @@ dependencies {
     implementation Deps.androidx_lifecycle_viewmodel_ktx
     implementation Deps.androidx_lifecycle_viewmodel_ss
     implementation Deps.androidx_core
+    implementation Deps.androidx_core_ktx
     implementation Deps.androidx_transition
     implementation Deps.google_material
 

--- a/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarUIView.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarUIView.kt
@@ -8,6 +8,7 @@ import android.graphics.PorterDuff
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
+import androidx.core.graphics.drawable.toBitmap
 import androidx.recyclerview.widget.RecyclerView
 import io.reactivex.Observable
 import io.reactivex.Observer
@@ -21,7 +22,6 @@ import mozilla.components.feature.awesomebar.provider.SearchSuggestionProvider
 import mozilla.components.feature.awesomebar.provider.SessionSuggestionProvider
 import mozilla.components.feature.search.SearchUseCases
 import mozilla.components.feature.session.SessionUseCases
-import mozilla.components.support.ktx.android.graphics.drawable.toBitmap
 import mozilla.components.support.ktx.android.view.hideKeyboard
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ThemeManager

--- a/app/src/main/java/org/mozilla/fenix/search/awesomebar/ShortcutsSuggestionProvider.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/awesomebar/ShortcutsSuggestionProvider.kt
@@ -1,10 +1,10 @@
 package org.mozilla.fenix.search.awesomebar
 
 import android.content.Context
+import androidx.core.graphics.drawable.toBitmap
 import mozilla.components.browser.search.SearchEngine
 import mozilla.components.browser.search.SearchEngineManager
 import mozilla.components.concept.awesomebar.AwesomeBar
-import mozilla.components.support.ktx.android.graphics.drawable.toBitmap
 import org.mozilla.fenix.R
 import java.util.UUID
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -154,6 +154,7 @@ object Deps {
     const val androidx_navigation_ui = "androidx.navigation:navigation-ui:${Versions.androidx_navigation}"
     const val androidx_recyclerview = "androidx.recyclerview:recyclerview:${Versions.androidx_recyclerview}"
     const val androidx_core = "androidx.core:core:${Versions.androidx_core}"
+    const val androidx_core_ktx = "androidx.core:core-ktx:${Versions.androidx_core}"
     const val androidx_transition = "androidx.transition:transition:${Versions.androidx_transition}"
     const val google_material = "com.google.android.material:material:${Versions.google_material}"
 


### PR DESCRIPTION
In A.C. `0.56.0` `Drawable.toBitmap()` [was removed](https://github.com/mozilla-mobile/android-components/commit/c29c33773c5f1fb0453abcbeb525e198c3bd1363#diff-343723a0cb380f664aedf0dfed5c1c2fR43) from `support-ktx`.

Using implementation from `android-ktx` instead.

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] ~~**Tests**: This PR includes thorough tests or an explanation of why it does not~~
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~