### PR TITLE
Unbreak Nightly: Closes #4719: Get rid of fragment-testing dependency and create fragments in StoreProviderTest manually.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -415,12 +415,6 @@ dependencies {
     }
 
     testImplementation 'org.apache.maven:maven-ant-tasks:2.1.3'
-    debugImplementation Deps.fragment_testing, {
-        exclude group: 'androidx.test', module: 'core'
-    }
-    forPerformanceTestImplementation Deps.fragment_testing, {
-        exclude group: 'androidx.test', module: 'core'
-    }
     // For production builds, the native code for all `org.mozilla.appservices`
     // dependencies gets compiled together into a single "megazord" build, and
     // different megazords are published for different subsets of features. Ref

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -203,7 +203,6 @@ object Deps {
     const val tools_test_runner = "androidx.test:runner:${Versions.tools_test_runner}"
     const val uiautomator = "com.android.support.test.uiautomator:uiautomator-v18:${Versions.uiautomator}"
     const val robolectric = "org.robolectric:robolectric:${Versions.robolectric}"
-    const val fragment_testing = "androidx.fragment:fragment-testing:${Versions.androidx_fragment}"
     const val androidx_junit = "androidx.test.ext:junit:${Versions.androidx_test_ext}"
     const val androidx_test_core = "androidx.test:core:${Versions.androidx_testing}"
 


### PR DESCRIPTION
See the comments in #4719 to understand how I ended up here. TL;DR: Nightly is currently broken and this fixes the issue. The setup `fragment-testing` requires is bananas. Getting rid of it until the linked Google issue is fixed seems to be the best path forward in my opinion. 

---

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
