### PR TITLE
For #5213 - Add helper to set menu color 

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/ext/Context.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/Context.kt
@@ -18,18 +18,17 @@ import android.view.ViewGroup
 import androidx.annotation.AttrRes
 import androidx.annotation.ColorInt
 import androidx.annotation.StringRes
-import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentActivity
 import mozilla.components.browser.search.SearchEngineManager
 import mozilla.components.support.base.log.Log
 import mozilla.components.support.base.log.Log.Priority.WARN
+import mozilla.components.support.ktx.android.content.getColorFromAttr
 import org.mozilla.fenix.BuildConfig
 import org.mozilla.fenix.Config
 import org.mozilla.fenix.FenixApplication
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.Components
 import org.mozilla.fenix.components.metrics.MetricController
-import org.mozilla.fenix.theme.ThemeManager
 import org.mozilla.fenix.utils.Settings
 
 /**
@@ -106,8 +105,7 @@ fun Context.getRootView(): View? =
  * Returns the color int corresponding to the attribute.
  */
 @ColorInt
-fun Context.getColorFromAttr(@AttrRes attr: Int) =
-    ContextCompat.getColor(this, ThemeManager.resolveAttribute(attr, this))
+fun Context.getColorFromAttr(@AttrRes attr: Int) = getColorFromAttr(attr)
 
 fun Context.settings(isCrashReportEnabledInBuild: Boolean = BuildConfig.CRASH_REPORTING && Config.channel.isReleased) =
     Settings.getInstance(this, isCrashReportEnabledInBuild)

--- a/app/src/main/java/org/mozilla/fenix/library/LibraryFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/LibraryFragment.kt
@@ -19,9 +19,9 @@ import androidx.fragment.app.Fragment
 import androidx.navigation.Navigation
 import kotlinx.android.synthetic.main.fragment_library.*
 import mozilla.appservices.places.BookmarkRoot
+import mozilla.components.support.ktx.android.content.getColorFromAttr
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.metrics.Event
-import org.mozilla.fenix.ext.getColorFromAttr
 import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.requireComponents
 

--- a/app/src/main/java/org/mozilla/fenix/library/LibraryPageView.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/LibraryPageView.kt
@@ -21,9 +21,9 @@ import androidx.core.view.forEach
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.android.extensions.LayoutContainer
 import kotlinx.android.synthetic.main.library_site_item.view.*
+import mozilla.components.support.ktx.android.content.getColorFromAttr
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.asActivity
-import org.mozilla.fenix.ext.getColorFromAttr
 
 open class LibraryPageView(
     override val containerView: ViewGroup
@@ -40,8 +40,8 @@ open class LibraryPageView(
             context.getColorFromAttr(R.attr.primaryText),
             context.getColorFromAttr(R.attr.foundation)
         )
-        libraryItemsList.children.forEach {
-                item -> item.overflow_menu.visibility = View.VISIBLE
+        libraryItemsList.children.forEach { item ->
+            item.overflow_menu.visibility = View.VISIBLE
         }
     }
 
@@ -54,8 +54,8 @@ open class LibraryPageView(
             ContextCompat.getColor(context, R.color.white_color),
             context.getColorFromAttr(R.attr.accentHighContrast)
         )
-        libraryItemsList.children.forEach {
-            item -> item.overflow_menu.visibility = View.INVISIBLE
+        libraryItemsList.children.forEach { item ->
+            item.overflow_menu.visibility = View.INVISIBLE
         }
     }
 

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragment.kt
@@ -18,16 +18,16 @@ import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavDirections
 import androidx.navigation.fragment.findNavController
 import kotlinx.android.synthetic.main.fragment_bookmark.view.*
-import kotlinx.coroutines.async
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.Dispatchers.Main
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.ObsoleteCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.withContext
 import mozilla.appservices.places.BookmarkRoot
 import mozilla.components.concept.storage.BookmarkNode
@@ -248,12 +248,9 @@ class BookmarkFragment : LibraryPageFragment<BookmarkNode>(), BackHandler {
     private suspend fun deleteSelectedBookmarks(selected: Set<BookmarkNode>) {
         CoroutineScope(IO).launch {
             val tempStorage = context?.bookmarkStorage
-            val deferreds = selected.map {
-                async {
-                    tempStorage?.deleteNode(it.guid)
-                }
-            }
-            deferreds.awaitAll()
+            selected.map {
+                async { tempStorage?.deleteNode(it.guid) }
+            }.awaitAll()
         }
     }
 

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/addfolder/AddBookmarkFolderFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/addfolder/AddBookmarkFolderFragment.kt
@@ -4,8 +4,6 @@
 
 package org.mozilla.fenix.library.bookmarks.addfolder
 
-import android.graphics.PorterDuff
-import android.graphics.PorterDuffColorFilter
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.Menu
@@ -26,7 +24,6 @@ import kotlinx.coroutines.launch
 import mozilla.appservices.places.BookmarkRoot
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.metrics.Event
-import org.mozilla.fenix.ext.getColorFromAttr
 import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.library.bookmarks.BookmarksSharedViewModel
@@ -73,9 +70,6 @@ class AddBookmarkFolderFragment : Fragment() {
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         inflater.inflate(R.menu.bookmarks_add_folder, menu)
-        val textColor = requireContext().getColorFromAttr(R.attr.primaryText)
-        menu.findItem(R.id.confirm_add_folder_button).icon.colorFilter =
-            PorterDuffColorFilter(textColor, PorterDuff.Mode.SRC_IN)
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/edit/EditBookmarkFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/edit/EditBookmarkFragment.kt
@@ -5,8 +5,6 @@
 package org.mozilla.fenix.library.bookmarks.edit
 
 import android.content.DialogInterface
-import android.graphics.PorterDuff
-import android.graphics.PorterDuffColorFilter
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.Menu
@@ -42,7 +40,6 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.components
-import org.mozilla.fenix.ext.getColorFromAttr
 import org.mozilla.fenix.ext.getRootView
 import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.requireComponents
@@ -150,9 +147,6 @@ class EditBookmarkFragment : Fragment() {
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         inflater.inflate(R.menu.bookmarks_edit, menu)
-        val textColor = requireContext().getColorFromAttr(R.attr.primaryText)
-        menu.findItem(R.id.delete_bookmark_button).icon.colorFilter =
-            PorterDuffColorFilter(textColor, PorterDuff.Mode.SRC_IN)
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragment.kt
@@ -5,8 +5,6 @@
 package org.mozilla.fenix.library.history
 
 import android.content.DialogInterface
-import android.graphics.PorterDuff.Mode.SRC_IN
-import android.graphics.PorterDuffColorFilter
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.Menu
@@ -14,9 +12,9 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import androidx.annotation.MenuRes
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.content.ContextCompat
 import androidx.lifecycle.Observer
 import androidx.lifecycle.lifecycleScope
 import kotlinx.android.synthetic.main.fragment_history.view.*
@@ -133,22 +131,15 @@ class HistoryFragment : LibraryPageFragment<HistoryItem>(), BackHandler {
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        val mode = historyStore.state.mode
-        when (mode) {
+        @MenuRes
+        val menuRes = when (historyStore.state.mode) {
             HistoryFragmentState.Mode.Normal -> R.menu.library_menu
             is HistoryFragmentState.Mode.Editing -> R.menu.history_select_multi
-            else -> null
-        }?.let { inflater.inflate(it, menu) }
-
-        if (mode is HistoryFragmentState.Mode.Editing) {
-            menu.findItem(R.id.share_history_multi_select)?.run {
-                isVisible = true
-                icon.colorFilter = PorterDuffColorFilter(
-                    ContextCompat.getColor(context!!, R.color.white_color),
-                    SRC_IN
-                )
-            }
+            else -> return
         }
+
+        inflater.inflate(menuRes, menu)
+        menu.findItem(R.id.share_history_multi_select)?.isVisible = true
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean = when (item.itemId) {

--- a/app/src/main/res/menu/bookmarks_add_folder.xml
+++ b/app/src/main/res/menu/bookmarks_add_folder.xml
@@ -3,13 +3,11 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
-      xmlns:app="http://schemas.android.com/apk/res-auto"
-      xmlns:tools="http://schemas.android.com/tools">
+      xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
             android:id="@+id/confirm_add_folder_button"
             android:icon="@drawable/mozac_ic_check"
-            android:iconTint="?primaryText"
+            app:iconTint="?primaryText"
             android:title="@string/bookmark_add_folder"
-            app:showAsAction="ifRoom"
-            tools:targetApi="o" />
+            app:showAsAction="ifRoom" />
 </menu>

--- a/app/src/main/res/menu/bookmarks_edit.xml
+++ b/app/src/main/res/menu/bookmarks_edit.xml
@@ -3,14 +3,12 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
-      xmlns:app="http://schemas.android.com/apk/res-auto"
-      xmlns:tools="http://schemas.android.com/tools">
+      xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
             android:id="@+id/delete_bookmark_button"
             android:icon="@drawable/ic_delete"
-            android:iconTint="?primaryText"
+            app:iconTint="?primaryText"
             android:title="@string/bookmark_menu_delete_button"
             android:contentDescription="@string/bookmark_menu_delete_button"
-            app:showAsAction="ifRoom"
-            tools:targetApi="o" />
+            app:showAsAction="ifRoom" />
 </menu>

--- a/app/src/main/res/menu/bookmarks_menu.xml
+++ b/app/src/main/res/menu/bookmarks_menu.xml
@@ -3,20 +3,17 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
         android:id="@+id/add_bookmark_folder"
         android:icon="@drawable/ic_folder_new"
-        android:iconTint="?primaryText"
+        app:iconTint="?primaryText"
         android:title="@string/bookmark_add_folder"
-        app:showAsAction="ifRoom"
-        tools:targetApi="o" />
+        app:showAsAction="ifRoom" />
     <item
         android:id="@+id/libraryClose"
         android:icon="@drawable/ic_close"
-        android:iconTint="?primaryText"
+        app:iconTint="?primaryText"
         android:title="@string/content_description_close_button"
-        app:showAsAction="ifRoom"
-        tools:targetApi="o" />
+        app:showAsAction="ifRoom" />
 </menu>

--- a/app/src/main/res/menu/bookmarks_select_folder.xml
+++ b/app/src/main/res/menu/bookmarks_select_folder.xml
@@ -3,13 +3,11 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
-      xmlns:app="http://schemas.android.com/apk/res-auto"
-      xmlns:tools="http://schemas.android.com/tools">
+      xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
             android:id="@+id/add_folder_button"
             android:icon="@drawable/ic_new"
-            android:iconTint="?primaryText"
+            app:iconTint="?primaryText"
             android:title="@string/bookmark_select_folder"
-            app:showAsAction="ifRoom"
-            tools:targetApi="o" />
+            app:showAsAction="ifRoom" />
 </menu>

--- a/app/src/main/res/menu/bookmarks_select_multi.xml
+++ b/app/src/main/res/menu/bookmarks_select_multi.xml
@@ -2,34 +2,24 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<menu xmlns:android="http://schemas.android.com/apk/res/android" xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools">
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
         android:id="@+id/edit_bookmark_multi_select"
         android:icon="@drawable/ic_edit"
-        android:iconTint="@color/white_color"
+        app:iconTint="@color/white_color"
         android:title="@string/bookmark_edit"
-        app:showAsAction="ifRoom"
-        tools:targetApi="o" />
+        app:showAsAction="ifRoom" />
     <item
         android:id="@+id/open_bookmarks_in_new_tabs_multi_select"
-        android:icon="@drawable/ic_new"
-        android:iconTint="?primaryText"
         android:title="@string/bookmark_menu_open_in_new_tab_button"
-        app:showAsAction="never"
-        tools:targetApi="o" />
+        app:showAsAction="never" />
     <item
         android:id="@+id/open_bookmarks_in_private_tabs_multi_select"
-        android:icon="@drawable/ic_new"
-        android:iconTint="?primaryText"
         android:title="@string/bookmark_menu_open_in_private_tab_button"
-        app:showAsAction="never"
-        tools:targetApi="o" />
+        app:showAsAction="never" />
     <item
         android:id="@+id/delete_bookmarks_multi_select"
-        android:icon="@drawable/ic_new"
-        android:iconTint="?primaryText"
         android:title="@string/bookmark_menu_delete_button"
-        app:showAsAction="never"
-        tools:targetApi="o" />
+        app:showAsAction="never" />
 </menu>

--- a/app/src/main/res/menu/bookmarks_select_multi_not_item.xml
+++ b/app/src/main/res/menu/bookmarks_select_multi_not_item.xml
@@ -2,13 +2,12 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<menu xmlns:android="http://schemas.android.com/apk/res/android" xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools">
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
         android:id="@+id/delete_bookmarks_multi_select"
         android:icon="@drawable/mozac_ic_delete"
-        android:iconTint="?primaryText"
+        app:iconTint="@color/white_color"
         android:title="@string/bookmark_menu_delete_button"
-        app:showAsAction="ifRoom"
-        tools:targetApi="o" />
+        app:showAsAction="ifRoom" />
 </menu>

--- a/app/src/main/res/menu/history_select_multi.xml
+++ b/app/src/main/res/menu/history_select_multi.xml
@@ -3,34 +3,23 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
-      xmlns:app="http://schemas.android.com/apk/res-auto"
-      xmlns:tools="http://schemas.android.com/tools">
+      xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
             android:id="@+id/share_history_multi_select"
             android:icon="@drawable/ic_hollow_share"
-            android:iconTint="?primaryText"
+            app:iconTint="@color/white_color"
             android:title="@string/browser_menu_share"
-            app:showAsAction="ifRoom"
-            tools:targetApi="o" />
+            app:showAsAction="ifRoom" />
     <item
             android:id="@+id/open_history_in_new_tabs_multi_select"
-            android:icon="@drawable/ic_new"
-            android:iconTint="?primaryText"
             android:title="@string/bookmark_menu_open_in_new_tab_button"
-            app:showAsAction="never"
-            tools:targetApi="o" />
+            app:showAsAction="never" />
     <item
             android:id="@+id/open_history_in_private_tabs_multi_select"
-            android:icon="@drawable/ic_new"
-            android:iconTint="?primaryText"
             android:title="@string/bookmark_menu_open_in_private_tab_button"
-            app:showAsAction="never"
-            tools:targetApi="o" />
+            app:showAsAction="never" />
     <item
             android:id="@+id/delete_history_multi_select"
-            android:icon="@drawable/ic_new"
-            android:iconTint="?primaryText"
             android:title="@string/bookmark_menu_delete_button"
-            app:showAsAction="never"
-            tools:targetApi="o" />
+            app:showAsAction="never" />
 </menu>

--- a/app/src/main/res/menu/library_menu.xml
+++ b/app/src/main/res/menu/library_menu.xml
@@ -3,13 +3,11 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
         android:id="@+id/libraryClose"
         android:icon="@drawable/ic_close"
-        android:iconTint="?primaryText"
+        app:iconTint="?primaryText"
         android:title="@string/content_description_close_button"
-        app:showAsAction="ifRoom"
-        tools:targetApi="o" />
+        app:showAsAction="ifRoom" />
 </menu>


### PR DESCRIPTION
We accidentally hid the warnings that `iconTint` isn't used below Oreo. Added a helper to set the menu color for every icon (since they're always the same color as each other).

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture