### PR TITLE
Closes #4240 - Exclude custom tabs from displayed tab count

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/DeleteBrowsingDataFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/DeleteBrowsingDataFragment.kt
@@ -148,7 +148,7 @@ class DeleteBrowsingDataFragment : Fragment() {
 
     private fun updateTabCount() {
         view?.open_tabs_item?.apply {
-            val openTabs = requireComponents.core.sessionManager.size
+            val openTabs = requireComponents.core.sessionManager.sessions.size
             subtitleView.text = resources.getString(R.string.preferences_delete_browsing_data_tabs_subtitle, openTabs)
         }
     }


### PR DESCRIPTION
I'm assuming this is what we want because we are deleting excluding custom tabs. But tagging @boek to confirm since I think you worked on this :)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
