### PR TITLE
Remove @ObsoleteCoroutinesApi from TestCore 

### DIFF
--- a/app/src/test/java/org/mozilla/fenix/TestApplication.kt
+++ b/app/src/test/java/org/mozilla/fenix/TestApplication.kt
@@ -4,10 +4,8 @@
 
 package org.mozilla.fenix
 
-import kotlinx.coroutines.ObsoleteCoroutinesApi
 import org.mozilla.fenix.components.TestComponents
 
-@ObsoleteCoroutinesApi
 class TestApplication : FenixApplication() {
 
     override val components = TestComponents(this)

--- a/app/src/test/java/org/mozilla/fenix/components/TestComponents.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/TestComponents.kt
@@ -6,12 +6,10 @@ package org.mozilla.fenix.components
 
 import android.content.Context
 import io.mockk.mockk
-import kotlinx.coroutines.ObsoleteCoroutinesApi
 import mozilla.components.support.test.mock
 import org.mockito.Mockito.`when`
 import org.mozilla.fenix.utils.ClipboardHandler
 
-@ObsoleteCoroutinesApi
 class TestComponents(private val context: Context) : Components(context) {
     override val backgroundServices by lazy {
         mockk<BackgroundServices>(relaxed = true)

--- a/app/src/test/java/org/mozilla/fenix/components/TestCore.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/TestCore.kt
@@ -6,14 +6,12 @@ package org.mozilla.fenix.components
 
 import android.content.Context
 import io.mockk.mockk
-import kotlinx.coroutines.ObsoleteCoroutinesApi
 import mozilla.components.browser.engine.gecko.GeckoEngine
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.fetch.Client
 
-@ObsoleteCoroutinesApi
-class TestCore(private val context: Context) : Core(context) {
+class TestCore(context: Context) : Core(context) {
 
     override val engine = mockk<GeckoEngine>(relaxed = true)
     override val sessionManager = SessionManager(engine)


### PR DESCRIPTION
This is now unneeded. I'll file a follow-up issue to remove it from tests too.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture