### PR TITLE
For #1114: Show playing tab

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/ext/Session.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/Session.kt
@@ -6,13 +6,16 @@ package org.mozilla.fenix.ext
 
 import android.content.Context
 import mozilla.components.browser.session.Session
+import mozilla.components.feature.media.state.MediaState
 import org.mozilla.fenix.home.sessioncontrol.Tab
 
-fun Session.toTab(context: Context, selected: Boolean? = null): Tab {
+fun Session.toTab(context: Context, selected: Boolean? = null, mediaState: MediaState? = null): Tab {
     return Tab(
         this.id,
         this.url,
         this.url.urlToTrimmedHost(context),
         this.title,
-        selected)
+        selected,
+        mediaState
+    )
 }

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlComponent.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlComponent.kt
@@ -5,13 +5,12 @@
 package org.mozilla.fenix.home.sessioncontrol
 
 import android.content.Context
-import android.os.Parcelable
 import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import io.reactivex.Observer
-import kotlinx.android.parcel.Parcelize
 import mozilla.components.browser.session.Session
+import mozilla.components.feature.media.state.MediaState
 import mozilla.components.service.fxa.sharing.ShareableAccount
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.ext.components
@@ -46,14 +45,14 @@ class SessionControlComponent(
     }
 }
 
-@Parcelize
 data class Tab(
     val sessionId: String,
     val url: String,
     val hostname: String,
     val title: String,
-    val selected: Boolean? = null
-) : Parcelable
+    val selected: Boolean? = null,
+    var mediaState: MediaState? = null
+)
 
 fun List<Tab>.toSessionBundle(context: Context): MutableList<Session> {
     val sessionBundle = mutableListOf<Session>()
@@ -62,7 +61,6 @@ fun List<Tab>.toSessionBundle(context: Context): MutableList<Session> {
             sessionBundle.add(session)
         }
     }
-
     return sessionBundle
 }
 
@@ -108,6 +106,8 @@ sealed class TabAction : Action {
     data class Select(val tabView: View, val sessionId: String) : TabAction()
     data class Close(val sessionId: String) : TabAction()
     data class Share(val sessionId: String) : TabAction()
+    data class PauseMedia(val sessionId: String) : TabAction()
+    data class PlayMedia(val sessionId: String) : TabAction()
     object PrivateBrowsingLearnMore : TabAction()
 }
 

--- a/app/src/main/res/drawable/pause_with_background.xml
+++ b/app/src/main/res/drawable/pause_with_background.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape android:shape="oval">
+            <size
+                android:width="24dp"
+                android:height="24dp" />
+            <solid android:color="?above" />
+            <stroke android:color="?above"
+                android:width="2dp"/>
+        </shape>
+    </item>
+    <item>
+        <vector
+            android:width="24dp"
+            android:height="24dp"
+            android:viewportWidth="24"
+            android:viewportHeight="24">
+            <path
+                android:fillColor="?accent"
+                android:pathData="M12,2a10,10 0,1 0,10 10A10,10 0,0 0,12 2zM10.5,16.125a0.375,0.375 0,0 1,-0.375 0.375h-2.25A0.375,0.375 0,0 1,7.5 16.125v-8.25A0.375,0.375 0,0 1,7.875 7.5h2.25A0.375,0.375 0,0 1,10.5 7.875zM16.5,16.125a0.375,0.375 0,0 1,-0.375 0.375h-2.25a0.375,0.375 0,0 1,-0.375 -0.375v-8.25A0.375,0.375 0,0 1,13.875 7.5h2.25A0.375,0.375 0,0 1,16.5 7.875z"/>
+        </vector>
+    </item>
+</layer-list>

--- a/app/src/main/res/drawable/play_with_background.xml
+++ b/app/src/main/res/drawable/play_with_background.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape android:shape="oval">
+            <size
+                android:width="24dp"
+                android:height="24dp" />
+            <solid android:color="?above" />
+            <stroke android:color="?above"
+                android:width="2dp"/>
+        </shape>
+    </item>
+    <item>
+        <vector
+            android:width="24dp"
+            android:height="24dp"
+            android:viewportWidth="24"
+            android:viewportHeight="24">
+            <path
+                android:fillColor="?accent"
+                android:pathData="M12,22a10,10 0,1 1,10 -10,10 10,0 0,1 -10,10zM10,16.363l6,-3.5a1,1 0,0 0,0 -1.732l-6,-3.5A1,1 0,0 0,8.5 8.5v7a1,1 0,0 0,1.5 0.863z"/>
+        </vector>
+    </item>
+</layer-list>

--- a/app/src/main/res/layout/tab_list_row.xml
+++ b/app/src/main/res/layout/tab_list_row.xml
@@ -35,6 +35,21 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
+        <ImageButton
+            android:id="@+id/play_pause_button"
+            android:contentDescription="@string/mozac_feature_media_notification_action_pause"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:elevation="10dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:src="@drawable/pause_with_background"
+            android:visibility="gone"
+            app:layout_constraintCircleAngle="45"
+            app:layout_constraintCircleRadius="30dp"
+            app:layout_constraintCircle="@id/favicon_image"
+            app:layout_constraintEnd_toEndOf="@id/favicon_image"
+            app:layout_constraintTop_toTopOf="@id/favicon_image" />
+
         <TextView
                 android:id="@+id/hostname"
                 android:layout_width="0dp"
@@ -75,13 +90,15 @@
                 app:layout_constraintTop_toTopOf="parent"/>
 
         <View
-                android:id="@+id/selected_border"
-                android:layout_width="0dp"
-                android:layout_height="0dp"
-                android:background="@drawable/session_border"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+            android:id="@+id/selected_border"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:background="@drawable/session_border"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.0" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.cardview.widget.CardView>


### PR DESCRIPTION
Known issues: 
* it can take 250ms to update the icon of the play/pause button: https://github.com/mozilla-mobile/android-components/issues/4353
* selectableItemBackground does not play nicely with the play/pause button since it is above another `imageView`. I believe this may be an Android bug, unfortunately.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features


Tests: no tests included as these are all things added to the HomeFragment. It should likely get some UI tests, though, and I will file a ticket for those.

Screenshots: 

<img width="350" alt="image" src="https://user-images.githubusercontent.com/4400286/64738668-b3eeaf80-d4a4-11e9-9c99-9ca6c9035b1a.png">

<img width="350" alt="image" src="https://user-images.githubusercontent.com/4400286/64738646-9d485880-d4a4-11e9-9f73-0118beab84df.png">



Accessibility: The button itself is only 24x24dp, that being said I increase the tap size to 48x48 so make it in line with the accessibility guidelines. Ive also added a dynamic ContentDescription that updates to play/pause based on the state of the button.


<!-- To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts". -->
