### PR TITLE
Upgrade to A-C 15.0.0-SNAPSHOT (incl. required changes)

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -201,7 +201,7 @@ abstract class BaseBrowserFragment : Fragment(), BackHandler, SessionManager.Obs
 
             findInPageIntegration.set(
                 feature = FindInPageIntegration(
-                    sessionManager = sessionManager,
+                    store = store,
                     sessionId = customTabSessionId,
                     stub = view.stubFindInPage,
                     engineView = view.engineView,

--- a/app/src/main/java/org/mozilla/fenix/components/Components.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Components.kt
@@ -21,7 +21,14 @@ class Components(private val context: Context) {
     val core by lazy { Core(context) }
     val search by lazy { Search(context) }
     val useCases by lazy {
-        UseCases(context, core.sessionManager, core.engine.settings, search.searchEngineManager, core.client)
+        UseCases(
+            context,
+            core.sessionManager,
+            core.store,
+            core.engine.settings,
+            search.searchEngineManager,
+            core.client
+        )
     }
     val intentProcessors by lazy {
         IntentProcessors(context, core.sessionManager, useCases.sessionUseCases, useCases.searchUseCases)

--- a/app/src/main/java/org/mozilla/fenix/components/FindInPageIntegration.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/FindInPageIntegration.kt
@@ -6,8 +6,9 @@ package org.mozilla.fenix.components
 
 import android.view.View
 import android.view.ViewStub
-import mozilla.components.browser.session.SessionManager
-import mozilla.components.browser.session.runWithSessionIdOrSelected
+import mozilla.components.browser.state.selector.findCustomTabOrSelectedTab
+import mozilla.components.browser.state.state.CustomTabSessionState
+import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.feature.findinpage.FindInPageFeature
@@ -17,22 +18,22 @@ import org.mozilla.fenix.test.Mockable
 
 @Mockable
 class FindInPageIntegration(
-    private val sessionManager: SessionManager,
+    private val store: BrowserStore,
     private val sessionId: String? = null,
     stub: ViewStub,
     private val engineView: EngineView,
     private val toolbar: BrowserToolbar
 ) : InflationAwareFeature(stub) {
     override fun onViewInflated(view: View): LifecycleAwareFeature {
-        return FindInPageFeature(sessionManager, view as FindInPageView, engineView) {
+        return FindInPageFeature(store, view as FindInPageView, engineView) {
             toolbar.visibility = View.VISIBLE
             view.visibility = View.GONE
         }
     }
 
     override fun onLaunch(view: View, feature: LifecycleAwareFeature) {
-        sessionManager.runWithSessionIdOrSelected(sessionId) { session ->
-            if (!session.isCustomTabSession()) {
+        store.state.findCustomTabOrSelectedTab(sessionId)?.let { session ->
+            if (session !is CustomTabSessionState) {
                 toolbar.visibility = View.GONE
             }
             view.visibility = View.VISIBLE

--- a/app/src/main/java/org/mozilla/fenix/components/UseCases.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/UseCases.kt
@@ -7,6 +7,7 @@ package org.mozilla.fenix.components
 import android.content.Context
 import mozilla.components.browser.search.SearchEngineManager
 import mozilla.components.browser.session.SessionManager
+import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.Settings
 import mozilla.components.concept.fetch.Client
 import mozilla.components.feature.app.links.AppLinksUseCases
@@ -27,6 +28,7 @@ import org.mozilla.fenix.test.Mockable
 class UseCases(
     private val context: Context,
     private val sessionManager: SessionManager,
+    private val store: BrowserStore,
     private val engineSettings: Settings,
     private val searchEngineManager: SearchEngineManager,
     private val httpClient: Client
@@ -55,7 +57,7 @@ class UseCases(
 
     val webAppUseCases by lazy { WebAppUseCases(context, sessionManager, httpClient, supportWebApps = false) }
 
-    val downloadUseCases by lazy { DownloadsUseCases(sessionManager) }
+    val downloadUseCases by lazy { DownloadsUseCases(store) }
 
-    val contextMenuUseCases by lazy { ContextMenuUseCases(sessionManager) }
+    val contextMenuUseCases by lazy { ContextMenuUseCases(sessionManager, store) }
 }

--- a/app/src/test/java/org/mozilla/fenix/components/TestComponents.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/TestComponents.kt
@@ -23,6 +23,7 @@ class TestComponents(private val context: Context) : Components(context) {
         UseCases(
             context,
             core.sessionManager,
+            core.store,
             core.engine.settings,
             search.searchEngineManager,
             core.client

--- a/app/src/test/java/org/mozilla/fenix/components/TestCore.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/TestCore.kt
@@ -9,6 +9,7 @@ import io.mockk.mockk
 import kotlinx.coroutines.ObsoleteCoroutinesApi
 import mozilla.components.browser.engine.gecko.GeckoEngine
 import mozilla.components.browser.session.SessionManager
+import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.fetch.Client
 
 @ObsoleteCoroutinesApi
@@ -17,4 +18,5 @@ class TestCore(private val context: Context) : Core(context) {
     override val engine = mockk<GeckoEngine>(relaxed = true)
     override val sessionManager = SessionManager(engine)
     override val client = mockk<Client>()
+    override val store = mockk<BrowserStore>()
 }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -35,7 +35,7 @@ object Versions {
     const val androidx_work = "2.0.1"
     const val google_material = "1.1.0-alpha10"
 
-    const val mozilla_android_components = "14.0.1"
+    const val mozilla_android_components = "15.0.0-SNAPSHOT"
     // Note that android-components also depends on application-services,
     // and in fact is our main source of appservices-related functionality.
     // The version number below tracks the application-services version


### PR DESCRIPTION
Upgrade to A-C 15.0.0-SNAPSHOT and fixes API breakage.

🛑 For after the release branch has been cut 🛑 . 