### PR TITLE
Update to Mozilla Android Components 4.0.0-SNAPSHOT.

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -33,7 +33,7 @@ private object Versions {
     const val androidx_work = "2.0.1"
     const val google_material = "1.1.0-alpha07"
 
-    const val mozilla_android_components = "3.0.0-SNAPSHOT"
+    const val mozilla_android_components = "4.0.0-SNAPSHOT"
     // Note that android-components also depends on application-services,
     // and in fact is our main source of appservices-related functionality.
     // The version number below tracks the application-services version


### PR DESCRIPTION
Two major reasons:
* 4.0.0 will be released next Tuesday, before the Fenix 1.1 target date.
* It fixes the `INSTALL_FAILED_CONFLICTING_PROVIDER` error introduces in AC 3.0.0 which prevents multiple apps using `feature-prompts` to be installed on the same device.