### PR TITLE
No issue: Pass color resource for what's new menu item by id!!

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeMenu.kt
@@ -5,7 +5,6 @@
 package org.mozilla.fenix.home
 
 import android.content.Context
-import androidx.core.content.ContextCompat
 import mozilla.components.browser.menu.BrowserMenuBuilder
 import mozilla.components.browser.menu.item.BrowserMenuDivider
 import mozilla.components.browser.menu.item.BrowserMenuHighlightableItem
@@ -60,7 +59,7 @@ class HomeMenu(
                 highlight = BrowserMenuHighlightableItem.Highlight(
                     startImageResource = R.drawable.ic_whats_new_notification,
                     backgroundResource = ThemeManager.resolveAttribute(R.attr.selectableItemBackground, context),
-                    colorResource = ContextCompat.getColor(context, R.color.whats_new_notification_color)
+                    colorResource = R.color.whats_new_notification_color
                 ),
                 isHighlighted = { WhatsNew.shouldHighlightWhatsNew(context) }
             ) {


### PR DESCRIPTION
No behavior changes just fixes following lint error:

```
src/app/src/main/java/org/mozilla/fenix/home/HomeMenu.kt:63: Error: Expected a color resource id (R.color.) but received an RGB integer [ResourceType]
                      colorResource = ContextCompat.getColor(context, R.color.whats_new_notification_color)
                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

<!-- To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts". -->
