### PR TITLE
Update to use Mozilla Android Components 6.0.2.

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -33,7 +33,7 @@ object Versions {
     const val androidx_work = "2.0.1"
     const val google_material = "1.1.0-alpha07"
 
-    const val mozilla_android_components = "6.0.1"
+    const val mozilla_android_components = "6.0.2"
     // Note that android-components also depends on application-services,
     // and in fact is our main source of appservices-related functionality.
     // The version number below tracks the application-services version


### PR DESCRIPTION
Updating for the upcoming Fenix 1.2 RC 1 build.

This new build contains a fix for `service-glean`:
 * Fixed a bug in`TimeSpanMetricType` that prevented multiple consecutive `start()`/`stop()` calls. This resulted in the `glean.baseline.duration` being missing from most [`baseline`](https://mozilla.github.io/glean/book/user/pings/baseline.html) pings.

----

* [Release notes](https://mozilla-mobile.github.io/android-components/changelog/#602)
* [Commits](https://github.com/mozilla-mobile/android-components/compare/v6.0.1...v6.0.2)

