### PR TITLE
Do not launch in Private Mode

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -102,6 +102,10 @@ open class FenixApplication : Application() {
         if (FeatureFlags.sendTabEnabled && components.backgroundServices.pushConfig != null) {
             PushProcessor.install(components.backgroundServices.push)
         }
+
+        // In order to prevent user information from leaking to other users always set
+        // privateMode to false on application start.
+        Settings.getInstance(this).setPrivateMode(false)
     }
 
     private fun registerRxExceptionHandling() {


### PR DESCRIPTION
A bug that was bothering me personally so I decided to fix it.

When the app launches do not launch in Private Mode in order to prevent usage leaks to other users of the device.

Steps to reproduce on previous versions:

1. Switch to private browsing mode
2. Close the app by swiping it away on the Android app switcher
3. Re-open the app and it is still in private mode

The point of Private Mode (as said even on the screen itself) is to protect your privacy from other users on the same device. While closing the app in private mode **does** close all the tabs, remaining in private mode is still a leak of user information since it reveals that the previous user was hiding something.

This was done in a burst of midnight inspiration and is my first PR to Fenix as well as my first time even seeing Kotlin. So please let me know if there is anything I can do to improve this.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)

Passes tests

- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not

This is a one line patch without major change in functionality

- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one

Same as above

- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

Accessibility has not changed