### PR TITLE
For #5141 Changed "learn more" link to be accessible to Talkback users 

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/exceptions/ExceptionsView.kt
+++ b/app/src/main/java/org/mozilla/fenix/exceptions/ExceptionsView.kt
@@ -6,8 +6,7 @@ package org.mozilla.fenix.exceptions
 
 import android.text.SpannableString
 import android.text.method.LinkMovementMethod
-import android.text.style.ClickableSpan
-import android.text.style.ForegroundColorSpan
+import android.text.style.UnderlineSpan
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -58,25 +57,15 @@ class ExceptionsView(
             adapter = ExceptionsAdapter(interactor)
             layoutManager = LinearLayoutManager(container.context)
         }
-        val descriptionText = String
-            .format(
-                view.exceptions_empty_view.text.toString(),
-                System.getProperty("line.separator")
-            )
-        val linkStartIndex = descriptionText.indexOf("\n\n") + 2
-        val linkAction = object : ClickableSpan() {
-            override fun onClick(widget: View?) {
-                interactor.onLearnMore()
-            }
+        val learnMoreText = view.exceptions_learn_more.text.toString()
+        val textWithLink = SpannableString(learnMoreText).apply {
+            setSpan(UnderlineSpan(), 0, learnMoreText.length, 0)
         }
-        val textWithLink = SpannableString(descriptionText).apply {
-            setSpan(linkAction, linkStartIndex, descriptionText.length, 0)
-            val colorSpan = ForegroundColorSpan(view.exceptions_empty_view.currentTextColor)
-            setSpan(colorSpan, linkStartIndex, descriptionText.length, 0)
+        with(view.exceptions_learn_more) {
+            movementMethod = LinkMovementMethod.getInstance()
+            text = textWithLink
+            setOnClickListener { interactor.onLearnMore() }
         }
-
-        view.exceptions_empty_view.movementMethod = LinkMovementMethod.getInstance()
-        view.exceptions_empty_view.text = textWithLink
     }
 
     fun update(state: ExceptionsFragmentState) {

--- a/app/src/main/res/layout/component_exceptions.xml
+++ b/app/src/main/res/layout/component_exceptions.xml
@@ -3,26 +3,45 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/exceptions_wrapper"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:visibility="gone"
-        android:id="@+id/exceptions_list"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        tools:listitem="@layout/exception_item" />
-
-    <TextView
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/exceptions_empty_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="top"
-        android:layout_margin="12dp"
-        android:text="@string/exceptions_empty_message"
-        android:textColor="?secondaryText"
-        android:textSize="16sp"
-        android:visibility="visible" />
+        android:layout_margin="@dimen/exceptions_description_margin">
+
+        <TextView
+            android:id="@+id/exceptions_empty_message"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="4dp"
+            android:text="@string/exceptions_empty_message_description"
+            android:textColor="?secondaryText"
+            android:textSize="16sp"
+            android:visibility="visible"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/exceptions_learn_more"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="4dp"
+            android:text="@string/exceptions_empty_message_learn_more_link"
+            android:textColor="?secondaryText"
+            android:textSize="16sp"
+            android:visibility="visible"
+            app:layout_constraintTop_toBottomOf="@id/exceptions_empty_message" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/exceptions_list"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone"
+        tools:listitem="@layout/exception_item" />
 </FrameLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -31,6 +31,7 @@
     <dimen name="site_permissions_exceptions_item_text_size">18sp</dimen>
     <dimen name="site_permissions_exceptions_item_height">56dp</dimen>
     <dimen name="component_collection_creation_list_margin">16dp</dimen>
+    <dimen name="exceptions_description_margin">12dp</dimen>
 
     <dimen name="context_menu_height">48dp</dimen>
     <dimen name="context_menu_x_offset">8dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -238,8 +238,11 @@
     <string name="preferences_tracking_protection_exceptions_description">Tracking Protection is off for these websites</string>
     <!-- Button in Exceptions Preference to turn on tracking protection for all sites (remove all exceptions) -->
     <string name="preferences_tracking_protection_exceptions_turn_on_for_all">Turn on for all sites</string>
-    <!-- Text displayed when there are no exceptions, includes a learn more link that brings users to a tracking protection SUMO page -->
-    <string name="exceptions_empty_message">Exceptions let you disable tracking protection for selected sites.\n\nLearn more</string>
+    <!-- Text displayed when there are no exceptions -->
+    <string name="exceptions_empty_message_description">Exceptions let you disable tracking protection for selected sites.</string>
+    <!-- Text displayed when there are no exceptions, with learn more link that brings users to a tracking protection SUMO page -->
+    <string name="exceptions_empty_message_learn_more_link">Learn more</string>
+
     <!-- Description in Quick Settings that tells user tracking protection is off globally for all sites, and links to Settings to turn it on -->
     <string name="preferences_tracking_protection_turned_off_globally">Turned off globally, go to Settings to turn it on.</string>
 


### PR DESCRIPTION
Added TextView with link text with padding to avoid overlap
Used UnderlineSpan to show text as link
Split string exceptions_empty_message, one for each TextView
Set clickListener on TextView so it can be accessed via Talkback

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

<!-- To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts". -->
