### PR TITLE
For #4124 - Remove browser toolbar editing code

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -31,7 +31,6 @@ import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.component_search.*
 import kotlinx.android.synthetic.main.fragment_browser.*
 import kotlinx.android.synthetic.main.fragment_browser.view.*
-import kotlinx.android.synthetic.main.fragment_search.*
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.Dispatchers.Main
 import kotlinx.coroutines.Job
@@ -152,17 +151,14 @@ class BrowserFragment : Fragment(), BackHandler {
 
         toolbarComponent = ToolbarComponent(
             view.browserLayout,
-            ActionBusFactory.get(this), customTabSessionId,
+            ActionBusFactory.get(this),
+            customTabSessionId,
             (activity as HomeActivity).browsingModeManager.isPrivate,
-            false,
-            search_engine_icon,
             FenixViewModelProvider.create(
                 this,
                 ToolbarViewModel::class.java
             ) {
-                ToolbarViewModel(
-                    SearchState("", getSessionById()?.searchTerms ?: "", isEditing = false)
-                )
+                ToolbarViewModel(SearchState())
             }
         )
 

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarComponent.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarComponent.kt
@@ -5,10 +5,8 @@
 package org.mozilla.fenix.components.toolbar
 
 import android.view.ViewGroup
-import android.widget.ImageView
 import androidx.core.content.ContextCompat
 import kotlinx.android.synthetic.main.component_search.*
-import mozilla.components.browser.search.SearchEngine
 import mozilla.components.browser.toolbar.BrowserToolbar
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ThemeManager
@@ -26,8 +24,6 @@ class ToolbarComponent(
     bus: ActionBusFactory,
     private val sessionId: String?,
     private val isPrivate: Boolean,
-    private val startInEditMode: Boolean,
-    private val engineIconView: ImageView? = null,
     viewModelProvider: UIComponentViewModelProvider<SearchState, SearchChange>
 ) :
     UIComponent<SearchState, SearchAction, SearchChange>(
@@ -41,11 +37,9 @@ class ToolbarComponent(
     override fun initView() = ToolbarUIView(
         sessionId,
         isPrivate,
-        startInEditMode,
         container,
         actionEmitter,
-        changesObservable,
-        engineIconView
+        changesObservable
     )
 
     init {
@@ -69,42 +63,19 @@ class ToolbarComponent(
     }
 }
 
-data class SearchState(
-    val query: String,
-    val searchTerm: String,
-    val isEditing: Boolean,
-    val engine: SearchEngine? = null,
-    val focused: Boolean = isEditing,
-    val isQueryUpdated: Boolean = false
-) : ViewState
+class SearchState : ViewState
 
 sealed class SearchAction : Action {
-    data class UrlCommitted(val url: String, val session: String?, val engine: SearchEngine? = null) : SearchAction()
-    data class TextChanged(val query: String) : SearchAction()
     object ToolbarClicked : SearchAction()
     data class ToolbarMenuItemTapped(val item: ToolbarMenu.Item) : SearchAction()
-    object EditingCanceled : SearchAction()
 }
 
-sealed class SearchChange : Change {
-    data class QueryTextChanged(val query: String) : SearchChange()
-    object ToolbarRequestedFocus : SearchChange()
-    object ToolbarClearedFocus : SearchChange()
-    data class SearchShortcutEngineSelected(val engine: SearchEngine) : SearchChange()
-}
+sealed class SearchChange : Change
 
 class ToolbarViewModel(initialState: SearchState) :
     UIComponentViewModelBase<SearchState, SearchChange>(initialState, reducer) {
 
     companion object {
-        val reducer: Reducer<SearchState, SearchChange> = { state, change ->
-            when (change) {
-                is SearchChange.QueryTextChanged -> state.copy(query = change.query, isQueryUpdated = true)
-                is SearchChange.ToolbarClearedFocus -> state.copy(focused = false)
-                is SearchChange.ToolbarRequestedFocus -> state.copy(focused = true)
-                is SearchChange.SearchShortcutEngineSelected ->
-                    state.copy(engine = change.engine)
-            }
-        }
+        val reducer: Reducer<SearchState, SearchChange> = { state, _ -> state }
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarUIView.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarUIView.kt
@@ -4,10 +4,8 @@
 
 package org.mozilla.fenix.components.toolbar
 
-import android.graphics.drawable.BitmapDrawable
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import android.widget.ImageView
 import androidx.core.content.ContextCompat
 import io.reactivex.Observable
 import io.reactivex.Observer
@@ -16,7 +14,6 @@ import mozilla.components.browser.domains.autocomplete.ShippedDomainsProvider
 import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.support.ktx.android.util.dpToFloat
 import mozilla.components.support.ktx.android.util.dpToPx
-import org.jetbrains.anko.backgroundDrawable
 import org.mozilla.fenix.R
 import org.mozilla.fenix.customtabs.CustomTabToolbarMenu
 import org.mozilla.fenix.ext.components
@@ -25,17 +22,13 @@ import org.mozilla.fenix.mvi.UIView
 class ToolbarUIView(
     sessionId: String?,
     isPrivate: Boolean,
-    startInEditMode: Boolean,
     container: ViewGroup,
     actionEmitter: Observer<SearchAction>,
-    changesObservable: Observable<SearchChange>,
-    private val engineIconView: ImageView? = null
+    changesObservable: Observable<SearchChange>
 ) :
     UIView<SearchState, SearchAction, SearchChange>(container, actionEmitter, changesObservable) {
 
     val toolbarIntegration: ToolbarIntegration
-    var state: SearchState? = null
-        private set
 
     override val view: BrowserToolbar = LayoutInflater.from(container.context)
         .inflate(R.layout.component_search, container, true)
@@ -48,18 +41,11 @@ class ToolbarUIView(
         val sessionManager = view.context.components.core.sessionManager
         val session = sessionId?.let { sessionManager.findSessionById(it) }
             ?: sessionManager.selectedSession
+        val isCustomTabSession = session?.isCustomTabSession() == true
 
         view.apply {
-            if (startInEditMode) {
-                editMode()
-            }
-
             elevation = TOOLBAR_ELEVATION.dpToFloat(resources.displayMetrics)
 
-            setOnUrlCommitListener {
-                actionEmitter.onNext(SearchAction.UrlCommitted(it, sessionId, state?.engine))
-            false
-            }
             onUrlClicked = {
                 actionEmitter.onNext(SearchAction.ToolbarClicked)
                 false
@@ -67,31 +53,16 @@ class ToolbarUIView(
 
             browserActionMargin = browserActionMarginDp.dpToPx(resources.displayMetrics)
 
-            val isCustomTabSession = (session?.isCustomTabSession() == true)
-
-            urlBoxView = if (isCustomTabSession) { null } else urlBackground
-            progressBarGravity = if (isCustomTabSession) { PROGRESS_BOTTOM } else PROGRESS_TOP
+            urlBoxView = if (isCustomTabSession) null else urlBackground
+            progressBarGravity = if (isCustomTabSession) PROGRESS_BOTTOM else PROGRESS_TOP
 
             textColor = ContextCompat.getColor(context, R.color.photonGrey30)
 
             hint = context.getString(R.string.search_hint)
-
-            setOnEditListener(object : mozilla.components.concept.toolbar.Toolbar.OnEditListener {
-                override fun onCancelEditing(): Boolean {
-                    actionEmitter.onNext(SearchAction.EditingCanceled)
-                    return false
-                }
-                override fun onTextChanged(text: String) {
-                    url = text
-                    actionEmitter.onNext(SearchAction.TextChanged(text))
-                }
-            })
         }
 
         with(view.context) {
-            val isCustom = session?.isCustomTabSession() ?: false
-
-            val menuToolbar = if (isCustom) {
+            val menuToolbar = if (isCustomTabSession) {
                 CustomTabToolbarMenu(
                     this,
                     sessionManager,
@@ -120,77 +91,7 @@ class ToolbarUIView(
         }
     }
 
-    override fun updateView() = Consumer<SearchState> {
-        var newState = it
-        if (shouldUpdateEngineIcon(newState)) {
-            updateEngineIcon(newState)
-        }
-
-        if (shouldClearSearchURL(it)) {
-            newState = SearchState("", "", it.isEditing, it.engine, it.focused, it.isQueryUpdated)
-        }
-
-        if (newState != it || shouldUpdateEditingState(newState)) {
-            updateEditingState(newState)
-        }
-
-        if (newState.focused) {
-            view.focus()
-        } else {
-            view.clearFocus()
-        }
-
-        state = newState
-    }
-
-    private fun shouldUpdateEngineIcon(newState: SearchState): Boolean {
-        return newState.isEditing && (engineDidChange(newState) || state == null)
-    }
-
-    private fun updateEngineIcon(newState: SearchState) {
-        with(view.context) {
-            val defaultEngineIcon = components.search.searchEngineManager.defaultSearchEngine?.icon
-            val searchIcon = newState.engine?.icon ?: defaultEngineIcon
-            val draw = BitmapDrawable(resources, searchIcon)
-            val iconSize =
-                containerView?.context!!.resources.getDimension(R.dimen.preference_icon_drawable_size).toInt()
-            draw.setBounds(0, 0, iconSize, iconSize)
-            engineIconView?.backgroundDrawable = draw
-        }
-    }
-
-    private fun shouldClearSearchURL(newState: SearchState): Boolean {
-        with(view.context) {
-            val defaultEngine = this
-                .components
-                .search
-                .searchEngineManager
-                .defaultSearchEngine
-
-            return (newState.engine != null && newState.engine != defaultEngine) ||
-                    (state?.engine != null && state?.engine != defaultEngine)
-        }
-    }
-
-    private fun shouldUpdateEditingState(newState: SearchState): Boolean {
-        return !engineDidChange(newState) && (state?.isEditing != newState.isEditing)
-    }
-
-    private fun updateEditingState(newState: SearchState) {
-        if (newState.isEditing) {
-            view.setSearchTerms(newState.searchTerm)
-            view.url = newState.query
-            if (!newState.isQueryUpdated) {
-                view.editMode()
-            }
-        } else {
-            view.displayMode()
-        }
-    }
-
-    private fun engineDidChange(newState: SearchState): Boolean {
-        return newState.engine != state?.engine
-    }
+    override fun updateView() = Consumer<SearchState> {}
 
     companion object {
         private const val TOOLBAR_ELEVATION = 16


### PR DESCRIPTION
@boek confirmed yesterday that the toolbar in the browser fragment is never actually used for editing, just display. (Instead, clicking directs to the search fragment.) This change removes all the code used just for editing, which never actually gets used.

This ends up removing most of search state, but I left basic empty classes and will leave a full refactor for later.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
