### PR TITLE
For #4877: Restored logic for closing tabs when not on browserFragment 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -447,6 +447,8 @@ dependencies {
 
     androidTestImplementation Deps.androidx_test_core
     androidTestImplementation Deps.espresso_idling_resources
+    debugImplementation Deps.androidx_fragment_testing
+
 
     androidTestImplementation Deps.tools_test_runner
     androidTestImplementation Deps.tools_test_rules

--- a/app/src/main/java/org/mozilla/fenix/collections/CreateCollectionFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/collections/CreateCollectionFragment.kt
@@ -187,11 +187,10 @@ class CreateCollectionFragment : DialogFragment() {
 
     private fun closeTabsIfNecessary(tabs: List<Tab>) {
         // Only close the tabs if the user is not on the BrowserFragment
-        if (viewModel.previousFragmentId == R.id.browserFragment) {
+        if (viewModel.previousFragmentId == R.id.browserFragment) { return }
             val components = requireComponents
             tabs.asSequence()
                 .mapNotNull { tab -> components.core.sessionManager.findSessionById(tab.sessionId) }
                 .forEach { session -> components.useCases.tabsUseCases.removeTab(session) }
         }
-    }
 }

--- a/app/src/test/java/org/mozilla/fenix/collections/CreateCollectionFragmentTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/collections/CreateCollectionFragmentTest.kt
@@ -1,0 +1,51 @@
+package org.mozilla.fenix.collections
+
+import androidx.fragment.app.testing.FragmentScenario
+import androidx.fragment.app.testing.launchFragment
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import assertk.assertThat
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
+import kotlinx.coroutines.ObsoleteCoroutinesApi
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.fenix.TestApplication
+
+import org.robolectric.annotation.Config
+
+@ObsoleteCoroutinesApi
+@RunWith(AndroidJUnit4::class)
+@Config(application = TestApplication::class)
+class CreateCollectionFragmentTest {
+
+    private lateinit var scenario: FragmentScenario<CreateCollectionFragment>
+
+    @Before
+    fun setUp() {
+        scenario = launchFragment<CreateCollectionFragment>()
+    }
+    @Test
+    fun `fragment is loading`() {
+        assertThat(scenario).isNotNull()
+    }
+
+    @Test
+    fun `fragment is recreating`() {
+        scenario.recreate()
+        assertThat(scenario).isNotNull()
+    }
+
+    @Test
+    fun `creation dialog shows and can be dismissed`() {
+        with(scenario) {
+            onFragment { fragment ->
+                assertThat(fragment.dialog).isNotNull()
+                assertThat(fragment.requireDialog().isShowing).isTrue()
+                fragment.dismiss()
+                assertThat(fragment.dialog).isNull()
+            }
+        }
+    }
+}

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -64,6 +64,7 @@ object Versions {
     const val robolectric = "4.2"
 
     const val google_ads_id_version = "16.0.0"
+    const val androidx_fragment_testing_version = "1.2.0-alpha02"
 }
 
 @Suppress("unused")
@@ -212,4 +213,5 @@ object Deps {
     const val fenix_megazord_forUnitTests = "org.mozilla.appservices:fenix-megazord-forUnitTests:${Versions.mozilla_appservices}"
 
     const val google_ads_id = "com.google.android.gms:play-services-ads-identifier:${Versions.google_ads_id_version}"
+    const val androidx_fragment_testing = "androidx.fragment:fragment-testing:${Versions.androidx_fragment_testing_version}"
 }


### PR DESCRIPTION
Added return in function when saving collections coming from browser fragment

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

<!-- To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts". -->