### PR TITLE
WORK IN PROGRESS: Remove "abi" product flavor and introduce "engine" product flavor.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,6 +12,7 @@ import com.android.build.gradle.internal.tasks.AppPreBuildTask
 import org.gradle.internal.logging.text.StyledTextOutput.Style
 import org.gradle.internal.logging.text.StyledTextOutputFactory
 import static org.gradle.api.tasks.testing.TestResult.ResultType
+import com.android.build.OutputFile
 
 android {
     compileSdkVersion 28
@@ -50,24 +51,54 @@ android {
             applicationIdSuffix ".performancetest"
             debuggable true
         }
-        nightlyLegacy releaseTemplate >> {
+        fenixNightlyLegacy releaseTemplate >> {
             buildConfigField "boolean", "USE_RELEASE_VERSIONING", "true"
         }
-        nightly releaseTemplate >> {
+        fenixNightly releaseTemplate >> {
             applicationIdSuffix ".nightly"
             buildConfigField "boolean", "USE_RELEASE_VERSIONING", "true"
         }
-        beta releaseTemplate >> {
+        fenixBeta releaseTemplate >> {
             applicationIdSuffix ".beta"
             buildConfigField "boolean", "USE_RELEASE_VERSIONING", "true"
         }
-        production releaseTemplate >> {
+        fenixProduction releaseTemplate >> {
             buildConfigField "boolean", "USE_RELEASE_VERSIONING", "true"
         }
     }
 
     variantFilter { // There's a "release" build type that exists by default that we don't use (it's replaced by "nightly" and "beta")
         if (buildType.name == 'release') {
+            setIgnore true
+        }
+
+        // Current build variant setup:
+        //
+        //                      | geckoNightly  | geckoBeta |
+        // |--------------------|---------------|-----------|
+        // | debug              | ✅            | ✅       | Both variants for testing and development.
+        // | forPerformanceTest | ✅            | ✅       | Both variants unless the perf team only cares about Nightly (TBD).
+        // | fenixNightlyLegacy | ❌            | ✅       | For now GV Beta - the same version we ship with (TBD). Release type will be decommissioned soon.
+        // | fenixNightly       | ❌            | ✅       | For now GV Beta - the same version we ship with (TBD).
+        // | fenixBeta          | ❌            | ✅       | Fenix Beta ships with GV Beta
+        // | fenixProduction    | ❌            | ✅       | Fenix Production ships with GV Beta
+        //
+
+        def flavors = flavors*.name.toString().toLowerCase()
+
+        if (buildType.name == 'fenixNightlyLegacy' && flavors.contains("geckonightly")) {
+            setIgnore true
+        }
+
+        if (buildType.name == 'fenixNightly' && flavors.contains("geckonightly")) {
+            setIgnore true
+        }
+
+        if (buildType.name == 'fenixBeta' && flavors.contains("geckonightly")) {
+            setIgnore true
+        }
+
+        if (buildType.name == 'fenixProduction' && flavors.contains("geckonightly")) {
             setIgnore true
         }
     }
@@ -77,32 +108,25 @@ android {
         unitTests.includeAndroidResources = true
     }
 
-    flavorDimensions "abi"
+    flavorDimensions "engine"
 
     productFlavors {
-        arm {
-            dimension "abi"
-            ndk {
-                abiFilter "armeabi-v7a"
-            }
+        geckoNightly {
+            dimension "engine"
         }
-        aarch64 {
-            dimension "abi"
-            ndk {
-                abiFilter "arm64-v8a"
-            }
+
+        geckoBeta {
+            dimension "engine"
         }
-        x86 {
-            dimension "abi"
-            ndk {
-                abiFilter "x86"
-            }
-        }
-        x86_64 {
-            dimension "abi"
-            ndk {
-                abiFilter "x86_64"
-            }
+    }
+
+    splits {
+        abi {
+            enable true
+
+            reset()
+
+            include "x86", "armeabi-v7a", "arm64-v8a", "x86_64"
         }
     }
 
@@ -119,6 +143,8 @@ android {
         exclude 'META-INF/atomicfu.kotlin_module'
     }
 }
+
+def baseVersionCode = generatedVersionCode
 
 android.applicationVariants.all { variant ->
 
@@ -138,14 +164,10 @@ android.applicationVariants.all { variant ->
 // Generate version codes for builds
 // -------------------------------------------------------------------------------------------------
 
-    def buildType = variant.buildType.name
-    def versionCode = null
     def isDebug = variant.buildType.resValues['IS_DEBUG']?.value ?: false
     def useReleaseVersioning = variant.buildType.buildConfigFields['USE_RELEASE_VERSIONING']?.value ?: false
 
     if (useReleaseVersioning) {
-        versionCode = generatedVersionCode
-
         // The Google Play Store does not allow multiple APKs for the same app that all have the
         // same version code. Therefore we need to have different version codes for our ARM and x86
         // builds.
@@ -154,17 +176,24 @@ android.applicationVariants.all { variant ->
         // Our x86 builds need a higher version code to avoid installing ARM builds on an x86 device
         // with ARM compatibility mode.
 
-        if (variant.flavorName.contains("x86_64")) {
-            versionCode = versionCode + 3
-        } else if (variant.flavorName.contains("x86")) {
-            versionCode = versionCode + 2
-        } else if (variant.flavorName.contains("aarch64")) {
-            versionCode = versionCode + 1
-        }// else variant.flavorName.contains("Arm")) use generated version code
+        variant.outputs.each { output ->
+            def abi = output.getFilter(OutputFile.ABI)
 
-        variant.outputs.all {
-            versionCodeOverride = versionCode
-            versionNameOverride = Config.releaseVersionName(project)
+            def versionCodeOverride
+
+            if (abi == "x86_64") {
+                versionCodeOverride = baseVersionCode + 3
+            } else if (abi == "x86") {
+                versionCodeOverride = baseVersionCode + 2
+            } else if (abi == "arm64-v8a") {
+                versionCodeOverride = baseVersionCode + 1
+            } else if (abi == "armeabi-v7a") {
+                versionCodeOverride = baseVersionCode
+            } else {
+                throw RuntimeException("Unknown ABI: $abi")
+            }
+
+            println("versionCode for $abi = $versionCodeOverride")
         }
 
         // If this is a release build, validate that "versionName" is set
@@ -271,6 +300,9 @@ androidExtensions {
 dependencies {
     implementation project(':architecture')
 
+    geckoNightlyImplementation Deps.mozilla_browser_engine_gecko_nightly
+    geckoBetaImplementation Deps.mozilla_browser_engine_gecko_beta
+
     implementation Deps.kotlin_stdlib
     implementation Deps.kotlin_coroutines
     implementation Deps.androidx_appcompat
@@ -303,7 +335,6 @@ dependencies {
     implementation Deps.mozilla_browser_domains
     implementation Deps.mozilla_browser_icons
     implementation Deps.mozilla_browser_menu
-    implementation Deps.mozilla_browser_engine_gecko_beta
     implementation Deps.mozilla_browser_search
     implementation Deps.mozilla_browser_session
     implementation Deps.mozilla_browser_storage_sync
@@ -429,7 +460,7 @@ task printBuildVariants {
         def variantData = android.applicationVariants.collect { variant -> [
             name: variant.name,
             buildType: variant.buildType.name,
-            abi: variant.productFlavors.find { it.dimension == 'abi' }.name,
+            engine: variant.productFlavors.find { it.dimension == 'engine' }.name,
             isSigned: variant.signingReady,
         ]}
         println "variants: " + groovy.json.JsonOutput.toJson(variantData)

--- a/automation/taskcluster/lib/gradle.py
+++ b/automation/taskcluster/lib/gradle.py
@@ -19,7 +19,7 @@ def get_variants_for_build_type(build_type):
         raise ValueError("Could not get build variants from gradle")
 
     print("Got variants: {}".format(variants))
-    return [Variant(variant_dict['name'], variant_dict['abi'], variant_dict['isSigned'], variant_dict['buildType'])
+    return [Variant(variant_dict['name'], variant_dict['engine'], variant_dict['isSigned'], variant_dict['buildType'])
             for variant_dict in variants
             if variant_dict['buildType'] == build_type]
 

--- a/automation/taskcluster/lib/variant.py
+++ b/automation/taskcluster/lib/variant.py
@@ -1,16 +1,16 @@
 class Variant:
-    def __init__(self, raw, abi, is_signed, build_type):
+    def __init__(self, raw, engine, is_signed, build_type):
         self.raw = raw
-        self.abi = abi
+        self.engine = engine
         self.build_type = build_type
         self._is_signed = is_signed
         self.for_gradle_command = raw[:1].upper() + raw[1:]
-        self.platform = 'android-{}-{}'.format(self.abi, self.build_type)
+        self.platform = 'android-{}-{}'.format(self.engine, self.build_type)
 
     def apk_absolute_path(self):
-        return '/opt/fenix/app/build/outputs/apk/{abi}/{build_type}/app-{abi}-{build_type}{unsigned}.apk'.format(
+        return '/opt/fenix/app/build/outputs/apk/{engine}/{build_type}/app-{engine}-{build_type}{unsigned}.apk'.format(
             build_type=self.build_type,
-            abi=self.abi,
+            engine=self.engine,
             unsigned='' if self._is_signed else '-unsigned',
         )
 

--- a/config/pre-push-recommended.sh
+++ b/config/pre-push-recommended.sh
@@ -17,4 +17,4 @@
 ./gradlew -q \
         ktlint \
         detekt \
-        app:assembleX86Debug
+        app:assembleDebug

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,5 +17,5 @@ android.useAndroidX=true
 android.enableJetifier=true
 android.enableR8=true
 android.enableR8.fullMode=true
-android.enableUnitTestBinaryResources=true
+android.enableUnitTestBinaryResources=false
 org.gradle.parallel=false


### PR DESCRIPTION
Incomplete draft. DO NOT MERGE yet. Opening PR to test on taskcluster and share with @mitchhentges.

~~Depends on #4297 (first commit in this PR)~~ Landed ✅

----

This patch will allow us to build Fenix against GeckoView Nightly and GeckoView Beta by
introducing a new flavor dimension: `engine = [geckoNightly, geckoBeta]`.

In addition to that it adds a `fenix`  prefix to the nightly, beta and production flavors
to reduce the ambiguity between Fenix beta/nightly and GeckoView beta/nightly.

For now the build types have the following engine variants enabled:

**debug**: `geckoNightly, geckoBeta`
Both variants enabled for local development and testing.

**forPerformanceTest**: `geckoNightly, geckoBeta`
Both variants enabled unless the perf team only cares about Nightly (tbd)

**fenixNightlyLegacy**: `geckoBeta`
Uses GeckoView Beta for now - the same version we ship production builds with (same behavior
as before). This release type will eventualyl be decommissioned once we switch to a separate
Nightly app on Google Play.

**fenixNightly**: `geckoBeta`
Uses GeckoView Beta for now - the same version we ship production builds with (same behavior
as before). Changing this build to use GeckoView Nightly is currently being discussed.

**fenixBeta**: `geckoBeta`
Fenix Beta uses GeckoView Beta.

**fenixProduction**: `geckoBeta`
Fenix Production uses GeckoView Beta (69) currently.

----

AC provides a mechanism to write feature flags that depend on a specific engine version. I'll write a wiki page or email explaining that once this gets closer to landing.