### PR TITLE
For #3077 - Replaces connect another device dialog with a scree

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/SupportUtils.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SupportUtils.kt
@@ -28,7 +28,8 @@ object SupportUtils {
         PRIVATE_BROWSING_MYTHS("common-myths-about-private-browsing"),
         YOUR_RIGHTS("your-rights"),
         TRACKING_PROTECTION("tracking-protection-firefox-preview"),
-        WHATS_NEW("whats-new-firefox-preview")
+        WHATS_NEW("whats-new-firefox-preview"),
+        SEND_TABS("send-tab-firefox-preview-another-device")
     }
 
     /**

--- a/app/src/main/java/org/mozilla/fenix/share/AddNewDeviceFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/share/AddNewDeviceFragment.kt
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.share
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
+import kotlinx.android.synthetic.main.fragment_add_new_device.*
+import org.mozilla.fenix.R
+import org.mozilla.fenix.settings.SupportUtils
+
+class AddNewDeviceFragment : Fragment() {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? = inflater.inflate(R.layout.fragment_add_new_device, container, false)
+
+    override fun onResume() {
+        super.onResume()
+        (activity as AppCompatActivity).title = getString(R.string.sync_add_new_device_title)
+        (activity as AppCompatActivity).supportActionBar?.show()
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        learn_button.setOnClickListener {
+            val intent = SupportUtils.createCustomTabIntent(
+                requireContext(),
+                SupportUtils.getSumoURLForTopic(requireContext(), SupportUtils.SumoTopic.SEND_TABS)
+            )
+            startActivity(intent)
+        }
+
+        connect_button.setOnClickListener {
+            AlertDialog.Builder(requireContext()).apply {
+                setMessage(R.string.sync_connect_device_dialog)
+                setPositiveButton(R.string.sync_confirmation_button) { dialog, _ -> dialog.cancel() }
+                create()
+            }.show()
+        }
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/share/ShareController.kt
+++ b/app/src/main/java/org/mozilla/fenix/share/ShareController.kt
@@ -10,7 +10,6 @@ import android.content.Intent.ACTION_SEND
 import android.content.Intent.EXTRA_TEXT
 import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
 import androidx.annotation.VisibleForTesting
-import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
 import androidx.navigation.NavController
 import com.google.android.material.snackbar.Snackbar
@@ -88,11 +87,8 @@ class DefaultShareController(
     }
 
     override fun handleAddNewDevice() {
-        AlertDialog.Builder(fragment.requireContext()).apply {
-            setMessage(R.string.sync_connect_device_dialog)
-            setPositiveButton(R.string.sync_confirmation_button) { dialog, _ -> dialog.cancel() }
-            create()
-        }.show()
+        val directions = ShareFragmentDirections.actionShareFragmentToAddNewDeviceFragment()
+        navController.navigate(directions)
     }
 
     override fun handleShareToDevice(device: Device) {

--- a/app/src/main/res/layout/fragment_add_new_device.xml
+++ b/app/src/main/res/layout/fragment_add_new_device.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+    <LinearLayout
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:background="@color/sync_error_background_color"
+        android:baselineAligned="false">
+
+        <FrameLayout
+            android:id="@+id/icon_frame"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content">
+            <androidx.preference.internal.PreferenceImageView
+                android:id="@android:id/icon"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:maxWidth="48dp"
+                app:maxHeight="48dp"/>
+        </FrameLayout>
+
+        <RelativeLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="15dp"
+            android:layout_marginEnd="6dp"
+            android:paddingEnd="0dp"
+            android:paddingTop="16dp"
+            android:paddingBottom="16dp"
+            android:gravity="center_horizontal"
+            android:layout_weight="1">
+
+            <TextView
+                android:id="@+id/errorSummary"
+                android:drawableStart="@drawable/ic_info"
+                android:text="@string/sync_add_new_device_message"
+                android:drawablePadding="8dp"
+                android:drawableTint="@color/sync_error_text_color"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textColor="@color/sync_error_text_color"
+                android:textSize="16sp"
+                android:ellipsize="marquee"
+                android:fadingEdge="horizontal"
+                android:visibility="visible"/>
+
+        </RelativeLayout>
+
+        <LinearLayout
+            android:id="@android:id/widget_frame"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:orientation="vertical"/>
+
+    </LinearLayout>
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/learn_button"
+        style="@style/ThemeIndependentMaterialGreyButton"
+        android:padding="16dp"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginEnd="8dp"
+        android:text="@string/sync_add_new_device_learn_button" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/connect_button"
+        style="@style/ThemeIndependentMaterialGreyButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginEnd="8dp"
+        android:text="@string/sync_add_new_device_connect_button" />
+</LinearLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -504,6 +504,9 @@
         <action
             android:id="@+id/action_shareFragment_to_accountProblemFragment"
             app:destination="@id/accountProblemFragment" />
+        <action
+            android:id="@+id/action_shareFragment_to_addNewDeviceFragment"
+            app:destination="@id/addNewDeviceFragment" />
     </dialog>
     <dialog
         android:id="@+id/quickSettingsSheetDialogFragment"
@@ -581,4 +584,9 @@
         android:id="@+id/deleteBrowsingDataOnQuitFragment"
         android:name="org.mozilla.fenix.settings.DeleteBrowsingDataOnQuitFragment"
         android:label="DeleteBrowsingDataOnQuitFragment" />
+
+    <fragment
+        android:id="@+id/addNewDeviceFragment"
+        android:name="org.mozilla.fenix.share.AddNewDeviceFragment"
+        android:label="AddNewDeviceFragment" />
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -379,7 +379,6 @@
     <!-- Text for the button to open tabs of the selected collection -->
     <string name="collection_open_tabs">Open tabs</string>
 
-
     <!-- History -->
     <!-- Text for the button to clear all history -->
     <string name="history_delete_all">Delete history</string>
@@ -597,6 +596,14 @@
     <string name="sync_confirmation_button">Got it</string>
     <!-- Share error message -->
     <string name="share_error_snackbar">Cannot share to this app</string>
+    <!-- Add new device screen title -->
+    <string name="sync_add_new_device_title">Send to device</string>
+    <!-- Text for the warning message on the Add new device screen -->
+    <string name="sync_add_new_device_message">No Devices Connected</string>
+    <!-- Text for the button to learn about sending tabs -->
+    <string name="sync_add_new_device_learn_button">Learn About Sending Tabs…</string>
+    <!-- Text for the button to connect another device -->
+    <string name="sync_add_new_device_connect_button">Connect Another Device…</string>
 
     <!-- Notifications -->
     <!-- The user visible name of the "notification channel" (Android 8+ feature) for the ongoing notification shown while a browsing session is active. -->


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/1250545/65193329-91720e80-da2f-11e9-8df5-c39e7eb81844.png)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture