### PR TITLE
For #2357: Removes snapping threshold on home fragment

### DIFF
--- a/app/src/main/res/xml/home_scene.xml
+++ b/app/src/main/res/xml/home_scene.xml
@@ -12,7 +12,8 @@
         <OnSwipe
             motion:dragDirection="dragUp"
             motion:touchAnchorId="@id/home_component"
-            motion:touchAnchorSide="top" />
+            motion:touchAnchorSide="top"
+            motion:onTouchUp="stop"/>
 
         <KeyFrameSet>
             <KeyPosition


### PR DESCRIPTION
Here's a demo of the new behavior:
![demo 2019-07-03 12_37_23](https://user-images.githubusercontent.com/4400286/60620239-880dca00-9d8f-11e9-8d3e-f5ccb543ed2b.gif)


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
