### PR TITLE
For #5231: Private browsing shortcut opens Private Mode start screen

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/PrivateShortcutCreateManager.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/PrivateShortcutCreateManager.kt
@@ -12,7 +12,7 @@ import androidx.core.content.pm.ShortcutManagerCompat
 import androidx.core.graphics.drawable.IconCompat
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
-import org.mozilla.fenix.home.intent.StartSearchIntentProcessor
+import org.mozilla.fenix.home.intent.StartInPrivateModeProcessor
 import java.util.UUID
 
 /**
@@ -32,10 +32,7 @@ object PrivateShortcutCreateManager {
                 action = Intent.ACTION_VIEW
                 flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
                 putExtra(HomeActivity.PRIVATE_BROWSING_MODE, true)
-                putExtra(
-                    HomeActivity.OPEN_TO_SEARCH,
-                    StartSearchIntentProcessor.PRIVATE_BROWSING_PINNED_SHORTCUT
-                )
+                putExtra(StartInPrivateModeProcessor.PRIVATE_BROWSING_PINNED_SHORTCUT, true)
             })
             .build()
         val homeScreenIntent = Intent(Intent.ACTION_MAIN)

--- a/app/src/main/java/org/mozilla/fenix/home/intent/StartInPrivateModeProcessor.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/intent/StartInPrivateModeProcessor.kt
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.home.intent
+
+import android.content.Intent
+import androidx.navigation.NavController
+import org.mozilla.fenix.NavGraphDirections
+import org.mozilla.fenix.components.metrics.Event
+import org.mozilla.fenix.components.metrics.MetricController
+import org.mozilla.fenix.ext.nav
+
+/**
+ * Tapping the private browsing mode launcher icon should open Private Mode start screen.
+ */
+class StartInPrivateModeProcessor(
+    private val metrics: MetricController
+) : HomeIntentProcessor {
+
+    override fun process(intent: Intent, navController: NavController, out: Intent): Boolean {
+        val event = intent.extras?.getBoolean(PRIVATE_BROWSING_PINNED_SHORTCUT)
+        return if (event != null) {
+            if (event) {
+                metrics.track(Event.PrivateBrowsingPinnedShortcutPrivateTab)
+            }
+            val directions = NavGraphDirections.actionGlobalHomeFragment()
+            navController.nav(null, directions)
+            true
+        } else {
+            false
+        }
+    }
+
+    companion object {
+        const val PRIVATE_BROWSING_PINNED_SHORTCUT = "private_browsing_pinned_shortcut"
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/home/intent/StartSearchIntentProcessor.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/intent/StartSearchIntentProcessor.kt
@@ -14,7 +14,6 @@ import org.mozilla.fenix.ext.nav
 
 /**
  * When the search widget is tapped, Fenix should open to the search fragment.
- * Tapping the private browsing mode launcher icon should also open to the search fragment.
  */
 class StartSearchIntentProcessor(
     private val metrics: MetricController
@@ -27,7 +26,6 @@ class StartSearchIntentProcessor(
                 SEARCH_WIDGET -> metrics.track(Event.SearchWidgetNewTabPressed)
                 STATIC_SHORTCUT_NEW_TAB -> metrics.track(Event.PrivateBrowsingStaticShortcutTab)
                 STATIC_SHORTCUT_NEW_PRIVATE_TAB -> metrics.track(Event.PrivateBrowsingStaticShortcutPrivateTab)
-                PRIVATE_BROWSING_PINNED_SHORTCUT -> metrics.track(Event.PrivateBrowsingPinnedShortcutPrivateTab)
             }
 
             out.removeExtra(HomeActivity.OPEN_TO_SEARCH)
@@ -47,6 +45,5 @@ class StartSearchIntentProcessor(
         const val SEARCH_WIDGET = "search_widget"
         const val STATIC_SHORTCUT_NEW_TAB = "static_shortcut_new_tab"
         const val STATIC_SHORTCUT_NEW_PRIVATE_TAB = "static_shortcut_new_private_tab"
-        const val PRIVATE_BROWSING_PINNED_SHORTCUT = "private_browsing_pinned_shortcut"
     }
 }


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture