### PR TITLE
Fixes #4354: Updated SearchFragment state after returning from SearchEngineFragment.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/search/SearchStore.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchStore.kt
@@ -35,6 +35,7 @@ sealed class SearchEngineSource {
  * @property query The current search query string
  * @property showShortcutEnginePicker Whether or not to show the available search engine view
  * @property searchEngineSource The current selected search engine with the context of how it was selected
+ * @property defaultEngineSource The current default search engine source
  * @property showSuggestions Whether or not to show search suggestions for the selected search engine in the AwesomeBar
  * @property showVisitedSitesBookmarks Whether or not to show history and bookmark suggestions in the AwesomeBar
  * @property session The current session if available
@@ -43,6 +44,7 @@ data class SearchState(
     val query: String,
     val showShortcutEnginePicker: Boolean,
     val searchEngineSource: SearchEngineSource,
+    val defaultEngineSource: SearchEngineSource.Default,
     val showSuggestions: Boolean,
     val showVisitedSitesBookmarks: Boolean,
     val session: Session?
@@ -53,6 +55,7 @@ data class SearchState(
  */
 sealed class SearchAction : Action {
     data class SearchShortcutEngineSelected(val engine: SearchEngine) : SearchAction()
+    data class SelectNewDefaultSearchEngine(val engine: SearchEngine) : SearchAction()
     data class ShowSearchShortcutEnginePicker(val show: Boolean) : SearchAction()
     data class UpdateQuery(val query: String) : SearchAction()
 }
@@ -71,5 +74,10 @@ fun searchStateReducer(state: SearchState, action: SearchAction): SearchState {
             state.copy(showShortcutEnginePicker = action.show)
         is SearchAction.UpdateQuery ->
             state.copy(query = action.query)
+        is SearchAction.SelectNewDefaultSearchEngine ->
+            state.copy(
+                searchEngineSource = SearchEngineSource.Default(action.engine),
+                showShortcutEnginePicker = false
+            )
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/search/SearchStoreTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/search/SearchStoreTest.kt
@@ -48,6 +48,7 @@ class SearchStoreTest {
     private fun emptyDefaultState(): SearchState = SearchState(
         query = "",
         searchEngineSource = mockk(),
+        defaultEngineSource = mockk(),
         showShortcutEnginePicker = false,
         showSuggestions = false,
         showVisitedSitesBookmarks = false,


### PR DESCRIPTION

The user has the option to go to 'Shortcuts' -> 'Search engine settings'
to modify the default search engine. When returning from that settings
screen we need to update it to account for any changes.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks.
- [x] **Tests**: No tests. Small change.
- [x] **Changelog**: This PR does not need a changelog entry.
- [x] **Accessibility**: The code in this PR does not include any user facing accessibility features.
