### PR TITLE
For #3750: Crash when tapping "Blocked" on Google Maps after disabling  location requests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,4 +67,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [AC #2725](https://github.com/mozilla-mobile/android-components/issues/2725) Updated tracking protectionPolicy to [recommend](https://github.com/mozilla-mobile/android-components/blob/master/components/concept/engine/src/main/java/mozilla/components/concept/engine/EngineSession.kt#L156)
 - #2789 Custom tabs is not covering the full screen size.
 - #2893, #2673, #2916, #2314: Fix several crashes navigating from external links
+- #3750 - Crash when tapping "Blocked" on Google Maps after disabling location requests
 ### Removed

--- a/app/src/main/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsSheetDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsSheetDialogFragment.kt
@@ -203,7 +203,7 @@ class QuickSettingsSheetDialogFragment : AppCompatDialogFragment() {
                     }
                     is QuickSettingsAction.TogglePermission -> {
 
-                        lifecycleScope.launch {
+                        lifecycleScope.launch(Dispatchers.IO) {
                             sitePermissions = quickSettingsComponent.toggleSitePermission(
                                 context = requireContext(),
                                 featurePhone = it.featurePhone,
@@ -236,7 +236,7 @@ class QuickSettingsSheetDialogFragment : AppCompatDialogFragment() {
     private val sessionObserver = object : Session.Observer {
         override fun onUrlChanged(session: Session, url: String) {
             super.onUrlChanged(session, url)
-            lifecycleScope.launch {
+            lifecycleScope.launch(Dispatchers.IO) {
                 val host = session.url.toUri()?.host
                 val sitePermissions: SitePermissions? = host?.let {
                     val storage = requireContext().components.core.permissionStorage


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
