### PR TITLE
For #4064: Old R8 & keep rules are inhibiting optimizations

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -32,19 +32,6 @@
 -keep class org.mozilla.gecko.util.DebugConfig { *; }
 
 ####################################################################################################
-# Kotlinx
-####################################################################################################
-
--keep class kotlinx.coroutines.internal.MainDispatcherFactory {}
--keep class kotlinx.coroutines.CoroutineExceptionHandler {}
--keepnames class kotlinx.coroutines.android.AndroidExceptionPreHandler {}
--keepnames class kotlinx.coroutines.android.AndroidDispatcherFactory {}
--keepclassmembernames class kotlinx.** {
-    volatile <fields>;
-}
-
-
-####################################################################################################
 # Force removal of slow Dispatchers.Main ServiceLoader
 #
 # Please remove these rules when Android Gradle Plugin 3.6+ & coroutines 1.3.0+ are both in use
@@ -59,7 +46,13 @@
 # Mozilla Application Services
 ####################################################################################################
 
--keep class mozilla.appservices.FenixMegazord  { *; }
+-keep class mozilla.appservices.** { *; }
+
+####################################################################################################
+# ViewModels
+####################################################################################################
+
+-keep class org.mozilla.fenix.**ViewModel { *; }
 
 ####################################################################################################
 # Adjust

--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,14 @@
 
 buildscript {
     repositories {
+        // remove next line after Android Gradle Plugin 3.6.0+ is stable
+        maven { url "http://storage.googleapis.com/r8-releases/raw/master"}
         google()
         jcenter()
     }
     dependencies {
+        // remove next line after Android Gradle Plugin 3.6.0+ is stable
+        classpath Deps.tools_newestR8
         classpath Deps.tools_androidgradle
         classpath Deps.tools_kotlingradle
         classpath Deps.androidx_safeargs

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -6,6 +6,7 @@ object Versions {
     const val kotlin = "1.3.30"
     const val coroutines = "1.3.0-RC2"
     const val android_gradle_plugin = "3.5.0"
+    const val newest_r8 = "ceaee94e172c6c057cc05e646f5324853fc5d4c5"
     const val rxAndroid = "2.1.0"
     const val rxKotlin = "2.3.0"
     const val rxBindings = "3.0.0-alpha2"
@@ -68,6 +69,7 @@ object Versions {
 @Suppress("unused")
 object Deps {
     const val tools_androidgradle = "com.android.tools.build:gradle:${Versions.android_gradle_plugin}"
+    const val tools_newestR8 = "com.android.tools:r8:${Versions.newest_r8}"
     const val tools_kotlingradle = "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.kotlin}"
     const val kotlin_stdlib = "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${Versions.kotlin}"
     const val kotlin_coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.coroutines}"


### PR DESCRIPTION
It seems despite what Google engineers originally told us, we needed a newer version of R8 and no added Kotlin coroutine keep rules in order to clear up the ServiceLoader calls.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
