### PR TITLE
For #5599: Remove dependency on fetch_httpurlconnection  

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -422,8 +422,6 @@ dependencies {
     debugImplementation Deps.leakcanary
     releaseImplementation Deps.leakcanary_noop
 
-    implementation Deps.mozilla_lib_fetch_httpurlconnection
-
     implementation Deps.androidx_legacy
     implementation Deps.androidx_paging
     implementation Deps.androidx_preference

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
@@ -9,9 +9,11 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import mozilla.components.browser.engine.gecko.fetch.GeckoViewFetchClient
 import mozilla.components.service.glean.BuildConfig
 import mozilla.components.service.glean.Glean
 import mozilla.components.service.glean.config.Configuration
+import mozilla.components.service.glean.net.ConceptFetchHttpUploader
 import mozilla.components.service.glean.private.NoExtraKeys
 import mozilla.components.support.utils.Browsers
 import org.mozilla.fenix.GleanMetrics.BookmarksManagement
@@ -431,7 +433,11 @@ class GleanMetricsService(private val context: Context) : MetricsService {
         // can handle events being recorded before it's initialized.
         starter = MainScope().launch {
             Glean.registerPings(Pings)
-            Glean.initialize(context, Configuration(channel = BuildConfig.BUILD_TYPE))
+            Glean.initialize(context,
+                Configuration(channel = BuildConfig.BUILD_TYPE,
+                    httpClient = ConceptFetchHttpUploader(
+                        lazy { GeckoViewFetchClient(context) }
+                    )))
         }
 
         setStartupMetrics()

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import mozilla.components.browser.engine.gecko.fetch.GeckoViewFetchClient
 import mozilla.components.service.glean.BuildConfig
 import mozilla.components.service.glean.Glean
 import mozilla.components.service.glean.config.Configuration
@@ -436,7 +435,7 @@ class GleanMetricsService(private val context: Context) : MetricsService {
             Glean.initialize(context,
                 Configuration(channel = BuildConfig.BUILD_TYPE,
                     httpClient = ConceptFetchHttpUploader(
-                        lazy { GeckoViewFetchClient(context) }
+                        lazy(LazyThreadSafetyMode.NONE) { context.components.core.client }
                     )))
         }
 

--- a/app/src/test/java/org/mozilla/fenix/ext/BrowserIconsTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/ext/BrowserIconsTest.kt
@@ -1,18 +1,18 @@
 package org.mozilla.fenix.ext
 
-import mozilla.components.support.test.robolectric.testContext
 import android.widget.ImageView
-import kotlinx.coroutines.ObsoleteCoroutinesApi
-import io.mockk.verify
 import io.mockk.spyk
-import mozilla.components.browser.icons.IconRequest
-import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
-import org.junit.Test
-import org.mozilla.fenix.TestApplication
+import io.mockk.verify
+import kotlinx.coroutines.ObsoleteCoroutinesApi
+import mozilla.components.browser.engine.gecko.fetch.GeckoViewFetchClient
 import mozilla.components.browser.icons.BrowserIcons
+import mozilla.components.browser.icons.IconRequest
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.fenix.TestApplication
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
-import org.junit.runner.RunWith
 
 @ObsoleteCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
@@ -22,7 +22,7 @@ class BrowserIconsTest {
     @Test
     fun loadIntoViewTest() {
         val imageView = spyk(ImageView(testContext))
-        val icons = spyk(BrowserIcons(testContext, httpClient = HttpURLConnectionClient()))
+        val icons = spyk(BrowserIcons(testContext, httpClient = GeckoViewFetchClient(testContext)))
         val myUrl = "https://mozilla.com"
         val request = spyk(IconRequest(url = myUrl))
         icons.loadIntoView(imageView, myUrl)

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -143,7 +143,6 @@ object Deps {
     const val mozilla_ui_icons = "org.mozilla.components:ui-icons:${Versions.mozilla_android_components}"
 
     const val mozilla_lib_crash = "org.mozilla.components:lib-crash:${Versions.mozilla_android_components}"
-    const val mozilla_lib_fetch_httpurlconnection = "org.mozilla.components:lib-fetch-httpurlconnection:${Versions.mozilla_android_components}"
     const val mozilla_lib_push_firebase = "org.mozilla.components:lib-push-firebase:${Versions.mozilla_android_components}"
 
     const val mozilla_ui_publicsuffixlist = "org.mozilla.components:lib-publicsuffixlist:${Versions.mozilla_android_components}"


### PR DESCRIPTION
This PR removes an unused dependency to ensure it doesn't get used. Using httpurlconnection would foil the ability to funnel all traffic through the secure proxy tunnel.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture