### PR TITLE
4513 add bookmarks progress bar

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkDeselectNavigationListener.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkDeselectNavigationListener.kt
@@ -23,7 +23,7 @@ class BookmarkDeselectNavigationListener(
         navController.addOnDestinationChangedListener(this)
     }
 
-    @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+    @OnLifecycleEvent(Lifecycle.Event.ON_PAUSE)
     fun onDestroy() {
         navController.removeOnDestinationChangedListener(this)
     }

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkDeselectNavigationListener.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkDeselectNavigationListener.kt
@@ -33,6 +33,7 @@ class BookmarkDeselectNavigationListener(
      */
     override fun onDestinationChanged(controller: NavController, destination: NavDestination, arguments: Bundle?) {
         if (destination.id != R.id.bookmarkFragment || differentFromSelectedFolder(arguments)) {
+            // TODO this is currently called when opening the bookmark menu. Fix this if possible
             bookmarkInteractor.onAllBookmarksDeselected()
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragment.kt
@@ -73,7 +73,7 @@ class BookmarkFragment : LibraryPageFragment<BookmarkNode>(), BackHandler, Accou
         val view = inflater.inflate(R.layout.fragment_bookmark, container, false)
 
         bookmarkStore = StoreProvider.get(this) {
-            BookmarkFragmentStore(BookmarkFragmentState(null, isLoading = true))
+            BookmarkFragmentStore(BookmarkFragmentState(null))
         }
         bookmarkInteractor = BookmarkFragmentInteractor(
             bookmarkStore = bookmarkStore,

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragment.kt
@@ -73,7 +73,7 @@ class BookmarkFragment : LibraryPageFragment<BookmarkNode>(), BackHandler, Accou
         val view = inflater.inflate(R.layout.fragment_bookmark, container, false)
 
         bookmarkStore = StoreProvider.get(this) {
-            BookmarkFragmentStore(BookmarkFragmentState(null))
+            BookmarkFragmentStore(BookmarkFragmentState(null, isLoading = true))
         }
         bookmarkInteractor = BookmarkFragmentInteractor(
             bookmarkStore = bookmarkStore,

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragmentStore.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragmentStore.kt
@@ -20,7 +20,11 @@ class BookmarkFragmentStore(
  * @property tree The current tree of bookmarks, if one is loaded
  * @property mode The current bookmark multi-selection mode
  */
-data class BookmarkFragmentState(val tree: BookmarkNode?, val mode: Mode = Mode.Normal) : State {
+data class BookmarkFragmentState(
+    val tree: BookmarkNode?,
+    val mode: Mode = Mode.Normal,
+    val isLoading: Boolean
+) : State {
     sealed class Mode {
         open val selectedItems = emptySet<BookmarkNode>()
 
@@ -58,7 +62,8 @@ private fun bookmarkFragmentStateReducer(
                     BookmarkFragmentState.Mode.Normal
                 } else {
                     BookmarkFragmentState.Mode.Selecting(items.toSet())
-                }
+                },
+                isLoading = false
             )
         }
         is BookmarkFragmentAction.Select ->

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragmentStore.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragmentStore.kt
@@ -23,7 +23,7 @@ class BookmarkFragmentStore(
 data class BookmarkFragmentState(
     val tree: BookmarkNode?,
     val mode: Mode = Mode.Normal,
-    val isLoading: Boolean
+    val isLoading: Boolean = true
 ) : State {
     sealed class Mode {
         open val selectedItems = emptySet<BookmarkNode>()

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkView.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkView.kt
@@ -7,6 +7,7 @@ package org.mozilla.fenix.library.bookmarks
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.isVisible
 import kotlinx.android.synthetic.main.component_bookmark.view.*
 import mozilla.appservices.places.BookmarkRoot
 import mozilla.components.concept.storage.BookmarkNode
@@ -130,6 +131,7 @@ class BookmarkView(
                     view.bookmark_list
                 )
         }
+        view.bookmarks_progress_bar.isVisible = state.isLoading
     }
 
     override fun onBackPressed(): Boolean {

--- a/app/src/main/res/layout/component_bookmark.xml
+++ b/app/src/main/res/layout/component_bookmark.xml
@@ -30,4 +30,10 @@
             android:textSize="16sp"
             android:visibility="gone" />
 
+    <ProgressBar
+        android:id="@+id/bookmarks_progress_bar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center" />
+
 </FrameLayout>

--- a/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkFragmentStoreTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkFragmentStoreTest.kt
@@ -9,7 +9,9 @@ import assertk.assertions.isEqualTo
 import kotlinx.coroutines.runBlocking
 import mozilla.components.concept.storage.BookmarkNode
 import mozilla.components.concept.storage.BookmarkNodeType
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class BookmarkFragmentStoreTest {
@@ -132,6 +134,30 @@ class BookmarkFragmentStoreTest {
         store.dispatch(BookmarkFragmentAction.Change(newTree)).join()
 
         assertThat(initialState.copy(tree = newTree, mode = BookmarkFragmentState.Mode.Normal)).isEqualTo(store.state)
+    }
+
+    @Test
+    fun `selecting and deselecting bookmarks does not affect loading state`() = runBlocking {
+        val initialState = BookmarkFragmentState(tree, isLoading = true)
+        val store = BookmarkFragmentStore(initialState)
+
+        store.dispatch(BookmarkFragmentAction.Select(newTree)).join()
+        assertTrue(store.state.isLoading)
+
+        store.dispatch(BookmarkFragmentAction.Deselect(newTree)).join()
+        assertTrue(store.state.isLoading)
+
+        store.dispatch(BookmarkFragmentAction.DeselectAll).join()
+        assertTrue(store.state.isLoading)
+    }
+
+    @Test
+    fun `changing bookmarks disables loading state`() = runBlocking {
+        val initialState = BookmarkFragmentState(tree, isLoading = true)
+        val store = BookmarkFragmentStore(initialState)
+
+        store.dispatch(BookmarkFragmentAction.Change(newTree)).join()
+        assertFalse(store.state.isLoading)
     }
 
     private val item = BookmarkNode(BookmarkNodeType.ITEM, "456", "123", 0, "Mozilla", "http://mozilla.org", null)

--- a/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkFragmentStoreTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkFragmentStoreTest.kt
@@ -25,7 +25,8 @@ class BookmarkFragmentStoreTest {
 
         store.dispatch(BookmarkFragmentAction.Change(tree)).join()
 
-        assertThat(initialState.copy(tree = tree)).isEqualTo(store.state)
+        assertThat(tree).isEqualTo(store.state.tree)
+        assertThat(initialState.mode).isEqualTo(store.state.mode)
     }
 
     @Test
@@ -37,7 +38,8 @@ class BookmarkFragmentStoreTest {
 
         store.dispatch(BookmarkFragmentAction.Change(newTree)).join()
 
-        assertThat(initialState.copy(tree = newTree)).isEqualTo(store.state)
+        assertThat(newTree).isEqualTo(store.state.tree)
+        assertThat(initialState.mode).isEqualTo(store.state.mode)
     }
 
     @Test
@@ -49,7 +51,8 @@ class BookmarkFragmentStoreTest {
 
         store.dispatch(BookmarkFragmentAction.Change(tree)).join()
 
-        assertSame(initialState, store.state)
+        assertThat(initialState.tree).isEqualTo(store.state.tree)
+        assertThat(initialState.mode).isEqualTo(store.state.mode)
     }
 
     @Test
@@ -59,7 +62,8 @@ class BookmarkFragmentStoreTest {
 
         store.dispatch(BookmarkFragmentAction.Change(newTree)).join()
 
-        assertThat(BookmarkFragmentState(newTree, BookmarkFragmentState.Mode.Selecting(setOf(subfolder)))).isEqualTo(store.state)
+        assertThat(newTree).isEqualTo(store.state.tree)
+        assertThat(BookmarkFragmentState.Mode.Selecting(setOf(subfolder))).isEqualTo(store.state.mode)
     }
 
     @Test
@@ -133,7 +137,10 @@ class BookmarkFragmentStoreTest {
 
         store.dispatch(BookmarkFragmentAction.Change(newTree)).join()
 
-        assertThat(initialState.copy(tree = newTree, mode = BookmarkFragmentState.Mode.Normal)).isEqualTo(store.state)
+        store.state.run {
+            assertThat(newTree).isEqualTo(tree)
+            assertThat(BookmarkFragmentState.Mode.Normal).isEqualTo(mode)
+        }
     }
 
     @Test


### PR DESCRIPTION
Note that this adds very simple loading behavior. We start in loading state, and whenever we get any bookmark data we clear that state. We may want to have more nuanced loading behavior in the future (e.g., show a progress bar beneath cached bookmarks while syncing), but that would require UX support.

![bookmarks-progress-bar](https://user-images.githubusercontent.com/13170306/65563190-9d614300-defd-11e9-843e-d03cc7fb9317.gif)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture