### PR TITLE
Separates tracker bucket sorting code

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackerBuckets.kt
+++ b/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackerBuckets.kt
@@ -1,0 +1,81 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.trackingprotection
+
+import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy.TrackingCategory.AD
+import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy.TrackingCategory.ANALYTICS
+import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy.TrackingCategory.CRYPTOMINING
+import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy.TrackingCategory.FINGERPRINTING
+import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy.TrackingCategory.SOCIAL
+import mozilla.components.concept.engine.content.blocking.Tracker
+import org.mozilla.fenix.ext.getHostFromUrl
+import org.mozilla.fenix.trackingprotection.TrackingProtectionCategory.CRYPTOMINERS
+import org.mozilla.fenix.trackingprotection.TrackingProtectionCategory.FINGERPRINTERS
+import org.mozilla.fenix.trackingprotection.TrackingProtectionCategory.SOCIAL_MEDIA_TRACKERS
+import org.mozilla.fenix.trackingprotection.TrackingProtectionCategory.TRACKING_CONTENT
+import java.util.EnumMap
+
+/**
+ * Sorts [Tracker]s into different buckets and exposes them as a map.
+ */
+class TrackerBuckets {
+
+    private var trackers = emptyList<Tracker>()
+    var buckets = emptyMap<TrackingProtectionCategory, List<String>>()
+        private set
+
+    /**
+     * If [newTrackers] has changed since the last call,
+     * update [buckets] based on the new trackers list.
+     */
+    fun updateIfNeeded(newTrackers: List<Tracker>) {
+        if (newTrackers != trackers) {
+            trackers = newTrackers
+            buckets = putTrackersInBuckets(newTrackers)
+        }
+    }
+
+    /**
+     * Returns true if there are no trackers.
+     */
+    fun isEmpty() = buckets.isEmpty()
+
+    /**
+     * Gets the tracker URLs for a given category.
+     */
+    operator fun get(key: TrackingProtectionCategory) = buckets[key].orEmpty()
+
+    companion object {
+
+        private fun putTrackersInBuckets(
+            list: List<Tracker>
+        ): Map<TrackingProtectionCategory, List<String>> {
+            val map = EnumMap<TrackingProtectionCategory, List<String>>(TrackingProtectionCategory::class.java)
+            for (item in list) {
+                when {
+                    CRYPTOMINING in item.trackingCategories -> {
+                        map[CRYPTOMINERS] = map[CRYPTOMINERS].orEmpty() +
+                                (item.url.getHostFromUrl() ?: item.url)
+                    }
+                    FINGERPRINTING in item.trackingCategories -> {
+                        map[FINGERPRINTERS] = map[FINGERPRINTERS].orEmpty() +
+                                (item.url.getHostFromUrl() ?: item.url)
+                    }
+                    SOCIAL in item.trackingCategories -> {
+                        map[SOCIAL_MEDIA_TRACKERS] = map[SOCIAL_MEDIA_TRACKERS].orEmpty() +
+                                (item.url.getHostFromUrl() ?: item.url)
+                    }
+                    AD in item.trackingCategories ||
+                            SOCIAL in item.trackingCategories ||
+                            ANALYTICS in item.trackingCategories -> {
+                        map[TRACKING_CONTENT] = map[TRACKING_CONTENT].orEmpty() +
+                                (item.url.getHostFromUrl() ?: item.url)
+                    }
+                }
+            }
+            return map
+        }
+    }
+}

--- a/app/src/test/java/org/mozilla/fenix/trackingprotection/TrackerBucketsTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/trackingprotection/TrackerBucketsTest.kt
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.trackingprotection
+
+import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy.TrackingCategory.AD
+import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy.TrackingCategory.FINGERPRINTING
+import mozilla.components.concept.engine.content.blocking.Tracker
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mozilla.fenix.trackingprotection.TrackingProtectionCategory.CRYPTOMINERS
+import org.mozilla.fenix.trackingprotection.TrackingProtectionCategory.FINGERPRINTERS
+import org.mozilla.fenix.trackingprotection.TrackingProtectionCategory.TRACKING_CONTENT
+
+class TrackerBucketsTest {
+
+    @Test
+    fun `initializes with empty map`() {
+        assertTrue(TrackerBuckets().isEmpty())
+        assertTrue(TrackerBuckets().buckets.isEmpty())
+    }
+
+    @Test
+    fun `getter accesses corresponding bucket`() {
+        val buckets = TrackerBuckets()
+        buckets.updateIfNeeded(listOf(
+            Tracker("http://facebook.com", listOf(FINGERPRINTING, AD)),
+            Tracker("https://google.com", listOf(AD)),
+            Tracker("https://mozilla.com")
+        ))
+
+        assertEquals(listOf("google.com"), buckets[TRACKING_CONTENT])
+        assertEquals(listOf("facebook.com"), buckets[FINGERPRINTERS])
+        assertEquals(emptyList<String>(), buckets[CRYPTOMINERS])
+    }
+
+    @Test
+    fun `sorts trackers into bucket`() {
+        val buckets = TrackerBuckets()
+        buckets.updateIfNeeded(listOf(
+            Tracker("http://facebook.com", listOf(FINGERPRINTING, AD)),
+            Tracker("https://google.com", listOf(AD)),
+            Tracker("https://mozilla.com")
+        ))
+
+        assertEquals(mapOf(
+            TRACKING_CONTENT to listOf("google.com"),
+            FINGERPRINTERS to listOf("facebook.com")
+        ), buckets.buckets)
+    }
+}


### PR DESCRIPTION
- Added `TrackerBuckets` to handle logic of putting blocked trackers into different buckets. 
- Changed the backing map from `HashMap` to `EnumMap`.
- Saved some memory by sharing a click listener across the different buttons.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

<!-- To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts". -->
