### PR TITLE
Bug 1566849 Youtube QOE for Fenix - additional changes

### DIFF
--- a/automation/taskcluster/lib/tasks.py
+++ b/automation/taskcluster/lib/tasks.py
@@ -621,7 +621,7 @@ class TaskBuilder(object):
             description='Raptor YouTube Playback on Fenix',
             test_name='raptor-youtube-playback',
             job_symbol='ytp',
-            group_symbol='Rap-fenix',
+            group_symbol='Rap',
             force_run_on_64_bit_device=force_run_on_64_bit_device,
         )
 
@@ -667,7 +667,7 @@ class TaskBuilder(object):
             "--download-symbols=ondemand",
         ]]
         # Bug 1558456 - Stop tracking youtube-playback-test on motoG5 for >1080p cases
-        if variant.abi == 'arm':
+        if variant.abi == 'arm' and test_name == 'raptor-youtube-playback':
             params_query = '&'.join(ARM_RAPTOR_URL_PARAMS)
             add_extra_params_option = "--test-url-params={}".format(params_query)
             command[0].append(add_extra_params_option)


### PR DESCRIPTION
Changed the group_symbol to 'Rap' and added a new condition for ARM_RAPTOR_URL_PARAMS usage to avoid adding the exclude parameter to all Fenix tests.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
