### PR TITLE
No issue: Add OSS licenses link to About page

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,6 +7,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply from: "$project.rootDir/automation/gradle/versionCode.gradle"
 apply plugin: 'androidx.navigation.safeargs.kotlin'
+apply plugin: 'com.google.android.gms.oss-licenses-plugin'
 
 import com.android.build.gradle.internal.tasks.AppPreBuildTask
 import org.gradle.internal.logging.text.StyledTextOutput.Style
@@ -289,8 +290,8 @@ dependencies {
     implementation Deps.anko_constraintlayout
 
     implementation Deps.sentry
-
     implementation Deps.leanplum
+    implementation Deps.osslicenses_library
 
     implementation Deps.mozilla_concept_engine
     implementation Deps.mozilla_concept_push

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -99,6 +99,12 @@
             android:enabled="${isRaptorEnabled}"
             android:exported="${isRaptorEnabled}" />
 
+        <activity android:name="com.google.android.gms.oss.licenses.OssLicensesMenuActivity"
+            android:theme="@style/Theme.AppCompat.DayNight.DarkActionBar"/>
+
+        <activity android:name="com.google.android.gms.oss.licenses.OssLicensesActivity"
+            android:theme="@style/Theme.AppCompat.DayNight.DarkActionBar"/>
+
         <service
             android:name=".customtabs.CustomTabsService"
             android:exported="true"

--- a/app/src/main/java/org/mozilla/fenix/settings/AboutFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/AboutFragment.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.fenix.settings
 
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Build.VERSION.SDK_INT
@@ -14,6 +15,7 @@ import android.view.ViewGroup
 import androidx.annotation.RequiresApi
 import androidx.core.content.pm.PackageInfoCompat
 import androidx.fragment.app.Fragment
+import com.google.android.gms.oss.licenses.OssLicensesMenuActivity
 import kotlinx.android.synthetic.main.fragment_about.*
 import org.mozilla.fenix.BuildConfig
 import org.mozilla.fenix.R
@@ -57,6 +59,16 @@ class AboutFragment : Fragment() {
         about_text.text = aboutText
         about_content.text = content
         build_date.text = buildDate
+
+        view_licenses_button.setOnClickListener {
+            startActivity(Intent(context, OssLicensesMenuActivity::class.java))
+            OssLicensesMenuActivity.setActivityTitle(
+                getString(
+                    R.string.open_source_licenses_title,
+                    getString(R.string.app_name)
+                )
+            )
+        }
     }
 
     companion object {

--- a/app/src/main/res/layout/fragment_about.xml
+++ b/app/src/main/res/layout/fragment_about.xml
@@ -67,6 +67,20 @@
                 tools:text="Monday 1/2 @ 5:00 PM"
                 android:textAlignment="center" />
 
+        <TextView
+                android:id="@+id/view_licenses_button"
+                android:layout_margin="16dp"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/about_open_source_licenses"
+                android:textSize="16sp"
+                android:textColor="?accent"
+                android:textStyle="bold"
+                android:textAllCaps="false"
+                app:layout_constraintTop_toBottomOf="@id/build_date"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent" />
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 
 </ScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -772,4 +772,11 @@
     <string name="etp_panel_off">Protections are OFF for this site</string>
     <!-- Header for exceptions list for which sites enhanced tracking protection is always off -->
     <string name="enhanced_tracking_protection_exceptions">Enhanced Tracking Protection is off for these websites</string>
+    <!-- About page Your rights link text -->
+    <string name="about_your_rights">Your rights</string>
+    <!-- About page link text to open open source licenses screen -->
+    <string name="about_open_source_licenses">Open source libraries we use</string>
+    <!-- Open source licenses page title
+    The first parameter is the app name -->
+    <string name="open_source_licenses_title">%s | OSS Libraries</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ buildscript {
         classpath Deps.tools_kotlingradle
         classpath Deps.androidx_safeargs
         classpath Deps.allopen
+        classpath Deps.osslicenses_plugin
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -13,6 +13,8 @@ object Versions {
     const val sentry = "1.7.10"
     const val leakcanary = "1.6.3"
     const val leanplum = "5.2.3"
+    const val osslicenses_plugin = "0.9.5"
+    const val osslicenses_library = "17.0.0"
 
     const val androidx_appcompat = "1.1.0-rc01"
     const val androidx_coordinator_layout = "1.1.0-beta01"
@@ -74,6 +76,8 @@ object Deps {
     const val kotlin_coroutines_android = "org.jetbrains.kotlinx:kotlinx-coroutines-android:${Versions.coroutines}"
 
     const val allopen = "org.jetbrains.kotlin:kotlin-allopen:${Versions.kotlin}"
+    const val osslicenses_plugin = "com.google.android.gms:oss-licenses-plugin:${Versions.osslicenses_plugin}"
+    const val osslicenses_library = "com.google.android.gms:play-services-oss-licenses:${Versions.osslicenses_library}"
 
     const val rxKotlin = "io.reactivex.rxjava2:rxkotlin:${Versions.rxKotlin}"
     const val rxAndroid = "io.reactivex.rxjava2:rxandroid:${Versions.rxAndroid}"


### PR DESCRIPTION
Strings were approved already. This is a very simple solution until A-C has time to design something that looks nicer that incorporates all of our licenses from JVM and GeckoView. For now, JVM licenses are linked from the About page and GeckoView licenses are visible from about:license.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
