### PR TITLE
Closes #1350: Use GeckoView fetch client for service-fretboard / kinto

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -17,7 +17,6 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 import mozilla.components.concept.fetch.Client
-import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
 import mozilla.components.service.fretboard.Fretboard
 import mozilla.components.service.fretboard.source.kinto.KintoExperimentSource
 import mozilla.components.service.fretboard.storage.flatfile.FlatFileExperimentStorage
@@ -47,24 +46,24 @@ open class FenixApplication : Application() {
     }
 
     open fun setupApplication() {
-        // loadExperiments does things that run in parallel with the rest of setup.
-        // Call the function as early as possible so there's maximum overlap.
-        experimentLoader = loadExperiments()
-
+        setupCrashReporting()
         setDayNightTheme()
         val megazordEnabled = setupMegazord()
         setupLogging(megazordEnabled)
         registerRxExceptionHandling()
-        setupCrashReporting()
         enableStrictMode()
 
         if (!isMainProcess()) {
             // If this is not the main process then do not continue with the initialization here. Everything that
             // follows only needs to be done in our app's main process and should not be done in other processes like
             // a GeckoView child process or the crash handling process. Most importantly we never want to end up in a
-            // situation where we create a GeckoRuntime from the Gecko child process (
+            // situation where we create a GeckoRuntime from the Gecko child process.
             return
         }
+
+        // We want to call this function as early as possible, but only once and
+        // on the main process, as it uses Gecko to fetch experiments from the server.
+        experimentLoader = loadExperiments()
 
         setupLeakCanary()
         if (Settings.getInstance(this).isTelemetryEnabled) {
@@ -132,17 +131,17 @@ open class FenixApplication : Application() {
     }
 
     private fun loadExperiments(): Deferred<Boolean> {
+        val experimentsFile = File(filesDir, EXPERIMENTS_JSON_FILENAME)
+        val experimentSource = KintoExperimentSource(
+            EXPERIMENTS_BASE_URL,
+            EXPERIMENTS_BUCKET_NAME,
+            EXPERIMENTS_COLLECTION_NAME,
+            components.core.client
+        )
+        // TODO add ValueProvider to keep clientID in sync with Glean when ready
+        fretboard = Fretboard(experimentSource, FlatFileExperimentStorage(experimentsFile))
+
         return GlobalScope.async(Dispatchers.IO) {
-            val experimentsFile = File(filesDir, EXPERIMENTS_JSON_FILENAME)
-            val experimentSource = KintoExperimentSource(
-                EXPERIMENTS_BASE_URL,
-                EXPERIMENTS_BUCKET_NAME,
-                EXPERIMENTS_COLLECTION_NAME,
-                // TODO Switch back to components.core.client (see https://github.com/mozilla-mobile/fenix/issues/1329)
-                HttpURLConnectionClient()
-            )
-            // TODO add ValueProvider to keep clientID in sync with Glean when ready
-            fretboard = Fretboard(experimentSource, FlatFileExperimentStorage(experimentsFile))
             fretboard.loadExperiments()
             Logger.debug("Bucket is ${fretboard.getUserBucket(this@FenixApplication)}")
             Logger.debug("Experiments active: ${fretboard.getExperimentsMap(this@FenixApplication)}")


### PR DESCRIPTION
The latest version of Raptor now writes a configuration file containing all Gecko runtime args before launching the application. With this we no longer have a race condition on startup where we potentially initialized the Gecko runtime before Raptor could have supplied its arguments. So, we can now switch back to Gecko fetch for Fretboard/Kinto.

In addition, this PR also makes sure we only load/fetch experiments once. Fenix was initializing Fretboard for both the main and :tab processes, which is unnecessary.

I am marking this as "Do Not Load" until the Raptor changes land in production tomorrow. As a follow-up, we can then also remove our custom `BrowserPerformanceTestActivity` and all raptor-specific build configurations, as we can simply test the release build directly. Raptor just launches a .VIEW intent without any extras now.
