### PR TITLE
Fixes #4863 changed navigation to homeFragment on close button

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/LibraryPageFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/LibraryPageFragment.kt
@@ -5,19 +5,13 @@
 package org.mozilla.fenix.library
 
 import androidx.fragment.app.Fragment
-import androidx.navigation.fragment.findNavController
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.HomeActivity
-import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
 
 abstract class LibraryPageFragment<T> : Fragment() {
 
     abstract val selectedItems: Set<T>
-
-    protected fun close() {
-        findNavController().popBackStack(R.id.libraryFragment, true)
-    }
 
     protected fun openItemsInNewTab(private: Boolean = false, toUrl: (T) -> String?) {
         context?.components?.useCases?.tabsUseCases?.let { tabsUseCases ->

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragment.kt
@@ -187,8 +187,10 @@ class BookmarkFragment : LibraryPageFragment<BookmarkNode>(), BackHandler, Accou
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.libraryClose -> {
-                invokePendingDeletion()
-                close()
+                navigate(
+                    BookmarkFragmentDirections
+                        .actionBookmarkFragmentToHomeFragment()
+                )
                 true
             }
             R.id.add_bookmark_folder -> {

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragment.kt
@@ -162,7 +162,7 @@ class HistoryFragment : LibraryPageFragment<HistoryItem>(), BackHandler {
             true
         }
         R.id.libraryClose -> {
-            close()
+            nav(R.id.historyFragment, HistoryFragmentDirections.actionHistoryFragmentToHomeFragment())
             true
         }
         R.id.delete_history_multi_select -> {


### PR DESCRIPTION
Bookmarks:removed invokePendingDeletion, it is being called in navigate()
LibraryPageFragment: removed not used close()

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
