### PR TITLE
Closes #3914: Exclude gecko.util.DebugConfig from Proguard optimization

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -26,6 +26,11 @@
 -dontwarn com.google.**
 -dontwarn org.mozilla.geckoview.**
 
+# Raptor now writes a *-config.yaml file to specify Gecko runtime settings (e.g. the profile dir). This
+# file gets deserialized into a DebugConfig object, which is why we need to keep this class
+# and its members.
+-keep class org.mozilla.gecko.util.DebugConfig { *; }
+
 ####################################################################################################
 # Kotlinx
 ####################################################################################################


### PR DESCRIPTION
@rwood-moz is working on a new way to launch Raptor which makes use of @ncalexan's enhancement to provide Gecko runtime settings (e.g. the profile directory containing the web extension) in a .yaml file instead of passing those along as intent args to `BrowserPerformanceTestActivity`.

With this (and once the Raptor changes land), we can get rid of the custom raptor/performancetest buildtype, as well as the test config and activity. We can then actually test the release build type directly.

The .yaml file gets parsed into an `org.mozilla.gecko.util.DebugConfig` object which currently gets optimized away by Proguard (its fields get stripped, the class itself is also referenced by GeckoRuntime). So, this PR adds an exclusion rule to prevent that, and makes things work with the latest Raptor. 

Note that by default, the configuration is not read in release builds unless `set-debug-app` is specified.

This is just to make things work. We can refactor/remove the unneeded activity and buildconfig once the Raptor changes land in production. The class is pretty small and already in the release builds so I don't think adding the exclusion rule should be an issue: https://dxr.mozilla.org/mozilla-central/source/mobile/android/geckoview/src/main/java/org/mozilla/gecko/util/DebugConfig.java