### PR TITLE
Closes #4040 - Remove NestedScrollView from Bookmark Layout

### DIFF
--- a/app/src/main/res/layout/fragment_bookmark.xml
+++ b/app/src/main/res/layout/fragment_bookmark.xml
@@ -7,13 +7,10 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context="org.mozilla.fenix.library.bookmarks.BookmarkFragment">
-    <androidx.core.widget.NestedScrollView
+
+    <LinearLayout
+        android:id="@+id/bookmark_layout"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
-        <LinearLayout
-            android:id="@+id/bookmark_layout"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:orientation="vertical" />
-    </androidx.core.widget.NestedScrollView>
+        android:layout_height="match_parent"
+        android:orientation="vertical" />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
A nested scroll view doesn't allow the recyclerview to bind its items efficiently so we were binding every item when inited. I tested and removing it greatly improved the speed of attaching this list.
A side effect of this is we will see a cut off button in landscape so I will file a follow up issue to move the sign in view to the adapter.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
