### PR TITLE
Pin Android Components version to 0.56.2.

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -30,13 +30,13 @@ private object Versions {
     const val androidx_transition = "1.1.0-rc02"
     const val google_material = "1.1.0-alpha07"
 
-    const val mozilla_android_components = "0.56.0-SNAPSHOT"
+    const val mozilla_android_components = "0.56.2"
     // Note that android-components also depends on application-services,
     // and in fact is our main source of appservices-related functionality.
     // The version number below tracks the application-services version
     // that we depend on directly for tests, and it's important that it
     // be kept in sync with the version used by android-components above.
-    const val mozilla_appservices = "0.30.0"
+    const val mozilla_appservices = "0.31.2"
 
     const val autodispose = "1.1.0"
     const val adjust = "4.11.4"

--- a/buildSrc/src/main/java/Gecko.kt
+++ b/buildSrc/src/main/java/Gecko.kt
@@ -3,18 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object GeckoVersions {
-    const val nightly_version = "69.0.20190522093426"
-    const val beta_version = "68.0.20190604110028"
+    const val beta_version = "68.0.20190611143747"
     const val release_version = "67.0.20190521210220"
 }
 
 @Suppress("MaxLineLength")
 object Gecko {
-    const val geckoview_nightly_arm = "org.mozilla.geckoview:geckoview-nightly-armeabi-v7a:${GeckoVersions.nightly_version}"
-    const val geckoview_nightly_aarch64 = "org.mozilla.geckoview:geckoview-nightly-arm64-v8a:${GeckoVersions.nightly_version}"
-    const val geckoview_nightly_x86 = "org.mozilla.geckoview:geckoview-nightly-x86:${GeckoVersions.nightly_version}"
-    const val geckoview_nightly_x86_64 = "org.mozilla.geckoview:geckoview-nightly-x86_64:${GeckoVersions.nightly_version}"
-
     const val geckoview_beta_arm = "org.mozilla.geckoview:geckoview-beta-armeabi-v7a:${GeckoVersions.beta_version}"
     const val geckoview_beta_aarch64 = "org.mozilla.geckoview:geckoview-beta-arm64-v8a:${GeckoVersions.beta_version}"
     const val geckoview_beta_x86 = "org.mozilla.geckoview:geckoview-beta-x86:${GeckoVersions.beta_version}"


### PR DESCRIPTION
This will pin Android Components to the latest stable release 0.56.2. We will do more dot releases throughout the week as needed.

This patch also updates GeckoView Beta and Application Services to use a version matching the one from the AC release.

I removed the GeckoView nightly artifats and version numbers here since with nightly it's no longer needed to define them in an app project. The right GeckoView version will be picked up from AC automatically.