### PR TITLE
[WIP] Add Desktop site icon

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
@@ -131,9 +131,7 @@ class DefaultToolbarMenu(
                 onItemTapped.invoke(ToolbarMenu.Item.Library)
             },
 
-            BrowserMenuImageText(
-                context.getString(R.string.browser_menu_desktop_site),
-                R.drawable.ic_desktop,
+            BrowserMenuSwitch(context.getString(R.string.browser_menu_desktop_site),
                 requestDesktopStateProvider, { checked ->
                     onItemTapped.invoke(ToolbarMenu.Item.RequestDesktop(checked))
                 }),

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
@@ -131,6 +131,7 @@ class DefaultToolbarMenu(
                 onItemTapped.invoke(ToolbarMenu.Item.Library)
             },
 
+            // TODO: Add icon R.drawable.ic_desktop
             BrowserMenuSwitch(context.getString(R.string.browser_menu_desktop_site),
                 requestDesktopStateProvider, { checked ->
                     onItemTapped.invoke(ToolbarMenu.Item.RequestDesktop(checked))

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
@@ -131,7 +131,9 @@ class DefaultToolbarMenu(
                 onItemTapped.invoke(ToolbarMenu.Item.Library)
             },
 
-            BrowserMenuSwitch(context.getString(R.string.browser_menu_desktop_site),
+            BrowserMenuImageText(
+                context.getString(R.string.browser_menu_desktop_site),
+                R.drawable.ic_desktop,
                 requestDesktopStateProvider, { checked ->
                     onItemTapped.invoke(ToolbarMenu.Item.RequestDesktop(checked))
                 }),

--- a/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabToolbarMenu.kt
@@ -117,6 +117,7 @@ class CustomTabToolbarMenu(
                 onItemTapped.invoke(ToolbarMenu.Item.Share)
             },
 
+            // TODO: Add icon R.drawable.ic_desktop
             BrowserMenuSwitch(context.getString(R.string.browser_menu_desktop_site),
                 { session?.desktopMode ?: false }, { checked ->
                     onItemTapped.invoke(ToolbarMenu.Item.RequestDesktop(checked))

--- a/app/src/main/res/drawable/ic_desktop.xml
+++ b/app/src/main/res/drawable/ic_desktop.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="?primaryText"
+        android:pathData="M15.5 12H15V3a1 1 0 0 0-1-1H2a1 1 0 0 0-1 1v9H.5a.5.5 0 0 0-.5.5v1a.5.5 0 0 0 .5.5h15a.5.5 0 0 0 .5-.5v-1a.5.5 0 0 0-.5-.5zM10 13H6v-1h4zm3-2H3V4h10z" />
+</vector>


### PR DESCRIPTION
Attempts to fix #1071 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### Checklist

- [x] Import Desktop icon
- [ ] Find a way to use icons with BrowserMenuSwitch (blocked by https://github.com/mozilla-mobile/android-components/issues/3715 ?)
  - [ ] Add icon to DefaultToolbarMenu.kt
  - [ ] Add icon to CustomTabToolbarMenu.kt
  - [ ] Make sure it is accessible after this change.

I got the ![Desktop Icon](https://design.firefox.com/icons/icons/desktop/device-desktop-16.svg) from [Photon Icons](https://design.firefox.com/icons/viewer/#desktop), and manually converted it to xml following ic_library.xml.
