### PR TITLE
For #3388: Set max length for account device name

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/AccountSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/AccountSettingsFragment.kt
@@ -6,10 +6,12 @@ package org.mozilla.fenix.settings
 
 import android.content.Context
 import android.os.Bundle
+import android.text.InputFilter
 import android.text.format.DateUtils
 import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.Navigation
 import androidx.preference.CheckBoxPreference
+import androidx.preference.EditTextPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceCategory
 import androidx.preference.PreferenceFragmentCompat
@@ -111,10 +113,13 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), CoroutineScope {
         // Device Name
         val deviceConstellation = accountManager.authenticatedAccount()?.deviceConstellation()
         val deviceNameKey = context!!.getPreferenceKey(R.string.pref_key_sync_device_name)
-        findPreference<Preference>(deviceNameKey)?.apply {
+        findPreference<EditTextPreference>(deviceNameKey)?.apply {
             onPreferenceChangeListener = getChangeListenerForDeviceName()
             deviceConstellation?.state()?.currentDevice?.let { device ->
                 summary = device.displayName
+            }
+            setOnBindEditTextListener { editText ->
+                editText.filters = arrayOf(InputFilter.LengthFilter(DEVICE_NAME_MAX_LENGTH))
             }
         }
 
@@ -256,5 +261,9 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), CoroutineScope {
                 DateUtils.getRelativeTimeSpanString(lastSyncTime)
             )
         }
+    }
+
+    companion object {
+        private const val DEVICE_NAME_MAX_LENGTH = 128
     }
 }


### PR DESCRIPTION
We have to add the length filter from inside the preference since applying the xml attribute does not get applied to the internal EditText.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
