### PR TITLE
For #2960 Closes #3671 - Fixes bookmark deletion with undo, wraps list

### DIFF
--- a/app/src/main/res/layout/component_bookmark.xml
+++ b/app/src/main/res/layout/component_bookmark.xml
@@ -5,7 +5,7 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="wrap_content">
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/bookmark_list"
@@ -25,5 +25,4 @@
         android:textColor="?secondaryText"
         android:textSize="16sp"
         android:visibility="gone" />
-
 </FrameLayout>

--- a/app/src/main/res/layout/fragment_bookmark.xml
+++ b/app/src/main/res/layout/fragment_bookmark.xml
@@ -2,10 +2,14 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/bookmark_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    tools:context="org.mozilla.fenix.library.bookmarks.BookmarkFragment" />
+    tools:context="org.mozilla.fenix.library.bookmarks.BookmarkFragment">
+    <LinearLayout
+        android:id="@+id/bookmark_layout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical" />
+</androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
Doing something similar to what we do on HomeFragment right now with tabs, but not exactly. Because deleting bookmarks is async the `invokeOnCompletion` is called immediately when invoking a previous job. We have to continue to fake the UI because we don't know when they are actually deleted... So I propose saving them in a Set that we will then add the bookmark to when it's slated to be deleted and remove from when they are cancelled. The most not ideal part is that we won't be able to remove them from the Set when they are actually deleted but doesn't seem to matter when updating the "fake" UI to remove them from the display if they no longer exist. I did a lot of testing and nothing seems to break here.

Also includes a fix to wrap the bookmark list content to be able to see the "sign in" button and a fix to make the parent view a CoordinatorLayout to better handle snackbar interactions. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
