### PR TITLE
Enable Gecko metrics exfiltration through Glean

### DIFF
--- a/app/src/geckoBeta/java/org/mozilla/fenix/engine/GeckoProvider.kt
+++ b/app/src/geckoBeta/java/org/mozilla/fenix/engine/GeckoProvider.kt
@@ -4,6 +4,7 @@
 
 import android.content.Context
 import android.os.Bundle
+import mozilla.components.browser.engine.gecko.glean.GeckoAdapter
 import mozilla.components.lib.crash.handler.CrashHandlerService
 import org.mozilla.fenix.utils.Settings
 import org.mozilla.geckoview.GeckoRuntime
@@ -33,6 +34,7 @@ object GeckoProvider {
         val runtimeSettings = builder
             .crashHandler(CrashHandlerService::class.java)
             .useContentProcessHint(true)
+            .telemetryDelegate(GeckoAdapter())
             .build()
 
         if (!Settings.getInstance(context).shouldUseAutoSize) {

--- a/app/src/geckoNightly/java/org/mozilla/fenix/engine/GeckoProvider.kt
+++ b/app/src/geckoNightly/java/org/mozilla/fenix/engine/GeckoProvider.kt
@@ -4,6 +4,7 @@
 
 import android.content.Context
 import android.os.Bundle
+import mozilla.components.browser.engine.gecko.glean.GeckoAdapter
 import mozilla.components.lib.crash.handler.CrashHandlerService
 import org.mozilla.fenix.utils.Settings
 import org.mozilla.geckoview.GeckoRuntime
@@ -33,6 +34,7 @@ object GeckoProvider {
         val runtimeSettings = builder
             .crashHandler(CrashHandlerService::class.java)
             .useContentProcessHint(true)
+            .telemetryDelegate(GeckoAdapter())
             .build()
 
         if (!Settings.getInstance(context).shouldUseAutoSize) {


### PR DESCRIPTION
This is similar to mozilla-mobile/reference-browser#864 . This disabled the legacy telemetry mechanism and enables the streaming telemetry for exfiltrating Gecko metrics through Glean.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

<!-- To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts". -->
