### PR TITLE
Extract current mode from home fragment

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/Mode.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/Mode.kt
@@ -1,0 +1,81 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.home
+
+import android.content.Context
+import io.reactivex.Observer
+import mozilla.components.concept.sync.AccountObserver
+import mozilla.components.concept.sync.AuthType
+import mozilla.components.concept.sync.OAuthAccount
+import mozilla.components.concept.sync.Profile
+import mozilla.components.service.fxa.sharing.ShareableAccount
+import org.mozilla.fenix.browser.browsingmode.BrowsingMode
+import org.mozilla.fenix.browser.browsingmode.BrowsingModeManager
+import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.home.sessioncontrol.SessionControlChange
+import org.mozilla.fenix.onboarding.FenixOnboarding
+
+/**
+ * Describes various states of the home fragment UI.
+ */
+sealed class Mode {
+    object Normal : Mode()
+    object Private : Mode()
+    data class Onboarding(val state: OnboardingState) : Mode()
+
+    companion object {
+        fun fromBrowsingMode(browsingMode: BrowsingMode) = when (browsingMode) {
+            BrowsingMode.Normal -> Normal
+            BrowsingMode.Private -> Private
+        }
+    }
+}
+
+/**
+ * Describes various onboarding states.
+ */
+sealed class OnboardingState {
+    // Signed out, without an option to auto-login using a shared FxA account.
+    object SignedOutNoAutoSignIn : OnboardingState()
+    // Signed out, with an option to auto-login into a shared FxA account.
+    data class SignedOutCanAutoSignIn(val withAccount: ShareableAccount) : OnboardingState()
+    // Signed in.
+    object SignedIn : OnboardingState()
+}
+
+class CurrentMode(
+    private val context: Context,
+    private val onboarding: FenixOnboarding,
+    private val browsingModeManager: BrowsingModeManager,
+    private val emitter: Observer<SessionControlChange>
+) : AccountObserver {
+
+    private val accountManager = context.components.backgroundServices.accountManager
+
+    fun getCurrentMode() = if (onboarding.userHasBeenOnboarded()) {
+        Mode.fromBrowsingMode(browsingModeManager.mode)
+    } else {
+        val account = accountManager.authenticatedAccount()
+        if (account != null) {
+            Mode.Onboarding(OnboardingState.SignedIn)
+        } else {
+            val availableAccounts = accountManager.shareableAccounts(context)
+            if (availableAccounts.isEmpty()) {
+                Mode.Onboarding(OnboardingState.SignedOutNoAutoSignIn)
+            } else {
+                Mode.Onboarding(OnboardingState.SignedOutCanAutoSignIn(availableAccounts[0]))
+            }
+        }
+    }
+
+    fun emitModeChanges() {
+        emitter.onNext(SessionControlChange.ModeChange(getCurrentMode()))
+    }
+
+    override fun onAuthenticated(account: OAuthAccount, authType: AuthType) = emitModeChanges()
+    override fun onAuthenticationProblems() = emitModeChanges()
+    override fun onLoggedOut() = emitModeChanges()
+    override fun onProfileUpdated(profile: Profile) = emitModeChanges()
+}

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlAdapter.kt
@@ -17,6 +17,7 @@ import androidx.recyclerview.widget.RecyclerView
 import io.reactivex.Observer
 import kotlinx.android.synthetic.main.tab_list_row.*
 import mozilla.components.feature.media.state.MediaState
+import org.mozilla.fenix.home.OnboardingState
 import org.mozilla.fenix.home.sessioncontrol.viewholders.CollectionHeaderViewHolder
 import org.mozilla.fenix.home.sessioncontrol.viewholders.CollectionViewHolder
 import org.mozilla.fenix.home.sessioncontrol.viewholders.NoContentMessageViewHolder

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlComponent.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlComponent.kt
@@ -11,9 +11,8 @@ import androidx.recyclerview.widget.RecyclerView
 import io.reactivex.Observer
 import mozilla.components.browser.session.Session
 import mozilla.components.feature.media.state.MediaState
-import mozilla.components.service.fxa.sharing.ShareableAccount
-import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.home.Mode
 import org.mozilla.fenix.mvi.Action
 import org.mozilla.fenix.mvi.ActionBusFactory
 import org.mozilla.fenix.mvi.Change
@@ -62,31 +61,6 @@ fun List<Tab>.toSessionBundle(context: Context): MutableList<Session> {
         }
     }
     return sessionBundle
-}
-
-/**
- * Describes various onboarding states.
- */
-sealed class OnboardingState {
-    // Signed out, without an option to auto-login using a shared FxA account.
-    object SignedOutNoAutoSignIn : OnboardingState()
-    // Signed out, with an option to auto-login into a shared FxA account.
-    data class SignedOutCanAutoSignIn(val withAccount: ShareableAccount) : OnboardingState()
-    // Signed in.
-    object SignedIn : OnboardingState()
-}
-
-sealed class Mode {
-    object Normal : Mode()
-    object Private : Mode()
-    data class Onboarding(val state: OnboardingState) : Mode()
-
-    companion object {
-        fun fromBrowsingMode(browsingMode: BrowsingMode) = when (browsingMode) {
-            BrowsingMode.Normal -> Normal
-            BrowsingMode.Private -> Private
-        }
-    }
 }
 
 data class SessionControlState(

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlUIView.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlUIView.kt
@@ -13,6 +13,8 @@ import io.reactivex.Observable
 import io.reactivex.Observer
 import io.reactivex.functions.Consumer
 import org.mozilla.fenix.R
+import org.mozilla.fenix.home.Mode
+import org.mozilla.fenix.home.OnboardingState
 import org.mozilla.fenix.mvi.UIView
 
 val noTabMessage = AdapterItem.NoContentMessage(

--- a/app/src/test/java/org/mozilla/fenix/home/ModeTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/ModeTest.kt
@@ -1,0 +1,123 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.home
+
+import android.content.Context
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
+import io.reactivex.Observer
+import mozilla.components.service.fxa.manager.FxaAccountManager
+import mozilla.components.service.fxa.sharing.ShareableAccount
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.mozilla.fenix.browser.browsingmode.BrowsingMode
+import org.mozilla.fenix.browser.browsingmode.BrowsingModeManager
+import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.home.sessioncontrol.SessionControlChange
+import org.mozilla.fenix.onboarding.FenixOnboarding
+
+class ModeTest {
+
+    private lateinit var context: Context
+    private lateinit var accountManager: FxaAccountManager
+    private lateinit var onboarding: FenixOnboarding
+    private lateinit var browsingModeManager: BrowsingModeManager
+    private lateinit var emitter: Observer<SessionControlChange>
+    private lateinit var currentMode: CurrentMode
+
+    @Before
+    fun setup() {
+        context = mockk(relaxed = true)
+        accountManager = mockk(relaxed = true)
+        onboarding = mockk(relaxed = true)
+        browsingModeManager = mockk(relaxed = true)
+        emitter = mockk(relaxed = true)
+
+        every { context.components.backgroundServices.accountManager } returns accountManager
+
+        currentMode = CurrentMode(
+            context,
+            onboarding,
+            browsingModeManager,
+            emitter
+        )
+    }
+
+    @Test
+    fun `get current mode after onboarding`() {
+        every { onboarding.userHasBeenOnboarded() } returns true
+        every { browsingModeManager.mode } returns BrowsingMode.Normal
+
+        assertEquals(Mode.Normal, currentMode.getCurrentMode())
+    }
+
+    @Test
+    fun `get current private mode after onboarding`() {
+        every { onboarding.userHasBeenOnboarded() } returns true
+        every { browsingModeManager.mode } returns BrowsingMode.Private
+
+        assertEquals(Mode.Private, currentMode.getCurrentMode())
+    }
+
+    @Test
+    fun `get current onboarding mode when signed in`() {
+        every { onboarding.userHasBeenOnboarded() } returns false
+        every { accountManager.authenticatedAccount() } returns mockk()
+
+        assertEquals(Mode.Onboarding(OnboardingState.SignedIn), currentMode.getCurrentMode())
+    }
+
+    @Test
+    fun `get current onboarding mode when signed out`() {
+        every { onboarding.userHasBeenOnboarded() } returns false
+        every { accountManager.authenticatedAccount() } returns null
+        every { accountManager.shareableAccounts(context) } returns emptyList()
+
+        assertEquals(Mode.Onboarding(OnboardingState.SignedOutNoAutoSignIn), currentMode.getCurrentMode())
+    }
+
+    @Test
+    fun `get current onboarding mode when can auto sign in`() {
+        val shareableAccount: ShareableAccount = mockk()
+        every { onboarding.userHasBeenOnboarded() } returns false
+        every { accountManager.authenticatedAccount() } returns null
+        every { accountManager.shareableAccounts(context) } returns listOf(shareableAccount)
+
+        assertEquals(
+            Mode.Onboarding(OnboardingState.SignedOutCanAutoSignIn(shareableAccount)),
+            currentMode.getCurrentMode()
+        )
+    }
+
+    @Test
+    fun `emit mode change`() {
+        every { onboarding.userHasBeenOnboarded() } returns true
+        every { browsingModeManager.mode } returns BrowsingMode.Normal
+
+        currentMode.emitModeChanges()
+
+        verify { emitter.onNext(SessionControlChange.ModeChange(Mode.Normal)) }
+    }
+
+    @Test
+    fun `account observer calls emitModeChanges`() {
+        val spy = spyk(currentMode)
+
+        spy.onAuthenticated(mockk(), mockk())
+        verify { spy.emitModeChanges() }
+
+        spy.onAuthenticationProblems()
+        verify { spy.emitModeChanges() }
+
+        spy.onLoggedOut()
+        verify { spy.emitModeChanges() }
+
+        spy.onProfileUpdated(mockk())
+        verify { spy.emitModeChanges() }
+    }
+}


### PR DESCRIPTION
Pulls out the function for getting the current mode and emitting when it changes. Long-term this should probably be moved to some state for the home fragment.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

<!-- To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts". -->
