### PR TITLE
For #4094 - Improved original PR to fix screenshots tests API21

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
@@ -16,6 +16,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import androidx.test.espresso.matcher.ViewMatchers.Visibility
 import org.hamcrest.CoreMatchers
+import org.mozilla.fenix.R
 
 /**
  * Implementation of Robot Pattern for the settings menu.
@@ -50,3 +51,5 @@ private fun assertAdvancedHeading() = onView(ViewMatchers.withText("Advanced"))
     .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
 private fun goBackButton() = onView(CoreMatchers.allOf(withContentDescription("Navigate up")))
+
+fun swipeToBottom() = onView(ViewMatchers.withId(R.id.recycler_view)).perform(ViewActions.swipeUp())

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuRobot.kt
@@ -39,7 +39,7 @@ class ThreeDotMenuRobot {
         private val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
 
         fun openSettings(interact: SettingsRobot.() -> Unit): SettingsRobot.Transition {
-            mDevice.wait(Until.findObject(By.text("Settings")), waitingTime)
+            mDevice.wait(Until.findObject(By.text("R.string.settings")), waitingTime)
             settingsButton().click()
 
             SettingsRobot().interact()
@@ -47,7 +47,7 @@ class ThreeDotMenuRobot {
         }
 
         fun openLibrary(interact: LibraryRobot.() -> Unit): LibraryRobot.Transition {
-            mDevice.wait(Until.findObject(By.text("Library")), waitingTime)
+            mDevice.wait(Until.findObject(By.text("R.string.Library")), waitingTime)
             libraryButton().click()
 
             LibraryRobot().interact()
@@ -90,7 +90,7 @@ class ThreeDotMenuRobot {
 private fun threeDotMenuRecyclerViewExists() {
     onView(withId(R.id.mozac_browser_menu_recyclerView)).check(matches(isDisplayed()))
 }
-private fun settingsButton() = onView(allOf(withText("Settings")))
+private fun settingsButton() = onView(allOf(withText(R.string.settings)))
 private fun assertSettingsButton() = settingsButton()
     .check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/screenshots/ThreeDotMenuScreenShotTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/screenshots/ThreeDotMenuScreenShotTest.kt
@@ -9,19 +9,14 @@ import org.junit.Test
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.HomeActivityTestRule
+import org.mozilla.fenix.helpers.TestAssetHelper
 
 import tools.fastlane.screengrab.Screengrab
 import tools.fastlane.screengrab.locale.LocaleTestRule
 
-import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.action.ViewActions
-import androidx.test.espresso.action.ViewActions.click
-import androidx.test.espresso.action.ViewActions.swipeUp
-import androidx.test.espresso.matcher.ViewMatchers.withId
-
 import br.com.concretesolutions.kappuccino.actions.ClickActions
-import org.hamcrest.Matchers.allOf
 import org.mozilla.fenix.ui.robots.homeScreen
+import org.mozilla.fenix.ui.robots.swipeToBottom
 
 class ThreeDotMenuScreenShotTest : ScreenshotTest() {
     @Rule @JvmField
@@ -37,7 +32,8 @@ class ThreeDotMenuScreenShotTest : ScreenshotTest() {
 
     @Test
     fun threeDotMenu() {
-        onView(allOf(withId(R.id.menuButton))).perform(click())
+        homeScreen {
+        }.openThreeDotMenu { }
         Screengrab.screenshot("three-dot-menu")
         device.pressBack()
     }
@@ -46,11 +42,10 @@ class ThreeDotMenuScreenShotTest : ScreenshotTest() {
     fun settingsTest() {
         homeScreen {
         }.openThreeDotMenu {
-        }
-        settingsButton2()
+        }.openSettings { }
         Screengrab.screenshot("settings")
 
-        SystemClock.sleep(1000)
+        SystemClock.sleep(TestAssetHelper.waitingTime)
         settingsAccount()
         Screengrab.screenshot("settings-sync")
         device.pressBack()
@@ -76,23 +71,16 @@ class ThreeDotMenuScreenShotTest : ScreenshotTest() {
     fun settingsAfterScrollMenusTest() {
         homeScreen {
         }.openThreeDotMenu {
+        }.openSettings {
+            swipeToBottom()
         }
-        settingsButton2()
-        SystemClock.sleep(1000)
-        onView(withId(R.id.switch_widget)).perform(ViewActions.swipeUp())
-        onView(withId(R.id.switch_widget)).perform(ViewActions.swipeUp())
-        Screengrab.screenshot("settings-scroll")
-        SystemClock.sleep(2000)
+        Screengrab.screenshot("settings-scroll-to-bottom")
+        SystemClock.sleep(TestAssetHelper.waitingTime)
 
         settingsRemoveData()
         Screengrab.screenshot("settings-delete-browsing-data")
         device.pressBack()
-
-        SystemClock.sleep(1000)
-        onView(withId(R.id.switch_widget)).perform(ViewActions.swipeUp())
-        onView(withId(R.id.switch_widget)).perform(ViewActions.swipeUp())
-        Screengrab.screenshot("settings-scroll")
-        SystemClock.sleep(3000)
+        SystemClock.sleep(TestAssetHelper.waitingTime)
 
         settingsTelemetry()
         Screengrab.screenshot("settings-telemetry")
@@ -100,34 +88,12 @@ class ThreeDotMenuScreenShotTest : ScreenshotTest() {
     }
 
     @Test
-    fun settingsScrollToBottomTest() {
-        homeScreen {
-        }.openThreeDotMenu {
-        }
-        settingsButton2()
-        SystemClock.sleep(1000)
-        onView(withId(R.id.switch_widget)).perform(ViewActions.swipeUp())
-        onView(withId(R.id.switch_widget)).perform(ViewActions.swipeUp())
-        onView(withId(R.id.switch_widget)).perform(ViewActions.swipeUp())
-        Screengrab.screenshot("settings-scroll2")
-        SystemClock.sleep(1000)
-
-        onView(withId(R.id.switch_widget)).perform(ViewActions.swipeUp())
-        onView(withId(R.id.switch_widget)).perform(ViewActions.swipeUp())
-        Screengrab.screenshot("settings-scroll3")
-        SystemClock.sleep(1000)
-
-        onView(withId(R.id.recycler_view)).perform(swipeUp())
-        Screengrab.screenshot("settings-scroll4")
-    }
-
-    @Test
     fun libraryTest() {
         homeScreen {
         }.openThreeDotMenu {
-        }
-        libraryButton()
+        }.openLibrary { }
         Screengrab.screenshot("library")
+
         bookmarksButton()
         Screengrab.screenshot("library-bookmarks")
         device.pressBack()
@@ -136,8 +102,6 @@ class ThreeDotMenuScreenShotTest : ScreenshotTest() {
     }
 }
 
-fun settingsButton2() = ClickActions.click { text(R.string.settings) }
-fun libraryButton() = ClickActions.click { text(R.string.browser_menu_your_library) }
 fun bookmarksButton() = ClickActions.click { text(R.string.library_bookmarks) }
 fun historyButton() = ClickActions.click { text(R.string.library_history) }
 fun settingsAccount() = ClickActions.click { text(R.string.preferences_sync) }


### PR DESCRIPTION
use robot for three dot menu screenshot

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x ] **Tests**: This PR includes thorough tests or an explanation of why it does not

Tests are passing on Firebase for both [API21](https://console.firebase.google.com/project/moz-fx-mobile-firebase-testlab/testlab/histories/bh.dee052bb5e1bdd86/matrices/6851263798743099237) and [API28](https://console.firebase.google.com/project/moz-fx-mobile-firebase-testlab/testlab/histories/bh.dee052bb5e1bdd86/matrices/6667186957969251427)

Previous PR #4138 was reverted due to unrelated issues and closed so I'm crating this new one with the improvements requested in that PR: 

- Screenshots tests are using the existing Robots. Once the new ones are added, they will be added to the tests too. In order to do that I had to modify two of the implemented robots so that elements are accessed by string and not text, otherwise tests will not work in other languages @rpappalax please confirm this is fine with the robots implementation
- Some actions (like swipeUp) added to existing robots
- Timeout used is the one given by the `TestAssetHelper`

I think that's all, please let me know if I'm missing something else...Thanks!