### PR TITLE
Closes #4419: Move PublicSuffixList to root component

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -75,7 +75,7 @@ open class HomeActivity : AppCompatActivity(), ShareFragment.TabsSharedCallback 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        components.utils.publicSuffixList.prefetch()
+        components.publicSuffixList.prefetch()
         setupThemeAndBrowsingMode()
 
         setContentView(R.layout.activity_home)

--- a/app/src/main/java/org/mozilla/fenix/components/Components.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Components.kt
@@ -5,6 +5,7 @@
 package org.mozilla.fenix.components
 
 import android.content.Context
+import mozilla.components.lib.publicsuffixlist.PublicSuffixList
 import org.mozilla.fenix.test.Mockable
 
 /**
@@ -21,4 +22,5 @@ class Components(private val context: Context) {
     val useCases by lazy { UseCases(context, core.sessionManager, core.engine.settings, search.searchEngineManager) }
     val utils by lazy { Utilities(context, core.sessionManager, useCases.sessionUseCases, useCases.searchUseCases) }
     val analytics by lazy { Analytics(context) }
+    val publicSuffixList by lazy { PublicSuffixList(context) }
 }

--- a/app/src/main/java/org/mozilla/fenix/components/Utilities.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Utilities.kt
@@ -10,7 +10,6 @@ import mozilla.components.feature.customtabs.CustomTabIntentProcessor
 import mozilla.components.feature.intent.TabIntentProcessor
 import mozilla.components.feature.search.SearchUseCases
 import mozilla.components.feature.session.SessionUseCases
-import mozilla.components.lib.publicsuffixlist.PublicSuffixList
 import org.mozilla.fenix.test.Mockable
 
 /**
@@ -38,6 +37,4 @@ class Utilities(
     val customTabIntentProcessor by lazy {
         CustomTabIntentProcessor(sessionManager, sessionUseCases.loadUrl, context.resources)
     }
-
-    val publicSuffixList by lazy { PublicSuffixList(context) }
 }

--- a/app/src/main/java/org/mozilla/fenix/ext/String.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/String.kt
@@ -37,7 +37,7 @@ fun String.urlToTrimmedHost(context: Context): String {
     return try {
         val host = toUri().hostWithoutCommonPrefixes ?: return this
         runBlocking {
-            context.components.utils.publicSuffixList.stripPublicSuffix(host).await()
+            context.components.publicSuffixList.stripPublicSuffix(host).await()
         }
     } catch (e: MalformedURLException) {
         this


### PR DESCRIPTION
With the PublicSuffixList class in Utilities, the first instantiation
of it (prefetching in onCreate), causes the Utilities to instantiate
and thus slowing down startup by needing the SearchEngineManager from
instantiating as well.

This fixes #4419, read there for more details.

Moving this back to the root component fixes the immediate perf issue.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
