### PR TITLE
For #2684: Add an extension function Session.toTab to map Session to Tab and clean up their usage

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -79,8 +79,7 @@ import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.enterToImmersiveMode
 import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.requireComponents
-import org.mozilla.fenix.ext.urlToTrimmedHost
-import org.mozilla.fenix.home.sessioncontrol.Tab
+import org.mozilla.fenix.ext.toTab
 import org.mozilla.fenix.lib.Do
 import org.mozilla.fenix.mvi.ActionBusFactory
 import org.mozilla.fenix.mvi.getAutoDisposeObservable
@@ -747,7 +746,7 @@ class BrowserFragment : Fragment(), BackHandler, CoroutineScope {
     private fun showSaveToCollection() {
         val context = context ?: return
         getSessionById()?.let {
-            val tabs = Tab(it.id, it.url, it.url.urlToTrimmedHost(context), it.title)
+            val tabs = it.toTab(context)
             val viewModel = activity?.run {
                 ViewModelProviders.of(this).get(CreateCollectionViewModel::class.java)
             }

--- a/app/src/main/java/org/mozilla/fenix/ext/Session.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/Session.kt
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.ext
+
+import android.content.Context
+import mozilla.components.browser.session.Session
+import org.mozilla.fenix.home.sessioncontrol.Tab
+
+fun Session.toTab(context: Context, selected: Boolean? = null): Tab {
+    return Tab(
+        this.id,
+        this.url,
+        this.url.urlToTrimmedHost(context),
+        this.title,
+        selected,
+        this.thumbnail
+    )
+}

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -57,7 +57,7 @@ import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.requireComponents
-import org.mozilla.fenix.ext.urlToTrimmedHost
+import org.mozilla.fenix.ext.toTab
 import org.mozilla.fenix.home.sessioncontrol.CollectionAction
 import org.mozilla.fenix.home.sessioncontrol.Mode
 import org.mozilla.fenix.home.sessioncontrol.OnboardingAction
@@ -575,14 +575,7 @@ class HomeFragment : Fragment(), CoroutineScope, AccountObserver {
                     .filter { it.id != sessionId }
                     .map {
                         val selected = it == sessionManager.selectedSession
-                        Tab(
-                            it.id,
-                            it.url,
-                            it.url.urlToTrimmedHost(context!!),
-                            it.title,
-                            selected,
-                            it.thumbnail
-                        )
+                        it.toTab(context!!, selected)
                     }
             )
         )
@@ -622,14 +615,7 @@ class HomeFragment : Fragment(), CoroutineScope, AccountObserver {
             .filter { (activity as HomeActivity).browsingModeManager.isPrivate == it.private }
             .map {
                 val selected = it == sessionManager.selectedSession
-                Tab(
-                    it.id,
-                    it.url,
-                    it.url.urlToTrimmedHost(context),
-                    it.title,
-                    selected,
-                    it.thumbnail
-                )
+                it.toTab(context, selected)
             }
     }
 
@@ -648,7 +634,7 @@ class HomeFragment : Fragment(), CoroutineScope, AccountObserver {
         val context = context?.let { it } ?: return
 
         val tabs = requireComponents.core.sessionManager.sessions.filter { !it.private }
-            .map { Tab(it.id, it.url, it.url.urlToTrimmedHost(context), it.title) }
+            .map { it.toTab(context) }
 
         val viewModel = activity?.run {
             ViewModelProviders.of(this).get(CreateCollectionViewModel::class.java)


### PR DESCRIPTION
Fixes #2684.

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
