### PR TITLE
No issue: Update Android Gradle Plugin to 3.4.1

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -5,7 +5,7 @@
 private object Versions {
     const val kotlin = "1.3.30"
     const val coroutines = "1.2.1"
-    const val android_gradle_plugin = "3.3.2"
+    const val android_gradle_plugin = "3.4.1"
     const val rxAndroid = "2.1.0"
     const val rxKotlin = "2.3.0"
     const val rxBindings = "3.0.0-alpha2"


### PR DESCRIPTION
Tested and verified the app with the latest Android Gradle Plugin. We need these updates for improvements to build speeds as well as runtime optimizations in R8. AGP 3.4.1 is the recommended plugin for the stable Android Studio 3.4.1, which most of us are using.