### PR TITLE
Separate custom tab specific code for toolbar

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -60,14 +60,13 @@ import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.components.FindInPageIntegration
 import org.mozilla.fenix.components.StoreProvider
 import org.mozilla.fenix.components.metrics.Event
+import org.mozilla.fenix.components.toolbar.BaseBrowserToolbarView
+import org.mozilla.fenix.components.toolbar.BaseToolbarIntegration
 import org.mozilla.fenix.components.toolbar.BrowserFragmentState
 import org.mozilla.fenix.components.toolbar.BrowserFragmentStore
 import org.mozilla.fenix.components.toolbar.BrowserToolbarController
-import org.mozilla.fenix.components.toolbar.BrowserToolbarView
-import org.mozilla.fenix.components.toolbar.BrowserToolbarViewInteractor
 import org.mozilla.fenix.components.toolbar.DefaultBrowserToolbarController
 import org.mozilla.fenix.components.toolbar.QuickActionSheetState
-import org.mozilla.fenix.components.toolbar.ToolbarIntegration
 import org.mozilla.fenix.downloads.DownloadService
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.enterToImmersiveMode
@@ -87,8 +86,7 @@ import org.mozilla.fenix.theme.ThemeManager
 @Suppress("TooManyFunctions", "LargeClass")
 abstract class BaseBrowserFragment : Fragment(), BackHandler, SessionManager.Observer {
     protected lateinit var browserStore: BrowserFragmentStore
-    protected lateinit var browserInteractor: BrowserToolbarViewInteractor
-    protected lateinit var browserToolbarView: BrowserToolbarView
+    protected lateinit var browserToolbarView: BaseBrowserToolbarView
 
     private val sessionFeature = ViewBoundFeatureWrapper<SessionFeature>()
     private val windowFeature = ViewBoundFeatureWrapper<WindowFeature>()
@@ -97,7 +95,7 @@ abstract class BaseBrowserFragment : Fragment(), BackHandler, SessionManager.Obs
     private val appLinksFeature = ViewBoundFeatureWrapper<AppLinksFeature>()
     private val promptsFeature = ViewBoundFeatureWrapper<PromptFeature>()
     private val findInPageIntegration = ViewBoundFeatureWrapper<FindInPageIntegration>()
-    private val toolbarIntegration = ViewBoundFeatureWrapper<ToolbarIntegration>()
+    private val toolbarIntegration = ViewBoundFeatureWrapper<BaseToolbarIntegration>()
     private val sitePermissionsFeature = ViewBoundFeatureWrapper<SitePermissionsFeature>()
     private val fullScreenFeature = ViewBoundFeatureWrapper<FullScreenFeature>()
     private val swipeRefreshFeature = ViewBoundFeatureWrapper<SwipeRefreshFeature>()
@@ -182,15 +180,9 @@ abstract class BaseBrowserFragment : Fragment(), BackHandler, SessionManager.Obs
                 scope = lifecycleScope
             )
 
-            browserInteractor =
-                createBrowserToolbarViewInteractor(
-                    browserToolbarController,
-                    customTabSessionId?.let { sessionManager.findSessionById(it) })
-
-            browserToolbarView = BrowserToolbarView(
-                container = view.browserLayout,
-                interactor = browserInteractor,
-                customTabSession = customTabSessionId?.let { sessionManager.findSessionById(it) }
+            browserToolbarView = createBrowserToolbarView(
+                view.browserLayout,
+                browserToolbarController
             )
 
             toolbarIntegration.set(
@@ -502,10 +494,10 @@ abstract class BaseBrowserFragment : Fragment(), BackHandler, SessionManager.Obs
         return false
     }
 
-    protected abstract fun createBrowserToolbarViewInteractor(
-        browserToolbarController: BrowserToolbarController,
-        session: Session?
-    ): BrowserToolbarViewInteractor
+    protected abstract fun createBrowserToolbarView(
+        container: ViewGroup,
+        browserToolbarController: BrowserToolbarController
+    ): BaseBrowserToolbarView
 
     protected abstract fun navToQuickSettingsSheet(session: Session, sitePermissions: SitePermissions?)
 

--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -48,7 +48,7 @@ import org.mozilla.fenix.components.TabCollectionStorage
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.components.toolbar.BrowserInteractor
 import org.mozilla.fenix.components.toolbar.BrowserToolbarController
-import org.mozilla.fenix.components.toolbar.BrowserToolbarViewInteractor
+import org.mozilla.fenix.components.toolbar.BrowserToolbarView
 import org.mozilla.fenix.components.toolbar.QuickActionSheetAction
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.increaseTapArea
@@ -180,10 +180,10 @@ class BrowserFragment : BaseBrowserFragment(), BackHandler {
         return readerViewFeature.onBackPressed() || super.onBackPressed()
     }
 
-    override fun createBrowserToolbarViewInteractor(
-        browserToolbarController: BrowserToolbarController,
-        session: Session?
-    ): BrowserToolbarViewInteractor {
+    override fun createBrowserToolbarView(
+        container: ViewGroup,
+        browserToolbarController: BrowserToolbarController
+    ): BrowserToolbarView {
         val context = requireContext()
 
         val interactor = BrowserInteractor(
@@ -201,12 +201,15 @@ class BrowserFragment : BaseBrowserFragment(), BackHandler {
                 }
             ),
             readerModeController = DefaultReaderModeController(readerViewFeature),
-            currentSession = session
+            currentSession = getSessionById()
         )
 
-        quickActionSheetView = QuickActionSheetView(view!!.nestedScrollQuickAction, interactor)
+        quickActionSheetView = QuickActionSheetView(requireView().nestedScrollQuickAction, interactor)
 
-        return interactor
+        return BrowserToolbarView(
+            container = container,
+            interactor = interactor
+        )
     }
 
     override fun navToQuickSettingsSheet(session: Session, sitePermissions: SitePermissions?) {

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BaseBrowserToolbarView.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BaseBrowserToolbarView.kt
@@ -1,0 +1,132 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.components.toolbar
+
+import android.view.Gravity
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.LinearLayout
+import android.widget.PopupWindow
+import androidx.core.content.ContextCompat
+import kotlinx.android.extensions.LayoutContainer
+import kotlinx.android.synthetic.main.browser_toolbar_popup_window.view.*
+import mozilla.components.browser.toolbar.BrowserToolbar
+import mozilla.components.support.ktx.android.util.dpToFloat
+import mozilla.components.support.ktx.android.util.dpToPx
+import org.jetbrains.anko.dimen
+import org.mozilla.fenix.R
+import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.theme.ThemeManager
+import org.mozilla.fenix.utils.ClipboardHandler
+
+interface BrowserToolbarViewInteractor {
+    fun onBrowserToolbarPaste(text: String)
+    fun onBrowserToolbarPasteAndGo(text: String)
+    fun onBrowserToolbarClicked()
+    fun onBrowserToolbarMenuItemTapped(item: ToolbarMenu.Item)
+}
+
+abstract class BaseBrowserToolbarView(
+    final override val containerView: ViewGroup,
+    val interactor: BrowserToolbarViewInteractor,
+    private val sessionId: String?
+) : LayoutContainer {
+
+    val view: BrowserToolbar = LayoutInflater.from(containerView.context)
+        .inflate(R.layout.component_search, containerView, true)
+        .findViewById(R.id.toolbar)
+
+    abstract val toolbarIntegration: BaseToolbarIntegration
+
+    init {
+        view.setOnUrlLongClickListener { view ->
+            val clipboard = view.context.components.clipboardHandler
+            val customView = LayoutInflater
+                .from(view.context)
+                .inflate(R.layout.browser_toolbar_popup_window, null)
+
+            onUrlLongClick(customView, clipboard)
+            true
+        }
+    }
+
+    protected open fun onUrlLongClick(customView: View, clipboard: ClipboardHandler) {
+        val popupWindow = PopupWindow(
+            customView,
+            LinearLayout.LayoutParams.WRAP_CONTENT,
+            view.context.dimen(R.dimen.context_menu_height),
+            true
+        )
+
+        popupWindow.elevation = view.context.dimen(R.dimen.mozac_browser_menu_elevation).toFloat()
+
+        customView.copy.setOnClickListener {
+            popupWindow.dismiss()
+
+            clipboard.text = getSessionById()?.url
+        }
+
+        customView.paste.setOnClickListener {
+            popupWindow.dismiss()
+            interactor.onBrowserToolbarPaste(clipboard.text!!)
+        }
+
+        customView.paste_and_go.setOnClickListener {
+            popupWindow.dismiss()
+            interactor.onBrowserToolbarPasteAndGo(clipboard.text!!)
+        }
+
+        popupWindow.showAsDropDown(view, view.context.dimen(R.dimen.context_menu_x_offset), 0, Gravity.START)
+    }
+
+    protected open fun styleBrowserToolbar(toolbar: BrowserToolbar) {
+        toolbar.apply {
+            elevation = TOOLBAR_ELEVATION.dpToFloat(resources.displayMetrics)
+
+            onUrlClicked = {
+                interactor.onBrowserToolbarClicked()
+                false
+            }
+
+            browserActionMargin = browserActionMarginDp.dpToPx(resources.displayMetrics)
+
+            textColor = ContextCompat.getColor(context, R.color.photonGrey30)
+
+            hint = context.getString(R.string.search_hint)
+
+            suggestionBackgroundColor = ContextCompat.getColor(
+                containerView.context,
+                R.color.suggestion_highlight_color
+            )
+
+            textColor = ContextCompat.getColor(
+                containerView.context,
+                ThemeManager.resolveAttribute(R.attr.primaryText, containerView.context)
+            )
+
+            hintColor = ContextCompat.getColor(
+                containerView.context,
+                ThemeManager.resolveAttribute(R.attr.secondaryText, containerView.context)
+            )
+        }
+    }
+
+    @Suppress("UNUSED_PARAMETER")
+    fun update(state: BrowserFragmentState) {
+        // Intentionally leaving this as a stub for now since we don't actually want to update currently
+    }
+
+    protected fun getSessionById() = view.context.components.core.sessionManager.run {
+        sessionId?.let { findSessionById(it) } ?: selectedSession
+    }
+
+    companion object {
+        internal const val TOOLBAR_ELEVATION = 16
+        internal const val PROGRESS_BOTTOM = 0
+        internal const val PROGRESS_TOP = 1
+        const val browserActionMarginDp = 8
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BaseToolbarIntegration.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BaseToolbarIntegration.kt
@@ -1,0 +1,83 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.components.toolbar
+
+import android.content.Context
+import androidx.appcompat.content.res.AppCompatResources
+import com.airbnb.lottie.LottieCompositionFactory
+import com.airbnb.lottie.LottieDrawable
+import mozilla.components.browser.toolbar.BrowserToolbar
+import mozilla.components.feature.toolbar.ToolbarFeature
+import mozilla.components.feature.toolbar.ToolbarPresenter
+import mozilla.components.lib.publicsuffixlist.PublicSuffixList
+import mozilla.components.support.base.feature.LifecycleAwareFeature
+import org.mozilla.fenix.FeatureFlags
+import org.mozilla.fenix.R
+import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.theme.ThemeManager
+
+abstract class BaseToolbarIntegration(
+    context: Context,
+    toolbar: BrowserToolbar,
+    toolbarMenu: ToolbarMenu,
+    renderStyle: ToolbarFeature.RenderStyle,
+    sessionId: String?,
+    isPrivate: Boolean,
+    displaySeperator: Boolean
+) : LifecycleAwareFeature {
+
+    init {
+        toolbar.setMenuBuilder(toolbarMenu.menuBuilder)
+        toolbar.private = isPrivate
+
+        LottieCompositionFactory
+            .fromRawRes(context, ThemeManager.resolveAttribute(R.attr.shieldLottieFile, context))
+            .addListener { result ->
+                val lottieDrawable = LottieDrawable()
+                lottieDrawable.composition = result
+                val useEnhancedTrackingProtection =
+                    context.settings().shouldUseTrackingProtection && FeatureFlags.etpCategories
+                toolbar.displayTrackingProtectionIcon = useEnhancedTrackingProtection
+                toolbar.displaySeparatorView = displaySeperator && useEnhancedTrackingProtection
+
+                toolbar.setTrackingProtectionIcons(
+                    iconOnNoTrackersBlocked = AppCompatResources.getDrawable(
+                        context,
+                        R.drawable.ic_tracking_protection_enabled
+                    )!!,
+                    iconOnTrackersBlocked = lottieDrawable,
+                    iconDisabledForSite = AppCompatResources.getDrawable(
+                        context,
+                        R.drawable.ic_tracking_protection_disabled
+                    )!!
+                )
+            }
+    }
+
+    private val toolbarPresenter: ToolbarPresenter = ToolbarPresenter(
+        toolbar,
+        context.components.core.store,
+        sessionId,
+        ToolbarFeature.UrlRenderConfiguration(
+            PublicSuffixList(context),
+            registrableDomainColor = ThemeManager.resolveAttribute(R.attr.primaryText, context),
+            renderStyle = renderStyle
+        )
+    )
+
+    private var menuPresenter =
+        MenuPresenter(toolbar, context.components.core.sessionManager, sessionId)
+
+    final override fun start() {
+        menuPresenter.start()
+        toolbarPresenter.start()
+    }
+
+    final override fun stop() {
+        menuPresenter.stop()
+        toolbarPresenter.stop()
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarView.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarView.kt
@@ -4,174 +4,62 @@
 
 package org.mozilla.fenix.components.toolbar
 
-import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.LinearLayout
-import android.widget.PopupWindow
-import androidx.core.content.ContextCompat
-import androidx.core.view.isVisible
-import kotlinx.android.extensions.LayoutContainer
+import androidx.core.view.isGone
 import kotlinx.android.synthetic.main.browser_toolbar_popup_window.view.*
 import mozilla.components.browser.domains.autocomplete.ShippedDomainsProvider
-import mozilla.components.browser.session.Session
 import mozilla.components.browser.toolbar.BrowserToolbar
-import mozilla.components.support.ktx.android.util.dpToFloat
-import mozilla.components.support.ktx.android.util.dpToPx
-import org.jetbrains.anko.dimen
 import org.mozilla.fenix.R
-import org.mozilla.fenix.customtabs.CustomTabToolbarMenu
 import org.mozilla.fenix.ext.components
-import org.mozilla.fenix.theme.ThemeManager
-
-interface BrowserToolbarViewInteractor {
-    fun onBrowserToolbarPaste(text: String)
-    fun onBrowserToolbarPasteAndGo(text: String)
-    fun onBrowserToolbarClicked()
-    fun onBrowserToolbarMenuItemTapped(item: ToolbarMenu.Item)
-}
+import org.mozilla.fenix.utils.ClipboardHandler
 
 class BrowserToolbarView(
-    private val container: ViewGroup,
-    private val interactor: BrowserToolbarViewInteractor,
-    private val customTabSession: Session?
-) : LayoutContainer {
-
-    override val containerView: View?
-        get() = container
+    container: ViewGroup,
+    interactor: BrowserToolbarViewInteractor
+) : BaseBrowserToolbarView(container, interactor, sessionId = null) {
 
     private val urlBackground = LayoutInflater.from(container.context)
         .inflate(R.layout.layout_url_background, container, false)
 
-    val view: BrowserToolbar = LayoutInflater.from(container.context)
-        .inflate(R.layout.component_search, container, true)
-        .findViewById(R.id.toolbar)
-
-    val toolbarIntegration: ToolbarIntegration
+    override val toolbarIntegration: ToolbarIntegration
 
     init {
-        val isCustomTabSession = customTabSession != null
+        val components = container.context.components
+        toolbarIntegration = ToolbarIntegration(
+            container.context,
+            view,
+            container,
+            DefaultToolbarMenu(
+                container.context,
+                hasAccountProblem = components.backgroundServices.accountManager.accountNeedsReauth(),
+                requestDesktopStateProvider = {
+                    getSessionById()?.desktopMode ?: false
+                },
+                onItemTapped = { interactor.onBrowserToolbarMenuItemTapped(it) }
+            ),
+            ShippedDomainsProvider().also { it.initialize(container.context) },
+            components.core.historyStorage,
+            components.core.sessionManager,
+            sessionId = null,
+            isPrivate = getSessionById()?.private ?: false
+        )
 
-        view.setOnUrlLongClickListener {
-            val clipboard = view.context.components.clipboardHandler
-            val customView = LayoutInflater.from(view.context).inflate(R.layout.browser_toolbar_popup_window, null)
-            val popupWindow = PopupWindow(customView,
-                LinearLayout.LayoutParams.WRAP_CONTENT,
-                view.context.dimen(R.dimen.context_menu_height),
-                true
-            )
-
-            val selectedSession = container.context.components.core.sessionManager.selectedSession
-
-            popupWindow.elevation = view.context.dimen(R.dimen.mozac_browser_menu_elevation).toFloat()
-
-            customView.paste.isVisible = !clipboard.text.isNullOrEmpty() && !isCustomTabSession
-            customView.paste_and_go.isVisible = !clipboard.text.isNullOrEmpty() && !isCustomTabSession
-
-            customView.copy.setOnClickListener {
-                popupWindow.dismiss()
-                if (isCustomTabSession) {
-                    clipboard.text = customTabSession?.url
-                } else {
-                    clipboard.text = selectedSession?.url
-                }
-            }
-
-            customView.paste.setOnClickListener {
-                popupWindow.dismiss()
-                interactor.onBrowserToolbarPaste(clipboard.text!!)
-            }
-
-            customView.paste_and_go.setOnClickListener {
-                popupWindow.dismiss()
-                interactor.onBrowserToolbarPasteAndGo(clipboard.text!!)
-            }
-
-            popupWindow.showAsDropDown(view, view.context.dimen(R.dimen.context_menu_x_offset), 0, Gravity.START)
-
-            true
-        }
-
-        with(container.context) {
-            val sessionManager = components.core.sessionManager
-
-            view.apply {
-                elevation = TOOLBAR_ELEVATION.dpToFloat(resources.displayMetrics)
-
-                onUrlClicked = {
-                    interactor.onBrowserToolbarClicked()
-                    false
-                }
-
-                browserActionMargin = browserActionMarginDp.dpToPx(resources.displayMetrics)
-
-                urlBoxView = if (isCustomTabSession) null else urlBackground
-                progressBarGravity = if (isCustomTabSession) PROGRESS_BOTTOM else PROGRESS_TOP
-
-                textColor = ContextCompat.getColor(context, R.color.photonGrey30)
-
-                hint = context.getString(R.string.search_hint)
-
-                suggestionBackgroundColor = ContextCompat.getColor(
-                    container.context,
-                    R.color.suggestion_highlight_color
-                )
-
-                textColor = ContextCompat.getColor(
-                    container.context,
-                    ThemeManager.resolveAttribute(R.attr.primaryText, container.context)
-                )
-
-                hintColor = ContextCompat.getColor(
-                    container.context,
-                    ThemeManager.resolveAttribute(R.attr.secondaryText, container.context)
-                )
-            }
-
-            val menuToolbar = if (isCustomTabSession) {
-                CustomTabToolbarMenu(
-                    this,
-                    sessionManager,
-                    customTabSession?.id,
-                    onItemTapped = {
-                        interactor.onBrowserToolbarMenuItemTapped(it)
-                    }
-                )
-            } else {
-                DefaultToolbarMenu(
-                    this,
-                    hasAccountProblem = components.backgroundServices.accountManager.accountNeedsReauth(),
-                    requestDesktopStateProvider = {
-                        sessionManager.selectedSession?.desktopMode ?: false
-                    },
-                    onItemTapped = { interactor.onBrowserToolbarMenuItemTapped(it) }
-                )
-            }
-
-            toolbarIntegration = ToolbarIntegration(
-                this,
-                view,
-                container,
-                menuToolbar,
-                ShippedDomainsProvider().also { it.initialize(this) },
-                components.core.historyStorage,
-                components.core.sessionManager,
-                customTabSession?.id,
-                customTabSession?.private ?: sessionManager.selectedSession?.private ?: false
-            )
-        }
+        styleBrowserToolbar(view)
     }
 
-    @Suppress("UNUSED_PARAMETER")
-    fun update(state: BrowserFragmentState) {
-        // Intentionally leaving this as a stub for now since we don't actually want to update currently
+    override fun onUrlLongClick(customView: View, clipboard: ClipboardHandler) {
+        super.onUrlLongClick(customView, clipboard)
+
+        customView.paste.isGone = clipboard.text.isNullOrEmpty()
+        customView.paste_and_go.isGone = clipboard.text.isNullOrEmpty()
     }
 
-    companion object {
-        private const val TOOLBAR_ELEVATION = 16
-        private const val PROGRESS_BOTTOM = 0
-        private const val PROGRESS_TOP = 1
-        const val browserActionMarginDp = 8
+    override fun styleBrowserToolbar(toolbar: BrowserToolbar) {
+        super.styleBrowserToolbar(toolbar)
+
+        toolbar.urlBoxView = urlBackground
+        toolbar.progressBarGravity = PROGRESS_TOP
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/CustomTabBrowserToolbarView.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/CustomTabBrowserToolbarView.kt
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.components.toolbar
+
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.view.isGone
+import kotlinx.android.synthetic.main.browser_toolbar_popup_window.view.*
+import mozilla.components.browser.toolbar.BrowserToolbar
+import org.mozilla.fenix.customtabs.CustomTabToolbarMenu
+import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.utils.ClipboardHandler
+
+class CustomTabBrowserToolbarView(
+    container: ViewGroup,
+    interactor: BrowserToolbarViewInteractor,
+    sessionId: String?
+) : BaseBrowserToolbarView(container, interactor, sessionId) {
+
+    override val toolbarIntegration = CustomTabToolbarIntegration(
+        view.context,
+        view,
+        CustomTabToolbarMenu(
+            view.context,
+            view.context.components.core.sessionManager,
+            sessionId,
+            onItemTapped = {
+                interactor.onBrowserToolbarMenuItemTapped(it)
+            }
+        ),
+        sessionId,
+        isPrivate = getSessionById()?.private ?: false
+    )
+
+    init {
+        styleBrowserToolbar(view)
+    }
+
+    override fun onUrlLongClick(customView: View, clipboard: ClipboardHandler) {
+        super.onUrlLongClick(customView, clipboard)
+
+        customView.paste.isGone = true
+        customView.paste_and_go.isGone = true
+    }
+
+    override fun styleBrowserToolbar(toolbar: BrowserToolbar) {
+        super.styleBrowserToolbar(toolbar)
+
+        toolbar.urlBoxView = null
+        toolbar.progressBarGravity = PROGRESS_BOTTOM
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/CustomTabToolbarIntegration.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/CustomTabToolbarIntegration.kt
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.components.toolbar
+
+import android.content.Context
+import android.view.Gravity
+import androidx.coordinatorlayout.widget.CoordinatorLayout
+import mozilla.components.browser.toolbar.BrowserToolbar
+import mozilla.components.feature.toolbar.ToolbarFeature
+
+class CustomTabToolbarIntegration(
+    context: Context,
+    toolbar: BrowserToolbar,
+    toolbarMenu: ToolbarMenu,
+    sessionId: String? = null,
+    isPrivate: Boolean
+) : BaseToolbarIntegration(
+    context,
+    toolbar,
+    toolbarMenu,
+    ToolbarFeature.RenderStyle.RegistrableDomain,
+    sessionId,
+    isPrivate,
+    displaySeperator = false
+) {
+
+    init {
+        toolbar.private = isPrivate
+
+        // Remove toolbar shadow
+        toolbar.elevation = 0f
+
+        // Make the toolbar go to the top.
+        (toolbar.layoutParams as CoordinatorLayout.LayoutParams).gravity = Gravity.TOP
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarIntegration.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarIntegration.kt
@@ -6,29 +6,19 @@ package org.mozilla.fenix.components.toolbar
 
 import android.content.Context
 import android.view.ViewGroup
-import androidx.appcompat.content.res.AppCompatResources
 import androidx.navigation.NavOptions
 import androidx.navigation.Navigation
-import com.airbnb.lottie.LottieCompositionFactory
-import com.airbnb.lottie.LottieDrawable
 import androidx.navigation.fragment.FragmentNavigator
 import mozilla.components.browser.domains.autocomplete.DomainAutocompleteProvider
 import mozilla.components.browser.session.SessionManager
-import mozilla.components.browser.session.runWithSession
 import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.concept.storage.HistoryStorage
 import mozilla.components.feature.toolbar.ToolbarAutocompleteFeature
 import mozilla.components.feature.toolbar.ToolbarFeature
-import mozilla.components.feature.toolbar.ToolbarPresenter
-import mozilla.components.lib.publicsuffixlist.PublicSuffixList
-import mozilla.components.support.base.feature.LifecycleAwareFeature
 import mozilla.components.support.ktx.android.view.hideKeyboard
-import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.R
-import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.settings
-import org.mozilla.fenix.theme.ThemeManager
 
 class ToolbarIntegration(
     context: Context,
@@ -40,83 +30,43 @@ class ToolbarIntegration(
     sessionManager: SessionManager,
     sessionId: String? = null,
     isPrivate: Boolean
-) : LifecycleAwareFeature {
-
-    private var renderStyle: ToolbarFeature.RenderStyle = ToolbarFeature.RenderStyle.UncoloredUrl
+) : BaseToolbarIntegration(
+    context,
+    toolbar,
+    toolbarMenu,
+    ToolbarFeature.RenderStyle.UncoloredUrl,
+    sessionId,
+    isPrivate,
+    displaySeperator = true
+) {
 
     init {
-        toolbar.setMenuBuilder(toolbarMenu.menuBuilder)
-        toolbar.private = isPrivate
-
-        run {
-            sessionManager.runWithSession(sessionId) {
-                it.isCustomTabSession()
-            }.also { isCustomTab ->
-                if (isCustomTab) {
-                    renderStyle = ToolbarFeature.RenderStyle.RegistrableDomain
-                    return@run
-                }
-
-                val task = LottieCompositionFactory
-                    .fromRawRes(
-                        context,
-                        ThemeManager.resolveAttribute(R.attr.shieldLottieFile, context)
+        val tabsAction = TabCounterToolbarButton(sessionManager, isPrivate) {
+            toolbar.hideKeyboard()
+            // We need to dynamically add the options here because if you do it in XML it overwrites
+            val options = NavOptions.Builder()
+                .setPopUpTo(R.id.nav_graph, false)
+                .setEnterAnim(R.anim.fade_in)
+                .build()
+            val extras =
+                FragmentNavigator.Extras.Builder()
+                    .addSharedElement(
+                        browserLayout,
+                        "$TAB_ITEM_TRANSITION_NAME${sessionManager.selectedSession?.id}"
                     )
-                task.addListener { result ->
-                    val lottieDrawable = LottieDrawable()
-                    lottieDrawable.composition = result
-                    toolbar.displayTrackingProtectionIcon =
-                        context.settings().shouldUseTrackingProtection && FeatureFlags.etpCategories
-                    toolbar.displaySeparatorView =
-                        context.settings().shouldUseTrackingProtection && FeatureFlags.etpCategories
-
-                    toolbar.setTrackingProtectionIcons(
-                        iconOnNoTrackersBlocked = AppCompatResources.getDrawable(
-                            context,
-                            R.drawable.ic_tracking_protection_enabled
-                        )!!,
-                        iconOnTrackersBlocked = lottieDrawable,
-                        iconDisabledForSite = AppCompatResources.getDrawable(
-                            context,
-                            R.drawable.ic_tracking_protection_disabled
-                        )!!
-                    )
-                }
-
-                val tabsAction = TabCounterToolbarButton(
-                    sessionManager,
-                    {
-                        toolbar.hideKeyboard()
-                        // We need to dynamically add the options here because if you do it in XML it overwrites
-                        val options = NavOptions.Builder().setPopUpTo(R.id.nav_graph, false)
-                            .setEnterAnim(R.anim.fade_in).build()
-                        val extras =
-                            FragmentNavigator.Extras.Builder()
-                                .addSharedElement(
-                                    browserLayout,
-                                    "$TAB_ITEM_TRANSITION_NAME${sessionManager.selectedSession?.id}"
-                                )
-                                .build()
-                        val navController = Navigation.findNavController(toolbar)
-                        if (!navController.popBackStack(
-                                R.id.homeFragment,
-                                false
-                            )
-                        ) {
-                            navController.nav(
-                                R.id.browserFragment,
-                                R.id.action_browserFragment_to_homeFragment,
-                                null,
-                                options,
-                                extras
-                            )
-                        }
-                    },
-                    isPrivate
+                    .build()
+            val navController = Navigation.findNavController(toolbar)
+            if (!navController.popBackStack(R.id.homeFragment, false)) {
+                navController.nav(
+                    R.id.browserFragment,
+                    R.id.action_browserFragment_to_homeFragment,
+                    null,
+                    options,
+                    extras
                 )
-                toolbar.addBrowserAction(tabsAction)
             }
         }
+        toolbar.addBrowserAction(tabsAction)
 
         ToolbarAutocompleteFeature(toolbar).apply {
             addDomainProvider(domainAutocompleteProvider)
@@ -124,28 +74,6 @@ class ToolbarIntegration(
                 addHistoryStorageProvider(historyStorage)
             }
         }
-    }
-
-    private val toolbarPresenter: ToolbarPresenter = ToolbarPresenter(
-        toolbar,
-        context.components.core.store,
-        sessionId,
-        ToolbarFeature.UrlRenderConfiguration(
-            PublicSuffixList(context),
-            ThemeManager.resolveAttribute(R.attr.primaryText, context), renderStyle = renderStyle
-        )
-    )
-    private var menuPresenter =
-        MenuPresenter(toolbar, context.components.core.sessionManager, sessionId)
-
-    override fun start() {
-        menuPresenter.start()
-        toolbarPresenter.start()
-    }
-
-    override fun stop() {
-        menuPresenter.stop()
-        toolbarPresenter.stop()
     }
 
     companion object {

--- a/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabsIntegration.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabsIntegration.kt
@@ -5,23 +5,16 @@
 package org.mozilla.fenix.customtabs
 
 import android.app.Activity
-import android.view.Gravity
 import android.view.View
-import androidx.appcompat.content.res.AppCompatResources
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.widget.NestedScrollView
-import com.airbnb.lottie.LottieCompositionFactory
-import com.airbnb.lottie.LottieDrawable
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.feature.customtabs.CustomTabsToolbarFeature
 import mozilla.components.support.base.feature.BackHandler
 import mozilla.components.support.base.feature.LifecycleAwareFeature
-import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.toolbar.ToolbarMenu
-import org.mozilla.fenix.ext.settings
-import org.mozilla.fenix.theme.ThemeManager
 
 class CustomTabsIntegration(
     sessionManager: SessionManager,
@@ -34,9 +27,6 @@ class CustomTabsIntegration(
 ) : LifecycleAwareFeature, BackHandler {
 
     init {
-        // Remove toolbar shadow
-        toolbar.elevation = 0f
-
         // Reduce margin height of EngineView from the top for the toolbar
         engineLayout.run {
             (layoutParams as CoordinatorLayout.LayoutParams).apply {
@@ -45,40 +35,8 @@ class CustomTabsIntegration(
             }
         }
 
-        // Make the toolbar go to the top.
-        toolbar.run {
-            (layoutParams as CoordinatorLayout.LayoutParams).apply {
-                gravity = Gravity.TOP
-            }
-        }
-
         // Hide the Quick Action Bar.
         quickActionbar.visibility = View.GONE
-
-        val task = LottieCompositionFactory
-            .fromRawRes(
-                activity,
-                ThemeManager.resolveAttribute(R.attr.shieldLottieFile, activity)
-            )
-        task.addListener { result ->
-            val lottieDrawable = LottieDrawable()
-            lottieDrawable.composition = result
-            toolbar.displayTrackingProtectionIcon =
-                activity.settings().shouldUseTrackingProtection && FeatureFlags.etpCategories
-            toolbar.displaySeparatorView = false
-
-            toolbar.setTrackingProtectionIcons(
-                iconOnNoTrackersBlocked = AppCompatResources.getDrawable(
-                    activity,
-                    R.drawable.ic_tracking_protection_enabled
-                )!!,
-                iconOnTrackersBlocked = lottieDrawable,
-                iconDisabledForSite = AppCompatResources.getDrawable(
-                    activity,
-                    R.drawable.ic_tracking_protection_disabled
-                )!!
-            )
-        }
     }
 
     private val customTabToolbarMenu by lazy {

--- a/app/src/main/java/org/mozilla/fenix/customtabs/ExternalAppBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/ExternalAppBrowserFragment.kt
@@ -6,6 +6,7 @@ package org.mozilla.fenix.customtabs
 
 import android.view.Gravity
 import android.view.View
+import android.view.ViewGroup
 import kotlinx.android.synthetic.main.component_search.*
 import kotlinx.android.synthetic.main.fragment_browser.view.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -21,6 +22,7 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.browser.BaseBrowserFragment
 import org.mozilla.fenix.components.toolbar.BrowserToolbarController
 import org.mozilla.fenix.components.toolbar.BrowserToolbarInteractor
+import org.mozilla.fenix.components.toolbar.CustomTabBrowserToolbarView
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.requireComponents
@@ -49,7 +51,9 @@ class ExternalAppBrowserFragment : BaseBrowserFragment(), BackHandler {
                         activity,
                         view.nestedScrollQuickAction,
                         view.swipeRefresh,
-                        onItemTapped = { browserInteractor.onBrowserToolbarMenuItemTapped(it) }
+                        onItemTapped = {
+                            browserToolbarView.interactor.onBrowserToolbarMenuItemTapped(it)
+                        }
                     ),
                     owner = this,
                     view = view)
@@ -90,10 +94,14 @@ class ExternalAppBrowserFragment : BaseBrowserFragment(), BackHandler {
         return customTabsIntegration.onBackPressed() || super.removeSessionIfNeeded()
     }
 
-    override fun createBrowserToolbarViewInteractor(
-        browserToolbarController: BrowserToolbarController,
-        session: Session?
-    ) = BrowserToolbarInteractor(browserToolbarController)
+    override fun createBrowserToolbarView(
+        container: ViewGroup,
+        browserToolbarController: BrowserToolbarController
+    ) = CustomTabBrowserToolbarView(
+        container,
+        BrowserToolbarInteractor(browserToolbarController),
+        sessionId = customTabSessionId
+    )
 
     override fun navToQuickSettingsSheet(session: Session, sitePermissions: SitePermissions?) {
         val directions = ExternalAppBrowserFragmentDirections


### PR DESCRIPTION
Trying to get rid of "isCustomTab" checks. Splits out the toolbar setup code so separate classes are used for normal tabs and custom tabs.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture