### PR TITLE
Add glinter overrides.

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -5,6 +5,9 @@
 
 $schema: moz://mozilla.org/schemas/glean/metrics/1-0-0
 
+no_lint:
+  - CATEGORY_GENERIC
+
 events:
   app_opened:
     type: event
@@ -1435,6 +1438,9 @@ tab:
     notification_emails:
       - fenix-core@mozilla.com
     expires: "2020-03-01"
+    no_lint:
+      - COMMON_PREFIX
+
   media_pause:
     type: event
     description: >


### PR DESCRIPTION
Glean now includes a "glinter" which warns against certain naming conventions in Glean metrics.  This glinter currently treats the validations as warnings, but some day they will be treated as errors.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1580812

This PR adds linting overrides for the violations to these recommendations that already exist in Fenix so that when the warnings become errors Glean will not break the Fenix build.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture