### PR TITLE
For #5312 - Send ETP Strict/Standard event

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/RadioButtonPreference.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/RadioButtonPreference.kt
@@ -97,6 +97,7 @@ open class RadioButtonPreference @JvmOverloads constructor(
         radioButton?.isChecked = isChecked
         context.settings().preferences.edit().putBoolean(key, isChecked)
             .apply()
+        onPreferenceChangeListener.onPreferenceChange(this, isChecked)
     }
 
     private fun bindRadioButton(holder: PreferenceViewHolder) {

--- a/app/src/main/java/org/mozilla/fenix/settings/TrackingProtectionFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/TrackingProtectionFragment.kt
@@ -90,15 +90,17 @@ class TrackingProtectionFragment : PreferenceFragmentCompat() {
     private fun bindStrict() {
         val keyStrict = getString(R.string.pref_key_tracking_protection_strict)
         radioStrict = requireNotNull(findPreference(keyStrict))
-        radioStrict.onPreferenceChangeListener = SharedPreferenceUpdater()
         radioStrict.isVisible = FeatureFlags.etpCategories
         radioStrict.onPreferenceChangeListener = object : SharedPreferenceUpdater() {
             override fun onPreferenceChange(preference: Preference, newValue: Any?): Boolean {
-                context?.metrics?.track(
-                    Event.TrackingProtectionSettingChanged(
-                        Event.TrackingProtectionSettingChanged.Setting.STRICT
+                if (newValue == true) {
+                    updateTrackingProtectionPolicy()
+                    context?.metrics?.track(
+                        Event.TrackingProtectionSettingChanged(
+                            Event.TrackingProtectionSettingChanged.Setting.STRICT
+                        )
                     )
-                )
+                }
                 return super.onPreferenceChange(preference, newValue)
             }
         }
@@ -109,9 +111,6 @@ class TrackingProtectionFragment : PreferenceFragmentCompat() {
                     .actionTrackingProtectionFragmentToTrackingProtectionBlockingFragment(true)
             )
         }
-        radioStrict.onClickListener {
-            updateTrackingProtectionPolicy()
-        }
     }
 
     private fun bindStandard() {
@@ -120,11 +119,14 @@ class TrackingProtectionFragment : PreferenceFragmentCompat() {
         radioStandard.isVisible = FeatureFlags.etpCategories
         radioStandard.onPreferenceChangeListener = object : SharedPreferenceUpdater() {
             override fun onPreferenceChange(preference: Preference, newValue: Any?): Boolean {
-                context?.metrics?.track(
-                    Event.TrackingProtectionSettingChanged(
-                        Event.TrackingProtectionSettingChanged.Setting.STANDARD
+                if (newValue == true) {
+                    updateTrackingProtectionPolicy()
+                    context?.metrics?.track(
+                        Event.TrackingProtectionSettingChanged(
+                            Event.TrackingProtectionSettingChanged.Setting.STANDARD
+                        )
                     )
-                )
+                }
                 return super.onPreferenceChange(preference, newValue)
             }
         }
@@ -134,9 +136,6 @@ class TrackingProtectionFragment : PreferenceFragmentCompat() {
                 TrackingProtectionFragmentDirections
                     .actionTrackingProtectionFragmentToTrackingProtectionBlockingFragment(false)
             )
-        }
-        radioStandard.onClickListener {
-            updateTrackingProtectionPolicy()
         }
     }
 


### PR DESCRIPTION
Updated to send preference change callbacks correctly for our custom radio preference, and in turn send our metrics correctly

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture