### PR TITLE
Closes #1022: Auto-publication workflow for android-component 

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,29 @@ To push without running the pre-push hook (e.g. doc updates):
 git push <remote> --no-verify
 ```
 
+## local.properties helpers
+There are multiple helper flags available via `local.properties` that will help speed up local development workflow
+when working across multiple layers of the dependency stack - specifically, with android-components, geckoview or application-services.
+
+### android-components auto-publication workflow
+Specify a relative path to your local `android-components` checkout via `autoPublish.android-components.dir`.
+
+If enabled, during a Fenix build android-components will be compiled and locally published if it has been modified,
+and published versions of android-components modules will be automatically used instead of whatever is declared in Dependencies.kt.
+
+### application-services composite builds
+Specify a relative path to your local `application-services` checkout via `substitutions.application-services.dir`.
+
+If enabled, a multi-project gradle build will be configured, and any application-services dependency will be substituted
+for the local version. Any changes to `application-services` will be automatically included in Fenix builds.
+
+### GeckoView
+Specify a relative path to your local `mozilla-central` checkout via `dependencySubstitutions.geckoviewTopsrcdir`,
+and optional a path to m-c object directory via `dependencySubstitutions.geckoviewTopobjdir`.
+
+If these are configured, local builds of GeckoView will be used instead of what's configured in Dependencies.kt.
+For more details, see https://mozilla.github.io/geckoview/contributor/geckoview-quick-start#include-geckoview-as-a-dependency
+
 ## License
 
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -633,3 +633,8 @@ if (gradle.hasProperty('localProperties.dependencySubstitutions.geckoviewTopsrcd
     ext.topsrcdir = gradle."localProperties.dependencySubstitutions.geckoviewTopsrcdir"
     apply from: "${topsrcdir}/substitute-local-geckoview.gradle"
 }
+
+if (gradle.hasProperty('localProperties.autoPublish.android-components.dir')) {
+    ext.acSrcDir = gradle."localProperties.autoPublish.android-components.dir"
+    apply from: "../${acSrcDir}/substitute-local-ac.gradle"
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,18 +1,38 @@
 include ':app', ':architecture'
 
+def log(message) {
+    logger.lifecycle("[settings] ${message}")
+}
+
+def runCmd(cmd, workingDir, successMessage) {
+    def proc = cmd.execute(null, new File(workingDir))
+    def standardOutput = new ByteArrayOutputStream()
+    def standardError = new ByteArrayOutputStream()
+    proc.consumeProcessOutput(standardOutput, standardError)
+    proc.waitFor()
+
+    if (proc.exitValue() != 0) {
+        throw new GradleException("Process '${cmd}' finished with non-zero exit value ${proc.exitValue()}:\n\nstdout:\n${standardOutput.toString()}\n\nstderr:\n${standardError.toString()}")
+    } else {
+        log(successMessage)
+    }
+    return standardOutput
+}
+
 //////////////////////////////////////////////////////////////////////////
 // Local Development overrides
 //////////////////////////////////////////////////////////////////////////
 
-Properties localProperties = null;
-String settingAppServicesPath = "substitutions.application-services.dir";
+Properties localProperties = null
+String settingAppServicesPath = "substitutions.application-services.dir"
+String settingAndroidComponentsPath = "autoPublish.android-components.dir"
 
 if (file('local.properties').canRead()) {
     localProperties = new Properties()
     localProperties.load(file('local.properties').newDataInputStream())
-    logger.lifecycle('Local configuration: loaded local.properties')
+    log('Loaded local.properties')
 } else {
-    logger.lifecycle('Local configuration: absent local.properties; proceeding as normal.')
+    log('Missing local.properties; see https://github.com/mozilla-mobile/fenix/blob/master/README.md#local-properties-helpers for instructions.')
 }
 
 if (localProperties != null) {
@@ -20,12 +40,33 @@ if (localProperties != null) {
         gradle.ext.set("localProperties.${prop.key}", prop.value)
     }
 
-    String appServicesLocalPath = localProperties.getProperty(settingAppServicesPath);
+    String appServicesLocalPath = localProperties.getProperty(settingAppServicesPath)
 
     if (appServicesLocalPath != null) {
-        logger.lifecycle("Local configuration: substituting application-services modules from path: $appServicesLocalPath")
+        log("Enabling composite build with application-services modules from: $appServicesLocalPath")
         includeBuild(appServicesLocalPath)
     } else {
-        logger.lifecycle("Local configuration: application-services substitution path missing. Specify it via '$settingAppServicesPath' setting.")
+        log("Disabled composite builds with application-services. Enable them by settings '$settingAppServicesPath' in local.properties")
+    }
+
+    String androidComponentsLocalPath = localProperties.getProperty(settingAndroidComponentsPath)
+
+    if (androidComponentsLocalPath != null) {
+        log("Enabling automatic publication of android-components from: $androidComponentsLocalPath")
+        log("Determining if android-components are up-to-date...")
+        def compileAcCmd = ["${androidComponentsLocalPath}/gradlew", "compileReleaseKotlin"]
+        def compileOutput = runCmd(compileAcCmd, androidComponentsLocalPath, "Compiled android-components.")
+        // This is somewhat brittle: parse last line of gradle output, to fish out how many tasks were executed.
+        // One executed task means gradle didn't do any work other than executing the top-level 'compile' task.
+        def compileTasksExecuted = compileOutput.toString().split('\n').last().split(':')[1].split(' ')[1]
+        if (compileTasksExecuted.equals("1")) {
+            log("android-components are up-to-date, skipping publication.")
+        } else {
+            log("android-components changed, publishing locally...")
+            def publishAcCmd = ["${androidComponentsLocalPath}/gradlew", "publishToMavenLocal", "-Plocal=true"]
+            runCmd(publishAcCmd, androidComponentsLocalPath, "Published android-components.")
+        }
+    } else {
+        log("Disabled auto-publication of android-components. Enable it by settings '$settingAndroidComponentsPath' in local.properties")
     }
 }


### PR DESCRIPTION
This requires an android-components counterpart: https://github.com/mozilla-mobile/android-components/pull/4658

Initially, I went down the "make composite builds work well with a-c" rabbithole, and while they generally worked, experience in Android Studio was horrible. It would get _very_ confused and broken. So instead, I've settled for automating a publication workflow.

This patch enabled support for an auto-publication workflow for android-components.
It automates a common pattern seen in local development:

Old way:
- after every change in a-c, publish it locally with a unique version (bumping it manually)
- manually modify Fenix to consume a custom version of a-c from a mavenLocal repository
- this involves modifying Dependencies.kt for each new a-c version, fixing a few things in `app/build.gradle`, and specifying a new repository in `build.gradle`. 

New way:
- set a flag in fenix's local.properties to enable auto-publication
- run Fenix builds after making changes to a-c. Changes in a-c will be automatically picked up.
- no other changes are necessary to any Fenix files other than a single flag in local.properties!
- manually bumping android-components is no longer needed!