### PR TITLE
Fixes #4997: Changed navigation to ShareFragment 

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.launch
 import mozilla.components.browser.session.Session
 import mozilla.components.concept.engine.EngineView
+import org.mozilla.fenix.NavGraphDirections
 import org.mozilla.fenix.R
 import org.mozilla.fenix.browser.BrowserFragment
 import org.mozilla.fenix.browser.BrowserFragmentDirections
@@ -96,8 +97,8 @@ class DefaultBrowserToolbarController(
             ToolbarMenu.Item.Share -> {
                 val currentUrl = currentSession?.url
                 currentUrl?.apply {
-                    val directions = BrowserFragmentDirections.actionBrowserFragmentToShareFragment(this)
-                    navController.nav(R.id.browserFragment, directions)
+                    val directions = NavGraphDirections.actionGlobalShareFragment(this)
+                    navController.navigate(directions)
                 }
             }
             ToolbarMenu.Item.NewTab -> {

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -513,4 +513,6 @@
     <dialog
         android:id="@+id/signOutFragment"
         android:name="org.mozilla.fenix.settings.SignOutFragment" />
+    <action android:id="@+id/action_global_shareFragment"
+            app:destination="@id/shareFragment"/>
 </navigation>

--- a/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarControllerTest.kt
@@ -23,6 +23,7 @@ import mozilla.components.feature.tabs.TabsUseCases
 import org.junit.Before
 import org.junit.Test
 import org.mozilla.fenix.HomeActivity
+import org.mozilla.fenix.NavGraphDirections
 import org.mozilla.fenix.R
 import org.mozilla.fenix.browser.BrowserFragment
 import org.mozilla.fenix.browser.BrowserFragmentDirections
@@ -225,14 +226,12 @@ class DefaultBrowserToolbarControllerTest {
         val item = ToolbarMenu.Item.Share
 
         every { currentSession.url } returns "https://mozilla.org"
+        val directions = NavGraphDirections.actionGlobalShareFragment(currentSession.url)
 
         controller.handleToolbarItemInteraction(item)
 
         verify { metrics.track(Event.BrowserMenuItemTapped(Event.BrowserMenuItemTapped.Item.SHARE)) }
-        verify {
-            val directions = BrowserFragmentDirections.actionBrowserFragmentToShareFragment(currentSession.url)
-            navController.nav(R.id.browserFragment, directions)
-        }
+        verify { navController.navigate(directions) }
     }
 
     @Test


### PR DESCRIPTION
Added global navigation action to share fragment in navigation graph
Changed share button action to use global navigation to ShareFragment

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

<!-- To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts". -->