### PR TITLE
No issue: only sync once on startup/onResume

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -104,7 +104,7 @@ open class HomeActivity : AppCompatActivity(), ShareFragment.TabsSharedCallback 
                 accountManager.initAsync().await()
                 // If we're authenticated, kick-off a sync and a device state refresh.
                 accountManager.authenticatedAccount()?.let {
-                    accountManager.syncNowAsync(startup = true)
+                    accountManager.syncNowAsync(startup = true, debounce = true)
                     it.deviceConstellation().pollForEventsAsync().await()
                 }
             }


### PR DESCRIPTION
This uses the new `debounce` API to sync, making sure we don't sync as part of `onResume`.

See https://github.com/mozilla-mobile/android-components/pull/4129 for details.