### PR TITLE
Don't substitute application-services packages which are not part of the megazord

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -455,7 +455,8 @@ afterEvaluate {
                     }
                 }
                 // Check whether it was already megazorded.
-                if (! dependency.requested.name.endsWith("-withoutLib")) {
+                // Hack: sync15 is pure kotlin, and thus not part of the megazord.
+                if (! dependency.requested.name.endsWith("-withoutLib") && dependency.requested.name != "sync15") {
                     // Use either the -forUnitTests megazord, or the default one.
                     def substitution
                     if (dependency.requested.name.endsWith("-forUnitTests")) {


### PR DESCRIPTION
This is a hack, but will only be necessary until https://github.com/mozilla/application-services/pull/1103 (which I'll be getting back to soon) lands (which will delete that whole `afterEvaluate` block, actually).

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
