### PR TITLE
For #3829 - Do Not Open To Browser With Intents Launched From History

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/IntentReceiverActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/IntentReceiverActivity.kt
@@ -56,10 +56,19 @@ class IntentReceiverActivity : Activity() {
             }
             intent.action == Intent.ACTION_VIEW -> {
                 intent.setClassName(applicationContext, HomeActivity::class.java.name)
-                if (!intent.getBooleanExtra(NotificationManager.RECEIVE_TABS_TAG, false)) {
-                    intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                if ((intent.flags and Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY) != 0) {
+                    // This Intent was launched from history (recent apps). Android will redeliver the
+                    // original Intent (which might be a VIEW intent). However if there's no active browsing
+                    // session then we do not want to re-process the Intent and potentially re-open a website
+                    // from a session that the user already "erased".
+                    false
+                } else {
+                    if (!intent.getBooleanExtra(NotificationManager.RECEIVE_TABS_TAG, false)) {
+                        intent.flags =
+                            Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                    }
+                    true
                 }
-                true
             }
             else -> {
                 intent.setClassName(applicationContext, HomeActivity::class.java.name)


### PR DESCRIPTION
Solution taken [from Focus](https://github.com/mozilla-mobile/focus-android/blob/master/app/src/main/java/org/mozilla/focus/session/IntentProcessor.kt#L32-L37)
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
