### PR TITLE
For #3401: Update toolbar tab counter when view is attached

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/TabCounterToolbarButton.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/TabCounterToolbarButton.kt
@@ -28,14 +28,21 @@ class TabCounterToolbarButton(
 
         val view = TabCounter(parent.context).apply {
             reference = WeakReference(this)
-            setCount(sessionManager.sessions.count {
-                    it.private == isPrivate
-                })
             setOnClickListener {
                 showTabs.invoke()
             }
             contentDescription =
                 parent.context.getString(R.string.mozac_feature_tabs_toolbar_tabs_button)
+
+            addOnAttachStateChangeListener(object : View.OnAttachStateChangeListener {
+                override fun onViewAttachedToWindow(v: View?) {
+                    setCount(sessionManager.sessions.count {
+                        it.private == isPrivate
+                    })
+                }
+
+                override fun onViewDetachedFromWindow(v: View?) { /* no-op */ }
+            })
         }
 
         // Set selectableItemBackgroundBorderless


### PR DESCRIPTION
The issue here is that the observer in the Tabs counter is not registered until the view is attached to the window. This means there is a space open where the restore would be completed before the tabs observe is registered, and therefore not knowing that the sessions have already been restored.

The smallest change we can make to fix this issue, is to wait until the tab counter view has been attached, and then update the count.

cc: @csadilek 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
