### PR TITLE
Bug 1571029 - Put raptor emails back

### DIFF
--- a/taskcluster/ci/raptor/kind.yml
+++ b/taskcluster/ci/raptor/kind.yml
@@ -2,6 +2,7 @@
 loader: taskgraph.loader.transform:loader
 transforms:
     - fenix_taskgraph.transforms.raptor:transforms
+    - fenix_taskgraph.transforms.notify:transforms
     - taskgraph.transforms.job:transforms
     - taskgraph.transforms.task:transforms
 
@@ -16,10 +17,20 @@ only-for-abis:
     - arm64-v8a
 
 job-defaults:
-    worker-type:
-        by-abi:
-            armeabi-v7a: t-bitbar-gw-perf-g5
-            arm64-v8a: t-bitbar-gw-perf-p2
+    dependencies:
+        geckoview-nightly: geckoview-nightly
+    notify:
+        by-level:
+            '3':
+                email:
+                    content: This calls for an action of the Performance team. Use the link to view it on Treeherder.
+                    link:
+                        text: Treeherder Job
+                        href: 'https://treeherder.mozilla.org/#/jobs?repo={product_name}&revision={head_rev}&searchStr={task_name}'
+                    on-reasons: [failed]
+                    subject: '[{product_name}] Raptor job "{task_name}" failed'
+                    to-addresses: [perftest-alerts@mozilla.com]
+            default: {}
     run-on-tasks-for: []
     treeherder:
         kind: test
@@ -28,8 +39,10 @@ job-defaults:
             by-abi:
                 arm64-v8a: android-hw-p2-8-0-android-aarch64/opt
                 armeabi-v7a: android-hw-g5-7-0-arm7-api-16/opt
-    dependencies:
-        geckoview-nightly: geckoview-nightly
+    worker-type:
+        by-abi:
+            armeabi-v7a: t-bitbar-gw-perf-g5
+            arm64-v8a: t-bitbar-gw-perf-p2
     worker:
         max-run-time: 3600
         env:

--- a/taskcluster/fenix_taskgraph/transforms/notify.py
+++ b/taskcluster/fenix_taskgraph/transforms/notify.py
@@ -1,0 +1,41 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+"""
+Handle notifications like emails.
+"""
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+import copy
+import json
+
+from taskgraph.transforms.base import TransformSequence
+from taskgraph.util.treeherder import inherit_treeherder_from_dep
+from taskgraph.util.schema import resolve_keyed_by
+
+transforms = TransformSequence()
+
+
+@transforms.add
+def add_notify_email(config, tasks):
+    for task in tasks:
+        notify = task.pop('notify', {})
+        email_config = notify.get('email')
+        if email_config:
+            extra = task.setdefault('extra', {})
+            notify = extra.setdefault('notify', {})
+            notify['email'] = {
+                'content': email_config['content'],
+                'subject': email_config['subject'],
+                'link': email_config.get('link', None),
+            }
+
+            routes = task.setdefault('routes', [])
+            routes.extend([
+                'notify.email.{}.on-{}'.format(address, reason)
+                for address in email_config['to-addresses']
+                for reason in email_config['on-reasons']
+            ])
+
+        yield task

--- a/taskcluster/fenix_taskgraph/transforms/raptor.py
+++ b/taskcluster/fenix_taskgraph/transforms/raptor.py
@@ -91,3 +91,23 @@ def build_raptor_task(config, tasks):
         task["run"]["command"].extend(task.pop("args", []))
 
         yield task
+
+
+@transforms.add
+def fill_email_data(config, tasks):
+    product_name = config.graph_config['taskgraph']['repositories']['mobile']['name']
+    format_kwargs = {
+        "product_name": product_name.lower(),
+        "head_rev": config.params["head_rev"],
+    }
+
+    for task in tasks:
+        format_kwargs["task_name"] = task["name"]
+
+        resolve_keyed_by(task, 'notify', item_name=task["name"], level=config.params["level"])
+        email = task["notify"].get("email")
+        if email:
+            email["link"]["href"] = email["link"]["href"].format(**format_kwargs)
+            email["subject"] = email["subject"].format(**format_kwargs)
+
+        yield task


### PR DESCRIPTION
Puts the logic implemented in #4492 back in. It was removed in #5361, when the taskgraph migration happened. Thanks for showing how to put emails in https://github.com/mozilla-mobile/firefox-tv/pull/2892, @mitchhentges \o/

There's a difference with #4492: the decision task doesn't email out anymore. The reason is: I currently don't see a way for taskgraph to handle it (cc @tomprince to check me on this).

Tested in staging at https://tools.taskcluster.net/groups/U6Ujoih7Q4O96fpef6ODQA 

cc @davehunt 


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture