### PR TITLE
Regression: Nightly package name should be "org.mozilla.fenix.nightly"

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,6 +48,7 @@ android {
             debuggable true
         }
         nightly releaseTemplate >> {
+            applicationIdSuffix ".nightly"
             buildConfigField "boolean", "USE_RELEASE_VERSIONING", "true"
         }
         beta releaseTemplate >> {


### PR DESCRIPTION
[When changing nightly target app from `org.mozilla.fenix` to `org.mozilla.fenix.nightly`](https://github.com/mozilla-mobile/fenix/pull/3740), I didn't update the package name.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
