### PR TITLE
Use new feature-downloads API....

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -150,6 +150,7 @@ abstract class BaseBrowserFragment : Fragment(), BackHandler, SessionManager.Obs
     protected open fun initializeUI(view: View): Session? {
         val context = requireContext()
         val sessionManager = context.components.core.sessionManager
+        val store = context.components.core.store
 
         return getSessionById()?.also { session ->
 
@@ -240,9 +241,10 @@ abstract class BaseBrowserFragment : Fragment(), BackHandler, SessionManager.Obs
             downloadsFeature.set(
                 feature = DownloadsFeature(
                     context.applicationContext,
-                    sessionManager = sessionManager,
+                    store = store,
+                    useCases = context.components.useCases.downloadUseCases,
                     fragmentManager = childFragmentManager,
-                    sessionId = customTabSessionId,
+                    customTabId = customTabSessionId,
                     downloadManager = FetchDownloadManager(
                         context.applicationContext,
                         DownloadService::class

--- a/app/src/main/java/org/mozilla/fenix/components/UseCases.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/UseCases.kt
@@ -10,6 +10,7 @@ import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.engine.Settings
 import mozilla.components.concept.fetch.Client
 import mozilla.components.feature.app.links.AppLinksUseCases
+import mozilla.components.feature.downloads.DownloadsUseCases
 import mozilla.components.feature.pwa.WebAppUseCases
 import mozilla.components.feature.search.SearchUseCases
 import mozilla.components.feature.session.SessionUseCases
@@ -52,4 +53,6 @@ class UseCases(
     val appLinksUseCases by lazy { AppLinksUseCases(context.applicationContext) }
 
     val webAppUseCases by lazy { WebAppUseCases(context, sessionManager, httpClient, supportWebApps = false) }
+
+    val downloadUseCases by lazy { DownloadsUseCases(sessionManager) }
 }


### PR DESCRIPTION
This PR addresses the API changes that will happen with the next AC snapshot after https://github.com/mozilla-mobile/android-components/pull/4390 lands.