### PR TITLE
Revert "Use @JvmOverloads instead of multiple constructors"

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/LibraryListItem.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/LibraryListItem.kt
@@ -8,7 +8,6 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import androidx.constraintlayout.widget.ConstraintLayout
-import androidx.core.content.withStyledAttributes
 import kotlinx.android.synthetic.main.library_list_item.view.*
 import org.mozilla.fenix.R
 
@@ -20,18 +19,28 @@ class LibraryListItem @JvmOverloads constructor(
     init {
         LayoutInflater.from(context).inflate(R.layout.library_list_item, this, true)
 
-        context.withStyledAttributes(attrs, R.styleable.LibraryListItem, defStyleAttr, 0) {
-            val id = getResourceId(
-                R.styleable.LibraryListItem_listItemIcon,
-                R.drawable.library_icon_reading_list_circle_background
-            )
-            libraryIcon?.background = resources.getDrawable(id, context.theme)
-            libraryItemTitle?.text = resources.getString(
-                getResourceId(
-                    R.styleable.LibraryListItem_listItemTitle,
-                    R.string.browser_menu_your_library
-                )
-            )
+        attrs.let {
+            context.theme.obtainStyledAttributes(
+                it,
+                R.styleable.LibraryListItem,
+                0, 0
+            ).apply {
+                try {
+                    val id = getResourceId(
+                        R.styleable.LibraryListItem_listItemIcon,
+                        R.drawable.library_icon_reading_list_circle_background
+                    )
+                    libraryIcon?.background = resources.getDrawable(id, context.theme)
+                    libraryItemTitle?.text = resources.getString(
+                        getResourceId(
+                            R.styleable.LibraryListItem_listItemTitle,
+                            R.string.browser_menu_your_library
+                        )
+                    )
+                } finally {
+                    recycle()
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/settings/AccountAuthErrorPreference.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/AccountAuthErrorPreference.kt
@@ -12,12 +12,12 @@ import androidx.preference.Preference
 import androidx.preference.PreferenceViewHolder
 import org.mozilla.fenix.R
 
-class AccountAuthErrorPreference @JvmOverloads constructor(
-    context: Context,
-    attrs: AttributeSet? = null,
-    attributeSetId: Int = 0
-) : Preference(context, attrs, attributeSetId) {
+class AccountAuthErrorPreference : Preference {
     var email: String? = null
+
+    constructor(context: Context) : super(context)
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
+    constructor(context: Context, attrs: AttributeSet?, attributeSetId: Int) : super(context, attrs, attributeSetId)
 
     init {
         layoutResource = R.layout.account_auth_error_preference

--- a/app/src/main/java/org/mozilla/fenix/settings/AccountPreference.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/AccountPreference.kt
@@ -12,13 +12,13 @@ import androidx.preference.Preference
 import androidx.preference.PreferenceViewHolder
 import org.mozilla.fenix.R
 
-class AccountPreference @JvmOverloads constructor(
-    context: Context,
-    attrs: AttributeSet? = null,
-    attributeSetId: Int = 0
-) : Preference(context, attrs, attributeSetId) {
+class AccountPreference : Preference {
     var displayName: String? = null
     var email: String? = null
+
+    constructor(context: Context) : super(context)
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
+    constructor(context: Context, attrs: AttributeSet?, attributeSetId: Int) : super(context, attrs, attributeSetId)
 
     init {
         layoutResource = R.layout.account_preference

--- a/app/src/main/java/org/mozilla/fenix/settings/DefaultBrowserPreference.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/DefaultBrowserPreference.kt
@@ -12,13 +12,17 @@ import androidx.preference.PreferenceViewHolder
 import mozilla.components.support.utils.Browsers
 import org.mozilla.fenix.R
 
-class DefaultBrowserPreference @JvmOverloads constructor(
-    context: Context,
-    attrs: AttributeSet? = null,
-    attributeSetId: Int = 0
-) : Preference(context, attrs, attributeSetId) {
+class DefaultBrowserPreference : Preference {
 
     private var switchView: Switch? = null
+
+    constructor(context: Context) : super(context)
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
+    constructor(context: Context, attrs: AttributeSet?, attributeSetId: Int) : super(
+        context,
+        attrs,
+        attributeSetId
+    )
 
     init {
         widgetLayoutResource = R.layout.preference_default_browser

--- a/app/src/main/java/org/mozilla/fenix/settings/DeleteBrowsingDataItem.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/DeleteBrowsingDataItem.kt
@@ -9,7 +9,6 @@ import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
-import androidx.core.content.withStyledAttributes
 import kotlinx.android.synthetic.main.delete_browsing_data_item.view.*
 import org.mozilla.fenix.R
 
@@ -42,23 +41,33 @@ class DeleteBrowsingDataItem @JvmOverloads constructor(
             onCheckListener?.invoke(isChecked)
         }
 
-        context.withStyledAttributes(attrs, R.styleable.DeleteBrowsingDataItem, defStyleAttr, 0) {
-            val iconId = getResourceId(
-                R.styleable.DeleteBrowsingDataItem_deleteBrowsingDataItemIcon,
-                R.drawable.library_icon_reading_list_circle_background
-            )
-            val titleId = getResourceId(
-                R.styleable.DeleteBrowsingDataItem_deleteBrowsingDataItemTitle,
-                R.string.browser_menu_your_library
-            )
-            val subtitleId = getResourceId(
-                R.styleable.DeleteBrowsingDataItem_deleteBrowsingDataItemSubtitle,
-                R.string.browser_menu_your_library
-            )
+        attrs.let {
+            context.theme.obtainStyledAttributes(
+                it,
+                R.styleable.DeleteBrowsingDataItem,
+                0, 0
+            ).apply {
+                try {
+                    val iconId = getResourceId(
+                        R.styleable.DeleteBrowsingDataItem_deleteBrowsingDataItemIcon,
+                        R.drawable.library_icon_reading_list_circle_background
+                    )
+                    val titleId = getResourceId(
+                        R.styleable.DeleteBrowsingDataItem_deleteBrowsingDataItemTitle,
+                        R.string.browser_menu_your_library
+                    )
+                    val subtitleId = getResourceId(
+                        R.styleable.DeleteBrowsingDataItem_deleteBrowsingDataItemSubtitle,
+                        R.string.browser_menu_your_library
+                    )
 
-            icon.background = resources.getDrawable(iconId, context.theme)
-            title.text = resources.getString(titleId)
-            subtitle.text = resources.getString(subtitleId)
+                    icon.background = resources.getDrawable(iconId, context.theme)
+                    title.text = resources.getString(titleId)
+                    subtitle.text = resources.getString(subtitleId)
+                } finally {
+                    recycle()
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/settings/RadioButtonPreference.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/RadioButtonPreference.kt
@@ -5,6 +5,7 @@
 package org.mozilla.fenix.settings
 
 import android.content.Context
+import android.content.res.TypedArray
 import android.text.TextUtils
 import android.util.AttributeSet
 import android.view.View
@@ -12,7 +13,6 @@ import android.widget.RadioButton
 import android.widget.TextView
 import androidx.core.content.ContextCompat
 import androidx.core.content.res.TypedArrayUtils
-import androidx.core.content.withStyledAttributes
 import androidx.core.text.HtmlCompat
 import androidx.preference.Preference
 import androidx.preference.PreferenceViewHolder
@@ -20,11 +20,7 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.ThemeManager
 import org.mozilla.fenix.utils.Settings
 
-class RadioButtonPreference @JvmOverloads constructor(
-    context: Context,
-    attrs: AttributeSet? = null,
-    attributeSetId: Int = 0
-) : Preference(context, attrs, attributeSetId) {
+class RadioButtonPreference : Preference {
     private val radioGroups = mutableListOf<RadioButtonPreference>()
     private lateinit var summaryView: TextView
     private lateinit var radioButton: RadioButton
@@ -34,27 +30,6 @@ class RadioButtonPreference @JvmOverloads constructor(
 
     init {
         layoutResource = R.layout.preference_widget_radiobutton
-
-        context.withStyledAttributes(
-            attrs,
-            androidx.preference.R.styleable.Preference,
-            TypedArrayUtils.getAttr(
-                context, androidx.preference.R.attr.preferenceStyle, android.R.attr.preferenceStyle
-            ),
-            0
-        ) {
-            if (hasValue(androidx.preference.R.styleable.Preference_defaultValue)) {
-                defaultValue = getBoolean(
-                    androidx.preference.R.styleable.Preference_defaultValue,
-                    false
-                )
-            } else if (hasValue(androidx.preference.R.styleable.Preference_android_defaultValue)) {
-                defaultValue = getBoolean(
-                    androidx.preference.R.styleable.Preference_android_defaultValue,
-                    false
-                )
-            }
-        }
     }
 
     /* In devices with Android 6, when we use android:button="@null" android:drawableStart doesn't work via xml
@@ -68,6 +43,16 @@ class RadioButtonPreference @JvmOverloads constructor(
             this?.setBounds(0, 0, this.intrinsicWidth, this.intrinsicHeight)
         }
         this.setCompoundDrawables(buttonDrawable, null, null, null)
+    }
+
+    constructor(context: Context, attrs: AttributeSet) : super(context, attrs) {
+        val typedArray = context.obtainStyledAttributes(
+            attrs, androidx.preference.R.styleable.Preference, TypedArrayUtils.getAttr(
+                context, androidx.preference.R.attr.preferenceStyle,
+                android.R.attr.preferenceStyle
+            ), 0
+        )
+        initDefaultValue(typedArray)
     }
 
     fun addToRadioGroup(radioPreference: RadioButtonPreference) {
@@ -107,6 +92,20 @@ class RadioButtonPreference @JvmOverloads constructor(
         radioButton = holder.findViewById(R.id.radio_button) as RadioButton
         radioButton.isChecked = Settings.getInstance(context).preferences.getBoolean(key, false)
         radioButton.setStartCheckedIndicator()
+    }
+
+    private fun initDefaultValue(typedArray: TypedArray) {
+        if (typedArray.hasValue(androidx.preference.R.styleable.Preference_defaultValue)) {
+            defaultValue = typedArray.getBoolean(
+                androidx.preference.R.styleable.Preference_defaultValue,
+                false
+            )
+        } else if (typedArray.hasValue(androidx.preference.R.styleable.Preference_android_defaultValue)) {
+            defaultValue = typedArray.getBoolean(
+                androidx.preference.R.styleable.Preference_android_defaultValue,
+                false
+            )
+        }
     }
 
     private fun toggleRadioGroups() {

--- a/app/src/main/java/org/mozilla/fenix/settings/RadioSearchEngineListPreference.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/RadioSearchEngineListPreference.kt
@@ -12,13 +12,17 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.utils.Settings
 
-class RadioSearchEngineListPreference @JvmOverloads constructor(
-    context: Context,
-    attrs: AttributeSet? = null,
-    defStyleAttr: Int = 0
-) : SearchEngineListPreference(context, attrs, defStyleAttr) {
+class RadioSearchEngineListPreference : SearchEngineListPreference {
     override val itemResId: Int
         get() = R.layout.search_engine_radio_button
+
+    constructor(context: Context, attrs: AttributeSet) : super(context, attrs)
+
+    constructor(context: Context, attrs: AttributeSet, defStyleAttr: Int) : super(
+        context,
+        attrs,
+        defStyleAttr
+    )
 
     override fun updateDefaultItem(defaultButton: CompoundButton) {
         defaultButton.isChecked = true

--- a/app/src/main/java/org/mozilla/fenix/settings/SearchEngineListPreference.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SearchEngineListPreference.kt
@@ -28,11 +28,7 @@ import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.utils.Settings
 import kotlin.coroutines.CoroutineContext
 
-abstract class SearchEngineListPreference @JvmOverloads constructor(
-    context: Context,
-    attrs: AttributeSet? = null,
-    defStyleAttr: Int = 0
-) : Preference(context, attrs, defStyleAttr), CompoundButton.OnCheckedChangeListener, CoroutineScope {
+abstract class SearchEngineListPreference : Preference, CompoundButton.OnCheckedChangeListener, CoroutineScope {
     private val job = Job()
     override val coroutineContext: CoroutineContext
         get() = job + Dispatchers.Main
@@ -41,7 +37,15 @@ abstract class SearchEngineListPreference @JvmOverloads constructor(
 
     protected abstract val itemResId: Int
 
-    init {
+    constructor(context: Context, attrs: AttributeSet) : super(context, attrs) {
+        layoutResource = R.layout.preference_search_engine_chooser
+    }
+
+    constructor(context: Context, attrs: AttributeSet, defStyleAttr: Int) : super(
+        context,
+        attrs,
+        defStyleAttr
+    ) {
         layoutResource = R.layout.preference_search_engine_chooser
     }
 


### PR DESCRIPTION
Reverts mozilla-mobile/fenix#3618

This is causing weird things in our custom settings and I don't have time to look into it today. @NotWoods happy for you to follow up and see if you can fix when you have time!

![Screenshot_20190625-162053](https://user-images.githubusercontent.com/25442310/60140127-67c58600-9765-11e9-9059-f0ff098afdc5.png)
