### PR TITLE
Use new async API to load and access search engines

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/Search.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Search.kt
@@ -31,12 +31,11 @@ class Search(private val context: Context) {
         ).apply {
             registerForLocaleUpdates(context)
             GlobalScope.launch {
-                loadAsync(context).await()
+                defaultSearchEngine = getDefaultSearchEngineAsync(
+                    context,
+                    Settings.getInstance(context).defaultSearchEngineName
+                )
             }
-            defaultSearchEngine = getDefaultSearchEngine(
-                context,
-                Settings.getInstance(context).defaultSearchEngineName
-            )
         }
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarView.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarView.kt
@@ -152,9 +152,8 @@ class AwesomeBarView(
 
             defaultSearchSuggestionProvider =
                 SearchSuggestionProvider(
-                    searchEngine = components.search.searchEngineManager.getDefaultSearchEngine(
-                        this
-                    ),
+                    context = this,
+                    searchEngineManager = components.search.searchEngineManager,
                     searchUseCase = searchUseCase,
                     fetchClient = components.core.client,
                     mode = SearchSuggestionProvider.Mode.MULTIPLE_SUGGESTIONS,


### PR DESCRIPTION
Use the new asynchronous features of the search engine
manager from a-c to avoid the latency required to load
the default search engine.

@csadilek and I worked on this PR together (I mostly typed what he told me to type). 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

<!-- To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts". -->