### PR TITLE
Use Mozilla Android Components 14.0.1 

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -35,7 +35,7 @@ object Versions {
     const val androidx_work = "2.0.1"
     const val google_material = "1.1.0-alpha10"
 
-    const val mozilla_android_components = "14.0.0"
+    const val mozilla_android_components = "14.0.1"
     // Note that android-components also depends on application-services,
     // and in fact is our main source of appservices-related functionality.
     // The version number below tracks the application-services version


### PR DESCRIPTION
Includes the fix for https://github.com/mozilla-mobile/fenix/issues/5486 and https://github.com/mozilla-mobile/android-components/pull/4511 for the upcoming release.