### PR TITLE
Update to use Mozilla Android Components 6.0.1.

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -33,7 +33,7 @@ object Versions {
     const val androidx_work = "2.0.1"
     const val google_material = "1.1.0-alpha07"
 
-    const val mozilla_android_components = "6.0.0"
+    const val mozilla_android_components = "6.0.1"
     // Note that android-components also depends on application-services,
     // and in fact is our main source of appservices-related functionality.
     // The version number below tracks the application-services version


### PR DESCRIPTION
Updating for the upcoming Fenix 1.2 RC 1 build.

This new build contains two updates over 6.0.0:
* `feature-app-links`: Fixed [3944](https://github.com/mozilla-mobile/android-components/issues/3944) causing third-party apps being opened when links with a javascript scheme are clicked. - This was considered a blocker for the Fenix release during AC triage.
* Updated translations

----

* [Release notes](https://mozilla-mobile.github.io/android-components/changelog/#601)
* [Commits](https://github.com/mozilla-mobile/android-components/compare/v6.0.0...v6.0.1)

