### PR TITLE
Tie allowUndo to a coroutine scope

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -561,7 +561,8 @@ class HomeFragment : Fragment(), CoroutineScope, AccountObserver {
         allowUndo(
             view!!,
             getString(R.string.snackbar_tabs_deleted),
-            getString(R.string.snackbar_deleted_undo), {
+            getString(R.string.snackbar_deleted_undo),
+            onCancel = {
                 deleteAllSessionsJob = null
                 emitSessionChanges()
             },
@@ -588,7 +589,8 @@ class HomeFragment : Fragment(), CoroutineScope, AccountObserver {
         allowUndo(
             view!!,
             getString(R.string.snackbar_tab_deleted),
-            getString(R.string.snackbar_deleted_undo), {
+            getString(R.string.snackbar_deleted_undo),
+            onCancel = {
                 pendingSessionDeletion = null
                 emitSessionChanges()
             },

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragment.kt
@@ -266,7 +266,8 @@ class BookmarkFragment : Fragment(), CoroutineScope, BackHandler, AccountObserve
                                     R.string.bookmark_deletion_snackbar_message,
                                     it.item.url?.urlToTrimmedHost(context)
                                 ),
-                                getString(R.string.bookmark_undo_deletion), { refreshBookmarks() }
+                                getString(R.string.bookmark_undo_deletion),
+                                onCancel = this::refreshBookmarks
                             ) {
                                 context.bookmarkStorage()?.deleteNode(it.item.guid)
                                 metrics()?.track(Event.RemoveBookmark)
@@ -343,7 +344,8 @@ class BookmarkFragment : Fragment(), CoroutineScope, BackHandler, AccountObserve
 
                 allowUndo(
                     view!!, getString(R.string.bookmark_deletion_multiple_snackbar_message),
-                    getString(R.string.bookmark_undo_deletion), { refreshBookmarks() }
+                    getString(R.string.bookmark_undo_deletion),
+                    onCancel = this::refreshBookmarks
                 ) {
                     deleteSelectedBookmarks(selectedBookmarks)
                     // Since this runs in a coroutine, we can't depend on the fragment still being attached.

--- a/app/src/main/java/org/mozilla/fenix/utils/Undo.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Undo.kt
@@ -26,15 +26,13 @@ internal const val UNDO_DELAY = 3000L
  * @param onCancel A suspend block to execute in case of cancellation.
  * @param operation A suspend block to execute if user doesn't cancel via the displayed [FenixSnackbar].
  */
-fun allowUndo(
+fun CoroutineScope.allowUndo(
     view: View,
     message: String,
     undoActionTitle: String,
     onCancel: suspend () -> Unit = {},
     operation: suspend () -> Unit
 ) {
-    val mainScope = CoroutineScope(Dispatchers.Main)
-
     // By using an AtomicBoolean, we achieve memory effects of reading and
     // writing a volatile variable.
     val requestedUndo = AtomicBoolean(false)
@@ -45,7 +43,7 @@ fun allowUndo(
         .setText(message)
         .setAction(undoActionTitle) {
             requestedUndo.set(true)
-            mainScope.launch {
+            launch {
                 onCancel.invoke()
             }
         }
@@ -55,7 +53,7 @@ fun allowUndo(
 
     // Wait a bit, and if user didn't request cancellation, proceed with
     // requested operation and hide the snackbar.
-    mainScope.launch {
+    launch {
         delay(UNDO_DELAY)
 
         if (!requestedUndo.get()) {


### PR DESCRIPTION
`allowUndo` previously had its own scope. By re-using an existing scope it can be cancelled automatically when a fragment is destroyed.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
