### PR TITLE
For #3731 Improved UX for opening tabs from a Collection

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -532,7 +532,7 @@ class HomeFragment : Fragment(), AccountObserver {
                 val context = requireContext()
                 val components = context.components
 
-                action.collection.tabs.forEach {
+                action.collection.tabs.reversed().forEach {
                     val session = it.restore(
                         context = context,
                         engine = components.core.engine,

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/CollectionViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/CollectionViewHolder.kt
@@ -132,25 +132,28 @@ class CollectionItemMenu(
     private val menuItems by lazy {
         listOf(
             SimpleBrowserMenuItem(
-                context.getString(R.string.collection_delete),
-                textColorResource = ThemeManager.resolveAttribute(R.attr.destructive, context)
+                context.getString(R.string.collection_open_tabs)
             ) {
-                onItemTapped.invoke(Item.DeleteCollection)
+                onItemTapped.invoke(Item.OpenTabs)
             },
-            SimpleBrowserMenuItem(
-                context.getString(R.string.add_tab)
-            ) {
-                onItemTapped.invoke(Item.AddTab)
-            }.apply { visible = { sessionHasOpenTabs } },
+
             SimpleBrowserMenuItem(
                 context.getString(R.string.collection_rename)
             ) {
                 onItemTapped.invoke(Item.RenameCollection)
             },
+
             SimpleBrowserMenuItem(
-                context.getString(R.string.collection_open_tabs)
+                context.getString(R.string.add_tab)
             ) {
-                onItemTapped.invoke(Item.OpenTabs)
+                onItemTapped.invoke(Item.AddTab)
+            }.apply { visible = { sessionHasOpenTabs } },
+
+            SimpleBrowserMenuItem(
+                context.getString(R.string.collection_delete),
+                textColorResource = ThemeManager.resolveAttribute(R.attr.destructive, context)
+            ) {
+                onItemTapped.invoke(Item.DeleteCollection)
             }
         )
     }


### PR DESCRIPTION
Changed order of items for a collection's overflow menu.
Changed the order tabs open to keep same order from collections

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture