### PR TITLE
For #4412: Only consume state change when UI initialized

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -227,6 +227,27 @@ class BrowserFragment : Fragment(), BackHandler {
             browserToolbarView.view.setOnSiteSecurityClickedListener {
                 showQuickSettingsDialog()
             }
+
+            customTabSessionId?.let { customTabSessionId ->
+                customTabsIntegration.set(
+                    feature = CustomTabsIntegration(
+                        requireContext(),
+                        requireComponents.core.sessionManager,
+                        toolbar,
+                        customTabSessionId,
+                        activity,
+                        view.nestedScrollQuickAction,
+                        view.swipeRefresh,
+                        onItemTapped = { browserInteractor.onBrowserToolbarMenuItemTapped(it) }
+                    ),
+                    owner = this,
+                    view = view)
+            }
+
+            consumeFrom(browserStore) {
+                quickActionSheetView.update(it)
+                browserToolbarView.update(it)
+            }
         }
 
         contextMenuFeature.set(
@@ -404,27 +425,6 @@ class BrowserFragment : Fragment(), BackHandler {
             owner = this,
             view = view
         )
-
-        customTabSessionId?.let {
-            customTabsIntegration.set(
-                feature = CustomTabsIntegration(
-                    requireContext(),
-                    requireComponents.core.sessionManager,
-                    toolbar,
-                    it,
-                    activity,
-                    view.nestedScrollQuickAction,
-                    view.swipeRefresh,
-                    onItemTapped = { browserInteractor.onBrowserToolbarMenuItemTapped(it) }
-                ),
-                owner = this,
-                view = view)
-        }
-
-        consumeFrom(browserStore) {
-            quickActionSheetView.update(it)
-            browserToolbarView.update(it)
-        }
     }
 
     private fun themeReaderViewControlsForPrivateMode(view: View) = with(view) {


### PR DESCRIPTION
We forgot that in our recent refactoring. We should only hook up the store observer when we have the UI initialized. Also, the custom tabs need the toolbar so that should move in as well.

Here are the two crashes in Sentry (started yesterday): 
https://sentry.prod.mozaws.net/operations/fenix-nightly/issues/6105592
https://sentry.prod.mozaws.net/operations/fenix-nightly/issues/6105755

Ultimately, we need to address https://github.com/mozilla-mobile/fenix/issues/4427 for a proper solution, but first let's fix the crashes.