### PR TITLE
Closes #4114 - Re-enable app-links for non-http schemes.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -240,7 +240,7 @@ class BrowserFragment : Fragment(), BackHandler {
                 requireContext(),
                 sessionManager = sessionManager,
                 sessionId = customTabSessionId,
-                interceptLinkClicks = false,
+                interceptLinkClicks = true,
                 fragmentManager = requireFragmentManager()
             ),
             owner = this,


### PR DESCRIPTION
Closes #4114.

This PR is simple. This re-enables the interception of links by `feature-app-links`.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
