### PR TITLE
For #4799 #4790 - Don't pass in session to BrowserToolbarController

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -70,7 +70,6 @@ import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.enterToImmersiveMode
 import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.requireComponents
-import org.mozilla.fenix.ext.toTab
 import org.mozilla.fenix.quickactionsheet.QuickActionSheetBehavior
 import org.mozilla.fenix.settings.SupportUtils
 import org.mozilla.fenix.utils.Settings
@@ -172,7 +171,6 @@ abstract class BaseBrowserFragment : Fragment(), BackHandler, SessionManager.Obs
                     it.action = Intent.ACTION_VIEW
                     it.flags = Intent.FLAG_ACTIVITY_NEW_TASK
                 },
-                currentSessionAsTab = session.toTab(context!!),
                 bottomSheetBehavior = QuickActionSheetBehavior.from(nestedScrollQuickAction)
             )
 

--- a/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarControllerTest.kt
@@ -11,6 +11,7 @@ import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkStatic
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.ObsoleteCoroutinesApi
@@ -34,6 +35,7 @@ import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.components.metrics.MetricController
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.nav
+import org.mozilla.fenix.ext.toTab
 import org.mozilla.fenix.home.sessioncontrol.Tab
 import org.mozilla.fenix.home.sessioncontrol.TabCollection
 import org.mozilla.fenix.quickactionsheet.QuickActionSheetBehavior
@@ -73,9 +75,13 @@ class DefaultBrowserToolbarControllerTest {
             viewModel = viewModel,
             getSupportUrl = getSupportUrl,
             openInFenixIntent = openInFenixIntent,
-            currentSessionAsTab = currentSessionAsTab,
             bottomSheetBehavior = bottomSheetBehavior
         )
+
+        mockkStatic(
+            "org.mozilla.fenix.ext.SessionKt"
+        )
+        every { any<Session>().toTab(any()) } returns currentSessionAsTab
 
         every { context.components.analytics } returns analytics
         every { analytics.metrics } returns metrics
@@ -342,7 +348,6 @@ class DefaultBrowserToolbarControllerTest {
             viewModel = viewModel,
             getSupportUrl = getSupportUrl,
             openInFenixIntent = openInFenixIntent,
-            currentSessionAsTab = currentSessionAsTab,
             bottomSheetBehavior = bottomSheetBehavior
         )
 


### PR DESCRIPTION
Just two things that were missed in the quick followup. Tried to keep the diff small. 
1. We need to use the sessionmanager selected session for the collections interaction
2. We need to pass the session ID to the searchfragment for use there.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
