### PR TITLE
Fixes #3602:navigate to top of home screen after tapping "start browsing"

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -294,7 +294,7 @@ class HomeFragment : Fragment(), AccountObserver {
         Do exhaustive when (action) {
             is OnboardingAction.Finish -> {
                 onboarding.finish()
-
+                homeLayout?.progress = 0F
                 val mode = currentMode(context!!)
                 getManagedEmitter<SessionControlChange>().onNext(
                     SessionControlChange.ModeChange(


### PR DESCRIPTION
After onboarding.finish(), added navigation to homeFragment

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
