### PR TITLE
Use Mozilla Android Components 6.0.0 release.

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -33,7 +33,7 @@ object Versions {
     const val androidx_work = "2.0.1"
     const val google_material = "1.1.0-alpha07"
 
-    const val mozilla_android_components = "6.0.0-SNAPSHOT"
+    const val mozilla_android_components = "6.0.0"
     // Note that android-components also depends on application-services,
     // and in fact is our main source of appservices-related functionality.
     // The version number below tracks the application-services version


### PR DESCRIPTION
We released Android Components 6.0.0 today. Let's switch to this stable version until we cut the release branch for building Fenix 1.2 RC 1.

Note that we'll ship a 6.0.1 release (probably today) to fix one bug and update the translations in AC.