### PR TITLE
Use new UseCases APIs after download migration.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/Components.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Components.kt
@@ -21,7 +21,7 @@ class Components(private val context: Context) {
     val core by lazy { Core(context) }
     val search by lazy { Search(context) }
     val useCases by lazy {
-        UseCases(context, core.sessionManager, core.engine.settings, search.searchEngineManager, core.client)
+        UseCases(context, core.sessionManager, core.store, core.engine.settings, search.searchEngineManager, core.client)
     }
     val intentProcessors by lazy {
         IntentProcessors(context, core.sessionManager, useCases.sessionUseCases, useCases.searchUseCases)

--- a/app/src/main/java/org/mozilla/fenix/components/UseCases.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/UseCases.kt
@@ -7,6 +7,7 @@ package org.mozilla.fenix.components
 import android.content.Context
 import mozilla.components.browser.search.SearchEngineManager
 import mozilla.components.browser.session.SessionManager
+import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.Settings
 import mozilla.components.concept.fetch.Client
 import mozilla.components.feature.app.links.AppLinksUseCases
@@ -27,6 +28,7 @@ import org.mozilla.fenix.test.Mockable
 class UseCases(
     private val context: Context,
     private val sessionManager: SessionManager,
+    private val store: BrowserStore,
     private val engineSettings: Settings,
     private val searchEngineManager: SearchEngineManager,
     private val httpClient: Client
@@ -55,7 +57,7 @@ class UseCases(
 
     val webAppUseCases by lazy { WebAppUseCases(context, sessionManager, httpClient, supportWebApps = false) }
 
-    val downloadUseCases by lazy { DownloadsUseCases(sessionManager) }
+    val downloadUseCases by lazy { DownloadsUseCases(store) }
 
-    val contextMenuUseCases by lazy { ContextMenuUseCases(sessionManager) }
+    val contextMenuUseCases by lazy { ContextMenuUseCases(sessionManager, store) }
 }


### PR DESCRIPTION
In preparation for the API breakage that we are going to introduce in AC in this PR:
https://github.com/mozilla-mobile/android-components/pull/4506