### PR TITLE
Remove deprecatd support-ktx methods

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -15,6 +15,8 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.core.content.getSystemService
+import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProviders
 import androidx.navigation.fragment.NavHostFragment.findNavController
@@ -52,7 +54,6 @@ import mozilla.components.feature.sitepermissions.SitePermissionsRules
 import mozilla.components.support.base.feature.BackHandler
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
 import mozilla.components.support.ktx.android.view.exitImmersiveModeIfNeeded
-import mozilla.components.support.ktx.kotlin.toUri
 import org.mozilla.fenix.BrowsingModeManager
 import org.mozilla.fenix.BuildConfig
 import org.mozilla.fenix.FenixViewModelProvider
@@ -818,8 +819,9 @@ class BrowserFragment : Fragment(), BackHandler, CoroutineScope {
     }
 
     private fun Session.copyUrl(context: Context) {
-        val clipBoard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-        clipBoard.primaryClip = ClipData.newPlainText(url, url)
+        context.getSystemService<ClipboardManager>()?.apply {
+            primaryClip = ClipData.newPlainText(url, url)
+        }
     }
 
     private fun subscribeToSession(): Session.Observer {

--- a/app/src/main/java/org/mozilla/fenix/components/NotificationManager.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/NotificationManager.kt
@@ -15,6 +15,7 @@ import android.net.Uri
 import android.os.Build
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.getSystemService
 import mozilla.components.concept.sync.DeviceEvent
 import mozilla.components.concept.sync.TabData
 import mozilla.components.support.base.log.logger.Logger
@@ -95,8 +96,7 @@ class NotificationManager(private val context: Context) {
         }
         // Register the channel with the system. Once this is done, we can't change importance or other notification
         // channel behaviour. We will be able to change 'name' and 'description' if we so choose.
-        val notificationManager: NotificationManager =
-            context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        val notificationManager: NotificationManager = context.getSystemService()!!
         notificationManager.createNotificationChannel(channel)
     }
 

--- a/app/src/main/java/org/mozilla/fenix/ext/String.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/String.kt
@@ -7,10 +7,10 @@
 package org.mozilla.fenix.ext
 
 import android.content.Context
+import androidx.core.net.toUri
 import java.net.MalformedURLException
 import java.net.URL
 import mozilla.components.support.ktx.android.net.hostWithoutCommonPrefixes
-import mozilla.components.support.ktx.kotlin.toUri
 
 /**
  * Replaces the keys with the values with the map provided.
@@ -36,7 +36,7 @@ fun String?.getHostFromUrl(): String? = try {
  */
 suspend fun String.urlToTrimmedHost(context: Context): String {
     return try {
-        val host = this.toUri().hostWithoutCommonPrefixes ?: return this
+        val host = toUri().hostWithoutCommonPrefixes ?: return this
         context.components.publicSuffixList.stripPublicSuffix(host).await()
     } catch (e: MalformedURLException) {
         this

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragment.kt
@@ -18,6 +18,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
+import androidx.core.content.getSystemService
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProviders
 import androidx.navigation.NavController
@@ -398,8 +399,9 @@ class BookmarkFragment : Fragment(), CoroutineScope, BackHandler, AccountObserve
     }
 
     private fun BookmarkNode.copyUrl(context: Context) {
-        val clipBoard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-        clipBoard.primaryClip = ClipData.newPlainText(url, url)
+        context.getSystemService<ClipboardManager>()?.apply {
+            primaryClip = ClipData.newPlainText(url, url)
+        }
     }
 
     @SuppressWarnings("ReturnCount")

--- a/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarUIView.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarUIView.kt
@@ -8,6 +8,7 @@ import android.graphics.PorterDuff
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
+import androidx.core.graphics.drawable.toBitmap
 import androidx.recyclerview.widget.RecyclerView
 import io.reactivex.Observable
 import io.reactivex.Observer
@@ -21,7 +22,6 @@ import mozilla.components.feature.awesomebar.provider.SearchSuggestionProvider
 import mozilla.components.feature.awesomebar.provider.SessionSuggestionProvider
 import mozilla.components.feature.search.SearchUseCases
 import mozilla.components.feature.session.SessionUseCases
-import mozilla.components.support.ktx.android.graphics.drawable.toBitmap
 import mozilla.components.support.ktx.android.view.hideKeyboard
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ThemeManager

--- a/app/src/main/java/org/mozilla/fenix/search/awesomebar/ShortcutsSuggestionProvider.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/awesomebar/ShortcutsSuggestionProvider.kt
@@ -1,10 +1,10 @@
 package org.mozilla.fenix.search.awesomebar
 
 import android.content.Context
+import androidx.core.graphics.drawable.toBitmap
 import mozilla.components.browser.search.SearchEngine
 import mozilla.components.browser.search.SearchEngineManager
 import mozilla.components.concept.awesomebar.AwesomeBar
-import mozilla.components.support.ktx.android.graphics.drawable.toBitmap
 import org.mozilla.fenix.R
 import java.util.UUID
 
@@ -21,6 +21,10 @@ class ShortcutsSuggestionProvider(
 
     override val shouldClearSuggestions: Boolean
         get() = false
+
+    private val settingsIcon by lazy {
+        context.getDrawable(R.drawable.ic_settings)?.toBitmap()
+    }
 
     override suspend fun onInputChanged(text: String): List<AwesomeBar.Suggestion> {
         val suggestions = mutableListOf<AwesomeBar.Suggestion>()
@@ -42,9 +46,7 @@ class ShortcutsSuggestionProvider(
         suggestions.add(
             AwesomeBar.Suggestion(
                 provider = this,
-                icon = { _, _ ->
-                    context.getDrawable(R.drawable.ic_settings)?.toBitmap()
-                },
+                icon = { _, _ -> settingsIcon },
                 title = context.getString(R.string.search_shortcuts_engine_settings),
                 onSuggestionClicked = {
                     selectShortcutEngineSettings()

--- a/app/src/main/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsComponent.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsComponent.kt
@@ -6,8 +6,8 @@ package org.mozilla.fenix.settings.quicksettings
 
 import android.content.Context
 import android.view.ViewGroup
+import androidx.core.net.toUri
 import mozilla.components.feature.sitepermissions.SitePermissions
-import mozilla.components.support.ktx.kotlin.toUri
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.mvi.ViewState
 import org.mozilla.fenix.mvi.Change

--- a/app/src/main/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsSheetDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsSheetDialogFragment.kt
@@ -18,6 +18,7 @@ import android.view.ViewGroup
 import android.widget.LinearLayout
 import androidx.appcompat.app.AppCompatDialogFragment
 import androidx.appcompat.view.ContextThemeWrapper
+import androidx.core.net.toUri
 import androidx.core.widget.NestedScrollView
 import androidx.navigation.fragment.NavHostFragment.findNavController
 import com.google.android.material.bottomsheet.BottomSheetDialog
@@ -27,7 +28,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import mozilla.components.browser.session.Session
 import mozilla.components.feature.sitepermissions.SitePermissions
-import mozilla.components.support.ktx.kotlin.toUri
 import org.mozilla.fenix.FenixViewModelProvider
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.IntentReceiverActivity

--- a/app/src/main/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsUIView.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsUIView.kt
@@ -14,6 +14,7 @@ import android.widget.TextView
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.appcompat.widget.AppCompatTextView
 import androidx.core.content.ContextCompat
+import androidx.core.net.toUri
 import io.reactivex.Observable
 import io.reactivex.Observer
 import io.reactivex.functions.Consumer
@@ -21,7 +22,6 @@ import mozilla.components.feature.sitepermissions.SitePermissions
 import mozilla.components.feature.sitepermissions.SitePermissions.Status.BLOCKED
 import mozilla.components.feature.sitepermissions.SitePermissions.Status.NO_DECISION
 import mozilla.components.support.ktx.android.net.hostWithoutCommonPrefixes
-import mozilla.components.support.ktx.kotlin.toUri
 import org.mozilla.fenix.R
 import org.mozilla.fenix.mvi.UIView
 import org.mozilla.fenix.settings.PhoneFeature


### PR DESCRIPTION
mozilla-mobile/android-components#3317 and mozilla-mobile/android-components#3319 remove these methods in favour of the identical Android KTX methods.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
