### PR TITLE
For #3252: Reader mode appearance buttons are not visible in PB

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -13,8 +13,11 @@ import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
+import android.widget.RadioButton
 import androidx.appcompat.app.AppCompatActivity
 import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
 import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
@@ -356,6 +359,12 @@ class BrowserFragment : Fragment(), BackHandler, CoroutineScope {
             view.swipeRefresh.setOnChildScrollUpCallback { _, _ -> true }
         }
 
+        if ((activity as HomeActivity).browsingModeManager.isPrivate) {
+            // We need to update styles for private mode programmatically for now:
+            // https://github.com/mozilla-mobile/android-components/issues/3400
+            themeReaderViewControlsForPrivateMode(view.readerViewControlsBar)
+        }
+
         readerViewFeature.set(
             feature = ReaderViewFeature(
                 requireContext(),
@@ -396,6 +405,26 @@ class BrowserFragment : Fragment(), BackHandler, CoroutineScope {
 
         toolbarComponent.getView().setOnSiteSecurityClickedListener {
             showQuickSettingsDialog()
+        }
+    }
+
+    private fun themeReaderViewControlsForPrivateMode(view: View) = with(view) {
+        listOf(
+            R.id.mozac_feature_readerview_font_size_decrease,
+            R.id.mozac_feature_readerview_font_size_increase
+        ).map {
+            findViewById<Button>(it)
+        }.forEach {
+            it.setTextColor(ContextCompat.getColorStateList(context, R.color.readerview_private_button_color))
+        }
+
+        listOf(
+            R.id.mozac_feature_readerview_font_serif,
+            R.id.mozac_feature_readerview_font_sans_serif
+        ).map {
+            findViewById<RadioButton>(it)
+        }.forEach {
+            it.setTextColor(ContextCompat.getColorStateList(context, R.color.readerview_private_radio_color))
         }
     }
 

--- a/app/src/main/res/color/readerview_private_button_color.xml
+++ b/app/src/main/res/color/readerview_private_button_color.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="true" android:color="@color/primary_text_private_theme" />
+    <item android:state_enabled="false" android:color="@color/mozac_feature_readerview_text_color_disabled" />
+</selector>

--- a/app/src/main/res/color/readerview_private_radio_color.xml
+++ b/app/src/main/res/color/readerview_private_radio_color.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_checked="true" android:color="@color/mozac_feature_readerview_selected" />
+    <item android:state_checked="false" android:color="@color/primary_text_private_theme" />
+</selector>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -148,6 +148,7 @@
 
     <!-- Reader View colors -->
     <color name="mozac_feature_readerview_text_color">@color/primary_text_light_theme</color>
+    <color name="mozac_feature_readerview_selected">@color/accent_high_contrast_dark_theme</color>
 
     <!-- Onboarding colors -->
     <color name="onboarding_card_background_dark">#20123A</color>


### PR DESCRIPTION
See also https://github.com/mozilla-mobile/android-components/issues/3400 which describes why this solution is needed and (once resolved) will allow for a cleaner fix in the future.