### PR TITLE
Update Android Components 0.56.4.

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -30,7 +30,7 @@ private object Versions {
     const val androidx_transition = "1.1.0-rc02"
     const val google_material = "1.1.0-alpha07"
 
-    const val mozilla_android_components = "0.56.2"
+    const val mozilla_android_components = "0.56.4"
     // Note that android-components also depends on application-services,
     // and in fact is our main source of appservices-related functionality.
     // The version number below tracks the application-services version


### PR DESCRIPTION
This version is identical with 0.56.2 but with a patch applied for: https://github.com/mozilla-mobile/android-components/issues/3433 (https://github.com/mozilla-mobile/android-components/commit/261e147b3b07c0cf70f1503fc1ba12094a435a8a). We recommend updating to that version before building a release candidate.

Edit: Updated to 0.56.4 that includes updated translations on top of 0.56.3.