### PR TITLE
Use Mozilla Android Components 15.0.0-SNAPSHOT.

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -35,7 +35,7 @@ object Versions {
     const val androidx_work = "2.0.1"
     const val google_material = "1.1.0-alpha10"
 
-    const val mozilla_android_components = "14.0.0-SNAPSHOT"
+    const val mozilla_android_components = "15.0.0-SNAPSHOT"
     // Note that android-components also depends on application-services,
     // and in fact is our main source of appservices-related functionality.
     // The version number below tracks the application-services version


### PR DESCRIPTION
Updating to the next snapshot version. I assume you want to merge this *after* cutting the release branch so that no 15.0.0 changes get into the release branch.