### PR TITLE
Only use iconTint in XML for bookmark menus

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragment.kt
@@ -4,8 +4,6 @@
 
 package org.mozilla.fenix.library.bookmarks
 
-import android.graphics.PorterDuff.Mode.SRC_IN
-import android.graphics.PorterDuffColorFilter
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.Menu
@@ -14,7 +12,6 @@ import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.content.ContextCompat
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
@@ -176,13 +173,8 @@ class BookmarkFragment : LibraryPageFragment<BookmarkNode>(), BackHandler, Accou
                 } else {
                     inflater.inflate(R.menu.bookmarks_select_multi, menu)
                 }
-                menu.findItem(R.id.edit_bookmark_multi_select)?.run {
-                    isVisible = mode.selectedItems.size == 1
-                    icon.colorFilter = PorterDuffColorFilter(
-                        ContextCompat.getColor(context!!, R.color.white_color),
-                        SRC_IN
-                    )
-                }
+
+                menu.findItem(R.id.edit_bookmark_multi_select)?.isVisible = mode.selectedItems.size == 1
             }
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/addfolder/AddBookmarkFolderFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/addfolder/AddBookmarkFolderFragment.kt
@@ -4,8 +4,6 @@
 
 package org.mozilla.fenix.library.bookmarks.addfolder
 
-import android.graphics.PorterDuff.Mode.SRC_IN
-import android.graphics.PorterDuffColorFilter
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.Menu
@@ -26,7 +24,6 @@ import kotlinx.coroutines.launch
 import mozilla.appservices.places.BookmarkRoot
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.metrics.Event
-import org.mozilla.fenix.ext.getColorFromAttr
 import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.library.bookmarks.BookmarksSharedViewModel
@@ -73,8 +70,6 @@ class AddBookmarkFolderFragment : Fragment() {
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         inflater.inflate(R.menu.bookmarks_add_folder, menu)
-        menu.findItem(R.id.confirm_add_folder_button).icon.colorFilter =
-            PorterDuffColorFilter(context!!.getColorFromAttr(R.attr.primaryText), SRC_IN)
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/edit/EditBookmarkFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/edit/EditBookmarkFragment.kt
@@ -5,8 +5,6 @@
 package org.mozilla.fenix.library.bookmarks.edit
 
 import android.content.DialogInterface
-import android.graphics.PorterDuff.Mode.SRC_IN
-import android.graphics.PorterDuffColorFilter
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.Menu
@@ -41,7 +39,6 @@ import mozilla.components.support.ktx.android.view.hideKeyboard
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.components.metrics.Event
-import org.mozilla.fenix.ext.getColorFromAttr
 import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.setRootTitles
@@ -153,11 +150,6 @@ class EditBookmarkFragment : Fragment() {
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         inflater.inflate(R.menu.bookmarks_edit, menu)
-        menu.findItem(R.id.delete_bookmark_button).apply {
-            icon.colorFilter =
-                PorterDuffColorFilter(context!!.getColorFromAttr(R.attr.primaryText), SRC_IN)
-            setContentDescription(this, getString(R.string.bookmark_menu_delete_button))
-        }
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/selectfolder/SelectBookmarkFolderFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/selectfolder/SelectBookmarkFolderFragment.kt
@@ -4,8 +4,6 @@
 
 package org.mozilla.fenix.library.bookmarks.selectfolder
 
-import android.graphics.PorterDuff.Mode.SRC_IN
-import android.graphics.PorterDuffColorFilter
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.Menu
@@ -20,6 +18,7 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
 import kotlinx.android.synthetic.main.fragment_select_bookmark_folder.*
 import kotlinx.android.synthetic.main.fragment_select_bookmark_folder.view.*
 import kotlinx.coroutines.Dispatchers.IO
@@ -31,7 +30,6 @@ import mozilla.components.concept.storage.BookmarkNode
 import mozilla.components.concept.sync.AccountObserver
 import mozilla.components.concept.sync.OAuthAccount
 import org.mozilla.fenix.R
-import org.mozilla.fenix.ext.getColorFromAttr
 import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.setRootTitles
@@ -104,11 +102,9 @@ class SelectBookmarkFolderFragment : Fragment(), AccountObserver {
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        val visitedAddBookmark = SelectBookmarkFolderFragmentArgs.fromBundle(arguments!!).visitedAddBookmark
-        if (!visitedAddBookmark) {
+        val args: SelectBookmarkFolderFragmentArgs by navArgs()
+        if (!args.visitedAddBookmark) {
             inflater.inflate(R.menu.bookmarks_select_folder, menu)
-            menu.findItem(R.id.add_folder_button).icon.colorFilter =
-                PorterDuffColorFilter(context!!.getColorFromAttr(R.attr.primaryText), SRC_IN)
         }
     }
 

--- a/app/src/main/res/menu/bookmarks_edit.xml
+++ b/app/src/main/res/menu/bookmarks_edit.xml
@@ -10,6 +10,7 @@
             android:icon="@drawable/ic_delete"
             android:iconTint="?primaryText"
             android:title="@string/bookmark_menu_delete_button"
+            android:contentDescription="@string/bookmark_menu_delete_button"
             app:showAsAction="ifRoom"
             tools:targetApi="o" />
 </menu>

--- a/app/src/main/res/menu/bookmarks_select_multi.xml
+++ b/app/src/main/res/menu/bookmarks_select_multi.xml
@@ -7,7 +7,7 @@
     <item
         android:id="@+id/edit_bookmark_multi_select"
         android:icon="@drawable/ic_edit"
-        android:iconTint="?primaryText"
+        android:iconTint="@color/white_color"
         android:title="@string/bookmark_edit"
         app:showAsAction="ifRoom"
         tools:targetApi="o" />


### PR DESCRIPTION
Setting the tint again in `onCreateOptionsMenu` seems to be redundant.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
