### PR TITLE
No issue: Fix search widget launch for 1x1, 2x1 icons  

### DIFF
--- a/app/src/main/res/layout/search_widget_extra_small_v1.xml
+++ b/app/src/main/res/layout/search_widget_extra_small_v1.xml
@@ -10,7 +10,7 @@
         android:background="@drawable/rounded_white_corners"
         android:layout_gravity="center">
 
-    <ImageButton
+    <ImageView
             android:layout_width="40dp"
             android:layout_height="40dp"
             android:background="@drawable/ic_logo_widget"

--- a/app/src/main/res/layout/search_widget_extra_small_v2.xml
+++ b/app/src/main/res/layout/search_widget_extra_small_v2.xml
@@ -10,7 +10,7 @@
         android:background="@drawable/rounded_white_corners"
         android:layout_gravity="center">
 
-    <ImageButton
+    <ImageView
             android:layout_width="40dp"
             android:layout_height="40dp"
             android:background="@drawable/ic_logo_widget"

--- a/app/src/main/res/layout/search_widget_small_no_mic.xml
+++ b/app/src/main/res/layout/search_widget_small_no_mic.xml
@@ -11,7 +11,7 @@
         android:layout_gravity="center"
         android:orientation="vertical">
 
-    <ImageButton
+    <ImageView
             android:layout_width="40dp"
             android:layout_height="40dp"
             android:background="@drawable/ic_logo_widget"


### PR DESCRIPTION
Search widget won't launch with 1x1, 2x1 icons. This PR fixes that.
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
