### PR TITLE
Fix broken privateModeScreenItemsTest UI test

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/TestAssetHelper.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/TestAssetHelper.kt
@@ -15,7 +15,7 @@ import java.util.concurrent.TimeUnit
  */
 object TestAssetHelper {
     @Suppress("MagicNumber")
-    val waitingTime: Long = TimeUnit.SECONDS.toMillis(15)
+    val waitingTime: Long = TimeUnit.SECONDS.toMillis(45)
     val waitingTimeShort: Long = TimeUnit.SECONDS.toMillis(1)
     data class TestAsset(val url: Uri, val content: String)
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
@@ -11,13 +11,9 @@ import org.junit.Before
 import org.junit.After
 import org.mozilla.fenix.helpers.HomeActivityTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
-import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.By
-import androidx.test.uiautomator.Until
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import okhttp3.mockwebserver.MockWebServer
-import org.mozilla.fenix.ui.robots.PRIVATE_SESSION_MESSAGE
 import org.mozilla.fenix.ui.robots.homeScreen
 
 /**
@@ -135,7 +131,7 @@ class HomeScreenTest {
         // browse to mock web page so tab elements appear
         }.enterURLAndEnterToBrowser(defaultWebPage.url) {
         }.goBackToHomeScreen {
-            verifyPrivateSessionHeader()
+//            verifyPrivateSessionHeader()
             verifyAddTabButton()
             verifyShareTabsButton(visible = true)
             verifyGarbageCanButton(visible = true)

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
@@ -131,7 +131,7 @@ class HomeScreenTest {
         // browse to mock web page so tab elements appear
         }.enterURLAndEnterToBrowser(defaultWebPage.url) {
         }.goBackToHomeScreen {
-//            verifyPrivateSessionHeader()
+            verifyPrivateSessionHeader()
             verifyAddTabButton()
             verifyShareTabsButton(visible = true)
             verifyGarbageCanButton(visible = true)

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
@@ -7,12 +7,16 @@ package org.mozilla.fenix.ui
 import androidx.test.uiautomator.UiDevice
 import org.junit.Rule
 import org.junit.Test
-import org.junit.Ignore
+import org.junit.Before
+import org.junit.After
 import org.mozilla.fenix.helpers.HomeActivityTestRule
+import org.mozilla.fenix.helpers.TestAssetHelper
+import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.Until
-import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
+import org.mozilla.fenix.helpers.AndroidAssetDispatcher
+import okhttp3.mockwebserver.MockWebServer
 import org.mozilla.fenix.ui.robots.PRIVATE_SESSION_MESSAGE
 import org.mozilla.fenix.ui.robots.homeScreen
 
@@ -27,9 +31,23 @@ class HomeScreenTest {
     /* ktlint-disable no-blank-line-before-rbrace */ // This imposes unreadable grouping.
 
     private val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+    private lateinit var mockWebServer: MockWebServer
 
     @get:Rule
     val activityTestRule = HomeActivityTestRule()
+
+    @Before
+    fun setUp() {
+        mockWebServer = MockWebServer().apply {
+            setDispatcher(AndroidAssetDispatcher())
+            start()
+        }
+    }
+
+    @After
+    fun tearDown() {
+        mockWebServer.shutdown()
+    }
 
     @Test
     fun homeScreenItemsTest() {
@@ -94,45 +112,35 @@ class HomeScreenTest {
     }
 
     @Test
-    @Ignore("Temp disable broken test - see:  https://github.com/mozilla-mobile/fenix/issues/5050")
-
     fun privateModeScreenItemsTest() {
+        val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
         homeScreen { }.dismissOnboarding()
         homeScreen { }.togglePrivateBrowsingMode()
 
         homeScreen {
-            verifyHomeScreen()
             verifyNavigationToolbar()
             verifyHomePrivateBrowsingButton()
             verifyHomeMenu()
             verifyHomeWordmark()
+            verifyPrivateSessionHeader()
             verifyAddTabButton()
             verifyShareTabsButton(visible = false)
-            verifyCloseTabsButton(visible = false)
-            verifyPrivateSessionHeader()
+            verifyGarbageCanButton(visible = false)
+            verifyCloseTabButton(visible = false)
             verifyPrivateSessionMessage(visible = true)
             verifyHomeToolbar()
             verifyHomeComponent()
-        }
 
-        homeScreen { }.addNewTab()
-
-        homeScreen {
-            // To deal with the race condition where multiple "add tab" buttons are present,
-            // we need to wait until previous HomeFragment View objects are gone.
-            mDevice.wait(Until.gone(By.text(PRIVATE_SESSION_MESSAGE)), waitingTime)
-            verifyHomeScreen()
-            verifyNavigationToolbar()
-            verifyHomePrivateBrowsingButton()
-            verifyHomeMenu()
-            verifyHomeWordmark()
+        // browse to mock web page so tab elements appear
+        }.enterURLAndEnterToBrowser(defaultWebPage.url) {
+        }.goBackToHomeScreen {
+            verifyPrivateSessionHeader()
             verifyAddTabButton()
             verifyShareTabsButton(visible = true)
-            verifyCloseTabsButton(visible = true)
-            verifyPrivateSessionHeader()
+            verifyGarbageCanButton(visible = true)
+            verifyCloseTabButton(visible = true)
             verifyPrivateSessionMessage(visible = false)
-            verifyHomeToolbar()
-            verifyHomeComponent()
         }
     }
 }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
@@ -101,8 +101,8 @@ class TabbedBrowsingTest {
             verifyTabCounter("1")
         }.openHomeScreen {
             verifyExistingTabList()
-            verifyShareTabsButton(true)
-            verifyCloseTabsButton(true)
+            verifyShareTabsButton()
+            verifyCloseTabButton()
         }.togglePrivateBrowsingMode()
 
         // Verify private tabs remain in private browsing mode

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -71,12 +71,14 @@ class BrowserRobot {
             HomeScreenRobot().interact()
             return HomeScreenRobot.Transition()
         }
-    }
-}
 
-fun browserScreen(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
-    BrowserRobot().interact()
-    return BrowserRobot.Transition()
+        fun goBackToHomeScreen(interact: HomeScreenRobot.() -> Unit): HomeScreenRobot.Transition {
+            mDevice.waitForIdle()
+            mDevice.pressBack()
+            HomeScreenRobot().interact()
+            return HomeScreenRobot.Transition()
+        }
+    }
 }
 
 private fun dismissOnboardingButton() = onView(ViewMatchers.withId(R.id.close_onboarding))

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
@@ -17,7 +17,11 @@ import androidx.test.espresso.matcher.ViewMatchers.Visibility
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.*
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.UiDevice
+import androidx.test.uiautomator.UiSelector
+import androidx.test.uiautomator.UiScrollable
+import androidx.test.uiautomator.Until
 import androidx.test.uiautomator.Until.findObject
 import okhttp3.mockwebserver.MockWebServer
 import org.hamcrest.CoreMatchers

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
@@ -17,10 +17,7 @@ import androidx.test.espresso.matcher.ViewMatchers.Visibility
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.By
-import androidx.test.uiautomator.UiDevice
-import androidx.test.uiautomator.UiScrollable
-import androidx.test.uiautomator.UiSelector
+import androidx.test.uiautomator.*
 import androidx.test.uiautomator.Until.findObject
 import okhttp3.mockwebserver.MockWebServer
 import org.hamcrest.CoreMatchers
@@ -108,7 +105,7 @@ class HomeScreenRobot {
 
         fun openSearch(interact: SearchRobot.() -> Unit): SearchRobot.Transition {
             mDevice.wait(
-                findObject(By.text("Search or enter address")),
+                Until.findObject(By.text("Search or enter address")),
                 TestAssetHelper.waitingTime
             )
             navigationToolbar().perform(click())
@@ -119,7 +116,7 @@ class HomeScreenRobot {
 
         fun enterURLAndEnterToBrowser(url: Uri, interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
             mDevice.wait(
-                findObject(By.text("Search or enter address")),
+                Until.findObject(By.text("Search or enter address")),
                 TestAssetHelper.waitingTime
             )
             urlBar().click()
@@ -172,13 +169,13 @@ private fun navigationToolbar() =
     onView(CoreMatchers.allOf(ViewMatchers.withText("Search or enter address")))
 
 private fun assertNavigationToolbar() {
-    mDevice.wait(findObject(By.text("Search or enter address")), waitingTime)
+    mDevice.wait(Until.findObject(By.text("Search or enter address")), waitingTime)
     onView(CoreMatchers.allOf(ViewMatchers.withText("Search or enter address")))
         .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 }
 
 private fun assertHomeScreen() {
-    mDevice.wait(findObject(By.res("homeLayout")), waitingTime)
+    mDevice.wait(Until.findObject(By.res("homeLayout")), waitingTime)
     onView(ViewMatchers.withResourceName("homeLayout"))
         .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 }
@@ -201,7 +198,7 @@ private fun assertOpenTabsHeader() =
         .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
 private fun assertAddTabButton() {
-    mDevice.wait(findObject(By.res("add_tab_button")), waitingTime)
+    mDevice.wait(Until.findObject(By.res("add_tab_button")), waitingTime)
     onView(CoreMatchers.allOf(ViewMatchers.withId(R.id.add_tab_button), isDisplayed()))
         .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 }
@@ -333,7 +330,7 @@ private fun assertStartBrowsingButton() =
 
 // Private mode elements
 private fun assertPrivateSessionHeader() {
-    mDevice.wait(findObject(By.text("Private session")), waitingTime)
+    mDevice.wait(Until.findObject(By.text("Private session")), waitingTime)
     onView(CoreMatchers.allOf(ViewMatchers.withText("Private session")))
         .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 }
@@ -350,7 +347,7 @@ private fun assertPrivateSessionMessage(visible: Boolean) =
         )
 
 private fun assertShareTabsButton(visible: Boolean) {
-    mDevice.wait(findObject(By.res("share_tabs_button")), waitingTime)
+    mDevice.wait(Until.findObject(By.res("share_tabs_button")), waitingTime)
     onView(ViewMatchers.withId(R.id.share_tabs_button))
         .check(
             if (visible) matches(withEffectiveVisibility(Visibility.VISIBLE)) else matches(
@@ -359,7 +356,7 @@ private fun assertShareTabsButton(visible: Boolean) {
 }
 
 private fun assertGarbageCanButton(visible: Boolean) {
-    mDevice.wait(findObject(By.res("close_tabs_button")), waitingTime)
+    mDevice.wait(Until.findObject(By.res("close_tabs_button")), waitingTime)
     onView(ViewMatchers.withId(R.id.close_tabs_button))
         .check(
             if (visible) matches(withEffectiveVisibility(Visibility.VISIBLE)) else matches(
@@ -368,7 +365,7 @@ private fun assertGarbageCanButton(visible: Boolean) {
 }
 
 private fun assertCloseTabButton(visible: Boolean) {
-    mDevice.wait(findObject(By.res("close_tab_button")), waitingTime)
+    mDevice.wait(Until.findObject(By.res("close_tab_button")), waitingTime)
     onView(ViewMatchers.withId(R.id.close_tab_button))
         .check(
             if (visible) matches(withEffectiveVisibility(Visibility.VISIBLE)) else doesNotExist()

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NavigationToolbarRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NavigationToolbarRobot.kt
@@ -60,7 +60,6 @@ fun navigationToolbar(interact: NavigationToolbarRobot.() -> Unit): NavigationTo
     return NavigationToolbarRobot.Transition()
 }
 
-private fun dismissOnboardingButton() = onView(ViewMatchers.withId(R.id.close_onboarding))
 private fun urlBar() = onView(ViewMatchers.withId(R.id.toolbar))
 private fun awesomeBar() = onView(ViewMatchers.withId(R.id.mozac_browser_toolbar_edit_url_view))
 private fun threeDotButton() = onView(ViewMatchers.withContentDescription("Menu"))

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuRobot.kt
@@ -160,8 +160,11 @@ private fun shareTabButton() = onView(allOf(withText("Share tabs")))
 private fun assertShareTabButton() = shareTabButton()
     .check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 private fun shareButton() = onView(allOf(withText("Share")))
-private fun assertShareButton() = shareButton()
-    .check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+private fun assertShareButton() {
+    mDevice.wait(Until.findObject(By.text("Share")), waitingTime)
+    shareButton()
+        .check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+}
 
 private fun saveCollectionButton() = onView(allOf(withText("Save to collection")))
 private fun assertSaveCollectionButton() = saveCollectionButton()

--- a/automation/taskcluster/androidTest/flank-arm64-v8a.yml
+++ b/automation/taskcluster/androidTest/flank-arm64-v8a.yml
@@ -47,3 +47,7 @@ flank:
   # repeat tests - the amount of times to run the tests.
   # 1 runs the tests once. 10 runs all the tests 10x
   repeat-tests: 1
+
+  # The number of times a TestExecution should be re-attempted if one or more\nof its test cases fail for any reason.
+  # The maximum number of reruns allowed is 10. Default is 0, which implies no reruns.
+  num-flaky-test-attempts: 3

--- a/automation/taskcluster/androidTest/flank-armeabi-v7a.yml
+++ b/automation/taskcluster/androidTest/flank-armeabi-v7a.yml
@@ -45,3 +45,8 @@ flank:
   # repeat tests - the amount of times to run the tests.
   # 1 runs the tests once. 10 runs all the tests 10x
   repeat-tests: 1
+
+  # The number of times a TestExecution should be re-attempted if one or more\nof its test cases fail for any reason.
+  # The maximum number of reruns allowed is 10. Default is 0, which implies no reruns.
+  num-flaky-test-attempts: 3
+

--- a/automation/taskcluster/androidTest/flank-x86-tablet.yml
+++ b/automation/taskcluster/androidTest/flank-x86-tablet.yml
@@ -41,9 +41,16 @@ gcloud:
 
 flank:
   project: GOOGLE_PROJECT
+
   # test shards - the amount of groups to split the test suite into
   # set to -1 to use one shard per test.
-  max-test-shards: -1 
+  max-test-shards: -1
+
   # repeat tests - the amount of times to run the tests.
   # 1 runs the tests once. 10 runs all the tests 10x
   repeat-tests: 1
+
+  # The number of times a TestExecution should be re-attempted if one or more\nof its test cases fail for any reason.
+  # The maximum number of reruns allowed is 10. Default is 0, which implies no reruns.
+  num-flaky-test-attempts: 3
+

--- a/automation/taskcluster/androidTest/flank-x86.yml
+++ b/automation/taskcluster/androidTest/flank-x86.yml
@@ -45,3 +45,8 @@ flank:
   # repeat tests - the amount of times to run the tests.
   # 1 runs the tests once. 10 runs all the tests 10x
   repeat-tests: 1
+
+  # The number of times a TestExecution should be re-attempted if one or more\nof its test cases fail for any reason.
+  # The maximum number of reruns allowed is 10. Default is 0, which implies no reruns.
+  num-flaky-test-attempts: 3
+

--- a/automation/taskcluster/androidTest/flank-x86_64.yml
+++ b/automation/taskcluster/androidTest/flank-x86_64.yml
@@ -39,9 +39,16 @@ gcloud:
 
 flank:
   project: GOOGLE_PROJECT
+
   # test shards - the amount of groups to split the test suite into
   # set to -1 to use one shard per test.
-  max-test-shards: -1 
+  max-test-shards: -1
+
   # repeat tests - the amount of times to run the tests.
   # 1 runs the tests once. 10 runs all the tests 10x
   repeat-tests: 1
+
+  # The number of times a TestExecution should be re-attempted if one or more\nof its test cases fail for any reason.
+  # The maximum number of reruns allowed is 10. Default is 0, which implies no reruns.
+  num-flaky-test-attempts: 3
+


### PR DESCRIPTION
Closes #4959 #5050 

1. Fixes broken Fix broken privateModeScreenItemsTest UI test 
2. Address flakiness with Tabs tests
3. enable Firebase parameter `num-flaky-test-attempts` 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [x] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

<!-- To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts". -->
