### PR TITLE
Fix #4856 - Rebind FindInPageFeature in onStart()

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/FindInPageIntegration.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/FindInPageIntegration.kt
@@ -4,17 +4,13 @@
 
 package org.mozilla.fenix.components
 
-import android.content.Context
-import android.util.AttributeSet
 import android.view.View
 import android.view.ViewStub
-import androidx.coordinatorlayout.widget.CoordinatorLayout
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.session.runWithSessionIdOrSelected
 import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.feature.findinpage.FindInPageFeature
-import mozilla.components.feature.findinpage.view.FindInPageBar
 import mozilla.components.feature.findinpage.view.FindInPageView
 import mozilla.components.support.base.feature.LifecycleAwareFeature
 import org.mozilla.fenix.test.Mockable
@@ -42,44 +38,5 @@ class FindInPageIntegration(
             view.visibility = View.VISIBLE
             (feature as FindInPageFeature).bind(session)
         }
-    }
-}
-
-/**
- * [CoordinatorLayout.Behavior] that will always position the [FindInPageBar] above the [BrowserToolbar] (including
- * when the browser toolbar is scrolling or performing a snap animation).
- */
-@Suppress("unused") // Referenced from XML
-class FindInPageBarBehavior(
-    context: Context,
-    attrs: AttributeSet
-) : CoordinatorLayout.Behavior<FindInPageBar>(context, attrs) {
-    override fun layoutDependsOn(
-        parent: CoordinatorLayout,
-        child: FindInPageBar,
-        dependency: View
-    ): Boolean {
-        if (dependency is BrowserToolbar) {
-            return true
-        }
-
-        return super.layoutDependsOn(parent, child, dependency)
-    }
-
-    override fun onDependentViewChanged(
-        parent: CoordinatorLayout,
-        child: FindInPageBar,
-        dependency: View
-    ): Boolean {
-        return if (dependency is BrowserToolbar) {
-            repositionFindInPageBar(child, dependency)
-            true
-        } else {
-            false
-        }
-    }
-
-    private fun repositionFindInPageBar(findInPageView: FindInPageBar, toolbar: BrowserToolbar) {
-        findInPageView.translationY = (toolbar.translationY + toolbar.height * -1.0).toFloat()
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/components/InflationAwareFeature.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/InflationAwareFeature.kt
@@ -49,7 +49,7 @@ abstract class InflationAwareFeature(
      * when the view is inflated.
      */
     override fun start() {
-        // We don't do anything because we only want to start the feature when it's being used.
+        feature?.start()
     }
 
     override fun stop() {

--- a/app/src/test/java/org/mozilla/fenix/components/InflationAwareFeatureTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/InflationAwareFeatureTest.kt
@@ -10,7 +10,6 @@ import org.junit.Test
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
-import org.mockito.Mockito.verifyNoMoreInteractions
 import java.lang.ref.WeakReference
 
 class InflationAwareFeatureTest {
@@ -58,18 +57,14 @@ class InflationAwareFeatureTest {
     }
 
     @Test
-    fun `start does nothing`() {
-        val stub: ViewStub = mock()
-        val inflationFeature: InflationAwareFeature = spy(TestableInflationAwareFeature(stub))
+    fun `start should be delegated to the inner feature`() {
+        val inflationFeature: InflationAwareFeature = spy(TestableInflationAwareFeature(mock()))
         val innerFeature: LifecycleAwareFeature = mock()
-
         inflationFeature.feature = innerFeature
-        inflationFeature.view = WeakReference(mock())
 
         inflationFeature.start()
 
-        verifyNoMoreInteractions(innerFeature)
-        verifyNoMoreInteractions(stub)
+        verify(innerFeature).start()
     }
 
     @Test


### PR DESCRIPTION
FindInPageFeature is used inside the app as a LifecycleAwareFeature and as such
it receives the onStart / onStop lifecycle calls.
The onStart() lifecycle call would not get passed to the feature but in
onStop() FindInPageFeature will detach it's Presenter and Interactor so when
the user comes back to the screen she could not interact anymore with the
feature.
To fix this we'll rebind it's Presenter and Interactor in onStart().

When working on this I saw the FindInPageBarBehavior is unused so I made
a second commit for code cleanup.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks.
- [x] **Tests**: This PR does not includes tests as it comes with only small modifications for not yet tested components.
- [x] **Accessibility**: The code in this PR or does not include any user facing features.

<!-- To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts". -->