### PR TITLE
Move creation of GeckoRuntime to flavor-specific source set.

### DIFF
--- a/app/src/geckoBeta/java/org/mozilla/fenix/engine/GeckoProvider.kt
+++ b/app/src/geckoBeta/java/org/mozilla/fenix/engine/GeckoProvider.kt
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import android.content.Context
+import android.os.Bundle
+import mozilla.components.lib.crash.handler.CrashHandlerService
+import org.mozilla.fenix.utils.Settings
+import org.mozilla.geckoview.GeckoRuntime
+import org.mozilla.geckoview.GeckoRuntimeSettings
+
+object GeckoProvider {
+    var testConfig: Bundle? = null
+    private var runtime: GeckoRuntime? = null
+
+    @Synchronized
+    fun getOrCreateRuntime(context: Context): GeckoRuntime {
+        if (runtime == null) {
+            runtime = createRuntime(context)
+        }
+
+        return runtime!!
+    }
+
+    private fun createRuntime(context: Context): GeckoRuntime {
+        val builder = GeckoRuntimeSettings.Builder()
+
+        testConfig?.let {
+            builder.extras(it)
+                .remoteDebuggingEnabled(true)
+        }
+
+        val runtimeSettings = builder
+            .crashHandler(CrashHandlerService::class.java)
+            .useContentProcessHint(true)
+            .build()
+
+        if (!Settings.getInstance(context).shouldUseAutoSize) {
+            runtimeSettings.automaticFontSizeAdjustment = false
+            val fontSize = Settings.getInstance(context).fontSizeFactor
+            runtimeSettings.fontSizeFactor = fontSize
+        }
+
+        return GeckoRuntime.create(context, runtimeSettings)
+    }
+}

--- a/app/src/geckoNightly/java/org/mozilla/fenix/engine/GeckoProvider.kt
+++ b/app/src/geckoNightly/java/org/mozilla/fenix/engine/GeckoProvider.kt
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import android.content.Context
+import android.os.Bundle
+import mozilla.components.lib.crash.handler.CrashHandlerService
+import org.mozilla.fenix.utils.Settings
+import org.mozilla.geckoview.GeckoRuntime
+import org.mozilla.geckoview.GeckoRuntimeSettings
+
+object GeckoProvider {
+    var testConfig: Bundle? = null
+    private var runtime: GeckoRuntime? = null
+
+    @Synchronized
+    fun getOrCreateRuntime(context: Context): GeckoRuntime {
+        if (runtime == null) {
+            runtime = createRuntime(context)
+        }
+
+        return runtime!!
+    }
+
+    private fun createRuntime(context: Context): GeckoRuntime {
+        val builder = GeckoRuntimeSettings.Builder()
+
+        testConfig?.let {
+            builder.extras(it)
+                .remoteDebuggingEnabled(true)
+        }
+
+        val runtimeSettings = builder
+            .crashHandler(CrashHandlerService::class.java)
+            .useContentProcessHint(true)
+            .build()
+
+        if (!Settings.getInstance(context).shouldUseAutoSize) {
+            runtimeSettings.automaticFontSizeAdjustment = false
+            val fontSize = Settings.getInstance(context).fontSizeFactor
+            runtimeSettings.fontSizeFactor = fontSize
+        }
+
+        return GeckoRuntime.create(context, runtimeSettings)
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserPerformanceTestActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserPerformanceTestActivity.kt
@@ -4,12 +4,12 @@
 
 package org.mozilla.fenix.browser
 
+import GeckoProvider
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import mozilla.components.support.utils.SafeIntent
 import org.mozilla.fenix.IntentReceiverActivity
-import org.mozilla.fenix.ext.components
 
 /**
  * This activity is used for performance testing with Raptor/tp6:
@@ -20,7 +20,7 @@ class BrowserPerformanceTestActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        components.core.testConfig = SafeIntent(intent).extras
+        GeckoProvider.testConfig = SafeIntent(intent).extras
 
         val intent = Intent(intent)
 

--- a/app/src/test/java/org/mozilla/fenix/components/TestCore.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/TestCore.kt
@@ -9,12 +9,10 @@ import io.mockk.mockk
 import kotlinx.coroutines.ObsoleteCoroutinesApi
 import mozilla.components.browser.engine.gecko.GeckoEngine
 import mozilla.components.browser.session.SessionManager
-import org.mozilla.geckoview.GeckoRuntime
 
 @ObsoleteCoroutinesApi
 class TestCore(private val context: Context) : Core(context) {
 
-    override val runtime = mockk<GeckoRuntime>(relaxed = true)
     override val engine = mockk<GeckoEngine>(relaxed = true)
     override val sessionManager = SessionManager(engine)
 }


### PR DESCRIPTION
Since we are now able to build against GeckoView Nightly and GeckoView Beta, we should create the GeckoRuntime from a flavor-specific source set.

Creating the runtime is not covered by the AC abstraction and so API changes in GeckoView Nightly can break the build and leaves us with no option to fix it from a shared code base. Separating the creation of `GeckoRuntime` allows us to adapt individually and also to configure the runtimes differently.