### PR TITLE
For #4652: HomeFragment Crash "Can not.. after onSaveInstanceState"

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -24,6 +24,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.Observer
 import androidx.lifecycle.OnLifecycleEvent
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.FragmentNavigator
 import androidx.navigation.fragment.NavHostFragment.findNavController
@@ -677,7 +678,9 @@ class HomeFragment : Fragment(), AccountObserver {
 
         val tabs = getListOfSessions().toTabs()
 
-        val viewModel: CreateCollectionViewModel by activityViewModels()
+        val viewModel: CreateCollectionViewModel by activityViewModels {
+            ViewModelProvider.NewInstanceFactory() // this is a workaround for #4652
+        }
         viewModel.tabs = tabs
         val selectedTabs =
             tabs.find { tab -> tab.sessionId == selectedTabId }


### PR DESCRIPTION
This is a workaround to use the older ViewModel.Factory to avoid crashes using the new SavedStateViewModels.
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
