### PR TITLE
For #4863 - Remove delay in HomeFragment onPreDraw

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/utils/FragmentPreDrawManager.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/FragmentPreDrawManager.kt
@@ -7,7 +7,6 @@ package org.mozilla.fenix.utils
 import androidx.core.view.doOnPreDraw
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 /**
@@ -23,14 +22,9 @@ class FragmentPreDrawManager(
     fun execute(code: () -> Unit) {
         fragment.view?.doOnPreDraw {
             fragment.viewLifecycleOwner.lifecycleScope.launch {
-                delay(ANIM_SCROLL_DELAY)
                 code()
                 fragment.startPostponedEnterTransition()
             }
         }
-    }
-
-    companion object {
-        private const val ANIM_SCROLL_DELAY = 100L
     }
 }


### PR DESCRIPTION
Not sure why we had this delay but animations don't seem to break without it (famous last words). Slow loading of the homescreen is causing weird transitions so let's get rid of it
