### PR TITLE
Move settings classes to packages

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt
@@ -30,7 +30,7 @@ import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.toTab
 import org.mozilla.fenix.lib.Do
 import org.mozilla.fenix.quickactionsheet.QuickActionSheetBehavior
-import org.mozilla.fenix.utils.deleteAndQuit
+import org.mozilla.fenix.settings.deletebrowsingdata.deleteAndQuit
 
 /**
  * An interface that handles the view manipulation of the BrowserToolbar, triggered by the Interactor

--- a/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
@@ -64,6 +64,8 @@ import org.mozilla.fenix.ext.getPreferenceKey
 import org.mozilla.fenix.ext.metrics
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.settings.account.AccountAuthErrorPreference
+import org.mozilla.fenix.settings.account.AccountPreference
 import org.mozilla.fenix.utils.ItsNotBrokenSnack
 
 @SuppressWarnings("TooManyFunctions", "LargeClass")

--- a/app/src/main/java/org/mozilla/fenix/settings/account/AccountAuthErrorPreference.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/account/AccountAuthErrorPreference.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.fenix.settings
+package org.mozilla.fenix.settings.account
 
 import android.content.Context
 import android.util.AttributeSet

--- a/app/src/main/java/org/mozilla/fenix/settings/account/AccountPreference.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/account/AccountPreference.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.fenix.settings
+package org.mozilla.fenix.settings.account
 
 import android.content.Context
 import android.util.AttributeSet

--- a/app/src/main/java/org/mozilla/fenix/settings/account/AccountProblemFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/account/AccountProblemFragment.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.fenix.settings
+package org.mozilla.fenix.settings.account
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity

--- a/app/src/main/java/org/mozilla/fenix/settings/account/SignOutFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/account/SignOutFragment.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.fenix.settings
+package org.mozilla.fenix.settings.account
 
 import android.app.Dialog
 import android.os.Bundle

--- a/app/src/main/java/org/mozilla/fenix/settings/account/TurnOnSyncFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/account/TurnOnSyncFragment.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.fenix.settings
+package org.mozilla.fenix.settings.account
 
 import android.os.Bundle
 import android.view.LayoutInflater

--- a/app/src/main/java/org/mozilla/fenix/settings/deletebrowsingdata/DeleteAndQuit.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/deletebrowsingdata/DeleteAndQuit.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.fenix.utils
+package org.mozilla.fenix.settings.deletebrowsingdata
 
 import android.app.Activity
 import kotlinx.coroutines.CoroutineScope
@@ -11,9 +11,6 @@ import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.mozilla.fenix.ext.settings
-import org.mozilla.fenix.settings.DefaultDeleteBrowsingDataController
-import org.mozilla.fenix.settings.DeleteBrowsingDataController
-import org.mozilla.fenix.settings.DeleteBrowsingDataOnQuitType
 
 /**
  * Deletes selected browsing data and finishes the activity.

--- a/app/src/main/java/org/mozilla/fenix/settings/deletebrowsingdata/DeleteBrowsingDataController.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/deletebrowsingdata/DeleteBrowsingDataController.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.fenix.settings
+package org.mozilla.fenix.settings.deletebrowsingdata
 
 import android.content.Context
 import kotlinx.coroutines.Dispatchers

--- a/app/src/main/java/org/mozilla/fenix/settings/deletebrowsingdata/DeleteBrowsingDataFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/deletebrowsingdata/DeleteBrowsingDataFragment.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.fenix.settings
+package org.mozilla.fenix.settings.deletebrowsingdata
 
 import android.content.DialogInterface
 import android.os.Bundle
@@ -44,7 +44,7 @@ class DeleteBrowsingDataFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        controller = DefaultDeleteBrowsingDataController(context!!)
+        controller = DefaultDeleteBrowsingDataController(requireContext())
 
         sessionObserver = object : SessionManager.Observer {
             override fun onSessionAdded(session: Session) = updateTabCount()

--- a/app/src/main/java/org/mozilla/fenix/settings/deletebrowsingdata/DeleteBrowsingDataItem.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/deletebrowsingdata/DeleteBrowsingDataItem.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.fenix.settings
+package org.mozilla.fenix.settings.deletebrowsingdata
 
 import android.content.Context
 import android.util.AttributeSet

--- a/app/src/main/java/org/mozilla/fenix/settings/deletebrowsingdata/DeleteBrowsingDataOnQuitFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/deletebrowsingdata/DeleteBrowsingDataOnQuitFragment.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.fenix.settings
+package org.mozilla.fenix.settings.deletebrowsingdata
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
@@ -13,6 +13,7 @@ import androidx.preference.SwitchPreference
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.getPreferenceKey
 import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.settings.SharedPreferenceUpdater
 
 class DeleteBrowsingDataOnQuitFragment : PreferenceFragmentCompat() {
 

--- a/app/src/main/java/org/mozilla/fenix/settings/deletebrowsingdata/DeleteBrowsingDataOnQuitType.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/deletebrowsingdata/DeleteBrowsingDataOnQuitType.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.fenix.settings
+package org.mozilla.fenix.settings.deletebrowsingdata
 
 import android.content.Context
 import androidx.annotation.StringRes

--- a/app/src/main/java/org/mozilla/fenix/settings/search/RadioSearchEngineListPreference.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/search/RadioSearchEngineListPreference.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.fenix.settings
+package org.mozilla.fenix.settings.search
 
 import android.content.Context
 import android.util.AttributeSet

--- a/app/src/main/java/org/mozilla/fenix/settings/search/SearchEngineFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/search/SearchEngineFragment.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.fenix.settings
+package org.mozilla.fenix.settings.search
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
@@ -11,6 +11,7 @@ import androidx.preference.SwitchPreference
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.getPreferenceKey
 import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.settings.SharedPreferenceUpdater
 
 class SearchEngineFragment : PreferenceFragmentCompat() {
 

--- a/app/src/main/java/org/mozilla/fenix/settings/search/SearchEngineListPreference.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/search/SearchEngineListPreference.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.fenix.settings
+package org.mozilla.fenix.settings.search
 
 import android.content.Context
 import android.content.res.Resources

--- a/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsDetailsExceptionsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsDetailsExceptionsFragment.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.fenix.settings
+package org.mozilla.fenix.settings.sitepermissions
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
@@ -20,6 +20,7 @@ import org.jetbrains.anko.yesButton
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.getPreferenceKey
+import org.mozilla.fenix.settings.PhoneFeature
 import org.mozilla.fenix.settings.PhoneFeature.CAMERA
 import org.mozilla.fenix.settings.PhoneFeature.LOCATION
 import org.mozilla.fenix.settings.PhoneFeature.MICROPHONE

--- a/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsExceptionsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsExceptionsFragment.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.fenix.settings
+package org.mozilla.fenix.settings.sitepermissions
 
 import android.os.Bundle
 import android.view.LayoutInflater

--- a/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsFragment.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.fenix.settings
+package org.mozilla.fenix.settings.sitepermissions
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
@@ -13,6 +13,7 @@ import androidx.preference.PreferenceFragmentCompat
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.getPreferenceKey
 import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.settings.PhoneFeature
 
 @SuppressWarnings("TooManyFunctions")
 class SitePermissionsFragment : PreferenceFragmentCompat() {
@@ -69,7 +70,8 @@ class SitePermissionsFragment : PreferenceFragmentCompat() {
     }
 
     private fun navigateToPhoneFeature(phoneFeature: PhoneFeature) {
-        val directions = SitePermissionsFragmentDirections.actionSitePermissionsToManagePhoneFeatures(phoneFeature.id)
+        val directions = SitePermissionsFragmentDirections
+            .actionSitePermissionsToManagePhoneFeatures(phoneFeature.id)
         Navigation.findNavController(view!!).navigate(directions)
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsManageExceptionsPhoneFeatureFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsManageExceptionsPhoneFeatureFragment.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.fenix.settings
+package org.mozilla.fenix.settings.sitepermissions
 
 import android.content.Intent
 import android.net.Uri
@@ -27,6 +27,9 @@ import org.jetbrains.anko.yesButton
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.settings.PhoneFeature
+import org.mozilla.fenix.settings.initBlockedByAndroidView
+import org.mozilla.fenix.settings.setStartCheckedIndicator
 
 @SuppressWarnings("TooManyFunctions")
 class SitePermissionsManageExceptionsPhoneFeatureFragment : Fragment() {

--- a/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsManagePhoneFeatureFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsManagePhoneFeatureFragment.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.fenix.settings
+package org.mozilla.fenix.settings.sitepermissions
 
 import android.content.Intent
 import android.graphics.Color
@@ -27,6 +27,9 @@ import mozilla.components.feature.sitepermissions.SitePermissionsRules.Action.BL
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.settings.PhoneFeature
+import org.mozilla.fenix.settings.initBlockedByAndroidView
+import org.mozilla.fenix.settings.setStartCheckedIndicator
 import org.mozilla.fenix.utils.Settings
 
 @SuppressWarnings("TooManyFunctions")

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -22,7 +22,7 @@ import org.mozilla.fenix.Config
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.metrics.MozillaProductDetector
 import org.mozilla.fenix.ext.getPreferenceKey
-import org.mozilla.fenix.settings.DeleteBrowsingDataOnQuitType
+import org.mozilla.fenix.settings.deletebrowsingdata.DeleteBrowsingDataOnQuitType
 import org.mozilla.fenix.settings.PhoneFeature
 import java.security.InvalidParameterException
 

--- a/app/src/main/res/layout/fragment_delete_browsing_data.xml
+++ b/app/src/main/res/layout/fragment_delete_browsing_data.xml
@@ -29,7 +29,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical">
-            <org.mozilla.fenix.settings.DeleteBrowsingDataItem
+            <org.mozilla.fenix.settings.deletebrowsingdata.DeleteBrowsingDataItem
                 android:id="@+id/open_tabs_item"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -40,7 +40,7 @@
                 android:focusable="true"
                 app:deleteBrowsingDataItemTitle="@string/preferences_delete_browsing_data_tabs_title"
                 app:deleteBrowsingDataItemSubtitle="@string/preferences_delete_browsing_data_tabs_subtitle" />
-            <org.mozilla.fenix.settings.DeleteBrowsingDataItem
+            <org.mozilla.fenix.settings.deletebrowsingdata.DeleteBrowsingDataItem
                 android:id="@+id/browsing_data_item"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -51,7 +51,7 @@
                 android:focusable="true"
                 app:deleteBrowsingDataItemTitle="@string/preferences_delete_browsing_data_browsing_data_title"
                 app:deleteBrowsingDataItemSubtitle="@string/preferences_delete_browsing_data_browsing_data_subtitle" />
-            <org.mozilla.fenix.settings.DeleteBrowsingDataItem
+            <org.mozilla.fenix.settings.deletebrowsingdata.DeleteBrowsingDataItem
                 android:id="@+id/collections_item"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -62,7 +62,7 @@
                 android:focusable="true"
                 app:deleteBrowsingDataItemTitle="@string/preferences_delete_browsing_data_collections_title"
                 app:deleteBrowsingDataItemSubtitle="@string/preferences_delete_browsing_data_collections_subtitle" />
-            <org.mozilla.fenix.settings.DeleteBrowsingDataItem
+            <org.mozilla.fenix.settings.deletebrowsingdata.DeleteBrowsingDataItem
                 android:id="@+id/cookies_item"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -74,7 +74,7 @@
                 android:visibility="gone"
                 app:deleteBrowsingDataItemTitle="@string/preferences_delete_browsing_data_cookies"
                 app:deleteBrowsingDataItemSubtitle="@string/preferences_delete_browsing_data_cookies_subtitle" />
-            <org.mozilla.fenix.settings.DeleteBrowsingDataItem
+            <org.mozilla.fenix.settings.deletebrowsingdata.DeleteBrowsingDataItem
                 android:id="@+id/cached_files_item"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -86,7 +86,7 @@
                 android:visibility="gone"
                 app:deleteBrowsingDataItemTitle="@string/preferences_delete_browsing_data_cached_files"
                 app:deleteBrowsingDataItemSubtitle="@string/preferences_delete_browsing_data_cached_files_subtitle" />
-            <org.mozilla.fenix.settings.DeleteBrowsingDataItem
+            <org.mozilla.fenix.settings.deletebrowsingdata.DeleteBrowsingDataItem
                 android:id="@+id/site_permissions_item"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -115,7 +115,7 @@
 
     <fragment
         android:id="@+id/SitePermissionsManagePhoneFeature"
-        android:name="org.mozilla.fenix.settings.SitePermissionsManagePhoneFeatureFragment"
+        android:name="org.mozilla.fenix.settings.sitepermissions.SitePermissionsManagePhoneFeatureFragment"
         tools:layout="@layout/fragment_manage_site_permissions_feature_phone">
         <argument
             android:name="permission"
@@ -124,7 +124,7 @@
 
     <fragment
         android:id="@+id/sitePermissionsExceptionsFragment"
-        android:name="org.mozilla.fenix.settings.SitePermissionsExceptionsFragment"
+        android:name="org.mozilla.fenix.settings.sitepermissions.SitePermissionsExceptionsFragment"
         android:label="@string/preference_exceptions"
         tools:layout="@layout/fragment_site_permissions_exceptions">
         <action
@@ -135,7 +135,7 @@
 
     <fragment
         android:id="@+id/sitePermissionsDetailsExceptionsFragment"
-        android:name="org.mozilla.fenix.settings.SitePermissionsDetailsExceptionsFragment"
+        android:name="org.mozilla.fenix.settings.sitepermissions.SitePermissionsDetailsExceptionsFragment"
         tools:layout="@xml/site_permissions_details_exceptions_preferences">
         <action
             android:id="@+id/action_site_permissions_to_exceptions_to_manage_phone_feature"
@@ -148,7 +148,7 @@
 
     <fragment
         android:id="@+id/sitePermissionsManageExceptionsPhoneFeatureFragment"
-        android:name="org.mozilla.fenix.settings.SitePermissionsManageExceptionsPhoneFeatureFragment"
+        android:name="org.mozilla.fenix.settings.sitepermissions.SitePermissionsManageExceptionsPhoneFeatureFragment"
         tools:layout="@layout/fragment_manage_site_permissions_feature_phone">
         <argument
             android:name="phoneFeatureId"
@@ -372,7 +372,7 @@
         android:label="@string/preferences_data_choices" />
     <fragment
         android:id="@+id/sitePermissionsFragment"
-        android:name="org.mozilla.fenix.settings.SitePermissionsFragment"
+        android:name="org.mozilla.fenix.settings.sitepermissions.SitePermissionsFragment"
         android:label="@string/preferences_site_permissions">
         <action
             android:id="@+id/action_site_permissions_to_manage_phone_features"
@@ -398,12 +398,12 @@
     </fragment>
     <fragment
         android:id="@+id/searchEngineFragment"
-        android:name="org.mozilla.fenix.settings.SearchEngineFragment"
+        android:name="org.mozilla.fenix.settings.search.SearchEngineFragment"
         android:label="@string/preferences_search" />
 
     <fragment
         android:id="@+id/turnOnSyncFragment"
-        android:name="org.mozilla.fenix.settings.TurnOnSyncFragment"
+        android:name="org.mozilla.fenix.settings.account.TurnOnSyncFragment"
         android:label="@string/preferences_sync">
         <action
             android:id="@+id/action_turnOnSyncFragment_to_pairFragment"
@@ -455,7 +455,7 @@
     </fragment>
     <fragment
         android:id="@+id/deleteBrowsingDataFragment"
-        android:name="org.mozilla.fenix.settings.DeleteBrowsingDataFragment"
+        android:name="org.mozilla.fenix.settings.deletebrowsingdata.DeleteBrowsingDataFragment"
         android:label="@string/preferences_delete_browsing_data" />
     <fragment
         android:id="@+id/exceptionsFragment"
@@ -540,14 +540,14 @@
     </dialog>
     <fragment
         android:id="@+id/accountProblemFragment"
-        android:name="org.mozilla.fenix.settings.AccountProblemFragment">
+        android:name="org.mozilla.fenix.settings.account.AccountProblemFragment">
         <action
             android:id="@+id/action_accountProblemFragment_to_signOutFragment"
             app:destination="@id/signOutFragment" />
     </fragment>
     <dialog
         android:id="@+id/signOutFragment"
-        android:name="org.mozilla.fenix.settings.SignOutFragment" />
+        android:name="org.mozilla.fenix.settings.account.SignOutFragment" />
     <action
         android:id="@+id/action_global_shareFragment"
         app:destination="@id/shareFragment" />
@@ -582,7 +582,7 @@
     </fragment>
     <fragment
         android:id="@+id/deleteBrowsingDataOnQuitFragment"
-        android:name="org.mozilla.fenix.settings.DeleteBrowsingDataOnQuitFragment"
+        android:name="org.mozilla.fenix.settings.deletebrowsingdata.DeleteBrowsingDataOnQuitFragment"
         android:label="DeleteBrowsingDataOnQuitFragment" />
 
     <fragment

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -19,11 +19,11 @@
         app:iconSpaceReserved="false"
         app:isPreferenceVisible="false">
 
-        <org.mozilla.fenix.settings.AccountPreference
+        <org.mozilla.fenix.settings.account.AccountPreference
             android:icon="@drawable/ic_account"
             android:key="@string/pref_key_account" />
 
-        <org.mozilla.fenix.settings.AccountAuthErrorPreference
+        <org.mozilla.fenix.settings.account.AccountAuthErrorPreference
             android:icon="@drawable/ic_account_warning"
             android:key="@string/pref_key_account_auth_error"/>
     </androidx.preference.PreferenceCategory>

--- a/app/src/main/res/xml/search_engine_preferences.xml
+++ b/app/src/main/res/xml/search_engine_preferences.xml
@@ -9,7 +9,7 @@
         android:title="@string/preferences_default_search_engine"
         android:selectable="false"
         app:iconSpaceReserved="false">
-        <org.mozilla.fenix.settings.RadioSearchEngineListPreference
+        <org.mozilla.fenix.settings.search.RadioSearchEngineListPreference
             android:selectable="false"/>
         <SwitchPreference
             android:defaultValue="true"

--- a/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarControllerTest.kt
@@ -47,7 +47,7 @@ import org.mozilla.fenix.ext.toTab
 import org.mozilla.fenix.home.sessioncontrol.Tab
 import org.mozilla.fenix.home.sessioncontrol.TabCollection
 import org.mozilla.fenix.quickactionsheet.QuickActionSheetBehavior
-import org.mozilla.fenix.utils.deleteAndQuit
+import org.mozilla.fenix.settings.deletebrowsingdata.deleteAndQuit
 
 @ExperimentalCoroutinesApi
 @ObsoleteCoroutinesApi
@@ -98,7 +98,7 @@ class DefaultBrowserToolbarControllerTest {
         every { any<Session>().toTab(any()) } returns currentSessionAsTab
 
         mockkStatic(
-            "org.mozilla.fenix.utils.DeleteAndQuitKt"
+            "org.mozilla.fenix.settings.deletebrowsingdata.DeleteAndQuitKt"
         )
         every { deleteAndQuit(any(), any()) } just Runs
 

--- a/app/src/test/java/org/mozilla/fenix/settings/account/AccountSettingsFragmentStoreTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/account/AccountSettingsFragmentStoreTest.kt
@@ -2,16 +2,12 @@
    License, v. 2.0. If a copy of the MPL was not distributed with this
    file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.fenix.settings
+package org.mozilla.fenix.settings.account
 
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotSame
 import org.junit.Test
-import org.mozilla.fenix.settings.account.AccountSettingsFragmentAction
-import org.mozilla.fenix.settings.account.AccountSettingsFragmentState
-import org.mozilla.fenix.settings.account.AccountSettingsFragmentStore
-import org.mozilla.fenix.settings.account.LastSyncTime
 
 class AccountSettingsFragmentStoreTest {
 

--- a/app/src/test/java/org/mozilla/fenix/settings/account/AccountSettingsInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/account/AccountSettingsInteractorTest.kt
@@ -2,7 +2,7 @@
    License, v. 2.0. If a copy of the MPL was not distributed with this
    file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.fenix.settings
+package org.mozilla.fenix.settings.account
 
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination
@@ -12,10 +12,6 @@ import io.mockk.verify
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.mozilla.fenix.R
-import org.mozilla.fenix.settings.account.AccountSettingsFragmentAction
-import org.mozilla.fenix.settings.account.AccountSettingsFragmentDirections
-import org.mozilla.fenix.settings.account.AccountSettingsInteractor
-import org.mozilla.fenix.settings.account.AccountSettingsFragmentStore
 
 class AccountSettingsInteractorTest {
 

--- a/app/src/test/java/org/mozilla/fenix/settings/deletebrowsingdata/DefaultDeleteBrowsingDataControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/deletebrowsingdata/DefaultDeleteBrowsingDataControllerTest.kt
@@ -2,7 +2,7 @@
  *  License, v. 2.0. If a copy of the MPL was not distributed with this
  *  file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.fenix.settings
+package org.mozilla.fenix.settings.deletebrowsingdata
 
 import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/app/src/test/java/org/mozilla/fenix/settings/deletebrowsingdata/DeleteAndQuitTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/deletebrowsingdata/DeleteAndQuitTest.kt
@@ -4,7 +4,7 @@
 
 @file:Suppress("DEPRECATION")
 
-package org.mozilla.fenix.utils
+package org.mozilla.fenix.settings.deletebrowsingdata
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.mockk.every
@@ -30,7 +30,7 @@ import org.mozilla.fenix.TestApplication
 import org.mozilla.fenix.components.PermissionStorage
 import org.mozilla.fenix.ext.clearAndCommit
 import org.mozilla.fenix.ext.components
-import org.mozilla.fenix.settings.DeleteBrowsingDataOnQuitType
+import org.mozilla.fenix.utils.Settings
 import org.robolectric.annotation.Config
 
 @ObsoleteCoroutinesApi

--- a/app/src/test/java/org/mozilla/fenix/utils/SettingsTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/utils/SettingsTest.kt
@@ -19,7 +19,7 @@ import org.junit.runner.RunWith
 import org.mozilla.fenix.TestApplication
 import org.mozilla.fenix.ext.clearAndCommit
 import org.mozilla.fenix.ext.settings
-import org.mozilla.fenix.settings.DeleteBrowsingDataOnQuitType
+import org.mozilla.fenix.settings.deletebrowsingdata.DeleteBrowsingDataOnQuitType
 import org.mozilla.fenix.settings.PhoneFeature
 import org.robolectric.annotation.Config
 


### PR DESCRIPTION
Cleans up the settings folder a little bit by moving classes to subfolders.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

<!-- To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts". -->
