### PR TITLE
Move classes out of top-level package

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -140,7 +140,7 @@
 
         <service android:name=".downloads.DownloadService" />
         <receiver
-            android:name=".SearchWidgetProvider">
+            android:name=".widget.SearchWidgetProvider">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
             </intent-filter>

--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -34,6 +34,9 @@ import mozilla.components.support.ktx.kotlin.isUrl
 import mozilla.components.support.ktx.kotlin.toNormalizedUrl
 import mozilla.components.support.utils.SafeIntent
 import mozilla.components.support.utils.toSafeIntent
+import org.mozilla.fenix.browser.browsingmode.BrowsingMode
+import org.mozilla.fenix.browser.browsingmode.BrowsingModeManager
+import org.mozilla.fenix.browser.browsingmode.DefaultBrowsingModeManager
 import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.components.isSentryEnabled
 import org.mozilla.fenix.components.metrics.Event
@@ -42,6 +45,8 @@ import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.getRootView
 import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.share.ShareFragment
+import org.mozilla.fenix.theme.DefaultThemeManager
+import org.mozilla.fenix.theme.ThemeManager
 import org.mozilla.fenix.utils.Settings
 
 @SuppressWarnings("TooManyFunctions", "LargeClass")

--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -52,7 +52,7 @@ import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.IntentReceiverActivity
 import org.mozilla.fenix.R
-import org.mozilla.fenix.ThemeManager
+import org.mozilla.fenix.theme.ThemeManager
 import org.mozilla.fenix.collections.CreateCollectionViewModel
 import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.components.FindInPageIntegration

--- a/app/src/main/java/org/mozilla/fenix/browser/browsingmode/BrowsingModeManager.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/browsingmode/BrowsingModeManager.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.fenix
+package org.mozilla.fenix.browser.browsingmode
 
 import org.mozilla.fenix.utils.Settings
 

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt
@@ -14,8 +14,8 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.ObsoleteCoroutinesApi
 import mozilla.components.browser.session.Session
 import mozilla.components.concept.engine.EngineView
-import org.mozilla.fenix.BrowsingMode
-import org.mozilla.fenix.BrowsingModeManager
+import org.mozilla.fenix.browser.browsingmode.BrowsingMode
+import org.mozilla.fenix.browser.browsingmode.BrowsingModeManager
 import org.mozilla.fenix.R
 import org.mozilla.fenix.browser.BrowserFragment
 import org.mozilla.fenix.browser.BrowserFragmentDirections

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarView.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarView.kt
@@ -11,7 +11,7 @@ import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.support.ktx.android.util.dpToFloat
 import mozilla.components.support.ktx.android.util.dpToPx
 import org.mozilla.fenix.R
-import org.mozilla.fenix.ThemeManager
+import org.mozilla.fenix.theme.ThemeManager
 import org.mozilla.fenix.customtabs.CustomTabToolbarMenu
 import org.mozilla.fenix.ext.components
 

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
@@ -11,10 +11,10 @@ import mozilla.components.browser.menu.item.BrowserMenuHighlightableItem
 import mozilla.components.browser.menu.item.BrowserMenuImageText
 import mozilla.components.browser.menu.item.BrowserMenuItemToolbar
 import mozilla.components.browser.menu.item.BrowserMenuSwitch
-import org.mozilla.fenix.BrowsingMode
+import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
-import org.mozilla.fenix.ThemeManager
+import org.mozilla.fenix.theme.ThemeManager
 import org.mozilla.fenix.ext.asActivity
 import org.mozilla.fenix.ext.components
 

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarIntegration.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarIntegration.kt
@@ -21,7 +21,7 @@ import mozilla.components.lib.publicsuffixlist.PublicSuffixList
 import mozilla.components.support.base.feature.LifecycleAwareFeature
 import mozilla.components.support.ktx.android.view.hideKeyboard
 import org.mozilla.fenix.R
-import org.mozilla.fenix.ThemeManager
+import org.mozilla.fenix.theme.ThemeManager
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.utils.Settings

--- a/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabActivity.kt
@@ -7,8 +7,8 @@ package org.mozilla.fenix.customtabs
 import androidx.navigation.NavDestination
 import mozilla.components.browser.session.intent.getSessionId
 import mozilla.components.support.utils.SafeIntent
-import org.mozilla.fenix.CustomTabBrowsingModeManager
-import org.mozilla.fenix.CustomTabThemeManager
+import org.mozilla.fenix.browser.browsingmode.CustomTabBrowsingModeManager
+import org.mozilla.fenix.theme.CustomTabThemeManager
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.components.metrics.Event
 
@@ -22,7 +22,8 @@ open class CustomTabActivity : HomeActivity() {
 
     final override fun getIntentSessionId(intent: SafeIntent) = intent.getSessionId()
 
-    final override fun createBrowsingModeManager() = CustomTabBrowsingModeManager()
+    final override fun createBrowsingModeManager() =
+        CustomTabBrowsingModeManager()
 
     final override fun createThemeManager() = CustomTabThemeManager()
 }

--- a/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabToolbarMenu.kt
@@ -14,7 +14,7 @@ import mozilla.components.browser.menu.item.SimpleBrowserMenuItem
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import org.mozilla.fenix.R
-import org.mozilla.fenix.ThemeManager
+import org.mozilla.fenix.theme.ThemeManager
 import org.mozilla.fenix.components.toolbar.ToolbarMenu
 
 class CustomTabToolbarMenu(

--- a/app/src/main/java/org/mozilla/fenix/ext/Context.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/Context.kt
@@ -25,7 +25,7 @@ import mozilla.components.support.base.log.Log
 import mozilla.components.support.base.log.Log.Priority.WARN
 import org.mozilla.fenix.FenixApplication
 import org.mozilla.fenix.R
-import org.mozilla.fenix.ThemeManager
+import org.mozilla.fenix.theme.ThemeManager
 import org.mozilla.fenix.components.Components
 import org.mozilla.fenix.components.metrics.MetricController
 

--- a/app/src/main/java/org/mozilla/fenix/home/HomeMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeMenu.kt
@@ -9,7 +9,7 @@ import mozilla.components.browser.menu.BrowserMenuBuilder
 import mozilla.components.browser.menu.item.BrowserMenuDivider
 import mozilla.components.browser.menu.item.BrowserMenuImageText
 import org.mozilla.fenix.R
-import org.mozilla.fenix.ThemeManager
+import org.mozilla.fenix.theme.ThemeManager
 
 class HomeMenu(
     private val context: Context,

--- a/app/src/main/java/org/mozilla/fenix/home/PrivateBrowsingButtonView.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/PrivateBrowsingButtonView.kt
@@ -6,8 +6,8 @@ package org.mozilla.fenix.home
 
 import android.view.View
 import androidx.annotation.StringRes
-import org.mozilla.fenix.BrowsingMode
-import org.mozilla.fenix.BrowsingModeManager
+import org.mozilla.fenix.browser.browsingmode.BrowsingMode
+import org.mozilla.fenix.browser.browsingmode.BrowsingModeManager
 import org.mozilla.fenix.R
 
 /**

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlComponent.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlComponent.kt
@@ -14,7 +14,7 @@ import io.reactivex.Observer
 import kotlinx.android.parcel.Parcelize
 import mozilla.components.browser.session.Session
 import mozilla.components.service.fxa.sharing.ShareableAccount
-import org.mozilla.fenix.BrowsingMode
+import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.mvi.Action
 import org.mozilla.fenix.mvi.ActionBusFactory

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/CollectionViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/CollectionViewHolder.kt
@@ -16,7 +16,7 @@ import kotlinx.android.synthetic.main.collection_home_list_row.view.*
 import mozilla.components.browser.menu.BrowserMenuBuilder
 import mozilla.components.browser.menu.item.SimpleBrowserMenuItem
 import org.mozilla.fenix.R
-import org.mozilla.fenix.ThemeManager
+import org.mozilla.fenix.theme.ThemeManager
 import org.mozilla.fenix.components.description
 import org.mozilla.fenix.ext.getIconColor
 import org.mozilla.fenix.ext.increaseTapArea

--- a/app/src/main/java/org/mozilla/fenix/library/LibraryPageFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/LibraryPageFragment.kt
@@ -6,7 +6,7 @@ package org.mozilla.fenix.library
 
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
-import org.mozilla.fenix.BrowsingMode
+import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkController.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkController.kt
@@ -10,7 +10,7 @@ import androidx.navigation.NavController
 import androidx.navigation.NavDirections
 import mozilla.components.concept.storage.BookmarkNode
 import org.mozilla.fenix.BrowserDirection
-import org.mozilla.fenix.BrowsingMode
+import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.FenixSnackbarPresenter

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragmentInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragmentInteractor.kt
@@ -6,7 +6,7 @@ package org.mozilla.fenix.library.bookmarks
 
 import mozilla.components.concept.storage.BookmarkNode
 import mozilla.components.concept.storage.BookmarkNodeType
-import org.mozilla.fenix.BrowsingMode
+import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.components.metrics.MetricController
 import org.mozilla.fenix.lib.Do

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkItemMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkItemMenu.kt
@@ -10,7 +10,7 @@ import mozilla.components.browser.menu.item.SimpleBrowserMenuItem
 import mozilla.components.concept.storage.BookmarkNode
 import mozilla.components.concept.storage.BookmarkNodeType
 import org.mozilla.fenix.R
-import org.mozilla.fenix.ThemeManager
+import org.mozilla.fenix.theme.ThemeManager
 import org.mozilla.fenix.library.LibraryItemMenu
 
 class BookmarkItemMenu(

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragment.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.launch
 import mozilla.components.lib.state.ext.consumeFrom
 import mozilla.components.support.base.feature.BackHandler
 import org.mozilla.fenix.BrowserDirection
-import org.mozilla.fenix.BrowsingMode
+import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.Components

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryItemMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryItemMenu.kt
@@ -8,7 +8,7 @@ import android.content.Context
 import mozilla.components.browser.menu.BrowserMenuBuilder
 import mozilla.components.browser.menu.item.SimpleBrowserMenuItem
 import org.mozilla.fenix.R
-import org.mozilla.fenix.ThemeManager
+import org.mozilla.fenix.theme.ThemeManager
 import org.mozilla.fenix.library.LibraryItemMenu
 
 class HistoryItemMenu(

--- a/app/src/main/java/org/mozilla/fenix/settings/Extensions.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/Extensions.kt
@@ -12,7 +12,7 @@ import androidx.preference.Preference
 import mozilla.components.feature.sitepermissions.SitePermissions
 import mozilla.components.support.ktx.android.view.putCompoundDrawablesRelative
 import org.mozilla.fenix.R
-import org.mozilla.fenix.ThemeManager
+import org.mozilla.fenix.theme.ThemeManager
 
 fun SitePermissions.toggle(featurePhone: PhoneFeature): SitePermissions {
     return when (featurePhone) {

--- a/app/src/main/java/org/mozilla/fenix/theme/ThemeManager.kt
+++ b/app/src/main/java/org/mozilla/fenix/theme/ThemeManager.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.fenix
+package org.mozilla.fenix.theme
 
 import android.app.Activity
 import android.content.Context
@@ -14,6 +14,8 @@ import android.util.TypedValue
 import android.view.View
 import android.view.Window
 import androidx.annotation.StyleRes
+import org.mozilla.fenix.R
+import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.ext.getColorFromAttr
 
 abstract class ThemeManager {

--- a/app/src/main/java/org/mozilla/fenix/widget/SearchWidgetProvider.kt
+++ b/app/src/main/java/org/mozilla/fenix/widget/SearchWidgetProvider.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.fenix
+package org.mozilla.fenix.widget
 
 import android.app.PendingIntent
 import android.appwidget.AppWidgetManager
@@ -14,6 +14,9 @@ import android.os.Bundle
 import android.speech.RecognizerIntent
 import android.view.View
 import android.widget.RemoteViews
+import org.mozilla.fenix.HomeActivity
+import org.mozilla.fenix.IntentReceiverActivity
+import org.mozilla.fenix.R
 import org.mozilla.fenix.utils.Settings
 
 class SearchWidgetProvider : AppWidgetProvider() {
@@ -93,7 +96,8 @@ class SearchWidgetProvider : AppWidgetProvider() {
             .let { intent ->
                 intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
                 intent.putExtra(HomeActivity.OPEN_TO_SEARCH, true)
-                PendingIntent.getActivity(context, REQUEST_CODE_NEW_TAB, intent, PendingIntent.FLAG_UPDATE_CURRENT)
+                PendingIntent.getActivity(context,
+                    REQUEST_CODE_NEW_TAB, intent, PendingIntent.FLAG_UPDATE_CURRENT)
             }
     }
 
@@ -107,7 +111,8 @@ class SearchWidgetProvider : AppWidgetProvider() {
         val intentSpeech = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH)
 
         return intentSpeech.resolveActivity(context.packageManager)?.let {
-            PendingIntent.getActivity(context, REQUEST_CODE_VOICE, voiceIntent, 0)
+            PendingIntent.getActivity(context,
+                REQUEST_CODE_VOICE, voiceIntent, 0)
         }
     }
 

--- a/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarControllerTest.kt
@@ -22,8 +22,8 @@ import mozilla.components.feature.session.SessionUseCases
 import mozilla.components.feature.tabs.TabsUseCases
 import org.junit.Before
 import org.junit.Test
-import org.mozilla.fenix.BrowsingMode
-import org.mozilla.fenix.BrowsingModeManager
+import org.mozilla.fenix.browser.browsingmode.BrowsingMode
+import org.mozilla.fenix.browser.browsingmode.BrowsingModeManager
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.browser.BrowserFragment

--- a/app/src/test/java/org/mozilla/fenix/home/PrivateBrowsingButtonViewTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/PrivateBrowsingButtonViewTest.kt
@@ -11,8 +11,8 @@ import io.mockk.verify
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
-import org.mozilla.fenix.BrowsingMode
-import org.mozilla.fenix.BrowsingModeManager
+import org.mozilla.fenix.browser.browsingmode.BrowsingMode
+import org.mozilla.fenix.browser.browsingmode.BrowsingModeManager
 import org.mozilla.fenix.R
 
 class PrivateBrowsingButtonViewTest {

--- a/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkControllerTest.kt
@@ -21,7 +21,7 @@ import mozilla.components.concept.storage.BookmarkNodeType
 import org.junit.Before
 import org.junit.Test
 import org.mozilla.fenix.BrowserDirection
-import org.mozilla.fenix.BrowsingMode
+import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.FenixSnackbarPresenter

--- a/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkFragmentInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkFragmentInteractorTest.kt
@@ -15,7 +15,7 @@ import mozilla.components.concept.storage.BookmarkNode
 import mozilla.components.concept.storage.BookmarkNodeType
 import org.junit.Before
 import org.junit.Test
-import org.mozilla.fenix.BrowsingMode
+import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.components.metrics.MetricController
 


### PR DESCRIPTION
- `.theme.ThemeManager`
- `.browser.browsingmode.BrowsingModeManager`
- `.widget.SearchWidgetProvider`

Long-term we plan to add more code for some of these features so its better that they aren't at the top-level package.
