### PR TITLE
Update bug numbers to URLs

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -14,7 +14,7 @@ events:
       source:
         description: "The method used to open Fenix. Possible values are: `app_icon`, `custom_tab` or `link`"
     bugs:
-    - 968
+    - https://github.com/mozilla-mobile/fenix/issue/968
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/1067#issuecomment-474598673
     notification_emails:
@@ -29,7 +29,7 @@ events:
       source:
         description: "The view the user was on when they initiated the search (For example: `Home` or `Browser`)"
     bugs:
-    - 959
+    - https://github.com/mozilla-mobile/fenix/issue/959
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/1067#issuecomment-474598673
     notification_emails:
@@ -43,7 +43,7 @@ events:
       autocomplete:
         description: "A boolean that tells us whether the URL was autofilled by an Autocomplete suggestion"
     bugs:
-    - 959
+    - https://github.com/mozilla-mobile/fenix/issue/959
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/1067#issuecomment-474598673
     notification_emails:
@@ -62,7 +62,7 @@ events:
           * shortcut.action
           * shortcut.suggestion
     bugs:
-    - 959
+    - https://github.com/mozilla-mobile/fenix/issue/959
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/1067#issuecomment-474598673
     - https://github.com/mozilla-mobile/fenix/pull/1677
@@ -80,7 +80,7 @@ events:
           Settings, Library, Help, Desktop Site toggle on/off, Find in Page, New Tab,
           Private Tab, Share, Report Site Issue, Back/Forward button, Reload Button, Quit
     bugs:
-    - 1024
+    - https://github.com/mozilla-mobile/fenix/issue/1024
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/1214#issue-264756708
     - https://github.com/mozilla-mobile/fenix/pull/5098#issuecomment-529658996
@@ -94,7 +94,7 @@ events:
     send_in_pings:
     - baseline
     bugs:
-    - 1301
+    - https://github.com/mozilla-mobile/fenix/issue/1301
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/1785
     notification_emails:
@@ -112,8 +112,8 @@ events:
       enabled:
         description: "Whether or not the preference is *now* enabled"
     bugs:
-    - 975
-    - 5094
+    - https://github.com/mozilla-mobile/fenix/issue/975
+    - https://github.com/mozilla-mobile/fenix/issue/5094
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/1896
     - https://github.com/mozilla-mobile/fenix/pull/5704
@@ -128,7 +128,7 @@ events:
       source:
         description: "The location from which the user selected the what's new button. Either 'about' or 'home'"
     bugs:
-      - 5021
+      - https://github.com/mozilla-mobile/fenix/issue/5021
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/5090
     notification_emails:
@@ -144,7 +144,7 @@ search_shortcuts:
       engine:
         description: "The name of the built-in search engine the user selected as a string"
     bugs:
-      - 793
+      - https://github.com/mozilla-mobile/fenix/issue/793
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/1202#issuecomment-476870449
     notification_emails:
@@ -157,7 +157,7 @@ crash_reporter:
     description: >
       The crash reporter was displayed
     bugs:
-    - 1040
+    - https://github.com/mozilla-mobile/fenix/issue/1040
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/1214#issue-264756708
     notification_emails:
@@ -171,7 +171,7 @@ crash_reporter:
       crash_submitted:
         description: "A boolean that tells us whether or not the user submitted a crash report"
     bugs:
-    - 1040
+    - https://github.com/mozilla-mobile/fenix/issue/1040
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/1214#issue-264756708
     notification_emails:
@@ -192,7 +192,7 @@ context_menu:
           save_image, share_link, copy_link, copy_image_location
           ```
     bugs:
-    - 957
+    - https://github.com/mozilla-mobile/fenix/issue/957
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/1344#issuecomment-479285010
     notification_emails:
@@ -205,7 +205,7 @@ find_in_page:
     description: >
       A user opened the find in page UI
     bugs:
-    - 1036
+    - https://github.com/mozilla-mobile/fenix/issue/1036
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/1344#issuecomment-479285010
     notification_emails:
@@ -216,7 +216,7 @@ find_in_page:
     description: >
       A user closed the find in page UI
     bugs:
-    - 1036
+    - https://github.com/mozilla-mobile/fenix/issue/1036
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/1344#issuecomment-479285010
     notification_emails:
@@ -227,7 +227,7 @@ find_in_page:
     description: >
       A user clicked the "next result" button
     bugs:
-    - 1036
+    - https://github.com/mozilla-mobile/fenix/issue/1036
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/1344#issuecomment-479285010
     notification_emails:
@@ -238,7 +238,7 @@ find_in_page:
     description: >
       A user clicked the "previous result" button
     bugs:
-    - 1036
+    - https://github.com/mozilla-mobile/fenix/issue/1036
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/1344#issuecomment-479285010
     notification_emails:
@@ -249,7 +249,7 @@ find_in_page:
     description: >
       A user searched the page
     bugs:
-    - 1036
+    - https://github.com/mozilla-mobile/fenix/issue/1036
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/1344#issuecomment-479285010
     notification_emails:
@@ -262,7 +262,7 @@ quick_action_sheet:
     description: >
       A user opened the quick action sheet UI
     bugs:
-    - 1195
+    - https://github.com/mozilla-mobile/fenix/issue/1195
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/1362#issuecomment-479668466
     notification_emails:
@@ -273,7 +273,7 @@ quick_action_sheet:
     description: >
       A user closed the quick action sheet UI
     bugs:
-    - 1195
+    - https://github.com/mozilla-mobile/fenix/issue/1195
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/1362#issuecomment-479668466
     notification_emails:
@@ -284,7 +284,7 @@ quick_action_sheet:
     description: >
       A user tapped the share button
     bugs:
-    - 1195
+    - https://github.com/mozilla-mobile/fenix/issue/1195
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/1362#issuecomment-479668466
     notification_emails:
@@ -295,7 +295,7 @@ quick_action_sheet:
     description: >
       A user tapped the bookmark button
     bugs:
-    - 1195
+    - https://github.com/mozilla-mobile/fenix/issue/1195
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/1362#issuecomment-479668466
     notification_emails:
@@ -306,7 +306,7 @@ quick_action_sheet:
     description: >
       A user tapped the download button
     bugs:
-    - 1195
+    - https://github.com/mozilla-mobile/fenix/issue/1195
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/1362#issuecomment-479668466
     notification_emails:
@@ -317,7 +317,7 @@ quick_action_sheet:
     description: >
       A user tapped the open in app button
     bugs:
-      - 1195
+      - https://github.com/mozilla-mobile/fenix/issue/1195
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/4629
     notification_emails:
@@ -333,7 +333,7 @@ metrics:
     send_in_pings:
     - metrics
     bugs:
-    - 960
+    - https://github.com/mozilla-mobile/fenix/issue/960
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/1067#issuecomment-474598673
     notification_emails:
@@ -352,7 +352,7 @@ metrics:
     - metrics
     - baseline
     bugs:
-    - 1158
+    - https://github.com/mozilla-mobile/fenix/issue/1158
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/1677
     - https://github.com/mozilla-mobile/fenix/pull/5216
@@ -369,7 +369,7 @@ metrics:
     send_in_pings:
     - metrics
     bugs:
-    - 1192
+    - https://github.com/mozilla-mobile/fenix/issue/1192
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/1953/
     - https://github.com/mozilla-mobile/fenix/pull/5216
@@ -384,7 +384,7 @@ metrics:
     send_in_pings:
     - metrics
     bugs:
-    - 1192
+    - https://github.com/mozilla-mobile/fenix/issue/1192
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/1953/
     - https://github.com/mozilla-mobile/fenix/pull/5216
@@ -399,7 +399,7 @@ metrics:
     send_in_pings:
       - metrics
     bugs:
-      - 1298
+      - https://github.com/mozilla-mobile/fenix/issue/1298
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/5579
     notification_emails:
@@ -419,7 +419,7 @@ search.default_engine:
     send_in_pings:
     - metrics
     bugs:
-    - 800
+    - https://github.com/mozilla-mobile/fenix/issue/800
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/1606
     - https://github.com/mozilla-mobile/fenix/pull/5216
@@ -437,7 +437,7 @@ search.default_engine:
     send_in_pings:
     - metrics
     bugs:
-    - 800
+    - https://github.com/mozilla-mobile/fenix/issue/800
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/1606
     - https://github.com/mozilla-mobile/fenix/pull/5216
@@ -456,7 +456,7 @@ search.default_engine:
     send_in_pings:
     - metrics
     bugs:
-    - 800
+    - https://github.com/mozilla-mobile/fenix/issue/800
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/1606
     - https://github.com/mozilla-mobile/fenix/pull/5216
@@ -470,7 +470,7 @@ bookmarks_management:
     description: >
       A user opened a bookmark in a new tab.
     bugs:
-    - 974
+    - https://github.com/mozilla-mobile/fenix/issue/974
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/1708
     notification_emails:
@@ -481,7 +481,7 @@ bookmarks_management:
     description: >
       A user opened multiple bookmarks at once in new tabs.
     bugs:
-    - 974
+    - https://github.com/mozilla-mobile/fenix/issue/974
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/1708
     notification_emails:
@@ -492,7 +492,7 @@ bookmarks_management:
     description: >
       A user opened a bookmark in a new private tab.
     bugs:
-    - 974
+    - https://github.com/mozilla-mobile/fenix/issue/974
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/1708
     notification_emails:
@@ -503,7 +503,7 @@ bookmarks_management:
     description: >
       A user opened multiple bookmarks at once in new private tabs.
     bugs:
-    - 974
+    - https://github.com/mozilla-mobile/fenix/issue/974
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/1708
     notification_emails:
@@ -514,7 +514,7 @@ bookmarks_management:
     description: >
       A user edited the title and/or URL of an existing bookmark.
     bugs:
-    - 974
+    - https://github.com/mozilla-mobile/fenix/issue/974
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/1708
     notification_emails:
@@ -525,7 +525,7 @@ bookmarks_management:
     description: >
       A user moved an existing bookmark or folder to another folder.
     bugs:
-    - 974
+    - https://github.com/mozilla-mobile/fenix/issue/974
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/1708
     notification_emails:
@@ -536,7 +536,7 @@ bookmarks_management:
     description: >
       A user removed a bookmark item.
     bugs:
-    - 974
+    - https://github.com/mozilla-mobile/fenix/issue/974
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/1708
     notification_emails:
@@ -547,7 +547,7 @@ bookmarks_management:
     description: >
       A user removed multiple bookmarks at once.
     bugs:
-    - 974
+    - https://github.com/mozilla-mobile/fenix/issue/974
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/1708
     notification_emails:
@@ -558,7 +558,7 @@ bookmarks_management:
     description: >
       A user shared a bookmark.
     bugs:
-    - 974
+    - https://github.com/mozilla-mobile/fenix/issue/974
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/1708
     notification_emails:
@@ -569,7 +569,7 @@ bookmarks_management:
     description: >
       A user copied a bookmark.
     bugs:
-    - 974
+    - https://github.com/mozilla-mobile/fenix/issue/974
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/1708
     notification_emails:
@@ -580,7 +580,7 @@ bookmarks_management:
     description: >
       A user added a new bookmark folder.
     bugs:
-    - 974
+    - https://github.com/mozilla-mobile/fenix/issue/974
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/1708
     notification_emails:
@@ -591,7 +591,7 @@ bookmarks_management:
     description: >
       A user removed a bookmark folder.
     bugs:
-      - 3174
+      - https://github.com/mozilla-mobile/fenix/issue/3174
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/3724
     notification_emails:
@@ -604,7 +604,7 @@ custom_tab:
     description: >
       A user closed the custom tab
     bugs:
-    - 977
+    - https://github.com/mozilla-mobile/fenix/issue/977
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/1697
     notification_emails:
@@ -615,7 +615,7 @@ custom_tab:
     description: >
       A user pressed the action button provided by the launching app
     bugs:
-    - 977
+    - https://github.com/mozilla-mobile/fenix/issue/977
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/1697
     notification_emails:
@@ -626,7 +626,7 @@ custom_tab:
     description: >
       A user opened the custom tabs menu
     bugs:
-    - 977
+    - https://github.com/mozilla-mobile/fenix/issue/977
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/1697
     notification_emails:
@@ -643,8 +643,8 @@ activation:
     send_in_pings:
     - activation
     bugs:
-    - 1538011
-    - 1501822
+    - https://bugzilla.mozilla.org/1538011
+    - https://bugzilla.mozilla.org/1501822
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/1707#issuecomment-486972209
     notification_emails:
@@ -660,7 +660,7 @@ activation:
     send_in_pings:
     - activation
     bugs:
-    - 1538011
+    - https://bugzilla.mozilla.org/1538011
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/1707#issuecomment-486972209
     notification_emails:
@@ -673,7 +673,7 @@ qr_scanner:
     description: >
       A user opened the QR scanner
     bugs:
-    - 1857
+    - https://github.com/mozilla-mobile/fenix/issue/1857
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/2524#issuecomment-492739967
     notification_emails:
@@ -684,7 +684,7 @@ qr_scanner:
     description: >
       A user scanned a QR code, causing a confirmation prompt to display asking if they want to navigate to the page
     bugs:
-    - 1857
+    - https://github.com/mozilla-mobile/fenix/issue/1857
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/2524#issuecomment-492739967
     notification_emails:
@@ -695,7 +695,7 @@ qr_scanner:
     description: >
       A user tapped "allow" on the prompt, directing the user to the website scanned
     bugs:
-    - 1857
+    - https://github.com/mozilla-mobile/fenix/issue/1857
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/2524#issuecomment-492739967
     notification_emails:
@@ -706,7 +706,7 @@ qr_scanner:
     description: >
       A user tapped "deny" on the prompt, putting the user back to the scanning view
     bugs:
-    - 1857
+    - https://github.com/mozilla-mobile/fenix/issue/1857
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/2524#issuecomment-492739967
     notification_emails:
@@ -719,7 +719,7 @@ library:
     description: >
       A user opened the library
     bugs:
-    - 976
+    - https://github.com/mozilla-mobile/fenix/issue/976
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/2538#issuecomment-492830242
     notification_emails:
@@ -730,7 +730,7 @@ library:
     description: >
       A user closed the library
     bugs:
-    - 976
+    - https://github.com/mozilla-mobile/fenix/issue/976
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/2538#issuecomment-492830242
     notification_emails:
@@ -744,7 +744,7 @@ library:
       item:
         description: "The library item the user selected"
     bugs:
-    - 976
+    - https://github.com/mozilla-mobile/fenix/issue/976
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/2538#issuecomment-492830242
     notification_emails:
@@ -760,7 +760,7 @@ error_page:
       error_type:
         description: "The error type of the error page encountered"
     bugs:
-    - 1242
+    - https://github.com/mozilla-mobile/fenix/issue/1242
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/2491#issuecomment-492414486
     notification_emails:
@@ -773,7 +773,7 @@ sync_auth:
     description: >
       A user opened the sync authentication page
     bugs:
-    - 1190
+    - https://github.com/mozilla-mobile/fenix/issue/1190
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/2745#issuecomment-494918532
     notification_emails:
@@ -784,7 +784,7 @@ sync_auth:
     description: >
       A user closed the sync page
     bugs:
-    - 1190
+    - https://github.com/mozilla-mobile/fenix/issue/1190
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/2745#issuecomment-494918532
     notification_emails:
@@ -795,7 +795,7 @@ sync_auth:
     description: >
       A user pressed the sign in button on the sync authentication page and was successfully signed in to FxA
     bugs:
-    - 1190
+    - https://github.com/mozilla-mobile/fenix/issue/1190
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/2745#issuecomment-494918532
     notification_emails:
@@ -806,7 +806,7 @@ sync_auth:
     description: >
       A user pressed the sign out button on the sync account page and was successfully signed out of FxA
     bugs:
-      - 1190
+      - https://github.com/mozilla-mobile/fenix/issue/1190
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/2745#issuecomment-494918532
     notification_emails:
@@ -817,7 +817,7 @@ sync_auth:
     description: >
       User registered a new Firefox Account, and was signed into it
     bugs:
-      - 4971
+      - https://github.com/mozilla-mobile/fenix/issue/4971
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/4931#issuecomment-529740300
     notification_emails:
@@ -828,7 +828,7 @@ sync_auth:
     description: >
       User signed into FxA by pairing with a different Firefox browser, using a QR code
     bugs:
-      - 4971
+      - https://github.com/mozilla-mobile/fenix/issue/4971
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/4931#issuecomment-529740300
     notification_emails:
@@ -839,7 +839,7 @@ sync_auth:
     description: >
       User signed into FxA via an account shared from another locally installed Mozilla application (e.g. Fennec)
     bugs:
-      - 4971
+      - https://github.com/mozilla-mobile/fenix/issue/4971
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/4931#issuecomment-529740300
     notification_emails:
@@ -850,7 +850,7 @@ sync_auth:
     description: >
       Account manager automatically recovered FxA authentication state without direct user involvement
     bugs:
-      - 4971
+      - https://github.com/mozilla-mobile/fenix/issue/4971
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/4931#issuecomment-529740300
     notification_emails:
@@ -861,7 +861,7 @@ sync_auth:
     description: >
       User authenticated via FxA using an unknown mechanism. "Known" mechanisms are currently sign-in, sign-up and pairing
     bugs:
-      - 4971
+      - https://github.com/mozilla-mobile/fenix/issue/4971
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/4931#issuecomment-529740300
     notification_emails:
@@ -872,7 +872,7 @@ sync_auth:
     description: >
       A user pressed the scan pairing button on the sync authentication page
     bugs:
-    - 1190
+    - https://github.com/mozilla-mobile/fenix/issue/1190
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/2745#issuecomment-494918532
     notification_emails:
@@ -885,7 +885,7 @@ sync_account:
     description: >
       A user opened the sync account page
     bugs:
-    - 1190
+    - https://github.com/mozilla-mobile/fenix/issue/1190
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/2745#issuecomment-494918532
     notification_emails:
@@ -896,7 +896,7 @@ sync_account:
     description: >
       A user closed the sync account page
     bugs:
-    - 1190
+    - https://github.com/mozilla-mobile/fenix/issue/1190
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/2745#issuecomment-494918532
     notification_emails:
@@ -907,7 +907,7 @@ sync_account:
     description: >
       A user pressed the sync now button on the sync account page
     bugs:
-    - 1190
+    - https://github.com/mozilla-mobile/fenix/issue/1190
     data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/2745#issuecomment-494918532
     notification_emails:
@@ -918,7 +918,7 @@ sync_account:
     description: >
       A user sent the current tab to another FxA device
     bugs:
-      - 4908
+      - https://github.com/mozilla-mobile/fenix/issue/4908
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/5106
     notification_emails:
@@ -929,7 +929,7 @@ sync_account:
     description: >
       A user pressed the "sign in to send tab" button inside the share tab menu
     bugs:
-      - 4908
+      - https://github.com/mozilla-mobile/fenix/issue/4908
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/5106
     notification_emails:
@@ -942,7 +942,7 @@ history:
     description: >
       A user opened the history screen
     bugs:
-      - 2362
+      - https://github.com/mozilla-mobile/fenix/issue/2362
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/3940
     notification_emails:
@@ -953,7 +953,7 @@ history:
     description: >
       A user removed a history item
     bugs:
-      - 2362
+      - https://github.com/mozilla-mobile/fenix/issue/2362
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/3940
     notification_emails:
@@ -964,7 +964,7 @@ history:
     description: >
       A user removed all history items
     bugs:
-      - 2362
+      - https://github.com/mozilla-mobile/fenix/issue/2362
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/3940
     notification_emails:
@@ -975,7 +975,7 @@ history:
     description: >
       A user shared a history item
     bugs:
-      - 2362
+      - https://github.com/mozilla-mobile/fenix/issue/2362
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/3940
     notification_emails:
@@ -986,7 +986,7 @@ history:
     description: >
       A user opened a history item
     bugs:
-      - 2362
+      - https://github.com/mozilla-mobile/fenix/issue/2362
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/3940
     notification_emails:
@@ -999,7 +999,7 @@ reader_mode:
     description: >
       Reader mode is available for the current page
     bugs:
-      - 2267
+      - https://github.com/mozilla-mobile/fenix/issue/2267
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/3941
     notification_emails:
@@ -1010,7 +1010,7 @@ reader_mode:
     description: >
       A user opened reader mode
     bugs:
-      - 2267
+      - https://github.com/mozilla-mobile/fenix/issue/2267
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/3941
     notification_emails:
@@ -1021,7 +1021,7 @@ reader_mode:
     description: >
       A user closed reader mode
     bugs:
-      - 2267
+      - https://github.com/mozilla-mobile/fenix/issue/2267
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/4328
     notification_emails:
@@ -1032,7 +1032,7 @@ reader_mode:
     description: >
       A user tapped the appearance button
     bugs:
-      - 2267
+      - https://github.com/mozilla-mobile/fenix/issue/2267
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/3941
     notification_emails:
@@ -1045,7 +1045,7 @@ collections:
     description: >
       A user renamed a collection
     bugs:
-      - 969
+      - https://github.com/mozilla-mobile/fenix/issue/969
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/3935
     notification_emails:
@@ -1056,7 +1056,7 @@ collections:
     description: >
       A user restored a tab from collection tab list
     bugs:
-      - 969
+      - https://github.com/mozilla-mobile/fenix/issue/969
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/3935
     notification_emails:
@@ -1067,7 +1067,7 @@ collections:
     description: >
       A user tapped "open tabs" from collection menu
     bugs:
-      - 969
+      - https://github.com/mozilla-mobile/fenix/issue/969
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/3935
     notification_emails:
@@ -1078,7 +1078,7 @@ collections:
     description: >
       A user tapped remove tab from collection tab list
     bugs:
-      - 969
+      - https://github.com/mozilla-mobile/fenix/issue/969
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/3935
     notification_emails:
@@ -1089,7 +1089,7 @@ collections:
     description: >
       A user tapped share collection
     bugs:
-      - 969
+      - https://github.com/mozilla-mobile/fenix/issue/969
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/3935
     notification_emails:
@@ -1100,7 +1100,7 @@ collections:
     description: >
       A user tapped delete collection from collection menu
     bugs:
-      - 969
+      - https://github.com/mozilla-mobile/fenix/issue/969
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/3935
     notification_emails:
@@ -1116,7 +1116,7 @@ collections:
       tabs_selected:
         description: "The number of tabs added to the collection"
     bugs:
-      - 969
+      - https://github.com/mozilla-mobile/fenix/issue/969
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/3935
     notification_emails:
@@ -1132,7 +1132,7 @@ collections:
       tabs_selected:
         description: "The number of tabs added to the collection"
     bugs:
-      - 969
+      - https://github.com/mozilla-mobile/fenix/issue/969
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/3935
     notification_emails:
@@ -1143,7 +1143,7 @@ collections:
     description: >
       A user opened the select tabs screen (the first step of the collection creation flow)
     bugs:
-      - 969
+      - https://github.com/mozilla-mobile/fenix/issue/969
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/3935
     notification_emails:
@@ -1154,7 +1154,7 @@ collections:
     description: >
       A user tapped the "add tab" button in the three dot menu of collections
     bugs:
-      - 969
+      - https://github.com/mozilla-mobile/fenix/issue/969
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/4358
     notification_emails:
@@ -1165,7 +1165,7 @@ collections:
     description: >
       A user long pressed on a tab, triggering the collection creation screen
     bugs:
-      - 969
+      - https://github.com/mozilla-mobile/fenix/issue/969
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/4358
     notification_emails:
@@ -1177,7 +1177,7 @@ collections:
       A user pressed the "save to collection" button on either the home or browser screen, triggering the
       collection creation screen to open (tab_select_opened)
     bugs:
-      - 969
+      - https://github.com/mozilla-mobile/fenix/issue/969
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/4358
     notification_emails:
@@ -1193,7 +1193,7 @@ collections:
     description: >
       A user pressed the "rename collection" button in the three dot menu
     bugs:
-      - 969
+      - https://github.com/mozilla-mobile/fenix/issue/969
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/4539
     notification_emails:
@@ -1207,7 +1207,7 @@ search_widget:
       A user pressed anywhere from the Firefox logo until the start of the microphone icon, opening a
       new tab search screen.
     bugs:
-      - 4457
+      - https://github.com/mozilla-mobile/fenix/issue/4457
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/4714
     notification_emails:
@@ -1218,7 +1218,7 @@ search_widget:
     description: >
       A user pressed the microphone icon, opening a new voice search screen.
     bugs:
-      - 4457
+      - https://github.com/mozilla-mobile/fenix/issue/4457
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/4714
     notification_emails:
@@ -1232,7 +1232,7 @@ private_browsing_mode:
       A user pressed the garbage can icon on the private browsing home page,
       deleting all private tabs.
     bugs:
-      - 4658
+      - https://github.com/mozilla-mobile/fenix/issue/4658
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/4968
     notification_emails:
@@ -1244,7 +1244,7 @@ private_browsing_mode:
       A user pressed the "undo" button in the snackbar that is shown when the garbage icon is
       tapped.
     bugs:
-      - 4658
+      - https://github.com/mozilla-mobile/fenix/issue/4658
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/4968
     notification_emails:
@@ -1255,7 +1255,7 @@ private_browsing_mode:
     description: >
       A user pressed the private browsing mode notification itself.
     bugs:
-      - 4658
+      - https://github.com/mozilla-mobile/fenix/issue/4658
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/4968
     notification_emails:
@@ -1266,7 +1266,7 @@ private_browsing_mode:
     description: >
       A user pressed the private browsing mode notification's "Open" button.
     bugs:
-      - 4658
+      - https://github.com/mozilla-mobile/fenix/issue/4658
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/4968
     notification_emails:
@@ -1277,7 +1277,7 @@ private_browsing_mode:
     description: >
       A user pressed the private browsing mode notification's "Delete and Open" button.
     bugs:
-      - 4658
+      - https://github.com/mozilla-mobile/fenix/issue/4658
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/4968
     notification_emails:
@@ -1290,7 +1290,7 @@ tracking_protection:
     description: >
       A user added a tracking protection exception through the TP toggle in the panel.
     bugs:
-      - 5312
+      - https://github.com/mozilla-mobile/fenix/issue/5312
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/5414#issuecomment-532847188
     notification_emails:
@@ -1301,7 +1301,7 @@ tracking_protection:
     description: >
       A user opened tracking protection settings from the panel.
     bugs:
-      - 5312
+      - https://github.com/mozilla-mobile/fenix/issue/5312
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/5414#issuecomment-532847188
     notification_emails:
@@ -1312,7 +1312,7 @@ tracking_protection:
     description: >
       A user pressed the tracking protection shield icon in toolbar.
     bugs:
-      - 5312
+      - https://github.com/mozilla-mobile/fenix/issue/5312
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/5414#issuecomment-532847188
     notification_emails:
@@ -1323,7 +1323,7 @@ tracking_protection:
     description: >
       A user pressed into a list of categorized trackers in tracking protection panel.
     bugs:
-      - 5312
+      - https://github.com/mozilla-mobile/fenix/issue/5312
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/5414#issuecomment-532847188
     notification_emails:
@@ -1334,7 +1334,7 @@ tracking_protection:
     description: >
       A user opened tracking protection settings through settings.
     bugs:
-      - 5312
+      - https://github.com/mozilla-mobile/fenix/issue/5312
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/5414#issuecomment-532847188
     notification_emails:
@@ -1348,7 +1348,7 @@ tracking_protection:
       etp_setting:
         description: "The new setting for ETP: strict, standard"
     bugs:
-      - 5312
+      - https://github.com/mozilla-mobile/fenix/issue/5312
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/5414#issuecomment-532847188
     notification_emails:
@@ -1361,7 +1361,7 @@ private_browsing_shortcut:
     description: >
       A user pressed the "Add private browsing shortcut" button in settings.
     bugs:
-      - 4658
+      - https://github.com/mozilla-mobile/fenix/issue/4658
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/5194
     notification_emails:
@@ -1372,7 +1372,7 @@ private_browsing_shortcut:
     description: >
       A user pressed the "Add shortcut" button when the contextual feature recommender appeared.
     bugs:
-      - 4658
+      - https://github.com/mozilla-mobile/fenix/issue/4658
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/5194
     notification_emails:
@@ -1383,7 +1383,7 @@ private_browsing_shortcut:
     description: >
       A user pressed the "No thanks" button when the contextual feature recommender appeared.
     bugs:
-      - 4658
+      - https://github.com/mozilla-mobile/fenix/issue/4658
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/5194
     notification_emails:
@@ -1394,7 +1394,7 @@ private_browsing_shortcut:
     description: >
       A user pressed the pinned private shortcut in Android home screen, opening up a new private search.
     bugs:
-      - 4658
+      - https://github.com/mozilla-mobile/fenix/issue/4658
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/5194
     notification_emails:
@@ -1405,7 +1405,7 @@ private_browsing_shortcut:
     description: >
       A user pressed the long-press shortcut "Open new tab", opening up a new search.
     bugs:
-      - 4658
+      - https://github.com/mozilla-mobile/fenix/issue/4658
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/5194
     notification_emails:
@@ -1416,7 +1416,7 @@ private_browsing_shortcut:
     description: >
       A user pressed the long-press shortcut "Open new private tab", opening up a new private search.
     bugs:
-      - 4658
+      - https://github.com/mozilla-mobile/fenix/issue/4658
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/5194
     notification_emails:
@@ -1429,7 +1429,7 @@ tab:
     description: >
       A user pressed the play icon on a tab from the home screen
     bugs:
-      - 5197
+      - https://github.com/mozilla-mobile/fenix/issue/5197
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/5266
     notification_emails:
@@ -1440,7 +1440,7 @@ tab:
     description: >
       A user pressed the pause icon on a tab from the home screen
     bugs:
-      - 5197
+      - https://github.com/mozilla-mobile/fenix/issue/5197
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/5266
     notification_emails:
@@ -1453,7 +1453,7 @@ media_notification:
     description: >
       A user pressed the play icon on the media notification
     bugs:
-      - 5197
+      - https://github.com/mozilla-mobile/fenix/issue/5197
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/5520
     notification_emails:
@@ -1464,7 +1464,7 @@ media_notification:
     description: >
       A user pressed the pause icon on the media notification
     bugs:
-      - 5197
+      - https://github.com/mozilla-mobile/fenix/issue/5197
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/5520
     notification_emails:
@@ -1481,7 +1481,7 @@ experiments.metrics:
       experiment. This is done by recording the experiment branch name in this string metric which
       allows the experiment to be transparent and unobtrusive to the user.
     bugs:
-      - 1543986
+      - https://bugzilla.mozilla.org/1543986
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1543986#c4
     notification_emails:


### PR DESCRIPTION
In Glean, we have decided to deprecate the use of bug numbers in metric definitions, in favor of using full URLs.  Fenix' own metric metadata is the perfect case in point for why: It currently mixes bugs from bugzilla and Github in the same file, and while for a human there isn't much ambiguity given the different size of the numbers, for automated tooling, this is going to get annoying...

This simply replaces all of the bug numbers with URLs.  Bug numbers will probably be treated as errors by Glean at some point in the near future.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture