### PR TITLE
Fixes #4774 - Use vector drawable compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove forced focus of toolbar on homescreen
 - #4529 - Fixed an issue where the app would sometimes return to a blank toolbar
 - #4427 - Fixed an issue where the app would sometimes return to the home fragment
+- #4774 - Fixed how the tracking protection and HTTP icon appear in quick settings on Android 5 and 6.
 
 ### Removed
 

--- a/app/src/main/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsUIView.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsUIView.kt
@@ -111,7 +111,7 @@ class QuickSettingsUIView(
             drawableTint = R.color.photonGreen50
         } else {
             stringId = R.string.quick_settings_sheet_insecure_connection
-            drawableId = R.drawable.mozac_ic_globe
+            drawableId = R.drawable.mozac_ic_broken_lock
             drawableTint = R.color.photonRed50
         }
 

--- a/app/src/main/java/org/mozilla/fenix/settings/quicksettings/TrackingProtectionSettingView.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/quicksettings/TrackingProtectionSettingView.kt
@@ -8,6 +8,7 @@ import android.view.View
 import android.widget.CompoundButton
 import android.widget.Switch
 import android.widget.TextView
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.view.isVisible
 import io.reactivex.Observer
 import mozilla.components.support.ktx.android.view.putCompoundDrawablesRelativeWithIntrinsicBounds
@@ -23,7 +24,7 @@ class TrackingProtectionSettingView(
 
     init {
         trackingProtectionSwitch.putCompoundDrawablesRelativeWithIntrinsicBounds(
-            start = container.context.getDrawable(R.drawable.ic_tracking_protection)
+            start = AppCompatResources.getDrawable(container.context, R.drawable.ic_tracking_protection)
         )
     }
 


### PR DESCRIPTION
Was waiting on 9.0.0 snapshot to switch out the HTTP icon.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
