### PR TITLE
1567988: Reduce likelihood of invalid URL loading Glean build script

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -439,7 +439,13 @@ task printGeckoviewVersions {
     }
 }
 
-apply from: 'https://github.com/mozilla-mobile/android-components/raw/master/components/service/glean/scripts/sdk_generator.gradle'
+def glean_android_components_tag = (
+    Versions.mozilla_android_components.endsWith('-SNAPSHOT') ?
+        'master' :
+        'v' + Versions.mozilla_android_components
+)
+
+apply from: 'https://github.com/mozilla-mobile/android-components/raw/' + glean_android_components_tag + '/components/service/glean/scripts/sdk_generator.gradle'
 
 // For production builds, the native code for all `org.mozilla.appservices` dependencies gets compiled together
 // into a single "megazord" build, and different megazords are published for different subsets of features.


### PR DESCRIPTION
The build script uses the android-components version to as a git tag to download Glean's build helper script.  This works fine when the library version corresponds directly to a git tag.  However, when using a `SNAPSHOT`, the best we can do is to use `master`, which, while not exactly the right thing, works the majority of the time.

This change will automatically use master when the library version ends in `SNAPSHOT`.  I consider this a stopgap measure -- there is [another bug open](https://bugzilla.mozilla.org/show_bug.cgi?id=1567991) to find a better long-term solution.  However, this will at least prevent the footgun of forgetting to update the URL when moving the android-components version between SNAPSHOT and non-SNAPSHOT versions.

Cc: @Dexterp37 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
