### PR TITLE
fixes #4435 - changed title of menuItem for delete and added content description

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/edit/EditBookmarkFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/edit/EditBookmarkFragment.kt
@@ -20,6 +20,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.Navigation
+import androidx.core.view.MenuItemCompat.setContentDescription
 import com.jakewharton.rxbinding3.widget.textChanges
 import com.uber.autodispose.AutoDispose
 import com.uber.autodispose.android.lifecycle.AndroidLifecycleScopeProvider
@@ -146,8 +147,11 @@ class EditBookmarkFragment : Fragment() {
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         inflater.inflate(R.menu.bookmarks_edit, menu)
-        menu.findItem(R.id.delete_bookmark_button).icon.colorFilter =
-            PorterDuffColorFilter(context!!.getColorFromAttr(R.attr.primaryText), SRC_IN)
+        menu.findItem(R.id.delete_bookmark_button).apply {
+            icon.colorFilter =
+                PorterDuffColorFilter(context!!.getColorFromAttr(R.attr.primaryText), SRC_IN)
+            setContentDescription(this, getString(R.string.bookmark_menu_delete_button))
+        }
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/app/src/main/res/menu/bookmarks_edit.xml
+++ b/app/src/main/res/menu/bookmarks_edit.xml
@@ -9,7 +9,7 @@
             android:id="@+id/delete_bookmark_button"
             android:icon="@drawable/ic_delete"
             android:iconTint="?primaryText"
-            android:title="@string/bookmark_edit"
+            android:title="@string/bookmark_menu_delete_button"
             app:showAsAction="ifRoom"
             tools:targetApi="o" />
 </menu>


### PR DESCRIPTION
setting menu title should have also set content description. I added the setContentDescription programmatically in order to ensure that the content description is being set. If content description matches title it won't be read twice


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
