### PR TITLE
For #4960: Initialize push only if available

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -66,8 +66,6 @@ open class FenixApplication : Application() {
             return
         }
 
-        setupPush()
-
         // Make sure the engine is initialized and ready to use.
         components.core.engine.warmUp()
 
@@ -100,12 +98,7 @@ open class FenixApplication : Application() {
             components.analytics.metrics.start()
         }
 
-        // Sets the PushFeature as the singleton instance for push messages to go to.
-        // We need the push feature setup here to deliver messages in the case where the service
-        // starts up the app first.
-        if (FeatureFlags.sendTabEnabled && components.backgroundServices.pushConfig != null) {
-            PushProcessor.install(components.backgroundServices.push)
-        }
+        setupPush()
     }
 
     private fun registerRxExceptionHandling() {
@@ -184,10 +177,18 @@ open class FenixApplication : Application() {
     }
 
     private fun setupPush() {
-        components
-            .backgroundServices
-            .push
-            .initialize()
+        // Sets the PushFeature as the singleton instance for push messages to go to.
+        // We need the push feature setup here to deliver messages in the case where the service
+        // starts up the app first.
+        if (FeatureFlags.sendTabEnabled && components.backgroundServices.pushConfig != null) {
+            val push = components.backgroundServices.push
+
+            // Install the AutoPush singleton to receive messages.
+            PushProcessor.install(push)
+
+            // Initialize the service. This could potentially be done in a coroutine in the future.
+            push.initialize()
+        }
     }
 
     private fun setupCrashReporting() {


### PR DESCRIPTION
Fixes start-up crash for debug builds since Firebase keys are not available for those builds.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
