### PR TITLE
For #3829 - Add pop up to nav_graph to browser to home nav

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarIntegration.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarIntegration.kt
@@ -57,7 +57,7 @@ class ToolbarIntegration(
                     {
                         toolbar.hideKeyboard()
                         // We need to dynamically add the options here because if you do it in XML it overwrites
-                        val options = NavOptions.Builder().setPopUpTo(R.id.homeFragment, true)
+                        val options = NavOptions.Builder().setPopUpTo(R.id.nav_graph, false)
                             .setEnterAnim(R.anim.fade_in).build()
                         val extras = null
 // Disabled while awaiting a better solution to #3209


### PR DESCRIPTION
This will make it so you can't ever back press home and get back to browser even if you came from another app

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
