### PR TITLE
For #975: Removes leakcanary and default browser telemetry

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -141,9 +141,8 @@ events:
       A user toggled a preference switch in settings
     extra_keys:
       preference_key:
-        description: "The preference key for the switch preference the user toggled. We currently track: leakcanary,
-          make_default_browser, show_search_suggestions, show_visited_sites_bookmarks, remote_debugging, telemetry,
-          tracking_protection"
+        description: "The preference key for the switch preference the user toggled. We currently track:
+          show_search_suggestions, show_visited_sites_bookmarks, remote_debugging, telemetry, tracking_protection"
       enabled:
         description: "Whether or not the preference is *now* enabled"
     bugs:

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/Metrics.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/Metrics.kt
@@ -94,8 +94,6 @@ sealed class Event {
 
     data class PreferenceToggled(val preferenceKey: String, val enabled: Boolean, val context: Context) : Event() {
         private val switchPreferenceTelemetryAllowList = listOf(
-            context.getString(R.string.pref_key_leakcanary),
-            context.getString(R.string.pref_key_make_default_browser),
             context.getString(R.string.pref_key_show_search_suggestions),
             context.getString(R.string.pref_key_show_visited_sites_bookmarks),
             context.getString(R.string.pref_key_remote_debugging),


### PR DESCRIPTION
QA has confirmed that the toggle for `make_default_browser` does not function. This makes sense, as we're setting it with custom behavior. 

We also need to remove leak canary as it only exists in debug builds

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
