### PR TITLE
Replace deprecated pxToDp

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarUIView.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarUIView.kt
@@ -14,7 +14,8 @@ import io.reactivex.Observer
 import io.reactivex.functions.Consumer
 import mozilla.components.browser.domains.autocomplete.ShippedDomainsProvider
 import mozilla.components.browser.toolbar.BrowserToolbar
-import mozilla.components.support.ktx.android.content.res.pxToDp
+import mozilla.components.support.ktx.android.util.dpToFloat
+import mozilla.components.support.ktx.android.util.dpToPx
 import org.jetbrains.anko.backgroundDrawable
 import org.mozilla.fenix.R
 import org.mozilla.fenix.customtabs.CustomTabToolbarMenu
@@ -53,7 +54,7 @@ class ToolbarUIView(
                 editMode()
             }
 
-            elevation = resources.pxToDp(TOOLBAR_ELEVATION).toFloat()
+            elevation = TOOLBAR_ELEVATION.dpToFloat(resources.displayMetrics)
 
             setOnUrlCommitListener {
                 actionEmitter.onNext(SearchAction.UrlCommitted(it, sessionId, state?.engine))
@@ -64,7 +65,7 @@ class ToolbarUIView(
                 false
             }
 
-            browserActionMargin = resources.pxToDp(browserActionMarginDp)
+            browserActionMargin = browserActionMarginDp.dpToPx(resources.displayMetrics)
 
             val isCustomTabSession = (session?.isCustomTabSession() == true)
 

--- a/app/src/main/java/org/mozilla/fenix/ext/View.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/View.kt
@@ -7,10 +7,10 @@ package org.mozilla.fenix.ext
 import android.graphics.Rect
 import android.view.TouchDelegate
 import android.view.View
-import mozilla.components.support.ktx.android.content.res.pxToDp
+import mozilla.components.support.ktx.android.util.dpToPx
 
-fun View?.increaseTapArea(extraDps: Int) {
-    val dips = this!!.resources.pxToDp(extraDps)
+fun View.increaseTapArea(extraDps: Int) {
+    val dips = extraDps.dpToPx(resources.displayMetrics)
     val parent = this.parent as View
     parent.post {
         val touchRect = Rect()

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/TabInCollectionViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/TabInCollectionViewHolder.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import mozilla.components.browser.icons.IconRequest
-import mozilla.components.support.ktx.android.content.res.pxToDp
+import mozilla.components.support.ktx.android.util.dpToFloat
 import org.jetbrains.anko.backgroundColor
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
@@ -50,13 +50,13 @@ class TabInCollectionViewHolder(
     init {
         collection_tab_icon.clipToOutline = true
         collection_tab_icon.outlineProvider = object : ViewOutlineProvider() {
-            override fun getOutline(view: View?, outline: Outline?) {
+            override fun getOutline(view: View, outline: Outline?) {
                 outline?.setRoundRect(
                     0,
                     0,
-                    view!!.width,
+                    view.width,
                     view.height,
-                    view.context.resources.pxToDp(TabViewHolder.favIconBorderRadiusInPx).toFloat()
+                    TabViewHolder.favIconBorderRadiusInPx.dpToFloat(view.context.resources.displayMetrics)
                 )
             }
         }

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/TabViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/TabViewHolder.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.launch
 import mozilla.components.browser.icons.IconRequest
 import mozilla.components.browser.menu.BrowserMenuBuilder
 import mozilla.components.browser.menu.item.SimpleBrowserMenuItem
-import mozilla.components.support.ktx.android.content.res.pxToDp
+import mozilla.components.support.ktx.android.util.dpToFloat
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.increaseTapArea
@@ -76,7 +76,7 @@ class TabViewHolder(
                     0,
                     view!!.width,
                     view.height,
-                    view.context.resources.pxToDp(favIconBorderRadiusInPx).toFloat()
+                    favIconBorderRadiusInPx.dpToFloat(view.context.resources.displayMetrics)
                 )
             }
         }

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/selectfolder/SelectBookmarkFolderAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/selectfolder/SelectBookmarkFolderAdapter.kt
@@ -14,7 +14,7 @@ import kotlinx.android.extensions.LayoutContainer
 import kotlinx.android.synthetic.main.bookmark_row.*
 import mozilla.components.concept.storage.BookmarkNode
 import mozilla.components.concept.storage.BookmarkNodeType
-import mozilla.components.support.ktx.android.content.res.pxToDp
+import mozilla.components.support.ktx.android.util.dpToPx
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.getColorIntFromAttr
 import org.mozilla.fenix.library.bookmarks.BookmarksSharedViewModel
@@ -110,8 +110,8 @@ class SelectBookmarkFolderAdapter(private val sharedViewModel: BookmarksSharedVi
             bookmark_layout.setOnClickListener {
                 selectionInterface.itemSelected(folder.node)
             }
-            val padding =
-                containerView.resources.pxToDp(dpsToIndent) * (if (folder.depth > maxDepth) maxDepth else folder.depth)
+            val pxToIndent = dpsToIndent.dpToPx(containerView.resources.displayMetrics)
+            val padding = pxToIndent * if (folder.depth > maxDepth) maxDepth else folder.depth
             bookmark_layout.setPadding(padding, 0, 0, 0)
         }
 


### PR DESCRIPTION
We deprecated `pxToDp` and renamed it to `dpToPx`. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
