### PR TITLE
Resolves "no such file or directory" CI error for firebase secret

### DIFF
--- a/automation/taskcluster/helper/get-secret.py
+++ b/automation/taskcluster/helper/get-secret.py
@@ -12,6 +12,12 @@ import taskcluster
 
 def write_secret_to_file(path, data, key, base64decode=False, json_secret=False, append=False, prefix=''):
     path = os.path.join(os.path.dirname(__file__), '../../../' + path)
+    try:
+        os.makedirs(os.path.dirname(path))
+    except OSError as error:
+        if error.errno != errno.EEXIST:
+            raise
+
     with open(path, 'a' if append else 'w') as f:
         value = data['secret'][key]
         if base64decode:


### PR DESCRIPTION
When placing the `firebase` secret, we need to create the directory structure for the `nightlyLegacy` build type

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
