### PR TITLE
Fixes #3922: Added accessibility announcement for history empty state.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryView.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryView.kt
@@ -121,6 +121,9 @@ class HistoryView(
     fun updateEmptyState(userHasHistory: Boolean) {
         history_list.isVisible = userHasHistory
         history_empty_view.isVisible = !userHasHistory
+        if (!userHasHistory) {
+            history_empty_view.announceForAccessibility(context.getString(R.string.history_empty_message))
+        }
     }
 
     override fun onBackPressed(): Boolean {


### PR DESCRIPTION
Sent an announcement when the list becomes empty in order to tell the user
that there is no history.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR does not need a changelog entry.
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).
