### PR TITLE
Bug 1580778 - Put lint jobs back on Treeherder

### DIFF
--- a/taskcluster/ci/lint/kind.yml
+++ b/taskcluster/ci/lint/kind.yml
@@ -19,26 +19,39 @@ job-defaults:
     run:
         use-caches: false
     run-on-tasks-for: [github-pull-request, github-push]
+    treeherder:
+        kind: test
+        platform: 'lint/opt'
+        tier: 1
 
 jobs:
-    detekt:
-        description: 'Running detekt over all modules'
-        run:
-            using: gradlew
-            gradlew: [detekt]
-    ktlint:
-        description: 'Running ktlint over all modules'
-        run:
-            using: gradlew
-            gradlew: [ktlint]
     compare-locales:
         description: 'Validate strings.xml with compare-locales'
         run:
             using: run-task
             cwd: '{checkout}'
             command: 'pip install --user "compare-locales>=5.0.2,<6.0" && compare-locales --validate l10n.toml .'
+        treeherder:
+            symbol: compare-locale
+            tier: 2
+    detekt:
+        description: 'Running detekt over all modules'
+        run:
+            using: gradlew
+            gradlew: [detekt]
+        treeherder:
+            symbol: detekt
+    ktlint:
+        description: 'Running ktlint over all modules'
+        run:
+            using: gradlew
+            gradlew: [ktlint]
+        treeherder:
+            symbol: ktlint
     lint:
         description: 'Running tlint over all modules'
         run:
             using: gradlew
             gradlew: [lintDebug]
+        treeherder:
+            symbol: lint


### PR DESCRIPTION
Regressed in #5430. Reference-browser has the same regression. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture