### PR TITLE
Closes #5852 - Use createAddedTestFragment in tests

### DIFF
--- a/app/src/test/java/org/mozilla/fenix/collections/CreateCollectionFragmentTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/collections/CreateCollectionFragmentTest.kt
@@ -4,17 +4,16 @@
 
 package org.mozilla.fenix.collections
 
-import androidx.fragment.app.FragmentActivity
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import assertk.assertThat
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
 import assertk.assertions.isTrue
 import kotlinx.coroutines.ObsoleteCoroutinesApi
+import mozilla.components.support.test.robolectric.createAddedTestFragment
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.TestApplication
-import org.robolectric.Robolectric
 import org.robolectric.annotation.Config
 
 @ObsoleteCoroutinesApi
@@ -23,18 +22,7 @@ import org.robolectric.annotation.Config
 class CreateCollectionFragmentTest {
     @Test
     fun `creation dialog shows and can be dismissed`() {
-        val activity = Robolectric.buildActivity(FragmentActivity::class.java)
-            .create()
-            .start()
-            .resume()
-            .get()
-
-        val fragment = CreateCollectionFragment()
-
-        activity.supportFragmentManager.beginTransaction().apply {
-            add(fragment, "test")
-            commitNow()
-        }
+        val fragment = createAddedTestFragment { CreateCollectionFragment() }
 
         assertThat(fragment.dialog).isNotNull()
         assertThat(fragment.requireDialog().isShowing).isTrue()

--- a/app/src/test/java/org/mozilla/fenix/components/StoreProviderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/StoreProviderTest.kt
@@ -5,18 +5,17 @@
 package org.mozilla.fenix.components
 
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.FragmentActivity
 import kotlinx.coroutines.ObsoleteCoroutinesApi
 import mozilla.components.lib.state.Action
 import mozilla.components.lib.state.State
 import mozilla.components.lib.state.Store
+import mozilla.components.support.test.robolectric.createAddedTestFragment
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.TestApplication
-import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
@@ -46,18 +45,7 @@ class StoreProviderTest {
 
     @Test
     fun `get returns store`() {
-        val activity = Robolectric.buildActivity(FragmentActivity::class.java)
-            .create()
-            .start()
-            .resume()
-            .get()
-
-        val fragment = Fragment()
-
-        activity.supportFragmentManager.beginTransaction().apply {
-            add(fragment, "test")
-            commitNow()
-        }
+        val fragment = createAddedTestFragment { Fragment() }
 
         val store = StoreProvider.get(fragment) { basicStore }
         assertEquals(basicStore, store)
@@ -65,18 +53,7 @@ class StoreProviderTest {
 
     @Test
     fun `get only calls createStore if needed`() {
-        val activity = Robolectric.buildActivity(FragmentActivity::class.java)
-            .create()
-            .start()
-            .resume()
-            .get()
-
-        val fragment = Fragment()
-
-        activity.supportFragmentManager.beginTransaction().apply {
-            add(fragment, "test")
-            commitNow()
-        }
+        val fragment = createAddedTestFragment { Fragment() }
 
         var createCalled = false
         val createStore = {


### PR DESCRIPTION
In case of missing potential test code parts where I could use this method, please point me to them.
I've searched all usages of `Robolectric.buildActivity(FragmentActivity::class.java)` and only found these.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture