### PR TITLE
Configure either geckoview beta or nightly at compile-time

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -80,21 +80,13 @@ android {
         // |--------------------|---------------|-----------|
         // | debug              | ✅            | ✅       | Both variants for testing and development.
         // | forPerformanceTest | ✅            | ✅       | Both variants unless the perf team only cares about Nightly (TBD).
-        // | fenixNightlyLegacy | ❌            | ✅       | For now GV Beta - the same version we ship with (TBD). Release type will be decommissioned soon.
-        // | fenixNightly       | ❌            | ✅       | For now GV Beta - the same version we ship with (TBD).
+        // | fenixNightlyLegacy | ✅            | ✅       | Release type will be decommissioned soon.
+        // | fenixNightly       | ✅            | ✅       | Built with both, but only the "geckoNightly" one is published to Google Play
         // | fenixBeta          | ❌            | ✅       | Fenix Beta ships with GV Beta
         // | fenixProduction    | ❌            | ✅       | Fenix Production ships with GV Beta
         //
 
         def flavors = flavors*.name.toString().toLowerCase()
-
-        if (buildType.name == 'fenixNightlyLegacy' && flavors.contains("geckonightly")) {
-            setIgnore true
-        }
-
-        if (buildType.name == 'fenixNightly' && flavors.contains("geckonightly")) {
-            setIgnore true
-        }
 
         if (buildType.name == 'fenixBeta' && flavors.contains("geckonightly")) {
             setIgnore true

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,6 +14,7 @@ import com.android.build.gradle.internal.tasks.AppPreBuildTask
 import org.gradle.internal.logging.text.StyledTextOutput.Style
 import org.gradle.internal.logging.text.StyledTextOutputFactory
 import static org.gradle.api.tasks.testing.TestResult.ResultType
+import com.android.build.OutputFile
 
 android {
     compileSdkVersion 28
@@ -52,24 +53,54 @@ android {
             applicationIdSuffix ".performancetest"
             debuggable true
         }
-        nightlyLegacy releaseTemplate >> {
+        fenixNightlyLegacy releaseTemplate >> {
             buildConfigField "boolean", "USE_RELEASE_VERSIONING", "true"
         }
-        nightly releaseTemplate >> {
+        fenixNightly releaseTemplate >> {
             applicationIdSuffix ".nightly"
             buildConfigField "boolean", "USE_RELEASE_VERSIONING", "true"
         }
-        beta releaseTemplate >> {
+        fenixBeta releaseTemplate >> {
             applicationIdSuffix ".beta"
             buildConfigField "boolean", "USE_RELEASE_VERSIONING", "true"
         }
-        production releaseTemplate >> {
+        fenixProduction releaseTemplate >> {
             buildConfigField "boolean", "USE_RELEASE_VERSIONING", "true"
         }
     }
 
     variantFilter { // There's a "release" build type that exists by default that we don't use (it's replaced by "nightly" and "beta")
         if (buildType.name == 'release') {
+            setIgnore true
+        }
+
+        // Current build variant setup:
+        //
+        //                      | geckoNightly  | geckoBeta |
+        // |--------------------|---------------|-----------|
+        // | debug              | ✅            | ✅       | Both variants for testing and development.
+        // | forPerformanceTest | ✅            | ✅       | Both variants unless the perf team only cares about Nightly (TBD).
+        // | fenixNightlyLegacy | ❌            | ✅       | For now GV Beta - the same version we ship with (TBD). Release type will be decommissioned soon.
+        // | fenixNightly       | ❌            | ✅       | For now GV Beta - the same version we ship with (TBD).
+        // | fenixBeta          | ❌            | ✅       | Fenix Beta ships with GV Beta
+        // | fenixProduction    | ❌            | ✅       | Fenix Production ships with GV Beta
+        //
+
+        def flavors = flavors*.name.toString().toLowerCase()
+
+        if (buildType.name == 'fenixNightlyLegacy' && flavors.contains("geckonightly")) {
+            setIgnore true
+        }
+
+        if (buildType.name == 'fenixNightly' && flavors.contains("geckonightly")) {
+            setIgnore true
+        }
+
+        if (buildType.name == 'fenixBeta' && flavors.contains("geckonightly")) {
+            setIgnore true
+        }
+
+        if (buildType.name == 'fenixProduction' && flavors.contains("geckonightly")) {
             setIgnore true
         }
     }
@@ -79,32 +110,25 @@ android {
         unitTests.includeAndroidResources = true
     }
 
-    flavorDimensions "abi"
+    flavorDimensions "engine"
 
     productFlavors {
-        arm {
-            dimension "abi"
-            ndk {
-                abiFilter "armeabi-v7a"
-            }
+        geckoNightly {
+            dimension "engine"
         }
-        aarch64 {
-            dimension "abi"
-            ndk {
-                abiFilter "arm64-v8a"
-            }
+
+        geckoBeta {
+            dimension "engine"
         }
-        x86 {
-            dimension "abi"
-            ndk {
-                abiFilter "x86"
-            }
-        }
-        x86_64 {
-            dimension "abi"
-            ndk {
-                abiFilter "x86_64"
-            }
+    }
+
+    splits {
+        abi {
+            enable true
+
+            reset()
+
+            include "x86", "armeabi-v7a", "arm64-v8a", "x86_64"
         }
     }
 
@@ -126,6 +150,8 @@ android {
     }
 }
 
+def baseVersionCode = generatedVersionCode
+
 android.applicationVariants.all { variant ->
 
 // -------------------------------------------------------------------------------------------------
@@ -144,14 +170,10 @@ android.applicationVariants.all { variant ->
 // Generate version codes for builds
 // -------------------------------------------------------------------------------------------------
 
-    def buildType = variant.buildType.name
-    def versionCode = null
     def isDebug = variant.buildType.resValues['IS_DEBUG']?.value ?: false
     def useReleaseVersioning = variant.buildType.buildConfigFields['USE_RELEASE_VERSIONING']?.value ?: false
 
     if (useReleaseVersioning) {
-        versionCode = generatedVersionCode
-
         // The Google Play Store does not allow multiple APKs for the same app that all have the
         // same version code. Therefore we need to have different version codes for our ARM and x86
         // builds.
@@ -160,17 +182,24 @@ android.applicationVariants.all { variant ->
         // Our x86 builds need a higher version code to avoid installing ARM builds on an x86 device
         // with ARM compatibility mode.
 
-        if (variant.flavorName.contains("x86_64")) {
-            versionCode = versionCode + 3
-        } else if (variant.flavorName.contains("x86")) {
-            versionCode = versionCode + 2
-        } else if (variant.flavorName.contains("aarch64")) {
-            versionCode = versionCode + 1
-        }// else variant.flavorName.contains("Arm")) use generated version code
+        variant.outputs.each { output ->
+            def abi = output.getFilter(OutputFile.ABI)
 
-        variant.outputs.all {
-            versionCodeOverride = versionCode
-            versionNameOverride = Config.releaseVersionName(project)
+            def versionCodeOverride
+
+            if (abi == "x86_64") {
+                versionCodeOverride = baseVersionCode + 3
+            } else if (abi == "x86") {
+                versionCodeOverride = baseVersionCode + 2
+            } else if (abi == "arm64-v8a") {
+                versionCodeOverride = baseVersionCode + 1
+            } else if (abi == "armeabi-v7a") {
+                versionCodeOverride = baseVersionCode
+            } else {
+                throw RuntimeException("Unknown ABI: $abi")
+            }
+
+            println("versionCode for $abi = $versionCodeOverride")
         }
 
         // If this is a release build, validate that "versionName" is set
@@ -277,6 +306,9 @@ androidExtensions {
 dependencies {
     implementation project(':architecture')
 
+    geckoNightlyImplementation Deps.mozilla_browser_engine_gecko_nightly
+    geckoBetaImplementation Deps.mozilla_browser_engine_gecko_beta
+
     implementation Deps.kotlin_stdlib
     implementation Deps.kotlin_coroutines
     implementation Deps.androidx_appcompat
@@ -309,7 +341,6 @@ dependencies {
     implementation Deps.mozilla_browser_domains
     implementation Deps.mozilla_browser_icons
     implementation Deps.mozilla_browser_menu
-    implementation Deps.mozilla_browser_engine_gecko_beta
     implementation Deps.mozilla_browser_search
     implementation Deps.mozilla_browser_session
     implementation Deps.mozilla_browser_storage_sync
@@ -490,7 +521,7 @@ task printBuildVariants {
         def variantData = android.applicationVariants.collect { variant -> [
             name: variant.name,
             buildType: variant.buildType.name,
-            abi: variant.productFlavors.find { it.dimension == 'abi' }.name,
+            engine: variant.productFlavors.find { it.dimension == 'engine' }.name,
             isSigned: variant.signingReady,
         ]}
         println "variants: " + groovy.json.JsonOutput.toJson(variantData)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -506,17 +506,22 @@ if (project.hasProperty("coverage")) {
 }
 
 // -------------------------------------------------------------------------------------------------
-// Task for printing all build variants to build variants in parallel in automation
+// Task for printing APK information for the requested variant
+// Usage: "./gradlew printVariant -PvariantBuildType=nightly -PvariantEngine=geckoNightly"
 // -------------------------------------------------------------------------------------------------
-task printBuildVariants {
+task printVariant {
     doLast {
-        def variantData = android.applicationVariants.collect { variant -> [
-            name: variant.name,
-            buildType: variant.buildType.name,
-            engine: variant.productFlavors.find { it.dimension == 'engine' }.name,
-            isSigned: variant.signingReady,
-        ]}
-        println "variants: " + groovy.json.JsonOutput.toJson(variantData)
+        def rawVariant = android.applicationVariants.find {
+            it.buildType.name == variantBuildType &&
+                    it.productFlavors.find { it.dimension == 'engine' }.name == variantEngine
+        }
+        println 'variant: ' + groovy.json.JsonOutput.toJson([
+            name: rawVariant.name,
+            apks: rawVariant.variantData.outputScope.apkDatas.collect { [
+                    abi: it.filters.find { it.filterType == 'ABI' }.identifier,
+                    fileName: it.outputFileName,
+            ]}
+        ])
     }
 }
 

--- a/automation/taskcluster/decision_task.py
+++ b/automation/taskcluster/decision_task.py
@@ -15,7 +15,7 @@ import re
 
 import taskcluster
 
-from lib.gradle import get_variants_for_build_type
+from lib.gradle import get_variant
 from lib.tasks import (
     fetch_mozharness_task_id,
     schedule_task_graph,
@@ -25,7 +25,6 @@ from lib.chain_of_trust import (
     populate_chain_of_trust_task_graph,
     populate_chain_of_trust_required_but_unused_files
 )
-from lib.variant import Variant
 
 REPO_URL = os.environ.get('MOBILE_HEAD_REPOSITORY')
 COMMIT = os.environ.get('MOBILE_HEAD_REV')
@@ -61,10 +60,10 @@ def pr():
     signing_tasks = {}
     other_tasks = {}
 
-    for variant in get_variants_for_build_type('debug'):
-        assemble_task_id = taskcluster.slugId()
-        build_tasks[assemble_task_id] = BUILDER.craft_assemble_pr_task(variant)
-        build_tasks[taskcluster.slugId()] = BUILDER.craft_test_pr_task(variant, True)
+    variant = get_variant('debug', 'geckoNightly')
+    assemble_task_id = taskcluster.slugId()
+    build_tasks[assemble_task_id] = BUILDER.craft_assemble_pr_task(variant)
+    build_tasks[taskcluster.slugId()] = BUILDER.craft_test_pr_task(variant)
 
     for craft_function in (
         BUILDER.craft_detekt_task,
@@ -80,12 +79,12 @@ def pr():
 def push():
     all_tasks = pr()
     other_tasks = all_tasks[-1]
-    other_tasks[taskcluster.slugId()] = BUILDER.craft_ui_tests_task() 
+    other_tasks[taskcluster.slugId()] = BUILDER.craft_ui_tests_task()
 
     if SHORT_HEAD_BRANCH == 'master':
         other_tasks[taskcluster.slugId()] = BUILDER.craft_dependencies_task()
 
-    return all_tasks 
+    return all_tasks
 
 
 def raptor(is_staging):
@@ -96,41 +95,41 @@ def raptor(is_staging):
     mozharness_task_id = fetch_mozharness_task_id()
     gecko_revision = taskcluster.Queue().task(mozharness_task_id)['payload']['env']['GECKO_HEAD_REV']
 
-    for variant in [Variant.from_values(abi, False, 'forPerformanceTest') for abi in ('aarch64', 'arm')]:
-        assemble_task_id = taskcluster.slugId()
-        build_tasks[assemble_task_id] = BUILDER.craft_assemble_raptor_task(variant)
-        signing_task_id = taskcluster.slugId()
-        signing_tasks[signing_task_id] = BUILDER.craft_raptor_signing_task(assemble_task_id, variant, is_staging)
+    variant = get_variant('forPerformanceTest', 'geckoNightly')
+    assemble_task_id = taskcluster.slugId()
+    build_tasks[assemble_task_id] = BUILDER.craft_assemble_raptor_task(variant)
+    signing_task_id = taskcluster.slugId()
+    signing_tasks[signing_task_id] = BUILDER.craft_raptor_signing_task(assemble_task_id, variant, is_staging)
 
+    for abi in ('aarch64', 'arm'):
         all_raptor_craft_functions = [
             BUILDER.craft_raptor_tp6m_cold_task(for_suite=i)
-            for i in range(1, 28)
-        ] + [
-            BUILDER.craft_raptor_youtube_playback_task,
-        ]
+                for i in range(1, 28)
+            ] + [
+                BUILDER.craft_raptor_youtube_playback_task,
+            ]
         for craft_function in all_raptor_craft_functions:
-            args = (signing_task_id, mozharness_task_id, variant, gecko_revision)
+            args = (signing_task_id, mozharness_task_id, abi, gecko_revision)
             other_tasks[taskcluster.slugId()] = craft_function(*args)
 
     return (build_tasks, signing_tasks, other_tasks)
 
 
-def release(channel, is_staging, version_name):
-    variants = get_variants_for_build_type(channel)
-    architectures = [variant.abi for variant in variants]
-    apk_paths = ["public/build/{}/target.apk".format(arch) for arch in architectures]
+def release(channel, engine, is_staging, version_name):
+    variant = get_variant('fenix' + channel.capitalize(), engine)
+    taskcluster_apk_paths = variant.upstream_artifacts()
 
     build_tasks = {}
     signing_tasks = {}
     push_tasks = {}
 
     build_task_id = taskcluster.slugId()
-    build_tasks[build_task_id] = BUILDER.craft_assemble_release_task(architectures, channel, is_staging, version_name)
+    build_tasks[build_task_id] = BUILDER.craft_assemble_release_task(variant, is_staging, version_name)
 
     signing_task_id = taskcluster.slugId()
     signing_tasks[signing_task_id] = BUILDER.craft_release_signing_task(
         build_task_id,
-        apk_paths=apk_paths,
+        taskcluster_apk_paths,
         channel=channel,
         is_staging=is_staging,
     )
@@ -138,7 +137,7 @@ def release(channel, is_staging, version_name):
     push_task_id = taskcluster.slugId()
     push_tasks[push_task_id] = BUILDER.craft_push_task(
         signing_task_id,
-        apks=apk_paths,
+        taskcluster_apk_paths,
         channel=channel,
         # TODO until org.mozilla.fenix.nightly is made public, put it on the internally-testable track
         override_google_play_track=None if channel != "nightly" else "internal",
@@ -152,10 +151,8 @@ def nightly_to_production_app(is_staging, version_name):
     # Since the Fenix nightly was launched, we've pushed it to the production app "org.mozilla.fenix" on the
     # "nightly" track. We're moving towards having each channel be published to its own app, but we need to
     # keep updating this "backwards-compatible" nightly for a while yet
-    build_type = 'nightlyLegacy'
-    variants = get_variants_for_build_type(build_type)
-    architectures = [variant.abi for variant in variants]
-    apk_paths = ["public/build/{}/target.apk".format(arch) for arch in architectures]
+    variant = get_variant('fenixNightlyLegacy', 'geckoNightly')
+    taskcluster_apk_paths = variant.upstream_artifacts()
 
     build_tasks = {}
     signing_tasks = {}
@@ -163,12 +160,12 @@ def nightly_to_production_app(is_staging, version_name):
     other_tasks = {}
 
     build_task_id = taskcluster.slugId()
-    build_tasks[build_task_id] = BUILDER.craft_assemble_release_task(architectures, build_type, is_staging, version_name)
+    build_tasks[build_task_id] = BUILDER.craft_assemble_release_task(variant, is_staging, version_name)
 
     signing_task_id = taskcluster.slugId()
     signing_tasks[signing_task_id] = BUILDER.craft_release_signing_task(
         build_task_id,
-        apk_paths=apk_paths,
+        taskcluster_apk_paths,
         channel='production',  # Since we're publishing to the "production" app, we need to sign for production
         index_channel='nightly',
         is_staging=is_staging,
@@ -177,16 +174,17 @@ def nightly_to_production_app(is_staging, version_name):
     push_task_id = taskcluster.slugId()
     push_tasks[push_task_id] = BUILDER.craft_push_task(
         signing_task_id,
-        apks=apk_paths,
+        taskcluster_apk_paths,
         channel='production',  # We're publishing to the "production" app on the "nightly" track
         override_google_play_track='nightly',
         is_staging=is_staging,
     )
 
-    nimbledroid_task_id = taskcluster.slugId()
-    other_tasks[nimbledroid_task_id] = BUILDER.craft_upload_apk_nimbledroid_task(
-        build_task_id
-    )
+    if not is_staging:
+        nimbledroid_task_id = taskcluster.slugId()
+        other_tasks[nimbledroid_task_id] = BUILDER.craft_upload_apk_nimbledroid_task(
+            build_task_id
+        )
 
     return (build_tasks, signing_tasks, push_tasks, other_tasks)
 
@@ -213,26 +211,25 @@ if __name__ == "__main__":
 
     result = parser.parse_args()
     command = result.command
-    taskcluster_queue = taskcluster.Queue({'baseUrl': 'http://taskcluster/queue/v1'})
 
-    if command in ('pull-request'):
+    if command == 'pull-request':
         ordered_groups_of_tasks = pr()
-    elif command in ('push'):
+    elif command == 'push':
         ordered_groups_of_tasks = push()
     elif command == 'raptor':
         ordered_groups_of_tasks = raptor(result.staging)
     elif command == 'nightly':
         nightly_version = datetime.datetime.now().strftime('Nightly %y%m%d %H:%M')
-        ordered_groups_of_tasks = release('nightly', result.staging, nightly_version) \
+        ordered_groups_of_tasks = release('nightly', 'geckoNightly', result.staging, nightly_version) \
             + nightly_to_production_app(result.staging, nightly_version)
     elif command == 'github-release':
         version = result.tag[1:]  # remove prefixed "v"
         beta_semver = re.compile(r'^v\d+\.\d+\.\d+-beta\.\d+$')
         production_semver = re.compile(r'^v\d+\.\d+\.\d+(-rc\.\d+)?$')
         if beta_semver.match(result.tag):
-            ordered_groups_of_tasks = release('beta', result.staging, version)
+            ordered_groups_of_tasks = release('beta', 'geckoBeta', result.staging, version)
         elif production_semver.match(result.tag):
-            ordered_groups_of_tasks = release('production', result.staging, version)
+            ordered_groups_of_tasks = release('production', 'geckoBeta', result.staging, version)
         else:
             raise ValueError('Github tag must be in semver format and prefixed with a "v", '
                              'e.g.: "v1.0.0-beta.0" (beta), "v1.0.0-rc.0" (production) or "v1.0.0" (production)')

--- a/automation/taskcluster/lib/gradle.py
+++ b/automation/taskcluster/lib/gradle.py
@@ -6,26 +6,28 @@ from __future__ import print_function
 import json
 import subprocess
 
-from lib.variant import Variant
+from lib.variant import Variant, VariantApk
 
 
-def get_variants_for_build_type(build_type):
-    print("Fetching build variants from gradle")
-    output = _run_gradle_process('printBuildVariants')
-    content = _extract_content_from_command_output(output, prefix='variants: ')
-    variants = json.loads(content)
-
-    if len(variants) == 0:
-        raise ValueError("Could not get build variants from gradle")
-
-    print("Got variants: {}".format(variants))
-    return [Variant(variant_dict['name'], variant_dict['engine'], variant_dict['isSigned'], variant_dict['buildType'])
-            for variant_dict in variants
-            if variant_dict['buildType'] == build_type]
+def get_variant(build_type, engine):
+    print("Fetching variant information for build_type='{}', engine='{}'".format(build_type, engine))
+    output = _run_gradle_process('printVariant', variantBuildType=build_type, variantEngine=engine)
+    content = _extract_content_from_command_output(output, prefix='variant: ')
+    raw_variant = json.loads(content)
+    return Variant(
+        raw_variant['name'],
+        build_type,
+        [VariantApk(build_type, raw_apk['abi'], engine, raw_apk['fileName']) for raw_apk in raw_variant['apks']]
+    )
 
 
-def _run_gradle_process(gradle_command):
-    process = subprocess.Popen(["./gradlew", "--no-daemon", "--quiet", gradle_command], stdout=subprocess.PIPE)
+def _run_gradle_process(gradle_command, **kwargs):
+    gradle_properties = [
+        '-P{property_name}={value}'.format(property_name=property_name, value=value)
+        for property_name, value in kwargs.iteritems()
+    ]
+
+    process = subprocess.Popen(["./gradlew", "--no-daemon", "--quiet", gradle_command] + gradle_properties, stdout=subprocess.PIPE)
     output, err = process.communicate()
     exit_code = process.wait()
 

--- a/automation/taskcluster/lib/gradle.py
+++ b/automation/taskcluster/lib/gradle.py
@@ -19,7 +19,7 @@ def get_variants_for_build_type(build_type):
         raise ValueError("Could not get build variants from gradle")
 
     print("Got variants: {}".format(variants))
-    return [Variant(variant_dict['name'], variant_dict['abi'], variant_dict['isSigned'], variant_dict['buildType'])
+    return [Variant(variant_dict['name'], variant_dict['engine'], variant_dict['isSigned'], variant_dict['buildType'])
             for variant_dict in variants
             if variant_dict['buildType'] == build_type]
 

--- a/automation/taskcluster/lib/variant.py
+++ b/automation/taskcluster/lib/variant.py
@@ -1,20 +1,27 @@
+import taskcluster
+
+
+class VariantApk:
+    def __init__(self, build_type, abi, engine, file_name):
+        self.abi = abi
+        self.taskcluster_path = 'public/build/{}/{}/target.apk'.format(abi, engine)
+        self.absolute_path = '/opt/fenix/app/build/outputs/apk/{}/{}/{}'.format(engine, build_type, file_name)
+
+
 class Variant:
-    def __init__(self, raw, engine, is_signed, build_type):
-        self.raw = raw
-        self.engine = engine
+    def __init__(self, name, build_type, apks):
+        self.name = name
         self.build_type = build_type
-        self._is_signed = is_signed
-        self.for_gradle_command = raw[:1].upper() + raw[1:]
-        self.platform = 'android-{}-{}'.format(self.engine, self.build_type)
+        self._apks = apks
 
-    def apk_absolute_path(self):
-        return '/opt/fenix/app/build/outputs/apk/{engine}/{build_type}/app-{engine}-{build_type}{unsigned}.apk'.format(
-            build_type=self.build_type,
-            engine=self.engine,
-            unsigned='' if self._is_signed else '-unsigned',
-        )
+    def artifacts(self):
+        return {
+            apk.taskcluster_path: {
+                'type': 'file',
+                'path': apk.absolute_path,
+                'expires': taskcluster.stringDate(taskcluster.fromNow('1 year')),
+            } for apk in self._apks
+        }
 
-    @staticmethod
-    def from_values(abi, is_signed, build_type):
-        raw = abi + build_type[:1].upper() + build_type[1:]
-        return Variant(raw, abi, is_signed, build_type)
+    def upstream_artifacts(self):
+        return [apk.taskcluster_path for apk in self._apks]

--- a/automation/taskcluster/lib/variant.py
+++ b/automation/taskcluster/lib/variant.py
@@ -1,16 +1,16 @@
 class Variant:
-    def __init__(self, raw, abi, is_signed, build_type):
+    def __init__(self, raw, engine, is_signed, build_type):
         self.raw = raw
-        self.abi = abi
+        self.engine = engine
         self.build_type = build_type
         self._is_signed = is_signed
         self.for_gradle_command = raw[:1].upper() + raw[1:]
-        self.platform = 'android-{}-{}'.format(self.abi, self.build_type)
+        self.platform = 'android-{}-{}'.format(self.engine, self.build_type)
 
     def apk_absolute_path(self):
-        return '/opt/fenix/app/build/outputs/apk/{abi}/{build_type}/app-{abi}-{build_type}{unsigned}.apk'.format(
+        return '/opt/fenix/app/build/outputs/apk/{engine}/{build_type}/app-{engine}-{build_type}{unsigned}.apk'.format(
             build_type=self.build_type,
-            abi=self.abi,
+            engine=self.engine,
             unsigned='' if self._is_signed else '-unsigned',
         )
 

--- a/config/pre-push-recommended.sh
+++ b/config/pre-push-recommended.sh
@@ -17,4 +17,4 @@
 ./gradlew -q \
         ktlint \
         detekt \
-        app:assembleX86Debug
+        app:assembleDebug

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,5 +17,5 @@ android.useAndroidX=true
 android.enableJetifier=true
 android.enableR8=true
 android.enableR8.fullMode=true
-android.enableUnitTestBinaryResources=true
+android.enableUnitTestBinaryResources=false
 org.gradle.parallel=false


### PR DESCRIPTION
Replaces #4325.
At compile time, you can choose either the `geckoNightly` or `geckoBeta` flavor.
Also updates automation to coalesce more work into less tasks by taking advantage of the APK splitting work that Sebastian did in the original PR.

[Staging nightly release](https://tools.taskcluster.net/groups/JKHgNcGZSSi7RNZKAJ48vg).

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
