### PR TITLE
Fix #4372 - Set SitePermissionsDetailsExceptionsFragment toolbar title in onResume

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/SitePermissionsDetailsExceptionsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SitePermissionsDetailsExceptionsFragment.kt
@@ -30,13 +30,10 @@ class SitePermissionsDetailsExceptionsFragment : PreferenceFragmentCompat() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        (activity as AppCompatActivity).supportActionBar?.show()
 
         sitePermissions = SitePermissionsDetailsExceptionsFragmentArgs
             .fromBundle(requireArguments())
             .sitePermissions
-
-        (activity as AppCompatActivity).title = sitePermissions.origin
     }
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
@@ -45,6 +42,10 @@ class SitePermissionsDetailsExceptionsFragment : PreferenceFragmentCompat() {
 
     override fun onResume() {
         super.onResume()
+        (activity as AppCompatActivity).apply {
+            title = sitePermissions.origin
+            supportActionBar?.show()
+        }
         lifecycleScope.launch(IO) {
             val context = requireContext()
             sitePermissions =


### PR DESCRIPTION
The flow we are currently using involves setting a new title for the containing
Activity when the user navigates to a new Fragment.
This happened for SitePermissionsDetailsExceptionsFragment in it's onCreate().
Opening a permission (SitePermissionsManageExceptionsPhoneFeatureFragment) will
set a new title in it's onCreate() but going back from this new Fragment will
not create again a new SitePermissionsDetailsExceptionsFragment.
As a workaround I moved the call to set Activity's title in onResume().



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks.
- [x] **Tests**: No tests. Minor chance for a not yet tested component.
- [x] **Changelog**: This PR does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md)
