### PR TITLE
Use Raptor release now that GV release is used

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -446,7 +446,7 @@ task printBuildVariants {
 
 task printGeckoviewVersions {
     doLast {
-        println "beta: " + groovy.json.JsonOutput.toJson(GeckoVersions.beta_version)
+        println "release: " + groovy.json.JsonOutput.toJson(GeckoVersions.release_version)
     }
 }
 

--- a/automation/taskcluster/decision_task.py
+++ b/automation/taskcluster/decision_task.py
@@ -85,8 +85,8 @@ def raptor(is_staging):
     signing_tasks = {}
     other_tasks = {}
 
-    geckoview_beta_version = get_geckoview_versions()['beta']
-    mozharness_task_id = fetch_mozharness_task_id(geckoview_beta_version)
+    geckoview_version = get_geckoview_versions()
+    mozharness_task_id = fetch_mozharness_task_id(geckoview_version)
     gecko_revision = taskcluster.Queue().task(mozharness_task_id)['payload']['env']['GECKO_HEAD_REV']
 
     for variant in [Variant.from_values(abi, False, 'forPerformanceTest') for abi in ('aarch64', 'arm')]:

--- a/automation/taskcluster/lib/gradle.py
+++ b/automation/taskcluster/lib/gradle.py
@@ -28,14 +28,12 @@ def get_geckoview_versions():
     print("Fetching geckoview version from gradle")
     output = _run_gradle_process('printGeckoviewVersions')
 
-    versions = {}
-    for version_type in ('beta',):
-        version = _extract_content_from_command_output(output, prefix='{}: '.format(version_type))
-        version = version.strip('"')
-        versions[version_type] = version
-        print('Got {} version: "{}"'.format(version_type, version))
+    version_type = 'release'
+    version = _extract_content_from_command_output(output, prefix='{}: '.format(version_type))
+    version = version.strip('"')
+    print('Got geckoview {} version: "{}"'.format(version_type, version))
 
-    return versions
+    return version
 
 
 def _run_gradle_process(gradle_command):

--- a/automation/taskcluster/lib/tasks.py
+++ b/automation/taskcluster/lib/tasks.py
@@ -580,7 +580,7 @@ class TaskBuilder(object):
                         "test_packages_url": "{}/{}/artifacts/public/build/en-US/target.test_packages.json".format(_DEFAULT_TASK_URL, mozharness_task_id),
                         "installer_url": apk_url,
                     }),
-                    "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/releases/mozilla-beta",
+                    "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/releases/mozilla-release",
                     "GECKO_HEAD_REV": gecko_revision,
                     "MOZ_AUTOMATION": "1",
                     "MOZ_HIDE_RESULTS_TABLE": "1",
@@ -600,7 +600,7 @@ class TaskBuilder(object):
                 },
                 "mounts": [{
                     "content": {
-                        "url": "https://hg.mozilla.org/releases/mozilla-beta/raw-file/{}/taskcluster/scripts/tester/test-linux.sh".format(gecko_revision),
+                        "url": "https://hg.mozilla.org/releases/mozilla-release/raw-file/{}/taskcluster/scripts/tester/test-linux.sh".format(gecko_revision),
                     },
                     "file": "test-linux.sh",
                 }]
@@ -655,7 +655,7 @@ def schedule_task_graph(ordered_groups_of_tasks):
 
 
 def fetch_mozharness_task_id(geckoview_beta_version):
-    raptor_index = 'gecko.v2.mozilla-beta.geckoview-version.{}.mobile.android-x86_64-beta-opt'.format(
+    raptor_index = 'gecko.v2.mozilla-release.geckoview-version.{}.mobile.android-x86_64-beta-opt'.format(
         geckoview_beta_version
     )
     return taskcluster.Index().findTask(raptor_index)['taskId']


### PR DESCRIPTION
Fixes https://treeherder.mozilla.org/logviewer.html#/jobs?job_id=256659101&repo=fenix&lineNumber=387 (found by @davehunt) 

Fallout of https://github.com/mozilla-mobile/fenix/pull/4020. cc @pocmo @boek 

I tested the decision task locally. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
