### PR TITLE
Bump a-s version to 0.34.0, update the FxA integration

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -325,7 +325,6 @@ dependencies {
     implementation Deps.mozilla_feature_qr
     implementation Deps.mozilla_feature_search
     implementation Deps.mozilla_feature_session
-    implementation Deps.mozilla_feature_sync
     implementation Deps.mozilla_feature_toolbar
     implementation Deps.mozilla_feature_tabs
     implementation Deps.mozilla_feature_findinpage

--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -147,7 +147,7 @@ open class HomeActivity : AppCompatActivity(), ShareFragment.TabsSharedCallback 
                 accountManager.initAsync().await()
                 // If we're authenticated, kick-off a sync and a device state refresh.
                 accountManager.authenticatedAccount()?.let {
-                    syncManager?.syncNow(startup = true)
+                    accountManager.syncNowAsync(startup = true)
                     it.deviceConstellation().refreshDeviceStateAsync().await()
                 }
             }

--- a/app/src/main/java/org/mozilla/fenix/customtabs/AuthCustomTabActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/AuthCustomTabActivity.kt
@@ -21,8 +21,6 @@ class AuthCustomTabActivity : CustomTabActivity() {
 
         override fun onAuthenticationProblems() {}
 
-        override fun onError(error: Exception) {}
-
         override fun onLoggedOut() {}
 
         override fun onProfileUpdated(profile: Profile) {}

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -745,10 +745,6 @@ class HomeFragment : Fragment(), AccountObserver {
         emitAccountChanges()
     }
 
-    override fun onError(error: Exception) {
-        emitAccountChanges()
-    }
-
     override fun onLoggedOut() {
         emitAccountChanges()
     }

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragment.kt
@@ -414,9 +414,6 @@ class BookmarkFragment : Fragment(), BackHandler, AccountObserver {
         }
     }
 
-    override fun onError(error: Exception) {
-    }
-
     override fun onLoggedOut() {
         getManagedEmitter<SignInChange>().onNext(SignInChange.SignedOut)
     }

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/selectfolder/SelectBookmarkFolderFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/selectfolder/SelectBookmarkFolderFragment.kt
@@ -154,9 +154,6 @@ class SelectBookmarkFolderFragment : Fragment(), AccountObserver {
         getManagedEmitter<SignInChange>().onNext(SignInChange.SignedIn)
     }
 
-    override fun onError(error: Exception) {
-    }
-
     override fun onLoggedOut() {
         getManagedEmitter<SignInChange>().onNext(SignInChange.SignedOut)
     }

--- a/app/src/main/java/org/mozilla/fenix/settings/AccountProblemFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/AccountProblemFragment.kt
@@ -84,8 +84,6 @@ class AccountProblemFragment : PreferenceFragmentCompat(), AccountObserver {
 
     override fun onAuthenticationProblems() {}
 
-    override fun onError(error: Exception) {}
-
     // We're told there are no more auth problems since there is no more account; close this fragment.
     override fun onLoggedOut() {
         lifecycleScope.launch {

--- a/app/src/main/java/org/mozilla/fenix/settings/AccountSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/AccountSettingsFragment.kt
@@ -24,11 +24,11 @@ import mozilla.components.concept.sync.ConstellationState
 import mozilla.components.concept.sync.DeviceConstellationObserver
 import mozilla.components.concept.sync.OAuthAccount
 import mozilla.components.concept.sync.Profile
-import mozilla.components.concept.sync.SyncStatusObserver
-import mozilla.components.feature.sync.getLastSynced
 import mozilla.components.service.fxa.FxaException
 import mozilla.components.service.fxa.FxaPanicException
 import mozilla.components.service.fxa.manager.FxaAccountManager
+import mozilla.components.service.fxa.sync.SyncStatusObserver
+import mozilla.components.service.fxa.sync.getLastSynced
 import mozilla.components.support.base.log.logger.Logger
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.FenixSnackbar
@@ -48,8 +48,6 @@ class AccountSettingsFragment : PreferenceFragmentCompat() {
                 findNavController().popBackStack()
             }
         }
-
-        override fun onError(error: Exception) {}
 
         override fun onLoggedOut() {
             lifecycleScope.launch {
@@ -97,18 +95,8 @@ class AccountSettingsFragment : PreferenceFragmentCompat() {
         val syncNow = context!!.getPreferenceKey(R.string.pref_key_sync_now)
         val preferenceSyncNow = findPreference<Preference>(syncNow)
         preferenceSyncNow?.let {
-            preferenceSyncNow.onPreferenceClickListener = getClickListenerForSyncNow()
-
-            // Current sync state
-            updateLastSyncedTimePref(context!!, preferenceSyncNow)
-            requireComponents.backgroundServices.syncManager?.let {
-                if (it.isSyncRunning()) {
-                    preferenceSyncNow.title = getString(R.string.sync_syncing_in_progress)
-                    preferenceSyncNow.isEnabled = false
-                } else {
-                    preferenceSyncNow.isEnabled = true
-                }
-            }
+            it.onPreferenceClickListener = getClickListenerForSyncNow()
+            updateLastSyncedTimePref(context!!, it)
         }
 
         // Device Name
@@ -129,7 +117,9 @@ class AccountSettingsFragment : PreferenceFragmentCompat() {
 
         // NB: ObserverRegistry will take care of cleaning up internal references to 'observer' and
         // 'owner' when appropriate.
-        requireComponents.backgroundServices.syncManager?.register(syncStatusObserver, owner = this, autoPause = true)
+        requireComponents.backgroundServices.accountManager.registerForSyncEvents(
+            syncStatusObserver, owner = this, autoPause = true
+        )
     }
 
     private fun getClickListenerForSignOut(): Preference.OnPreferenceClickListener {
@@ -144,11 +134,11 @@ class AccountSettingsFragment : PreferenceFragmentCompat() {
 
     private fun getClickListenerForSyncNow(): Preference.OnPreferenceClickListener {
         return Preference.OnPreferenceClickListener {
-            // Trigger a sync.
-            requireComponents.analytics.metrics.track(Event.SyncAccountSyncNow)
-            requireComponents.backgroundServices.syncManager?.syncNow()
-            // Poll for device events.
             lifecycleScope.launch {
+                requireComponents.analytics.metrics.track(Event.SyncAccountSyncNow)
+                // Trigger a sync.
+                requireComponents.backgroundServices.accountManager.syncNowAsync().await()
+                // Poll for device events.
                 accountManager.authenticatedAccount()
                     ?.deviceConstellation()
                     ?.refreshDeviceStateAsync()
@@ -175,9 +165,10 @@ class AccountSettingsFragment : PreferenceFragmentCompat() {
             // This may fail, and we'll have a disparity in the UI until `updateDeviceName` is called.
             lifecycleScope.launch(IO) {
                 try {
-                    accountManager.authenticatedAccount()?.let {
-                        it.deviceConstellation().setDeviceNameAsync(newValue)
-                    }
+                    accountManager.authenticatedAccount()
+                        ?.deviceConstellation()
+                        ?.setDeviceNameAsync(newValue)
+                        ?.await()
                 } catch (e: FxaPanicException) {
                     throw e
                 } catch (e: FxaException) {

--- a/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
@@ -350,8 +350,6 @@ class SettingsFragment : PreferenceFragmentCompat(), AccountObserver {
         }
     }
 
-    override fun onError(error: Exception) {}
-
     override fun onLoggedOut() {
         lifecycleScope.launch {
             context?.let {

--- a/app/src/main/java/org/mozilla/fenix/settings/TurnOnSyncFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/TurnOnSyncFragment.kt
@@ -87,7 +87,6 @@ class TurnOnSyncFragment : Fragment(), AccountObserver {
     }
 
     override fun onAuthenticationProblems() {}
-    override fun onError(error: Exception) {}
     override fun onLoggedOut() {}
     override fun onProfileUpdated(profile: Profile) {}
 }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -111,7 +111,6 @@ object Deps {
     const val mozilla_feature_qr = "org.mozilla.components:feature-qr:${Versions.mozilla_android_components}"
     const val mozilla_feature_search = "org.mozilla.components:feature-search:${Versions.mozilla_android_components}"
     const val mozilla_feature_session = "org.mozilla.components:feature-session:${Versions.mozilla_android_components}"
-    const val mozilla_feature_sync = "org.mozilla.components:feature-sync:${Versions.mozilla_android_components}"
     const val mozilla_feature_tabs = "org.mozilla.components:feature-tabs:${Versions.mozilla_android_components}"
     const val mozilla_feature_downloads = "org.mozilla.components:feature-downloads:${Versions.mozilla_android_components}"
     const val mozilla_feature_storage = "org.mozilla.components:feature-storage:${Versions.mozilla_android_components}"

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -39,7 +39,7 @@ private object Versions {
     // The version number below tracks the application-services version
     // that we depend on directly for tests, and it's important that it
     // be kept in sync with the version used by android-components above.
-    const val mozilla_appservices = "0.31.2"
+    const val mozilla_appservices = "0.34.0"
 
     const val autodispose = "1.1.0"
     const val adjust = "4.11.4"


### PR DESCRIPTION
A-C updated version of A-S that it's using (see https://github.com/mozilla-mobile/android-components/pull/3727), so we need to updated the hard-coded version in Fenix as well.

This also updates the FxA integration to account for breaking API changes.