### PR TITLE
Use Mozilla Android Components 4.0.0.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -450,9 +450,7 @@ task printGeckoviewVersions {
     }
 }
 
-// Normally this should use the same version as the glean dependency. But since we are currently using AC snapshots we
-// can't reference a git tag with a specific version here. So we are just using "master" and hoping for the best.
-apply from: 'https://github.com/mozilla-mobile/android-components/raw/master/components/service/glean/scripts/sdk_generator.gradle'
+apply from: 'https://github.com/mozilla-mobile/android-components/raw/v' + Versions.mozilla_android_components + '/components/service/glean/scripts/sdk_generator.gradle'
 
 // For production builds, the native code for all `org.mozilla.appservices` dependencies gets compiled together
 // into a single "megazord" build, and different megazords are published for different subsets of features.

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-private object Versions {
+object Versions {
     const val kotlin = "1.3.30"
     const val coroutines = "1.2.1"
     const val android_gradle_plugin = "3.4.1"
@@ -33,7 +33,7 @@ private object Versions {
     const val androidx_work = "2.0.1"
     const val google_material = "1.1.0-alpha07"
 
-    const val mozilla_android_components = "4.0.0-SNAPSHOT"
+    const val mozilla_android_components = "4.0.0"
     // Note that android-components also depends on application-services,
     // and in fact is our main source of appservices-related functionality.
     // The version number below tracks the application-services version


### PR DESCRIPTION
4.0.0 was released today and is the version we should ship Fenix 1.1 RC 1 with. If there are AC related release blockers coming up during QA testing then we will ship 4.0.x dot releases to address them and keep the risk low.