### PR TITLE
Closes #4021: Add the page title as subject when sharing page

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -520,7 +520,7 @@ class BrowserFragment : Fragment(), BackHandler {
                     is QuickActionAction.SharePressed -> {
                         requireComponents.analytics.metrics.track(Event.QuickActionSheetShareTapped)
                         getSessionById()?.let { session ->
-                            shareUrl(session.url)
+                            shareUrl(session.url, session.title)
                         }
                     }
                     is QuickActionAction.DownloadsPressed -> {
@@ -729,9 +729,7 @@ class BrowserFragment : Fragment(), BackHandler {
                 sessionUseCases.requestDesktopSite.invoke(action.item.isChecked, session)
             }
             ToolbarMenu.Item.Share -> getSessionById()?.let { session ->
-                session.url.apply {
-                    shareUrl(this)
-                }
+                shareUrl(session.url, session.title)
             }
             ToolbarMenu.Item.NewPrivateTab -> {
                 val directions = BrowserFragmentDirections
@@ -951,8 +949,8 @@ class BrowserFragment : Fragment(), BackHandler {
         }
     }
 
-    private fun shareUrl(url: String) {
-        val directions = BrowserFragmentDirections.actionBrowserFragmentToShareFragment(url = url)
+    private fun shareUrl(url: String, title: String) {
+        val directions = BrowserFragmentDirections.actionBrowserFragmentToShareFragment(url = url, title = title)
         nav(R.id.browserFragment, directions)
     }
 

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -391,7 +391,7 @@ class HomeFragment : Fragment(), AccountObserver {
             is TabAction.Share -> {
                 invokePendingDeleteJobs()
                 sessionManager.findSessionById(action.sessionId)?.let { session ->
-                    share(session.url)
+                    share(session.url, session.title)
                 }
             }
             is TabAction.CloseAll -> {
@@ -715,10 +715,11 @@ class HomeFragment : Fragment(), AccountObserver {
         }
     }
 
-    private fun share(url: String? = null, tabs: List<ShareTab>? = null) {
+    private fun share(url: String? = null, title: String? = null, tabs: List<ShareTab>? = null) {
         val directions =
             HomeFragmentDirections.actionHomeFragmentToShareFragment(
                 url = url,
+                title = title,
                 tabs = tabs?.toTypedArray()
             )
         nav(R.id.homeFragment, directions)

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragment.kt
@@ -118,7 +118,9 @@ class HistoryFragment : Fragment(), BackHandler {
             val selectedHistory = (historyComponent.uiView as HistoryUIView).getSelected()
             when {
                 selectedHistory.size == 1 ->
-                    share(selectedHistory.first().url)
+                    with(selectedHistory.first()) {
+                        share(url, title)
+                    }
                 selectedHistory.size > 1 -> {
                     val shareTabs = selectedHistory.map { ShareTab(it.url, it.title) }
                     share(tabs = shareTabs)
@@ -285,10 +287,11 @@ class HistoryFragment : Fragment(), BackHandler {
         }
     }
 
-    private fun share(url: String? = null, tabs: List<ShareTab>? = null) {
+    private fun share(url: String? = null, title: String? = null, tabs: List<ShareTab>? = null) {
         val directions =
             HistoryFragmentDirections.actionHistoryFragmentToShareFragment(
                 url = url,
+                title = title,
                 tabs = tabs?.toTypedArray()
             )
         nav(R.id.historyFragment, directions)

--- a/app/src/main/java/org/mozilla/fenix/share/ShareFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/share/ShareFragment.kt
@@ -6,6 +6,7 @@ package org.mozilla.fenix.share
 
 import android.content.Intent
 import android.content.Intent.ACTION_SEND
+import android.content.Intent.EXTRA_SUBJECT
 import android.content.Intent.EXTRA_TEXT
 import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
 import android.os.Bundle
@@ -118,6 +119,10 @@ class ShareFragment : AppCompatDialogFragment() {
                         type = "text/plain"
                         flags = FLAG_ACTIVITY_NEW_TASK
                         setClassName(it.item.packageName, it.item.activityName)
+                    }
+                    if (tabs.size == 1) {
+                        val shareTitle = tabs[0].title
+                        intent.putExtra(EXTRA_SUBJECT, shareTitle)
                     }
                     startActivity(intent)
                     dismiss()


### PR DESCRIPTION
Add the page title as subject when sharing a single web page from:
- BrowserFragment
- BookmarkFragment
- HomeFragment
- HistoryFragment


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
