### PR TITLE
Fixes #4488: Shows snackbar on bookmark deletion from edit fragment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- #4488 - Adds ability to show snackbar when deleting bookmark/bookmark folder in edit bookmark fragment
 - #4137 - Adds pagination to the history view
 - #3695 - Made search suggestions for other tabs clickable
 

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/edit/EditBookmarkFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/edit/EditBookmarkFragment.kt
@@ -40,7 +40,13 @@ import mozilla.components.support.ktx.android.view.hideKeyboard
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.components.metrics.Event
-import org.mozilla.fenix.ext.*
+import org.mozilla.fenix.ext.getColorFromAttr
+import org.mozilla.fenix.ext.nav
+import org.mozilla.fenix.ext.requireComponents
+import org.mozilla.fenix.ext.setRootTitles
+import org.mozilla.fenix.ext.withRootTitle
+import org.mozilla.fenix.ext.getRootView
+import org.mozilla.fenix.ext.urlToTrimmedHost
 import org.mozilla.fenix.library.bookmarks.BookmarksSharedViewModel
 import java.util.concurrent.TimeUnit
 


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

This doesn't make use of `Undo.allowUndo` as we already show a dialog for user confirmation, giving an option to undo, might break the flow (comments on this are welcomed). 

Also, would like to know how would one go ahead with writing a test case for something like this? Would it be an instrumented test case where the entire path is followed from home -> library -> bookmarks -> edit -> snackbar shown? Something like the ThreeDotMenuTest?  