### PR TITLE
Refactor `CrashReporterFragment` for UI tests.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -126,6 +126,9 @@ android.applicationVariants.all { variant ->
         }
     }
 
+    // TODO remove when proper DI solution will be introduced
+    buildConfigField 'Boolean', 'IS_TEST_BUILD', hasTest ? 'true' : 'false'
+
 // -------------------------------------------------------------------------------------------------
 // Generate version codes for builds
 // -------------------------------------------------------------------------------------------------
@@ -299,7 +302,9 @@ dependencies {
     implementation Deps.mozilla_feature_downloads
     implementation Deps.mozilla_browser_domains
     implementation Deps.mozilla_browser_icons
+    implementation Deps.mozilla_browser_menu
     implementation Deps.mozilla_browser_engine_gecko_beta
+    implementation Deps.mozilla_browser_search
     implementation Deps.mozilla_browser_session
     implementation Deps.mozilla_browser_storage_sync
     implementation Deps.mozilla_browser_toolbar
@@ -314,6 +319,7 @@ dependencies {
     implementation Deps.mozilla_feature_media
     implementation Deps.mozilla_feature_prompts
     implementation Deps.mozilla_feature_qr
+    implementation Deps.mozilla_feature_search
     implementation Deps.mozilla_feature_session
     implementation Deps.mozilla_feature_sync
     implementation Deps.mozilla_feature_toolbar
@@ -329,9 +335,11 @@ dependencies {
 
     implementation Deps.mozilla_support_ktx
     implementation Deps.mozilla_support_rustlog
+    implementation Deps.mozilla_support_utils
 
     implementation Deps.mozilla_ui_colors
     implementation Deps.mozilla_ui_icons
+    implementation Deps.mozilla_lib_publicsuffixlist
 
     implementation Deps.mozilla_lib_crash
     debugImplementation Deps.leakcanary
@@ -345,6 +353,7 @@ dependencies {
     x86_64Implementation Gecko.geckoview_beta_x86_64
 
     implementation Deps.androidx_legacy
+    implementation Deps.androidx_paging
     implementation Deps.androidx_preference
     implementation Deps.androidx_fragment
     implementation Deps.androidx_navigation_fragment
@@ -364,9 +373,6 @@ dependencies {
 
     implementation Deps.google_ads_id // Required for the Google Advertising ID
 
-//    androidTestImplementation Deps.tools_test_runner
-//    androidTestImplementation Deps.tools_espresso_core
-
     androidTestImplementation Deps.uiautomator
 
     androidTestImplementation Deps.espresso_core, {
@@ -384,16 +390,16 @@ dependencies {
 
     androidTestImplementation Deps.espresso_idling_resources
 
-    androidTestImplementation Deps.tools_test_runner
+    androidTestImplementation Deps.androidx_test_junit
+    androidTestImplementation Deps.androidx_test_runner
+    androidTestUtil Deps.androidx_test_orchestrator
     androidTestImplementation Deps.tools_test_rules
-    androidTestUtil Deps.orchestrator
-    androidTestImplementation Deps.espresso_core, {
-        exclude group: 'com.android.support', module: 'support-annotations'
-    }
+    androidTestImplementation Deps.mockito_core
+    androidTestImplementation Deps.mockito_kotlin
 
     testImplementation Deps.junit
     testImplementation Deps.robolectric
-    implementation Deps.fragment_testing
+    debugImplementation Deps.androidx_fragment_testing
     testImplementation Deps.places_forUnitTests
 
     testImplementation Deps.mockito_core

--- a/app/src/androidTest/java/org/mozilla/fenix/components/TestComponents.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/components/TestComponents.kt
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.components
+
+import mozilla.components.lib.publicsuffixlist.PublicSuffixList
+
+internal class TestComponents : IComponents {
+
+    override lateinit var backgroundServices: BackgroundServices
+    override lateinit var services: Services
+    override lateinit var core: Core
+    override lateinit var search: Search
+    override lateinit var useCases: UseCases
+    override lateinit var utils: Utilities
+    override lateinit var analytics: Analytics
+    override lateinit var publicSuffixList: PublicSuffixList
+}

--- a/app/src/androidTest/java/org/mozilla/fenix/crashes/CrashReporterFragmentTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/crashes/CrashReporterFragmentTest.kt
@@ -1,0 +1,315 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+@file:Suppress("unused")
+
+package org.mozilla.fenix.crashes
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.fragment.app.testing.FragmentScenario
+import androidx.fragment.app.testing.launchFragmentInContainer
+import androidx.navigation.NavController
+import androidx.navigation.Navigation
+import androidx.test.core.app.ApplicationProvider.getApplicationContext
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.ViewInteraction
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isChecked
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.MediumTest
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
+import com.nhaarman.mockitokotlin2.whenever
+import mozilla.components.browser.session.Session
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations.initMocks
+import org.mozilla.fenix.FenixApplication
+import org.mozilla.fenix.R
+import org.mozilla.fenix.components.TestComponents
+import org.mozilla.fenix.components.WrappedCrashRecoveryUseCase
+import org.mozilla.fenix.components.WrappedCrashReporter
+import org.mozilla.fenix.components.WrappedRemoveTabUseCase
+import org.mozilla.fenix.components.WrappedSessionManager
+import org.mozilla.fenix.components.WrappedSessionUseCases
+import org.mozilla.fenix.components.WrappedTabsUseCases
+import org.mozilla.fenix.components.metrics.Event
+import org.mozilla.fenix.components.metrics.MetricController
+import org.mozilla.fenix.helpers.click
+
+@MediumTest
+@RunWith(AndroidJUnit4::class)
+class CrashReporterFragmentTest {
+
+    @Mock
+    lateinit var metricController: MetricController
+
+    @Mock
+    lateinit var sessionManager: WrappedSessionManager
+
+    @Mock
+    lateinit var crashReporter: WrappedCrashReporter
+
+    @Mock
+    lateinit var crashRecoveryUseCase: WrappedCrashRecoveryUseCase
+
+    @Mock
+    lateinit var removeTabUseCase: WrappedRemoveTabUseCase
+
+    @Mock
+    lateinit var navController: NavController
+
+    @Before
+    fun setUp() {
+        initMocks(this)
+
+        getApplicationContext<FenixApplication>().components.let { it as TestComponents }.apply {
+            analytics = mock {
+                on { metrics } doReturn metricController
+                on { wrappedCrashReporter } doReturn crashReporter
+            }
+            core = mock {
+                on { wrappedSessionManager } doReturn sessionManager
+            }
+
+            useCases = run {
+                val sessionUseCases = mock<WrappedSessionUseCases> {
+                    on { crashRecovery } doReturn crashRecoveryUseCase
+                }
+                val tabsUseCases = mock<WrappedTabsUseCases> {
+                    on { removeTab } doReturn removeTabUseCase
+                }
+
+                mock {
+                    on { wrappedSessionUseCases } doReturn sessionUseCases
+                    on { wrappedTabsUseCases } doReturn tabsUseCases
+                }
+            }
+        }
+    }
+
+    @Test
+    fun defaultScreenState() {
+        // When
+        launchFragmentScenario()
+
+        // Then
+        verifyAll {
+            sendCrashCheckbox.shouldBeChecked()
+            closeTabButton.shouldBeDisplayed()
+            restoreTabButton.shouldBeDisplayed()
+
+            analyticsOpenedTracked()
+            stayedOnScreen()
+            noCrashReported()
+        }
+    }
+
+    @Test
+    fun noReactionOnInputIfThereIsNoActiveSession() {
+        // Given
+        whenever(sessionManager.selectedSession) doReturn null
+
+        // When
+        launchFragmentScenario()
+
+        closeTabButton.click()
+        restoreTabButton.click()
+
+        // Then
+        verifyAll {
+            closeTabButton.shouldBeDisplayed()
+            restoreTabButton.shouldBeDisplayed()
+
+            stayedOnScreen()
+            noCrashReported()
+        }
+    }
+
+    @Test
+    fun sendReportCheckboxIgnored() {
+        // Given
+        whenever(sessionManager.selectedSession) doReturn Session("")
+
+        // When
+        launchFragmentScenario()
+            .also(::enableCrashReporting)
+
+        sendCrashCheckbox.click() // This checkbox is actually ignored
+        closeTabButton.click()
+
+        // Then
+        verifyAll {
+            crashReported()
+        }
+    }
+
+    @Test
+    fun closeTab_enabledReporting() {
+        // Given
+        val currentSession = Session("")
+        whenever(sessionManager.selectedSession) doReturn currentSession
+
+        // When
+        launchFragmentScenario()
+            .also(::enableCrashReporting)
+
+        closeTabButton.click()
+
+        // Then
+        verifyAll {
+            analyticsOpenedTracked()
+            analyticsClosedWithReportTracked()
+            crashReported()
+            tabRemoved(currentSession)
+            recoveredFromCrash()
+            navigatedHome()
+        }
+    }
+
+    @Test
+    fun closeTab_disabledReporting() {
+        // Given
+        val currentSession = Session("")
+        whenever(sessionManager.selectedSession) doReturn currentSession
+
+        // When
+        launchFragmentScenario()
+            .also(::disableCrashReporting)
+
+        closeTabButton.click()
+
+        // Then
+        verifyAll {
+            analyticsOpenedTracked()
+            analyticsClosedWithoutReportTracked()
+            noCrashReported()
+            tabRemoved(currentSession)
+            recoveredFromCrash()
+            navigatedHome()
+        }
+    }
+
+    @Test
+    fun restoreTab_enabledReporting() {
+        // Given
+        val currentSession = Session("")
+        whenever(sessionManager.selectedSession) doReturn currentSession
+
+        // When
+        launchFragmentScenario()
+            .also(::enableCrashReporting)
+
+        restoreTabButton.click()
+
+        // Then
+        verifyAll {
+            analyticsOpenedTracked()
+            analyticsClosedWithReportTracked()
+            crashReported()
+            tabStayed()
+            recoveredFromCrash()
+            navigatedBack()
+        }
+    }
+
+    @Test
+    fun restoreTab_disabledReporting() {
+        // Given
+        val currentSession = Session("")
+        whenever(sessionManager.selectedSession) doReturn currentSession
+
+        // When
+        launchFragmentScenario()
+            .also(::disableCrashReporting)
+
+        restoreTabButton.click()
+
+        // Then
+        verifyAll {
+            analyticsOpenedTracked()
+            analyticsClosedWithoutReportTracked()
+            noCrashReported()
+            tabStayed()
+            recoveredFromCrash()
+            navigatedBack()
+        }
+    }
+
+    private fun launchFragmentScenario() = launchFragmentScenario(navController = navController)
+
+    // Verifications
+
+    private fun VerificationScope.analyticsOpenedTracked() =
+        verify(metricController).track(Event.CrashReporterOpened)
+
+    private fun VerificationScope.analyticsClosedWithReportTracked() =
+        verify(metricController).track(Event.CrashReporterClosed(crashSubmitted = true))
+
+    private fun VerificationScope.analyticsClosedWithoutReportTracked() =
+        verify(metricController).track(Event.CrashReporterClosed(crashSubmitted = false))
+
+    private fun VerificationScope.crashReported() = verify(crashReporter).submitReport(any())
+    private fun VerificationScope.noCrashReported() = verify(crashReporter, never()).submitReport(any())
+    private fun VerificationScope.tabStayed() = verifyZeroInteractions(removeTabUseCase)
+    private fun VerificationScope.tabRemoved(session: Session) = verify(removeTabUseCase).invoke(session)
+    private fun VerificationScope.recoveredFromCrash() = verify(crashRecoveryUseCase).invoke()
+    private fun VerificationScope.stayedOnScreen() = verifyZeroInteractions(navController)
+    private fun VerificationScope.navigatedBack() = navController.popBackStack()
+    private fun VerificationScope.navigatedHome() = navController.popBackStack(R.id.browserFragment, true)
+}
+
+private fun launchFragmentScenario(
+    args: CrashReporterFragmentArgs = createFragmentArguments(Error()),
+    navController: NavController
+) = launchFragmentInContainer<CrashReporterFragment>(args.toBundle(), R.style.NormalTheme).apply {
+    onFragment { fragment ->
+        Navigation.setViewNavController(fragment.view!!, navController)
+    }
+}
+
+private fun enableCrashReporting(scenario: FragmentScenario<CrashReporterFragment>) {
+    scenario.onFragment { fragment ->
+        fragment.crashReportingEnabled = { true }
+    }
+}
+
+private fun disableCrashReporting(scenario: FragmentScenario<CrashReporterFragment>) {
+    scenario.onFragment { fragment ->
+        fragment.crashReportingEnabled = { false }
+    }
+}
+
+private fun createFragmentArguments(throwable: Throwable) = CrashReporterFragmentArgs(
+    Intent().also { intent ->
+        intent.putExtra("mozilla.components.lib.crash.CRASH", Bundle().also { bundle ->
+            bundle.putSerializable("exception", throwable)
+        })
+    }
+)
+
+// View
+
+private val sendCrashCheckbox get() = onView(withId(R.id.send_crash_checkbox))
+private val closeTabButton get() = onView(withId(R.id.close_tab_button))
+private val restoreTabButton get() = onView(withId(R.id.restore_tab_button))
+
+// Verification
+
+private fun verifyAll(block: VerificationScope.() -> Unit) = VerificationScope.block()
+
+private object VerificationScope {
+
+    fun ViewInteraction.shouldBeChecked() = check(matches(isChecked()))!!
+    fun ViewInteraction.shouldBeDisplayed() = check(matches(isDisplayed()))!!
+}

--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -25,6 +25,8 @@ import mozilla.components.support.ktx.android.content.isMainProcess
 import mozilla.components.support.ktx.android.content.runOnlyInMainProcess
 import mozilla.components.support.rustlog.RustLog
 import org.mozilla.fenix.components.Components
+import org.mozilla.fenix.components.IComponents
+import org.mozilla.fenix.components.TestComponents
 import org.mozilla.fenix.utils.Settings
 import java.io.File
 
@@ -35,12 +37,22 @@ open class FenixApplication : Application() {
     lateinit var experimentLoader: Deferred<Boolean>
     var experimentLoaderComplete: Boolean = false
 
-    open val components by lazy { Components(this) }
+    open val components: IComponents by lazy {
+        if (BuildConfig.IS_TEST_BUILD) {
+            TestComponents()
+        } else {
+            Components(this)
+        }
+    }
 
     override fun onCreate() {
         super.onCreate()
 
-        setupApplication()
+        if (BuildConfig.IS_TEST_BUILD) {
+            setupTestApplication()
+        } else {
+            setupApplication()
+        }
     }
 
     open fun setupApplication() {
@@ -67,6 +79,8 @@ open class FenixApplication : Application() {
             components.analytics.metrics.start()
         }
     }
+
+    open fun setupTestApplication() {}
 
     private fun registerRxExceptionHandling() {
         RxJavaPlugins.setErrorHandler {

--- a/app/src/main/java/org/mozilla/fenix/components/Analytics.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Analytics.kt
@@ -74,6 +74,8 @@ class Analytics(
         )
     }
 
+    val wrappedCrashReporter: WrappedCrashReporter by lazy { RealWrappedCrashReporter(crashReporter) }
+
     val metrics: MetricController by lazy {
         MetricController.create(
             listOf(

--- a/app/src/main/java/org/mozilla/fenix/components/Components.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Components.kt
@@ -12,15 +12,30 @@ import org.mozilla.fenix.test.Mockable
  * Provides access to all components.
  */
 @Mockable
-class Components(private val context: Context) {
-    val backgroundServices by lazy {
+class Components(private val context: Context) : IComponents {
+
+    override val backgroundServices by lazy {
         BackgroundServices(context, core.historyStorage, core.bookmarksStorage, utils.notificationManager)
     }
-    val services by lazy { Services(backgroundServices.accountManager) }
-    val core by lazy { Core(context) }
-    val search by lazy { Search(context) }
-    val useCases by lazy { UseCases(context, core.sessionManager, core.engine.settings, search.searchEngineManager) }
-    val utils by lazy { Utilities(context, core.sessionManager, useCases.sessionUseCases, useCases.searchUseCases) }
-    val analytics by lazy { Analytics(context) }
-    val publicSuffixList by lazy { PublicSuffixList(context) }
+    override val services by lazy { Services(backgroundServices.accountManager) }
+    override val core by lazy { Core(context) }
+    override val search by lazy { Search(context) }
+    override val useCases by lazy {
+        UseCases(
+            context,
+            core.sessionManager,
+            core.engine.settings,
+            search.searchEngineManager
+        )
+    }
+    override val utils by lazy {
+        Utilities(
+            context,
+            core.sessionManager,
+            useCases.sessionUseCases,
+            useCases.searchUseCases
+        )
+    }
+    override val analytics by lazy { Analytics(context) }
+    override val publicSuffixList by lazy { PublicSuffixList(context) }
 }

--- a/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -128,6 +128,8 @@ class Core(private val context: Context) {
         }
     }
 
+    val wrappedSessionManager: WrappedSessionManager by lazy { RealWrappedSessionManager(sessionManager) }
+
     /**
      * Icons component for loading, caching and processing website icons.
      */

--- a/app/src/main/java/org/mozilla/fenix/components/IComponents.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/IComponents.kt
@@ -1,0 +1,15 @@
+package org.mozilla.fenix.components
+
+import mozilla.components.lib.publicsuffixlist.PublicSuffixList
+
+interface IComponents {
+
+    val backgroundServices: BackgroundServices
+    val services: Services
+    val core: Core
+    val search: Search
+    val useCases: UseCases
+    val utils: Utilities
+    val analytics: Analytics
+    val publicSuffixList: PublicSuffixList
+}

--- a/app/src/main/java/org/mozilla/fenix/components/TestComponents.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/TestComponents.kt
@@ -1,0 +1,15 @@
+package org.mozilla.fenix.components
+
+class TestComponents : IComponents {
+
+    override val backgroundServices get() = notDefined()
+    override val services get() = notDefined()
+    override val core get() = notDefined()
+    override val search get() = notDefined()
+    override val useCases get() = notDefined()
+    override val utils get() = notDefined()
+    override val analytics get() = notDefined()
+    override val publicSuffixList get() = notDefined()
+}
+
+private fun notDefined(): Nothing = throw NotImplementedError("Test component not provided")

--- a/app/src/main/java/org/mozilla/fenix/components/UseCases.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/UseCases.kt
@@ -30,10 +30,14 @@ class UseCases(
      */
     val sessionUseCases by lazy { SessionUseCases(sessionManager) }
 
+    val wrappedSessionUseCases: WrappedSessionUseCases by lazy { RealWrappedSessionUseCases(sessionUseCases) }
+
     /**
      * Use cases that provide tab management.
      */
     val tabsUseCases: TabsUseCases by lazy { TabsUseCases(sessionManager) }
+
+    val wrappedTabsUseCases: WrappedTabsUseCases by lazy { RealWrappedTabsUseCases(tabsUseCases) }
 
     /**
      * Use cases that provide search engine integration.

--- a/app/src/main/java/org/mozilla/fenix/components/wrappers.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/wrappers.kt
@@ -1,0 +1,82 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.components
+
+import mozilla.components.browser.session.Session
+import mozilla.components.browser.session.SessionManager
+import mozilla.components.feature.session.SessionUseCases
+import mozilla.components.feature.tabs.TabsUseCases
+import mozilla.components.lib.crash.Crash
+import mozilla.components.lib.crash.CrashReporter
+
+/*
+ * TODO this interfaces/classes are used for gentle transition to IoC implementation
+ */
+
+interface WrappedSessionUseCases {
+
+    val crashRecovery: WrappedCrashRecoveryUseCase
+}
+
+class RealWrappedSessionUseCases(delegate: SessionUseCases) :
+    WrappedSessionUseCases {
+
+    override val crashRecovery = RealWrappedCrashRecoveryUseCase(delegate.crashRecovery)
+}
+
+interface WrappedCrashRecoveryUseCase {
+
+    fun invoke(): Boolean
+}
+
+class RealWrappedCrashRecoveryUseCase(private val delegate: SessionUseCases.CrashRecoveryUseCase) :
+    WrappedCrashRecoveryUseCase {
+
+    override fun invoke() = delegate.invoke()
+}
+
+interface WrappedTabsUseCases {
+
+    val removeTab: WrappedRemoveTabUseCase
+}
+
+class RealWrappedTabsUseCases(delegate: TabsUseCases) :
+    WrappedTabsUseCases {
+
+    override val removeTab = RealWrappedRemoveTabUseCase(delegate.removeTab)
+}
+
+interface WrappedRemoveTabUseCase {
+
+    fun invoke(session: Session)
+}
+
+class RealWrappedRemoveTabUseCase(private val delegate: TabsUseCases.RemoveTabUseCase) :
+    WrappedRemoveTabUseCase {
+
+    override fun invoke(session: Session) = delegate.invoke(session)
+}
+
+interface WrappedCrashReporter {
+
+    fun submitReport(crash: Crash)
+}
+
+class RealWrappedCrashReporter(private val delegate: CrashReporter) :
+    WrappedCrashReporter {
+
+    override fun submitReport(crash: Crash) = delegate.submitReport(crash)
+}
+
+interface WrappedSessionManager {
+
+    val selectedSession: Session?
+}
+
+class RealWrappedSessionManager(private val delegate: SessionManager) :
+    WrappedSessionManager {
+
+    override val selectedSession get() = delegate.selectedSession
+}

--- a/app/src/main/java/org/mozilla/fenix/ext/Activity.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/Activity.kt
@@ -7,6 +7,7 @@ package org.mozilla.fenix.ext
 import android.app.Activity
 import android.view.View
 import android.view.WindowManager
+import androidx.appcompat.app.AppCompatActivity
 
 /**
  * Attempts to call immersive mode using the View to hide the status bar and navigation buttons.
@@ -18,4 +19,11 @@ fun Activity.enterToImmersiveMode() {
             or View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
             or View.SYSTEM_UI_FLAG_FULLSCREEN
             or View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY)
+}
+
+/**
+ * Hide action bar in [AppCompatActivity].
+ */
+fun Activity.hideActionBar() {
+    (this as? AppCompatActivity)?.supportActionBar?.hide()
 }

--- a/app/src/main/java/org/mozilla/fenix/ext/Context.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/Context.kt
@@ -21,7 +21,7 @@ import mozilla.components.support.base.log.Log
 import mozilla.components.support.base.log.Log.Priority.WARN
 import org.mozilla.fenix.FenixApplication
 import org.mozilla.fenix.R
-import org.mozilla.fenix.components.Components
+import org.mozilla.fenix.components.IComponents
 
 /**
  * Get the BrowserApplication object from a context.
@@ -32,7 +32,7 @@ val Context.application: FenixApplication
 /**
  * Get the requireComponents of this application.
  */
-val Context.components: Components
+val Context.components: IComponents
     get() = application.components
 
 fun Context.asActivity() = (this as? ContextThemeWrapper)?.baseContext as? Activity

--- a/app/src/main/java/org/mozilla/fenix/ext/Fragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/Fragment.kt
@@ -10,12 +10,12 @@ import androidx.navigation.NavDirections
 import androidx.navigation.NavOptions
 import androidx.navigation.Navigator
 import androidx.navigation.fragment.NavHostFragment.findNavController
-import org.mozilla.fenix.components.Components
+import org.mozilla.fenix.components.IComponents
 
 /**
  * Get the requireComponents of this application.
  */
-val Fragment.requireComponents: Components
+val Fragment.requireComponents: IComponents
     get() = requireContext().components
 
 fun Fragment.nav(@IdRes id: Int?, directions: NavDirections) {

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragment.kt
@@ -35,7 +35,7 @@ import org.mozilla.fenix.BrowsingModeManager
 import org.mozilla.fenix.FenixViewModelProvider
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
-import org.mozilla.fenix.components.Components
+import org.mozilla.fenix.components.IComponents
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.getHostFromUrl
 import org.mozilla.fenix.ext.nav
@@ -287,7 +287,7 @@ class HistoryFragment : Fragment(), CoroutineScope by MainScope(), BackHandler {
 
     private suspend fun deleteSelectedHistory(
         selected: List<HistoryItem>,
-        components: Components = requireComponents
+        components: IComponents = requireComponents
     ) {
         val storage = components.core.historyStorage
         for (item in selected) {

--- a/app/src/test/java/org/mozilla/fenix/TestApplication.kt
+++ b/app/src/test/java/org/mozilla/fenix/TestApplication.kt
@@ -5,13 +5,10 @@
 package org.mozilla.fenix
 
 import org.mozilla.fenix.components.Components
-import org.mozilla.fenix.components.TestComponents
+import org.mozilla.fenix.components.UnitTestComponents
 
 class TestApplication : FenixApplication() {
 
     override val components: Components
-        get() = TestComponents(this)
-
-    override fun setupApplication() {
-    }
+        get() = UnitTestComponents(this)
 }

--- a/app/src/test/java/org/mozilla/fenix/components/UnitTestComponents.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/UnitTestComponents.kt
@@ -3,7 +3,8 @@ package org.mozilla.fenix.components
 import android.content.Context
 import io.mockk.mockk
 
-class TestComponents(private val context: Context) : Components(context) {
+class UnitTestComponents(private val context: Context) : Components(context) {
+
     override val backgroundServices by lazy {
         mockk<BackgroundServices>(relaxed = true)
     }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -19,13 +19,15 @@ private object Versions {
     const val androidx_constraint_layout = "2.0.0-beta1"
     const val androidx_preference = "1.1.0-beta01"
     const val androidx_legacy = "1.0.0"
+    const val androidx_paging = "2.0.0"
     const val androidx_annotation = "1.1.0"
     const val androidx_lifecycle = "2.2.0-alpha01"
     const val androidx_fragment = "1.1.0-beta01"
     const val androidx_navigation = "2.1.0-alpha05"
     const val androidx_recyclerview = "1.1.0-alpha06"
     const val androidx_lifecycle_savedstate = "1.0.0-alpha01"
-    const val androidx_testing = "1.1.0-alpha08"
+    const val androidx_test = "1.1.0-alpha08"
+    const val androidx_test_ext = "1.0.0"
     const val androidx_core = "1.1.0-rc01"
     const val androidx_transition = "1.1.0-rc02"
     const val google_material = "1.1.0-alpha07"
@@ -44,6 +46,7 @@ private object Versions {
 
     const val junit = "4.12"
     const val mockito = "2.23.0"
+    const val mockito_kotlin = "2.1.0"
     const val mockk = "1.9.kotlin12"
     const val glide = "4.9.0"
     const val flipper = "0.21.0"
@@ -127,8 +130,10 @@ object Deps {
 
     const val mozilla_lib_crash = "org.mozilla.components:lib-crash:${Versions.mozilla_android_components}"
     const val mozilla_lib_fetch_httpurlconnection = "org.mozilla.components:lib-fetch-httpurlconnection:${Versions.mozilla_android_components}"
+    const val mozilla_lib_publicsuffixlist = "org.mozilla.components:lib-publicsuffixlist:${Versions.mozilla_android_components}"
 
     const val mozilla_support_base = "org.mozilla.components:support-base:${Versions.mozilla_android_components}"
+    const val mozilla_support_utils = "org.mozilla.components:support-utils:${Versions.mozilla_android_components}"
     const val mozilla_support_ktx = "org.mozilla.components:support-ktx:${Versions.mozilla_android_components}"
     const val mozilla_support_rustlog = "org.mozilla.components:support-rustlog:${Versions.mozilla_android_components}"
 
@@ -148,6 +153,7 @@ object Deps {
     const val androidx_lifecycle_viewmodel_ktx = "androidx.lifecycle:lifecycle-viewmodel-ktx:${Versions.androidx_lifecycle}"
     const val androidx_lifecycle_runtime = "androidx.lifecycle:lifecycle-runtime:${Versions.androidx_lifecycle}"
     const val androidx_lifecycle_viewmodel_ss = "androidx.lifecycle:lifecycle-viewmodel-savedstate:${Versions.androidx_lifecycle_savedstate}"
+    const val androidx_paging = "androidx.paging:paging-common:${Versions.androidx_paging}"
     const val androidx_preference = "androidx.preference:preference-ktx:${Versions.androidx_preference}"
     const val androidx_safeargs = "androidx.navigation:navigation-safe-args-gradle-plugin:${Versions.androidx_navigation}"
     const val androidx_navigation_fragment = "androidx.navigation:navigation-fragment:${Versions.androidx_navigation}"
@@ -168,6 +174,7 @@ object Deps {
 
     const val junit = "junit:junit:${Versions.junit}"
     const val mockito_core = "org.mockito:mockito-core:${Versions.mockito}"
+    const val mockito_kotlin = "com.nhaarman.mockitokotlin2:mockito-kotlin:${Versions.mockito_kotlin}"
     const val mockito_android = "org.mockito:mockito-android:${Versions.mockito}"
     const val mockk = "io.mockk:mockk:${Versions.mockk}"
 
@@ -178,15 +185,18 @@ object Deps {
     const val flipper_noop = "com.facebook.flipper:flipper-noop:${Versions.flipper}"
     const val soLoader = "com.facebook.soloader:soloader:${Versions.soLoader}"
 
+    const val androidx_test_junit = "androidx.test.ext:junit:${Versions.androidx_test_ext}"
+    const val androidx_test_runner = "androidx.test:runner:${Versions.tools_test_runner}"
+    const val androidx_test_orchestrator = "androidx.test:orchestrator:${Versions.orchestrator}"
+
+    const val androidx_fragment_testing = "androidx.fragment:fragment-testing:${Versions.androidx_test}"
+
     const val espresso_contrib = "com.android.support.test.espresso:espresso-contrib:${Versions.espresso_version}"
     const val espresso_core = "com.android.support.test.espresso:espresso-core:${Versions.espresso_core}"
     const val espresso_idling_resources = "com.android.support.test.espresso:espresso-idling-resource:${Versions.espresso_version}"
-    const val orchestrator = "androidx.test:orchestrator:${Versions.orchestrator}"
     const val tools_test_rules = "com.android.support.test:rules:${Versions.tools_test_rules}"
-    const val tools_test_runner = "com.android.support.test:runner:${Versions.tools_test_runner}"
     const val uiautomator = "com.android.support.test.uiautomator:uiautomator-v18:${Versions.uiautomator}"
     const val robolectric = "org.robolectric:robolectric:${Versions.robolectric}"
-    const val fragment_testing = "androidx.fragment:fragment-testing:${Versions.androidx_testing}"
     const val places_forUnitTests = "org.mozilla.appservices:places-forUnitTests:${Versions.mozilla_appservices}"
 
     const val google_ads_id = "com.google.android.gms:play-services-ads-identifier:${Versions.google_ads_id_version}"


### PR DESCRIPTION
I've dived into UI tests for Fenix this weekend and discovered that one can't simply start writing them. I think that with UI/integration tests we can cover many business cases, make refactoring easier and reduce number of bugs.

However I've tried to touch production code as little as possible but some changes seems unavoidable. Here is my attempt to introduce gentle transition towards following IoC principle for isolated screens.

Please note that there are two workarounds that should be removed once we'll introduce proper DI in the project:
  - `BuildConfig.IS_TEST_BUILD` for configuring test project in a different way than production one. Since we can't define application for `androidTest` manifest, only rewrite it's source file.
  - `Wrapped*` - wrapper interfaces/classes that allow mocking components for isolated testing purposes.

I'm aware that this changes will not be applied at least since MVP will not be released, however I suppose that it's better to rise this discussion rather sooner than later. :)

Consider this PR as call to discussion and don't hasitate to share your thoughts about wide range of questions raised here. :woman_astronaut: 

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] ~~**Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~
