### PR TITLE
For #5383 Refactored ETP layout to keep appearance for larger font size.

### DIFF
--- a/app/src/main/res/layout/tracking_protection_learn_more_preference.xml
+++ b/app/src/main/res/layout/tracking_protection_learn_more_preference.xml
@@ -6,7 +6,9 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginBottom="12dp">
+    android:layout_marginBottom="12dp"
+    android:paddingTop="20dp"
+    android:background="#FF0250BB">
 
     <ImageView
         android:id="@+id/imageView"
@@ -23,7 +25,6 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="20dp"
-        android:layout_marginBottom="20dp"
         android:ellipsize="none"
         android:letterSpacing="0.05"
         android:scrollHorizontally="false"
@@ -31,7 +32,7 @@
         android:text="@string/preference_enhanced_tracking_protection_explanation_title"
         android:textAppearance="@style/Header16TextStyle"
         android:textColor="@color/primary_text_dark_theme"
-        app:layout_constraintBottom_toTopOf="@android:id/summary"
+        app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintEnd_toStartOf="@id/guideline"
         app:layout_constraintStart_toStartOf="parent" />
 
@@ -39,22 +40,24 @@
         android:id="@android:id/summary"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:paddingTop="12dp"
+        android:paddingBottom="12dp"
         android:ellipsize="none"
         android:scrollHorizontally="false"
         android:text="@string/preference_enhanced_tracking_protection_explanation"
         android:textColor="@color/primary_text_dark_theme"
         android:textSize="12sp"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/learn_more"
         app:layout_constraintEnd_toStartOf="@id/guideline"
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toStartOf="@android:id/title"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toBottomOf="@android:id/title" />
 
     <TextView
         android:id="@+id/learn_more"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="20dp"
+        android:paddingBottom="12dp"
         android:ellipsize="none"
         android:text="@string/preference_enhanced_tracking_protection_explanation_learn_more"
         android:textColor="@color/primary_text_dark_theme"
@@ -62,12 +65,14 @@
         app:layout_constraintEnd_toStartOf="@id/guideline"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="@android:id/title"
-        app:layout_constraintTop_toBottomOf="@android:id/summary" />
+        app:layout_constraintTop_toBottomOf="@android:id/summary"
+        app:layout_constraintBottom_toBottomOf="parent"/>
 
     <ImageView
         android:layout_width="8dp"
         android:layout_height="0dp"
         android:layout_marginStart="12dp"
+        android:paddingBottom="12dp"
         android:importantForAccessibility="no"
         android:tint="@color/primary_text_dark_theme"
         app:layout_constraintBottom_toBottomOf="@id/learn_more"
@@ -80,5 +85,5 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_begin="210dp" />
+        app:layout_constraintGuide_percent="0.5" />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Added paddingTop to layout to maintain similar space above title.
Added image's bottom colour as background color to fill space below image.
Refactored TextViews alignment to chain.
Changed guideline to percent instead of dp for wider screens including tablets.

Scrrenshots for font size extremes:
**small** vs   **extra large**:
<img src=https://user-images.githubusercontent.com/48995920/65226897-5f64b900-dad0-11e9-94f0-b31293850486.png width = 48%> <img src=https://user-images.githubusercontent.com/48995920/65226896-5f64b900-dad0-11e9-97a4-d8acd4dea0c6.png width = 48%> 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture