### PR TITLE
Closes #4096: IllegalStateException in SearchFragment

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
@@ -19,14 +19,14 @@ import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.whenStarted
 import androidx.navigation.fragment.findNavController
 import kotlinx.android.synthetic.main.fragment_search.*
 import kotlinx.android.synthetic.main.fragment_search.view.*
-import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
 import mozilla.components.concept.storage.HistoryStorage
 import mozilla.components.feature.qr.QrFeature
-import mozilla.components.lib.state.Store
 import mozilla.components.lib.state.ext.observe
 import mozilla.components.support.base.feature.BackHandler
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
@@ -74,7 +74,7 @@ class SearchFragment : Fragment(), BackHandler {
 
         searchStore = StoreProvider.get(
             this,
-            Store(
+            SearchStore(
                 SearchState(
                 query = url,
                 showShortcutEnginePicker = false,
@@ -83,8 +83,7 @@ class SearchFragment : Fragment(), BackHandler {
                 ),
                 showSuggestions = Settings.getInstance(requireContext()).showSearchSuggestions,
                 showVisitedSitesBookmarks = Settings.getInstance(requireContext()).shouldShowVisitedSitesBookmarks,
-                session = session),
-                ::searchStateReducer
+                session = session)
             )
         )
 
@@ -168,12 +167,14 @@ class SearchFragment : Fragment(), BackHandler {
         }
 
         searchStore.observe(view) {
-            MainScope().launch {
-                awesomeBarView.update(it)
-                toolbarView.update(it)
-                updateSearchEngineIcon(it)
-                updateSearchShortuctsIcon(it)
-                updateSearchWithLabel(it)
+            viewLifecycleOwner.lifecycleScope.launch {
+                whenStarted {
+                    awesomeBarView.update(it)
+                    toolbarView.update(it)
+                    updateSearchEngineIcon(it)
+                    updateSearchShortuctsIcon(it)
+                    updateSearchWithLabel(it)
+                }
             }
         }
 

--- a/app/src/main/java/org/mozilla/fenix/search/SearchStore.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchStore.kt
@@ -11,9 +11,14 @@ import mozilla.components.lib.state.State
 import mozilla.components.lib.state.Store
 
 /**
- * An alias to make it easier to work with `Store<SearchState, SearchAction>`
+ * The [Store] for holding the [SearchState] and applying [SearchAction]s.
  */
-typealias SearchStore = Store<SearchState, SearchAction>
+class SearchStore(
+    initialState: SearchState
+) : Store<SearchState, SearchAction>(
+    initialState,
+    ::searchStateReducer
+)
 
 /**
  * Wraps a `SearchEngine` to give consumers the context that it was selected as a shortcut

--- a/app/src/test/java/org/mozilla/fenix/search/SearchStoreTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/search/SearchStoreTest.kt
@@ -16,7 +16,7 @@ class SearchStoreTest {
     @Test
     fun updateQuery() = runBlocking {
         val initialState = emptyDefaultState()
-        val store = SearchStore(initialState, ::searchStateReducer)
+        val store = SearchStore(initialState)
         val query = "test query"
 
         store.dispatch(SearchAction.UpdateQuery(query)).join()
@@ -27,7 +27,7 @@ class SearchStoreTest {
     @Test
     fun selectSearchShortcutEngine() = runBlocking {
         val initialState = emptyDefaultState()
-        val store = SearchStore(initialState, ::searchStateReducer)
+        val store = SearchStore(initialState)
         val searchEngine: SearchEngine = mockk()
 
         store.dispatch(SearchAction.SearchShortcutEngineSelected(searchEngine)).join()
@@ -38,7 +38,7 @@ class SearchStoreTest {
     @Test
     fun showSearchShortcutEnginePicker() = runBlocking {
         val initialState = emptyDefaultState()
-        val store = SearchStore(initialState, ::searchStateReducer)
+        val store = SearchStore(initialState)
 
         store.dispatch(SearchAction.ShowSearchShortcutEnginePicker(true)).join()
         assertNotSame(initialState, store.state)


### PR DESCRIPTION
There were two problems here:

- The `::searchStateReducer` method reference inside the `SearchFragment.onViewCreated` was leaking the fragment instance via the `Store`
- There's a bug in A-C where we notify a view bound observer whether or not the view is attached. I am addressing this here so we can fix the crash right away. We'll land a fix (and improved API) in A-C tomorrow

See also https://github.com/mozilla-mobile/android-components/issues/3803.

Luckily, the crash was easy to reproduce:
- Type and trigger a search
- Open settings menu and click "Private tab"

@pocmo and I also ran RoboTest to verify we no longer see the crash with these fixes.

