### PR TITLE
fix TabbedBrowsingTest.kt failure where Share Tabs element was not found

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
@@ -76,7 +76,7 @@ class TabbedBrowsingTest {
 
         }.openTabsListThreeDotMenu {
             verifyCloseAllTabsButton()
-            verifyShareButton()
+            verifyShareTabButton()
             verifySaveCollection()
         }
     }
@@ -130,7 +130,7 @@ class TabbedBrowsingTest {
             verifyExistingTabList()
         }.openTabsListThreeDotMenu {
             verifyCloseAllTabsButton()
-            verifyShareButton()
+            verifyShareTabButton()
             verifySaveCollection()
         }.closeAllTabs {
             verifyNoCollectionsHeader()

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuRobot.kt
@@ -39,6 +39,7 @@ class ThreeDotMenuRobot {
         shareButton().click()
         mDevice.wait(Until.findObject(By.text("SHARE A LINK")), waitingTime)
     }
+    fun verifyShareTabButton() = assertShareTabButton()
     fun verifySaveCollection() = assertSaveCollectionButton()
     fun verifyFindInPageButton() = assertFindInPageButton()
     fun verifyShareDialogTitle() = assertShareDialogTitle()
@@ -155,6 +156,9 @@ private fun closeAllTabsButton() = onView(allOf(withText("Close all tabs")))
 private fun assertCloseAllTabsButton() = closeAllTabsButton()
     .check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
+private fun shareTabButton() = onView(allOf(withText("Share tabs")))
+private fun assertShareTabButton() = shareTabButton()
+    .check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 private fun shareButton() = onView(allOf(withText("Share")))
 private fun assertShareButton() = shareButton()
     .check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

<!-- To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts". -->
