### PR TITLE
fixes #4237 - Cannot edit the default name of a collection only replace it

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/collections/CollectionCreationUIView.kt
+++ b/app/src/main/java/org/mozilla/fenix/collections/CollectionCreationUIView.kt
@@ -275,7 +275,6 @@ class CollectionCreationUIView(
             }
             is SaveCollectionStep.RenameCollection -> {
                 view.tab_list.isClickable = false
-                name_collection_edittext.isClickable = true
 
                 it.selectedTabCollection?.let { tabCollection ->
                     tabCollection.tabs.map { tab ->
@@ -289,7 +288,13 @@ class CollectionCreationUIView(
                         collectionCreationTabListAdapter.updateData(tabs, tabs.toSet(), true)
                     }
                 }
+                val constraint = nameCollectionConstraints
+                constraint.applyTo(view.collection_constraint_layout)
+                name_collection_edittext.setText(it.selectedTabCollection?.title)
+                name_collection_edittext.setSelection(0, name_collection_edittext.text.length)
 
+                back_button.text =
+                    view.context.getString(R.string.collection_rename)
                 back_button.setOnClickListener {
                     name_collection_edittext.hideKeyboard()
                     val handler = Handler()
@@ -314,19 +319,14 @@ class CollectionCreationUIView(
                     view.collection_constraint_layout,
                     transition
                 )
-                val constraint = nameCollectionConstraints
-                constraint.applyTo(view.collection_constraint_layout)
-                name_collection_edittext.setText(it.selectedTabCollection?.title)
-                name_collection_edittext.setSelection(0, name_collection_edittext.text.length)
-                back_button.text =
-                    view.context.getString(R.string.create_collection_name_collection)
+
             }
         }
         collectionSaveListAdapter.updateData(it.tabCollections, it.selectedTabs)
     }
 
     fun onResumed() {
-        if (step == SaveCollectionStep.NameCollection) {
+        if (step == SaveCollectionStep.NameCollection || step == SaveCollectionStep.RenameCollection) {
             view.name_collection_edittext.showKeyboard()
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/collections/CollectionCreationUIView.kt
+++ b/app/src/main/java/org/mozilla/fenix/collections/CollectionCreationUIView.kt
@@ -275,6 +275,7 @@ class CollectionCreationUIView(
             }
             is SaveCollectionStep.RenameCollection -> {
                 view.tab_list.isClickable = false
+                name_collection_edittext.isClickable = true
 
                 it.selectedTabCollection?.let { tabCollection ->
                     tabCollection.tabs.map { tab ->

--- a/app/src/main/java/org/mozilla/fenix/collections/CollectionCreationUIView.kt
+++ b/app/src/main/java/org/mozilla/fenix/collections/CollectionCreationUIView.kt
@@ -319,7 +319,6 @@ class CollectionCreationUIView(
                     view.collection_constraint_layout,
                     transition
                 )
-
             }
         }
         collectionSaveListAdapter.updateData(it.tabCollections, it.selectedTabs)


### PR DESCRIPTION
made name_collection_edittext field clickable when SaveCollectionStep.RenameCollection

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
