### PR TITLE
Use putCompoundDrawables helper

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/FenixSnackbarDelegate.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/FenixSnackbarDelegate.kt
@@ -5,6 +5,7 @@
 package org.mozilla.fenix.browser
 
 import android.view.View
+import androidx.annotation.StringRes
 import com.google.android.material.snackbar.Snackbar
 import mozilla.components.feature.contextmenu.ContextMenuCandidate
 import org.mozilla.fenix.components.FenixSnackbar
@@ -13,18 +14,15 @@ class FenixSnackbarDelegate(val view: View, private val anchorView: View?) :
     ContextMenuCandidate.SnackbarDelegate {
     override fun show(
         snackBarParentView: View,
-        text: Int,
+        @StringRes text: Int,
         duration: Int,
-        action: Int,
+        @StringRes action: Int,
         listener: ((v: View) -> Unit)?
     ) {
         val snackbar = FenixSnackbar.make(view, Snackbar.LENGTH_LONG).setText(view.context.getString(text))
-        if (listener != null) {
-            val newListener = {
+        if (listener != null && action != 0) {
+            snackbar.setAction(view.context.getString(action)) {
                 listener.invoke(view)
-            }
-            if (action != 0) {
-                snackbar.setAction(view.context.getString(action), newListener)
             }
         }
         snackbar.anchorView = anchorView

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/NoContentMessageViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/NoContentMessageViewHolder.kt
@@ -9,6 +9,7 @@ import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.android.synthetic.main.no_content_message.view.*
+import mozilla.components.support.ktx.android.view.putCompoundDrawablesRelativeWithIntrinsicBounds
 import org.mozilla.fenix.R
 
 class NoContentMessageViewHolder(private val view: View) : RecyclerView.ViewHolder(view) {
@@ -19,7 +20,7 @@ class NoContentMessageViewHolder(private val view: View) : RecyclerView.ViewHold
         @StringRes description: Int
     ) {
         with(view.context) {
-            view.no_content_header.setCompoundDrawablesRelativeWithIntrinsicBounds(0, 0, icon, 0)
+            view.no_content_header.putCompoundDrawablesRelativeWithIntrinsicBounds(end = getDrawable(icon))
             view.no_content_header.text = getString(header)
             view.no_content_description.text = getString(description)
         }

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingFirefoxAccountViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingFirefoxAccountViewHolder.kt
@@ -9,6 +9,7 @@ import androidx.appcompat.content.res.AppCompatResources
 import androidx.navigation.Navigation
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.android.synthetic.main.onboarding_firefox_account.view.*
+import mozilla.components.support.ktx.android.view.putCompoundDrawablesRelativeWithIntrinsicBounds
 import org.mozilla.fenix.R
 import org.mozilla.fenix.home.HomeFragmentDirections
 
@@ -40,7 +41,7 @@ class OnboardingFirefoxAccountViewHolder(private val view: View) : RecyclerView.
 
     private fun updateHeaderText(autoSignedIn: Boolean) {
         val icon = if (autoSignedIn) avatarAnonymousDrawable else firefoxAccountsDrawable
-        view.header_text.setCompoundDrawablesRelativeWithIntrinsicBounds(icon, null, null, null)
+        view.header_text.putCompoundDrawablesRelativeWithIntrinsicBounds(start = icon)
 
         val appName = view.context.getString(R.string.app_name)
         view.header_text.text =

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingIcon.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingIcon.kt
@@ -7,6 +7,7 @@ package org.mozilla.fenix.home.sessioncontrol.viewholders.onboarding
 import android.widget.TextView
 import androidx.annotation.DrawableRes
 import androidx.appcompat.content.res.AppCompatResources
+import mozilla.components.support.ktx.android.view.putCompoundDrawablesRelative
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.setBounds
 
@@ -18,5 +19,5 @@ fun TextView.setOnboardingIcon(@DrawableRes id: Int) {
     val size = context.resources.getDimensionPixelSize(R.dimen.onboarding_header_icon_height_width)
     icon?.setBounds(size)
 
-    setCompoundDrawablesRelative(icon, null, null, null)
+    putCompoundDrawablesRelative(start = icon)
 }

--- a/app/src/main/java/org/mozilla/fenix/quickactionsheet/QuickActionUIView.kt
+++ b/app/src/main/java/org/mozilla/fenix/quickactionsheet/QuickActionUIView.kt
@@ -8,6 +8,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
+import androidx.annotation.DrawableRes
+import androidx.core.content.edit
 import androidx.core.widget.NestedScrollView
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import io.reactivex.Observable
@@ -16,6 +18,7 @@ import io.reactivex.functions.Consumer
 import kotlinx.android.synthetic.main.fragment_browser.*
 import kotlinx.android.synthetic.main.layout_quick_action_sheet.*
 import kotlinx.android.synthetic.main.layout_quick_action_sheet.view.*
+import mozilla.components.support.ktx.android.view.putCompoundDrawablesRelativeWithIntrinsicBounds
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.components
@@ -133,17 +136,18 @@ class QuickActionUIView(
     }
 
     private fun updateReaderModeButton(withNotification: Boolean) {
-        if (withNotification) {
+        @DrawableRes
+        val readerTwoStateDrawableId = if (withNotification) {
             quickActionSheet.bounceSheet()
-            val readerTwoStateDrawable = view.context.getDrawable(R.drawable.reader_two_state_with_notification)
-            view.quick_action_read
-                .setCompoundDrawablesWithIntrinsicBounds(null, readerTwoStateDrawable, null, null)
-            Settings.getInstance(view.context).preferences.edit()
-                .putBoolean(view.context.getString(R.string.pref_key_reader_mode_notification), false).apply()
+            Settings.getInstance(view.context).preferences.edit {
+                putBoolean(view.context.getString(R.string.pref_key_reader_mode_notification), false)
+            }
+            R.drawable.reader_two_state_with_notification
         } else {
-            val readerTwoStateDrawable = view.context.getDrawable(R.drawable.reader_two_state)
-            view.quick_action_read
-                .setCompoundDrawablesWithIntrinsicBounds(null, readerTwoStateDrawable, null, null)
+            R.drawable.reader_two_state
         }
+        view.quick_action_read.putCompoundDrawablesRelativeWithIntrinsicBounds(
+            top = view.context.getDrawable(readerTwoStateDrawableId)
+        )
     }
 }

--- a/app/src/main/res/layout/no_content_message.xml
+++ b/app/src/main/res/layout/no_content_message.xml
@@ -19,6 +19,7 @@
             android:drawableTint="?primaryText"
             android:drawablePadding="8dp"
             tools:text="@tools:sample/lorem"
+            tools:drawableEnd="@drawable/ic_tab_collection"
             android:textAppearance="@style/HeaderTextStyle"
             android:textSize="16sp" />
 


### PR DESCRIPTION
Clean up code that sets compound drawables.

- Use new `putCompoundDrawables` helpers that I added to support-ktx, which let you use named arguments for the setters.
- Remove some duplicate code in if statements.
- Ensure relative drawables are used to support RTL languages.
- Ensure that drawables aren't loaded twice by using `tools:drawableStart` in layout files.
- Make `ClearableEditText` work in RTL languages.