### PR TITLE
Fixes #3529 - Display "Edit folder" title when editing a bookmark folder

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/edit/EditBookmarkFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/edit/EditBookmarkFragment.kt
@@ -71,8 +71,8 @@ class EditBookmarkFragment : Fragment(), CoroutineScope {
 
     override fun onResume() {
         super.onResume()
-        (activity as? AppCompatActivity)?.title = getString(R.string.edit_bookmark_fragment_title)
-        (activity as? AppCompatActivity)?.supportActionBar?.show()
+        val activity = activity as? AppCompatActivity
+        activity?.supportActionBar?.show()
 
         guidToEdit = EditBookmarkFragmentArgs.fromBundle(arguments!!).guidToEdit
         launch(IO) {
@@ -83,10 +83,12 @@ class EditBookmarkFragment : Fragment(), CoroutineScope {
             launch(Main) {
                 when (bookmarkNode?.type) {
                     BookmarkNodeType.FOLDER -> {
+                        activity?.title = getString(R.string.edit_bookmark_folder_fragment_title)
                         bookmark_url_edit.visibility = View.GONE
                         bookmark_url_label.visibility = View.GONE
                     }
                     BookmarkNodeType.ITEM -> {
+                        activity?.title = getString(R.string.edit_bookmark_fragment_title)
                     }
                     else -> throw IllegalArgumentException()
                 }

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -206,7 +206,6 @@
     <fragment
         android:id="@+id/bookmarkEditFragment"
         android:name="org.mozilla.fenix.library.bookmarks.edit.EditBookmarkFragment"
-        android:label="@string/edit_bookmark_fragment_title"
         tools:layout="@layout/fragment_edit_bookmark">
         <argument
             android:name="guidToEdit"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -406,6 +406,8 @@
     <string name="bookmarks_multi_select_title">%1$d selected</string>
     <!-- Bookmark editing screen title -->
     <string name="edit_bookmark_fragment_title">Edit bookmark</string>
+    <!-- Bookmark folder editing screen title -->
+    <string name="edit_bookmark_folder_fragment_title">Edit folder</string>
     <!-- Bookmark sign in button message -->
     <string name="bookmark_sign_in_button">Sign in to see synced bookmarks</string>
     <!-- Bookmark URL editing field label -->


### PR DESCRIPTION
I removed the android:label from nav_graph.xml for EditBookmarkFragment and now we set the title programmatically based on the type of the BookmarkNode. A new string was added - edit_bookmark_folder_fragment_title - since there wasn't any that could be used already.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
