### PR TITLE
Fixes #5351 - use session icon in tab view on home

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -6,6 +6,7 @@ package org.mozilla.fenix.home
 
 import android.animation.Animator
 import android.content.DialogInterface
+import android.graphics.Bitmap
 import android.graphics.drawable.BitmapDrawable
 import android.os.Bundle
 import android.view.Gravity
@@ -107,6 +108,10 @@ class HomeFragment : Fragment() {
 
     private val singleSessionObserver = object : Session.Observer {
         override fun onTitleChanged(session: Session, title: String) {
+            if (deleteAllSessionsJob == null) emitSessionChanges()
+        }
+
+        override fun onIconChanged(session: Session, icon: Bitmap?) {
             if (deleteAllSessionsJob == null) emitSessionChanges()
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlAdapter.kt
@@ -220,7 +220,7 @@ class SessionControlAdapter(
 
             if (it.shouldUpdateHostname) { holder.updateHostname(it.tab.hostname) }
             if (it.shouldUpdateTitle) { holder.updateTitle(it.tab.title) }
-            if (it.shouldUpdateUrl) { holder.updateFavIcon(it.tab.url) }
+            if (it.shouldUpdateUrl) { holder.updateFavIcon(it.tab.url, it.tab.sessionId) }
             if (it.shouldUpdateSelected) { holder.updateSelected(it.tab.selected ?: false) }
             if (it.shouldUpdateMediaState) {
                 holder.updatePlayPauseButton(it.tab.mediaState ?: MediaState.None)

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/TabViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/TabViewHolder.kt
@@ -16,6 +16,7 @@ import mozilla.components.browser.menu.BrowserMenuBuilder
 import mozilla.components.browser.menu.item.SimpleBrowserMenuItem
 import mozilla.components.feature.media.state.MediaState
 import mozilla.components.support.ktx.android.util.dpToFloat
+import org.jetbrains.anko.imageBitmap
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.components
@@ -92,7 +93,7 @@ class TabViewHolder(
         updateTab(tab)
         updateTitle(tab.title)
         updateHostname(tab.hostname)
-        updateFavIcon(tab.url)
+        updateFavIcon(tab.url, tab.sessionId)
         updateSelected(tab.selected ?: false)
         updatePlayPauseButton(tab.mediaState ?: MediaState.None)
         item_tab.transitionName = "$TAB_ITEM_TRANSITION_NAME${tab.sessionId}"
@@ -129,8 +130,16 @@ class TabViewHolder(
         hostname.text = text
     }
 
-    internal fun updateFavIcon(url: String) {
-        favicon_image.context.components.core.icons.loadIntoView(favicon_image, url)
+    internal fun updateFavIcon(url: String, sessionId: String) {
+        val icon = favicon_image.context.components.core
+            .sessionManager
+            .findSessionById(sessionId)?.icon
+
+        if (icon == null) {
+            favicon_image.context.components.core.icons.loadIntoView(favicon_image, url)
+        } else {
+            favicon_image.imageBitmap = icon
+        }
     }
 
     internal fun updateSelected(selected: Boolean) {


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not

<details><summary>GIF</summary>
<p>
<img src=https://user-images.githubusercontent.com/616399/66261515-b2529780-e783-11e9-9abc-40148bc42063.gif>
</p>
</details>

- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
