### PR TITLE
For #5142 Removed RadioButton from accessibility keeping one option for Talkback

### DIFF
--- a/app/src/main/res/layout/search_engine_radio_button.xml
+++ b/app/src/main/res/layout/search_engine_radio_button.xml
@@ -14,6 +14,7 @@
         android:id="@+id/radio_button"
         android:layout_width="@dimen/search_engine_radio_button_height"
         android:layout_height="@dimen/search_engine_radio_button_height"
+        android:importantForAccessibility="no"
         android:textAlignment="textStart"
         android:textAppearance="?android:attr/textAppearanceListItem"
         android:layout_marginStart="@dimen/radio_button_padding_horizontal"


### PR DESCRIPTION
Set android:importantForAccessibility = "no" for RadioButton

Before:
<img src=https://user-images.githubusercontent.com/48995920/64418296-6983c200-d0a3-11e9-9968-7c3f4cb5cf69.png width=49%/> <img src=https://user-images.githubusercontent.com/48995920/64418297-6983c200-d0a3-11e9-9a17-02f1c73a2392.png width=49%/>

After, only one selection option:
<img src=https://user-images.githubusercontent.com/48995920/64418071-faa66900-d0a2-11e9-9594-44c31f1a6d5a.png width=50%/>

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

<!-- To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts". -->
