### PR TITLE
fixes #3905 - "Go back" button too low on high risk error pages

### DIFF
--- a/app/src/main/res/raw/high_risk_error_style.css
+++ b/app/src/main/res/raw/high_risk_error_style.css
@@ -188,11 +188,15 @@ div[collapsed="true"] > .expander + * {
     width: auto;
   }
 
-  /* If the tablet is tall as well, add some padding to make content feel a bit more centered */
+  /* If the tablet is tall as well, add some padding to make content feel a bit more centered
+   border-box value of box-sizing property makes height property include both content and padding */
   @media (min-height: 550px) {
     #errorPageContainer {
       padding-top: 64px;
       min-height: calc(100% - 64px);
+      -webkit-box-sizing: border-box;
+         -moz-box-sizing: border-box;
+              box-sizing: border-box;
     }
   }
 }


### PR DESCRIPTION
 added to border-box value to box-sizing property for tablets so that the height property includes content and padding

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
