### PR TITLE
Remove SendTab feature flags and workarounds

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -18,17 +18,6 @@ object FeatureFlags {
     private val all = production or beta or nightly or debug
 
     /**
-     * Send Tab is a feature to lets you send a url/tab from a desktop to device and vice versa.
-     *
-     * NB: flipping this flag back and worth is currently not well supported and may need
-     * hand-holding. Consult with the android-components peers before changing.
-     *
-     * This flag is temporarily also used for the push service that is requires it to.
-     * See: https://github.com/mozilla-mobile/fenix/issues/4063
-     */
-    val sendTabEnabled = all
-
-    /**
      * Pull-to-refresh allows you to pull the web content down far enough to have the page to
      * reload.
      */

--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -180,7 +180,7 @@ open class FenixApplication : Application() {
         // Sets the PushFeature as the singleton instance for push messages to go to.
         // We need the push feature setup here to deliver messages in the case where the service
         // starts up the app first.
-        if (FeatureFlags.sendTabEnabled && components.backgroundServices.pushConfig != null) {
+        if (components.backgroundServices.pushConfig != null) {
             val push = components.backgroundServices.push
 
             // Install the AutoPush singleton to receive messages.

--- a/app/src/main/java/org/mozilla/fenix/components/BackgroundServices.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/BackgroundServices.kt
@@ -189,10 +189,7 @@ class BackgroundServices(
                         it.authenticatedAccount()?.deviceConstellation()
                             ?.processRawEventAsync(message)
                     }
-                },
-                ProcessLifecycleOwner.get(),
-                false
-            )
+                })
 
             // Notify observers for subscription changes.
             push.registerForSubscriptions(object : PushSubscriptionObserver {
@@ -210,18 +207,7 @@ class BackgroundServices(
                             )
                     }
                 }
-            }, ProcessLifecycleOwner.get(), false)
-
-            // For all the current Fenix users, we need to remove the current push token and
-            // re-subscribe again on the right push server. We should never do this otherwise!
-            // Should be removed after majority of our users are correctly subscribed.
-            // See: https://github.com/mozilla-mobile/fenix/issues/4218
-            val prefResetSubKey = "reset_broken_push_subscription"
-            if (!preferences.getBoolean(prefResetSubKey, false)) {
-                preferences.edit().putBoolean(prefResetSubKey, true).apply()
-                logger.info("Forcing push registration renewal")
-                push.forceRegistrationRenewal()
-            }
+            })
         }
         CoroutineScope(Dispatchers.Main).launch { it.initAsync().await() }
     }

--- a/app/src/main/java/org/mozilla/fenix/components/BackgroundServices.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/BackgroundServices.kt
@@ -34,7 +34,6 @@ import mozilla.components.service.fxa.manager.FxaAccountManager
 import mozilla.components.service.fxa.sync.GlobalSyncableStoreProvider
 import mozilla.components.support.base.log.logger.Logger
 import org.mozilla.fenix.Experiments
-import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.components
@@ -72,11 +71,7 @@ class BackgroundServices(
         // NB: flipping this flag back and worth is currently not well supported and may need hand-holding.
         // Consult with the android-components peers before changing.
         // See https://github.com/mozilla/application-services/issues/1308
-        capabilities = if (FeatureFlags.sendTabEnabled) {
-            setOf(DeviceCapability.SEND_TAB)
-        } else {
-            emptySet()
-        }
+        capabilities = setOf(DeviceCapability.SEND_TAB)
     )
     // If sync has been turned off on the server then disable syncing.
     private val syncConfig = if (context.isInExperiment(Experiments.asFeatureSyncDisabled)) {
@@ -176,58 +171,56 @@ class BackgroundServices(
     ).also {
         Settings.getInstance(context).fxaHasSyncedItems = syncConfig?.syncableStores?.isNotEmpty() ?: false
 
-        if (FeatureFlags.sendTabEnabled) {
-            it.registerForDeviceEvents(deviceEventObserver, ProcessLifecycleOwner.get(), false)
+        it.registerForDeviceEvents(deviceEventObserver, ProcessLifecycleOwner.get(), false)
 
-            // Enable push if we have the config.
-            if (pushConfig != null) {
+        // Enable push if we have the config.
+        if (pushConfig != null) {
 
-                // Register our account observer so we know how to update our push subscriptions.
-                it.register(accountObserver)
+            // Register our account observer so we know how to update our push subscriptions.
+            it.register(accountObserver)
 
-                val logger = Logger("AutoPushFeature")
+            val logger = Logger("AutoPushFeature")
 
-                // Notify observers for Services' messages.
-                push.registerForPushMessages(
-                    PushType.Services,
-                    object : Bus.Observer<PushType, String> {
-                        override fun onEvent(type: PushType, message: String) {
-                            it.authenticatedAccount()?.deviceConstellation()
-                                ?.processRawEventAsync(message)
-                        }
-                    },
-                    ProcessLifecycleOwner.get(),
-                    false
-                )
-
-                // Notify observers for subscription changes.
-                push.registerForSubscriptions(object : PushSubscriptionObserver {
-                    override fun onSubscriptionAvailable(subscription: AutoPushSubscription) {
-                        // Update for only the services subscription.
-                        if (subscription.type == PushType.Services) {
-                            logger.info("New push subscription received for FxA")
-                            it.authenticatedAccount()?.deviceConstellation()
-                                ?.setDevicePushSubscriptionAsync(
-                                    DevicePushSubscription(
-                                        endpoint = subscription.endpoint,
-                                        publicKey = subscription.publicKey,
-                                        authKey = subscription.authKey
-                                    )
-                                )
-                        }
+            // Notify observers for Services' messages.
+            push.registerForPushMessages(
+                PushType.Services,
+                object : Bus.Observer<PushType, String> {
+                    override fun onEvent(type: PushType, message: String) {
+                        it.authenticatedAccount()?.deviceConstellation()
+                            ?.processRawEventAsync(message)
                     }
-                }, ProcessLifecycleOwner.get(), false)
+                },
+                ProcessLifecycleOwner.get(),
+                false
+            )
 
-                // For all the current Fenix users, we need to remove the current push token and
-                // re-subscribe again on the right push server. We should never do this otherwise!
-                // Should be removed after majority of our users are correctly subscribed.
-                // See: https://github.com/mozilla-mobile/fenix/issues/4218
-                val prefResetSubKey = "reset_broken_push_subscription"
-                if (!preferences.getBoolean(prefResetSubKey, false)) {
-                    preferences.edit().putBoolean(prefResetSubKey, true).apply()
-                    logger.info("Forcing push registration renewal")
-                    push.forceRegistrationRenewal()
+            // Notify observers for subscription changes.
+            push.registerForSubscriptions(object : PushSubscriptionObserver {
+                override fun onSubscriptionAvailable(subscription: AutoPushSubscription) {
+                    // Update for only the services subscription.
+                    if (subscription.type == PushType.Services) {
+                        logger.info("New push subscription received for FxA")
+                        it.authenticatedAccount()?.deviceConstellation()
+                            ?.setDevicePushSubscriptionAsync(
+                                DevicePushSubscription(
+                                    endpoint = subscription.endpoint,
+                                    publicKey = subscription.publicKey,
+                                    authKey = subscription.authKey
+                                )
+                            )
+                    }
                 }
+            }, ProcessLifecycleOwner.get(), false)
+
+            // For all the current Fenix users, we need to remove the current push token and
+            // re-subscribe again on the right push server. We should never do this otherwise!
+            // Should be removed after majority of our users are correctly subscribed.
+            // See: https://github.com/mozilla-mobile/fenix/issues/4218
+            val prefResetSubKey = "reset_broken_push_subscription"
+            if (!preferences.getBoolean(prefResetSubKey, false)) {
+                preferences.edit().putBoolean(prefResetSubKey, true).apply()
+                logger.info("Forcing push registration renewal")
+                push.forceRegistrationRenewal()
             }
         }
         CoroutineScope(Dispatchers.Main).launch { it.initAsync().await() }

--- a/app/src/main/java/org/mozilla/fenix/share/ShareUIView.kt
+++ b/app/src/main/java/org/mozilla/fenix/share/ShareUIView.kt
@@ -12,7 +12,6 @@ import io.reactivex.Observable
 import io.reactivex.Observer
 import io.reactivex.functions.Consumer
 import kotlinx.android.synthetic.main.component_share.*
-import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.mvi.UIView
@@ -40,14 +39,12 @@ class ShareUIView(
         }
         intent_handler_recyclerview.adapter = adapter
 
-        // And authorized
-        if (FeatureFlags.sendTabEnabled &&
-            !view.context.components.backgroundServices.accountManager.accountNeedsReauth()
-        ) {
-            account_devices_recyclerview.adapter = AccountDevicesShareAdapter(view.context, actionEmitter)
-        } else {
+        if (view.context.components.backgroundServices.accountManager.accountNeedsReauth()) {
             send_tab_group.visibility = View.GONE
             account_header.visibility = View.GONE
+        } else {
+            account_devices_recyclerview.adapter =
+                AccountDevicesShareAdapter(view.context, actionEmitter)
         }
 
         container.setOnClickListener { actionEmitter.onNext(ShareAction.Close) }


### PR DESCRIPTION
We've had Send Tab enabled for all builds for a while now. We're also using Firebase push for more things so it's safe to remove the flag.

This also fixes #4218
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
