### PR TITLE
For #4201 fix app crash on renaming a collection 

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/collections/CreateCollectionFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/collections/CreateCollectionFragment.kt
@@ -150,7 +150,7 @@ class CreateCollectionFragment : DialogFragment() {
                 is CollectionCreationAction.RenameCollection -> {
                     dismiss()
                     viewLifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
-                        requireComponents.core.tabCollectionStorage.renameCollection(it.collection, it.name)
+                        context?.components?.core?.tabCollectionStorage?.renameCollection(it.collection, it.name)
                         context?.components?.analytics?.metrics?.track(Event.CollectionRenamed)
                     }
                 }

--- a/app/src/main/java/org/mozilla/fenix/collections/CreateCollectionFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/collections/CreateCollectionFragment.kt
@@ -151,7 +151,7 @@ class CreateCollectionFragment : DialogFragment() {
                     dismiss()
                     viewLifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
                         requireComponents.core.tabCollectionStorage.renameCollection(it.collection, it.name)
-                        requireComponents.analytics.metrics.track(Event.CollectionRenamed)
+                        context?.components?.analytics?.metrics?.track(Event.CollectionRenamed)
                     }
                 }
             }


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

App crashed because fragment was not attached to context
