### PR TITLE
For #778 - Rename CustomTabActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -66,7 +66,7 @@
         </activity>
 
         <activity
-            android:name=".customtabs.CustomTabActivity"
+            android:name=".customtabs.ExternalAppBrowserActivity"
             android:autoRemoveFromRecents="false"
             android:configChanges="keyboard|keyboardHidden|mcc|mnc|orientation|screenSize|locale|layoutDirection|smallestScreenSize|screenLayout"
             android:exported="false"

--- a/app/src/main/java/org/mozilla/fenix/components/IntentProcessors.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/IntentProcessors.kt
@@ -36,7 +36,9 @@ class IntentProcessors(
         TabIntentProcessor(sessionManager, sessionUseCases.loadUrl, searchUseCases.newTabSearch, isPrivate = true)
     }
 
-    val customTabIntentProcessor by lazy {
-        CustomTabIntentProcessor(sessionManager, sessionUseCases.loadUrl, context.resources)
+    val externalAppIntentProcessors by lazy {
+        listOf(
+            CustomTabIntentProcessor(sessionManager, sessionUseCases.loadUrl, context.resources)
+        )
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/customtabs/AuthCustomTabActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/AuthCustomTabActivity.kt
@@ -12,7 +12,7 @@ import org.mozilla.fenix.ext.components
 /**
  * A special custom tab for signing into a Firefox Account. The activity is closed once the user is signed in.
  */
-class AuthCustomTabActivity : CustomTabActivity() {
+class AuthCustomTabActivity : ExternalAppBrowserActivity() {
 
     private val accountStateObserver = object : AccountObserver {
         /**

--- a/app/src/main/java/org/mozilla/fenix/customtabs/ExternalAppBrowserActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/ExternalAppBrowserActivity.kt
@@ -17,7 +17,11 @@ import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.theme.CustomTabThemeManager
 import java.security.InvalidParameterException
 
-open class CustomTabActivity : HomeActivity() {
+/**
+ * Activity that holds the [ExternalAppBrowserFragment] that is launched within an external app,
+ * such as custom tabs and progressive web apps.
+ */
+open class ExternalAppBrowserActivity : HomeActivity() {
     final override fun getBreadcrumbMessage(destination: NavDestination): String {
         val fragmentName = resources.getResourceEntryName(destination.id)
         return "Changing to fragment $fragmentName, isCustomTab: true"

--- a/app/src/test/java/org/mozilla/fenix/customtabs/ExternalAppBrowserActivityTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/customtabs/ExternalAppBrowserActivityTest.kt
@@ -18,11 +18,11 @@ import org.robolectric.annotation.Config
 @ObsoleteCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
 @Config(application = TestApplication::class)
-class CustomTabActivityTest {
+class ExternalAppBrowserActivityTest {
 
     @Test
     fun getIntentSource() {
-        val activity = CustomTabActivity()
+        val activity = ExternalAppBrowserActivity()
 
         val launcherIntent = Intent(Intent.ACTION_MAIN).apply {
             addCategory(Intent.CATEGORY_LAUNCHER)


### PR DESCRIPTION
Extracted from #4914. Renames CustomTabActivity since it will also be used for TWAs and PWAs in addition to custom tabs. Also converts the custom tab intent processor into a list, since more items will be added once we merge in PWAs and TWAs.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture