### PR TITLE
Change Firebase device for UI tests

### DIFF
--- a/automation/taskcluster/androidTest/flank-x86.yml
+++ b/automation/taskcluster/androidTest/flank-x86.yml
@@ -13,13 +13,17 @@ gcloud:
   # will start test then leave socket open. reports will be published
   # to /results
   # see: https://github.com/TestArmada/flank/issues/339
-  async: false 
+  async: false
 
   # results-history-name
   # by default, set to app name
   # declare results-history-name to create a separate dropdown menu in Firebase 
   # see: https://github.com/TestArmada/flank/issues/341
   #results-history-name: tmp_parallel 
+
+  # The number of times a TestExecution should be re-attempted if one or more\nof its test cases fail for any reason.
+  # The maximum number of reruns allowed is 10. Default is 0, which implies no reruns.
+  num-flaky-test-attempts: 3
 
   # test and app are the only required args
   app: /app/path 
@@ -34,7 +38,7 @@ gcloud:
   performance-metrics: true
 
   device:
-   - model: Nexus9 
+   - model: Nexus6 
      version: 25
    - model: Pixel2 
      version: 28
@@ -48,6 +52,3 @@ flank:
   # 1 runs the tests once. 10 runs all the tests 10x
   repeat-tests: 1
 
-  # The number of times a TestExecution should be re-attempted if one or more\nof its test cases fail for any reason.
-  # The maximum number of reruns allowed is 10. Default is 0, which implies no reruns.
-  num-flaky-test-attempts: 3


### PR DESCRIPTION
This PR attempts to address test flakiness in the findInPage test which is probably restricted to a virtual device irregularity.  Also, moving num-flaky-test-attempts to proper config position although NOTE: this appears to be busted at the moment.  I've filed:
https://github.com/TestArmada/flank/issues/603

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture