### PR TITLE
No Issue: Add pre-push hook instruction for PowerShell

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,13 @@ To add it on Mac/Linux, run this command from the project root:
 ```sh
 ln -s ../../config/pre-push-recommended.sh .git/hooks/pre-push
 ```
-or for Windows run this command with administrative privileges:
+or for Windows run this command using the Command Prompt with administrative privileges:
 ```sh
 mklink .git\hooks\pre-push ..\..\config\pre-push-recommended.sh
+```
+or using PowerShell:
+```sh
+New-Item -ItemType SymbolicLink -Path .git\hooks\pre-push -Value (Resolve-Path config\pre-push-recommended.sh)
 ```
 
 To push without running the pre-push hook (e.g. doc updates):


### PR DESCRIPTION
The mklink command is not available in PowerShell, making the previous
documentation for pre-push hooks on Windows incomplete.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
