### PR TITLE
For #4412: SiteSecurityClickedListener set incorrectly

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -223,10 +223,10 @@ class BrowserFragment : Fragment(), BackHandler {
             )
 
             quickActionSheetView = QuickActionSheetView(view.nestedScrollQuickAction, browserInteractor)
-        }
 
-        browserToolbarView.view.setOnSiteSecurityClickedListener {
-            showQuickSettingsDialog()
+            browserToolbarView.view.setOnSiteSecurityClickedListener {
+                showQuickSettingsDialog()
+            }
         }
 
         contextMenuFeature.set(
@@ -419,10 +419,6 @@ class BrowserFragment : Fragment(), BackHandler {
                 ),
                 owner = this,
                 view = view)
-        }
-
-        browserToolbarView.view.setOnSiteSecurityClickedListener {
-            showQuickSettingsDialog()
         }
 
         consumeFrom(browserStore) {


### PR DESCRIPTION
We need to make sure to only set the listener when the toolbar is created, and only once.