### PR TITLE
After mege day: Switch from GV 68 beta to GV 68 release.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -307,7 +307,7 @@ dependencies {
     implementation Deps.mozilla_browser_domains
     implementation Deps.mozilla_browser_icons
     implementation Deps.mozilla_browser_menu
-    implementation Deps.mozilla_browser_engine_gecko_beta
+    implementation Deps.mozilla_browser_engine_gecko_release
     implementation Deps.mozilla_browser_search
     implementation Deps.mozilla_browser_session
     implementation Deps.mozilla_browser_storage_sync
@@ -350,10 +350,10 @@ dependencies {
 
     implementation Deps.mozilla_lib_fetch_httpurlconnection
 
-    armImplementation Gecko.geckoview_beta_arm
-    aarch64Implementation Gecko.geckoview_beta_aarch64
-    x86Implementation Gecko.geckoview_beta_x86
-    x86_64Implementation Gecko.geckoview_beta_x86_64
+    armImplementation Gecko.geckoview_release_arm
+    aarch64Implementation Gecko.geckoview_release_aarch64
+    x86Implementation Gecko.geckoview_release_x86
+    x86_64Implementation Gecko.geckoview_release_x86_64
 
     implementation Deps.androidx_legacy
     implementation Deps.androidx_paging

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -91,6 +91,7 @@ object Deps {
     const val mozilla_browser_awesomebar = "org.mozilla.components:browser-awesomebar:${Versions.mozilla_android_components}"
     const val mozilla_browser_engine_gecko_nightly = "org.mozilla.components:browser-engine-gecko-nightly:${Versions.mozilla_android_components}"
     const val mozilla_browser_engine_gecko_beta = "org.mozilla.components:browser-engine-gecko-beta:${Versions.mozilla_android_components}"
+    const val mozilla_browser_engine_gecko_release = "org.mozilla.components:browser-engine-gecko:${Versions.mozilla_android_components}"
     const val mozilla_browser_domains = "org.mozilla.components:browser-domains:${Versions.mozilla_android_components}"
     const val mozilla_browser_icons = "org.mozilla.components:browser-icons:${Versions.mozilla_android_components}"
     const val mozilla_browser_search = "org.mozilla.components:browser-search:${Versions.mozilla_android_components}"

--- a/buildSrc/src/main/java/Gecko.kt
+++ b/buildSrc/src/main/java/Gecko.kt
@@ -3,17 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object GeckoVersions {
-    const val beta_version = "68.0.20190612114833"
-    const val release_version = "67.0.20190521210220"
+    const val release_version = "68.0.20190711090008"
 }
 
 @Suppress("MaxLineLength")
 object Gecko {
-    const val geckoview_beta_arm = "org.mozilla.geckoview:geckoview-beta-armeabi-v7a:${GeckoVersions.beta_version}"
-    const val geckoview_beta_aarch64 = "org.mozilla.geckoview:geckoview-beta-arm64-v8a:${GeckoVersions.beta_version}"
-    const val geckoview_beta_x86 = "org.mozilla.geckoview:geckoview-beta-x86:${GeckoVersions.beta_version}"
-    const val geckoview_beta_x86_64 = "org.mozilla.geckoview:geckoview-beta-x86_64:${GeckoVersions.beta_version}"
-
     const val geckoview_release_arm = "org.mozilla.geckoview:geckoview-armeabi-v7a:${GeckoVersions.release_version}"
     const val geckoview_release_aarch64 = "org.mozilla.geckoview:geckoview-arm64-v8a:${GeckoVersions.release_version}"
     const val geckoview_release_x86 = "org.mozilla.geckoview:geckoview-x86:${GeckoVersions.release_version}"


### PR DESCRIPTION
Merge day has happened in the mozilla repository. This means that GeckoView 68.0 was released, Beta is now 69.0 and Nightly is 70.0. AC followed and updated the `browser-engine-gecko(-*)` components (latest 4.0.0-SNAPSHOT).

To keep Fenix on GeckoView 68.0 this patch switches from using GeckoView Beta to GeckoView Release (now 68.0).

The recommendation is to stay on 68.0 and not update to GeckoView Beta 69.0 yet, because:
* 68.0 is the version we have been using so far and there's a Fenix RC build coming up next week. So Let's reduce risk and stay on 68.
* There are currently GeckoView 69.0 perma test failures that we should wait for being resolved ([bug 1563997](https://bugzilla.mozilla.org/show_bug.cgi?id=1563997)).
* This is the first GeckoView 69 Beta build and that means it is still very close to Nightly right after merge day (higher risk).
* Snorp approved staying on 68 for RC 1.

In addition to that this patch removes the `geckoview_beta_` dependency definitions. With GeckoView Beta 69 we now have "fat" GeckoView builds (like for Nightly) and this means an app no longer needs to add those manually and synchronize them with AC - just adding `browser-engine-gecko-beta` is enough and the right GeckoView version will be added automatically (🎉 ).
