### PR TITLE
Remove redundant super calls

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -219,59 +219,56 @@ open class HomeActivity : AppCompatActivity(), ShareFragment.TabsSharedCallback 
         if (sessionObserver == null)
             sessionObserver = subscribeToSessions()
 
-        if (navHost.navController.currentDestination?.id == R.id.browserFragment) return
-        @IdRes var fragmentId: Int? = null
-        val directions = if (!navHost.navController.popBackStack(R.id.browserFragment, false)) {
-            when (from) {
-                BrowserDirection.FromGlobal ->
-                    NavGraphDirections.actionGlobalBrowser(customTabSessionId)
-                BrowserDirection.FromHome -> {
-                    fragmentId = R.id.homeFragment
-                    HomeFragmentDirections.actionHomeFragmentToBrowserFragment(customTabSessionId)
-                }
-                BrowserDirection.FromSearch -> {
-                    fragmentId = R.id.searchFragment
-                    SearchFragmentDirections.actionSearchFragmentToBrowserFragment(
-                        customTabSessionId
-                    )
-                }
-                BrowserDirection.FromSettings -> {
-                    fragmentId = R.id.settingsFragment
-                    SettingsFragmentDirections.actionSettingsFragmentToBrowserFragment(
-                        customTabSessionId
-                    )
-                }
-                BrowserDirection.FromBookmarks -> {
-                    fragmentId = R.id.bookmarkFragment
-                    BookmarkFragmentDirections.actionBookmarkFragmentToBrowserFragment(
-                        customTabSessionId
-                    )
-                }
-                BrowserDirection.FromBookmarksFolderSelect -> {
-                    fragmentId = R.id.bookmarkSelectFolderFragment
-                    SelectBookmarkFolderFragmentDirections
-                        .actionBookmarkSelectFolderFragmentToBrowserFragment(customTabSessionId)
-                }
-                BrowserDirection.FromHistory -> {
-                    fragmentId = R.id.historyFragment
-                    HistoryFragmentDirections.actionHistoryFragmentToBrowserFragment(
-                        customTabSessionId
-                    )
-                }
-                BrowserDirection.FromExceptions -> {
-                    fragmentId = R.id.exceptionsFragment
-                    ExceptionsFragmentDirections.actionExceptionsFragmentToBrowserFragment(
-                        customTabSessionId
-                    )
-                }
-            }
-        } else {
-            null
+        with(navHost.navController) {
+            if (currentDestination?.id == R.id.browserFragment || popBackStack(R.id.browserFragment, false)) return
         }
 
-        directions?.let {
-            navHost.navController.nav(fragmentId, it)
+        @IdRes var fragmentId: Int? = null
+        val directions = when (from) {
+            BrowserDirection.FromGlobal ->
+                NavGraphDirections.actionGlobalBrowser(customTabSessionId)
+            BrowserDirection.FromHome -> {
+                fragmentId = R.id.homeFragment
+                HomeFragmentDirections.actionHomeFragmentToBrowserFragment(customTabSessionId)
+            }
+            BrowserDirection.FromSearch -> {
+                fragmentId = R.id.searchFragment
+                SearchFragmentDirections.actionSearchFragmentToBrowserFragment(
+                    customTabSessionId
+                )
+            }
+            BrowserDirection.FromSettings -> {
+                fragmentId = R.id.settingsFragment
+                SettingsFragmentDirections.actionSettingsFragmentToBrowserFragment(
+                    customTabSessionId
+                )
+            }
+            BrowserDirection.FromBookmarks -> {
+                fragmentId = R.id.bookmarkFragment
+                BookmarkFragmentDirections.actionBookmarkFragmentToBrowserFragment(
+                    customTabSessionId
+                )
+            }
+            BrowserDirection.FromBookmarksFolderSelect -> {
+                fragmentId = R.id.bookmarkSelectFolderFragment
+                SelectBookmarkFolderFragmentDirections
+                    .actionBookmarkSelectFolderFragmentToBrowserFragment(customTabSessionId)
+            }
+            BrowserDirection.FromHistory -> {
+                fragmentId = R.id.historyFragment
+                HistoryFragmentDirections.actionHistoryFragmentToBrowserFragment(
+                    customTabSessionId
+                )
+            }
+            BrowserDirection.FromExceptions -> {
+                fragmentId = R.id.exceptionsFragment
+                ExceptionsFragmentDirections.actionExceptionsFragmentToBrowserFragment(
+                    customTabSessionId
+                )
+            }
         }
+
+        navHost.navController.nav(fragmentId, directions)
     }
 
     private fun load(
@@ -314,11 +311,11 @@ open class HomeActivity : AppCompatActivity(), ShareFragment.TabsSharedCallback 
         var urlLoading: String? = null
 
         override fun onLoadingStateChanged(session: Session, loading: Boolean) {
-            super.onLoadingStateChanged(session, loading)
-
-            if (loading) urlLoading = session.url
-            else if (urlLoading != null && !session.private)
+            if (loading) {
+                urlLoading = session.url
+            } else if (urlLoading != null && !session.private) {
                 components.analytics.metrics.track(Event.UriOpened)
+            }
         }
     }
 
@@ -360,24 +357,20 @@ open class HomeActivity : AppCompatActivity(), ShareFragment.TabsSharedCallback 
 
         return object : SessionManager.Observer {
             override fun onAllSessionsRemoved() {
-                super.onAllSessionsRemoved()
                 components.core.sessionManager.sessions.forEach {
                     it.unregister(singleSessionObserver)
                 }
             }
 
             override fun onSessionAdded(session: Session) {
-                super.onSessionAdded(session)
                 session.register(singleSessionObserver, this@HomeActivity)
             }
 
             override fun onSessionRemoved(session: Session) {
-                super.onSessionRemoved(session)
                 session.unregister(singleSessionObserver)
             }
 
             override fun onSessionsRestored() {
-                super.onSessionsRestored()
                 components.core.sessionManager.sessions.forEach {
                     it.register(singleSessionObserver, this@HomeActivity)
                 }

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarMetrics.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarMetrics.kt
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.components.toolbar
+
+import org.mozilla.fenix.components.metrics.Event
+import org.mozilla.fenix.components.metrics.MetricController
+
+// This method triggers the complexity warning. However it's actually not that hard to understand.
+@SuppressWarnings("ComplexMethod")
+fun trackToolbarItemInteraction(metrics: MetricController, action: SearchAction.ToolbarMenuItemTapped) {
+    val item = when (action.item) {
+        ToolbarMenu.Item.Back -> Event.BrowserMenuItemTapped.Item.BACK
+        ToolbarMenu.Item.Forward -> Event.BrowserMenuItemTapped.Item.FORWARD
+        ToolbarMenu.Item.Reload -> Event.BrowserMenuItemTapped.Item.RELOAD
+        ToolbarMenu.Item.Stop -> Event.BrowserMenuItemTapped.Item.STOP
+        ToolbarMenu.Item.Settings -> Event.BrowserMenuItemTapped.Item.SETTINGS
+        ToolbarMenu.Item.Library -> Event.BrowserMenuItemTapped.Item.LIBRARY
+        is ToolbarMenu.Item.RequestDesktop -> if (action.item.isChecked) {
+            Event.BrowserMenuItemTapped.Item.DESKTOP_VIEW_ON
+        } else {
+            Event.BrowserMenuItemTapped.Item.DESKTOP_VIEW_OFF
+        }
+        ToolbarMenu.Item.NewPrivateTab -> Event.BrowserMenuItemTapped.Item.NEW_PRIVATE_TAB
+        ToolbarMenu.Item.FindInPage -> Event.BrowserMenuItemTapped.Item.FIND_IN_PAGE
+        ToolbarMenu.Item.ReportIssue -> Event.BrowserMenuItemTapped.Item.REPORT_SITE_ISSUE
+        ToolbarMenu.Item.Help -> Event.BrowserMenuItemTapped.Item.HELP
+        ToolbarMenu.Item.NewTab -> Event.BrowserMenuItemTapped.Item.NEW_TAB
+        ToolbarMenu.Item.OpenInFenix -> Event.BrowserMenuItemTapped.Item.OPEN_IN_FENIX
+        ToolbarMenu.Item.Share -> Event.BrowserMenuItemTapped.Item.SHARE
+        ToolbarMenu.Item.SaveToCollection -> Event.BrowserMenuItemTapped.Item.SAVE_TO_COLLECTION
+    }
+
+    metrics.track(Event.BrowserMenuItemTapped(item))
+}

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -18,7 +18,10 @@ import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.widget.ConstraintLayout.LayoutParams.PARENT_ID
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.Observer
+import androidx.lifecycle.OnLifecycleEvent
 import androidx.lifecycle.ViewModelProviders
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.NavHostFragment.findNavController
@@ -31,13 +34,14 @@ import kotlinx.android.synthetic.main.fragment_home.view.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.sync.AccountObserver
 import mozilla.components.concept.sync.OAuthAccount
 import mozilla.components.concept.sync.Profile
+import mozilla.components.feature.tab.collections.TabCollection
 import org.jetbrains.anko.constraint.layout.ConstraintSetBuilder.Side.BOTTOM
 import org.jetbrains.anko.constraint.layout.ConstraintSetBuilder.Side.END
 import org.jetbrains.anko.constraint.layout.ConstraintSetBuilder.Side.START
@@ -68,7 +72,6 @@ import org.mozilla.fenix.home.sessioncontrol.SessionControlState
 import org.mozilla.fenix.home.sessioncontrol.SessionControlViewModel
 import org.mozilla.fenix.home.sessioncontrol.Tab
 import org.mozilla.fenix.home.sessioncontrol.TabAction
-import org.mozilla.fenix.home.sessioncontrol.TabCollection
 import org.mozilla.fenix.home.sessioncontrol.viewholders.CollectionViewHolder
 import org.mozilla.fenix.lib.Do
 import org.mozilla.fenix.mvi.ActionBusFactory
@@ -83,37 +86,23 @@ import kotlin.math.roundToInt
 @SuppressWarnings("TooManyFunctions", "LargeClass")
 class HomeFragment : Fragment(), AccountObserver {
     private val bus = ActionBusFactory.get(this)
-    private var tabCollectionObserver: Observer<List<TabCollection>>? = null
 
     private val singleSessionObserver = object : Session.Observer {
         override fun onTitleChanged(session: Session, title: String) {
-            super.onTitleChanged(session, title)
-            if (deleteAllSessionsJob != null) return
-            emitSessionChanges()
+            if (deleteAllSessionsJob == null) emitSessionChanges()
         }
     }
 
-    private lateinit var sessionObserver: BrowserSessionsObserver
-
     private val collectionStorageObserver = object : TabCollectionStorage.Observer {
         override fun onCollectionCreated(title: String, sessions: List<Session>) {
-            super.onCollectionCreated(title, sessions)
             scrollAndAnimateCollection(sessions.size)
         }
 
-        override fun onTabsAdded(
-            tabCollection: mozilla.components.feature.tab.collections.TabCollection,
-            sessions: List<Session>
-        ) {
-            super.onTabsAdded(tabCollection, sessions)
+        override fun onTabsAdded(tabCollection: TabCollection, sessions: List<Session>) {
             scrollAndAnimateCollection(sessions.size, tabCollection)
         }
 
-        override fun onCollectionRenamed(
-            tabCollection: mozilla.components.feature.tab.collections.TabCollection,
-            title: String
-        ) {
-            super.onCollectionRenamed(tabCollection, title)
+        override fun onCollectionRenamed(tabCollection: TabCollection, title: String) {
             showRenamedSnackbar()
         }
     }
@@ -151,9 +140,10 @@ class HomeFragment : Fragment(), AccountObserver {
 //        sharedElementEnterTransition = TransitionInflater.from(context).inflateTransition(android.R.transition.move)
 //            .setDuration(SHARED_TRANSITION_MS)
 
-        sessionObserver = BrowserSessionsObserver(sessionManager, singleSessionObserver) {
+        val sessionObserver = BrowserSessionsObserver(sessionManager, singleSessionObserver) {
             emitSessionChanges()
         }
+        lifecycle.addObserver(sessionObserver)
 
         if (!onboarding.userHasBeenOnboarded()) {
             requireComponents.analytics.metrics.track(Event.OpenedAppFirstRun)
@@ -228,17 +218,14 @@ class HomeFragment : Fragment(), AccountObserver {
 
         setupHomeMenu()
 
-        viewLifecycleOwner.lifecycleScope.launch(Dispatchers.Default) {
+        viewLifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
             val iconSize = resources.getDimension(R.dimen.preference_icon_drawable_size).toInt()
 
-            val searchIcon = requireComponents.search.searchEngineManager.getDefaultSearchEngine(
-                requireContext()
-            ).let {
-                BitmapDrawable(resources, it.icon)
-            }
+            val searchEngine = requireComponents.search.searchEngineManager.getDefaultSearchEngine(requireContext())
+            val searchIcon = BitmapDrawable(resources, searchEngine.icon)
             searchIcon.setBounds(0, 0, iconSize, iconSize)
 
-            runBlocking(Dispatchers.Main) {
+            withContext(Dispatchers.Main) {
                 search_engine_icon?.setImageDrawable(searchIcon)
             }
         }
@@ -249,9 +236,8 @@ class HomeFragment : Fragment(), AccountObserver {
                 orientation = BrowserMenu.Orientation.DOWN
             )
         }
-        val roundToInt =
+        view.toolbar.compoundDrawablePadding =
             (toolbarPaddingDp * Resources.getSystem().displayMetrics.density).roundToInt()
-        view.toolbar.compoundDrawablePadding = roundToInt
         view.toolbar.setOnClickListener {
             invokePendingDeleteJobs()
             onboarding.finish()
@@ -324,20 +310,10 @@ class HomeFragment : Fragment(), AccountObserver {
 
     override fun onStart() {
         super.onStart()
-        sessionObserver.onStart()
-        tabCollectionObserver = subscribeToTabCollections()
+        subscribeToTabCollections()
 
         // We only want this observer live just before we navigate away to the collection creation screen
         requireComponents.core.tabCollectionStorage.unregister(collectionStorageObserver)
-    }
-
-    override fun onStop() {
-        sessionObserver.onStop()
-        tabCollectionObserver?.let {
-            requireComponents.core.tabCollectionStorage.getCollections().removeObserver(it)
-        }
-
-        super.onStop()
     }
 
     private fun handleOnboardingAction(action: OnboardingAction) {
@@ -612,12 +588,12 @@ class HomeFragment : Fragment(), AccountObserver {
     }
 
     private fun subscribeToTabCollections(): Observer<List<TabCollection>> {
-        val observer = Observer<List<TabCollection>> {
+        return Observer<List<TabCollection>> {
             requireComponents.core.tabCollectionStorage.cachedTabCollections = it
             getManagedEmitter<SessionControlChange>().onNext(SessionControlChange.CollectionsChange(it))
+        }.also { observer ->
+            requireComponents.core.tabCollectionStorage.getCollections().observe(this, observer)
         }
-        requireComponents.core.tabCollectionStorage.getCollections().observe(this, observer)
-        return observer
     }
 
     private fun removeAllTabsWithUndo(listOfSessionsToDelete: List<Session>) {
@@ -683,11 +659,6 @@ class HomeFragment : Fragment(), AccountObserver {
         return sessionManager.filteredSessions(isPrivate, notPendingDeletion)
     }
 
-    private fun emitAccountChanges() {
-        val mode = currentMode()
-        getManagedEmitter<SessionControlChange>().onNext(SessionControlChange.ModeChange(mode))
-    }
-
     private fun showCollectionCreationFragment(
         selectedTabId: String? = null,
         selectedTabCollection: TabCollection? = null,
@@ -742,21 +713,15 @@ class HomeFragment : Fragment(), AccountObserver {
         Mode.Normal
     }
 
-    override fun onAuthenticationProblems() {
-        emitAccountChanges()
+    private fun emitAccountChanges() {
+        val mode = currentMode()
+        getManagedEmitter<SessionControlChange>().onNext(SessionControlChange.ModeChange(mode))
     }
 
-    override fun onAuthenticated(account: OAuthAccount) {
-        emitAccountChanges()
-    }
-
-    override fun onLoggedOut() {
-        emitAccountChanges()
-    }
-
-    override fun onProfileUpdated(profile: Profile) {
-        emitAccountChanges()
-    }
+    override fun onAuthenticationProblems() = emitAccountChanges()
+    override fun onAuthenticated(account: OAuthAccount) = emitAccountChanges()
+    override fun onLoggedOut() = emitAccountChanges()
+    override fun onProfileUpdated(profile: Profile) = emitAccountChanges()
 
     private fun scrollAndAnimateCollection(tabsAddedToCollectionSize: Int, changedCollection: TabCollection? = null) {
         if (view != null) {
@@ -885,15 +850,12 @@ private class BrowserSessionsObserver(
     private val manager: SessionManager,
     private val observer: Session.Observer,
     private val onChanged: () -> Unit
-) {
-
-    // TODO This is workaround. Should be removed when [mozilla.components.support.base.observer.ObserverRegistry]
-    // will not allow to subscribe to single session more than once.
-    private val observedSessions = mutableSetOf<Session>()
+) : LifecycleObserver {
 
     /**
      * Start observing
      */
+    @OnLifecycleEvent(Lifecycle.Event.ON_START)
     fun onStart() {
         manager.register(managerObserver)
         subscribeToAll()
@@ -902,6 +864,7 @@ private class BrowserSessionsObserver(
     /**
      * Stop observing (will not receive updates till next [onStop] call)
      */
+    @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
     fun onStop() {
         manager.unregister(managerObserver)
         unsubscribeFromAll()
@@ -916,21 +879,14 @@ private class BrowserSessionsObserver(
     }
 
     private fun subscribeTo(session: Session) {
-        if (!observedSessions.contains(session)) {
-            session.register(observer)
-            observedSessions += session
-        }
+        session.register(observer)
     }
 
     private fun unsubscribeFrom(session: Session) {
-        if (observedSessions.contains(session)) {
-            session.unregister(observer)
-            observedSessions -= session
-        }
+        session.unregister(observer)
     }
 
     private val managerObserver = object : SessionManager.Observer {
-
         override fun onSessionAdded(session: Session) {
             subscribeTo(session)
             onChanged()

--- a/app/src/main/java/org/mozilla/fenix/lib/Do.kt
+++ b/app/src/main/java/org/mozilla/fenix/lib/Do.kt
@@ -5,5 +5,14 @@
 package org.mozilla.fenix.lib
 
 object Do {
+
+    /**
+     * Indicates to the linter that the following when statement should be exhaustive.
+     *
+     * @sample Do exhaustive when (bool) {
+     *     true -> Unit
+     *     false -> Unit
+     * }
+     */
     inline infix fun <reified T> exhaustive(any: T?) = any
 }

--- a/app/src/main/java/org/mozilla/fenix/settings/DeleteBrowsingDataFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/DeleteBrowsingDataFragment.kt
@@ -40,30 +40,11 @@ class DeleteBrowsingDataFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         sessionObserver = object : SessionManager.Observer {
-            override fun onSessionAdded(session: Session) {
-                super.onSessionAdded(session)
-                updateTabCount()
-            }
-
-            override fun onSessionRemoved(session: Session) {
-                super.onSessionRemoved(session)
-                updateTabCount()
-            }
-
-            override fun onSessionSelected(session: Session) {
-                super.onSessionSelected(session)
-                updateTabCount()
-            }
-
-            override fun onSessionsRestored() {
-                super.onSessionsRestored()
-                updateTabCount()
-            }
-
-            override fun onAllSessionsRemoved() {
-                super.onAllSessionsRemoved()
-                updateTabCount()
-            }
+            override fun onSessionAdded(session: Session) = updateTabCount()
+            override fun onSessionRemoved(session: Session) = updateTabCount()
+            override fun onSessionSelected(session: Session) = updateTabCount()
+            override fun onSessionsRestored() = updateTabCount()
+            override fun onAllSessionsRemoved() = updateTabCount()
         }
 
         requireComponents.core.sessionManager.register(sessionObserver, owner = this)

--- a/app/src/main/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsSheetDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsSheetDialogFragment.kt
@@ -244,7 +244,6 @@ class QuickSettingsSheetDialogFragment : AppCompatDialogFragment() {
 
     private val sessionObserver = object : Session.Observer {
         override fun onUrlChanged(session: Session, url: String) {
-            super.onUrlChanged(session, url)
             lifecycleScope.launch(Dispatchers.IO) {
                 val host = session.url.toUri()?.host
                 val sitePermissions: SitePermissions? = host?.let {
@@ -265,7 +264,6 @@ class QuickSettingsSheetDialogFragment : AppCompatDialogFragment() {
         }
 
         override fun onTrackerBlockingEnabledChanged(session: Session, blockingEnabled: Boolean) {
-            super.onTrackerBlockingEnabledChanged(session, blockingEnabled)
             getManagedEmitter<QuickSettingsChange>().onNext(
                 QuickSettingsChange.Change(
                     session.url,
@@ -277,7 +275,6 @@ class QuickSettingsSheetDialogFragment : AppCompatDialogFragment() {
         }
 
         override fun onSecurityChanged(session: Session, securityInfo: Session.SecurityInfo) {
-            super.onSecurityChanged(session, securityInfo)
             getManagedEmitter<QuickSettingsChange>().onNext(
                 QuickSettingsChange.Change(
                     session.url,


### PR DESCRIPTION
Some observer interfaces have a default implementation of `= Unit` which we were calling. Also did various other cleanup.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
