### PR TITLE
Consume new `substitute-local-geckoview.gradle` script from Bug 1533465.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -554,3 +554,11 @@ afterEvaluate {
         }
     }
 }
+
+if (gradle.hasProperty('localProperties.dependencySubstitutions.geckoviewTopsrcdir')) {
+    if (gradle.hasProperty('localProperties.dependencySubstitutions.geckoviewTopobjdir')) {
+        ext.topobjdir = gradle."localProperties.dependencySubstitutions.geckoviewTopobjdir"
+    }
+    ext.topsrcdir = gradle."localProperties.dependencySubstitutions.geckoviewTopsrcdir"
+    apply from: "${topsrcdir}/substitute-local-geckoview.gradle"
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,6 +16,10 @@ if (file('local.properties').canRead()) {
 }
 
 if (localProperties != null) {
+    localProperties.each { prop ->
+        gradle.ext.set("localProperties.${prop.key}", prop.value)
+    }
+
     String appServicesLocalPath = localProperties.getProperty(settingAppServicesPath);
 
     if (appServicesLocalPath != null) {


### PR DESCRIPTION
I didn't see any docs in Fenix about substituting.  I'm tracking docs (in the shared repo, and in the GV repo) at https://bugzilla.mozilla.org/show_bug.cgi?id=1533465#c3.