### PR TITLE
fixes #4179 removed control highlight from disconnect button

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -300,6 +300,7 @@
     <style name="CreateCollectionDialogStyle" parent="DialogStyleBase"/>
     <style name="FirefoxAccountsDialogStyle" parent="DialogStyleBase">
         <item name="android:windowBackground">@drawable/scrim_background</item>
+        <item name="android:colorControlHighlight">@android:color/transparent</item>
     </style>
 
     <style name="ShareDialogStyle" parent="DialogStyleBase"/>


### PR DESCRIPTION
set colorControlHighlight to transparent in activity theme.
property cannot be set in view because it is overwritten by activity theme.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
