### PR TITLE
Fix the mklink command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ ln -s ../../config/pre-push-recommended.sh .git/hooks/pre-push
 ```
 or for Windows run this command with administrative privileges:
 ```sh
-mklink /d .git\hooks\pre-push ..\..\config\pre-push-recommended.sh
+mklink .git\hooks\pre-push ..\..\config\pre-push-recommended.sh
 ```
 
 To push without running the pre-push hook (e.g. doc updates):


### PR DESCRIPTION
The `mklink /d` creates a directory symbolic link. As here we need a file symbolic link, the `/d` switch must not be used.

See `mklink` documentation: https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/mklink



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
