### PR TITLE
1577253: Remove writing dependencies to an artifact

### DIFF
--- a/automation/taskcluster/decision_task.py
+++ b/automation/taskcluster/decision_task.py
@@ -81,9 +81,6 @@ def push():
     other_tasks = all_tasks[-1]
     other_tasks[taskcluster.slugId()] = BUILDER.craft_ui_tests_task()
 
-    if SHORT_HEAD_BRANCH == 'master':
-        other_tasks[taskcluster.slugId()] = BUILDER.craft_dependencies_task()
-
     return all_tasks
 
 

--- a/automation/taskcluster/lib/tasks.py
+++ b/automation/taskcluster/lib/tasks.py
@@ -272,35 +272,6 @@ class TaskBuilder(object):
             },
         )
 
-    def craft_dependencies_task(self):
-        # Output the dependencies to an artifact.  This is used by the
-        # telemetry probe scraper to determine all of the metrics that
-        # Fenix might send (both from itself and any of its dependent
-        # libraries that use Glean).
-        return self._craft_clean_gradle_task(
-            name='dependencies',
-            description='Write dependencies to a build artifact',
-            gradle_task='app:dependencies --configuration implementation > dependencies.txt',
-            treeherder={
-                'jobKind': 'test',
-                'machine': {
-                    'platform': 'lint',
-                },
-                'symbol': 'dependencies',
-                'tier': 1,
-            },
-            routes=[
-                'index.project.mobile.fenix.v2.branch.master.revision.{}'.format(self.commit)
-            ],
-            artifacts={
-                'public/dependencies.txt': {
-                    "type": 'file',
-                    "path": '/opt/fenix/dependencies.txt',
-                    "expires": taskcluster.stringDate(taskcluster.fromNow(DEFAULT_EXPIRES_IN)),
-                }
-            },
-        )
-
     def _craft_clean_gradle_task(
         self, name, description, gradle_task, artifacts=None, routes=None, treeherder=None, scopes=None
     ):


### PR DESCRIPTION
In order to determine what Glean metrics an application sends, we need to know all of the library dependencies that might also send metrics.  To support this, we were generating an artifact listing out all of the dependencies at each revision (using `./gradlew dependencies`), and the backend `probe_scraper` was using this information to create a merged set of all metrics.

We've since determined that this approach was too "brittle" and "clever" for its own good (and I say that as the developer who originally implemented it).  We are replacing this with hard-coded dependencies in the `probe_scraper` and an alerting system to help us catch "new metrics".

This just stops creating the dependencies artifact for Fenix.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
