### PR TITLE
Add no-op experiment to test service-experiments integration

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -907,6 +907,7 @@ history:
     notification_emails:
       - fenix-core@mozilla.com
     expires: "2020-03-01"
+
 reader_mode:
   available:
     type: event
@@ -1113,3 +1114,20 @@ collections:
     notification_emails:
       - fenix-core@mozilla.com
     expires: "2020-03-01"
+
+experiments.metrics:
+  test_experiment_2019_08_05:
+    type: string
+    description: >
+      Records the branch name of the active experiment, if the client is enrolled in the
+      `fenix-test-2019-08-05` experiment. This is intended to validate that the service-experiments
+      library properly matches clients to experiments and can take action based on a multi-branched
+      experiment. This is done by recording the experiment branch name in this string metric which
+      allows the experiment to be transparent and unobtrusive to the user.
+    bugs:
+      - 1543986
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1543986
+    notification_emails:
+      - mcooper@mozilla.com
+    expires: 2019-11-01

--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -1127,7 +1127,7 @@ experiments.metrics:
     bugs:
       - 1543986
     data_reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1543986
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1543986#c4
     notification_emails:
       - mcooper@mozilla.com
     expires: 2019-11-01

--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -1116,7 +1116,7 @@ collections:
     expires: "2020-03-01"
 
 experiments.metrics:
-  test_experiment_2019_08_05:
+  active_experiment:
     type: string
     description: >
       Records the branch name of the active experiment, if the client is enrolled in the

--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -88,7 +88,7 @@ open class FenixApplication : Application() {
         // library to get a list of experiments. It will take effect the second time the
         // application is launched.
         Experiments.withExperiment("fenix-test-2019-08-05") { branchName ->
-            ExperimentsMetrics.testExperiment20190805.set(branchName)
+            ExperimentsMetrics.activeExperiment.set(branchName)
         }
 
         setupLeakCanary()

--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -31,6 +31,7 @@ import mozilla.components.support.rusthttp.RustHttpConfig
 import mozilla.components.support.rustlog.RustLog
 import org.mozilla.fenix.components.Components
 import org.mozilla.fenix.utils.Settings
+import org.mozilla.fenix.GleanMetrics.ExperimentsMetrics
 import java.io.File
 
 @SuppressLint("Registered")
@@ -79,6 +80,16 @@ open class FenixApplication : Application() {
                 httpClient = lazy(LazyThreadSafetyMode.NONE) { components.core.client }
             )
         )
+
+        // When the `fenix-test-2019-08-05` experiment is active, record its branch in Glean
+        // telemetry. This will be used to validate that the experiment system correctly enrolls
+        // clients and segments them into branches. Note that this will not take effect the first
+        // time the application has launched, since there won't be enough time for the experiments
+        // library to get a list of experiments. It will take effect the second time the
+        // application is launched.
+        Experiments.withExperiment("fenix-test-2019-08-05") { branchName ->
+            ExperimentsMetrics.testExperiment20190805.set(branchName)
+        }
 
         setupLeakCanary()
         if (Settings.getInstance(this).isTelemetryEnabled) {

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -8,7 +8,7 @@
         <th>key</th>
         <th>type</th>
         <th>description</th>
-        <th>data deview</th>
+        <th>data review</th>
         <th>extras</th>
         <th>expires</th>
     </tr>
@@ -1056,6 +1056,14 @@ Data that is sent in the activation ping
         <td><a href="https://github.com/mozilla-mobile/fenix/pull/1707#issuecomment-486972209">link</a></td>
         <td></td>
         <td>2019-10-01</td>
+    </tr>
+    <tr>
+        <td>active_experiment</td>
+        <td>string</td>
+        <td>The branch name of the active experiment, if the client is enrolled in the `fenix-test-2019-08-05` experiment.</td>
+        <td><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1543986#c2">link</a></td>
+        <td></td>
+        <td>2019-11-01</td>
     </tr>
 </table>
 </pre>

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1061,7 +1061,7 @@ Data that is sent in the activation ping
         <td>active_experiment</td>
         <td>string</td>
         <td>The branch name of the active experiment, if the client is enrolled in the `fenix-test-2019-08-05` experiment.</td>
-        <td><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1543986#c2">link</a></td>
+        <td><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1543986#c4">link</a></td>
         <td></td>
         <td>2019-11-01</td>
     </tr>


### PR DESCRIPTION
This is for [bug 1556751](https://bugzilla.mozilla.org/show_bug.cgi?id=1556751) This change helps verify that the service-experiments library is correctly integrated into Fenix, and that it can correctly enroll users in an experiment. This is exactly the same test that was done in mozilla-mobile/reference-browser#827. That reference browser population was not large enough to completely verify the library's behavior, but no red flags were raised.

I don't think this feature needs tests because it is itself a test of the experiments system.

I'm not sure if this change builds or not. I am having some trouble with the metrics metadata. I'm still working on this.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
