### PR TITLE
Unbreak Nightly: Get rid of fragment-testing dependency and create fragments in test manually.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -452,9 +452,6 @@ dependencies {
 
     androidTestImplementation Deps.androidx_test_core
     androidTestImplementation Deps.espresso_idling_resources
-    debugImplementation (Deps.androidx_fragment_testing) {
-        exclude group: 'androidx.test', module: 'core'
-    }
 
     androidTestImplementation Deps.tools_test_runner
     androidTestImplementation Deps.tools_test_rules

--- a/app/src/test/java/org/mozilla/fenix/collections/CreateCollectionFragmentTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/collections/CreateCollectionFragmentTest.kt
@@ -1,51 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.collections
 
-import androidx.fragment.app.testing.FragmentScenario
-import androidx.fragment.app.testing.launchFragment
+import androidx.fragment.app.FragmentActivity
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import assertk.assertThat
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
 import assertk.assertions.isTrue
 import kotlinx.coroutines.ObsoleteCoroutinesApi
-import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.TestApplication
-
+import org.robolectric.Robolectric
 import org.robolectric.annotation.Config
 
 @ObsoleteCoroutinesApi
 @RunWith(AndroidJUnit4::class)
 @Config(application = TestApplication::class)
 class CreateCollectionFragmentTest {
-
-    private lateinit var scenario: FragmentScenario<CreateCollectionFragment>
-
-    @Before
-    fun setUp() {
-        scenario = launchFragment<CreateCollectionFragment>()
-    }
-    @Test
-    fun `fragment is loading`() {
-        assertThat(scenario).isNotNull()
-    }
-
-    @Test
-    fun `fragment is recreating`() {
-        scenario.recreate()
-        assertThat(scenario).isNotNull()
-    }
-
     @Test
     fun `creation dialog shows and can be dismissed`() {
-        with(scenario) {
-            onFragment { fragment ->
-                assertThat(fragment.dialog).isNotNull()
-                assertThat(fragment.requireDialog().isShowing).isTrue()
-                fragment.dismiss()
-                assertThat(fragment.dialog).isNull()
-            }
+        val activity = Robolectric.buildActivity(FragmentActivity::class.java)
+            .create()
+            .start()
+            .resume()
+            .get()
+
+        val fragment = CreateCollectionFragment()
+
+        activity.supportFragmentManager.beginTransaction().apply {
+            add(fragment, "test")
+            commitNow()
         }
+
+        assertThat(fragment.dialog).isNotNull()
+        assertThat(fragment.requireDialog().isShowing).isTrue()
+        fragment.dismiss()
+        assertThat(fragment.dialog).isNull()
     }
 }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -66,8 +66,6 @@ object Versions {
     const val google_ads_id_version = "16.0.0"
 
     const val airbnb_lottie = "3.0.7"
-
-    const val androidx_fragment_testing_version = "1.2.0-alpha02"
 }
 
 @Suppress("unused")
@@ -219,7 +217,6 @@ object Deps {
     const val fenix_megazord_forUnitTests = "org.mozilla.appservices:fenix-megazord-forUnitTests:${Versions.mozilla_appservices}"
 
     const val google_ads_id = "com.google.android.gms:play-services-ads-identifier:${Versions.google_ads_id_version}"
-    const val androidx_fragment_testing = "androidx.fragment:fragment-testing:${Versions.androidx_fragment_testing_version}"
 
     const val lottie = "com.airbnb.android:lottie:${Versions.airbnb_lottie}"
 }


### PR DESCRIPTION
This patch fixes Nightly builds and removes the `fragment-testing` dependency.

See issue #4719 and PR #4722 for history. The same issues have come up again after `fragment-testing` was reintroduced.

TL;DR: `fragment-testing` causes issues if not added to *every* build variant that is tested. Adding it to variants that get released introduces a security risk.

Until Google fixes the issues linked in #4719 not using `fragment-testing` is probably the best option. Since we are already using Robolectric we can test fragments manually and are not required to use `fragment-testing`. There's some boilerplate needed to create an activity and attach a fragment. I filed an AC issue to provide a nicer helper for that eventually: https://github.com/mozilla-mobile/android-components/issues/4120