### PR TITLE
For #1749 - Use Strict ETP by default, use Feature Flag for Settings

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/TrackingProtectionFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/TrackingProtectionFragment.kt
@@ -11,6 +11,7 @@ import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreference
 import org.mozilla.fenix.BrowserDirection
+import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
@@ -87,6 +88,7 @@ class TrackingProtectionFragment : PreferenceFragmentCompat() {
     private fun bindStrict() {
         val keyStrict = getString(R.string.pref_key_tracking_protection_strict)
         radioStrict = requireNotNull(findPreference(keyStrict))
+        radioStrict.isVisible = FeatureFlags.etpCategories
         radioStrict.onInfoClickListener {
             nav(
                 R.id.trackingProtectionFragment,
@@ -102,6 +104,7 @@ class TrackingProtectionFragment : PreferenceFragmentCompat() {
     private fun bindRecommended() {
         val keyStandard = getString(R.string.pref_key_tracking_protection_standard)
         radioStandard = requireNotNull(findPreference(keyStandard))
+        radioStandard.isVisible = FeatureFlags.etpCategories
         radioStandard.onInfoClickListener {
             nav(
                 R.id.trackingProtectionFragment,

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -165,7 +165,7 @@ class Settings private constructor(
 
     val useStrictTrackingProtection by booleanPreference(
         appContext.getPreferenceKey(R.string.pref_key_tracking_protection_strict),
-        false
+        true
     )
 
     val themeSettingString: String

--- a/app/src/main/res/xml/tracking_protection_preferences.xml
+++ b/app/src/main/res/xml/tracking_protection_preferences.xml
@@ -5,31 +5,33 @@
 <androidx.preference.PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <androidx.preference.Preference
-        app:allowDividerBelow="false"
         android:key="@string/pref_key_etp_learn_more"
         android:layout="@layout/tracking_protection_learn_more_preference"
         android:summary="@string/preference_enhanced_tracking_protection_explanation"
-        android:title="@string/preference_enhanced_tracking_protection_explanation_title" />
+        android:title="@string/preference_enhanced_tracking_protection_explanation_title"
+        app:allowDividerBelow="false" />
     <SwitchPreference
         android:defaultValue="true"
         android:icon="@drawable/ic_tracking_protection_enabled"
         android:key="@string/pref_key_tracking_protection"
         android:title="@string/preference_enhanced_tracking_protection" />
     <org.mozilla.fenix.settings.RadioButtonInfoPreference
+        android:defaultValue="false"
         android:dependency="@string/pref_key_tracking_protection"
-        android:defaultValue="true"
         android:key="@string/pref_key_tracking_protection_standard"
         android:summary="@string/preference_enhanced_tracking_protection_standard_description"
-        android:title="@string/preference_enhanced_tracking_protection_standard" />
+        android:title="@string/preference_enhanced_tracking_protection_standard"
+        app:isPreferenceVisible="false" />
     <org.mozilla.fenix.settings.RadioButtonInfoPreference
+        android:defaultValue="true"
         android:dependency="@string/pref_key_tracking_protection"
-        android:defaultValue="false"
         android:key="@string/pref_key_tracking_protection_strict"
         android:summary="@string/preference_enhanced_tracking_protection_strict_description"
-        android:title="@string/preference_enhanced_tracking_protection_strict" />
+        android:title="@string/preference_enhanced_tracking_protection_strict"
+        app:isPreferenceVisible="false" />
     <Preference
-        app:allowDividerAbove="true"
         android:icon="@drawable/ic_info"
         android:key="@string/pref_key_tracking_protection_exceptions"
-        android:title="@string/preferences_tracking_protection_exceptions" />
+        android:title="@string/preferences_tracking_protection_exceptions"
+        app:allowDividerAbove="true" />
 </androidx.preference.PreferenceScreen>

--- a/app/src/test/java/org/mozilla/fenix/utils/SettingsTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/utils/SettingsTest.kt
@@ -230,6 +230,13 @@ class SettingsTest {
     }
 
     @Test
+    fun shouldUseTrackingProtectionStrict() {
+        // When
+        // Then
+        assertTrue(settings.useStrictTrackingProtection)
+    }
+
+    @Test
     fun shouldUseAutoBatteryTheme() {
         // When just created
         // Then


### PR DESCRIPTION
Switches to using Strict by default and hides the "strict" and "recommended" selection behind feature flag because we need new strings.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

<!-- To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts". -->
