### PR TITLE
Re-enables pushing nightly to org.mozilla.fenix

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,6 +47,9 @@ android {
             applicationIdSuffix ".performancetest"
             debuggable true
         }
+        nightlyLegacy releaseTemplate >> {
+            buildConfigField "boolean", "USE_RELEASE_VERSIONING", "true"
+        }
         nightly releaseTemplate >> {
             applicationIdSuffix ".nightly"
             buildConfigField "boolean", "USE_RELEASE_VERSIONING", "true"

--- a/app/src/main/java/org/mozilla/fenix/Config.kt
+++ b/app/src/main/java/org/mozilla/fenix/Config.kt
@@ -19,6 +19,7 @@ object Config {
         "production" -> ReleaseChannel.Production
         "beta" -> ReleaseChannel.Beta
         "nightly" -> ReleaseChannel.Nightly
+        "nightlyLegacy" -> ReleaseChannel.Nightly
         "debug" -> ReleaseChannel.Debug
         else -> ReleaseChannel.Production // Performance-test builds should test production behaviour
     }

--- a/automation/taskcluster/decision_task.py
+++ b/automation/taskcluster/decision_task.py
@@ -131,6 +131,8 @@ def release(channel, is_staging, version_name):
         signing_task_id,
         apks=apk_paths,
         channel=channel,
+        # TODO until org.mozilla.fenix.nightly is made public, put it on the internally-testable track
+        override_google_play_track=None if channel != "nightly" else "internal",
         is_staging=is_staging,
     )
 

--- a/automation/taskcluster/decision_task.py
+++ b/automation/taskcluster/decision_task.py
@@ -137,6 +137,43 @@ def release(channel, is_staging, version_name):
     return (build_tasks, signing_tasks, push_tasks)
 
 
+def nightly_to_production_app(is_staging, version_name):
+    # Since the Fenix nightly was launched, we've pushed it to the production app "org.mozilla.fenix" on the
+    # "nightly" track. We're moving towards having each channel be published to its own app, but we need to
+    # keep updating this "backwards-compatible" nightly for a while yet
+    build_type = 'nightlyLegacy'
+    variants = get_variants_for_build_type(build_type)
+    architectures = [variant.abi for variant in variants]
+    apk_paths = ["public/target.{}.apk".format(arch) for arch in architectures]
+
+    build_tasks = {}
+    signing_tasks = {}
+    push_tasks = {}
+
+    build_task_id = taskcluster.slugId()
+    build_tasks[build_task_id] = BUILDER.craft_assemble_release_task(architectures, build_type, is_staging, version_name, index_channel='nightly')
+
+    signing_task_id = taskcluster.slugId()
+    signing_tasks[signing_task_id] = BUILDER.craft_release_signing_task(
+        build_task_id,
+        apk_paths=apk_paths,
+        channel='production',  # Since we're publishing to the "production" app, we need to sign for production
+        index_channel='nightly',
+        is_staging=is_staging,
+    )
+
+    push_task_id = taskcluster.slugId()
+    push_tasks[push_task_id] = BUILDER.craft_push_task(
+        signing_task_id,
+        apks=apk_paths,
+        channel='production',  # We're publishing to the "production" app on the "nightly" track
+        override_google_play_track='nightly',
+        is_staging=is_staging,
+    )
+
+    return (build_tasks, signing_tasks, push_tasks)
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description='Creates and submit a graph of tasks on Taskcluster.'
@@ -168,7 +205,8 @@ if __name__ == "__main__":
         ordered_groups_of_tasks = raptor(result.staging)
     elif command == 'nightly':
         nightly_version = datetime.datetime.now().strftime('Nightly %y%m%d %H:%M')
-        ordered_groups_of_tasks = release('nightly', result.staging, nightly_version)
+        ordered_groups_of_tasks = release('nightly', result.staging, nightly_version) \
+            + nightly_to_production_app(result.staging, nightly_version)
     elif command == 'github-release':
         version = result.tag[1:]  # remove prefixed "v"
         beta_semver = re.compile(r'^v\d+\.\d+\.\d+-beta\.\d+$')


### PR DESCRIPTION
In addition to pushing Nightly to `org.mozilla.fenix.nightly`, re-enable the legacy action of pushing it to `org.mozilla.fenix` under the nightly track.

# Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
