### PR TITLE
Remove ThumbnailsFeature.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -27,7 +27,6 @@ import kotlinx.coroutines.withContext
 import mozilla.appservices.places.BookmarkRoot
 import mozilla.components.browser.session.Session
 import mozilla.components.feature.readerview.ReaderViewFeature
-import mozilla.components.feature.session.ThumbnailsFeature
 import mozilla.components.feature.sitepermissions.SitePermissions
 import mozilla.components.lib.state.ext.consumeFrom
 import mozilla.components.support.base.feature.BackHandler
@@ -62,7 +61,6 @@ class BrowserFragment : BaseBrowserFragment(), BackHandler {
     private var quickActionSheetSessionObserver: QuickActionSheetSessionObserver? = null
 
     private val readerViewFeature = ViewBoundFeatureWrapper<ReaderViewFeature>()
-    private val thumbnailsFeature = ViewBoundFeatureWrapper<ThumbnailsFeature>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -91,16 +89,6 @@ class BrowserFragment : BaseBrowserFragment(), BackHandler {
         val sessionManager = requireComponents.core.sessionManager
 
         return super.initializeUI(view)?.also {
-
-            thumbnailsFeature.set(
-                feature = ThumbnailsFeature(
-                    requireContext(),
-                    view.engineView,
-                    requireComponents.core.sessionManager
-                ),
-                owner = this,
-                view = view
-            )
 
             readerViewFeature.set(
                 feature = ReaderViewFeature(

--- a/app/src/main/java/org/mozilla/fenix/ext/Session.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/Session.kt
@@ -14,7 +14,5 @@ fun Session.toTab(context: Context, selected: Boolean? = null): Tab {
         this.url,
         this.url.urlToTrimmedHost(context),
         this.title,
-        selected,
-        this.thumbnail
-    )
+        selected)
 }

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlComponent.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlComponent.kt
@@ -5,7 +5,6 @@
 package org.mozilla.fenix.home.sessioncontrol
 
 import android.content.Context
-import android.graphics.Bitmap
 import android.os.Parcelable
 import android.view.View
 import android.view.ViewGroup
@@ -53,8 +52,7 @@ data class Tab(
     val url: String,
     val hostname: String,
     val title: String,
-    val selected: Boolean? = null,
-    val thumbnail: Bitmap? = null
+    val selected: Boolean? = null
 ) : Parcelable
 
 fun List<Tab>.toSessionBundle(context: Context): MutableList<Session> {


### PR DESCRIPTION
We currently do not use thumbnails anywhere in the app. Not using the feature means we are
not taking thumbnails on every page load which means we are saving memory and CPU cycles.
