### PR TITLE
Closes #4671: Fix a potential NPE in BookmarkFragment

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragment.kt
@@ -237,7 +237,11 @@ class BookmarkFragment : LibraryPageFragment<BookmarkNode>(), BackHandler, Accou
     }
 
     private suspend fun refreshBookmarks() {
-        context?.bookmarkStorage()?.getTree(bookmarkStore.state.tree!!.guid, false).withOptionalDesktopFolders(context)
+        // The bookmark tree in our 'state' can be null - meaning, no bookmark tree has been selected.
+        // If that's the case, we don't know what node to refresh, and so we bail out.
+        // See https://github.com/mozilla-mobile/fenix/issues/4671
+        val currentGuid = bookmarkStore.state.tree?.guid ?: return
+        context?.bookmarkStorage()?.getTree(currentGuid, false).withOptionalDesktopFolders(context)
             ?.let { node ->
                 var rootNode = node
                 pendingBookmarksToDelete.forEach {


### PR DESCRIPTION
The fact that we can even get to such a state - means we're calling `onAuthenticated` before we had a chance to set a bookmark tree. That to me reads like a race condition.

However, I think we're going to simplify this code quite a bit in https://github.com/mozilla-mobile/fenix/issues/4046, and so let's just fix the obvious NPE for now.