### PR TITLE
Removes detekt/lint check from PR checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -2,7 +2,6 @@
 
 ### Pull Request checklist
 <!-- Before submitting the PR, please address each item -->
-- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
 - [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
 - [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
 - [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features


### PR DESCRIPTION
CI already checks if `detekt`/`ktlint` passes, and blocks merging the PR if it doesn't.
Therefore, we don't need contributors/maintainers to remember to check manually :smile:

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
