### PR TITLE
For #778: Follow-up to fix find in page

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/FindInPageIntegration.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/FindInPageIntegration.kt
@@ -33,7 +33,9 @@ class FindInPageIntegration(
 
     override fun onLaunch(view: View, feature: LifecycleAwareFeature) {
         store.state.findCustomTabOrSelectedTab(sessionId)?.let { tab ->
-            if (tab is CustomTabSessionState) {
+            if (tab !is CustomTabSessionState) {
+                // Hide the toolbar to display find in page query (only
+                // needs to be done for regular tabs with bottom toolbar).
                 toolbar.visibility = View.GONE
             }
             view.visibility = View.VISIBLE


### PR DESCRIPTION
Find in page just broke on master after merging https://github.com/mozilla-mobile/fenix/pull/4914. 

This expression was incorrectly inverted:
https://github.com/mozilla-mobile/fenix/pull/4914/files#diffa6785c308c16739108b147e7862f3997R36

We want to hide the toolbar only if we're not in a custom tab to show the find in page query input. For custom tabs, the toolbar is on top and doesn't need to be hidden.

Ran into this when investigating https://github.com/mozilla-mobile/fenix/issues/5534 which now failed because of this. So, the UI tests would have caught this, but it's ignored right now because of intermittent failures I was trying to reproduce :).