### PR TITLE
Regression: Nightly wouldn't build due to missing quotes

### DIFF
--- a/automation/taskcluster/lib/tasks.py
+++ b/automation/taskcluster/lib/tasks.py
@@ -69,7 +69,7 @@ class TaskBuilder(object):
 
         capitalized_channel = upper_case_first_letter(channel)
         gradle_commands = (
-            './gradlew --no-daemon -PversionName={} clean test assemble{}'.format(
+            './gradlew --no-daemon -PversionName="{}" clean test assemble{}'.format(
                 version_name, capitalized_channel),
         )
 


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

Net result is that, instead of:
`./gradlew --no-daemon -PversionName=Nightly 190701 06:04 clean test assembleNightly`
there'll be
`./gradlew --no-daemon -PversionName="Nightly 190701 06:04" clean test assembleNightly`