### PR TITLE
Fix #4436: hide onboarding before navigating to settings

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -573,7 +573,7 @@ class HomeFragment : Fragment(), AccountObserver {
                     invokePendingDeleteJobs()
                     if (!onboarding.userHasBeenOnboarded()) {
                         onboarding.finish()
-                        emitAccountChanges()
+                        emitModeChanges()
                     }
                     (activity as HomeActivity).openToBrowserAndLoad(
                         searchTermOrURL = SupportUtils.getSumoURLForTopic(
@@ -729,7 +729,7 @@ class HomeFragment : Fragment(), AccountObserver {
         Mode.fromBrowsingMode(browsingModeManager.mode)
     }
 
-    private fun emitAccountChanges() {
+    private fun emitModeChanges() {
         context?.let {
             val mode = currentMode(it)
             getManagedEmitter<SessionControlChange>().onNext(SessionControlChange.ModeChange(mode))
@@ -742,12 +742,12 @@ class HomeFragment : Fragment(), AccountObserver {
                 it.context.getString(R.string.onboarding_firefox_account_sync_is_on)
             ).show()
         }
-        emitAccountChanges()
+        emitModeChanges()
     }
 
-    override fun onAuthenticationProblems() = emitAccountChanges()
-    override fun onLoggedOut() = emitAccountChanges()
-    override fun onProfileUpdated(profile: Profile) = emitAccountChanges()
+    override fun onAuthenticationProblems() = emitModeChanges()
+    override fun onLoggedOut() = emitModeChanges()
+    override fun onProfileUpdated(profile: Profile) = emitModeChanges()
 
     private fun scrollAndAnimateCollection(
         tabsAddedToCollectionSize: Int,

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -571,6 +571,10 @@ class HomeFragment : Fragment(), AccountObserver {
                 }
                 HomeMenu.Item.Help -> {
                     invokePendingDeleteJobs()
+                    if (!onboarding.userHasBeenOnboarded()) {
+                        onboarding.finish()
+                        emitAccountChanges()
+                    }
                     (activity as HomeActivity).openToBrowserAndLoad(
                         searchTermOrURL = SupportUtils.getSumoURLForTopic(
                             context!!,


### PR DESCRIPTION
Hi,

new contributor here. This PR:
* hides onboarding before navigating to settings
* renames `emitAccountChanges` to `emitModeChanges`

Note: I think we probably want the same behavior when a user taps other menus.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
