### PR TITLE
For #5025 - Do not remove custom tab session with config removed

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabActivity.kt
@@ -52,7 +52,10 @@ open class CustomTabActivity : HomeActivity() {
             // then there's no way to get back to it other than relaunching it.
             val sessionId = getIntentSessionId(SafeIntent(intent))
             components.core.sessionManager.runWithSession(sessionId) { session ->
-                remove(session)
+                // If the custom tag config has been removed we are opening this in normal browsing
+                if (session.customTabConfig != null) {
+                    remove(session)
+                }
                 true
             }
         }


### PR DESCRIPTION
Fixing a side effect of https://github.com/mozilla-mobile/fenix/pull/4985

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

<!-- To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts". -->
