### PR TITLE
Publishes to a public track for the separate nightly app

### DIFF
--- a/taskcluster/fenix_taskgraph/pushapk.py
+++ b/taskcluster/fenix_taskgraph/pushapk.py
@@ -21,11 +21,6 @@ _CHANNEL_PER_TASK_NAME = {
     'production': 'production',
 }
 
-_GOOGLE_PLAY_TRACK_PER_TASK_NAME = {
-    'nightly': 'internal',
-    'nightly-legacy': 'nightly',
-}
-
 
 @transforms.add
 def build_name_and_attributes(config, tasks):
@@ -73,8 +68,8 @@ def build_worker_definition(config, tasks):
         worker_definition["certificate-alias"] = 'fenix' if task_name == 'production' else \
             "{}-{}".format(task["worker"]["product"], worker_definition["channel"])
 
-        if _GOOGLE_PLAY_TRACK_PER_TASK_NAME.get(task_name):
-            worker_definition["google-play-track"] = _GOOGLE_PLAY_TRACK_PER_TASK_NAME[task_name]
+        if task_name == 'nightly-legacy':
+            worker_definition["google-play-track"] = 'nightly'
 
         task["worker"].update(worker_definition)
         yield task


### PR DESCRIPTION
We published to the `internal` track while RelMan/QA/other teams performed all the verifications need to create the separate nightly app. Once the nightly app goes public, we should automatically publish new nightlies directly to the public track (`beta`, in this case).

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
- [ ] **Firefox Preview Nightly is publicly released**
