### PR TITLE
For #5279 - Don't use runBlocking in delete and quit

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/utils/DeleteAndQuit.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/DeleteAndQuit.kt
@@ -8,7 +8,6 @@ import android.content.Context
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import org.mozilla.fenix.ext.asActivity
 import org.mozilla.fenix.settings.DefaultDeleteBrowsingDataController
 
@@ -17,7 +16,7 @@ import org.mozilla.fenix.settings.DefaultDeleteBrowsingDataController
  */
 fun Context.deleteAndQuit(coroutineScope: CoroutineScope) {
     coroutineScope.launch {
-        runBlocking {
+        launch {
             val controller =
                 DefaultDeleteBrowsingDataController(this@deleteAndQuit, coroutineContext)
             if (Settings.getInstance(this@deleteAndQuit).deleteCacheOnQuit) {
@@ -37,7 +36,6 @@ fun Context.deleteAndQuit(coroutineScope: CoroutineScope) {
             if (Settings.getInstance(this@deleteAndQuit).deleteHistoryOnQuit) {
                 controller.deleteHistoryAndDOMStorages()
             }
-        }
-        this@deleteAndQuit.asActivity()?.finish()
+        }.invokeOnCompletion { this@deleteAndQuit.asActivity()?.finish() }
     }
 }


### PR DESCRIPTION
This fixes the ANR but if the deletion takes a long time there's no feedback mechanism. I will file a followup issue about adding a progress bar or something


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

<!-- To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts". -->
