### PR TITLE
Update to use Mozilla Android Components 5.0.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -439,7 +439,7 @@ task printGeckoviewVersions {
     }
 }
 
-apply from: 'https://github.com/mozilla-mobile/android-components/raw/v' + Versions.mozilla_android_components + '/components/service/glean/scripts/sdk_generator.gradle'
+apply from: 'https://github.com/mozilla-mobile/android-components/raw/master/components/service/glean/scripts/sdk_generator.gradle'
 
 // For production builds, the native code for all `org.mozilla.appservices` dependencies gets compiled together
 // into a single "megazord" build, and different megazords are published for different subsets of features.

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -33,7 +33,7 @@ object Versions {
     const val androidx_work = "2.0.1"
     const val google_material = "1.1.0-alpha07"
 
-    const val mozilla_android_components = "4.0.1"
+    const val mozilla_android_components = "5.0.0-SNAPSHOT"
     // Note that android-components also depends on application-services,
     // and in fact is our main source of appservices-related functionality.
     // The version number below tracks the application-services version


### PR DESCRIPTION
Updating Mozilla Android Components from 4.0.1 to 5.0.0. 

* Changelog: https://mozac.org/changelog/#500
* Commits: https://github.com/mozilla-mobile/android-components/compare/v4.0.1...v5.0.0