### PR TITLE
Use Mozilla Android Components 10.0.1.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
@@ -116,7 +116,7 @@ class DefaultToolbarMenu(
                     ThemeManager.resolveAttribute(R.attr.primaryText, context),
                 highlight = if (hasAccountProblem) {
                     BrowserMenuHighlightableItem.Highlight(
-                        imageResource = R.drawable.ic_alert,
+                        endImageResource = R.drawable.ic_alert,
                         backgroundResource = R.drawable.sync_error_background_with_ripple,
                         colorResource = R.color.sync_error_background_color
                     )

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -34,7 +34,7 @@ object Versions {
     const val androidx_work = "2.0.1"
     const val google_material = "1.1.0-alpha07"
 
-    const val mozilla_android_components = "10.0.0-SNAPSHOT"
+    const val mozilla_android_components = "10.0.1"
     // Note that android-components also depends on application-services,
     // and in fact is our main source of appservices-related functionality.
     // The version number below tracks the application-services version


### PR DESCRIPTION
Time to use a stable Android Components version again in order to get ready to cut the release branch.