### PR TITLE
For #3584 - Check if menu is open before showing a new one

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -239,11 +239,19 @@ class HomeFragment : Fragment() {
             }
         }
 
-        view.menuButton.setOnClickListener {
-            homeMenu?.menuBuilder?.build(requireContext())?.show(
-                anchor = it,
-                orientation = BrowserMenu.Orientation.DOWN
-            )
+        with(view.menuButton) {
+            var menu: PopupWindow? = null
+            setOnClickListener {
+                if (menu == null) {
+                    menu = homeMenu?.menuBuilder?.build(requireContext())?.show(
+                        anchor = it,
+                        orientation = BrowserMenu.Orientation.DOWN,
+                        onDismiss = { menu = null }
+                    )
+                } else {
+                    menu?.dismiss()
+                }
+            }
         }
         view.toolbar.compoundDrawablePadding =
             view.resources.getDimensionPixelSize(R.dimen.search_bar_search_engine_icon_padding)

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/TabHeaderViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/TabHeaderViewHolder.kt
@@ -6,6 +6,7 @@ package org.mozilla.fenix.home.sessioncontrol.viewholders
 
 import android.content.Context
 import android.view.View
+import android.widget.PopupWindow
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
 import io.reactivex.Observer
@@ -55,10 +56,19 @@ class TabHeaderViewHolder(
             }
 
             tabs_overflow_button.run {
+                var menu: PopupWindow? = null
                 setOnClickListener {
-                    tabsMenu.menuBuilder
-                        .build(view.context)
-                        .show(anchor = it, orientation = BrowserMenu.Orientation.DOWN)
+                    if (menu == null) {
+                        menu = tabsMenu.menuBuilder
+                            .build(view.context)
+                            .show(
+                                anchor = it,
+                                orientation = BrowserMenu.Orientation.DOWN,
+                                onDismiss = { menu = null }
+                            )
+                    } else {
+                        menu?.dismiss()
+                    }
                 }
             }
         }


### PR DESCRIPTION
Add a simple check for if the menu is showing depending on which we will know not to construct and show a new menu.
This check is to be done by both the "Open tabs menu" and the "Home menu"


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks
- [x] **Tests**: This PR does not includes tests as it only contains small changes in not yet tested components
- [x] **Screenshots**: This PR does not include screenshots because there are no UI changes, just small behavior ones which are easy to test.
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md)

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture