### PR TITLE
Fixes #4894: added workaround for SDK<24 vector drawable with gradient color

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/widget/SearchWidgetProvider.kt
+++ b/app/src/main/java/org/mozilla/fenix/widget/SearchWidgetProvider.kt
@@ -20,7 +20,11 @@ import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.IntentReceiverActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.utils.Settings
+import android.os.Build
+import androidx.appcompat.widget.AppCompatDrawableManager
+import androidx.core.graphics.drawable.toBitmap
 
+@Suppress("TooManyFunctions")
 class SearchWidgetProvider : AppWidgetProvider() {
 
     override fun onEnabled(context: Context) {
@@ -126,6 +130,7 @@ class SearchWidgetProvider : AppWidgetProvider() {
         text: String?
     ): RemoteViews {
         return RemoteViews(context.packageName, layout).apply {
+            setIcon(context)
             when (layout) {
                 R.layout.search_widget_extra_small_v1,
                 R.layout.search_widget_extra_small_v2,
@@ -140,6 +145,7 @@ class SearchWidgetProvider : AppWidgetProvider() {
                 R.layout.search_widget_large -> {
                     setOnClickPendingIntent(R.id.button_search_widget_new_tab, textSearchIntent)
                     setOnClickPendingIntent(R.id.button_search_widget_voice, voiceSearchIntent)
+                    setOnClickPendingIntent(R.id.button_search_widget_new_tab_icon, textSearchIntent)
                     setTextViewText(R.id.button_search_widget_new_tab, text)
                     // Unlike "small" widget, "medium" and "large" sizes do not have separate layouts
                     // that exclude the microphone icon, which is why we must hide it accordingly here.
@@ -148,6 +154,22 @@ class SearchWidgetProvider : AppWidgetProvider() {
                     }
                 }
             }
+        }
+    }
+
+    private fun RemoteViews.setIcon(context: Context) {
+        // gradient color available for android:fillColor only on SDK 24+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            setImageViewResource(
+                R.id.button_search_widget_new_tab_icon,
+                R.drawable.ic_logo_widget)
+        } else {
+            setImageViewBitmap(
+                R.id.button_search_widget_new_tab_icon,
+                AppCompatDrawableManager.get().getDrawable(
+                    context,
+                    R.drawable.ic_logo_widget
+                )?.toBitmap())
         }
     }
 

--- a/app/src/main/res/layout/search_widget_extra_small_v1.xml
+++ b/app/src/main/res/layout/search_widget_extra_small_v1.xml
@@ -11,8 +11,8 @@
         android:layout_gravity="center">
 
     <ImageView
+            android:id="@+id/button_search_widget_new_tab_icon"
             android:layout_width="40dp"
             android:layout_height="40dp"
-            android:background="@drawable/ic_logo_widget"
             android:layout_gravity="center"/>
 </FrameLayout>

--- a/app/src/main/res/layout/search_widget_extra_small_v2.xml
+++ b/app/src/main/res/layout/search_widget_extra_small_v2.xml
@@ -11,8 +11,8 @@
         android:layout_gravity="center">
 
     <ImageView
+            android:id="@+id/button_search_widget_new_tab_icon"
             android:layout_width="40dp"
             android:layout_height="40dp"
-            android:background="@drawable/ic_logo_widget"
             android:layout_gravity="center"/>
 </FrameLayout>

--- a/app/src/main/res/layout/search_widget_large.xml
+++ b/app/src/main/res/layout/search_widget_large.xml
@@ -10,16 +10,22 @@
         android:background="@drawable/rounded_white_corners"
         android:layout_gravity="center">
 
+    <ImageView
+            android:id="@+id/button_search_widget_new_tab_icon"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentStart="true"
+            android:padding="12dp"/>
+
     <TextView
             android:id="@+id/button_search_widget_new_tab"
+            android:layout_toEndOf="@id/button_search_widget_new_tab_icon"
             android:layout_width="match_parent"
             android:layout_height="32dp"
             android:gravity="center_vertical"
             android:textSize="15sp"
             android:textColor="@color/search_widget_text"
             android:letterSpacing="-0.025"
-            android:drawableStart="@drawable/ic_logo_widget"
-            android:drawablePadding="12dp"
             android:layout_marginStart="9dp"
             android:layout_marginTop="9dp"/>
 

--- a/app/src/main/res/layout/search_widget_medium.xml
+++ b/app/src/main/res/layout/search_widget_medium.xml
@@ -10,16 +10,22 @@
         android:background="@drawable/rounded_white_corners"
         android:layout_gravity="center">
 
+    <ImageView
+            android:id="@+id/button_search_widget_new_tab_icon"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentStart="true"
+            android:padding="12dp"/>
+
     <TextView
             android:id="@+id/button_search_widget_new_tab"
+            android:layout_toEndOf="@id/button_search_widget_new_tab_icon"
             android:layout_width="match_parent"
             android:layout_height="32dp"
             android:gravity="center_vertical"
             android:textSize="15sp"
             android:textColor="@color/search_widget_text"
             android:letterSpacing="-0.025"
-            android:drawableStart="@drawable/ic_logo_widget"
-            android:drawablePadding="12dp"
             android:layout_marginStart="9dp"
             android:layout_marginTop="9dp"/>
 

--- a/app/src/main/res/layout/search_widget_small.xml
+++ b/app/src/main/res/layout/search_widget_small.xml
@@ -16,9 +16,9 @@
             android:layout_marginTop="9dp">
 
         <ImageView
+                android:id="@+id/button_search_widget_new_tab_icon"
                 android:layout_width="32dp"
                 android:layout_height="32dp"
-                android:background="@drawable/ic_logo_widget"
                 android:layout_marginStart="9dp"/>
     </FrameLayout>
 

--- a/app/src/main/res/layout/search_widget_small_no_mic.xml
+++ b/app/src/main/res/layout/search_widget_small_no_mic.xml
@@ -12,8 +12,8 @@
         android:orientation="vertical">
 
     <ImageView
+            android:id="@+id/button_search_widget_new_tab_icon"
             android:layout_width="40dp"
             android:layout_height="40dp"
-            android:background="@drawable/ic_logo_widget"
             android:layout_gravity="center"/>
 </FrameLayout>


### PR DESCRIPTION
Removed drawableStart and added ImageView in layouts
Set ImageView logo programmatically: bitmap for SDK<24, vector for SDK>=24
Added onClickPendingIntent for ImageView in large and medium layouts

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
