### PR TITLE
Fix complete-pr which does not depend on lint tasks

### DIFF
--- a/taskcluster/ci/pr/kind.yml
+++ b/taskcluster/ci/pr/kind.yml
@@ -6,6 +6,7 @@ loader: taskgraph.loader.transform:loader
 
 kind-dependencies:
     - build
+    - lint
     - test
 
 transforms:


### PR DESCRIPTION
Before this patch, just 3 dependencies: https://tools.taskcluster.net/groups/CQQg9MbiTXKJczXU_t0UQw/tasks/VZIT-sj2Ql2SPjBUgcCR7w/details

After, all lint dependencies are here https://tools.taskcluster.net/groups/OepCmpdyQDyBSXlpS_Q8Zw/tasks/NI11cINRQ_upvSHcgMOVvA/details



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture