### PR TITLE
No issue: Enable Strict Mode in Debug Builds

### DIFF
--- a/app/src/debug/java/org/mozilla/fenix/DebugFenixApplication.kt
+++ b/app/src/debug/java/org/mozilla/fenix/DebugFenixApplication.kt
@@ -26,7 +26,6 @@ import java.io.File
 class DebugFenixApplication : FenixApplication() {
 
     override fun onCreate() {
-        super.onCreate()
         SoLoader.init(this, false)
 
         if (FlipperUtils.shouldEnableFlipper(this)) {
@@ -39,6 +38,8 @@ class DebugFenixApplication : FenixApplication() {
                 start()
             }
         }
+
+        super.onCreate()
     }
 
     private var heapDumper: ToggleableHeapDumper? = null

--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -8,6 +8,7 @@ import android.annotation.SuppressLint
 import android.app.Application
 import android.os.Build
 import android.os.Build.VERSION.SDK_INT
+import android.os.StrictMode
 import androidx.appcompat.app.AppCompatDelegate
 import io.reactivex.plugins.RxJavaPlugins
 import kotlinx.coroutines.Deferred
@@ -55,6 +56,7 @@ open class FenixApplication : Application() {
         setupLogging(megazordEnabled)
         registerRxExceptionHandling()
         setupCrashReporting()
+        enableStrictMode()
 
         if (!isMainProcess()) {
             // If this is not the main process then do not continue with the initialization here. Everything that
@@ -235,6 +237,27 @@ open class FenixApplication : Application() {
                     settings.setLightTheme(true)
                 }
             }
+        }
+    }
+
+    private fun enableStrictMode() {
+        if (BuildConfig.DEBUG) {
+            StrictMode.setThreadPolicy(
+                StrictMode.ThreadPolicy.Builder()
+                    .detectAll()
+                    .penaltyLog()
+                    .build()
+            )
+            var builder = StrictMode.VmPolicy.Builder()
+                .detectLeakedSqlLiteObjects()
+                .detectLeakedClosableObjects()
+                .detectLeakedRegistrationObjects()
+                .detectActivityLeaks()
+                .detectFileUriExposure()
+                .penaltyLog()
+            if (SDK_INT >= Build.VERSION_CODES.O) builder = builder.detectContentUriWithoutPermission()
+            if (SDK_INT >= Build.VERSION_CODES.P) builder = builder.detectNonSdkApiUsage()
+            StrictMode.setVmPolicy(builder.build())
         }
     }
 }


### PR DESCRIPTION
Enabling strict mode in debug builds should help with catching performance issues early where we forget to background long-running work and block the main thread instead. It should also help with catching non-SDK APIs we're using that are likely to go away soon. LogCat should get a lot more noisy after this change for Debug builds, but it's useful information to fix real problems.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
