### PR TITLE
Add browser-state component.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -340,6 +340,7 @@ dependencies {
     implementation Deps.mozilla_browser_menu
     implementation Deps.mozilla_browser_search
     implementation Deps.mozilla_browser_session
+    implementation Deps.mozilla_browser_state
     implementation Deps.mozilla_browser_storage_sync
     implementation Deps.mozilla_browser_toolbar
 

--- a/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -16,6 +16,8 @@ import mozilla.components.browser.engine.gecko.fetch.GeckoViewFetchClient
 import mozilla.components.browser.icons.BrowserIcons
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.session.storage.SessionStorage
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.browser.storage.sync.PlacesBookmarksStorage
 import mozilla.components.browser.storage.sync.PlacesHistoryStorage
 import mozilla.components.concept.engine.DefaultSettings
@@ -71,13 +73,20 @@ class Core(private val context: Context) {
     }
 
     /**
+     * The [BrowserStore] holds the global [BrowserState].
+     */
+    val store by lazy {
+        BrowserStore()
+    }
+
+    /**
      * The session manager component provides access to a centralized registry of
      * all browser sessions (i.e. tabs). It is initialized here to persist and restore
      * sessions from the [SessionStorage], and with a default session (about:blank) in
      * case all sessions/tabs are closed.
      */
     val sessionManager by lazy {
-        SessionManager(engine).also { sessionManager ->
+        SessionManager(engine, store).also { sessionManager ->
             // Install the "icons" WebExtension to automatically load icons for every visited website.
             icons.install(engine, sessionManager)
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -102,6 +102,7 @@ object Deps {
     const val mozilla_browser_icons = "org.mozilla.components:browser-icons:${Versions.mozilla_android_components}"
     const val mozilla_browser_search = "org.mozilla.components:browser-search:${Versions.mozilla_android_components}"
     const val mozilla_browser_session = "org.mozilla.components:browser-session:${Versions.mozilla_android_components}"
+    const val mozilla_browser_state = "org.mozilla.components:browser-state:${Versions.mozilla_android_components}"
     const val mozilla_browser_tabstray = "org.mozilla.components:browser-tabstray:${Versions.mozilla_android_components}"
     const val mozilla_browser_toolbar = "org.mozilla.components:browser-toolbar:${Versions.mozilla_android_components}"
     const val mozilla_browser_menu = "org.mozilla.components:browser-menu:${Versions.mozilla_android_components}"


### PR DESCRIPTION
Related to PR #5035.

AC is soon landing patches that will migrate components from `browser-session` to `browser-state`. This will mean that those components will want a `BrowserStore` instead of a `SessionManager`. With this patch we will already have it.

Passing the `BrowserStore` instance to `SessionManager` will take care of keeping both in sync until eventually `SessionManager` is no longer needed anymore (🍻).