### PR TITLE
For #5356 Improved private browsing "common myths" link accessibility 

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/PrivateBrowsingDescriptionViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/PrivateBrowsingDescriptionViewHolder.kt
@@ -6,8 +6,7 @@ package org.mozilla.fenix.home.sessioncontrol.viewholders
 
 import android.text.SpannableString
 import android.text.method.LinkMovementMethod
-import android.text.style.ClickableSpan
-import android.text.style.ForegroundColorSpan
+import android.text.style.UnderlineSpan
 import android.view.View
 import androidx.recyclerview.widget.RecyclerView
 import io.reactivex.Observer
@@ -24,26 +23,21 @@ class PrivateBrowsingDescriptionViewHolder(
 
     init {
         val resources = view.context.resources
-        // Format the description text to include a hyperlink
         val appName = resources.getString(R.string.app_name)
-        view.private_session_description.text = resources.getString(R.string.private_browsing_placeholder, appName)
-        val descriptionText = String
-            .format(view.private_session_description.text.toString(), System.getProperty("line.separator"))
-        val linkStartIndex = descriptionText.indexOf("\n\n") + 2
-        val linkAction = object : ClickableSpan() {
-            override fun onClick(widget: View?) {
+        view.private_session_description.text = resources.getString(
+            R.string.private_browsing_placeholder_description, appName
+        )
+        val commonMythsText = view.private_session_common_myths.text.toString()
+        val textWithLink = SpannableString(commonMythsText).apply {
+            setSpan(UnderlineSpan(), 0, commonMythsText.length, 0)
+        }
+        with(view.private_session_common_myths) {
+            movementMethod = LinkMovementMethod.getInstance()
+            text = textWithLink
+            setOnClickListener {
                 actionEmitter.onNext(TabAction.PrivateBrowsingLearnMore)
             }
         }
-        val textWithLink = SpannableString(descriptionText).apply {
-            setSpan(linkAction, linkStartIndex, descriptionText.length, 0)
-
-            val colorSpan = ForegroundColorSpan(view.private_session_description.currentTextColor)
-            setSpan(colorSpan, linkStartIndex, descriptionText.length, 0)
-        }
-
-        view.private_session_description.movementMethod = LinkMovementMethod.getInstance()
-        view.private_session_description.text = textWithLink
     }
 
     companion object {

--- a/app/src/main/res/layout/private_browsing_description.xml
+++ b/app/src/main/res/layout/private_browsing_description.xml
@@ -7,16 +7,29 @@
         android:id="@+id/private_session_description_wrapper"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_margin="16dp"
+        android:layout_margin="12dp"
+        android:importantForAccessibility="no"
         android:orientation="vertical">
     <TextView
             android:id="@+id/private_session_description"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:ellipsize="none"
+            android:padding="4dp"
             android:gravity="center_vertical"
             android:scrollHorizontally="false"
-            tools:text="@string/private_browsing_placeholder"
+            tools:text="@string/private_browsing_placeholder_description"
+            android:textColor="?primaryText"
+            android:textSize="14sp" />
+    <TextView
+            android:id="@+id/private_session_common_myths"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="4dp"
+            android:ellipsize="none"
+            android:gravity="center_vertical"
+            android:scrollHorizontally="false"
+            android:text="@string/private_browsing_common_myths"
             android:textColor="?primaryText"
             android:textSize="14sp" />
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,10 +24,12 @@
     <string name="private_browsing_title">You’re in a private session</string>
     <!-- Explanation for private browsing displayed to users on home view when they first enable private mode
         The first parameter is the name of the app defined in app_name (for example: Fenix) -->
-    <string name="private_browsing_placeholder">
+    <string name="private_browsing_placeholder_description">
          %1$s clears your search and browsing history when you quit the app or close all private tabs. While this doesn’t make you anonymous to websites or your internet service provider, it makes it
-        easier to keep what you do online private from anyone else who uses this device.\n\nCommon myths about private
-        browsing
+        easier to keep what you do online private from anyone else who uses this device.
+    </string>
+    <string name="private_browsing_common_myths">
+       Common myths about private browsing
     </string>
     <!-- Delete session button to erase your history in a private session -->
     <string name="private_browsing_delete_session">Delete session</string>


### PR DESCRIPTION
Added separate TextView for link text
Used UnderlineSpan to show text as link
Split string private_browsing_placeholder, one for each TextView
Set clickListener on TextView so it can be accessed via Talkback

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
<img src= https://user-images.githubusercontent.com/48995920/65410825-052b6700-ddf4-11e9-9569-c4b3d0c4eb3e.png width = 40%>

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture