### PR TITLE
Update to Mozilla Android Components 3.0.0-SNAPSHOT.

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -31,7 +31,7 @@ private object Versions {
     const val androidx_transition = "1.1.0-rc02"
     const val google_material = "1.1.0-alpha07"
 
-    const val mozilla_android_components = "2.0.0-SNAPSHOT"
+    const val mozilla_android_components = "3.0.0-SNAPSHOT"
     // Note that android-components also depends on application-services,
     // and in fact is our main source of appservices-related functionality.
     // The version number below tracks the application-services version


### PR DESCRIPTION
Given that we are planning to release 1.0.1 from `releases/v1.0`, it seems like we have some more time until we release from `master` and therefore we can continue with AC 3.0.0 which is going to be released next week.

I did a quick smoke test with AC 3.0.0-SNAPSHOT and the app compiles, launches and renders websites. :)