### PR TITLE
Issue #3756 - Mark HTTP sites insecure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - #4137 - Adds pagination to the history view
 - #3695 - Made search suggestions for other tabs clickable
+- #3756 - Mark HTTP sites as insecure
 
 ### Changed
 - Remove forced focus of toolbar on homescreen

--- a/app/src/main/res/drawable/ic_insecure.xml
+++ b/app/src/main/res/drawable/ic_insecure.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path android:fillColor="@color/mozac_ui_icons_fill"
+          android:pathData="M17.25 11c1 0 1.78 0.87 1.75 1.87v6.26c0 1-0.75 1.84-1.75 1.87H6.75l-0.1-0L16.62 11h0.63zm2.96-7.33a1 1 0 0 1 0 1.41l-15 15a1 1 0 1 1-1.42-1.41L5 17.47v-4.6c-0-1 0.75-1.84 1.75-1.87H7V8a4.99 4.99 0 0 1 9.53-2.07l2.26-2.26a1 1 0 0 1 1.42 0zM9 11h2.46l3.51-3.51A2.73 2.73 0 0 0 12.27 5h-0.53A2.74 2.74 0 0 0 9 7.74V11z" />
+</vector>

--- a/app/src/main/res/drawable/ic_site_secure.xml
+++ b/app/src/main/res/drawable/ic_site_secure.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<selector xmlns:android="http://schemas.android.com/apk/res/android" xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item android:drawable="@drawable/mozac_ic_lock" app:state_site_secure="true" />
+    <item android:drawable="@drawable/ic_insecure" />
+</selector>

--- a/app/src/main/res/layout/component_search.xml
+++ b/app/src/main/res/layout/component_search.xml
@@ -14,6 +14,7 @@
     android:background="@drawable/toolbar_background"
     app:browserToolbarClearColor="?primaryText"
     app:browserToolbarInsecureColor="?primaryText"
+    app:browserToolbarSecureColor="?primaryText"
+    app:browserToolbarSecurityIcon="@drawable/ic_site_secure"
     app:browserToolbarMenuColor="?primaryText"
-    app:browserToolbarProgressBarGravity="top"
-    app:browserToolbarSecureColor="?primaryText" />
+    app:browserToolbarProgressBarGravity="top"/>


### PR DESCRIPTION
![Screenshot_20190814-110437](https://user-images.githubusercontent.com/1782266/63032272-7dad1880-be83-11e9-8dce-1751e3973b81.png)

Changes the HTTP indicator to a broken padlock. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
