### PR TITLE
Fixes #4410: Modified visibility of 'Add Tab' button.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlAdapter.kt
@@ -49,7 +49,8 @@ sealed class AdapterItem(@LayoutRes val viewType: Int) {
     object CollectionHeader : AdapterItem(CollectionHeaderViewHolder.LAYOUT_ID)
     data class CollectionItem(
         val collection: TabCollection,
-        val expanded: Boolean
+        val expanded: Boolean,
+        val sessionHasOpenTabs: Boolean
     ) : AdapterItem(CollectionViewHolder.LAYOUT_ID) {
         override fun sameAs(other: AdapterItem) = other is CollectionItem && collection.id == other.collection.id
     }
@@ -135,8 +136,8 @@ class SessionControlAdapter(
                 holder.bind(icon, header, description)
             }
             is CollectionViewHolder -> {
-                val (collection, expanded) = item as AdapterItem.CollectionItem
-                holder.bindSession(collection, expanded)
+                val (collection, expanded, sessionHasOpenTabs) = item as AdapterItem.CollectionItem
+                holder.bindSession(collection, expanded, sessionHasOpenTabs)
             }
             is TabInCollectionViewHolder -> {
                 val (collection, tab, isLastTab) = item as AdapterItem.TabInCollectionItem

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlUIView.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlUIView.kt
@@ -47,7 +47,7 @@ private fun normalModeAdapterItems(
 
         // If the collection is expanded, we want to add all of its tabs beneath it in the adapter
         collections.map {
-            AdapterItem.CollectionItem(it, expandedCollections.contains(it.id))
+            AdapterItem.CollectionItem(it, expandedCollections.contains(it.id), tabs.isNotEmpty())
         }.forEach {
             items.add(it)
             if (it.expanded) {

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/CollectionViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/CollectionViewHolder.kt
@@ -34,10 +34,11 @@ class CollectionViewHolder(
 
     private lateinit var collection: TabCollection
     private var expanded = false
+    private var sessionHasOpenTabs = false
     private var collectionMenu: CollectionItemMenu
 
     init {
-        collectionMenu = CollectionItemMenu(view.context) {
+        collectionMenu = CollectionItemMenu(view.context, sessionHasOpenTabs) {
             when (it) {
                 is CollectionItemMenu.Item.DeleteCollection -> actionEmitter.onNext(CollectionAction.Delete(collection))
                 is CollectionItemMenu.Item.AddTab -> actionEmitter.onNext(CollectionAction.AddTab(collection))
@@ -68,9 +69,11 @@ class CollectionViewHolder(
         }
     }
 
-    fun bindSession(collection: TabCollection, expanded: Boolean) {
+    fun bindSession(collection: TabCollection, expanded: Boolean, sessionHasOpenTabs: Boolean) {
         this.collection = collection
         this.expanded = expanded
+        this.sessionHasOpenTabs = sessionHasOpenTabs
+        collectionMenu.sessionHasOpenTabs = sessionHasOpenTabs
         updateCollectionUI()
     }
 
@@ -114,6 +117,7 @@ class CollectionViewHolder(
 
 class CollectionItemMenu(
     private val context: Context,
+    var sessionHasOpenTabs: Boolean,
     private val onItemTapped: (Item) -> Unit = {}
 ) {
     sealed class Item {
@@ -137,7 +141,7 @@ class CollectionItemMenu(
                 context.getString(R.string.add_tab)
             ) {
                 onItemTapped.invoke(Item.AddTab)
-            },
+            }.apply { visible = { sessionHasOpenTabs } },
             SimpleBrowserMenuItem(
                 context.getString(R.string.collection_rename)
             ) {


### PR DESCRIPTION
I changed the visibility of 'Add Tab' button according to the number of
opened tabs. If there is at least one tab open, the button is displayed.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks.
- [x] **Tests**: This PR does not include tests.
- [x] **Changelog**: This PR does not need a changelog entry.
- [x] **Accessibility**: The code in this PR does not include any user facing accessibility features.
