### PR TITLE
For #5277: Pass app name to delete browsing data prompt

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/DeleteBrowsingDataFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/DeleteBrowsingDataFragment.kt
@@ -94,7 +94,12 @@ class DeleteBrowsingDataFragment : Fragment() {
     private fun askToDelete() {
         context?.let {
             AlertDialog.Builder(it).apply {
-                setMessage(R.string.delete_browsing_data_prompt_message_3)
+                setMessage(
+                    it.getString(
+                        R.string.delete_browsing_data_prompt_message_3,
+                        it.getString(R.string.app_name)
+                    )
+                )
 
                 setNegativeButton(R.string.delete_browsing_data_prompt_cancel) { it: DialogInterface, _ ->
                     it.cancel()


### PR DESCRIPTION
Follow up of #5309 

Without this PR the placeholder (%s) is shown.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

<!-- To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts". -->
