### PR TITLE
Use enum to simplify delete on quit code

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/DeleteBrowsingDataController.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/DeleteBrowsingDataController.kt
@@ -17,6 +17,7 @@ import kotlin.coroutines.CoroutineContext
 interface DeleteBrowsingDataController {
     suspend fun deleteTabs()
     suspend fun deleteBrowsingData()
+    suspend fun deleteHistoryAndDOMStorages()
     suspend fun deleteCollections(collections: List<TabCollection>)
     suspend fun deleteCookies()
     suspend fun deleteCachedFiles()
@@ -27,6 +28,7 @@ class DefaultDeleteBrowsingDataController(
     val context: Context,
     val coroutineContext: CoroutineContext = Dispatchers.Main
 ) : DeleteBrowsingDataController {
+
     override suspend fun deleteTabs() {
         withContext(coroutineContext) {
             context.components.useCases.tabsUseCases.removeAllTabs.invoke()
@@ -44,7 +46,7 @@ class DefaultDeleteBrowsingDataController(
         }
     }
 
-    suspend fun deleteHistoryAndDOMStorages() {
+    override suspend fun deleteHistoryAndDOMStorages() {
         withContext(coroutineContext) {
             context.components.core.engine.clearData(Engine.BrowsingData.select(Engine.BrowsingData.DOM_STORAGES))
         }

--- a/app/src/main/java/org/mozilla/fenix/settings/DeleteBrowsingDataOnQuitFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/DeleteBrowsingDataOnQuitFragment.kt
@@ -12,9 +12,22 @@ import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreference
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.getPreferenceKey
-import org.mozilla.fenix.utils.Settings
+import org.mozilla.fenix.ext.settings
 
 class DeleteBrowsingDataOnQuitFragment : PreferenceFragmentCompat() {
+
+    private val checkboxes by lazy {
+        val context = requireContext()
+        DeleteBrowsingDataOnQuitType.values()
+            .asSequence()
+            .mapNotNull { type ->
+                findPreference<CheckBoxPreference>(type.getPreferenceKey(context))?.let { pref ->
+                    type to pref
+                }
+            }
+            .toMap()
+    }
+
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         setPreferencesFromResource(R.xml.delete_browsing_data_quit_preferences, rootKey)
     }
@@ -25,81 +38,42 @@ class DeleteBrowsingDataOnQuitFragment : PreferenceFragmentCompat() {
         activity?.title = getString(R.string.preferences_delete_browsing_data_on_quit)
         (activity as AppCompatActivity).supportActionBar?.show()
 
+        // Delete Browsing Data on Quit Switch
+        val deleteOnQuitPref = findPreference<SwitchPreference>(
+            getPreferenceKey(R.string.pref_key_delete_browsing_data_on_quit)
+        )
+        deleteOnQuitPref?.apply {
+            onPreferenceChangeListener = object : SharedPreferenceUpdater() {
+                override fun onPreferenceChange(preference: Preference, newValue: Any?): Boolean {
+                    setAllCheckboxes(newValue as Boolean)
+                    return super.onPreferenceChange(preference, newValue)
+                }
+            }
+            isChecked = context.settings().shouldDeleteBrowsingDataOnQuit
+        }
+
         val checkboxUpdater = object : SharedPreferenceUpdater() {
             override fun onPreferenceChange(preference: Preference, newValue: Any?): Boolean {
                 super.onPreferenceChange(preference, newValue)
-                if (!Settings.getInstance(preference.context).shouldDeleteAnyDataOnQuit()) {
-                    findPreference<SwitchPreference>(
-                        getPreferenceKey(R.string.pref_key_delete_browsing_data_on_quit)
-                    )?.apply {
-                        isChecked = false
-                    }
-                    Settings.getInstance(preference.context).preferences.edit().putBoolean(
-                        getString(R.string.pref_key_delete_browsing_data_on_quit),
-                        false
-                    ).apply()
+                val settings = preference.context.settings()
+
+                if (!settings.shouldDeleteAnyDataOnQuit()) {
+                    deleteOnQuitPref?.isChecked = false
+                    settings.shouldDeleteBrowsingDataOnQuit = false
                 }
                 return true
             }
         }
 
-        val switchUpdater = object : SharedPreferenceUpdater() {
-            override fun onPreferenceChange(preference: Preference, newValue: Any?): Boolean {
-                setAllCheckboxes(newValue as Boolean)
-                return super.onPreferenceChange(preference, newValue)
-            }
-        }
-
-        findPreference<CheckBoxPreference>(getPreferenceKey(R.string.pref_key_delete_open_tabs_on_quit))?.apply {
-            onPreferenceChangeListener = checkboxUpdater
-        }
-        findPreference<CheckBoxPreference>(getPreferenceKey(R.string.pref_key_delete_browsing_history_on_quit))?.apply {
-            onPreferenceChangeListener = checkboxUpdater
-        }
-        findPreference<CheckBoxPreference>(getPreferenceKey(R.string.pref_key_delete_caches_on_quit))?.apply {
-            onPreferenceChangeListener = checkboxUpdater
-        }
-        findPreference<CheckBoxPreference>(getPreferenceKey(R.string.pref_key_delete_permissions_on_quit))?.apply {
-            onPreferenceChangeListener = checkboxUpdater
-        }
-        findPreference<CheckBoxPreference>(getPreferenceKey(R.string.pref_key_delete_cookies_on_quit))?.apply {
-            onPreferenceChangeListener = checkboxUpdater
-        }
-
-        // Delete Browsing Data on Quit Switch
-        val deleteOnQuitKey = getPreferenceKey(R.string.pref_key_delete_browsing_data_on_quit)
-        findPreference<SwitchPreference>(deleteOnQuitKey)?.apply {
-            onPreferenceChangeListener = switchUpdater
-            isChecked = Settings.getInstance(context!!).shouldDeleteBrowsingDataOnQuit
+        checkboxes.forEach { (_, pref) ->
+            pref.onPreferenceChangeListener = checkboxUpdater
         }
     }
 
     private fun setAllCheckboxes(newValue: Boolean) {
-        val openTabs =
-            findPreference<CheckBoxPreference>(getPreferenceKey(R.string.pref_key_delete_open_tabs_on_quit))
-        val history =
-            findPreference<CheckBoxPreference>(getPreferenceKey(R.string.pref_key_delete_browsing_history_on_quit))
-        val cache =
-            findPreference<CheckBoxPreference>(getPreferenceKey(R.string.pref_key_delete_caches_on_quit))
-        val permissions =
-            findPreference<CheckBoxPreference>(getPreferenceKey(R.string.pref_key_delete_permissions_on_quit))
-        val cookies =
-            findPreference<CheckBoxPreference>(getPreferenceKey(R.string.pref_key_delete_cookies_on_quit))
-
-        openTabs?.isChecked = newValue
-        history?.isChecked = newValue
-        cache?.isChecked = newValue
-        permissions?.isChecked = newValue
-        cookies?.isChecked = newValue
-
-        Settings.getInstance(context!!).preferences.edit().putBoolean(openTabs?.key, newValue)
-            .apply()
-        Settings.getInstance(context!!).preferences.edit().putBoolean(history?.key, newValue)
-            .apply()
-        Settings.getInstance(context!!).preferences.edit().putBoolean(cache?.key, newValue).apply()
-        Settings.getInstance(context!!).preferences.edit().putBoolean(permissions?.key, newValue)
-            .apply()
-        Settings.getInstance(context!!).preferences.edit().putBoolean(cookies?.key, newValue)
-            .apply()
+        checkboxes.forEach { (type, pref) ->
+            pref.isChecked = newValue
+            pref.context.settings().setDeleteDataOnQuit(type, newValue)
+        }
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/settings/DeleteBrowsingDataOnQuitType.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/DeleteBrowsingDataOnQuitType.kt
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.settings
+
+import android.content.Context
+import androidx.annotation.StringRes
+import org.mozilla.fenix.R
+import org.mozilla.fenix.ext.getPreferenceKey
+
+enum class DeleteBrowsingDataOnQuitType(@StringRes private val prefKey: Int) {
+    TABS(R.string.pref_key_delete_open_tabs_on_quit),
+    HISTORY(R.string.pref_key_delete_browsing_history_on_quit),
+    COOKIES(R.string.pref_key_delete_cookies_on_quit),
+    CACHE(R.string.pref_key_delete_caches_on_quit),
+    PERMISSIONS(R.string.pref_key_delete_permissions_on_quit);
+
+    fun getPreferenceKey(context: Context) = context.getPreferenceKey(prefKey)
+}

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -21,6 +21,7 @@ import org.mozilla.fenix.Config
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.metrics.MozillaProductDetector
 import org.mozilla.fenix.ext.getPreferenceKey
+import org.mozilla.fenix.settings.DeleteBrowsingDataOnQuitType
 import org.mozilla.fenix.settings.PhoneFeature
 import java.security.InvalidParameterException
 
@@ -174,38 +175,15 @@ class Settings private constructor(
         default = false
     )
 
-    var deleteTabsOnQuit by booleanPreference(
-        appContext.getPreferenceKey(R.string.pref_key_delete_open_tabs_on_quit),
-        default = false
-    )
+    fun getDeleteDataOnQuit(type: DeleteBrowsingDataOnQuitType): Boolean =
+        preferences.getBoolean(type.getPreferenceKey(appContext), false)
 
-    var deleteHistoryOnQuit by booleanPreference(
-        appContext.getPreferenceKey(R.string.pref_key_delete_browsing_history_on_quit),
-        default = false
-    )
-
-    var deleteCookiesOnQuit by booleanPreference(
-        appContext.getPreferenceKey(R.string.pref_key_delete_cookies_on_quit),
-        default = false
-    )
-
-    var deleteCacheOnQuit by booleanPreference(
-        appContext.getPreferenceKey(R.string.pref_key_delete_caches_on_quit),
-        default = false
-    )
-
-    var deletePermissionsOnQuit by booleanPreference(
-        appContext.getPreferenceKey(R.string.pref_key_delete_permissions_on_quit),
-        default = false
-    )
-
-    fun shouldDeleteAnyDataOnQuit(): Boolean {
-        return deleteCacheOnQuit ||
-                deleteCookiesOnQuit ||
-                deleteHistoryOnQuit ||
-                deletePermissionsOnQuit ||
-                deleteTabsOnQuit
+    fun setDeleteDataOnQuit(type: DeleteBrowsingDataOnQuitType, value: Boolean) {
+        preferences.edit().putBoolean(type.getPreferenceKey(appContext), value).apply()
     }
+
+    fun shouldDeleteAnyDataOnQuit() =
+        DeleteBrowsingDataOnQuitType.values().any { getDeleteDataOnQuit(it) }
 
     val themeSettingString: String
         get() = when {

--- a/app/src/test/java/org/mozilla/fenix/utils/DeleteAndQuitTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/utils/DeleteAndQuitTest.kt
@@ -30,6 +30,7 @@ import org.mozilla.fenix.TestApplication
 import org.mozilla.fenix.components.PermissionStorage
 import org.mozilla.fenix.ext.clearAndCommit
 import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.settings.DeleteBrowsingDataOnQuitType
 import org.robolectric.annotation.Config
 
 @ObsoleteCoroutinesApi
@@ -76,7 +77,7 @@ class DeleteAndQuitTest {
     @Test
     fun `delete only tabs and quit`() = runBlockingTest {
         // When
-        settings.deleteTabsOnQuit = true
+        settings.setDeleteDataOnQuit(DeleteBrowsingDataOnQuitType.TABS, true)
 
         deleteAndQuit(activity, this)
 
@@ -103,11 +104,9 @@ class DeleteAndQuitTest {
     @Test
     fun `delete everything and quit`() = runBlockingTest {
         // When
-        settings.deleteTabsOnQuit = true
-        settings.deletePermissionsOnQuit = true
-        settings.deleteHistoryOnQuit = true
-        settings.deleteCookiesOnQuit = true
-        settings.deleteCacheOnQuit = true
+        DeleteBrowsingDataOnQuitType.values().forEach {
+            settings.setDeleteDataOnQuit(it, true)
+        }
 
         deleteAndQuit(activity, this)
 

--- a/app/src/test/java/org/mozilla/fenix/utils/SettingsTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/utils/SettingsTest.kt
@@ -19,6 +19,7 @@ import org.junit.runner.RunWith
 import org.mozilla.fenix.TestApplication
 import org.mozilla.fenix.ext.clearAndCommit
 import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.settings.DeleteBrowsingDataOnQuitType
 import org.mozilla.fenix.settings.PhoneFeature
 import org.robolectric.annotation.Config
 
@@ -80,20 +81,20 @@ class SettingsTest {
         assertFalse(settings.shouldDeleteAnyDataOnQuit())
 
         // When
-        settings.deleteTabsOnQuit = true
+        settings.setDeleteDataOnQuit(DeleteBrowsingDataOnQuitType.TABS, true)
 
         // Then
         assertTrue(settings.shouldDeleteAnyDataOnQuit())
 
         // When
-        settings.deletePermissionsOnQuit = true
+        settings.setDeleteDataOnQuit(DeleteBrowsingDataOnQuitType.PERMISSIONS, true)
 
         // Then
         assertTrue(settings.shouldDeleteAnyDataOnQuit())
 
         // When
-        settings.deletePermissionsOnQuit = false
-        settings.deleteTabsOnQuit = false
+        settings.setDeleteDataOnQuit(DeleteBrowsingDataOnQuitType.TABS, false)
+        settings.setDeleteDataOnQuit(DeleteBrowsingDataOnQuitType.PERMISSIONS, false)
 
         // Then
         assertFalse(settings.shouldDeleteAnyDataOnQuit())


### PR DESCRIPTION
Uses the enum to get a list of all the different types of data that can be deleted on quit. Settings, DeleteBrowsingDataOnQuitFragment, and DeleteAndQuit will iterate through the list rather than copy-pasting similar code 5 times.

DeleteAndQuit has also been changed so that the deletion work is done in parallel rather than sequentially.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

<!-- To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts". -->
