### PR TITLE
No Issue: Move notification manager to member of background services

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/BackgroundServices.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/BackgroundServices.kt
@@ -48,8 +48,7 @@ import org.mozilla.fenix.test.Mockable
 class BackgroundServices(
     context: Context,
     historyStorage: PlacesHistoryStorage,
-    bookmarkStorage: PlacesBookmarksStorage,
-    notificationManager: NotificationManager
+    bookmarkStorage: PlacesBookmarksStorage
 ) {
     companion object {
         const val CLIENT_ID = "a2270f727f45f648"
@@ -233,5 +232,12 @@ class BackgroundServices(
             }
         }
         CoroutineScope(Dispatchers.Main).launch { it.initAsync().await() }
+    }
+
+    /**
+     * Provides notification functionality, manages notification channels.
+     */
+    val notificationManager by lazy {
+        NotificationManager(context)
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/components/Components.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Components.kt
@@ -13,7 +13,7 @@ import org.mozilla.fenix.test.Mockable
 @Mockable
 class Components(private val context: Context) {
     val backgroundServices by lazy {
-        BackgroundServices(context, core.historyStorage, core.bookmarksStorage, utils.notificationManager)
+        BackgroundServices(context, core.historyStorage, core.bookmarksStorage)
     }
     val services by lazy { Services(backgroundServices.accountManager) }
     val core by lazy { Core(context) }

--- a/app/src/main/java/org/mozilla/fenix/components/Utilities.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Utilities.kt
@@ -39,12 +39,5 @@ class Utilities(
         CustomTabIntentProcessor(sessionManager, sessionUseCases.loadUrl, context.resources)
     }
 
-    /**
-     * Provides notification functionality, manages notification channels.
-     */
-    val notificationManager by lazy {
-        NotificationManager(context)
-    }
-
     val publicSuffixList by lazy { PublicSuffixList(context) }
 }


### PR DESCRIPTION
Instead of taking notification manager as a parameter
(from the utils class), create one private to the
BackgroundServices class. This means that we do not need
to create the entirety of utilities just to use
the notification manager.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

cc @jonalmeida 