### PR TITLE
Update README.md to point to #fenix rather than #focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Before you attempt to make a contribution please read the [Community Participati
 
 * [View current Issues](https://github.com/mozilla-mobile/fenix/issues), [view current Pull Requests](https://github.com/mozilla-mobile/fenix/pulls), or [file a security issue][sec issue].
 
-* IRC: [#focus (irc.mozilla.org)](https://wiki.mozilla.org/IRC) | [view logs](https://mozilla.logbot.info/fenix/)
+* IRC: [#fenix (irc.mozilla.org)](https://wiki.mozilla.org/IRC) | [view logs](https://mozilla.logbot.info/fenix/)
 (**We're available Monday-Friday, GMT and PST working hours**).
 
 * [View the Wiki](https://github.com/mozilla-mobile/fenix/wiki).


### PR DESCRIPTION
I feel like this was just mistyped (or a carryover from when Focus was the only geckoview browser, maybe?), because the link to view chat logs was already pointing to #fenix 
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [This only changes a single word in the readme file. If this broke linters, I'd be worried.] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [Only changed a single word in the readme] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [Don't think this warrants a changelog entry.] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [Changing a single word in the readme file shouldn't make this any less accessible.] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
