### PR TITLE
Restrict Taskcluster to collaborators on PR

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -3,7 +3,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 version: 1
 policy:
-  pullRequests: public
+  # XXX We restrict taskcluster to collaborators so priviledged tests (like UI tests) can run on PRs
+  pullRequests: collaborators
 tasks:
   $let:
     decision_task_id: {$eval: as_slugid("decision_task")}


### PR DESCRIPTION
Pre-requisite to solve #4889 

I understand we need UI tests to run on PRs because many regressions happened over the past weeks. @rpappalax told me we get a couple of PRs opened by external contributors each week. So an okay-solution is to not run TC at all on PRs for external contributors.

This way, we can run privileged tests like the UI ones on PRs.  

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
