### PR TITLE
For #5798: Fix info icon pixelation

### DIFF
--- a/app/src/main/res/layout/preference_widget_radiobutton_with_info.xml
+++ b/app/src/main/res/layout/preference_widget_radiobutton_with_info.xml
@@ -63,8 +63,8 @@
 
     <ImageView
         android:id="@+id/info_button"
-        android:layout_width="20dp"
-        android:layout_height="20dp"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
         android:layout_marginStart="18dp"
         android:layout_marginEnd="18dp"
         android:src="@drawable/ic_info"


### PR DESCRIPTION
Changed ImageView size to original size of vector drawable.
This also changes info icon size to the one in original mocks.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture