### PR TITLE
No issue: Updates naming of launch links privately var

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/IntentReceiverActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/IntentReceiverActivity.kt
@@ -37,7 +37,7 @@ class IntentReceiverActivity : Activity() {
     }
 
     suspend fun processIntent(intent: Intent) {
-        val tabIntentProcessor = if (settings().alwaysOpenInPrivateMode) {
+        val tabIntentProcessor = if (settings().launchLinksInPrivateTab) {
             components.intentProcessors.privateIntentProcessor
         } else {
             components.intentProcessors.intentProcessor

--- a/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
@@ -45,7 +45,7 @@ import org.mozilla.fenix.R.string.pref_key_delete_browsing_data
 import org.mozilla.fenix.R.string.pref_key_delete_browsing_data_on_quit_preference
 import org.mozilla.fenix.R.string.pref_key_help
 import org.mozilla.fenix.R.string.pref_key_language
-import org.mozilla.fenix.R.string.pref_key_launch_links_in_private_mode
+import org.mozilla.fenix.R.string.pref_key_launch_links_in_private_tab
 import org.mozilla.fenix.R.string.pref_key_leakcanary
 import org.mozilla.fenix.R.string.pref_key_make_default_browser
 import org.mozilla.fenix.R.string.pref_key_privacy_link
@@ -251,17 +251,17 @@ class SettingsFragment : PreferenceFragmentCompat(), AccountObserver {
         val makeDefaultBrowserKey = getPreferenceKey(pref_key_make_default_browser)
         val leakKey = getPreferenceKey(pref_key_leakcanary)
         val debuggingKey = getPreferenceKey(pref_key_remote_debugging)
-        val preferenceAlwaysOpenInPrivateModeKey = getPreferenceKey(
-            pref_key_launch_links_in_private_mode
+        val preferenceLaunchLinksPrivateTabKey = getPreferenceKey(
+            pref_key_launch_links_in_private_tab
         )
 
         val preferenceMakeDefaultBrowser = findPreference<Preference>(makeDefaultBrowserKey)
         val preferenceLeakCanary = findPreference<Preference>(leakKey)
         val preferenceRemoteDebugging = findPreference<Preference>(debuggingKey)
-        val preferenceAlwaysOpenInPrivateMode = findPreference<SwitchPreference>(preferenceAlwaysOpenInPrivateModeKey)
+        val preferenceLaunchLinksInPrivateTab = findPreference<SwitchPreference>(preferenceLaunchLinksPrivateTabKey)
 
-        preferenceAlwaysOpenInPrivateMode?.setOnPreferenceClickListener {
-            requireContext().settings().alwaysOpenInPrivateMode = !requireContext().settings().alwaysOpenInPrivateMode
+        preferenceLaunchLinksInPrivateTab?.setOnPreferenceClickListener {
+            requireContext().settings().launchLinksInPrivateTab = !requireContext().settings().launchLinksInPrivateTab
             true
         }
 

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -87,8 +87,8 @@ class Settings private constructor(
         default = false
     )
 
-    var alwaysOpenInPrivateMode by booleanPreference(
-        appContext.getPreferenceKey(R.string.pref_key_launch_links_in_private_mode),
+    var launchLinksInPrivateTab by booleanPreference(
+        appContext.getPreferenceKey(R.string.pref_key_launch_links_in_private_tab),
         default = false
     )
 

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -99,7 +99,7 @@
     <string name="pref_key_tracking_protection_onboarding" translatable="false">pref_key_tracking_protection_onboarding</string>
 
     <!-- Privacy Settings -->
-    <string name="pref_key_launch_links_in_private_mode" translatable="false">pref_key_launch_links_in_private_mode</string>
+    <string name="pref_key_launch_links_in_private_tab" translatable="false">pref_key_launch_links_in_private_tab</string>
 
     <!-- Quick Action Sheet -->
     <string name="pref_key_bounce_quick_action" translatable="false">pref_key_bounce_quick_action</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -60,7 +60,7 @@
             android:title="@string/preference_enhanced_tracking_protection" />
         <androidx.preference.SwitchPreference
             android:defaultValue="false"
-            android:key="@string/pref_key_launch_links_in_private_mode"
+            android:key="@string/pref_key_launch_links_in_private_tab"
             android:title="@string/preferences_launch_links_in_private_mode" />
         <androidx.preference.Preference
             android:icon="@drawable/ic_private_browsing"

--- a/app/src/test/java/org/mozilla/fenix/IntentReceiverActivityTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/IntentReceiverActivityTest.kt
@@ -27,9 +27,9 @@ import org.robolectric.annotation.Config
 class IntentReceiverActivityTest {
 
     @Test
-    fun `process intent with alwaysOpenInPrivateMode set to true`() {
+    fun `process intent with launchLinksInPrivateTab set to true`() {
         runBlockingTest {
-            testContext.settings().alwaysOpenInPrivateMode = true
+            testContext.settings().launchLinksInPrivateTab = true
 
             val intent = Intent()
             `when`(testContext.components.intentProcessors.privateIntentProcessor.process(intent)).thenReturn(true)
@@ -44,9 +44,9 @@ class IntentReceiverActivityTest {
     }
 
     @Test
-    fun `process intent with alwaysOpenInPrivateMode set to false`() {
+    fun `process intent with launchLinksInPrivateTab set to false`() {
         runBlockingTest {
-            testContext.settings().alwaysOpenInPrivateMode = false
+            testContext.settings().launchLinksInPrivateTab = false
 
             val intent = Intent()
             `when`(testContext.components.intentProcessors.intentProcessor.process(intent)).thenReturn(true)

--- a/app/src/test/java/org/mozilla/fenix/utils/SettingsTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/utils/SettingsTest.kt
@@ -19,8 +19,8 @@ import org.junit.runner.RunWith
 import org.mozilla.fenix.TestApplication
 import org.mozilla.fenix.ext.clearAndCommit
 import org.mozilla.fenix.ext.settings
-import org.mozilla.fenix.settings.deletebrowsingdata.DeleteBrowsingDataOnQuitType
 import org.mozilla.fenix.settings.PhoneFeature
+import org.mozilla.fenix.settings.deletebrowsingdata.DeleteBrowsingDataOnQuitType
 import org.robolectric.annotation.Config
 
 @ObsoleteCoroutinesApi
@@ -55,19 +55,19 @@ class SettingsTest {
     }
 
     @Test
-    fun alwaysOpenInPrivateMode() {
+    fun launchLinksInPrivateTab() {
         // When just created
         // Then
-        assertFalse(settings.alwaysOpenInPrivateMode)
+        assertFalse(settings.launchLinksInPrivateTab)
 
         // When
-        settings.alwaysOpenInPrivateMode = true
+        settings.launchLinksInPrivateTab = true
 
         // Then
-        assertTrue(settings.alwaysOpenInPrivateMode)
+        assertTrue(settings.launchLinksInPrivateTab)
 
         // When
-        settings.alwaysOpenInPrivateMode = false
+        settings.launchLinksInPrivateTab = false
 
         // Then
         assertFalse(settings.usePrivateMode)


### PR DESCRIPTION
The previous name was pretty confusing



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture