### PR TITLE
Bug 1580778 - Fix nightly schedule which should be twice a day

### DIFF
--- a/.cron.yml
+++ b/.cron.yml
@@ -9,8 +9,9 @@ jobs:
           type: decision-task
           treeherder-symbol: Nd
           target-tasks-method: nightly
-      when: [{hour: 6, minute: 0}]
-      when: [{hour: 18, minute: 0}]
+      when:
+          - {hour: 6, minute: 0}
+          - {hour: 18, minute: 0}
     - name: raptor
       job:
           type: decision-task

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,5 +18,8 @@
 # By default the Android Components team will be the owner for everything in
 # the repo. Unless a later match takes precedence.
 * @mozilla-mobile/ACT @mozilla-mobile/fenix
+/.cron.yml /@mozilla-mobile/releng @mozilla-mobile/fenix
+/.taskcluster.yml /@mozilla-mobile/releng @mozilla-mobile/fenix
 /automation/ @mozilla-mobile/releng @mozilla-mobile/fenix
+/taskcluster/ /@mozilla-mobile/releng @mozilla-mobile/fenix
 /.github/ @mozilla-mobile/releng @mozilla-mobile/fenix


### PR DESCRIPTION
I owe you one @mitchhentges! I'm sorry, you were definitely right about the schedule. The data now on Treeherder shows there was really no job scheduled at 6am UTC. Here's the fix. 


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture