### PR TITLE
For #2945: Launches to blank screen and hangs on Nexus 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,4 +68,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - #2789 Custom tabs is not covering the full screen size.
 - #2893, #2673, #2916, #2314: Fix several crashes navigating from external links
 - #3750 - Crash when tapping "Blocked" on Google Maps after disabling location requests
+- #2945 - Fixed "Launches to blank screen and hangs on Nexus 10"
 ### Removed

--- a/app/src/main/java/org/mozilla/fenix/components/Search.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Search.kt
@@ -5,6 +5,7 @@
 package org.mozilla.fenix.components
 
 import android.content.Context
+import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import mozilla.components.browser.search.SearchEngineManager
@@ -21,7 +22,7 @@ class Search(private val context: Context) {
      * This component provides access to a centralized registry of search engines.
      */
     val searchEngineManager by lazy {
-        SearchEngineManager().apply {
+        SearchEngineManager(coroutineContext = IO).apply {
             registerForLocaleUpdates(context)
             GlobalScope.launch {
                 loadAsync(context).await()

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/ActivationPing.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/ActivationPing.kt
@@ -157,7 +157,7 @@ class ActivationPing(private val context: Context) {
         // Generate the activation_id.
         Activation.activationId.generateAndSet()
 
-        CoroutineScope(Dispatchers.Default).launch {
+        CoroutineScope(Dispatchers.IO).launch {
             val hashedId = getHashedIdentifier()
             if (hashedId != null) {
                 Logger.info("ActivationPing - generating ping with the hashed id")

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
@@ -247,7 +247,7 @@ class GleanMetricsService(private val context: Context) : MetricsService {
         if (initialized) return
         initialized = true
 
-        starter = CoroutineScope(Dispatchers.Default).launch {
+        starter = CoroutineScope(Dispatchers.IO).launch {
             Glean.registerPings(Pings)
             Glean.initialize(context, Configuration(channel = BuildConfig.BUILD_TYPE))
 


### PR DESCRIPTION
Lesson Learned: Always make sure you or the library method you're using specifies a dispatcher when using Kotlin Coroutines. The default dispatcher is almost always the wrong answer. I believe the default thread pool size still equals # of CPUs plus one. Using the default dispatcher when the IO dispatcher is needed will result in deadlocks, livelocks, and ANRs which only appear on cheaper devices with fewer CPUs. It's very common that these issues do not become noticeable until an app is deployed to production.

I will also change the default dispatcher used in Android Components to a better option.