### PR TITLE
For #3633: Add unit tests for SearchStore

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
@@ -163,7 +163,7 @@ class SearchFragment : Fragment(), BackHandler {
 
         search_shortcuts_button.setOnClickListener {
             val isOpen = searchStore.state.showShortcutEnginePicker
-            searchStore.dispatch(SearchAction.SearchShortcutEnginePicker(!isOpen))
+            searchStore.dispatch(SearchAction.ShowSearchShortcutEnginePicker(!isOpen))
 
             if (isOpen) {
                 requireComponents.analytics.metrics.track(Event.SearchShortcutMenuClosed)

--- a/app/src/main/java/org/mozilla/fenix/search/SearchStore.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchStore.kt
@@ -48,7 +48,7 @@ data class SearchState(
  */
 sealed class SearchAction : Action {
     data class SearchShortcutEngineSelected(val engine: SearchEngine) : SearchAction()
-    data class SearchShortcutEnginePicker(val show: Boolean) : SearchAction()
+    data class ShowSearchShortcutEnginePicker(val show: Boolean) : SearchAction()
     data class UpdateQuery(val query: String) : SearchAction()
 }
 
@@ -62,7 +62,7 @@ fun searchStateReducer(state: SearchState, action: SearchAction): SearchState {
                 searchEngineSource = SearchEngineSource.Shortcut(action.engine),
                 showShortcutEnginePicker = false
             )
-        is SearchAction.SearchShortcutEnginePicker ->
+        is SearchAction.ShowSearchShortcutEnginePicker ->
             state.copy(showShortcutEnginePicker = action.show)
         is SearchAction.UpdateQuery ->
             state.copy(query = action.query)

--- a/app/src/test/java/org/mozilla/fenix/search/SearchStoreTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/search/SearchStoreTest.kt
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.search
+
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import mozilla.components.browser.search.SearchEngine
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotSame
+import org.junit.Test
+
+class SearchStoreTest {
+
+    @Test
+    fun updateQuery() = runBlocking {
+        val initialState = emptyDefaultState()
+        val store = SearchStore(initialState, ::searchStateReducer)
+        val query = "test query"
+
+        store.dispatch(SearchAction.UpdateQuery(query)).join()
+        assertNotSame(initialState, store.state)
+        assertEquals(query, store.state.query)
+    }
+
+    @Test
+    fun selectSearchShortcutEngine() = runBlocking {
+        val initialState = emptyDefaultState()
+        val store = SearchStore(initialState, ::searchStateReducer)
+        val searchEngine: SearchEngine = mockk()
+
+        store.dispatch(SearchAction.SearchShortcutEngineSelected(searchEngine)).join()
+        assertNotSame(initialState, store.state)
+        assertEquals(SearchEngineSource.Shortcut(searchEngine), store.state.searchEngineSource)
+    }
+
+    @Test
+    fun showSearchShortcutEnginePicker() = runBlocking {
+        val initialState = emptyDefaultState()
+        val store = SearchStore(initialState, ::searchStateReducer)
+
+        store.dispatch(SearchAction.ShowSearchShortcutEnginePicker(true)).join()
+        assertNotSame(initialState, store.state)
+        assertEquals(true, store.state.showShortcutEnginePicker)
+    }
+
+    private fun emptyDefaultState(): SearchState = SearchState(
+        query = "",
+        searchEngineSource = mockk(),
+        showShortcutEnginePicker = false,
+        showSuggestions = false,
+        showVisitedSitesBookmarks = false,
+        session = null
+    )
+}


### PR DESCRIPTION
Follow-up for https://github.com/mozilla-mobile/fenix/pull/3985 to add unit tests for the new `SearchStore`. 

I've changed the name of `SearchShortcutEnginePicker` to `ShowSearchShortcutEnginePicker` to contain a verb and sound more like an action, but feedback / better name suggestions welcome :).