### PR TITLE
Create "fennecProduction" build type

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -90,6 +90,7 @@ android {
         // | fenixNightly       | ✅            | ✅       | Built with both, but only the "geckoNightly" one is published to Google Play
         // | fenixBeta          | ❌            | ✅       | Fenix Beta ships with GV Beta
         // | fenixProduction    | ❌            | ✅       | Fenix Production ships with GV Beta
+        // | fennecProduction   | ❌            | ✅       | Fenix build to replace production Firefox builds
         //
 
         def flavors = flavors*.name.toString().toLowerCase()
@@ -99,6 +100,10 @@ android {
         }
 
         if (buildType.name == 'fenixProduction' && flavors.contains("geckonightly")) {
+            setIgnore true
+        }
+
+        if (buildType.name == 'fennecProduction' && flavors.contains("geckonightly")) {
             setIgnore true
         }
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -72,6 +72,14 @@ android {
         fennecProduction releaseTemplate >> {
             buildConfigField "boolean", "USE_RELEASE_VERSIONING", "true"
             applicationIdSuffix ".firefox"
+            manifestPlaceholders = [
+                // This release type is meant to replace Firefox (Release channel) and therefore needs to inherit
+                // its sharedUserId for all eternity. Shipping an app update without sharedUserId can have
+                // fatal consequences. For example see:
+                //  - https://issuetracker.google.com/issues/36924841
+                //  - https://issuetracker.google.com/issues/36905922
+                "sharedUserId": "org.mozilla.firefox.sharedID"
+            ]
         }
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,7 +19,7 @@ import com.android.build.OutputFile
 android {
     compileSdkVersion 28
     defaultConfig {
-        applicationId "org.mozilla.fenix"
+        applicationId "org.mozilla"
         minSdkVersion Config.minSdkVersion
         targetSdkVersion Config.targetSdkVersion
         versionCode 1
@@ -43,32 +43,35 @@ android {
         debug {
             shrinkResources false
             minifyEnabled false
-            applicationIdSuffix ".debug"
+            applicationIdSuffix ".fenix.debug"
             manifestPlaceholders.isRaptorEnabled = "true"
             resValue "bool", "IS_DEBUG", "true"
             pseudoLocalesEnabled true
         }
         forPerformanceTest releaseTemplate >> { // the ">>" concatenates the raptor-specific options with the template
             manifestPlaceholders.isRaptorEnabled = "true"
-            applicationIdSuffix ".performancetest"
+            applicationIdSuffix ".fenix.performancetest"
             debuggable true
         }
         fenixNightlyLegacy releaseTemplate >> {
+            applicationIdSuffix ".fenix"
             buildConfigField "boolean", "USE_RELEASE_VERSIONING", "true"
         }
         fenixNightly releaseTemplate >> {
-            applicationIdSuffix ".nightly"
+            applicationIdSuffix ".fenix.nightly"
             buildConfigField "boolean", "USE_RELEASE_VERSIONING", "true"
         }
         fenixBeta releaseTemplate >> {
-            applicationIdSuffix ".beta"
+            applicationIdSuffix ".fenix.beta"
             buildConfigField "boolean", "USE_RELEASE_VERSIONING", "true"
         }
         fenixProduction releaseTemplate >> {
+            applicationIdSuffix ".fenix"
             buildConfigField "boolean", "USE_RELEASE_VERSIONING", "true"
         }
         fennecProduction releaseTemplate >> {
             buildConfigField "boolean", "USE_RELEASE_VERSIONING", "true"
+            applicationIdSuffix ".firefox"
         }
     }
 
@@ -167,8 +170,14 @@ android.applicationVariants.all { variant ->
 
     def isDebug = variant.buildType.resValues['IS_DEBUG']?.value ?: false
     def useReleaseVersioning = variant.buildType.buildConfigFields['USE_RELEASE_VERSIONING']?.value ?: false
-
     def versionName = Config.releaseVersionName(project)
+
+    println("----------------------------------------------")
+    println("Variant name:      " + variant.name)
+    println("Application ID:    " + [variant.mergedFlavor.applicationId, variant.buildType.applicationIdSuffix].findAll().join())
+    println("Build type:        " + variant.buildType.name)
+    println("Flavor:            " + variant.flavorName)
+    println("Telemetry enabled: " + !isDebug)
 
     if (useReleaseVersioning) {
         // The Google Play Store does not allow multiple APKs for the same app that all have the
@@ -224,13 +233,6 @@ android.applicationVariants.all { variant ->
             }
         }
     }
-
-    println("----------------------------------------------")
-    println("Variant name:      " + variant.name)
-    println("Build type:        " + variant.buildType.name)
-    println("Flavor:            " + variant.flavorName)
-    println("Version code:      " + (versionCode ?: variant.mergedFlavor.versionCode))
-    println("Telemetry enabled: " + !isDebug)
 
 // -------------------------------------------------------------------------------------------------
 // BuildConfig: Set variables for Sentry, Crash Reporting, and Telemetry

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -74,7 +74,9 @@ android {
             applicationIdSuffix ".firefox"
             manifestPlaceholders = [
                 // This release type is meant to replace Firefox (Release channel) and therefore needs to inherit
-                // its sharedUserId for all eternity. Shipping an app update without sharedUserId can have
+                // its sharedUserId for all eternity. See:
+                // https://searchfox.org/mozilla-central/search?q=moz_android_shared_id&case=false&regexp=false&path=
+                // Shipping an app update without sharedUserId can have
                 // fatal consequences. For example see:
                 //  - https://issuetracker.google.com/issues/36924841
                 //  - https://issuetracker.google.com/issues/36905922

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -67,6 +67,9 @@ android {
         fenixProduction releaseTemplate >> {
             buildConfigField "boolean", "USE_RELEASE_VERSIONING", "true"
         }
+        fennecProduction releaseTemplate >> {
+            buildConfigField "boolean", "USE_RELEASE_VERSIONING", "true"
+        }
     }
 
     variantFilter { // There's a "release" build type that exists by default that we don't use (it's replaced by "nightly" and "beta")

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -197,8 +197,9 @@ android.applicationVariants.all { variant ->
             def abi = output.getFilter(OutputFile.ABI)
 
             def versionCodeOverride
-
-            if (abi == "x86_64") {
+            if (variant.name.contains("Fennec")) {
+                versionCodeOverride = Config.generateFennecVersionCode(abi)
+            } else if (abi == "x86_64") {
                 versionCodeOverride = baseVersionCode + 3
             } else if (abi == "x86") {
                 versionCodeOverride = baseVersionCode + 2

--- a/app/src/fennecProduction/AndroidManifest.xml
+++ b/app/src/fennecProduction/AndroidManifest.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  sharedUserId: This release type is meant to replace Firefox (Release channel) and therefore needs to inherit
+                its sharedUserId for all eternity. Shipping an app update without sharedUserId can have
+                fatal consequences. For example see:
+                - https://issuetracker.google.com/issues/36924841
+                - https://issuetracker.google.com/issues/36905922
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+      android:sharedUserId="org.mozilla.firefox.sharedID">
+</manifest>
+

--- a/app/src/fennecProduction/AndroidManifest.xml
+++ b/app/src/fennecProduction/AndroidManifest.xml
@@ -7,6 +7,6 @@
                 - https://issuetracker.google.com/issues/36905922
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-      android:sharedUserId="org.mozilla.firefox.sharedID">
+      android:sharedUserId="${sharedUserId}">
 </manifest>
 

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -109,8 +109,8 @@ object Config {
 
         when {
             base < 0 -> throw RuntimeException("Cannot calculate versionCode. Hours underflow.")
-            base > pow(2.0, 17.0) -> throw RuntimeException("Cannot calculate versionCode. Hours overflow.")
-            base > (pow(2.0, 17.0) - (366 * 24)) ->
+            base > 0x20000 /* 2^17 */ -> throw RuntimeException("Cannot calculate versionCode. Hours overflow.")
+            base > 0x20000 - (366 * 24) ->
                 // You have one year to update the version scheme...
                 throw RuntimeException("Running out of low order bits calculating versionCode.")
         }

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -54,7 +54,8 @@ object Config {
 
     /**
      * Generates a versionCode that follows the same rules like legacy Fennec builds.
-     * Adapted from: https://searchfox.org/mozilla-central/source/python/mozbuild/mozbuild/android_version_code.py
+     * Adapted from:
+     * https://searchfox.org/mozilla-central/rev/34cb8d0a2a324043bcfc2c56f37b31abe7fb23a8/python/mozbuild/mozbuild/android_version_code.py
      */
     @JvmStatic
     fun generateFennecVersionCode(abi: String): Int {
@@ -89,10 +90,8 @@ object Config {
         // architecture (x86 or ARM). 64-bit builds have higher version codes so
         // they take precedence over 32-bit builds on devices that support 64-bit.
         //
-        //         The bit labelled 'g' is 1 if the build targets a recent API level, which
-        // is currently always the case, because Firefox no longer ships releases that
-        // are split by API levels. However, we may reintroduce a split in the future,
-        // in which case the release that targets an older API level will
+        //         The bit labelled 'g' is 1 was used for APK splits and is
+        //         nowadays always set to 1 until it serves a new purpose.
         //
         // We throw an explanatory exception when we are within one calendar year of
         // running out of build events.  This gives lots of time to update the version
@@ -132,7 +131,7 @@ object Config {
             version = version or (1 shl 1)
         }
 
-        // 'g' bit is currently always 1, but may depend on `min_sdk` in the future.
+        // 'g' bit is currently always 1 (see comment above)
         version = version or (1 shl 0)
 
         return version

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -1,4 +1,6 @@
 import org.gradle.api.Project
+import java.lang.Math.pow
+import java.lang.RuntimeException
 
 import java.text.SimpleDateFormat
 import java.time.LocalDateTime
@@ -40,5 +42,99 @@ object Config {
         val timeFormatter = DateTimeFormatter.ofPattern("h:mm a")
 
         return "${dateTime.dayOfWeek.toString().toLowerCase().capitalize()} ${dateTime.monthValue}/${dateTime.dayOfMonth} @ ${timeFormatter.format(dateTime)}"
+    }
+
+    private val fennecBaseVersionCode by lazy {
+        val format = SimpleDateFormat("YYYYMMDDHHMMSS", Locale.US)
+        val cutoff = format.parse("20150801000000")
+        val build = Date()
+
+        Math.floor((build.time - cutoff.time) / (1000.0 * 60.0 * 60.0)).toInt()
+    }
+
+    /**
+     * Generates a versionCode that follows the same rules like legacy Fennec builds.
+     * Adapted from: https://searchfox.org/mozilla-central/source/python/mozbuild/mozbuild/android_version_code.py
+     */
+    @JvmStatic
+    fun generateFennecVersionCode(abi: String): Int {
+        // The important consideration is that version codes be monotonically
+        // increasing (per Android package name) for all published builds.  The input
+        // build IDs are based on timestamps and hence are always monotonically
+        // increasing.
+        //
+        //         The generated v1 version codes look like (in binary):
+        //
+        // 0111 1000 0010 tttt tttt tttt tttt txpg
+        //
+        // The 17 bits labelled 't' represent the number of hours since midnight on
+        // September 1, 2015.  (2015090100 in YYYYMMMDDHH format.)  This yields a
+        // little under 15 years worth of hourly build identifiers, since 2**17 / (366
+        //         * 24) =~ 14.92.
+        //
+        //         The bits labelled 'x', 'p', and 'g' are feature flags.
+        //
+        // The bit labelled 'x' is 1 if the build is for an x86 or x86-64 architecture,
+        // and 0 otherwise, which means the build is for an ARM or ARM64 architecture.
+        // (Fennec no longer supports ARMv6, so ARM is equivalent to ARMv7.
+        //
+        //         ARM64 is also known as AArch64; it is logically ARMv8.)
+        //
+        // For the same release, x86 and x86_64 builds have higher version codes and
+        // take precedence over ARM builds, so that they are preferred over ARM on
+        // devices that have ARM emulation.
+        //
+        // The bit labelled 'p' is 1 if the build is for a 64-bit architecture (x86-64
+        //         or ARM64), and 0 otherwise, which means the build is for a 32-bit
+        // architecture (x86 or ARM). 64-bit builds have higher version codes so
+        // they take precedence over 32-bit builds on devices that support 64-bit.
+        //
+        //         The bit labelled 'g' is 1 if the build targets a recent API level, which
+        // is currently always the case, because Firefox no longer ships releases that
+        // are split by API levels. However, we may reintroduce a split in the future,
+        // in which case the release that targets an older API level will
+        //
+        // We throw an explanatory exception when we are within one calendar year of
+        // running out of build events.  This gives lots of time to update the version
+        // scheme.  The responsible individual should then bump the range (to allow
+        //         builds to continue) and use the time remaining to update the version scheme
+        // via the reserved high order bits.
+        //
+        //         N.B.: the reserved 0 bit to the left of the highest order 't' bit can,
+        //         sometimes, be used to bump the version scheme.  In addition, by reducing the
+        // granularity of the build identifiers (for example, moving to identifying
+        // builds every 2 or 4 hours), the version scheme may be adjusted further still
+        // without losing a (valuable) high order bit.
+
+        val base = fennecBaseVersionCode
+
+        when {
+            base < 0 -> throw RuntimeException("Cannot calculate versionCode. Hours underflow.")
+            base > pow(2.0, 17.0) -> throw RuntimeException("Cannot calculate versionCode. Hours overflow.")
+            base > (pow(2.0, 17.0) - (366 * 24)) ->
+                // You have one year to update the version scheme...
+                throw RuntimeException("Running out of low order bits calculating versionCode.")
+        }
+
+        var version = 0x78200000 // 1111000001000000000000000000000
+        // We reserve 1 "middle" high order bit for the future, and 3 low order bits
+        // for architecture and APK splits.
+        version = version or (base shl  3)
+
+
+        // 'x' bit is 1 for x86/x86-64 architectures
+        if (abi == "x86_64" || abi == "x86") {
+            version = version or (1 shl 2)
+        }
+
+        // 'p' bit is 1 for 64-bit architectures.
+        if (abi == "arm64-v8a" || abi == "x86_64") {
+            version = version or (1 shl 1)
+        }
+
+        // 'g' bit is currently always 1, but may depend on `min_sdk` in the future.
+        version = version or (1 shl 0)
+
+        return version
     }
 }


### PR DESCRIPTION
In addition to our `fenix*` build types this series of patches introduces a `fennecProduction` build type.

I only implemented the bare minimum that is required to replace an installed Firefox/Fennec release version with a `fennecProduction` build (if signed with the right key). This allows us to start working on release engineering tasks (actually building and signing APKs with the Fennec keys) and start the QA process (Let's see what surprises are waiting for us..).

This is only the foundation and there will be many more patches focused on data migration etc.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
