### PR TITLE
For #3846 - Pass in updated session icon to tabs

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/ext/Session.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/Session.kt
@@ -16,6 +16,7 @@ fun Session.toTab(context: Context, selected: Boolean? = null, mediaState: Media
         this.url.urlToTrimmedHost(context),
         this.title,
         selected,
-        mediaState
+        mediaState,
+        this.icon
     )
 }

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlAdapter.kt
@@ -45,7 +45,8 @@ sealed class AdapterItem(@LayoutRes val viewType: Int) {
         // Tell the adapter exactly what values have changed so it only has to draw those
         override fun getChangePayload(newItem: AdapterItem): Any? {
             (newItem as TabItem).let {
-                val shouldUpdateUrl = newItem.tab.url != this.tab.url
+                val shouldUpdateFavicon =
+                    newItem.tab.url != this.tab.url || newItem.tab.icon != this.tab.icon
                 val shouldUpdateHostname = newItem.tab.hostname != this.tab.hostname
                 val shouldUpdateTitle = newItem.tab.title != this.tab.title
                 val shouldUpdateSelected = newItem.tab.selected != this.tab.selected
@@ -53,7 +54,7 @@ sealed class AdapterItem(@LayoutRes val viewType: Int) {
 
                 return AdapterItemDiffCallback.TabChangePayload(
                     tab = newItem.tab,
-                    shouldUpdateUrl = shouldUpdateUrl,
+                    shouldUpdateFavicon = shouldUpdateFavicon,
                     shouldUpdateHostname = shouldUpdateHostname,
                     shouldUpdateTitle = shouldUpdateTitle,
                     shouldUpdateSelected = shouldUpdateSelected,
@@ -129,7 +130,7 @@ class AdapterItemDiffCallback : DiffUtil.ItemCallback<AdapterItem>() {
 
     data class TabChangePayload(
         val tab: Tab,
-        val shouldUpdateUrl: Boolean,
+        val shouldUpdateFavicon: Boolean,
         val shouldUpdateHostname: Boolean,
         val shouldUpdateTitle: Boolean,
         val shouldUpdateSelected: Boolean,
@@ -220,7 +221,9 @@ class SessionControlAdapter(
 
             if (it.shouldUpdateHostname) { holder.updateHostname(it.tab.hostname) }
             if (it.shouldUpdateTitle) { holder.updateTitle(it.tab.title) }
-            if (it.shouldUpdateUrl) { holder.updateFavIcon(it.tab.url, it.tab.sessionId) }
+            if (it.shouldUpdateFavicon) {
+                holder.updateFavIcon(it.tab.url, it.tab.icon)
+            }
             if (it.shouldUpdateSelected) { holder.updateSelected(it.tab.selected ?: false) }
             if (it.shouldUpdateMediaState) {
                 holder.updatePlayPauseButton(it.tab.mediaState ?: MediaState.None)

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlComponent.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlComponent.kt
@@ -5,6 +5,7 @@
 package org.mozilla.fenix.home.sessioncontrol
 
 import android.content.Context
+import android.graphics.Bitmap
 import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
@@ -50,7 +51,8 @@ data class Tab(
     val hostname: String,
     val title: String,
     val selected: Boolean? = null,
-    var mediaState: MediaState? = null
+    var mediaState: MediaState? = null,
+    val icon: Bitmap? = null
 )
 
 fun List<Tab>.toSessionBundle(context: Context): MutableList<Session> {

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/TabViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/TabViewHolder.kt
@@ -5,6 +5,7 @@
 package org.mozilla.fenix.home.sessioncontrol.viewholders
 
 import android.content.Context
+import android.graphics.Bitmap
 import android.graphics.Outline
 import android.view.View
 import android.view.ViewOutlineProvider
@@ -93,7 +94,7 @@ class TabViewHolder(
         updateTab(tab)
         updateTitle(tab.title)
         updateHostname(tab.hostname)
-        updateFavIcon(tab.url, tab.sessionId)
+        updateFavIcon(tab.url, tab.icon)
         updateSelected(tab.selected ?: false)
         updatePlayPauseButton(tab.mediaState ?: MediaState.None)
         item_tab.transitionName = "$TAB_ITEM_TRANSITION_NAME${tab.sessionId}"
@@ -130,11 +131,7 @@ class TabViewHolder(
         hostname.text = text
     }
 
-    internal fun updateFavIcon(url: String, sessionId: String) {
-        val icon = favicon_image.context.components.core
-            .sessionManager
-            .findSessionById(sessionId)?.icon
-
+    internal fun updateFavIcon(url: String, icon: Bitmap?) {
         if (icon == null) {
             favicon_image.context.components.core.icons.loadIntoView(favicon_image, url)
         } else {


### PR DESCRIPTION
A bit of cleanup after thinking about #5806 a bit more and should be able to close about #3846 after this

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture