### PR TITLE
Fix #4516: Search widget uses full width with 8dp margin

### DIFF
--- a/app/src/main/res/layout/search_widget_extra_large.xml
+++ b/app/src/main/res/layout/search_widget_extra_large.xml
@@ -7,7 +7,9 @@
               android:layout_width="match_parent"
               android:layout_height="match_parent">
 
-    <RelativeLayout android:layout_width="360dp"
+    <RelativeLayout android:layout_width="match_parent"
+                    android:layout_marginStart="8dp"
+                    android:layout_marginEnd="8dp"
                     android:layout_height="50dp"
                     android:background="@drawable/rounded_white_corners"
                     android:layout_gravity="center">

--- a/app/src/main/res/layout/search_widget_extra_small.xml
+++ b/app/src/main/res/layout/search_widget_extra_small.xml
@@ -7,11 +7,13 @@
               android:layout_width="match_parent"
               android:layout_height="match_parent">
 
-    <LinearLayout android:layout_width="64dp"
-            android:layout_height="50dp"
-            android:background="@drawable/rounded_white_corners"
-            android:layout_gravity="center"
-            android:orientation="vertical">
+    <LinearLayout android:layout_width="match_parent"
+            	  android:layout_marginStart="8dp"
+            	  android:layout_marginEnd="8dp"
+            	  android:layout_height="50dp"
+            	  android:background="@drawable/rounded_white_corners"
+            	  android:layout_gravity="center"
+            	  android:orientation="vertical">
 
         <ImageButton
                 android:id="@id/button_search_widget_new_tab"

--- a/app/src/main/res/layout/search_widget_large.xml
+++ b/app/src/main/res/layout/search_widget_large.xml
@@ -7,7 +7,9 @@
               android:layout_width="match_parent"
               android:layout_height="match_parent">
 
-    <RelativeLayout android:layout_width="256dp"
+    <RelativeLayout android:layout_width="match_parent"
+                    android:layout_marginStart="8dp"
+                    android:layout_marginEnd="8dp"
                     android:layout_height="50dp"
                     android:background="@drawable/rounded_white_corners"
                     android:layout_gravity="center">

--- a/app/src/main/res/layout/search_widget_medium.xml
+++ b/app/src/main/res/layout/search_widget_medium.xml
@@ -7,7 +7,9 @@
               android:layout_width="match_parent"
               android:layout_height="match_parent">
 
-    <RelativeLayout android:layout_width="192dp"
+    <RelativeLayout android:layout_width="match_parent"
+                    android:layout_marginStart="8dp"
+                    android:layout_marginEnd="8dp"
                     android:layout_height="50dp"
                     android:background="@drawable/rounded_white_corners"
                     android:layout_gravity="center">

--- a/app/src/main/res/layout/search_widget_small.xml
+++ b/app/src/main/res/layout/search_widget_small.xml
@@ -7,7 +7,9 @@
               android:layout_width="match_parent"
               android:layout_height="match_parent">
 
-    <RelativeLayout android:layout_width="100dp"
+    <RelativeLayout android:layout_width="match_parent"
+                    android:layout_marginStart="8dp"
+                    android:layout_marginEnd="8dp"
                     android:layout_height="50dp"
                     android:background="@drawable/rounded_white_corners"
                     android:layout_gravity="center">


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

<img src="https://user-images.githubusercontent.com/17825767/62622756-c4e95580-b927-11e9-9b10-20042f58519b.png" width=50%>
