### PR TITLE
Use Mozilla Android Components 8.0.0. 

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -34,7 +34,7 @@ object Versions {
     const val androidx_work = "2.0.1"
     const val google_material = "1.1.0-alpha07"
 
-    const val mozilla_android_components = "8.0.0-SNAPSHOT"
+    const val mozilla_android_components = "8.0.0"
     // Note that android-components also depends on application-services,
     // and in fact is our main source of appservices-related functionality.
     // The version number below tracks the application-services version


### PR DESCRIPTION
We released Mozilla Android Components 8.0.0 today.

* Release notes: https://mozac.org/changelog/#800
* Milestone: https://github.com/mozilla-mobile/android-components/milestone/67?closed=1

Let's switch to 8.0.0 for the upcoming code freeze / release branch. After that we can continue with 9.0.0-SNAPSHOT on master.