### PR TITLE
Use global navigation action for browser fragment

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/BrowserDirection.kt
+++ b/app/src/main/java/org/mozilla/fenix/BrowserDirection.kt
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix
+
+import androidx.annotation.IdRes
+
+/**
+ * Used with [HomeActivity.openToBrowser] to indicate which fragment
+ * the browser is being opened from.
+ *
+ * @property fragmentId ID of the fragment opening the browser in the navigation graph.
+ * An ID of `0` indicates a global action with no corresponding opening fragment.
+ */
+enum class BrowserDirection(@IdRes val fragmentId: Int) {
+    FromGlobal(0),
+    FromHome(R.id.homeFragment),
+    FromSearch(R.id.searchFragment),
+    FromSettings(R.id.settingsFragment),
+    FromBookmarks(R.id.bookmarkFragment),
+    FromHistory(R.id.historyFragment),
+    FromExceptions(R.id.exceptionsFragment)
+}

--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -35,16 +35,9 @@ import mozilla.components.support.utils.SafeIntent
 import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.components.isSentryEnabled
 import org.mozilla.fenix.components.metrics.Event
-import org.mozilla.fenix.exceptions.ExceptionsFragmentDirections
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.getRootView
 import org.mozilla.fenix.ext.nav
-import org.mozilla.fenix.home.HomeFragmentDirections
-import org.mozilla.fenix.library.bookmarks.BookmarkFragmentDirections
-import org.mozilla.fenix.library.bookmarks.selectfolder.SelectBookmarkFolderFragmentDirections
-import org.mozilla.fenix.library.history.HistoryFragmentDirections
-import org.mozilla.fenix.search.SearchFragmentDirections
-import org.mozilla.fenix.settings.SettingsFragmentDirections
 import org.mozilla.fenix.share.ShareFragment
 import org.mozilla.fenix.utils.Settings
 
@@ -225,7 +218,6 @@ open class HomeActivity : AppCompatActivity(), ShareFragment.TabsSharedCallback 
         load(searchTermOrURL, newTab, engine, forceSearch)
     }
 
-    @Suppress("ComplexMethod")
     fun openToBrowser(from: BrowserDirection, customTabSessionId: String? = null) {
         if (sessionObserver == null)
             sessionObserver = subscribeToSessions()
@@ -238,52 +230,8 @@ open class HomeActivity : AppCompatActivity(), ShareFragment.TabsSharedCallback 
             ) return
         }
 
-        @IdRes var fragmentId: Int? = null
-        val directions = when (from) {
-            BrowserDirection.FromGlobal ->
-                NavGraphDirections.actionGlobalBrowser(customTabSessionId)
-            BrowserDirection.FromHome -> {
-                fragmentId = R.id.homeFragment
-                HomeFragmentDirections.actionHomeFragmentToBrowserFragment(customTabSessionId)
-            }
-            BrowserDirection.FromSearch -> {
-                fragmentId = R.id.searchFragment
-                SearchFragmentDirections.actionSearchFragmentToBrowserFragment(
-                    customTabSessionId
-                )
-            }
-            BrowserDirection.FromSettings -> {
-                fragmentId = R.id.settingsFragment
-                SettingsFragmentDirections.actionSettingsFragmentToBrowserFragment(
-                    customTabSessionId
-                )
-            }
-            BrowserDirection.FromBookmarks -> {
-                fragmentId = R.id.bookmarkFragment
-                BookmarkFragmentDirections.actionBookmarkFragmentToBrowserFragment(
-                    customTabSessionId
-                )
-            }
-            BrowserDirection.FromBookmarksFolderSelect -> {
-                fragmentId = R.id.bookmarkSelectFolderFragment
-                SelectBookmarkFolderFragmentDirections
-                    .actionBookmarkSelectFolderFragmentToBrowserFragment(customTabSessionId)
-            }
-            BrowserDirection.FromHistory -> {
-                fragmentId = R.id.historyFragment
-                HistoryFragmentDirections.actionHistoryFragmentToBrowserFragment(
-                    customTabSessionId
-                )
-            }
-            BrowserDirection.FromExceptions -> {
-                fragmentId = R.id.exceptionsFragment
-                ExceptionsFragmentDirections.actionExceptionsFragmentToBrowserFragment(
-                    customTabSessionId
-                )
-            }
-        }
-
-        navHost.navController.nav(fragmentId, directions)
+        @IdRes val fragmentId = if (from.fragmentId != 0) from.fragmentId else null
+        navHost.navController.nav(fragmentId, NavGraphDirections.actionGlobalBrowser(customTabSessionId))
     }
 
     private fun load(
@@ -405,9 +353,4 @@ open class HomeActivity : AppCompatActivity(), ShareFragment.TabsSharedCallback 
         const val OPEN_TO_BROWSER_AND_LOAD = "open_to_browser_and_load"
         const val OPEN_TO_SEARCH = "open_to_search"
     }
-}
-
-enum class BrowserDirection {
-    FromGlobal, FromHome, FromSearch, FromSettings, FromBookmarks,
-    FromBookmarksFolderSelect, FromHistory, FromExceptions
 }


### PR DESCRIPTION
[Global actions](https://developer.android.com/guide/navigation/navigation-global-action) are meant to let multiple fragments navigate to the name destination. We can use the global browser fragment action for all browser fragment navigation and get rid of the complex switch case.

Builds towards separate custom tab fragment and PWA support.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
