### PR TITLE
For #2088: Use new async API to load default search engine in HomeFragment

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -82,6 +82,7 @@ import org.mozilla.fenix.onboarding.FenixOnboarding
 import org.mozilla.fenix.settings.SupportUtils
 import org.mozilla.fenix.share.ShareTab
 import org.mozilla.fenix.utils.FragmentPreDrawManager
+import org.mozilla.fenix.utils.Settings
 import org.mozilla.fenix.utils.allowUndo
 
 @SuppressWarnings("TooManyFunctions", "LargeClass")
@@ -206,8 +207,10 @@ class HomeFragment : Fragment(), AccountObserver {
         viewLifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
             val iconSize = resources.getDimension(R.dimen.preference_icon_drawable_size).toInt()
 
-            val searchEngine =
-                requireComponents.search.searchEngineManager.getDefaultSearchEngine(requireContext())
+            val searchEngine = requireComponents.search.searchEngineManager.getDefaultSearchEngineAsync(
+                requireContext(),
+                Settings.getInstance(requireContext()).defaultSearchEngineName
+            )
             val searchIcon = BitmapDrawable(resources, searchEngine.icon)
             searchIcon.setBounds(0, 0, iconSize, iconSize)
 

--- a/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
@@ -208,7 +208,11 @@ class SearchFragment : Fragment(), BackHandler {
         // The user has the option to go to 'Shortcuts' -> 'Search engine settings' to modify the default search engine.
         // When returning from that settings screen we need to update it to account for any changes.
         val currentDefaultEngine =
-            requireComponents.search.searchEngineManager.getDefaultSearchEngine(requireContext())
+            requireComponents.search.searchEngineManager.getDefaultSearchEngine(
+                requireContext(),
+                Settings.getInstance(requireContext()).defaultSearchEngineName
+            )
+
         if (searchStore.state.defaultEngineSource.searchEngine != currentDefaultEngine) {
             searchStore.dispatch(
                 SearchAction.SelectNewDefaultSearchEngine

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -35,7 +35,7 @@ object Versions {
     const val androidx_work = "2.0.1"
     const val google_material = "1.1.0-alpha07"
 
-    const val mozilla_android_components = "10.0.1"
+    const val mozilla_android_components = "11.0.0-SNAPSHOT"
     // Note that android-components also depends on application-services,
     // and in fact is our main source of appservices-related functionality.
     // The version number below tracks the application-services version


### PR DESCRIPTION
This is a follow-up for https://github.com/mozilla-mobile/fenix/pull/5023 to also use the async search engine manager API in the HomeFragment and fix a race condition which could cause the wrong search engine to be displayed on startup. 

Basically, looking up the search engines when initializing the fragment was dependent on the `SearchEngineManager` initialization logic (https://github.com/mozilla-mobile/fenix/blob/master/app/src/main/java/org/mozilla/fenix/components/Search.kt#L34) to have completed, which is no lo longer guaranteed as we're running all calls asynchronously. This fix (together with the upgrade to A-C 11.0.0-SNAPSHOT) makes sure that multiple concurrent calls to `getDefaultSearchEngineAsync` will have the same result, independent of execution order.

@hawkinsw can you review this, please :)?
