### PR TITLE
For #4529: Handle crash initializing CreateCollectionViewModel late

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -101,6 +101,8 @@ abstract class BaseBrowserFragment : Fragment(), BackHandler, SessionManager.Obs
     private var browserInitialized: Boolean = false
     private var initUIJob: Job? = null
 
+    val viewModel: CreateCollectionViewModel by activityViewModels()
+
     @CallSuper
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -145,7 +147,6 @@ abstract class BaseBrowserFragment : Fragment(), BackHandler, SessionManager.Obs
         val sessionManager = requireComponents.core.sessionManager
 
         return getSessionById()?.also { session ->
-            val viewModel: CreateCollectionViewModel by activityViewModels()
 
             val browserToolbarController = DefaultBrowserToolbarController(
                 context!!,


### PR DESCRIPTION
Fixing this Sentry crash trace: https://sentry.prod.mozaws.net/operations/fenix-nightly/issues/6127547/