### PR TITLE
Fixes #4795 fixed requestDesktopStateProvider value 

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarView.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarView.kt
@@ -90,7 +90,7 @@ class BrowserToolbarView(
                     this,
                     hasAccountProblem = components.backgroundServices.accountManager.accountNeedsReauth(),
                     requestDesktopStateProvider = {
-                        sessionManager.selectedSession?.private ?: false
+                        sessionManager.selectedSession?.desktopMode ?: false
                     },
                     onItemTapped = { interactor.onBrowserToolbarMenuItemTapped(it) }
                 )


### PR DESCRIPTION
RequestDesktopStateProvider was taken from private instead of desktopMode


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
