### PR TITLE
For #5898: Default browser toggle sends user to SUMO on Android 5&6

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/BrowserDirection.kt
+++ b/app/src/main/java/org/mozilla/fenix/BrowserDirection.kt
@@ -22,5 +22,6 @@ enum class BrowserDirection(@IdRes val fragmentId: Int) {
     FromHistory(R.id.historyFragment),
     FromExceptions(R.id.exceptionsFragment),
     FromAbout(R.id.aboutFragment),
-    FromTrackingProtection(R.id.trackingProtectionFragment)
+    FromTrackingProtection(R.id.trackingProtectionFragment),
+    FromDefaultBrowserSettingsFragment(R.id.defaultBrowserSettingsFragment)
 }

--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -54,6 +54,7 @@ import org.mozilla.fenix.library.bookmarks.BookmarkFragmentDirections
 import org.mozilla.fenix.library.history.HistoryFragmentDirections
 import org.mozilla.fenix.search.SearchFragmentDirections
 import org.mozilla.fenix.settings.AboutFragmentDirections
+import org.mozilla.fenix.settings.DefaultBrowserSettingsFragmentDirections
 import org.mozilla.fenix.settings.SettingsFragmentDirections
 import org.mozilla.fenix.settings.TrackingProtectionFragmentDirections
 import org.mozilla.fenix.theme.DefaultThemeManager
@@ -273,6 +274,10 @@ open class HomeActivity : AppCompatActivity() {
             AboutFragmentDirections.actionAboutFragmentToBrowserFragment(customTabSessionId)
         BrowserDirection.FromTrackingProtection ->
             TrackingProtectionFragmentDirections.actionTrackingProtectionFragmentToBrowserFragment(
+                customTabSessionId
+            )
+        BrowserDirection.FromDefaultBrowserSettingsFragment ->
+            DefaultBrowserSettingsFragmentDirections.actionDefaultBrowserSettingsFragmentToBrowserFragment(
                 customTabSessionId
             )
     }

--- a/app/src/main/java/org/mozilla/fenix/settings/DefaultBrowserSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/DefaultBrowserSettingsFragment.kt
@@ -10,12 +10,13 @@ import android.os.Build
 import android.os.Build.VERSION.SDK_INT
 import android.os.Bundle
 import android.provider.Settings.ACTION_MANAGE_DEFAULT_APPS_SETTINGS
-import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.preference.CheckBoxPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import mozilla.components.support.utils.Browsers
+import org.mozilla.fenix.BrowserDirection
+import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.getPreferenceKey
@@ -30,7 +31,11 @@ class DefaultBrowserSettingsFragment : PreferenceFragmentCompat() {
         SharedPreferences.OnSharedPreferenceChangeListener { sharedPreferences, key ->
             when (key) {
                 getPreferenceKey(R.string.pref_key_telemetry) -> {
-                    if (sharedPreferences.getBoolean(key, requireContext().settings().isTelemetryEnabled)) {
+                    if (sharedPreferences.getBoolean(
+                            key,
+                            requireContext().settings().isTelemetryEnabled
+                        )
+                    ) {
                         context?.components?.analytics?.metrics?.start()
                     } else {
                         context?.components?.analytics?.metrics?.stop()
@@ -42,7 +47,9 @@ class DefaultBrowserSettingsFragment : PreferenceFragmentCompat() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         context?.let {
-            preferenceManager.sharedPreferences.registerOnSharedPreferenceChangeListener(preferenceChangeListener)
+            preferenceManager.sharedPreferences.registerOnSharedPreferenceChangeListener(
+                preferenceChangeListener
+            )
         }
 
         val makeDefaultBrowserKey = getPreferenceKey(R.string.pref_key_make_default_browser)
@@ -54,7 +61,8 @@ class DefaultBrowserSettingsFragment : PreferenceFragmentCompat() {
 
     override fun onResume() {
         super.onResume()
-        (activity as AppCompatActivity).title = getString(R.string.preferences_set_as_default_browser)
+        (activity as AppCompatActivity).title =
+            getString(R.string.preferences_set_as_default_browser)
         (activity as AppCompatActivity).supportActionBar?.show()
 
         updatePreferences()
@@ -62,7 +70,9 @@ class DefaultBrowserSettingsFragment : PreferenceFragmentCompat() {
 
     override fun onDestroy() {
         context?.let {
-            preferenceManager.sharedPreferences.unregisterOnSharedPreferenceChangeListener(preferenceChangeListener)
+            preferenceManager.sharedPreferences.unregisterOnSharedPreferenceChangeListener(
+                preferenceChangeListener
+            )
         }
         super.onDestroy()
     }
@@ -93,13 +103,17 @@ class DefaultBrowserSettingsFragment : PreferenceFragmentCompat() {
                 true
             }
         } else {
-            defaultClickListener
+            Preference.OnPreferenceClickListener {
+                (activity as HomeActivity).openToBrowserAndLoad(
+                    searchTermOrURL = SupportUtils.getSumoURLForTopic(
+                        context!!,
+                        SupportUtils.SumoTopic.SET_AS_DEFAULT_BROWSER
+                    ),
+                    newTab = true,
+                    from = BrowserDirection.FromSettings
+                )
+                true
+            }
         }
     }
-
-    private val defaultClickListener =
-        Preference.OnPreferenceClickListener { preference ->
-            Toast.makeText(context, "${preference.title} Clicked", Toast.LENGTH_SHORT).show()
-            true
-        }
 }

--- a/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
@@ -9,8 +9,6 @@ import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
 import android.net.Uri
-import android.os.Build
-import android.os.Build.VERSION.SDK_INT
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
@@ -94,11 +92,6 @@ class SettingsFragment : PreferenceFragmentCompat(), AccountObserver {
         updateAccountUIState(context!!, requireComponents.backgroundServices.accountManager.accountProfile())
 
         preferenceManager.sharedPreferences.registerOnSharedPreferenceChangeListener(preferenceChangeListener)
-
-        if (SDK_INT <= Build.VERSION_CODES.M) {
-            findPreference<Preference>(getPreferenceKey(pref_key_make_default_browser))?.isVisible =
-                false
-        }
     }
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
@@ -159,7 +152,7 @@ class SettingsFragment : PreferenceFragmentCompat(), AccountObserver {
                 ItsNotBrokenSnack(context!!).showSnackbar(issueNumber = "220")
             }
             resources.getString(pref_key_make_default_browser) -> {
-                navigateToDefaultBrowserFragment()
+                navigateToDefaultBrowserSettingsFragment()
             }
             resources.getString(pref_key_data_choices) -> {
                 navigateToDataChoices()
@@ -281,8 +274,8 @@ class SettingsFragment : PreferenceFragmentCompat(), AccountObserver {
         Navigation.findNavController(view!!).navigate(directions)
     }
 
-    private fun navigateToDefaultBrowserFragment() {
-        val directions = SettingsFragmentDirections.actionSettingsFragmentToDefaultBrowserFragment()
+    private fun navigateToDefaultBrowserSettingsFragment() {
+        val directions = SettingsFragmentDirections.actionSettingsFragmentToDefaultBrowserSettingsFragment()
         Navigation.findNavController(view!!).navigate(directions)
     }
 

--- a/app/src/main/java/org/mozilla/fenix/settings/SupportUtils.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SupportUtils.kt
@@ -29,7 +29,8 @@ object SupportUtils {
         YOUR_RIGHTS("your-rights"),
         TRACKING_PROTECTION("tracking-protection-firefox-preview"),
         WHATS_NEW("whats-new-firefox-preview"),
-        SEND_TABS("send-tab-preview")
+        SEND_TABS("send-tab-preview"),
+        SET_AS_DEFAULT_BROWSER("set-firefox-preview-default")
     }
 
     /**

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -360,8 +360,8 @@
             android:id="@+id/action_settingsFragment_to_deleteBrowsingDataOnQuitFragment"
             app:destination="@id/deleteBrowsingDataOnQuitFragment" />
         <action
-            android:id="@+id/action_settingsFragment_to_defaultBrowserFragment"
-            app:destination="@id/defaultBrowserFragment" />
+            android:id="@+id/action_settingsFragment_to_defaultBrowserSettingsFragment"
+            app:destination="@id/defaultBrowserSettingsFragment" />
     </fragment>
     <fragment
         android:id="@+id/dataChoicesFragment"
@@ -587,7 +587,11 @@
         android:name="org.mozilla.fenix.share.AddNewDeviceFragment"
         android:label="AddNewDeviceFragment" />
     <fragment
-        android:id="@+id/defaultBrowserFragment"
+        android:id="@+id/defaultBrowserSettingsFragment"
         android:name="org.mozilla.fenix.settings.DefaultBrowserSettingsFragment"
-        android:label="DefaultBrowserFragment" />
+        android:label="DefaultBrowserSettingsFragment">
+        <action
+            android:id="@+id/action_defaultBrowserSettingsFragment_to_browserFragment"
+            app:destination="@id/browserFragment" />
+    </fragment>
 </navigation>

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -161,7 +161,6 @@ object Deps {
     const val leanplum = "com.leanplum:leanplum-core:${Versions.leanplum}"
     const val leanplumMessaging = "com.leanplum:leanplum-fcm:${Versions.leanplum}"
 
-
     const val androidx_annotation = "androidx.annotation:annotation:${Versions.androidx_annotation}"
     const val androidx_fragment = "androidx.fragment:fragment-ktx:${Versions.androidx_fragment}"
     const val androidx_appcompat = "androidx.appcompat:appcompat:${Versions.androidx_appcompat}"


### PR DESCRIPTION
Updated behavior for devices < Android 7:

![new behavior on lower api](https://user-images.githubusercontent.com/4400286/66587894-328c4a80-eb40-11e9-92ef-7cd6f7247efc.gif)



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture