### PR TITLE
For #5053: Removed google maps as intent handler for clipboard copy

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/share/ShareFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/share/ShareFragment.kt
@@ -14,6 +14,7 @@ import android.os.Parcelable
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatDialogFragment
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
@@ -55,12 +56,24 @@ class ShareFragment : AppCompatDialogFragment() {
                 flags = FLAG_ACTIVITY_NEW_TASK
             }
             val shareAppsActivities = getIntentActivities(shareIntent, context)
-            buildAppsList(shareAppsActivities, context)
+            val filteredShareAppsActivities = filterProviders(shareAppsActivities)
+            buildAppsList(filteredShareAppsActivities, context)
         }
 
         devicesListDeferred = lifecycleScope.async(Dispatchers.IO) {
             val fxaAccountManager = context.components.backgroundServices.accountManager
             buildDeviceList(fxaAccountManager)
+        }
+    }
+
+    // removes google maps intent handler for SendTextToClipboard from providers
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    fun filterProviders(shareAppsActivities: List<ResolveInfo>?): List<ResolveInfo>? {
+        return shareAppsActivities?.filterNot {
+            it.activityInfo.name.equals(
+                "com.google.android.apps.gmm.sharing.SendTextToClipboardActivity",
+                true) &&
+                    it.activityInfo.packageName.equals("com.google.android.apps.maps", true)
         }
     }
 

--- a/app/src/test/java/org/mozilla/fenix/share/ShareFragmentTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/share/ShareFragmentTest.kt
@@ -1,0 +1,35 @@
+package org.mozilla.fenix.share
+
+import android.content.pm.ResolveInfo
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isNotNull
+import org.junit.Test
+import org.robolectric.shadows.ShadowResolveInfo.newResolveInfo
+
+class ShareFragmentTest {
+    @Test
+    fun `filterProviders() removes unwanted providers`() {
+        val provider1 = newResolveInfo(
+            "provider 1", "activity 1", "package 1")
+        val provider2 = newResolveInfo(
+            "provider 2", "activity 2", "package 2")
+        val unwantedProvider1 = newResolveInfo(
+            "unwanted provider 1",
+            "com.google.android.apps.maps",
+            "com.google.android.apps.gmm.sharing.SendTextToClipboardActivity")
+
+        val initialProviders: List<ResolveInfo> = listOf(provider1, provider2)
+        val unwantedProviders: List<ResolveInfo> = listOf(unwantedProvider1)
+
+        val allProviders = initialProviders + unwantedProviders
+        val acceptedProviders = with(ShareFragment()) {
+            filterProviders(allProviders)
+        }
+
+        assertThat(acceptedProviders).isNotNull()
+        assertThat(acceptedProviders!!.size).isEqualTo(initialProviders.size)
+        assertThat(acceptedProviders.any { unwantedProviders.contains(it) }).isFalse()
+    }
+}


### PR DESCRIPTION
Filtered provider list removing intent handler by Google Maps that causes crash.

`SendTextToClipboardActivity` was added as intent handler in Google Maps and it looks exactly like the system's _copy to clipboard_ (same title and icon) but it raises a `SecurityException`. Probably a bug that will be fixed on Google's side in the future.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

<!-- To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts". -->