### PR TITLE
 Add basic test coverage for Glean metrics in Fenix 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -463,6 +463,7 @@ dependencies {
     androidTestImplementation Deps.mockwebserver
     testImplementation Deps.mozilla_support_test
     testImplementation Deps.androidx_junit
+    testImplementation Deps.androidx_work_testing
     testImplementation (Deps.robolectric) {
         exclude group: 'org.apache.maven'
     }

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
@@ -401,28 +401,36 @@ class GleanMetricsService(private val context: Context) : MetricsService {
             Glean.registerPings(Pings)
             Glean.initialize(context, Configuration(channel = BuildConfig.BUILD_TYPE))
 
-            Metrics.apply {
-                defaultBrowser.set(Browsers.all(context).isDefaultBrowser)
-                MozillaProductDetector.getMozillaBrowserDefault(context)?.also {
-                    defaultMozBrowser.set(it)
-                }
-                mozillaProducts.set(MozillaProductDetector.getInstalledMozillaProducts(context))
-            }
-
-            SearchDefaultEngine.apply {
-                val defaultEngine = context
-                    .components
-                    .search
-                    .searchEngineManager
-                    .defaultSearchEngine ?: return@apply
-
-                code.set(defaultEngine.identifier)
-                name.set(defaultEngine.name)
-                submissionUrl.set(defaultEngine.buildSearchUrl(""))
-            }
-
-            activationPing.checkAndSend()
+            setStartupMetrics()
         }
+    }
+
+    /**
+     * Sets some basic Glean metrics required by Fenix.
+     * This is a separate function to simplify testing.
+     */
+    internal fun setStartupMetrics() {
+        Metrics.apply {
+            defaultBrowser.set(Browsers.all(context).isDefaultBrowser)
+            MozillaProductDetector.getMozillaBrowserDefault(context)?.also {
+                defaultMozBrowser.set(it)
+            }
+            mozillaProducts.set(MozillaProductDetector.getInstalledMozillaProducts(context))
+        }
+
+        SearchDefaultEngine.apply {
+            val defaultEngine = context
+                .components
+                .search
+                .searchEngineManager
+                .defaultSearchEngine ?: return@apply
+
+            code.set(defaultEngine.identifier)
+            name.set(defaultEngine.name)
+            submissionUrl.set(defaultEngine.buildSearchUrl(""))
+        }
+
+        activationPing.checkAndSend()
     }
 
     override fun stop() {

--- a/app/src/test/java/org/mozilla/fenix/components/metrics/GleanMetricsServiceTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/metrics/GleanMetricsServiceTest.kt
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.components.metrics
+
+import kotlinx.coroutines.ObsoleteCoroutinesApi
+import mozilla.components.service.glean.testing.GleanTestRule
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.fenix.GleanMetrics.Events
+import org.mozilla.fenix.GleanMetrics.Metrics
+import org.mozilla.fenix.GleanMetrics.SearchDefaultEngine
+import org.mozilla.fenix.TestApplication
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@ObsoleteCoroutinesApi
+@RunWith(RobolectricTestRunner::class)
+@Config(application = TestApplication::class)
+class GleanMetricsServiceTest {
+    @get:Rule
+    val gleanRule = GleanTestRule(testContext)
+
+    @Test
+    fun `setStartupMetrics sets some base metrics`() {
+        val gleanService = GleanMetricsService(testContext)
+
+        // Set the metrics.
+        gleanService.setStartupMetrics()
+
+        // Verify that browser defaults metrics are set.
+        assertEquals(true, Metrics.defaultBrowser.testGetValue())
+        assertEquals(true, Metrics.defaultMozBrowser.testHasValue())
+        assertEquals(listOf("org.mozilla.fenix"), Metrics.mozillaProducts.testGetValue())
+
+        // Verify that search engine defaults are NOT set. This test does
+        // not mock most of the objects telemetry is collected from.
+        assertFalse(SearchDefaultEngine.code.testHasValue())
+        assertFalse(SearchDefaultEngine.name.testHasValue())
+        assertFalse(SearchDefaultEngine.submissionUrl.testHasValue())
+    }
+
+    @Test
+    fun `the app_opened event is correctly recorded`() {
+        val gleanService = GleanMetricsService(testContext)
+
+        // Build the event wrapper used by Fenix.
+        val event = Event.OpenedApp(Event.OpenedApp.Source.APP_ICON)
+
+        // Feed the wrapped event in the Glean service.
+        gleanService.track(event)
+
+        // Use the testing API to verify that it's correctly recorded.
+        assertTrue(Events.appOpened.testHasValue())
+
+        // Get all the recorded events. We only expect 1 to be recorded.
+        val events = Events.appOpened.testGetValue()
+        assertEquals(1, events.size)
+
+        // Verify that we get the expected content out.
+        assertEquals("events", events[0].category)
+        assertEquals("app_opened", events[0].name)
+
+        // We only expect 1 extra key.
+        assertEquals(1, events[0].extra!!.size)
+        assertEquals("APP_ICON", events[0].extra!!["source"])
+    }
+}

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -61,7 +61,7 @@ object Versions {
     const val tools_test_rules = "1.3.0-alpha02"
     const val tools_test_runner = "1.3.0-alpha02"
     const val uiautomator = "2.2.0"
-    const val robolectric = "4.2"
+    const val robolectric = "4.2.1"
 
     const val google_ads_id_version = "16.0.0"
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -181,6 +181,7 @@ object Deps {
     const val androidx_core_ktx = "androidx.core:core-ktx:${Versions.androidx_core}"
     const val androidx_transition = "androidx.transition:transition:${Versions.androidx_transition}"
     const val androidx_work_ktx = "androidx.work:work-runtime-ktx:${Versions.androidx_work}"
+    const val androidx_work_testing = "androidx.work:work-testing:${Versions.androidx_work}"
     const val google_material = "com.google.android.material:material:${Versions.google_material}"
 
     const val autodispose = "com.uber.autodispose:autodispose:${Versions.autodispose}"


### PR DESCRIPTION
This introduces test coverage, using the Glean SDK testing API, for the metrics that are set at startup
by Fenix in the GleanMetricsService.

This additional adds a basic test for the translation of the `app_opened` event.

**Note** this only adds basic things to catch any regression due to Glean SDK migration.

cc @liuche 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture