### PR TITLE
Clean up create collection view model and fragment

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -25,8 +25,8 @@ import kotlinx.coroutines.launch
 import mozilla.components.browser.search.SearchEngine
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
+import mozilla.components.browser.session.intent.EXTRA_SESSION_ID
 import mozilla.components.concept.engine.EngineView
-import mozilla.components.feature.intent.IntentProcessor
 import mozilla.components.lib.crash.Crash
 import mozilla.components.support.base.feature.BackHandler
 import mozilla.components.support.ktx.kotlin.isUrl
@@ -104,10 +104,7 @@ open class HomeActivity : AppCompatActivity(), ShareFragment.TabsSharedCallback 
     private fun setupThemeAndBrowsingMode() {
         browsingModeManager = createBrowsingModeManager()
         themeManager = createThemeManager(
-            when (browsingModeManager.isPrivate) {
-                true -> ThemeManager.Theme.Private
-                false -> ThemeManager.Theme.Normal
-            }
+            if (browsingModeManager.isPrivate) ThemeManager.Theme.Private else ThemeManager.Theme.Normal
         )
         setTheme(themeManager.currentTheme)
         ThemeManager.applyStatusBarTheme(window, themeManager, this)
@@ -195,7 +192,7 @@ open class HomeActivity : AppCompatActivity(), ShareFragment.TabsSharedCallback 
         var customTabSessionId: String? = null
 
         if (isCustomTab) {
-            customTabSessionId = SafeIntent(intent).getStringExtra(IntentProcessor.ACTIVE_SESSION_ID)
+            customTabSessionId = SafeIntent(intent).getStringExtra(EXTRA_SESSION_ID)
         }
 
         openToBrowser(BrowserDirection.FromGlobal, customTabSessionId)

--- a/app/src/main/java/org/mozilla/fenix/collections/CollectionCreationComponent.kt
+++ b/app/src/main/java/org/mozilla/fenix/collections/CollectionCreationComponent.kt
@@ -5,8 +5,6 @@
 package org.mozilla.fenix.collections
 
 import android.view.ViewGroup
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
 import org.mozilla.fenix.home.sessioncontrol.Tab
 import org.mozilla.fenix.home.sessioncontrol.TabCollection
 import org.mozilla.fenix.mvi.Action
@@ -18,19 +16,19 @@ import org.mozilla.fenix.mvi.UIComponentViewModelBase
 import org.mozilla.fenix.mvi.UIComponentViewModelProvider
 import org.mozilla.fenix.mvi.ViewState
 
-sealed class SaveCollectionStep {
-    object SelectTabs : SaveCollectionStep()
-    object SelectCollection : SaveCollectionStep()
-    object NameCollection : SaveCollectionStep()
-    object RenameCollection : SaveCollectionStep()
+enum class SaveCollectionStep {
+    SelectTabs,
+    SelectCollection,
+    NameCollection,
+    RenameCollection
 }
 
 data class CollectionCreationState(
-    val tabs: List<Tab> = listOf(),
-    val selectedTabs: Set<Tab> = setOf(),
+    val tabs: List<Tab> = emptyList(),
+    val selectedTabs: Set<Tab> = emptySet(),
     val saveCollectionStep: SaveCollectionStep = SaveCollectionStep.SelectTabs,
-    val tabCollections: List<TabCollection> = listOf(),
-    val selectedTabCollection: TabCollection?
+    val tabCollections: List<TabCollection> = emptyList(),
+    val selectedTabCollection: TabCollection? = null
 ) : ViewState
 
 sealed class CollectionCreationChange : Change {
@@ -78,42 +76,21 @@ class CollectionCreationComponent(
 
 class CollectionCreationViewModel(
     initialState: CollectionCreationState
-) :
-    UIComponentViewModelBase<CollectionCreationState, CollectionCreationChange>(
-        initialState,
-        reducer
-    ) {
-
-    class Factory(
-        private val initialState: CollectionCreationState
-    ) : ViewModelProvider.Factory {
-        @Suppress("UNCHECKED_CAST")
-        override fun <T : ViewModel?> create(modelClass: Class<T>): T =
-            CollectionCreationViewModel(initialState) as T
-    }
+) : UIComponentViewModelBase<CollectionCreationState, CollectionCreationChange>(initialState, reducer) {
 
     companion object {
-        val reducer: Reducer<CollectionCreationState, CollectionCreationChange> =
-            { state, change ->
-                when (change) {
-                    is CollectionCreationChange.AddAllTabs -> state.copy(selectedTabs = state.tabs.toSet())
-                    is CollectionCreationChange.RemoveAllTabs -> state.copy(selectedTabs = setOf())
-                    is CollectionCreationChange.TabListChange -> state.copy(tabs = change.tabs)
-                    is CollectionCreationChange.TabAdded -> {
-                        val selectedTabs = state.selectedTabs + setOf(change.tab)
-                        state.copy(selectedTabs = selectedTabs)
-                    }
-                    is CollectionCreationChange.TabRemoved -> {
-                        val selectedTabs = state.selectedTabs - setOf(change.tab)
-                        state.copy(selectedTabs = selectedTabs)
-                    }
-                    is CollectionCreationChange.StepChanged -> {
-                        state.copy(saveCollectionStep = change.saveCollectionStep)
-                    }
-                    is CollectionCreationChange.CollectionSelected -> {
-                        state.copy(selectedTabCollection = change.collection)
-                    }
-                }
+        val reducer: Reducer<CollectionCreationState, CollectionCreationChange> = { state, change ->
+            when (change) {
+                is CollectionCreationChange.AddAllTabs -> state.copy(selectedTabs = state.tabs.toSet())
+                is CollectionCreationChange.RemoveAllTabs -> state.copy(selectedTabs = setOf())
+                is CollectionCreationChange.TabListChange -> state.copy(tabs = change.tabs)
+                is CollectionCreationChange.TabAdded -> state.copy(selectedTabs = state.selectedTabs + change.tab)
+                is CollectionCreationChange.TabRemoved -> state.copy(selectedTabs = state.selectedTabs - change.tab)
+                is CollectionCreationChange.StepChanged ->
+                    state.copy(saveCollectionStep = change.saveCollectionStep)
+                is CollectionCreationChange.CollectionSelected ->
+                    state.copy(selectedTabCollection = change.collection)
             }
+        }
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/collections/CreateCollectionFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/collections/CreateCollectionFragment.kt
@@ -54,15 +54,7 @@ class CreateCollectionFragment : DialogFragment() {
                 this,
                 CollectionCreationViewModel::class.java
             ) {
-                CollectionCreationViewModel(
-                    CollectionCreationState(
-                        viewModel.tabs,
-                        viewModel.selectedTabs,
-                        viewModel.saveCollectionStep,
-                        viewModel.tabCollections,
-                        viewModel.selectedTabCollection
-                    )
-                )
+                CollectionCreationViewModel(viewModel.state)
             }
         )
         return view
@@ -91,7 +83,11 @@ class CreateCollectionFragment : DialogFragment() {
                     getManagedEmitter<CollectionCreationChange>()
                         .onNext(
                             CollectionCreationChange.StepChanged(
-                                viewModel.tabCollections.getStepForCollectionsSize()
+                                if (viewModel.state.tabCollections.isEmpty()) {
+                                    SaveCollectionStep.NameCollection
+                                } else {
+                                    SaveCollectionStep.SelectCollection
+                                }
                             )
                         )
                 }
@@ -159,41 +155,38 @@ class CreateCollectionFragment : DialogFragment() {
     }
 
     private fun handleBackPress(backPressFrom: SaveCollectionStep) {
-        when (backPressFrom) {
-            SaveCollectionStep.SelectTabs -> dismiss()
-            SaveCollectionStep.SelectCollection -> {
-                if (viewModel.tabs.size <= 1) dismiss() else {
-                    getManagedEmitter<CollectionCreationChange>().onNext(
-                        CollectionCreationChange.StepChanged(SaveCollectionStep.SelectTabs)
-                    )
-                }
+        val newStep = stepBack(backPressFrom)
+        if (newStep != null) {
+            getManagedEmitter<CollectionCreationChange>().onNext(CollectionCreationChange.StepChanged(newStep))
+        } else {
+            dismiss()
+        }
+    }
+
+    private fun stepBack(backFromStep: SaveCollectionStep): SaveCollectionStep? {
+        val state = viewModel.state
+        return when (backFromStep) {
+            SaveCollectionStep.SelectTabs, SaveCollectionStep.RenameCollection -> null
+            SaveCollectionStep.SelectCollection -> if (state.tabs.size <= 1) {
+                stepBack(SaveCollectionStep.SelectTabs)
+            } else {
+                SaveCollectionStep.SelectTabs
             }
-            SaveCollectionStep.NameCollection -> {
-                if (viewModel.tabCollections.isEmpty() && viewModel.tabs.size == 1) {
-                    dismiss()
-                } else {
-                    getManagedEmitter<CollectionCreationChange>()
-                        .onNext(
-                            CollectionCreationChange.StepChanged(
-                                viewModel.tabCollections.getBackStepForCollectionsSize()
-                            )
-                        )
-                }
-            }
-            SaveCollectionStep.RenameCollection -> {
-                dismiss()
+            SaveCollectionStep.NameCollection -> if (state.tabCollections.isEmpty()) {
+                stepBack(SaveCollectionStep.SelectCollection)
+            } else {
+                SaveCollectionStep.SelectCollection
             }
         }
     }
 
     private fun closeTabsIfNecessary(tabs: List<Tab>) {
         // Only close the tabs if the user is not on the BrowserFragment
-        if (viewModel.previousFragmentId == R.id.browserFragment) { return }
-
-        tabs.forEach {
-            requireComponents.core.sessionManager.findSessionById(it.sessionId)?.let { session ->
-                requireComponents.useCases.tabsUseCases.removeTab.invoke(session)
-            }
+        if (viewModel.previousFragmentId != R.id.browserFragment) {
+            val components = requireComponents
+            tabs.asSequence()
+                .mapNotNull { tab -> components.core.sessionManager.findSessionById(tab.sessionId) }
+                .forEach { session -> components.useCases.tabsUseCases.removeTab(session) }
         }
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/collections/CreateCollectionViewModel.kt
+++ b/app/src/main/java/org/mozilla/fenix/collections/CreateCollectionViewModel.kt
@@ -4,26 +4,46 @@
 
 package org.mozilla.fenix.collections
 
-import android.view.View
 import androidx.lifecycle.ViewModel
 import org.mozilla.fenix.home.sessioncontrol.Tab
 import org.mozilla.fenix.home.sessioncontrol.TabCollection
 
 class CreateCollectionViewModel : ViewModel() {
-    var selectedTabs = mutableSetOf<Tab>()
-    var tabs = listOf<Tab>()
-    var saveCollectionStep: SaveCollectionStep = SaveCollectionStep.SelectTabs
-    var tabCollections = listOf<TabCollection>()
-    var selectedTabCollection: TabCollection? = null
-    var snackbarAnchorView: View? = null
+    var state = CollectionCreationState()
+        private set
     var previousFragmentId: Int? = null
 
-    fun getStepForTabsAndCollectionSize(): SaveCollectionStep =
-        if (tabs.size > 1) SaveCollectionStep.SelectTabs else tabCollections.getStepForCollectionsSize()
+    fun updateCollection(
+        tabs: List<Tab>,
+        saveCollectionStep: SaveCollectionStep,
+        selectedTabCollection: TabCollection,
+        cachedTabCollections: List<TabCollection>
+    ) {
+        state = CollectionCreationState(
+            tabs = tabs,
+            selectedTabs = if (tabs.size == 1) setOf(tabs.first()) else emptySet(),
+            tabCollections = cachedTabCollections.reversed(),
+            selectedTabCollection = selectedTabCollection,
+            saveCollectionStep = saveCollectionStep
+        )
+    }
+
+    fun saveTabToCollection(
+        tabs: List<Tab>,
+        selectedTab: Tab?,
+        cachedTabCollections: List<TabCollection>
+    ) {
+        val tabCollections = cachedTabCollections.reversed()
+        state = CollectionCreationState(
+            tabs = tabs,
+            selectedTabs = selectedTab?.let { setOf(it) } ?: emptySet(),
+            tabCollections = tabCollections,
+            selectedTabCollection = null,
+            saveCollectionStep = when {
+                tabs.size > 1 -> SaveCollectionStep.SelectTabs
+                tabCollections.isNotEmpty() -> SaveCollectionStep.SelectCollection
+                else -> SaveCollectionStep.NameCollection
+            }
+        )
+    }
 }
-
-fun List<TabCollection>.getStepForCollectionsSize(): SaveCollectionStep =
-    if (isEmpty()) SaveCollectionStep.NameCollection else SaveCollectionStep.SelectCollection
-
-fun List<TabCollection>.getBackStepForCollectionsSize(): SaveCollectionStep =
-    if (isEmpty()) SaveCollectionStep.SelectTabs else SaveCollectionStep.SelectCollection

--- a/app/src/main/java/org/mozilla/fenix/collections/SaveCollectionListAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/collections/SaveCollectionListAdapter.kt
@@ -35,10 +35,9 @@ class SaveCollectionListAdapter(
         val collection = tabCollections[position]
         holder.bind(collection)
         holder.itemView.setOnClickListener {
-            collection.apply {
-                val action = CollectionCreationAction.SelectCollection(this, selectedTabs.toList())
-                actionEmitter.onNext(action)
-            }
+            actionEmitter.onNext(
+                CollectionCreationAction.SelectCollection(collection, selectedTabs.toList())
+            )
         }
     }
 

--- a/app/src/main/res/layout/component_collection_creation.xml
+++ b/app/src/main/res/layout/component_collection_creation.xml
@@ -81,6 +81,7 @@
         android:layout_marginStart="@dimen/component_collection_creation_list_margin"
         android:layout_marginTop="@dimen/component_collection_creation_list_margin"
         android:layout_marginEnd="@dimen/component_collection_creation_list_margin"
+        tools:listitem="@layout/collection_tab_list_row"
         app:layout_constraintBottom_toTopOf="@id/bottom_button_bar_layout"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/test/java/org/mozilla/fenix/collections/CreateCollectionViewModelTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/collections/CreateCollectionViewModelTest.kt
@@ -1,0 +1,150 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.collections
+
+import io.mockk.MockKAnnotations
+import io.mockk.mockk
+import mozilla.components.feature.tab.collections.TabCollection
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.mozilla.fenix.home.sessioncontrol.Tab
+
+class CreateCollectionViewModelTest {
+
+    private lateinit var viewModel: CreateCollectionViewModel
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this)
+
+        viewModel = CreateCollectionViewModel()
+    }
+
+    @Test
+    fun `initial state defaults`() {
+        assertEquals(
+            CollectionCreationState(
+                tabs = emptyList(),
+                selectedTabs = emptySet(),
+                saveCollectionStep = SaveCollectionStep.SelectTabs,
+                tabCollections = emptyList(),
+                selectedTabCollection = null
+            ),
+            viewModel.state
+        )
+        assertNull(viewModel.previousFragmentId)
+    }
+
+    @Test
+    fun `updateCollection copies tabs to state`() {
+        val tabs = listOf<Tab>(mockk(), mockk())
+        val tabCollections = listOf<TabCollection>(mockk(), mockk())
+        val selectedCollection: TabCollection = mockk()
+        viewModel.updateCollection(
+            tabs = tabs,
+            saveCollectionStep = SaveCollectionStep.SelectCollection,
+            selectedTabCollection = selectedCollection,
+            cachedTabCollections = tabCollections
+        )
+        assertEquals(tabs, viewModel.state.tabs)
+        assertEquals(SaveCollectionStep.SelectCollection, viewModel.state.saveCollectionStep)
+        assertEquals(selectedCollection, viewModel.state.selectedTabCollection)
+        assertEquals(tabCollections.reversed(), viewModel.state.tabCollections)
+    }
+
+    @Test
+    fun `updateCollection selects the only tab`() {
+        val tab: Tab = mockk()
+        viewModel.updateCollection(
+            tabs = listOf(tab),
+            saveCollectionStep = mockk(),
+            selectedTabCollection = mockk(),
+            cachedTabCollections = emptyList()
+        )
+        assertEquals(setOf(tab), viewModel.state.selectedTabs)
+
+        viewModel.updateCollection(
+            tabs = listOf(tab, mockk()),
+            saveCollectionStep = mockk(),
+            selectedTabCollection = mockk(),
+            cachedTabCollections = emptyList()
+        )
+        assertEquals(emptySet<Tab>(), viewModel.state.selectedTabs)
+
+        viewModel.updateCollection(
+            tabs = emptyList(),
+            saveCollectionStep = mockk(),
+            selectedTabCollection = mockk(),
+            cachedTabCollections = emptyList()
+        )
+        assertEquals(emptySet<Tab>(), viewModel.state.selectedTabs)
+    }
+
+    @Test
+    fun `saveTabToCollection copies tabs to state`() {
+        val tabs = listOf<Tab>(mockk(), mockk())
+        val tabCollections = listOf<TabCollection>(mockk(), mockk())
+        viewModel.saveTabToCollection(
+            tabs = tabs,
+            selectedTab = null,
+            cachedTabCollections = tabCollections
+        )
+        assertEquals(tabs, viewModel.state.tabs)
+        assertEquals(SaveCollectionStep.SelectTabs, viewModel.state.saveCollectionStep)
+        assertNull(viewModel.state.selectedTabCollection)
+        assertEquals(tabCollections.reversed(), viewModel.state.tabCollections)
+    }
+
+    @Test
+    fun `saveTabToCollection selects selectedTab`() {
+        val tab: Tab = mockk()
+        viewModel.saveTabToCollection(
+            tabs = listOf(mockk()),
+            selectedTab = tab,
+            cachedTabCollections = emptyList()
+        )
+        assertEquals(setOf(tab), viewModel.state.selectedTabs)
+
+        viewModel.saveTabToCollection(
+            tabs = listOf(mockk()),
+            selectedTab = null,
+            cachedTabCollections = emptyList()
+        )
+        assertEquals(emptySet<Tab>(), viewModel.state.selectedTabs)
+    }
+
+    @Test
+    fun `saveTabToCollection sets saveCollectionStep`() {
+        viewModel.saveTabToCollection(
+            tabs = listOf(mockk(), mockk()),
+            selectedTab = null,
+            cachedTabCollections = listOf(mockk())
+        )
+        assertEquals(SaveCollectionStep.SelectTabs, viewModel.state.saveCollectionStep)
+
+        viewModel.saveTabToCollection(
+            tabs = listOf(mockk()),
+            selectedTab = null,
+            cachedTabCollections = listOf(mockk())
+        )
+        assertEquals(SaveCollectionStep.SelectCollection, viewModel.state.saveCollectionStep)
+
+        viewModel.saveTabToCollection(
+            tabs = emptyList(),
+            selectedTab = null,
+            cachedTabCollections = listOf(mockk())
+        )
+        assertEquals(SaveCollectionStep.SelectCollection, viewModel.state.saveCollectionStep)
+
+        viewModel.saveTabToCollection(
+            tabs = emptyList(),
+            selectedTab = null,
+            cachedTabCollections = emptyList()
+        )
+        assertEquals(SaveCollectionStep.NameCollection, viewModel.state.saveCollectionStep)
+    }
+}


### PR DESCRIPTION
- `CreateCollectionViewModel` now just has `state` as a property, with setter functions. Long-term this logic could be moved into the store.
- `SaveCollectionStep` is an enum. Code using the step has been simplified.
- Switch to `EXTRA_SESSION_ID` from deprecated `ACTIVE_SESSION_ID` (same string).

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
