### PR TITLE
Closes #3880. Add detekt check for license header files. 

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/LibraryMenuTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/LibraryMenuTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.ui
 
 import org.junit.Rule

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BookmarksRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BookmarksRobot.kt
@@ -1,13 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.ui.robots
 
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions
-import androidx.test.espresso.matcher.ViewMatchers.withText
-import androidx.test.espresso.matcher.ViewMatchers.withParent
-import androidx.test.espresso.matcher.ViewMatchers.withId
-import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.espresso.matcher.ViewMatchers.Visibility
 import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
+import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withParent
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import org.hamcrest.Matchers.allOf
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.click

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HistoryRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HistoryRobot.kt
@@ -1,13 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.ui.robots
 
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions
-import androidx.test.espresso.matcher.ViewMatchers.withText
-import androidx.test.espresso.matcher.ViewMatchers.withParent
-import androidx.test.espresso.matcher.ViewMatchers.withId
-import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.espresso.matcher.ViewMatchers.Visibility
 import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
+import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withParent
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import org.hamcrest.Matchers.allOf
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.click

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/screenshots/DefaultHomeScreenTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/screenshots/DefaultHomeScreenTest.kt
@@ -1,7 +1,7 @@
-// /* This Source Code Form is subject to the terms of the Mozilla Public
-//  * License, v. 2.0. If a copy of the MPL was not distributed with this
-//  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-//
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // package org.mozilla.fenix.ui.screenshots
 //
 // import androidx.test.rule.ActivityTestRule

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/screenshots/MenuScreenShotTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/screenshots/MenuScreenShotTest.kt
@@ -1,7 +1,7 @@
-// /* This Source Code Form is subject to the terms of the Mozilla Public
-//  * License, v. 2.0. If a copy of the MPL was not distributed with this
-//  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-//
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 // package org.mozilla.fenix.ui.screenshots
 //
 // import android.os.SystemClock

--- a/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix
 
 /**

--- a/app/src/main/java/org/mozilla/fenix/components/InflationAwareFeature.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/InflationAwareFeature.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.components
 
 import android.view.View

--- a/app/src/main/java/org/mozilla/fenix/components/StoreProvider.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/StoreProvider.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.components
 

--- a/app/src/main/java/org/mozilla/fenix/exceptions/ExceptionsFragmentStore.kt
+++ b/app/src/main/java/org/mozilla/fenix/exceptions/ExceptionsFragmentStore.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.exceptions
 

--- a/app/src/main/java/org/mozilla/fenix/exceptions/ExceptionsInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/exceptions/ExceptionsInteractor.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.exceptions
 

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryController.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryController.kt
@@ -1,8 +1,6 @@
-/*
- *  This Source Code Form is subject to the terms of the Mozilla Public
- *  * License, v. 2.0. If a copy of the MPL was not distributed with this
- *  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.library.history
 

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragmentStore.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragmentStore.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.library.history
 

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryInteractor.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.library.history
 

--- a/app/src/main/java/org/mozilla/fenix/quickactionsheet/QuickActionSheetView.kt
+++ b/app/src/main/java/org/mozilla/fenix/quickactionsheet/QuickActionSheetView.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.quickactionsheet
 
@@ -17,8 +17,8 @@ import kotlinx.android.synthetic.main.layout_quick_action_sheet.*
 import kotlinx.android.synthetic.main.layout_quick_action_sheet.view.*
 import mozilla.components.support.ktx.android.view.putCompoundDrawablesRelativeWithIntrinsicBounds
 import org.mozilla.fenix.R
-import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.components.toolbar.BrowserFragmentState
+import org.mozilla.fenix.ext.settings
 
 interface QuickActionSheetViewInteractor {
     fun onQuickActionSheetOpened()

--- a/app/src/main/java/org/mozilla/fenix/search/SearchController.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchController.kt
@@ -1,7 +1,6 @@
-/*
- *  This Source Code Form is subject to the terms of the Mozilla Public
- *  * License, v. 2.0. If a copy of the MPL was not distributed with this
- *  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.search
 

--- a/app/src/main/java/org/mozilla/fenix/search/SearchFragmentStore.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchFragmentStore.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.search
 

--- a/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarView.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarView.kt
@@ -1,8 +1,8 @@
-package org.mozilla.fenix.search.awesomebar
-
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.search.awesomebar
 
 import android.graphics.PorterDuff.Mode.SRC_IN
 import android.graphics.PorterDuffColorFilter

--- a/app/src/main/java/org/mozilla/fenix/search/toolbar/ToolbarView.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/toolbar/ToolbarView.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.search.toolbar
 

--- a/app/src/main/java/org/mozilla/fenix/settings/SharedPreferenceUpdater.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SharedPreferenceUpdater.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.settings
 
 import androidx.core.content.edit

--- a/app/src/main/java/org/mozilla/fenix/settings/account/AccountSettingsFragmentStore.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/account/AccountSettingsFragmentStore.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.settings.account
 

--- a/app/src/main/java/org/mozilla/fenix/settings/account/AccountSettingsInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/account/AccountSettingsInteractor.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.settings.account
 

--- a/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionStore.kt
+++ b/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionStore.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.trackingprotection
 

--- a/app/src/main/java/org/mozilla/fenix/whatsnew/WhatsNew.kt
+++ b/app/src/main/java/org/mozilla/fenix/whatsnew/WhatsNew.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.whatsnew
 
 /* This Source Code Form is subject to the terms of the Mozilla Public

--- a/app/src/main/java/org/mozilla/fenix/whatsnew/WhatsNewStorage.kt
+++ b/app/src/main/java/org/mozilla/fenix/whatsnew/WhatsNewStorage.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.whatsnew
 
 /* This Source Code Form is subject to the terms of the Mozilla Public

--- a/app/src/main/java/org/mozilla/fenix/whatsnew/WhatsNewVersion.kt
+++ b/app/src/main/java/org/mozilla/fenix/whatsnew/WhatsNewVersion.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.whatsnew
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/app/src/test/java/org/mozilla/fenix/components/InflationAwareFeatureTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/InflationAwareFeatureTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.components
 
 import android.view.View

--- a/app/src/test/java/org/mozilla/fenix/components/toolbar/BrowserInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/toolbar/BrowserInteractorTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.components.toolbar
 
 import android.content.Context

--- a/app/src/test/java/org/mozilla/fenix/exceptions/ExceptionsFragmentStoreTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/exceptions/ExceptionsFragmentStoreTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.exceptions
 

--- a/app/src/test/java/org/mozilla/fenix/exceptions/ExceptionsInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/exceptions/ExceptionsInteractorTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.exceptions
 

--- a/app/src/test/java/org/mozilla/fenix/ext/ActivityTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/ext/ActivityTest.kt
@@ -1,18 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.ext
 
-import kotlinx.coroutines.ObsoleteCoroutinesApi
-import org.mozilla.fenix.TestApplication
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.Assert.assertTrue
-import org.junit.Assert.assertEquals
-import org.robolectric.Robolectric
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 import android.app.Activity
 import android.view.View
 import android.view.WindowManager
+import kotlinx.coroutines.ObsoleteCoroutinesApi
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.fenix.TestApplication
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
 
 @ObsoleteCoroutinesApi
 @RunWith(RobolectricTestRunner::class)

--- a/app/src/test/java/org/mozilla/fenix/ext/BrowserIconsTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/ext/BrowserIconsTest.kt
@@ -1,18 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.ext
 
-import mozilla.components.support.test.robolectric.testContext
 import android.widget.ImageView
-import kotlinx.coroutines.ObsoleteCoroutinesApi
-import io.mockk.verify
 import io.mockk.spyk
+import io.mockk.verify
+import kotlinx.coroutines.ObsoleteCoroutinesApi
+import mozilla.components.browser.icons.BrowserIcons
 import mozilla.components.browser.icons.IconRequest
 import mozilla.components.lib.fetch.httpurlconnection.HttpURLConnectionClient
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.mozilla.fenix.TestApplication
-import mozilla.components.browser.icons.BrowserIcons
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
-import org.junit.runner.RunWith
 
 @ObsoleteCoroutinesApi
 @RunWith(RobolectricTestRunner::class)

--- a/app/src/test/java/org/mozilla/fenix/ext/DrawableTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/ext/DrawableTest.kt
@@ -1,17 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.ext
 
-import kotlinx.coroutines.ObsoleteCoroutinesApi
-import org.mozilla.fenix.TestApplication
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
-import android.graphics.drawable.Drawable
-import android.graphics.Rect
 import android.graphics.Canvas
 import android.graphics.ColorFilter
+import android.graphics.Rect
+import android.graphics.drawable.Drawable
+import kotlinx.coroutines.ObsoleteCoroutinesApi
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.fenix.TestApplication
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
 @ObsoleteCoroutinesApi
 @RunWith(RobolectricTestRunner::class)

--- a/app/src/test/java/org/mozilla/fenix/ext/FragmentTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/ext/FragmentTest.kt
@@ -1,28 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.ext
 
-import kotlinx.coroutines.ObsoleteCoroutinesApi
-import mozilla.components.support.test.robolectric.testContext
-import org.mozilla.fenix.TestApplication
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
-import io.mockk.mockk
-import io.mockk.spyk
-import io.mockk.mockkStatic
-import io.mockk.verify
-import io.mockk.every
-import io.mockk.Runs
-import io.mockk.just
-import io.mockk.confirmVerified
 import androidx.fragment.app.Fragment
+import androidx.navigation.NavController
+import androidx.navigation.NavDestination
 import androidx.navigation.NavDirections
 import androidx.navigation.NavOptions
-import androidx.navigation.fragment.NavHostFragment.findNavController
-import androidx.navigation.fragment.NavHostFragment
-import androidx.navigation.NavDestination
-import androidx.navigation.NavController
 import androidx.navigation.Navigator.Extras
+import androidx.navigation.fragment.NavHostFragment
+import io.mockk.Runs
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.spyk
+import io.mockk.verify
+import kotlinx.coroutines.ObsoleteCoroutinesApi
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.fenix.TestApplication
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
 @ObsoleteCoroutinesApi
 @RunWith(RobolectricTestRunner::class)

--- a/app/src/test/java/org/mozilla/fenix/ext/LogTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/ext/LogTest.kt
@@ -1,16 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.ext
 
-import kotlinx.coroutines.ObsoleteCoroutinesApi
-import org.mozilla.fenix.TestApplication
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import android.util.Log
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.verify
-import android.util.Log
+import kotlinx.coroutines.ObsoleteCoroutinesApi
+import org.junit.Test
+import org.junit.runner.RunWith
 import org.mozilla.fenix.BuildConfig
+import org.mozilla.fenix.TestApplication
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
 @ObsoleteCoroutinesApi
 @RunWith(RobolectricTestRunner::class)

--- a/app/src/test/java/org/mozilla/fenix/ext/NavControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/ext/NavControllerTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.ext
 
 import android.os.Bundle

--- a/app/src/test/java/org/mozilla/fenix/ext/StringTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/ext/StringTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.ext
 
 import kotlinx.coroutines.ObsoleteCoroutinesApi

--- a/app/src/test/java/org/mozilla/fenix/library/history/HistoryControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/history/HistoryControllerTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.library.history
 

--- a/app/src/test/java/org/mozilla/fenix/quickactionsheet/DefaultQuickActionSheetControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/quickactionsheet/DefaultQuickActionSheetControllerTest.kt
@@ -1,8 +1,6 @@
-/*
- *  This Source Code Form is subject to the terms of the Mozilla Public
- *  * License, v. 2.0. If a copy of the MPL was not distributed with this
- *  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.quickactionsheet
 

--- a/app/src/test/java/org/mozilla/fenix/search/DefaultSearchControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/search/DefaultSearchControllerTest.kt
@@ -1,6 +1,6 @@
-/*  This Source Code Form is subject to the terms of the Mozilla Public
- *  License, v. 2.0. If a copy of the MPL was not distributed with this
- *  file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.search
 

--- a/app/src/test/java/org/mozilla/fenix/settings/account/AccountSettingsFragmentStoreTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/account/AccountSettingsFragmentStoreTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.settings.account
 

--- a/app/src/test/java/org/mozilla/fenix/settings/account/AccountSettingsInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/account/AccountSettingsInteractorTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.settings.account
 

--- a/app/src/test/java/org/mozilla/fenix/settings/deletebrowsingdata/DefaultDeleteBrowsingDataControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/deletebrowsingdata/DefaultDeleteBrowsingDataControllerTest.kt
@@ -1,6 +1,6 @@
-/*  This Source Code Form is subject to the terms of the Mozilla Public
- *  License, v. 2.0. If a copy of the MPL was not distributed with this
- *  file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.settings.deletebrowsingdata
 

--- a/app/src/test/java/org/mozilla/fenix/whatsnew/WhatsNewStorageTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/whatsnew/WhatsNewStorageTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.whatsnew
 
 /* This Source Code Form is subject to the terms of the Mozilla Public

--- a/app/src/test/java/org/mozilla/fenix/whatsnew/WhatsNewTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/whatsnew/WhatsNewTest.kt
@@ -1,8 +1,8 @@
-package org.mozilla.fenix.whatsnew
-
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.whatsnew
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.ObsoleteCoroutinesApi

--- a/app/src/test/java/org/mozilla/fenix/whatsnew/WhatsNewVersionTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/whatsnew/WhatsNewVersionTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.whatsnew
 
 /* This Source Code Form is subject to the terms of the Mozilla Public

--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,7 @@ configurations {
 
 dependencies {
     ktlint "com.pinterest:ktlint:0.34.2"
+    detektPlugins Deps.mozilla_tooling_detekt
 }
 
 task ktlint(type: JavaExec, group: "verification") {

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -148,6 +148,8 @@ object Deps {
 
     const val mozilla_ui_publicsuffixlist = "org.mozilla.components:lib-publicsuffixlist:${Versions.mozilla_android_components}"
 
+    const val mozilla_tooling_detekt = "org.mozilla.components:tooling-detekt:${Versions.mozilla_android_components}"
+
     const val mozilla_support_base = "org.mozilla.components:support-base:${Versions.mozilla_android_components}"
     const val mozilla_support_ktx = "org.mozilla.components:support-ktx:${Versions.mozilla_android_components}"
     const val mozilla_support_rusthttp = "org.mozilla.components:support-rusthttp:${Versions.mozilla_android_components}"

--- a/config/detekt.yml
+++ b/config/detekt.yml
@@ -375,3 +375,7 @@ style:
     active: true
     excludes: "**/*Test.kt, **/*Spec.kt, **/test/**, **/androidTest/**"
     excludeImports: 'java.util.*,kotlinx.android.synthetic.*'
+
+mozilla-rules:
+  AbsentOrWrongFileLicense:
+    active: true


### PR DESCRIPTION
**Depends on**: ~~[mozilla-mobile/android-components/4619](https://github.com/mozilla-mobile/android-components/pull/4619)~~ AC published to [Mozilla Maven Repository](https://maven.mozilla.org/?prefix=maven2/org/mozilla/components/tooling-detekt/).

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] ~~**Tests**: This PR includes thorough tests or an explanation of why it does not~~
- [x] ~~**Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not~~
- [x] ~~**Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture