### PR TITLE
Closes #3419: Use better accessibility strings for tab collections

### DIFF
--- a/app/src/main/res/layout/collection_home_list_row.xml
+++ b/app/src/main/res/layout/collection_home_list_row.xml
@@ -88,7 +88,7 @@
                 android:layout_marginStart="16dp"
                 android:layout_marginEnd="30dp"
                 android:background="?android:attr/selectableItemBackgroundBorderless"
-                android:contentDescription="@string/share_header"
+                android:contentDescription="@string/share_button_content_description"
                 android:src="@drawable/ic_hollow_share"
                 app:layout_constraintEnd_toStartOf="@id/collection_overflow_button"
                 app:layout_constraintTop_toTopOf="@id/collection_icon" />
@@ -100,7 +100,7 @@
                 android:layout_marginTop="16dp"
                 android:layout_marginEnd="4.5dp"
                 android:background="?android:attr/selectableItemBackgroundBorderless"
-                android:contentDescription="@string/tab_menu"
+                android:contentDescription="@string/collection_menu_button_content_description"
                 android:src="@drawable/ic_menu"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -488,6 +488,8 @@
     <!-- Collections -->
     <!-- Collections header on home fragment -->
     <string name="collections_header">Collections</string>
+    <!-- Content description (not visible, for screen readers etc.): Opens the collection menu when pressed -->
+    <string name="collection_menu_button_content_description">Collection menu</string>
     <!-- No Open Tabs Message Header -->
     <string name="no_collections_header">No collections</string>
     <!-- No Open Tabs Message Description -->
@@ -527,6 +529,9 @@
     <!-- Share -->
     <!-- Share screen header -->
     <string name="share_header">Send and Share</string>
+    <!-- Content description (not visible, for screen readers etc.):
+        "Share" button. Opens the share menu when pressed. -->
+    <string name="share_button_content_description">Share</string>
     <!-- Sub-header in the dialog to share a link to another app -->
     <string name="share_link_subheader">Share a link</string>
     <!-- Sub-header in the dialog to share a link to another sync device -->


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
