### PR TITLE
For #4495 - Clean up homescreen toolbar focus and content descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - #4137 - Adds pagination to the history view
 - #3695 - Made search suggestions for other tabs clickable
+- Remove forced focus of toolbar on homescreen
 
 ## [1.1.0 and earlier] - 2019-07-23
 ### Added

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
@@ -119,7 +119,7 @@ private fun assertHomePrivateBrowsingButton() = onView(ViewMatchers.withResource
 private fun assertHomeWordmark() = onView(ViewMatchers.withResourceName("wordmark"))
     .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 private fun assertHomeToolbar() = onView(ViewMatchers.withResourceName("toolbar"))
-    .check(matches(allOf(withEffectiveVisibility(Visibility.VISIBLE), ViewMatchers.hasFocus())))
+    .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 private fun assertOpenTabsHeader() =
     onView(CoreMatchers.allOf(ViewMatchers.withText("Open tabs")))
         .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -14,7 +14,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewTreeObserver
-import android.view.accessibility.AccessibilityEvent
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
@@ -240,7 +239,7 @@ class HomeFragment : Fragment(), AccountObserver {
         }
         view.toolbar.compoundDrawablePadding =
             (toolbarPaddingDp * Resources.getSystem().displayMetrics.density).roundToInt()
-        view.toolbar.setOnClickListener {
+        view.toolbar_wrapper.setOnClickListener {
             invokePendingDeleteJobs()
             onboarding.finish()
             val directions = HomeFragmentDirections.actionHomeFragmentToSearchFragment(null)
@@ -253,7 +252,6 @@ class HomeFragment : Fragment(), AccountObserver {
             nav(R.id.homeFragment, directions)
             requireComponents.analytics.metrics.track(Event.SearchBarTapped(Event.SearchBarTapped.Source.HOME))
         }
-        view.toolbar.requestFocus()
 
         val isPrivate = (activity as HomeActivity).browsingModeManager.isPrivate
 
@@ -309,8 +307,6 @@ class HomeFragment : Fragment(), AccountObserver {
         (activity as AppCompatActivity).supportActionBar?.hide()
 
         requireComponents.backgroundServices.accountManager.register(this, owner = this)
-
-        focusToolbarForAccessibility()
     }
 
     override fun onStart() {
@@ -820,14 +816,6 @@ class HomeFragment : Fragment(), AccountObserver {
                 }
                 FenixSnackbar.make(view, Snackbar.LENGTH_LONG).setText(view.context.getString(stringRes)).show()
             }
-        }
-    }
-
-    private fun focusToolbarForAccessibility() {
-        viewLifecycleOwner.lifecycleScope.launch {
-            delay(ACCESSIBILITY_FOCUS_DELAY)
-            toolbar.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_FOCUSED)
-            toolbar.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUSED)
         }
     }
 

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -2,12 +2,12 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<androidx.coordinatorlayout.widget.CoordinatorLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
+
     <androidx.constraintlayout.motion.widget.MotionLayout
         android:id="@+id/homeLayout"
         android:layout_width="match_parent"
@@ -15,14 +15,15 @@
         android:background="?homeBackground"
         app:layoutDescription="@xml/home_scene"
         tools:context=".home.HomeFragment">
+
         <ImageButton
             android:id="@+id/menuButton"
             android:layout_width="@dimen/glyph_button_height"
             android:layout_height="@dimen/glyph_button_height"
             android:layout_marginTop="12dp"
             android:background="?android:attr/selectableItemBackgroundBorderless"
-            android:src="@drawable/ic_menu"
             android:contentDescription="@string/content_description_menu"
+            android:src="@drawable/ic_menu"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
@@ -31,8 +32,8 @@
             android:layout_width="@dimen/glyph_button_height"
             android:layout_height="@dimen/glyph_button_height"
             android:background="?android:attr/selectableItemBackgroundBorderless"
-            android:src="@drawable/private_browsing_button"
             android:contentDescription="@string/content_description_private_browsing_button"
+            android:src="@drawable/private_browsing_button"
             app:layout_constraintEnd_toStartOf="@id/menuButton"
             app:layout_constraintTop_toTopOf="@id/menuButton" />
 
@@ -40,11 +41,14 @@
             android:id="@+id/wordmark"
             android:layout_width="wrap_content"
             android:layout_height="80dp"
-            android:layout_marginTop="24dp"
             android:layout_marginStart="16dp"
-            android:src="?fenixLogo"
-            android:contentDescription="@string/app_name"
+            android:layout_marginTop="24dp"
             android:adjustViewBounds="true"
+            android:clickable="false"
+            android:contentDescription="@string/app_name"
+            android:focusable="false"
+            android:importantForAccessibility="no"
+            android:src="?fenixLogo"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/menuButton" />
 
@@ -56,7 +60,9 @@
             android:layout_marginTop="48dp"
             android:layout_marginEnd="16dp"
             android:background="@drawable/home_search_background_normal"
+            android:contentDescription="@string/search_hint"
             android:elevation="@dimen/toolbar_elevation"
+            android:focusableInTouchMode="true"
             android:transitionName="toolbar_wrapper_transition"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -66,18 +72,22 @@
                 android:id="@+id/search_engine_icon"
                 android:layout_width="24dp"
                 android:layout_height="24dp"
-                android:layout_margin="12dp" />
+                android:layout_margin="12dp"
+                android:clickable="false"
+                android:focusable="false"
+                android:importantForAccessibility="no" />
 
             <TextView
                 android:id="@+id/toolbar"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
+                android:layout_height="wrap_content"
                 android:layout_gravity="center_vertical"
                 android:layout_marginStart="47dp"
-                android:clickable="true"
-                android:focusable="true"
-                android:focusableInTouchMode="true"
-                android:padding="12dp"
+                android:clickable="false"
+                android:focusable="false"
+                android:importantForAccessibility="no"
+                android:paddingStart="12dp"
+                android:paddingEnd="12dp"
                 android:text="@string/search_hint"
                 android:textColor="?primaryText"
                 android:textSize="15sp" />
@@ -87,13 +97,13 @@
             android:id="@+id/homeDivider"
             android:layout_width="match_parent"
             android:layout_height="1dp"
-            android:background="?neutralFaded"
-            app:layout_constraintTop_toBottomOf="@id/toolbar_wrapper"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            android:layout_marginTop="32dp"
             android:layout_marginStart="40dp"
-            android:layout_marginEnd="40dp"/>
+            android:layout_marginTop="32dp"
+            android:layout_marginEnd="40dp"
+            android:background="?neutralFaded"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/toolbar_wrapper" />
 
         <View
             android:id="@+id/homeDividerShadow"
@@ -101,9 +111,9 @@
             android:layout_height="3dp"
             android:alpha="0"
             android:background="@drawable/home_header_shadow"
-            app:layout_constraintTop_toBottomOf="@id/homeDivider"
+            app:layout_constraintEnd_toEndOf="@+id/homeDivider"
             app:layout_constraintStart_toStartOf="@+id/homeDivider"
-            app:layout_constraintEnd_toEndOf="@+id/homeDivider" />
+            app:layout_constraintTop_toBottomOf="@id/homeDivider" />
 
     </androidx.constraintlayout.motion.widget.MotionLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
- "Search or enter address" text is now centered correctly and doesn't jump around
- toolbar_wrapper takes the click listener so you can click anywhere on the toolbar (including over the search engine icon) and should navigate
- make search engine icon and toolbar text not focusable and not important for accessibility and give toolbar_wrapper the content description and focus
- Remove autofocusing of toolbar (This was discussed in #2142 so we forced focus but this caused other issues (#4447 and #4489))
- Make Firefox Preview icon not focusable (app name is already read as you open it)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
