### PR TITLE
For #1750: Adds gradient to private BrowserToolbar

### DIFF
--- a/app/src/main/res/drawable/toolbar_background.xml
+++ b/app/src/main/res/drawable/toolbar_background.xml
@@ -5,7 +5,12 @@
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item>
         <shape android:shape="rectangle">
-            <solid android:color="?foundation" />
+             <gradient
+                android:angle="45"
+                android:startColor="?toolbarStartGradient"
+                android:centerColor="?toolbarCenterGradient"
+                android:endColor="?toolbarEndGradient"
+                android:type="linear" />
         </shape>
     </item>
     <item android:gravity="top">

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -25,6 +25,9 @@
     <color name="toggle_off_track_normal_theme">@color/toggle_off_track_dark_theme</color>
     <color name="snackbar_normal_theme">@color/accent_bright_dark_theme</color>
     <color name="accent_on_dark_background_normal_theme">@color/accent_high_contrast_dark_theme</color>
+    <color name="toolbar_start_gradient_normal_theme">@color/toolbar_start_gradient_dark_theme</color>
+    <color name="toolbar_center_gradient_normal_theme">@color/toolbar_center_gradient_dark_theme</color>
+    <color name="toolbar_end_gradient_normal_theme">@color/toolbar_end_gradient_dark_theme</color>
 
     <!-- Collection icons-->
     <color name="collection_icon_color_violet">@color/collection_icon_color_violet_dark_theme</color>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -21,7 +21,6 @@
     <attr name="shadow" format="reference" />
     <attr name="destructive" format="reference"/>
     <attr name="disabled" format="reference" />
-
     <attr name="scrimStart" format="reference"/>
     <attr name="scrimEnd" format="reference"/>
 
@@ -31,6 +30,9 @@
     <attr name="privateBrowsingButtonAccent" format="reference" />
     <attr name="fenixLogo" format="reference" />
     <attr name="fenixSnackbarBackground" format="reference" />
+    <attr name="toolbarStartGradient" format="reference"/>
+    <attr name="toolbarCenterGradient" format="reference"/>
+    <attr name="toolbarEndGradient" format="reference"/>
 
     <declare-styleable name="LibraryListItem">
         <attr name="listItemTitle" format="reference" />

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -26,6 +26,9 @@
     <color name="collection_icon_color_pink_light_theme">#E31587</color>
     <color name="collection_icon_color_green_light_theme">#2AC3A2</color>
     <color name="collection_icon_color_yellow_light_theme">#E27F2E</color>
+    <color name="toolbar_start_gradient_light_theme">@color/foundation_light_theme</color>
+    <color name="toolbar_center_gradient_light_theme">@color/foundation_light_theme</color>
+    <color name="toolbar_end_gradient_light_theme">@color/foundation_light_theme</color>
 
     <!-- Dark theme color palette -->
     <color name="primary_text_dark_theme">#FBFBFE</color>
@@ -39,7 +42,7 @@
     <color name="accent_high_contrast_dark_theme">#AB71FF</color>
     <color name="tab_ring_dark_theme">@color/accent_dark_theme</color>
     <color name="neutral_dark_theme">@color/photonGrey20</color>
-    <color name="neutral_faded_dark_theme">#1FEDEDF0</color>
+    <color name="neutral_faded_dark_theme">#1FFBFBFE</color>
     <color name="shadow_dark_theme">#050505</color>
     <color name="destructive_dark_theme">#FF6A75</color>
     <color name="disabled_dark_theme">#66FBFBFE</color>
@@ -50,12 +53,15 @@
     <color name="collection_icon_color_pink_dark_theme">#FF6BBA</color>
     <color name="collection_icon_color_green_dark_theme">#88FFD1</color>
     <color name="collection_icon_color_yellow_dark_theme">#FFDE67</color>
+    <color name="toolbar_start_gradient_dark_theme">@color/foundation_dark_theme</color>
+    <color name="toolbar_center_gradient_dark_theme">@color/foundation_dark_theme</color>
+    <color name="toolbar_end_gradient_dark_theme">@color/foundation_dark_theme</color>
 
     <!-- Private theme color palette -->
     <color name="primary_text_private_theme">#FBFBFE</color>
     <color name="secondary_text_private_theme">#A7A2B7</color>
     <color name="contrast_text_private_theme">@color/primary_text_private_theme</color>
-    <color name="foundation_private_theme">#1D1133</color>
+    <color name="foundation_private_theme">#261E4B</color>
     <color name="inset_private_theme">#362A5C</color>
     <color name="above_private_theme">#291D4F</color>
     <color name="accent_private_theme">#9059FF</color>
@@ -63,7 +69,7 @@
     <color name="accent_high_contrast_private_theme">#AA71FF</color>
     <color name="tab_ring_private_theme">#F565FF</color>
     <color name="neutral_private_theme">@color/photonGrey20</color>
-    <color name="neutral_faded_private_theme">#1FEDEDF0</color>
+    <color name="neutral_faded_private_theme">#1FFBFBFE</color>
     <color name="shadow_private_theme">#2B1067</color>
     <color name="destructive_private_theme">#FF6A75</color>
     <color name="disabled_private_theme">#66FBFBFE</color>
@@ -71,6 +77,9 @@
     <color name="scrimEnd_private_theme">#F515141A</color>
     <color name="snackbar_private_theme">@color/accent_bright_private_theme</color>
     <color name="accent_on_dark_background_private_theme">@color/accent_high_contrast_private_theme</color>
+    <color name="toolbar_start_gradient_private_theme">#7529A7</color>
+    <color name="toolbar_center_gradient_private_theme">#492E85</color>
+    <color name="toolbar_end_gradient_private_theme">#383372</color>
 
     <!-- Normal theme colors for light mode -->
     <color name="primary_text_normal_theme">@color/primary_text_light_theme</color>
@@ -92,6 +101,9 @@
     <color name="scrimEnd_normal_theme">@color/scrimEnd_light_theme</color>
     <color name="snackbar_normal_theme">@color/accent_light_theme</color>
     <color name="accent_on_dark_background_normal_theme">@color/accent_bright_light_theme</color>
+    <color name="toolbar_start_gradient_normal_theme">@color/toolbar_start_gradient_light_theme</color>
+    <color name="toolbar_center_gradient_normal_theme">@color/toolbar_center_gradient_light_theme</color>
+    <color name="toolbar_end_gradient_normal_theme">@color/toolbar_end_gradient_light_theme</color>
 
     <!-- Bookmark buttons -->
     <color name="bookmark_favicon_background">#DFDFE3</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -45,6 +45,10 @@
         <item name="scrimEnd">@color/scrimEnd_normal_theme</item>
         <item name="snackbar">@color/snackbar_normal_theme</item>
         <item name="accentUsedOnDarkBackground">@color/accent_on_dark_background_normal_theme</item>
+        <item name="toolbarStartGradient">@color/toolbar_start_gradient_normal_theme</item>
+        <item name="toolbarCenterGradient">@color/toolbar_center_gradient_normal_theme</item>
+        <item name="toolbarEndGradient">@color/toolbar_end_gradient_normal_theme</item>
+
         <!-- Drawables -->
         <item name="fenixLogo">@drawable/ic_logo_wordmark_normal</item>
         <item name="homeBackground">@color/foundation_normal_theme</item>
@@ -121,6 +125,9 @@
         <item name="scrimEnd">@color/scrimEnd_private_theme</item>
         <item name="snackbar">@color/snackbar_private_theme</item>
         <item name="accentUsedOnDarkBackground">@color/accent_on_dark_background_private_theme</item>
+        <item name="toolbarStartGradient">@color/toolbar_start_gradient_private_theme</item>
+        <item name="toolbarCenterGradient">@color/toolbar_center_gradient_private_theme</item>
+        <item name="toolbarEndGradient">@color/toolbar_end_gradient_private_theme</item>
 
         <!-- Drawables -->
         <item name="fenixLogo">@drawable/ic_logo_wordmark_private</item>


### PR DESCRIPTION
Also updates the color of quickActionSheet ot be "above" attribute


Old neutral color divider lines:
<img width="350" alt="image" src="https://user-images.githubusercontent.com/4400286/62079653-05e4ba00-b204-11e9-8123-7cc926e3ab0b.png">

New neutral color divider lines:
<img width="350" alt="image" src="https://user-images.githubusercontent.com/4400286/62141915-3b3fe500-b2a2-11e9-9bbc-cd1e2ab95378.png">


