### PR TITLE
For #4066: Provide lazy inflation of Find In Page View

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -214,7 +214,7 @@ class BrowserFragment : Fragment(), BackHandler {
                 feature = FindInPageIntegration(
                     sessionManager = requireComponents.core.sessionManager,
                     sessionId = customTabSessionId,
-                    view = view.findInPageView,
+                    stub = view.stub_find_in_page,
                     engineView = view.engineView,
                     toolbar = toolbar
                 ),

--- a/app/src/main/java/org/mozilla/fenix/components/FindInPageIntegration.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/FindInPageIntegration.kt
@@ -5,8 +5,11 @@
 package org.mozilla.fenix.components
 
 import android.content.Context
+import android.os.Looper
 import android.util.AttributeSet
 import android.view.View
+import android.view.ViewStub
+import androidx.annotation.UiThread
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.session.runWithSessionIdOrSelected
@@ -19,40 +22,50 @@ import mozilla.components.support.base.feature.BackHandler
 import mozilla.components.support.base.feature.LifecycleAwareFeature
 import org.mozilla.fenix.test.Mockable
 
+/**
+ * This class provides lazy loading of the Find in Page View.
+ * It should be launched on the app's UI thread.
+ */
 @Mockable
 class FindInPageIntegration(
     private val sessionManager: SessionManager,
     private val sessionId: String? = null,
-    private val view: FindInPageView,
+    private val stub: ViewStub,
     engineView: EngineView,
     private val toolbar: BrowserToolbar
 ) : LifecycleAwareFeature, BackHandler {
-    private val feature = FindInPageFeature(sessionManager, view, engineView, ::onClose)
+
+    private var view: FindInPageView? = null
+    private val feature: FindInPageFeature by lazy(LazyThreadSafetyMode.NONE) {
+        view = stub.inflate() as FindInPageView
+        FindInPageFeature(sessionManager, view!!, engineView, ::onClose).also { it.start() }
+    }
 
     override fun start() {
-        feature.start()
     }
 
     override fun stop() {
-        feature.stop()
+        if (view != null) feature.stop()
     }
 
     override fun onBackPressed(): Boolean {
-        return feature.onBackPressed()
+        return if (view != null) feature.onBackPressed() else false
     }
 
     private fun onClose() {
         toolbar.visibility = View.VISIBLE
-        view.asView().visibility = View.GONE
+        view?.asView()?.visibility = View.GONE
     }
 
+    @UiThread
     fun launch() {
+        require(Looper.myLooper() == Looper.getMainLooper()) { "This method should be run on the main UI thread." }
         sessionManager.runWithSessionIdOrSelected(sessionId) {
             if (!it.isCustomTabSession()) {
                 toolbar.visibility = View.GONE
             }
-            view.asView().visibility = View.VISIBLE
             feature.bind(it)
+            view?.asView()?.visibility = View.VISIBLE
         }
     }
 }

--- a/app/src/main/res/layout/fragment_browser.xml
+++ b/app/src/main/res/layout/fragment_browser.xml
@@ -4,7 +4,6 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:mozac="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/browserLayout"
     android:layout_width="match_parent"
@@ -31,17 +30,13 @@
         app:behavior_peekHeight="12dp"
         app:layout_behavior="org.mozilla.fenix.quickactionsheet.QuickActionSheetBehavior" />
 
-    <mozilla.components.feature.findinpage.view.FindInPageBar
-        android:id="@+id/findInPageView"
-        android:layout_width="match_parent"
-        android:layout_height="56dp"
+    <ViewStub
+        android:id="@+id/stub_find_in_page"
+        android:inflatedId="@+id/findInPageView"
+        android:layout="@layout/stub_find_in_page"
         android:layout_gravity="bottom"
-        android:background="?foundation"
-        android:clickable="true"
-        android:visibility="gone"
-        app:findInPageNoMatchesTextColor="?attr/destructive"
-        mozac:findInPageButtonsTint="?primaryText"
-        mozac:findInPageResultCountTextColor="?primaryText" />
+        android:layout_width="match_parent"
+        android:layout_height="56dp" />
 
     <mozilla.components.feature.readerview.view.ReaderViewControlsBar
         android:id="@+id/readerViewControlsBar"

--- a/app/src/main/res/layout/stub_find_in_page.xml
+++ b/app/src/main/res/layout/stub_find_in_page.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<mozilla.components.feature.findinpage.view.FindInPageBar xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/findInPageView"
+    android:layout_width="match_parent"
+    android:layout_height="56dp"
+    android:layout_gravity="bottom"
+    android:background="?foundation"
+    android:clickable="true"
+    android:focusable="true"
+    app:findInPageNoMatchesTextColor="?attr/destructive"
+    app:findInPageButtonsTint="?primaryText"
+    app:findInPageResultCountTextColor="?primaryText" />


### PR DESCRIPTION
This performance change prevents the unconditional inflation of the Find in Page View, saving 15-30ms on every browser load by lazy loading it.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
