### PR TITLE
Fix mozilla-mobile#4436: dismiss onboarding when tapping a menu

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -551,12 +551,19 @@ class HomeFragment : Fragment(), AccountObserver {
         homeViewModel.motionLayoutProgress = homeLayout?.progress ?: 0F
     }
 
+    private fun hideOnboardingIfNeeded() {
+        if (!onboarding.userHasBeenOnboarded()) {
+            onboarding.finish()
+            emitModeChanges()
+        }
+    }
+
     private fun setupHomeMenu() {
         homeMenu = HomeMenu(requireContext()) {
             when (it) {
                 HomeMenu.Item.Settings -> {
                     invokePendingDeleteJobs()
-                    onboarding.finish()
+                    hideOnboardingIfNeeded()
                     nav(
                         R.id.homeFragment,
                         HomeFragmentDirections.actionHomeFragmentToSettingsFragment()
@@ -564,7 +571,7 @@ class HomeFragment : Fragment(), AccountObserver {
                 }
                 HomeMenu.Item.Library -> {
                     invokePendingDeleteJobs()
-                    onboarding.finish()
+                    hideOnboardingIfNeeded()
                     nav(
                         R.id.homeFragment,
                         HomeFragmentDirections.actionHomeFragmentToLibraryFragment()
@@ -572,10 +579,7 @@ class HomeFragment : Fragment(), AccountObserver {
                 }
                 HomeMenu.Item.Help -> {
                     invokePendingDeleteJobs()
-                    if (!onboarding.userHasBeenOnboarded()) {
-                        onboarding.finish()
-                        emitModeChanges()
-                    }
+                    hideOnboardingIfNeeded()
                     (activity as HomeActivity).openToBrowserAndLoad(
                         searchTermOrURL = SupportUtils.getSumoURLForTopic(
                             context!!,


### PR DESCRIPTION
hide onboarding before navigating to Settings or Your Library

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features