### PR TITLE
Integrate feature-media component (Nightly and debug builds only).

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -31,4 +31,18 @@ object FeatureFlags {
      * reload.
      */
     const val pullToRefreshEnabled = false
+
+    /**
+     * Integration of media features provided by `feature-media` component:
+     * - Background playback without the app getting killed
+     * - Media notification with play/pause controls
+     * - Audio Focus handling (pausing/resuming in agreement with other media apps)
+     * - Support for hardware controls to toggle play/pause (e.g. buttons on a headset)
+     *
+     * Behind nightly flag until all related Android Components issues are fixed and QA has signed
+     * off.
+     *
+     * https://github.com/mozilla-mobile/fenix/issues/4431
+     */
+    val mediaIntegration = nightly or debug
 }


### PR DESCRIPTION
Issue #4431

This patch enables the `MediaFeature` in Nightly and debug builds. There are still some minor AC issues to fix. But the feature is stable enough to use it in Nightly builds and start the QA process.

Integrating this component will bring the following features to Fenix:
- Background playback without the app getting killed
- Media notification with play/pause controls
- Audio Focus handling (pausing/resuming in agreement with other media apps)
- Support for hardware controls to toggle play/pause (e.g. buttons on a headset)

This will should at least the following Fenix issues:
- #2551 
- #1008
- #1113 
- #1753 