### PR TITLE
Update to use Mozilla Android Components 4.0.1.

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -33,7 +33,7 @@ object Versions {
     const val androidx_work = "2.0.1"
     const val google_material = "1.1.0-alpha07"
 
-    const val mozilla_android_components = "4.0.0"
+    const val mozilla_android_components = "4.0.1"
     // Note that android-components also depends on application-services,
     // and in fact is our main source of appservices-related functionality.
     // The version number below tracks the application-services version


### PR DESCRIPTION
Updating Mozilla Android Components from 4.0.0 to 4.0.1. It is recommended to perform this update before building Fenix 1.1 RC 1.

* Changelog: https://mozac.org/changelog/#401
* Commits: https://github.com/mozilla-mobile/android-components/compare/v4.0.0...v4.0.1

This update contains a fix for Glean (Fenix #4082; [Bug 1566764](https://bugzilla.mozilla.org/show_bug.cgi?id=1566764)) and updated translations.