### PR TITLE
For #3967 - Invokes pending deletion with more bookmark actions

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkController.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkController.kt
@@ -44,7 +44,8 @@ class DefaultBookmarkController(
     private val context: Context,
     private val navController: NavController,
     private val snackbarPresenter: FenixSnackbarPresenter,
-    private val deleteBookmarkNodes: (Set<BookmarkNode>, Event) -> Unit
+    private val deleteBookmarkNodes: (Set<BookmarkNode>, Event) -> Unit,
+    private val invokePendingDeletion: () -> Unit
 ) : BookmarkController {
 
     private val activity: HomeActivity = context as HomeActivity
@@ -77,7 +78,8 @@ class DefaultBookmarkController(
     }
 
     override fun handleBookmarkSharing(item: BookmarkNode) {
-        navigate(BookmarkFragmentDirections.actionBookmarkFragmentToShareFragment(
+        navigate(
+            BookmarkFragmentDirections.actionBookmarkFragmentToShareFragment(
                 url = item.url!!,
                 title = item.title
             )
@@ -93,10 +95,12 @@ class DefaultBookmarkController(
     }
 
     override fun handleBackPressed() {
+        invokePendingDeletion.invoke()
         navController.popBackStack()
     }
 
     override fun handleSigningIn() {
+        invokePendingDeletion.invoke()
         services.launchPairingSignIn(context, navController)
     }
 
@@ -106,6 +110,7 @@ class DefaultBookmarkController(
         from: BrowserDirection,
         mode: BrowsingMode
     ) {
+        invokePendingDeletion.invoke()
         with(activity) {
             browsingModeManager.mode = mode
             openToBrowserAndLoad(searchTermOrURL, newTab, from)
@@ -113,6 +118,7 @@ class DefaultBookmarkController(
     }
 
     private fun navigate(directions: NavDirections) {
+        invokePendingDeletion.invoke()
         navController.nav(R.id.bookmarkFragment, directions)
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkControllerTest.kt
@@ -38,6 +38,7 @@ class BookmarkControllerTest {
     private val navController: NavController = mockk(relaxed = true)
     private val snackbarPresenter: FenixSnackbarPresenter = mockk(relaxed = true)
     private val deleteBookmarkNodes: (Set<BookmarkNode>, Event) -> Unit = mockk(relaxed = true)
+    private val invokePendingDeletion: () -> Unit = mockk(relaxed = true)
 
     private val homeActivity: HomeActivity = mockk(relaxed = true)
     private val services: Services = mockk(relaxed = true)
@@ -63,13 +64,16 @@ class BookmarkControllerTest {
         )
 
         every { homeActivity.components.services } returns services
-        every { navController.currentDestination } returns NavDestination("").apply { id = R.id.bookmarkFragment }
+        every { navController.currentDestination } returns NavDestination("").apply {
+            id = R.id.bookmarkFragment
+        }
 
         controller = DefaultBookmarkController(
             context = homeActivity,
             navController = navController,
             snackbarPresenter = snackbarPresenter,
-            deleteBookmarkNodes = deleteBookmarkNodes
+            deleteBookmarkNodes = deleteBookmarkNodes,
+            invokePendingDeletion = invokePendingDeletion
         )
     }
 
@@ -78,6 +82,7 @@ class BookmarkControllerTest {
         controller.handleBookmarkTapped(item)
 
         verifyOrder {
+            invokePendingDeletion.invoke()
             homeActivity.browsingModeManager.mode = BrowsingMode.Normal
             homeActivity.openToBrowserAndLoad(item.url!!, true, BrowserDirection.FromBookmarks)
         }
@@ -88,6 +93,7 @@ class BookmarkControllerTest {
         controller.handleBookmarkExpand(tree)
 
         verify {
+            invokePendingDeletion.invoke()
             navController.navigate(BookmarkFragmentDirections.actionBookmarkFragmentSelf(tree.guid))
         }
     }
@@ -106,6 +112,7 @@ class BookmarkControllerTest {
         controller.handleBookmarkEdit(item)
 
         verify {
+            invokePendingDeletion.invoke()
             navController.navigate(BookmarkFragmentDirections.actionBookmarkFragmentToBookmarkEditFragment(item.guid))
         }
     }
@@ -141,6 +148,7 @@ class BookmarkControllerTest {
         controller.handleBookmarkSharing(item)
 
         verify {
+            invokePendingDeletion.invoke()
             navController.navigate(
                 BookmarkFragmentDirections.actionBookmarkFragmentToShareFragment(
                     item.url,
@@ -155,6 +163,7 @@ class BookmarkControllerTest {
         controller.handleOpeningBookmark(item, BrowsingMode.Normal)
 
         verifyOrder {
+            invokePendingDeletion.invoke()
             homeActivity.browsingModeManager.mode = BrowsingMode.Normal
             homeActivity.openToBrowserAndLoad(item.url!!, true, BrowserDirection.FromBookmarks)
         }
@@ -165,6 +174,7 @@ class BookmarkControllerTest {
         controller.handleOpeningBookmark(item, BrowsingMode.Private)
 
         verifyOrder {
+            invokePendingDeletion.invoke()
             homeActivity.browsingModeManager.mode = BrowsingMode.Private
             homeActivity.openToBrowserAndLoad(item.url!!, true, BrowserDirection.FromBookmarks)
         }
@@ -202,6 +212,7 @@ class BookmarkControllerTest {
         controller.handleBackPressed()
 
         verify {
+            invokePendingDeletion.invoke()
             navController.popBackStack()
         }
     }
@@ -211,6 +222,7 @@ class BookmarkControllerTest {
         controller.handleSigningIn()
 
         verify {
+            invokePendingDeletion.invoke()
             services.launchPairingSignIn(homeActivity, navController)
         }
     }


### PR DESCRIPTION
We were only doing this in onPause but I think it's too late by then. In my testing, this fixed the known issues but will need QA to try to find other points

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
