### PR TITLE
No issue: Add more useful test output to TaskCluster

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,6 +9,9 @@ apply from: "$project.rootDir/automation/gradle/versionCode.gradle"
 apply plugin: 'androidx.navigation.safeargs.kotlin'
 
 import com.android.build.gradle.internal.tasks.AppPreBuildTask
+import org.gradle.internal.logging.text.StyledTextOutput.Style
+import org.gradle.internal.logging.text.StyledTextOutputFactory
+import static org.gradle.api.tasks.testing.TestResult.ResultType
 
 android {
     compileSdkVersion 28
@@ -489,6 +492,48 @@ afterEvaluate {
                     dependency.useTarget(substitution)
                 }
             }
+        }
+    }
+
+    // Format test output. Ported from AC #2401
+    tasks.matching {it instanceof Test}.all {
+        systemProperty "robolectric.logging", "stdout"
+        systemProperty "logging.test-mode", "true"
+
+        testLogging.events = []
+
+        def out = services.get(StyledTextOutputFactory).create("tests")
+
+        beforeSuite { descriptor ->
+            if (descriptor.getClassName() != null) {
+                out.style(Style.Header).println("\nSUITE: " + descriptor.getClassName())
+            }
+        }
+
+        beforeTest { descriptor ->
+            out.style(Style.Description).println("  TEST: " + descriptor.getName())
+        }
+
+        onOutput { descriptor, event ->
+            logger.lifecycle("    " + event.message.trim())
+        }
+
+        afterTest { descriptor, result ->
+            switch (result.getResultType()) {
+                case ResultType.SUCCESS:
+                    out.style(Style.Success).println("  SUCCESS")
+                    break
+
+                case ResultType.FAILURE:
+                    out.style(Style.Failure).println("  FAILURE")
+                    logger.lifecycle("", result.getException())
+                    break
+
+                case ResultType.SKIPPED:
+                    out.style(Style.Info).println("  SKIPPED")
+                    break
+            }
+            logger.lifecycle("")
         }
     }
 }


### PR DESCRIPTION
This change lets us have TaskCluster logs that look more similar to those of Android Components. This means that we will actually see on a per unit test basis what is failing or passing!

This code is ported from [@pocmo's PR](https://github.com/mozilla-mobile/android-components/pull/2401)