### PR TITLE
Fixes #4211 changed SeekBar height to wrap_content to prevent misalined dot

### DIFF
--- a/app/src/main/res/layout/layout_percentage_seek_bar.xml
+++ b/app/src/main/res/layout/layout_percentage_seek_bar.xml
@@ -35,7 +35,7 @@
     <SeekBar
         android:id="@+id/seekbar"
         android:layout_width="0dp"
-        android:layout_height="0dp"
+        android:layout_height="wrap_content"
         android:paddingEnd="60dp"
         app:layout_constraintBottom_toBottomOf="@+id/seekbar_value"
         app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION

Changed height from match_constrained to wrap_content.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes [a changelog entry](https://github.com/mozilla-mobile/fenix/blob/master/CHANGELOG.md) or does not need one
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
