### PR TITLE
fixes #4193 - made close button for tabs more accessible.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/TabViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/TabViewHolder.kt
@@ -18,7 +18,6 @@ import mozilla.components.support.ktx.android.util.dpToFloat
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.components
-import org.mozilla.fenix.ext.increaseTapArea
 import org.mozilla.fenix.ext.loadIntoView
 import org.mozilla.fenix.home.sessioncontrol.SessionControlAction
 import org.mozilla.fenix.home.sessioncontrol.Tab
@@ -43,7 +42,6 @@ class TabViewHolder(
             }
         }
 
-        close_tab_button.increaseTapArea(buttonIncreaseDps)
         item_tab.setOnClickListener {
             actionEmitter.onNext(TabAction.Select(it, tab?.sessionId!!))
         }
@@ -55,7 +53,6 @@ class TabViewHolder(
         }
 
         close_tab_button?.run {
-            increaseTapArea(buttonIncreaseDps)
             setOnClickListener {
                 actionEmitter.onNext(TabAction.Close(tab?.sessionId!!))
             }

--- a/app/src/main/res/layout/tab_list_row.xml
+++ b/app/src/main/res/layout/tab_list_row.xml
@@ -72,8 +72,7 @@
                 android:src="@drawable/ic_close"
                 android:background="?android:attr/selectableItemBackgroundBorderless"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintBottom_toBottomOf="parent"/>
+                app:layout_constraintTop_toTopOf="parent"/>
 
         <View
                 android:id="@+id/selected_border"

--- a/app/src/main/res/layout/tab_list_row.xml
+++ b/app/src/main/res/layout/tab_list_row.xml
@@ -40,7 +40,6 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="8dp"
-                android:layout_marginEnd="8dp"
                 android:ellipsize="none"
                 android:singleLine="true"
                 android:textAppearance="@style/Header12TextStyle"
@@ -66,16 +65,15 @@
 
         <ImageButton
                 android:id="@+id/close_tab_button"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="4.5dp"
-                android:layout_marginEnd="4.5dp"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
                 android:alpha="0.8"
                 android:contentDescription="@string/close_tab"
                 android:src="@drawable/ic_close"
                 android:background="?android:attr/selectableItemBackgroundBorderless"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"/>
 
         <View
                 android:id="@+id/selected_border"


### PR DESCRIPTION
set recommended minimum size for accessibility 48x48, while keeping image size the same
removed margin from button and text as it was not needed anymore
aligned close button in center of tab to be visual consistent with alignment of favicon and more visual accessible

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
