### PR TITLE
For #3240 - Create AuthCustomTabActivity to fix dead end on auth

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          xmlns:tools="http://schemas.android.com/tools" package="org.mozilla.fenix">
+    xmlns:tools="http://schemas.android.com/tools"
+    package="org.mozilla.fenix">
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
 
@@ -14,53 +15,67 @@
     <uses-permission-sdk-23 android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
 
     <application
-            android:allowBackup="true"
-            android:icon="@mipmap/ic_launcher"
-            android:label="@string/app_name"
-            android:roundIcon="@mipmap/ic_launcher_round"
-            android:supportsRtl="true"
-            android:name=".FenixApplication"
-            android:theme="@style/NormalTheme"
-            android:usesCleartextTraffic="true"
-            tools:ignore="UnusedAttribute">
-        <activity android:name=".HomeActivity"
-                  android:launchMode="singleTask"
-                  android:windowSoftInputMode="adjustResize"
-                  android:configChanges="keyboard|keyboardHidden|mcc|mnc|orientation|screenSize|locale|layoutDirection|smallestScreenSize|screenLayout">
+        android:name=".FenixApplication"
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/NormalTheme"
+        android:usesCleartextTraffic="true"
+        tools:ignore="UnusedAttribute">
+        <activity
+            android:name=".HomeActivity"
+            android:configChanges="keyboard|keyboardHidden|mcc|mnc|orientation|screenSize|locale|layoutDirection|smallestScreenSize|screenLayout"
+            android:launchMode="singleTask"
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
+                <action android:name="android.intent.action.MAIN" />
 
-                <category android:name="android.intent.category.LAUNCHER"/>
+                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
 
-        <activity android:name=".customtabs.CustomTabActivity"
-                  android:configChanges="keyboard|keyboardHidden|mcc|mnc|orientation|screenSize|locale|layoutDirection|smallestScreenSize|screenLayout"
-                  android:windowSoftInputMode="adjustResize|stateAlwaysHidden"
-                  android:exported="false"
-                  android:taskAffinity=""
-                  android:persistableMode="persistNever"
-                  android:autoRemoveFromRecents="false"
-                  android:label="@string/app_name" />
+        <activity
+            android:name=".customtabs.CustomTabActivity"
+            android:autoRemoveFromRecents="false"
+            android:configChanges="keyboard|keyboardHidden|mcc|mnc|orientation|screenSize|locale|layoutDirection|smallestScreenSize|screenLayout"
+            android:exported="false"
+            android:label="@string/app_name"
+            android:persistableMode="persistNever"
+            android:taskAffinity=""
+            android:windowSoftInputMode="adjustResize|stateAlwaysHidden" />
+
+        <activity
+            android:name=".customtabs.AuthCustomTabActivity"
+            android:autoRemoveFromRecents="false"
+            android:configChanges="keyboard|keyboardHidden|mcc|mnc|orientation|screenSize|locale|layoutDirection|smallestScreenSize|screenLayout"
+            android:exported="false"
+            android:taskAffinity=""
+            android:windowSoftInputMode="adjustResize|stateAlwaysHidden" />
 
         <activity android:name=".IntentReceiverActivity">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
+
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
+
                 <data android:scheme="http" />
                 <data android:scheme="https" />
             </intent-filter>
 
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
+
                 <category android:name="android.intent.category.BROWSABLE" />
                 <category android:name="android.intent.category.DEFAULT" />
+
                 <data android:scheme="http" />
                 <data android:scheme="https" />
-                <data android:mimeType="text/html"/>
-                <data android:mimeType="text/plain"/>
-                <data android:mimeType="application/xhtml+xml"/>
+                <data android:mimeType="text/html" />
+                <data android:mimeType="text/plain" />
+                <data android:mimeType="application/xhtml+xml" />
             </intent-filter>
 
             <intent-filter>
@@ -76,17 +91,18 @@
 
             <meta-data
                 android:name="com.android.systemui.action_assist_icon"
-                android:resource="@mipmap/ic_launcher"/>
+                android:resource="@mipmap/ic_launcher" />
         </activity>
 
-        <activity android:name=".browser.BrowserPerformanceTestActivity"
-                  android:exported="${isRaptorEnabled}"
-                  android:enabled="${isRaptorEnabled}"/>
+        <activity
+            android:name=".browser.BrowserPerformanceTestActivity"
+            android:enabled="${isRaptorEnabled}"
+            android:exported="${isRaptorEnabled}" />
 
         <service
-                android:name=".customtabs.CustomTabsService"
-                android:exported="true"
-                tools:ignore="ExportedService">
+            android:name=".customtabs.CustomTabsService"
+            android:exported="true"
+            tools:ignore="ExportedService">
             <intent-filter>
                 <action android:name="android.support.customtabs.action.CustomTabsService" />
             </intent-filter>

--- a/app/src/main/java/org/mozilla/fenix/IntentReceiverActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/IntentReceiverActivity.kt
@@ -10,12 +10,14 @@ import android.os.Bundle
 import mozilla.components.browser.session.tab.CustomTabConfig
 import mozilla.components.support.utils.SafeIntent
 import org.mozilla.fenix.components.NotificationManager.Companion.RECEIVE_TABS_TAG
+import org.mozilla.fenix.customtabs.AuthCustomTabActivity
 import org.mozilla.fenix.customtabs.CustomTabActivity
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.utils.Settings
 
 class IntentReceiverActivity : Activity() {
 
+    @Suppress("ComplexMethod")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -34,7 +36,11 @@ class IntentReceiverActivity : Activity() {
 
         val openToBrowser = when {
             CustomTabConfig.isCustomTabIntent(SafeIntent(intent)) -> {
-                intent.setClassName(applicationContext, CustomTabActivity::class.java.name)
+                intent.setClassName(
+                    applicationContext,
+                    if (intent.hasExtra(getString(R.string.intent_extra_auth))) AuthCustomTabActivity::class.java.name
+                    else CustomTabActivity::class.java.name
+                )
                 true
             }
             intent.action == Intent.ACTION_VIEW -> {

--- a/app/src/main/java/org/mozilla/fenix/components/features/FirefoxAccountsAuthFeature.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/features/FirefoxAccountsAuthFeature.kt
@@ -46,7 +46,7 @@ class FirefoxAccountsAuthFeature(
             // UI to the user.
             // It's possible that the underlying problem will go away by the time the tab actually
             // loads, resulting in a confusing experience.
-            val intent = SupportUtils.createCustomTabIntent(context, authUrl)
+            val intent = SupportUtils.createAuthCustomTabIntent(context, authUrl)
             context.startActivity(intent)
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/customtabs/AuthCustomTabActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/AuthCustomTabActivity.kt
@@ -1,0 +1,36 @@
+package org.mozilla.fenix.customtabs
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+   License, v. 2.0. If a copy of the MPL was not distributed with this
+   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import mozilla.components.concept.sync.AccountObserver
+import mozilla.components.concept.sync.OAuthAccount
+import mozilla.components.concept.sync.Profile
+import mozilla.components.service.fxa.manager.FxaAccountManager
+import org.mozilla.fenix.ext.components
+
+class AuthCustomTabActivity : CustomTabActivity() {
+    private lateinit var accountManager: FxaAccountManager
+
+    // Navigate away from this activity when we have successful authentication
+    private val accountStateObserver = object : AccountObserver {
+        override fun onAuthenticated(account: OAuthAccount) {
+            this@AuthCustomTabActivity.finish()
+        }
+
+        override fun onAuthenticationProblems() {}
+
+        override fun onError(error: Exception) {}
+
+        override fun onLoggedOut() {}
+
+        override fun onProfileUpdated(profile: Profile) {}
+    }
+
+    override fun onResume() {
+        super.onResume()
+        accountManager = this.components.backgroundServices.accountManager
+        accountManager.register(accountStateObserver, this, true)
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabActivity.kt
@@ -6,6 +6,6 @@ package org.mozilla.fenix.customtabs
 
 import org.mozilla.fenix.HomeActivity
 
-class CustomTabActivity : HomeActivity() {
+open class CustomTabActivity : HomeActivity() {
     override val isCustomTab = true
 }

--- a/app/src/main/java/org/mozilla/fenix/settings/SupportUtils.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SupportUtils.kt
@@ -47,8 +47,17 @@ object SupportUtils {
     }
 
     fun createCustomTabIntent(context: Context, url: String) = Intent(Intent.ACTION_VIEW).apply {
-        putExtra("android.support.customtabs.extra.TOOLBAR_COLOR", R.attr.foundation.getColorFromAttr(context))
-        putExtra("android.support.customtabs.extra.SESSION", true)
+        putExtra(context.getString(R.string.intent_extra_toolbar_color), R.attr.foundation.getColorFromAttr(context))
+        putExtra(context.getString(R.string.intent_extra_session), true)
+        setClassName(context.applicationContext, IntentReceiverActivity::class.java.name)
+        data = Uri.parse(url)
+        setPackage(context.packageName)
+    }
+
+    fun createAuthCustomTabIntent(context: Context, url: String) = Intent(Intent.ACTION_VIEW).apply {
+        putExtra(context.getString(R.string.intent_extra_toolbar_color), R.attr.foundation.getColorFromAttr(context))
+        putExtra(context.getString(R.string.intent_extra_session), true)
+        putExtra(context.getString(R.string.intent_extra_auth), true)
         setClassName(context.applicationContext, IntentReceiverActivity::class.java.name)
         data = Uri.parse(url)
         setPackage(context.packageName)

--- a/app/src/main/res/values/static_strings.xml
+++ b/app/src/main/res/values/static_strings.xml
@@ -14,6 +14,9 @@
         %1$s is produced by Mozilla.
     </string>
 
+    <string name="intent_extra_toolbar_color" translatable="false">android.support.customtabs.extra.TOOLBAR_COLOR</string>
+    <string name="intent_extra_session" translatable="false">android.support.customtabs.extra.SESSION</string>
+    <string name="intent_extra_auth" translatable="false">support.customtabs.extra.AUTH</string>
 
     <!-- 1.0.1 strings -->
     <!-- Bookmark deletion confirmation -->


### PR DESCRIPTION
Would something like this possibly work? I just created a new CustomTabActivity that has an auth listener. I'm not sure how we want to deal with the other AccountObserver events though.
 
CC @boek because you had looked at this before :)
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
