### PR TITLE
Closes #394 - Trusted Web Activities

### DIFF
--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -13,9 +13,22 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
     <!-- Allows changing locales -->
-    <uses-permission android:name="android.permission.CHANGE_CONFIGURATION" />
+    <uses-permission android:name="android.permission.CHANGE_CONFIGURATION"
+            tools:ignore="ProtectedPermissions" />
 
     <application
             tools:replace="android:name"
-            android:name="org.mozilla.fenix.DebugFenixApplication"/>
+            android:name="org.mozilla.fenix.DebugFenixApplication">
+
+        <service android:name=".customtabs.CustomTabsService">
+            <!-- Trusted Web Activities are currently only supported in nightly. -->
+            <intent-filter tools:node="removeAll" />
+            <intent-filter>
+                <action android:name="android.support.customtabs.action.CustomTabsService" />
+                <category android:name="androidx.browser.trusted.category.TrustedWebActivities" />
+            </intent-filter>
+        </service>
+
+    </application>
+
 </manifest>

--- a/app/src/fenixNightly/AndroidManifest.xml
+++ b/app/src/fenixNightly/AndroidManifest.xml
@@ -1,0 +1,18 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        package="org.mozilla.fenix">
+
+    <application>
+
+        <service android:name=".customtabs.CustomTabsService">
+            <!-- Trusted Web Activities are currently only supported in nightly. -->
+            <intent-filter tools:node="removeAll" />
+            <intent-filter>
+                <action android:name="android.support.customtabs.action.CustomTabsService" />
+                <category android:name="androidx.browser.trusted.category.TrustedWebActivities" />
+            </intent-filter>
+        </service>
+
+    </application>
+
+</manifest>

--- a/app/src/main/java/org/mozilla/fenix/components/Components.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Components.kt
@@ -31,7 +31,14 @@ class Components(private val context: Context) {
         )
     }
     val intentProcessors by lazy {
-        IntentProcessors(context, core.sessionManager, useCases.sessionUseCases, useCases.searchUseCases)
+        IntentProcessors(
+            context,
+            core.sessionManager,
+            useCases.sessionUseCases,
+            useCases.searchUseCases,
+            core.client,
+            core.customTabsStore
+        )
     }
     val analytics by lazy { Analytics(context) }
     val publicSuffixList by lazy { PublicSuffixList(context) }

--- a/app/src/main/java/org/mozilla/fenix/components/IntentProcessors.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/IntentProcessors.kt
@@ -6,12 +6,16 @@ package org.mozilla.fenix.components
 
 import android.content.Context
 import mozilla.components.browser.session.SessionManager
+import mozilla.components.concept.fetch.Client
 import mozilla.components.feature.customtabs.CustomTabIntentProcessor
+import mozilla.components.feature.customtabs.store.CustomTabsServiceStore
 import mozilla.components.feature.intent.processing.TabIntentProcessor
 import mozilla.components.feature.pwa.ManifestStorage
 import mozilla.components.feature.pwa.intent.WebAppIntentProcessor
+import mozilla.components.feature.pwa.intent.TrustedWebActivityIntentProcessor
 import mozilla.components.feature.search.SearchUseCases
 import mozilla.components.feature.session.SessionUseCases
+import org.mozilla.fenix.BuildConfig
 import org.mozilla.fenix.test.Mockable
 
 /**
@@ -22,7 +26,9 @@ class IntentProcessors(
     private val context: Context,
     private val sessionManager: SessionManager,
     private val sessionUseCases: SessionUseCases,
-    private val searchUseCases: SearchUseCases
+    private val searchUseCases: SearchUseCases,
+    private val httpClient: Client,
+    private val customTabsStore: CustomTabsServiceStore
 ) {
     /**
      * Provides intent processing functionality for ACTION_VIEW and ACTION_SEND intents.
@@ -40,6 +46,14 @@ class IntentProcessors(
 
     val externalAppIntentProcessors by lazy {
         listOf(
+            TrustedWebActivityIntentProcessor(
+                sessionManager = sessionManager,
+                loadUrlUseCase = sessionUseCases.loadUrl,
+                httpClient = httpClient,
+                packageManager = context.packageManager,
+                apiKey = BuildConfig.DIGITAL_ASSET_LINKS_TOKEN,
+                store = customTabsStore
+            ),
             WebAppIntentProcessor(sessionManager, sessionUseCases.loadUrl, ManifestStorage(context)),
             CustomTabIntentProcessor(sessionManager, sessionUseCases.loadUrl, context.resources)
         )

--- a/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabsService.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabsService.kt
@@ -6,9 +6,12 @@ package org.mozilla.fenix.customtabs
 
 import mozilla.components.concept.engine.Engine
 import mozilla.components.feature.customtabs.AbstractCustomTabsService
+import org.mozilla.fenix.BuildConfig.DIGITAL_ASSET_LINKS_TOKEN
 import org.mozilla.fenix.ext.components
 
 class CustomTabsService : AbstractCustomTabsService() {
     override val engine: Engine by lazy { applicationContext.components.core.engine }
     override val customTabsServiceStore by lazy { applicationContext.components.core.customTabsStore }
+    override val httpClient by lazy { applicationContext.components.core.client }
+    override val apiKey: String? = DIGITAL_ASSET_LINKS_TOKEN
 }


### PR DESCRIPTION
Depends on mozilla-mobile/android-components#4440 and #4914

Adds support for Trusted Web Activities in Fenix nightly and debug.

Here are some apps using Trusted Web Activities we can test with:
- https://play.google.com/store/apps/details?id=com.tigeroakes.insightfulenergy
- https://play.google.com/store/apps/details?id=com.appspot.pwa_directory
- https://play.google.com/store/apps/details?id=br.com.quintoandar.inquilinos

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
