### PR TITLE
Fixes #2379 - Generic library selection

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/LibrarySiteItemView.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/LibrarySiteItemView.kt
@@ -13,10 +13,44 @@ import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.isVisible
 import kotlinx.android.synthetic.main.library_site_item.view.*
+import mozilla.components.browser.menu.BrowserMenu
+import mozilla.components.browser.menu.BrowserMenuBuilder
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.increaseTapArea
 import org.mozilla.fenix.ext.loadIntoView
+
+/**
+ * Interactor for items that can be selected on the bookmarks and history screens.
+ */
+interface SelectionInteractor<T> {
+    /**
+     * Called when an item is tapped to open it.
+     * @param item the tapped item to open.
+     */
+    fun open(item: T)
+
+    /**
+     * Called when an item is long pressed and selection mode is started,
+     * or when selection mode has already started an an item is tapped.
+     * @param item the item to select.
+     */
+    fun select(item: T)
+
+    /**
+     * Called when a selected item is tapped in selection mode and should no longer be selected.
+     * @param item the item to deselect.
+     */
+    fun deselect(item: T)
+}
+
+interface SelectionHolder<T> {
+    val selectedItems: Set<T>
+}
+
+interface LibraryItemMenu {
+    val menuBuilder: BrowserMenuBuilder
+}
 
 class LibrarySiteItemView @JvmOverloads constructor(
     context: Context,
@@ -61,6 +95,43 @@ class LibrarySiteItemView @JvmOverloads constructor(
 
     fun loadFavicon(url: String) {
         context.components.core.icons.loadIntoView(favicon, url)
+    }
+
+    fun attachMenu(menu: LibraryItemMenu) {
+        overflow_menu.setOnClickListener {
+            menu.menuBuilder.build(context).show(
+                anchor = it,
+                orientation = BrowserMenu.Orientation.DOWN
+            )
+        }
+    }
+
+    fun <T> setSelectionInteractor(item: T, holder: SelectionHolder<T>, interactor: SelectionInteractor<T>) {
+        setOnClickListener {
+            val selected = holder.selectedItems
+            when {
+                selected.isEmpty() -> interactor.open(item)
+                item in selected -> interactor.deselect(item)
+                else -> interactor.select(item)
+            }
+        }
+
+        setOnLongClickListener {
+            if (holder.selectedItems.isEmpty()) {
+                interactor.select(item)
+                true
+            } else {
+                false
+            }
+        }
+
+        favicon.setOnClickListener {
+            if (item in holder.selectedItems) {
+                interactor.deselect(item)
+            } else {
+                interactor.select(item)
+            }
+        }
     }
 
     enum class ItemType {

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragment.kt
@@ -153,7 +153,7 @@ class BookmarkFragment : LibraryPageFragment<BookmarkNode>(), BackHandler, Accou
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        when (val mode = bookmarkView.mode) {
+        when (val mode = bookmarkStore.state.mode) {
             BookmarkState.Mode.Normal -> {
                 inflater.inflate(R.menu.bookmarks_menu, menu)
             }

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkItemMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkItemMenu.kt
@@ -11,12 +11,13 @@ import mozilla.components.concept.storage.BookmarkNode
 import mozilla.components.concept.storage.BookmarkNodeType
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ThemeManager
+import org.mozilla.fenix.library.LibraryItemMenu
 
 class BookmarkItemMenu(
     private val context: Context,
     private val item: BookmarkNode,
     private val onItemTapped: (BookmarkItemMenu.Item) -> Unit = {}
-) {
+) : LibraryItemMenu {
 
     sealed class Item {
         object Edit : Item()
@@ -28,7 +29,7 @@ class BookmarkItemMenu(
         object Delete : Item()
     }
 
-    val menuBuilder by lazy { BrowserMenuBuilder(menuItems) }
+    override val menuBuilder by lazy { BrowserMenuBuilder(menuItems) }
 
     private val menuItems by lazy {
         listOfNotNull(

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkView.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkView.kt
@@ -13,13 +13,14 @@ import mozilla.components.concept.storage.BookmarkNode
 import mozilla.components.support.base.feature.BackHandler
 import org.mozilla.fenix.R
 import org.mozilla.fenix.library.LibraryPageView
+import org.mozilla.fenix.library.SelectionInteractor
 
 /**
  * Interface for the Bookmarks view.
  * This interface is implemented by objects that want to respond to user interaction on the bookmarks management UI.
  */
 @SuppressWarnings("TooManyFunctions")
-interface BookmarkViewInteractor {
+interface BookmarkViewInteractor : SelectionInteractor<BookmarkNode> {
 
     /**
      * Swaps the head of the bookmarks tree, replacing it with a new, updated bookmarks tree.
@@ -27,20 +28,6 @@ interface BookmarkViewInteractor {
      * @param node the head node of the new bookmarks tree
      */
     fun change(node: BookmarkNode)
-
-    /**
-     * Opens a tab for a bookmark item.
-     *
-     * @param item the bookmark item to open
-     */
-    fun open(item: BookmarkNode)
-
-    /**
-     * Expands a bookmark folder in the bookmarks tree, providing a view of a different folder elsewhere in the tree.
-     *
-     * @param folder the bookmark folder to expand
-     */
-    fun expand(folder: BookmarkNode)
 
     /**
      * Switches the current bookmark multi-selection mode.
@@ -55,20 +42,6 @@ interface BookmarkViewInteractor {
      * @param node the bookmark node to edit
      */
     fun edit(node: BookmarkNode)
-
-    /**
-     * Selects a bookmark node in multi-selection.
-     *
-     * @param node the bookmark node to select
-     */
-    fun select(node: BookmarkNode)
-
-    /**
-     * De-selects a bookmark node in multi-selection.
-     *
-     * @param node the bookmark node to deselect
-     */
-    fun deselect(node: BookmarkNode)
 
     /**
      * De-selects all bookmark nodes, clearing the multi-selection mode.
@@ -105,18 +78,11 @@ interface BookmarkViewInteractor {
     fun openInPrivateTab(item: BookmarkNode)
 
     /**
-     * Deletes a bookmark node.
+     * Deletes a set of bookmark node.
      *
-     * @param node the bookmark node to delete
+     * @param nodes the bookmark nodes to delete
      */
-    fun delete(node: BookmarkNode)
-
-    /**
-     * Deletes a set of bookmark nodes.
-     *
-     * @param nodes the set of bookmark nodes to delete
-     */
-    fun deleteMulti(nodes: Set<BookmarkNode>)
+    fun delete(nodes: Set<BookmarkNode>)
 
     /**
      * Handles back presses for the bookmark screen, so navigation up the tree is possible.
@@ -133,10 +99,8 @@ class BookmarkView(
     val view: View = LayoutInflater.from(container.context)
         .inflate(R.layout.component_bookmark, container, true)
 
-    var mode: BookmarkState.Mode = BookmarkState.Mode.Normal
-        private set
-    var tree: BookmarkNode? = null
-        private set
+    private var mode: BookmarkState.Mode = BookmarkState.Mode.Normal
+    private var tree: BookmarkNode? = null
     private var canGoBack = false
 
     private val bookmarkAdapter: BookmarkAdapter
@@ -157,7 +121,7 @@ class BookmarkView(
         }
 
         bookmarkAdapter.updateData(state.tree, mode)
-        when (state.mode) {
+        when (mode) {
             is BookmarkState.Mode.Normal ->
                 setUiForNormalMode(state.tree)
             is BookmarkState.Mode.Selecting ->

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/viewholders/BookmarkFolderViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/viewholders/BookmarkFolderViewHolder.kt
@@ -10,7 +10,7 @@ import mozilla.components.concept.storage.BookmarkNode
 import org.jetbrains.anko.image
 import org.mozilla.fenix.R
 import org.mozilla.fenix.library.LibrarySiteItemView
-import org.mozilla.fenix.library.bookmarks.BookmarkState
+import org.mozilla.fenix.library.SelectionHolder
 import org.mozilla.fenix.library.bookmarks.BookmarkViewInteractor
 import org.mozilla.fenix.library.bookmarks.inRoots
 
@@ -19,14 +19,15 @@ import org.mozilla.fenix.library.bookmarks.inRoots
  */
 class BookmarkFolderViewHolder(
     view: LibrarySiteItemView,
-    interactor: BookmarkViewInteractor
+    interactor: BookmarkViewInteractor,
+    private val selectionHolder: SelectionHolder<BookmarkNode>
 ) : BookmarkNodeViewHolder(view, interactor) {
 
-    override fun bind(item: BookmarkNode, mode: BookmarkState.Mode, selected: Boolean) {
+    override fun bind(item: BookmarkNode) {
 
         containerView.displayAs(LibrarySiteItemView.ItemType.FOLDER)
 
-        setClickListeners(mode, item, selected)
+        setSelectionListeners(item, selectionHolder)
 
         if (!item.inRoots()) {
             setupMenu(item)
@@ -34,31 +35,10 @@ class BookmarkFolderViewHolder(
             containerView.overflowView.visibility = View.GONE
         }
 
-        containerView.changeSelected(selected)
+        containerView.changeSelected(item in selectionHolder.selectedItems)
         containerView.iconView.image = containerView.context.getDrawable(R.drawable.ic_folder_icon)?.apply {
             setTint(ContextCompat.getColor(containerView.context, R.color.primary_text_light_theme))
         }
         containerView.titleView.text = item.title
-    }
-
-    private fun setClickListeners(
-        mode: BookmarkState.Mode,
-        item: BookmarkNode,
-        selected: Boolean
-    ) {
-        containerView.setOnClickListener {
-            when {
-                mode == BookmarkState.Mode.Normal -> interactor.expand(item)
-                selected -> interactor.deselect(item)
-                else -> interactor.select(item)
-            }
-        }
-
-        containerView.setOnLongClickListener {
-            if (mode == BookmarkState.Mode.Normal && !item.inRoots()) {
-                interactor.select(item)
-                true
-            } else false
-        }
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/viewholders/BookmarkItemViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/viewholders/BookmarkItemViewHolder.kt
@@ -6,7 +6,7 @@ package org.mozilla.fenix.library.bookmarks.viewholders
 
 import mozilla.components.concept.storage.BookmarkNode
 import org.mozilla.fenix.library.LibrarySiteItemView
-import org.mozilla.fenix.library.bookmarks.BookmarkState
+import org.mozilla.fenix.library.SelectionHolder
 import org.mozilla.fenix.library.bookmarks.BookmarkViewInteractor
 
 /**
@@ -14,10 +14,11 @@ import org.mozilla.fenix.library.bookmarks.BookmarkViewInteractor
  */
 class BookmarkItemViewHolder(
     view: LibrarySiteItemView,
-    interactor: BookmarkViewInteractor
+    interactor: BookmarkViewInteractor,
+    private val selectionHolder: SelectionHolder<BookmarkNode>
 ) : BookmarkNodeViewHolder(view, interactor) {
 
-    override fun bind(item: BookmarkNode, mode: BookmarkState.Mode, selected: Boolean) {
+    override fun bind(item: BookmarkNode) {
 
         containerView.displayAs(LibrarySiteItemView.ItemType.SITE)
 
@@ -25,8 +26,9 @@ class BookmarkItemViewHolder(
         containerView.titleView.text = if (item.title.isNullOrBlank()) item.url else item.title
         containerView.urlView.text = item.url
 
-        setClickListeners(mode, item, selected)
-        containerView.changeSelected(selected)
+        setSelectionListeners(item, selectionHolder)
+
+        containerView.changeSelected(item in selectionHolder.selectedItems)
         setColorsAndIcons(item.url)
     }
 
@@ -36,33 +38,5 @@ class BookmarkItemViewHolder(
         } else {
             containerView.iconView.setImageDrawable(null)
         }
-    }
-
-    private fun setClickListeners(
-        mode: BookmarkState.Mode,
-        item: BookmarkNode,
-        selected: Boolean
-    ) {
-        containerView.setOnClickListener {
-            when {
-                mode == BookmarkState.Mode.Normal -> interactor.open(item)
-                selected -> interactor.deselect(item)
-                else -> interactor.select(item)
-            }
-        }
-
-        containerView.setOnLongClickListener {
-            if (mode == BookmarkState.Mode.Normal) {
-                interactor.select(item)
-                true
-            } else false
-        }
-
-        containerView.iconView.setOnClickListener({
-            when {
-                selected -> interactor.deselect(item)
-                else -> interactor.select(item)
-            }
-        })
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/viewholders/BookmarkNodeViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/viewholders/BookmarkNodeViewHolder.kt
@@ -6,11 +6,10 @@ package org.mozilla.fenix.library.bookmarks.viewholders
 
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.android.extensions.LayoutContainer
-import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.concept.storage.BookmarkNode
 import org.mozilla.fenix.library.LibrarySiteItemView
+import org.mozilla.fenix.library.SelectionHolder
 import org.mozilla.fenix.library.bookmarks.BookmarkItemMenu
-import org.mozilla.fenix.library.bookmarks.BookmarkState
 import org.mozilla.fenix.library.bookmarks.BookmarkViewInteractor
 
 /**
@@ -18,11 +17,15 @@ import org.mozilla.fenix.library.bookmarks.BookmarkViewInteractor
  */
 abstract class BookmarkNodeViewHolder(
     override val containerView: LibrarySiteItemView,
-    val interactor: BookmarkViewInteractor
+    private val interactor: BookmarkViewInteractor
 ) :
     RecyclerView.ViewHolder(containerView), LayoutContainer {
 
-    abstract fun bind(item: BookmarkNode, mode: BookmarkState.Mode, selected: Boolean)
+    abstract fun bind(item: BookmarkNode)
+
+    protected fun setSelectionListeners(item: BookmarkNode, selectionHolder: SelectionHolder<BookmarkNode>) {
+        containerView.setSelectionInteractor(item, selectionHolder, interactor)
+    }
 
     protected fun setupMenu(item: BookmarkNode) {
         val bookmarkItemMenu = BookmarkItemMenu(containerView.context, item) {
@@ -33,15 +36,10 @@ abstract class BookmarkNodeViewHolder(
                 BookmarkItemMenu.Item.Share -> interactor.share(item)
                 BookmarkItemMenu.Item.OpenInNewTab -> interactor.openInNewTab(item)
                 BookmarkItemMenu.Item.OpenInPrivateTab -> interactor.openInPrivateTab(item)
-                BookmarkItemMenu.Item.Delete -> interactor.delete(item)
+                BookmarkItemMenu.Item.Delete -> interactor.delete(setOf(item))
             }
         }
 
-        containerView.overflowView.setOnClickListener {
-            bookmarkItemMenu.menuBuilder.build(containerView.context).show(
-                anchor = it,
-                orientation = BrowserMenu.Orientation.DOWN
-            )
-        }
+        containerView.attachMenu(bookmarkItemMenu)
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/viewholders/BookmarkSeparatorViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/viewholders/BookmarkSeparatorViewHolder.kt
@@ -6,7 +6,6 @@ package org.mozilla.fenix.library.bookmarks.viewholders
 
 import mozilla.components.concept.storage.BookmarkNode
 import org.mozilla.fenix.library.LibrarySiteItemView
-import org.mozilla.fenix.library.bookmarks.BookmarkState
 import org.mozilla.fenix.library.bookmarks.BookmarkViewInteractor
 
 /**
@@ -17,7 +16,7 @@ class BookmarkSeparatorViewHolder(
     interactor: BookmarkViewInteractor
 ) : BookmarkNodeViewHolder(view, interactor) {
 
-    override fun bind(item: BookmarkNode, mode: BookmarkState.Mode, selected: Boolean) {
+    override fun bind(item: BookmarkNode) {
         containerView.displayAs(LibrarySiteItemView.ItemType.SEPARATOR)
         setupMenu(item)
     }

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryAdapter.kt
@@ -11,6 +11,7 @@ import android.view.ViewGroup
 import androidx.paging.PagedListAdapter
 import androidx.recyclerview.widget.DiffUtil
 import org.mozilla.fenix.R
+import org.mozilla.fenix.library.SelectionHolder
 import org.mozilla.fenix.library.history.viewholders.HistoryListItemViewHolder
 import java.util.Calendar
 import java.util.Date
@@ -28,14 +29,16 @@ enum class HistoryItemTimeGroup {
 
 class HistoryAdapter(
     private val historyInteractor: HistoryInteractor
-) : PagedListAdapter<HistoryItem, HistoryListItemViewHolder>(historyDiffCallback) {
+) : PagedListAdapter<HistoryItem, HistoryListItemViewHolder>(historyDiffCallback), SelectionHolder<HistoryItem> {
+
     private var mode: HistoryState.Mode = HistoryState.Mode.Normal
+    override val selectedItems get() = mode.selectedItems
 
     override fun getItemViewType(position: Int): Int = HistoryListItemViewHolder.LAYOUT_ID
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): HistoryListItemViewHolder {
         val view = LayoutInflater.from(parent.context).inflate(viewType, parent, false)
-        return HistoryListItemViewHolder(view, historyInteractor)
+        return HistoryListItemViewHolder(view, historyInteractor, this)
     }
 
     fun updateMode(mode: HistoryState.Mode) {

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragment.kt
@@ -94,10 +94,11 @@ class HistoryFragment : LibraryPageFragment<HistoryItem>(), BackHandler {
 
     private fun deleteHistoryItems(items: Set<HistoryItem>) {
         lifecycleScope.launch {
-            val storage = context?.components?.core?.historyStorage
-            for (item in items) {
-                context?.components?.analytics?.metrics?.track(Event.HistoryItemRemoved)
-                storage?.deleteVisit(item.url, item.visitedAt)
+            context?.components?.run {
+                for (item in items) {
+                    analytics.metrics.track(Event.HistoryItemRemoved)
+                    core.historyStorage.deleteVisit(item.url, item.visitedAt)
+                }
             }
             viewModel.invalidate()
             historyStore.dispatch(HistoryAction.ExitDeletionMode)
@@ -134,7 +135,7 @@ class HistoryFragment : LibraryPageFragment<HistoryItem>(), BackHandler {
 
         if (mode is HistoryState.Mode.Editing) {
             menu.findItem(R.id.share_history_multi_select)?.run {
-                isVisible = mode.selectedItems.isNotEmpty()
+                isVisible = true
                 icon.colorFilter = PorterDuffColorFilter(
                     ContextCompat.getColor(context!!, R.color.white_color),
                     SRC_IN
@@ -212,7 +213,7 @@ class HistoryFragment : LibraryPageFragment<HistoryItem>(), BackHandler {
         )
     }
 
-    fun displayDeleteAllDialog() {
+    private fun displayDeleteAllDialog() {
         activity?.let { activity ->
             AlertDialog.Builder(activity).apply {
                 setMessage(R.string.history_delete_all_dialog)

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryInteractor.kt
@@ -15,29 +15,16 @@ class HistoryInteractor(
     private val invalidateOptionsMenu: () -> Unit,
     private val deleteHistoryItems: (Set<HistoryItem>) -> Unit
 ) : HistoryViewInteractor {
-    override fun onItemPress(item: HistoryItem) {
-        when (val mode = store.state.mode) {
-            is HistoryState.Mode.Normal -> openToBrowser(item)
-            is HistoryState.Mode.Editing -> {
-                val isSelected = mode.selectedItems.contains(item)
-
-                if (isSelected) {
-                    store.dispatch(HistoryAction.RemoveItemForRemoval(item))
-                } else {
-                    store.dispatch(HistoryAction.AddItemForRemoval(item))
-                }
-            }
-        }
+    override fun open(item: HistoryItem) {
+        openToBrowser(item)
     }
 
-    override fun onItemLongPress(item: HistoryItem) {
-        val isSelected = store.state.mode.selectedItems.contains(item)
+    override fun select(item: HistoryItem) {
+        store.dispatch(HistoryAction.AddItemForRemoval(item))
+    }
 
-        if (isSelected) {
-            store.dispatch(HistoryAction.RemoveItemForRemoval(item))
-        } else {
-            store.dispatch(HistoryAction.AddItemForRemoval(item))
-        }
+    override fun deselect(item: HistoryItem) {
+        store.dispatch(HistoryAction.RemoveItemForRemoval(item))
     }
 
     override fun onBackPressed(): Boolean {
@@ -55,10 +42,6 @@ class HistoryInteractor(
 
     override fun onDeleteAll() {
         displayDeleteAll.invoke()
-    }
-
-    override fun onDeleteOne(item: HistoryItem) {
-        deleteHistoryItems.invoke(setOf(item))
     }
 
     override fun onDeleteSome(items: Set<HistoryItem>) {

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryItemMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryItemMenu.kt
@@ -9,16 +9,17 @@ import mozilla.components.browser.menu.BrowserMenuBuilder
 import mozilla.components.browser.menu.item.SimpleBrowserMenuItem
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ThemeManager
+import org.mozilla.fenix.library.LibraryItemMenu
 
 class HistoryItemMenu(
     private val context: Context,
     private val onItemTapped: (Item) -> Unit = {}
-) {
+) : LibraryItemMenu {
     sealed class Item {
         object Delete : Item()
     }
 
-    val menuBuilder by lazy { BrowserMenuBuilder(menuItems) }
+    override val menuBuilder by lazy { BrowserMenuBuilder(menuItems) }
 
     private val menuItems by lazy {
         listOf(

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryView.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryView.kt
@@ -15,21 +15,13 @@ import kotlinx.android.synthetic.main.component_history.view.*
 import mozilla.components.support.base.feature.BackHandler
 import org.mozilla.fenix.R
 import org.mozilla.fenix.library.LibraryPageView
+import org.mozilla.fenix.library.SelectionInteractor
 
 /**
  * Interface for the HistoryViewInteractor. This interface is implemented by objects that want
  * to respond to user interaction on the HistoryView
  */
-interface HistoryViewInteractor {
-    /**
-     * Called when a user taps a history item
-     */
-    fun onItemPress(item: HistoryItem)
-
-    /**
-     * Called when a user long clicks a user
-     */
-    fun onItemLongPress(item: HistoryItem)
+interface HistoryViewInteractor : SelectionInteractor<HistoryItem> {
 
     /**
      * Called on backpressed to exit edit mode
@@ -45,12 +37,6 @@ interface HistoryViewInteractor {
      * Called when delete all is tapped
      */
     fun onDeleteAll()
-
-    /**
-     * Called when one history item is deleted
-     * @param item the history item to delete
-     */
-    fun onDeleteOne(item: HistoryItem)
 
     /**
      * Called when multiple history items are deleted

--- a/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkFragmentInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkFragmentInteractorTest.kt
@@ -117,7 +117,7 @@ class BookmarkFragmentInteractorTest {
 
     @Test
     fun `expand a level of bookmarks`() {
-        interactor.expand(tree)
+        interactor.open(tree)
 
         verify {
             navController.navigate(BookmarkFragmentDirections.actionBookmarkFragmentSelf(tree.guid))
@@ -236,7 +236,7 @@ class BookmarkFragmentInteractorTest {
 
     @Test
     fun `delete a bookmark item`() {
-        interactor.delete(item)
+        interactor.delete(setOf(item))
 
         verify {
             deleteBookmarkNodes(setOf(item), Event.RemoveBookmark)
@@ -245,7 +245,7 @@ class BookmarkFragmentInteractorTest {
 
     @Test
     fun `delete a bookmark folder`() {
-        interactor.delete(subfolder)
+        interactor.delete(setOf(subfolder))
 
         verify {
             deleteBookmarkNodes(setOf(subfolder), Event.RemoveBookmarkFolder)
@@ -254,7 +254,7 @@ class BookmarkFragmentInteractorTest {
 
     @Test
     fun `delete multiple bookmarks`() {
-        interactor.deleteMulti(setOf(item, subfolder))
+        interactor.delete(setOf(item, subfolder))
 
         verify {
             deleteBookmarkNodes(setOf(item, subfolder), Event.RemoveBookmarks)

--- a/app/src/test/java/org/mozilla/fenix/library/history/HistoryInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/history/HistoryInteractorTest.kt
@@ -31,7 +31,7 @@ class HistoryInteractorTest {
             mockk()
         )
 
-        interactor.onItemPress(historyItem)
+        interactor.open(historyItem)
         assertEquals(historyItem, historyItemReceived)
     }
 
@@ -51,7 +51,7 @@ class HistoryInteractorTest {
             mockk()
         )
 
-        interactor.onItemPress(historyItem)
+        interactor.select(historyItem)
 
         verify {
             store.dispatch(HistoryAction.AddItemForRemoval(historyItem))
@@ -74,7 +74,7 @@ class HistoryInteractorTest {
             mockk()
         )
 
-        interactor.onItemPress(historyItem)
+        interactor.deselect(historyItem)
 
         verify {
             store.dispatch(HistoryAction.RemoveItemForRemoval(historyItem))
@@ -133,22 +133,6 @@ class HistoryInteractorTest {
         )
         interactor.onDeleteAll()
         assertEquals(true, deleteAllDialogShown)
-    }
-
-    @Test
-    fun onDeleteOne() {
-        var itemsToDelete: Set<HistoryItem>? = null
-        val historyItem = HistoryItem(0, "title", "url", 0.toLong())
-        val interactor =
-            HistoryInteractor(
-                mockk(),
-                mockk(),
-                mockk(),
-                mockk(),
-                { itemsToDelete = it }
-            )
-        interactor.onDeleteOne(historyItem)
-        assertEquals(itemsToDelete, setOf(historyItem))
     }
 
     @Test


### PR DESCRIPTION
This change adds generic code for selecting bookmarks and history. Selection is based on a `selected` items set, which checks if an item is inside the set. Having zero items in the set corresponds to not being in selection mode.

This builds on #3707 so that PR should be merged first.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
