### PR TITLE
For #5873 Added on/off indicator for delete browsing data on exit pref

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
@@ -129,6 +129,16 @@ class SettingsFragment : PreferenceFragmentCompat(), AccountObserver {
         val appName = getString(R.string.app_name)
         aboutPreference?.title = getString(R.string.preferences_about, appName)
 
+        val deleteBrowsingDataPreference =
+            findPreference<Preference>(getPreferenceKey(R.string.pref_key_delete_browsing_data_on_quit_preference))
+        deleteBrowsingDataPreference?.summary = context?.let {
+            if (it.settings().shouldDeleteBrowsingDataOnQuit) {
+                getString(R.string.delete_browsing_data_quit_on)
+            } else {
+                getString(R.string.delete_browsing_data_quit_off)
+            }
+        }
+
         setupPreferences()
 
         updateAccountUIState(context!!, requireComponents.backgroundServices.accountManager.accountProfile())

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -539,6 +539,10 @@
     <string name="preference_option_autoplay_blocked">Video and audio blocked</string>
     <!-- Label that indicates video and audio autoplay is allowed -->
     <string name="preference_option_autoplay_allowed">Video and audio allowed</string>
+    <!-- Summary of delete browsing data on quit preference if it is set to on -->
+    <string name="delete_browsing_data_quit_on">On</string>
+    <!-- Summary of delete browsing data on quit preference if it is set to off -->
+    <string name="delete_browsing_data_quit_off">Off</string>
 
     <!-- Collections -->
     <!-- Label to describe what collections are to a new user without any collections -->


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture