### PR TITLE
fixes #3843 - (L10N) regression: alignment issue when saving tabs to collection

### DIFF
--- a/app/src/main/res/layout/component_collection_creation.xml
+++ b/app/src/main/res/layout/component_collection_creation.xml
@@ -126,7 +126,7 @@
         <TextView
             android:id="@+id/bottom_bar_text"
             android:layout_width="0dp"
-            android:layout_height="wrap_content"
+            android:layout_height="0dp"
             android:layout_marginStart="8dp"
             android:layout_marginEnd="8dp"
             android:gravity="center_vertical"


### PR DESCRIPTION

changed selectTabsText's (bottom_bar_text)height to match_constraints instead of wrap_content - this makes for a better calculation of space, avoids setting textView on two lines, with blank line below.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
