### PR TITLE
Fixes #5067 - Refactor ShareController to use SendTabUseCases

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -363,6 +363,7 @@ dependencies {
     implementation Deps.mozilla_feature_site_permissions
     implementation Deps.mozilla_feature_readerview
     implementation Deps.mozilla_feature_tab_collections
+    implementation Deps.mozilla_feature_sendtab
 
     implementation Deps.mozilla_service_firefox_accounts
     implementation Deps.mozilla_service_fretboard

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -388,7 +388,7 @@ class HomeFragment : Fragment(), AccountObserver {
                 invokePendingDeleteJobs()
                 val shareTabs = sessionManager
                     .sessionsOfType(private = (activity as HomeActivity).browsingModeManager.mode.isPrivate)
-                    .map { ShareTab(it.url, it.title, it.id) }
+                    .map { ShareTab(it.url, it.title) }
                     .toList()
                 share(tabs = shareTabs)
             }

--- a/app/src/main/java/org/mozilla/fenix/share/ShareController.kt
+++ b/app/src/main/java/org/mozilla/fenix/share/ShareController.kt
@@ -94,6 +94,8 @@ class DefaultShareController(
     fun getShareText() = sharedTabs.joinToString("\n") { tab -> tab.url }
 
     // Navigation between app fragments uses ShareTab as arguments. SendTabUseCases uses TabData.
-    private fun ShareTab.toTabData() = TabData(title, url)
-    private fun List<ShareTab>.toTabData() = map { it.toTabData() }
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    fun ShareTab.toTabData() = TabData(title, url)
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    fun List<ShareTab>.toTabData() = map { it.toTabData() }
 }

--- a/app/src/main/java/org/mozilla/fenix/share/ShareFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/share/ShareFragment.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import mozilla.components.concept.sync.DeviceCapability
 import mozilla.components.concept.sync.DeviceType
+import mozilla.components.feature.sendtab.SendTabUseCases
 import mozilla.components.service.fxa.manager.FxaAccountManager
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
@@ -81,14 +82,14 @@ class ShareFragment : AppCompatDialogFragment() {
         }
 
         val tabs = args.tabs?.toList() ?: listOf(ShareTab(args.url!!, args.title ?: ""))
-        val account = requireComponents.backgroundServices.accountManager.authenticatedAccount()
+        val accountManager = requireComponents.backgroundServices.accountManager
 
         shareInteractor = ShareInteractor(
             DefaultShareController(
                 fragment = this,
-                tabs = tabs,
+                sharedTabs = tabs,
                 navController = findNavController(),
-                account = account,
+                sendTabUseCases = SendTabUseCases(accountManager),
                 dismiss = ::dismiss
             )
         )
@@ -165,4 +166,4 @@ class ShareFragment : AppCompatDialogFragment() {
 }
 
 @Parcelize
-data class ShareTab(val url: String, val title: String, val sessionId: String? = null) : Parcelable
+data class ShareTab(val url: String, val title: String) : Parcelable

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -129,6 +129,7 @@ object Deps {
     const val mozilla_feature_site_permissions = "org.mozilla.components:feature-sitepermissions:${Versions.mozilla_android_components}"
     const val mozilla_feature_readerview = "org.mozilla.components:feature-readerview:${Versions.mozilla_android_components}"
     const val mozilla_feature_tab_collections = "org.mozilla.components:feature-tab-collections:${Versions.mozilla_android_components}"
+    const val mozilla_feature_sendtab = "org.mozilla.components:feature-sendtab:${Versions.mozilla_android_components}"
 
     const val mozilla_service_firefox_accounts = "org.mozilla.components:service-firefox-accounts:${Versions.mozilla_android_components}"
     const val mozilla_service_fretboard = "org.mozilla.components:service-fretboard:${Versions.mozilla_android_components}"


### PR DESCRIPTION
SendTabUseCases does offer a cleaner api for sharing tabs to account devices and allow us to respect Demeter's Law.
Navigation between app fragments uses ShareTab as arguments. The newly used
SendTabUseCases uses TabData which is not Parcelable.
For minimal changes we'll keep both data classes and ShareController will know
how to map between the two.
Removed the `sessionId` property of ShareTab as it isn't needed anymore.
Refactor ShareControllerTest following the use of SendTabUseCases.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks.
- [x] **Tests**: This PR includes thorough tests.
- [x] **Accessibility**: The code in this PR does not include any user facing features.

<!-- To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts". -->