### PR TITLE
fixes #4174 Talkback reads ' percent s' in strings with placeholders replaced by inline icon

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingPrivateBrowsingViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingPrivateBrowsingViewHolder.kt
@@ -41,6 +41,7 @@ class OnboardingPrivateBrowsingViewHolder(view: View) : RecyclerView.ViewHolder(
         }
 
         view.description_text.text = text
+        view.contentDescription = String.format(text.toString(), view.header_text.text)
     }
 
     class PrivateBrowsingImageSpan(


### PR DESCRIPTION
adds content description to 'browse privately' card, replacing placeholder %s with the header_text of card

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
