### PR TITLE
No issue: cleaned up formatting on Build Variants section of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,16 +70,19 @@ Note: Both Android SDK and NDK are required.
 We have a lot of build variants. Each variant is composed of two flavors. One flavor is the version of Gecko to use and the other describes 
 which app id and settings to use. Here is a description of what each means:
 
-**geckoBeta** (recommended) uses the Beta variant of the Gecko rendering engine, which corresponds to the next version of Gecko which will go to production
-**geckoNightly** uses the Nightly variant of the Gecko rendering engine, which is the version which will arrive after beta and is less stable
+- **geckoBeta** (recommended) uses the Beta variant of the Gecko rendering engine, which corresponds to the next version of Gecko which will go to production
+- **geckoNightly** uses the Nightly variant of the Gecko rendering engine, which is the version which will arrive after beta and is less stable
 
-**debug** uses debug symbols and debug signing, adds tools like LeakCanary for troubleshooting, and does not strip unused or wasteful code
-**fenixNightly** is a release build with nightly signing which uses the org.mozilla.fenix.nightly app id for nightly releases to Google Play
-**fenixNightlyLegacy** is a release build with release signing which uses the org.mozilla.fenix production app id along with nightly logos, which we're trying to phase out
-**fenixBeta** is a release build with beta signing which uses the org.mozilla.fenix.beta app id for beta releases to Google Play
-**fenixProduction** is a release build with release signing which uses the org.mozilla.fenix app id for production releases to Google Play
-**fennecProduction** is an experimental build with release signing which uses the org.mozilla.firefox app id and supports upgrading the older Firefox. **WARNING** Pre-production versions of this may result in data loss.
-**forPerformanceTest** is a release build with the debuggable flag set and test activities enabled for running Raptor performance tests
+<br />
+<br />
+
+- **debug** uses debug symbols and debug signing, adds tools like LeakCanary for troubleshooting, and does not strip unused or wasteful code
+- **fenixNightly** is a release build with nightly signing which uses the org.mozilla.fenix.nightly app id for nightly releases to Google Play
+- **fenixNightlyLegacy** is a release build with release signing which uses the org.mozilla.fenix production app id along with nightly logos, which we're trying to phase out
+- **fenixBeta** is a release build with beta signing which uses the org.mozilla.fenix.beta app id for beta releases to Google Play
+- **fenixProduction** is a release build with release signing which uses the org.mozilla.fenix app id for production releases to Google Play
+- **fennecProduction** is an experimental build with release signing which uses the org.mozilla.firefox app id and supports upgrading the older Firefox. **WARNING** Pre-production versions of this may result in data loss.
+- **forPerformanceTest** is a release build with the debuggable flag set and test activities enabled for running Raptor performance tests
 
 ## Pre-push hooks
 To reduce review turn-around time, we'd like all pushes to run tests locally. We'd


### PR DESCRIPTION
Updates readme formatting to improve readability of 'build variant' section.  No non-formatting changes were made.

Before:
<img width="925" alt="Screen Shot 2019-09-19 at 1 28 25 PM" src="https://user-images.githubusercontent.com/13170306/65279592-7c56b780-dae3-11e9-82ce-11be1a8190ef.png">

After:
<img width="919" alt="Screen Shot 2019-09-19 at 1 42 31 PM" src="https://user-images.githubusercontent.com/13170306/65279591-7c56b780-dae3-11e9-9dfa-062c535941a2.png">

