### PR TITLE
Closes #5233, don't display private-browsing-shortcut creation items if shortcut already exists

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/PrivateShortcutCreateManager.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/PrivateShortcutCreateManager.kt
@@ -26,11 +26,10 @@ object PrivateShortcutCreateManager {
     fun doesPrivateBrowsingPinnedShortcutExist(context: Context): Boolean {
         return if (SDK_INT >= Build.VERSION_CODES.N_MR1) {
             val pinnedShortcuts = context.getSystemService(ShortcutManager::class.java).pinnedShortcuts
-            if (pinnedShortcuts.any {
-                    it.intent?.extras?.getString(HomeActivity.OPEN_TO_SEARCH) ==
-                    StartSearchIntentProcessor.PRIVATE_BROWSING_PINNED_SHORTCUT })
-                return true
-            false
+            pinnedShortcuts.any {
+                it.intent?.extras?.getString(HomeActivity.OPEN_TO_SEARCH) ==
+                StartSearchIntentProcessor.PRIVATE_BROWSING_PINNED_SHORTCUT
+            }
         } else
             false
     }

--- a/app/src/main/java/org/mozilla/fenix/components/PrivateShortcutCreateManager.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/PrivateShortcutCreateManager.kt
@@ -14,11 +14,29 @@ import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.home.intent.StartSearchIntentProcessor
 import java.util.UUID
+import android.content.pm.ShortcutManager
+import android.os.Build
+import android.os.Build.VERSION.SDK_INT
 
 /**
- * Handles the creation of pinned shortcuts.
+ * Handles the creation and existence of pinned shortcuts.
  */
 object PrivateShortcutCreateManager {
+
+    fun doesPrivateBrowsingPinnedShortcutExist(context: Context) : Boolean {
+        return if (SDK_INT >= Build.VERSION_CODES.N_MR1) {
+            val pinnedShortcuts = context.getSystemService(ShortcutManager::class.java).pinnedShortcuts
+            for (s in pinnedShortcuts) {
+                if (s.intent?.extras?.getString(HomeActivity.OPEN_TO_SEARCH) ==
+                    StartSearchIntentProcessor.PRIVATE_BROWSING_PINNED_SHORTCUT) {
+                    return true
+                }
+            }
+            false
+        } else {
+            false
+        }
+    }
 
     fun createPrivateShortcut(context: Context) {
         if (!ShortcutManagerCompat.isRequestPinShortcutSupported(context)) return

--- a/app/src/main/java/org/mozilla/fenix/components/PrivateShortcutCreateManager.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/PrivateShortcutCreateManager.kt
@@ -26,18 +26,13 @@ object PrivateShortcutCreateManager {
     fun doesPrivateBrowsingPinnedShortcutExist(context: Context): Boolean {
         return if (SDK_INT >= Build.VERSION_CODES.N_MR1) {
             val pinnedShortcuts = context.getSystemService(ShortcutManager::class.java).pinnedShortcuts
-            if (pinnedShortcuts.any()) {
-                for (s in pinnedShortcuts) {
-                    if (s.intent?.extras?.getString(HomeActivity.OPEN_TO_SEARCH) ==
-                        StartSearchIntentProcessor.PRIVATE_BROWSING_PINNED_SHORTCUT) {
-                        return true
-                    }
-                }
-            }
+            if (pinnedShortcuts.any {
+                    it.intent?.extras?.getString(HomeActivity.OPEN_TO_SEARCH) ==
+                    StartSearchIntentProcessor.PRIVATE_BROWSING_PINNED_SHORTCUT })
+                return true
             false
-        } else {
+        } else
             false
-        }
     }
 
     fun createPrivateShortcut(context: Context) {

--- a/app/src/main/java/org/mozilla/fenix/components/PrivateShortcutCreateManager.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/PrivateShortcutCreateManager.kt
@@ -23,13 +23,15 @@ import android.os.Build.VERSION.SDK_INT
  */
 object PrivateShortcutCreateManager {
 
-    fun doesPrivateBrowsingPinnedShortcutExist(context: Context) : Boolean {
+    fun doesPrivateBrowsingPinnedShortcutExist(context: Context): Boolean {
         return if (SDK_INT >= Build.VERSION_CODES.N_MR1) {
             val pinnedShortcuts = context.getSystemService(ShortcutManager::class.java).pinnedShortcuts
-            for (s in pinnedShortcuts) {
-                if (s.intent?.extras?.getString(HomeActivity.OPEN_TO_SEARCH) ==
-                    StartSearchIntentProcessor.PRIVATE_BROWSING_PINNED_SHORTCUT) {
-                    return true
+            if (pinnedShortcuts.any()) {
+                for (s in pinnedShortcuts) {
+                    if (s.intent?.extras?.getString(HomeActivity.OPEN_TO_SEARCH) ==
+                        StartSearchIntentProcessor.PRIVATE_BROWSING_PINNED_SHORTCUT) {
+                        return true
+                    }
                 }
             }
             false

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -347,8 +347,9 @@ class HomeFragment : Fragment() {
                 }
             }
         }, owner = this)
+
         if (context.settings().showPrivateModeContextualFeatureRecommender &&
-            browsingModeManager.mode.isPrivate) {
+            browsingModeManager.mode.isPrivate && !PrivateShortcutCreateManager.doesPrivateBrowsingPinnedShortcutExist(requireContext())) {
             recommendPrivateBrowsingShortcut()
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -349,7 +349,8 @@ class HomeFragment : Fragment() {
         }, owner = this)
 
         if (context.settings().showPrivateModeContextualFeatureRecommender &&
-            browsingModeManager.mode.isPrivate && !PrivateShortcutCreateManager.doesPrivateBrowsingPinnedShortcutExist(requireContext())) {
+            browsingModeManager.mode.isPrivate &&
+            !PrivateShortcutCreateManager.doesPrivateBrowsingPinnedShortcutExist(context)) {
             recommendPrivateBrowsingShortcut()
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
@@ -133,7 +133,7 @@ class SettingsFragment : PreferenceFragmentCompat(), AccountObserver {
         }
 
         findPreference<Preference>(getPreferenceKey(R.string.pref_key_add_private_browsing_shortcut))?.apply {
-            isVisible = !PrivateShortcutCreateManager.doesPrivateBrowsingPinnedShortcutExist(requireContext())
+            isVisible = !PrivateShortcutCreateManager.doesPrivateBrowsingPinnedShortcutExist(context)
         }
 
         setupPreferences()

--- a/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
@@ -132,6 +132,10 @@ class SettingsFragment : PreferenceFragmentCompat(), AccountObserver {
             }
         }
 
+        findPreference<Preference>(getPreferenceKey(R.string.pref_key_add_private_browsing_shortcut))?.apply {
+            isVisible = !PrivateShortcutCreateManager.doesPrivateBrowsingPinnedShortcutExist(requireContext())
+        }
+
         setupPreferences()
 
         updateAccountUIState(context!!, requireComponents.backgroundServices.accountManager.accountProfile())


### PR DESCRIPTION
Closes issue #5233:

Added doesPrivateBrowsingPinnedShortcutExist() method to the PrivateShortcutCreateManager class to check for the existence of the shortcut.  Code only works on devices with API 25 or higher, so a check for that condition was also included in the new method.

Calls to the new method were added to the SettingsFragment and HomeFragment classes to determine whether the settings menu item and the recommendation dialog should be displayed.

**Quality**: The pre-push test failed to start on my windows 10 OS, but this code has been thoroughly tested manually on simulators and physical devices.

**Tests**: This code only effects UI appearance so not sure how to test for that and no tests were written.

**Screenshots**: This code does not add anything new to the UI, it only controls whether to display existing items.