### PR TITLE
Bug 1580778 - Fix signing scopes and indexes

### DIFF
--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -5,6 +5,7 @@ treeherder:
         'forPerformanceTest': 'Builds made for Raptor and other performance tests'
         'I': 'Docker Image Builds'
         'nightly': 'Nightly-related tasks'
+        'nightlyFennec': 'Nightly-related tasks with same APK configuration as Fennec'
         'nightlyLegacy': 'Nightly-related tasks that ship to https://play.google.com/store/apps/details?id=org.mozilla.fenix'
         'production': 'Release-related tasks'
         'Rap': 'Raptor tests'

--- a/taskcluster/ci/raptor/kind.yml
+++ b/taskcluster/ci/raptor/kind.yml
@@ -8,7 +8,7 @@ transforms:
 kind-dependencies:
     - signing
 only-for-build-types:
-    - raptor
+    - performance-test
 only-for-abis:
     - armeabi-v7a
     - arm64-v8a

--- a/taskcluster/ci/signing/kind.yml
+++ b/taskcluster/ci/signing/kind.yml
@@ -13,8 +13,6 @@ kind-dependencies:
 
 job-defaults:
     description: Sign Fenix
-    index:
-        type: signing
     worker-type:
         by-variant:
             (nightly|nightly-legacy|production):
@@ -22,14 +20,6 @@ job-defaults:
                     '3': signing
                     default: dep-signing
             default: dep-signing
-    worker:
-        signing-type:
-            by-variant:
-                (nightly|nightly-legacy|production):
-                    by-level:
-                        '3': release-signing
-                        default: dep-signing
-                default: dep-signing
     run-on-tasks-for: []
     treeherder:
         kind: build
@@ -40,7 +30,10 @@ jobs:
     performance-test:
         attributes:
             build-type: performance-test
-        worker-type: dep-signing
+        index:
+            type: signing
+        worker:
+            signing-type: dep-signing
         dependencies:
             build: 'assemble: geckoNightlyForPerformanceTest'   # comes from the old-decision task
         treeherder:
@@ -49,16 +42,46 @@ jobs:
     production:
         attributes:
             build-type: production
+        index:
+            type: signing
+        worker:
+            signing-type:
+                by-level:
+                    '3': production-signing
+                    default: dep-signing
         dependencies:
             build: 'Build FenixProduction task'  # comes from the old-decision task
         run-on-tasks-for: [github-release]
         treeherder:
             symbol: production(s)
 
+    fennec-production:
+        attributes:
+            build-type: fennec-production
+            nightly: true
+        index:
+            type: signing
+        worker:
+            signing-type:
+                by-level:
+                    '3': fennec-production-signing
+                    default: dep-signing
+        dependencies:
+            build: 'Build FennecProduction task' # comes from the old-decision task
+        treeherder:
+            symbol: nightlyFennec(s)
+
     nightly:
         attributes:
             build-type: nightly
             nightly: true
+        index:
+            type: signing
+        worker:
+            signing-type:
+                by-level:
+                    '3': nightly-signing
+                    default: dep-signing
         dependencies:
             build: 'Build FenixNightly task' # comes from the old-decision task
         treeherder:
@@ -68,6 +91,11 @@ jobs:
         attributes:
             build-type: nightly-legacy
             nightly: true
+        worker:
+            signing-type:
+                by-level:
+                    '3': production-signing
+                    default: dep-signing
         dependencies:
             build: 'Build FenixNightlyLegacy task'  # comes from the old-decision task
         treeherder:

--- a/taskcluster/fenix_taskgraph/signing.py
+++ b/taskcluster/fenix_taskgraph/signing.py
@@ -28,11 +28,14 @@ def fetch_old_decision_dependency(config, tasks):
 
 
 @transforms.add
-def define_signing_flags(config, tasks):
+def define_signing_attributes(config, tasks):
     for task in tasks:
         dep = task["primary-dependency"]
-        # Current kind will be prepended later in the transform chain.
-        task.setdefault("attributes", {}).update(dep.attributes.copy())
+        attributes = task.setdefault("attributes", {})
+        upstream_attributes = dep.attributes.copy()
+        upstream_attributes.update(attributes)
+        task["attributes"] = upstream_attributes
+
         task["attributes"]["signed"] = True
         if "run_on_tasks_for" in task["attributes"]:
             task["run-on-tasks-for"] = task["attributes"]["run_on_tasks_for"]


### PR DESCRIPTION
Follows #5425 up.

Fixes:
* Wrong index scopes for performance-test signing job https://treeherder.mozilla.org/logviewer.html#/jobs?job_id=267413540&repo=fenix&lineNumber=2830
* Wrong signing scope for nightly signing https://treeherder.mozilla.org/logviewer.html#/jobs?job_id=267417938&repo=fenix&lineNumber=22

I thoroughly made sure the indexes are all generated right this time. That is to say: I didn't create any new indexes (I did in #5409, because I thought it felt right) and I didn't miss the fennec signing job. 


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture