### PR TITLE
fixes #4434 - made close button for collections more accessible.

### DIFF
--- a/app/src/main/res/layout/collection_home_list_row.xml
+++ b/app/src/main/res/layout/collection_home_list_row.xml
@@ -78,32 +78,30 @@
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toStartOf="@id/collection_share_button"
                 app:layout_constraintStart_toStartOf="@id/collection_title"
-                app:layout_constraintTop_toBottomOf="@id/collection_share_button"
+                app:layout_constraintTop_toBottomOf="@id/collection_title"
                 tools:text="@tools:sample/lorem/random" />
 
         <ImageButton
                 android:id="@+id/collection_share_button"
-                android:layout_width="24dp"
-                android:layout_height="24dp"
-                android:layout_marginStart="16dp"
-                android:layout_marginEnd="30dp"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
                 android:background="?android:attr/selectableItemBackgroundBorderless"
                 android:contentDescription="@string/share_button_content_description"
                 android:src="@drawable/ic_hollow_share"
                 app:layout_constraintEnd_toStartOf="@id/collection_overflow_button"
+                app:layout_constraintBottom_toBottomOf="@id/collection_icon"
                 app:layout_constraintTop_toTopOf="@id/collection_icon" />
 
         <ImageButton
                 android:id="@+id/collection_overflow_button"
-                android:layout_width="24dp"
-                android:layout_height="24dp"
-                android:layout_marginTop="16dp"
-                android:layout_marginEnd="4.5dp"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
                 android:background="?android:attr/selectableItemBackgroundBorderless"
                 android:contentDescription="@string/collection_menu_button_content_description"
                 android:src="@drawable/ic_menu"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+                app:layout_constraintTop_toTopOf="@id/collection_icon"
+                app:layout_constraintBottom_toBottomOf="@id/collection_icon"/>
 
         <View
                 android:id="@+id/selected_border"

--- a/app/src/main/res/layout/tab_in_collection.xml
+++ b/app/src/main/res/layout/tab_in_collection.xml
@@ -21,6 +21,7 @@
 
         <ImageView
                 android:id="@+id/collection_tab_icon"
+                android:importantForAccessibility="no"
                 android:layout_width="24dp"
                 android:layout_height="24dp"
                 android:layout_marginTop="23dp"
@@ -62,16 +63,15 @@
 
         <ImageButton
                 android:id="@+id/collection_tab_close_button"
-                android:layout_width="8dp"
-                android:layout_height="8dp"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
                 android:background="?android:attr/selectableItemBackgroundBorderless"
                 android:contentDescription="@string/close_tab"
                 android:src="@drawable/ic_close"
-                android:layout_marginTop="13dp"
-                android:layout_marginEnd="13dp"
                 android:alpha="0.8"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent"/>
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"/>
 
         <View
                 android:id="@+id/divider_line"


### PR DESCRIPTION
set recommended minimum size for accessibility 48x48, while keeping image size the same
removed margin from button as it was not needed anymore
aligned close button in center of tab to be visual consistent with alignment of favicon and more visual accessible
implemented same visual solution as for #4193 - close button for tabs

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
