### PR TITLE
[#4089] Moved PublicSuffixList to a sub-component(Utilities) class.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -77,7 +77,7 @@ open class HomeActivity : AppCompatActivity(), ShareFragment.TabsSharedCallback 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        components.publicSuffixList.prefetch()
+        components.utils.publicSuffixList.prefetch()
         setupThemeAndBrowsingMode()
 
         setContentView(R.layout.activity_home)

--- a/app/src/main/java/org/mozilla/fenix/components/Components.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Components.kt
@@ -22,5 +22,4 @@ class Components(private val context: Context) {
     val useCases by lazy { UseCases(context, core.sessionManager, core.engine.settings, search.searchEngineManager) }
     val utils by lazy { Utilities(context, core.sessionManager, useCases.sessionUseCases, useCases.searchUseCases) }
     val analytics by lazy { Analytics(context) }
-    val publicSuffixList by lazy { PublicSuffixList(context) }
 }

--- a/app/src/main/java/org/mozilla/fenix/components/Components.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Components.kt
@@ -5,7 +5,6 @@
 package org.mozilla.fenix.components
 
 import android.content.Context
-import mozilla.components.lib.publicsuffixlist.PublicSuffixList
 import org.mozilla.fenix.test.Mockable
 
 /**

--- a/app/src/main/java/org/mozilla/fenix/components/Utilities.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Utilities.kt
@@ -9,6 +9,7 @@ import mozilla.components.browser.session.SessionManager
 import mozilla.components.feature.intent.IntentProcessor
 import mozilla.components.feature.search.SearchUseCases
 import mozilla.components.feature.session.SessionUseCases
+import mozilla.components.lib.publicsuffixlist.PublicSuffixList
 import org.mozilla.fenix.test.Mockable
 
 /**
@@ -39,4 +40,6 @@ class Utilities(
     val notificationManager by lazy {
         NotificationManager(context)
     }
+
+    val publicSuffixList by lazy { PublicSuffixList(context) }
 }

--- a/app/src/main/java/org/mozilla/fenix/ext/String.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/String.kt
@@ -37,7 +37,7 @@ fun String.urlToTrimmedHost(context: Context): String {
     return try {
         val host = toUri().hostWithoutCommonPrefixes ?: return this
         runBlocking {
-            context.components.publicSuffixList.stripPublicSuffix(host).await()
+            context.components.utils.publicSuffixList.stripPublicSuffix(host).await()
         }
     } catch (e: MalformedURLException) {
         this


### PR DESCRIPTION
Fixes #4089 
PR contains :
1) Moved PublicSuffixList to Utilities.kt.
2) Corrected References which were using PublicSuffixList.
