### PR TITLE
For #5460: Fixes styling of fill link from clipboard

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
@@ -280,10 +280,12 @@ class SearchFragment : Fragment(), BackHandler {
     }
 
     private fun updateClipboardSuggestion(searchState: SearchFragmentState, clipboardUrl: String?) {
-        fill_link_from_clipboard.visibility =
+        val shouldBeVisible =
             if (searchState.showClipboardSuggestions && searchState.query.isEmpty() && !clipboardUrl.isNullOrEmpty())
-                View.VISIBLE else View.GONE
+            View.VISIBLE else View.GONE
 
+        fill_link_from_clipboard.visibility = shouldBeVisible
+        divider_line.visibility = shouldBeVisible
         clipboard_url.text = clipboardUrl
     }
 

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -47,6 +47,7 @@
         android:id="@+id/fill_link_from_clipboard"
         android:layout_width="match_parent"
         android:layout_height="56dp"
+        android:layout_marginTop="8dp"
         android:focusable="true"
         android:clickable="true"
         android:background="?selectableItemBackground"
@@ -99,10 +100,21 @@
             app:layout_constraintVertical_chainStyle="packed"/>
     </androidx.constraintlayout.widget.ConstraintLayout>
 
+    <View
+        android:id="@+id/divider_line"
+        android:layout_width="match_parent"
+        android:layout_height="1.5dp"
+        android:background="?neutralFaded"
+        android:layout_marginStart="8dp"
+        app:layout_constraintStart_toStartOf="@id/fill_link_from_clipboard"
+        app:layout_constraintEnd_toEndOf="@id/fill_link_from_clipboard"
+        app:layout_constraintTop_toBottomOf="@id/fill_link_from_clipboard" />
+
     <TextView
         android:id="@+id/search_with_shortcuts"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginTop="18dp"
         android:fontFamily="Inter UI"
         android:letterSpacing="0.15"
         android:text="@string/search_shortcuts_search_with"


### PR DESCRIPTION
Updated Screens:
<img width="350" alt="Screen Shot 2019-09-20 at 2 46 41 PM" src="https://user-images.githubusercontent.com/4400286/65360685-b98b7a00-dbb5-11e9-8256-622fb76311b8.png">
<img width="350" alt="Screen Shot 2019-09-20 at 2 46 38 PM" src="https://user-images.githubusercontent.com/4400286/65360687-babca700-dbb5-11e9-9c5f-a3f234d87971.png">


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture