### PR TITLE
For #1134: Set UA to GeckoView 69.0 for whitelisted domains

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/UserAgentRewriter.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/UserAgentRewriter.kt
@@ -1,0 +1,37 @@
+package org.mozilla.fenix.browser
+
+import android.os.Build.VERSION.RELEASE
+import mozilla.components.concept.engine.EngineSession
+import mozilla.components.support.ktx.kotlin.sha1
+
+/**
+ * Utility to rewrite the User-Agent header for requests to whitelisted domains.
+ *
+ * Follow up: https://github.com/mozilla-mobile/fenix/issues/3341
+ */
+object UserAgentRewriter {
+
+    /**
+     * Updates the User-Agent based on the [whitelistUaFilter] to set the [userAgentGecko69] value.
+     */
+    fun maybeRewriteUserAgent(session: EngineSession, host: String) {
+        session.settings.userAgentString = if (whitelistUaFilter.contains(host.sha1())) {
+            userAgentGecko69
+        } else {
+            null
+        }
+    }
+
+    /**
+     * The white-listed domains.
+     */
+    private val whitelistUaFilter = setOf(
+        "1b12ecd917215146f79a0ac5e01b3059faadab47",
+        "a486f819018512f60a8a66324e51be0e1118a91d"
+    )
+
+    /**
+     * The User-Agent to use for the white-listed domains.
+     */
+    private val userAgentGecko69 = "Mozilla/5.0 (Android $RELEASE; Mobile; rv:69.0) Gecko/69.0 Firefox/69.0"
+}


### PR DESCRIPTION
Also filed a [follow-up issue](https://github.com/mozilla-mobile/fenix/issues/3341) to remove the interceptor when we upgrade to GV 69.0.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
