### PR TITLE
Bug 1580778 - Raptor: put ytp exceptions back

### DIFF
--- a/automation/taskcluster/lib/tasks.py
+++ b/automation/taskcluster/lib/tasks.py
@@ -1,9 +1,0 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-# Bug 1558456 - Stop tracking youtube-playback-test on motoG5 for >1080p cases
-ARM_RAPTOR_URL_PARAMS = [
-    "exclude=1,2,9,10,17,18,21,22,26,28,30,32,39,40,47,"
-    "48,55,56,63,64,71,72,79,80,83,84,89,90,95,96",
-]

--- a/taskcluster/ci/raptor/kind.yml
+++ b/taskcluster/ci/raptor/kind.yml
@@ -204,3 +204,9 @@ jobs:
         test-name: raptor-youtube-playback
         treeherder:
             symbol: 'Rap(ytp)'
+        args:
+            by-abi:
+                # Bug 1558456 - Stop tracking youtube-playback-test on motoG5 for >1080p cases
+                armeabi-v7a:
+                    - '--test-url-params=exclude=1,2,9,10,17,18,21,22,26,28,30,32,39,40,47,48,55,56,63,64,71,72,79,80,83,84,89,90,95,96'
+                default: []

--- a/taskcluster/fenix_taskgraph/transforms/raptor.py
+++ b/taskcluster/fenix_taskgraph/transforms/raptor.py
@@ -58,7 +58,7 @@ def build_raptor_task(config, tasks):
         task["name"] = "{}-{}-{}".format(task["name"], build_type, abi)
         task["description"] = "{}-{}".format(build_type, abi)
 
-        for key in ("worker-type", "treeherder.platform"):
+        for key in ("args", "treeherder.platform", "worker-type"):
             resolve_keyed_by(task, key, item_name=task["name"], **{"abi": abi})
 
         task["treeherder"] = inherit_treeherder_from_dep(task, signing)


### PR DESCRIPTION
I realized I didn't migrate one of the YouTube Perf jobs, correctly in https://github.com/mozilla-mobile/fenix/pull/5361. 


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture