### PR TITLE
For #4064: Dispatchers.Main still has long cold start delay (Phase II)

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -37,9 +37,23 @@
 
 -keep class kotlinx.coroutines.internal.MainDispatcherFactory {}
 -keep class kotlinx.coroutines.CoroutineExceptionHandler {}
+-keepnames class kotlinx.coroutines.android.AndroidExceptionPreHandler {}
+-keepnames class kotlinx.coroutines.android.AndroidDispatcherFactory {}
 -keepclassmembernames class kotlinx.** {
     volatile <fields>;
 }
+
+
+####################################################################################################
+# Force removal of slow Dispatchers.Main ServiceLoader
+#
+# Please remove these rules when Android Gradle Plugin 3.6+ & coroutines 1.3.0+ are both in use
+####################################################################################################
+# Ensure the custom, fast service loader implementation is removed.
+-assumevalues class kotlinx.coroutines.internal.MainDispatcherLoader {
+  boolean FAST_SERVICE_LOADER_ENABLED return false;
+}
+-checkdiscard class kotlinx.coroutines.internal.FastServiceLoader
 
 ####################################################################################################
 # Mozilla Application Services

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -4,8 +4,8 @@
 
 object Versions {
     const val kotlin = "1.3.30"
-    const val coroutines = "1.2.1"
-    const val android_gradle_plugin = "3.4.1"
+    const val coroutines = "1.3.0-RC2"
+    const val android_gradle_plugin = "3.5.0"
     const val rxAndroid = "2.1.0"
     const val rxKotlin = "2.3.0"
     const val rxBindings = "3.0.0-alpha2"


### PR DESCRIPTION
This change simply upgrades the Android Gradle Plugin and updates how R8/Proguard works to achieve performance improvements. It does not require new tests.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
