### PR TITLE
Fix bustage on Nightly cron from PR #4865

### DIFF
--- a/automation/taskcluster/decision_task.py
+++ b/automation/taskcluster/decision_task.py
@@ -160,7 +160,8 @@ def nightly_to_production_app(is_staging, version_name):
     other_tasks = {}
 
     build_task_id = taskcluster.slugId()
-    build_tasks[build_task_id] = BUILDER.craft_assemble_release_task(variant, is_staging, version_name)
+    build_tasks[build_task_id] = BUILDER.craft_assemble_release_task(
+        variant, 'nightlyLegacy', is_staging, version_name)
 
     signing_task_id = taskcluster.slugId()
     signing_tasks[signing_task_id] = BUILDER.craft_release_signing_task(


### PR DESCRIPTION
This should be enough to fix the Nightly cron (https://taskcluster-ui.herokuapp.com/tasks/ChLYOp7MTui0eMLrGkDwzg/runs/0/logs/https%3A%2F%2Fqueue.taskcluster.net%2Fv1%2Ftask%2FChLYOp7MTui0eMLrGkDwzg%2Fruns%2F0%2Fartifacts%2Fpublic%2Flogs%2Flive.log)

Most of the normal releng-mobile people are away until next week, but I'd like @mitchhentges to look at it once he's back, but we probably want a set of eyes before then so this can merge in.
