### PR TITLE
Closes #4052: Remove pending intent workaround.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -109,7 +109,6 @@ class BrowserFragment : Fragment(), BackHandler {
     private var tabCollectionObserver: Observer<List<TabCollection>>? = null
     private var sessionObserver: Session.Observer? = null
     private var sessionManagerObserver: SessionManager.Observer? = null
-    private var pendingOpenInBrowserIntent: Intent? = null
 
     private val sessionFeature = ViewBoundFeatureWrapper<SessionFeature>()
     private val contextMenuFeature = ViewBoundFeatureWrapper<ContextMenuFeature>()
@@ -631,10 +630,6 @@ class BrowserFragment : Fragment(), BackHandler {
         sessionManagerObserver?.let {
             requireComponents.core.sessionManager.unregister(it)
         }
-        pendingOpenInBrowserIntent?.let {
-            startActivity(it)
-            pendingOpenInBrowserIntent = null
-        }
     }
 
     override fun onBackPressed(): Boolean {
@@ -743,7 +738,7 @@ class BrowserFragment : Fragment(), BackHandler {
                 (BottomSheetBehavior.from(nestedScrollQuickAction as View) as QuickActionSheetBehavior).apply {
                     state = BottomSheetBehavior.STATE_COLLAPSED
                 }
-                FindInPageIntegration.launch?.invoke()
+                findInPageIntegration.get()?.launch()
                 requireComponents.analytics.metrics.track(Event.FindInPageOpened)
             }
             ToolbarMenu.Item.ReportIssue -> getSessionById()?.let { session ->
@@ -779,10 +774,10 @@ class BrowserFragment : Fragment(), BackHandler {
                 }
 
                 // Switch to the actual browser which should now display our new selected session
-                pendingOpenInBrowserIntent = Intent(context, IntentReceiverActivity::class.java).also {
+                startActivity(Intent(context, IntentReceiverActivity::class.java).also {
                     it.action = Intent.ACTION_VIEW
                     it.flags = Intent.FLAG_ACTIVITY_NEW_TASK
-                }
+                })
 
                 // Close this activity since it is no longer displaying any session
                 activity?.finish()

--- a/app/src/main/java/org/mozilla/fenix/components/FindInPageIntegration.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/FindInPageIntegration.kt
@@ -31,14 +31,10 @@ class FindInPageIntegration(
 
     override fun start() {
         feature.start()
-
-        FindInPageIntegration.launch = this::launch
     }
 
     override fun stop() {
         feature.stop()
-
-        FindInPageIntegration.launch = null
     }
 
     override fun onBackPressed(): Boolean {
@@ -50,7 +46,7 @@ class FindInPageIntegration(
         view.asView().visibility = View.GONE
     }
 
-    private fun launch() {
+    fun launch() {
         sessionManager.runWithSessionIdOrSelected(sessionId) {
             if (!it.isCustomTabSession()) {
                 toolbar.visibility = View.GONE
@@ -58,15 +54,6 @@ class FindInPageIntegration(
             view.asView().visibility = View.VISIBLE
             feature.bind(it)
         }
-    }
-
-    companion object {
-        // This is a workaround to let the menu item find this integration and active "Find in Page" mode. That's a bit
-        // ridiculous and there's no need that we create the toolbar menu items at app start time. Instead the
-        // ToolbarIntegration should create them and get the FindInPageIntegration injected as a dependency if the
-        // menu items need them.
-        var launch: (() -> Unit)? = null
-            private set
     }
 }
 


### PR DESCRIPTION
Previously we needed to set a static launch function to be invoked when the find in page
integration should be launched. Now we can access the integration class directly and
can avoid the static property that caused issues when used by multiple activities.