### PR TITLE
Closes #4431: Enable feature-media component for all builds.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -46,5 +46,5 @@ object FeatureFlags {
      *
      * https://github.com/mozilla-mobile/fenix/issues/4431
      */
-    val mediaIntegration = nightly or debug
+    const val mediaIntegration = true
 }


### PR DESCRIPTION
I just fixed the last media issue and now we can enable this for all builds. I'll continue to monitor issues and Sentry crashes related to the media features. And I'll request QA on the media issues that will be closed by this.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
