### PR TITLE
Breaking changes in feature-tab-collections restore

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -496,46 +496,23 @@ class HomeFragment : Fragment(), AccountObserver {
             }
             is CollectionAction.OpenTab -> {
                 invokePendingDeleteJobs()
-                val session = action.tab.restore(
+                val snapshot = action.tab.restore(
                     context = context!!,
                     engine = requireComponents.core.engine,
                     tab = action.tab,
                     restoreSessionId = false
                 )
-                if (session == null) {
-                    // We were unable to create a snapshot, so just load the tab instead
-                    (activity as HomeActivity).openToBrowserAndLoad(
-                        searchTermOrURL = action.tab.url,
-                        newTab = true,
-                        from = BrowserDirection.FromHome
-                    )
-                } else {
-                    requireComponents.core.sessionManager.add(
-                        session,
-                        true
-                    )
-                    (activity as HomeActivity).openToBrowser(BrowserDirection.FromHome)
-                }
+                sessionManager.restore(snapshot)
+                (activity as HomeActivity).openToBrowser(BrowserDirection.FromHome)
             }
             is CollectionAction.OpenTabs -> {
                 invokePendingDeleteJobs()
-                action.collection.tabs.forEach {
-                    val session = it.restore(
-                        context = context!!,
-                        engine = requireComponents.core.engine,
-                        tab = it,
-                        restoreSessionId = false
-                    )
-                    if (session == null) {
-                        // We were unable to create a snapshot, so just load the tab instead
-                        requireComponents.useCases.tabsUseCases.addTab.invoke(it.url)
-                    } else {
-                        requireComponents.core.sessionManager.add(
-                            session,
-                            requireComponents.core.sessionManager.selectedSession == null
-                        )
-                    }
-                }
+                val snapshot = action.collection.restore(
+                    context = context!!,
+                    engine = requireComponents.core.engine,
+                    restoreSessionId = false
+                )
+                sessionManager.restore(snapshot)
                 viewLifecycleOwner.lifecycleScope.launch {
                     delay(ANIM_SCROLL_DELAY)
                     sessionControlComponent.view.smoothScrollToPosition(0)


### PR DESCRIPTION
`restore` now returns a `SessionSnapshot`, so the code in `HomeFragment` can be simplified.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
