### PR TITLE
Closes #1331 - Filter consecutive history items using simplified URL

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/ext/String.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/String.kt
@@ -43,3 +43,20 @@ fun String.urlToTrimmedHost(context: Context): String {
         this
     }
 }
+
+/**
+ * Trims a URL string of its scheme and common prefixes.
+ *
+ * This is intended to act much like [PublicSuffixList.getPublicSuffixPlusOne()] but unlike
+ * that method, leaves the path, anchor, etc intact.
+ *
+ */
+fun String.simplifiedUrl(): String {
+    val afterScheme = this.substringAfter("://")
+    for (prefix in listOf("www.", "m.", "mobile.")) {
+        if (afterScheme.startsWith(prefix)) {
+            return afterScheme.substring(prefix.length)
+        }
+    }
+    return afterScheme
+}

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragment.kt
@@ -40,6 +40,7 @@ import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.getHostFromUrl
 import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.requireComponents
+import org.mozilla.fenix.ext.simplifiedUrl
 import org.mozilla.fenix.share.ShareTab
 import java.util.concurrent.TimeUnit
 
@@ -261,12 +262,20 @@ class HistoryFragment : Fragment(), BackHandler {
         // Until we have proper pagination, only display a limited set of history to avoid blowing up the UI.
         // See https://github.com/mozilla-mobile/fenix/issues/1393
         val sinceTimeMs = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(HISTORY_TIME_DAYS)
+        var previous: String? = null
+
         val items = requireComponents.core.historyStorage
             .getDetailedVisits(sinceTimeMs, excludeTypes = excludeTypes)
             // We potentially have a large amount of visits, and multiple processing steps.
             // Wrapping iterator in a sequence should make this a little memory-more efficient.
             .asSequence()
             .sortedByDescending { it.visitTime }
+            .filter {
+                val current = it.url.simplifiedUrl()
+                val isNotDuplicate = current != previous
+                previous = current
+                isNotDuplicate
+            }
             .mapIndexed { id, item ->
                 val title = item.title
                     ?.takeIf(String::isNotEmpty)


### PR DESCRIPTION
Closes #1331.

This PR introduces a string extension to strip a URL of its scheme and common prefixes.

There are going to be still occasions where this is not enough to de-dupe e.g. t.co/ -> bbc.co.uk -> bbc.com, but it's fixes the issue at hand.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- ~[ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~
