### PR TITLE
[WIP] Fix #1071 Add BrowserMenuImageSwitch for Desktop mode switch

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
@@ -11,6 +11,7 @@ import mozilla.components.browser.menu.item.BrowserMenuHighlightableItem
 import mozilla.components.browser.menu.item.BrowserMenuImageText
 import mozilla.components.browser.menu.item.BrowserMenuItemToolbar
 import mozilla.components.browser.menu.item.BrowserMenuSwitch
+import mozilla.components.browser.menu.item.BrowserMenuImageSwitch
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ThemeManager
@@ -131,11 +132,13 @@ class DefaultToolbarMenu(
                 onItemTapped.invoke(ToolbarMenu.Item.Library)
             },
 
-            // TODO: Add icon R.drawable.ic_desktop
-            BrowserMenuSwitch(context.getString(R.string.browser_menu_desktop_site),
+            BrowserMenuImageSwitch(
+               R.drawable.ic_desktop, 
+               context.getString(R.string.browser_menu_desktop_site),
                 requestDesktopStateProvider, { checked ->
                     onItemTapped.invoke(ToolbarMenu.Item.RequestDesktop(checked))
-                }),
+                }
+            ),
 
             BrowserMenuImageText(
                 context.getString(R.string.browser_menu_find_in_page),

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
@@ -131,9 +131,7 @@ class DefaultToolbarMenu(
                 onItemTapped.invoke(ToolbarMenu.Item.Library)
             },
 
-            BrowserMenuImageText(
-                context.getString(R.string.browser_menu_desktop_site),
-                R.drawable.ic_desktop,
+            BrowserMenuSwitch(context.getString(R.string.browser_menu_desktop_site),
                 requestDesktopStateProvider, { checked ->
                     onItemTapped.invoke(ToolbarMenu.Item.RequestDesktop(checked))
                 }),

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
@@ -131,6 +131,7 @@ class DefaultToolbarMenu(
                 onItemTapped.invoke(ToolbarMenu.Item.Library)
             },
 
+            // TODO: Add icon R.drawable.ic_desktop
             BrowserMenuSwitch(context.getString(R.string.browser_menu_desktop_site),
                 requestDesktopStateProvider, { checked ->
                     onItemTapped.invoke(ToolbarMenu.Item.RequestDesktop(checked))

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
@@ -131,7 +131,9 @@ class DefaultToolbarMenu(
                 onItemTapped.invoke(ToolbarMenu.Item.Library)
             },
 
-            BrowserMenuSwitch(context.getString(R.string.browser_menu_desktop_site),
+            BrowserMenuImageText(
+                context.getString(R.string.browser_menu_desktop_site),
+                R.drawable.ic_desktop,
                 requestDesktopStateProvider, { checked ->
                     onItemTapped.invoke(ToolbarMenu.Item.RequestDesktop(checked))
                 }),

--- a/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabToolbarMenu.kt
@@ -117,6 +117,7 @@ class CustomTabToolbarMenu(
                 onItemTapped.invoke(ToolbarMenu.Item.Share)
             },
 
+            // TODO: Add icon R.drawable.ic_desktop
             BrowserMenuSwitch(context.getString(R.string.browser_menu_desktop_site),
                 { session?.desktopMode ?: false }, { checked ->
                     onItemTapped.invoke(ToolbarMenu.Item.RequestDesktop(checked))

--- a/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabToolbarMenu.kt
@@ -10,6 +10,7 @@ import mozilla.components.browser.menu.item.BrowserMenuDivider
 import mozilla.components.browser.menu.item.BrowserMenuImageText
 import mozilla.components.browser.menu.item.BrowserMenuItemToolbar
 import mozilla.components.browser.menu.item.BrowserMenuSwitch
+import mozilla.components.browser.menu.item.BrowserMenuImageSwitch
 import mozilla.components.browser.menu.item.SimpleBrowserMenuItem
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
@@ -117,12 +118,14 @@ class CustomTabToolbarMenu(
                 onItemTapped.invoke(ToolbarMenu.Item.Share)
             },
 
-            // TODO: Add icon R.drawable.ic_desktop
-            BrowserMenuSwitch(context.getString(R.string.browser_menu_desktop_site),
-                { session?.desktopMode ?: false }, { checked ->
+            BrowserMenuImageSwitch(
+               R.drawable.ic_desktop, 
+               context.getString(R.string.browser_menu_desktop_site),
+               { session?.desktopMode ?: false }, { checked ->
                     onItemTapped.invoke(ToolbarMenu.Item.RequestDesktop(checked))
-                }),
+             }),
 
+       
             BrowserMenuImageText(
                 context.getString(R.string.browser_menu_find_in_page),
                 R.drawable.mozac_ic_search,

--- a/app/src/main/res/drawable/ic_desktop.xml
+++ b/app/src/main/res/drawable/ic_desktop.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="?primaryText"
+        android:pathData="M15.5 12H15V3a1 1 0 0 0-1-1H2a1 1 0 0 0-1 1v9H.5a.5.5 0 0 0-.5.5v1a.5.5 0 0 0 .5.5h15a.5.5 0 0 0 .5-.5v-1a.5.5 0 0 0-.5-.5zM10 13H6v-1h4zm3-2H3V4h10z" />
+</vector>


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture