### PR TITLE
Removes versionName check from gradle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -226,28 +226,6 @@ android.applicationVariants.all { variant ->
             output.versionNameOverride = versionName
             output.versionCodeOverride = versionCodeOverride
         }
-
-        // If this is a release build, validate that "versionName" is set
-        tasks.withType(AppPreBuildTask) { prebuildTask ->
-            // You can't add a closure to a variant, so we need to look for an early variant-specific type
-            // of task (AppPreBuildTask is the first) and filter to make sure we're looking at the task for
-            // this variant that we're currently configuring
-            if (prebuildTask.variantName != variant.name) {
-                return
-            }
-
-            // Append to the task so the first thing it does is run our validation
-            prebuildTask.doFirst {
-                if (!project.hasProperty('versionName')) {
-                    throw new RuntimeException("Release builds require the 'versionName' property to be set.\n" +
-                            "If you're using an IDE, set your build variant to be a \"debug\" type.\n" +
-                            "If you're using the command-line, either build a debug variant instead ('./gradlew assembleDebug')\n" +
-                            "\tor continue building the release build and set the \"versionName\" property ('./gradlew -PversionName=<...> assembleNightly').")
-                    // TODO when Android Studio 3.5.0 is prevalent, we can set the "debug" build type as the default
-                    // https://issuetracker.google.com/issues/36988145#comment59
-                }
-            }
-        }
     }
 
 // -------------------------------------------------------------------------------------------------

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -29,9 +29,10 @@ object Config {
 
     @JvmStatic
     fun releaseVersionName(project: Project): String {
-        // This function is called in the configuration phase, before gradle knows which variants we'll use.
-        // So, validation that "versionName" has been set happens elsewhere (at time of writing, we staple
-        // validation to tasks of type "AppPreBuildTask"
+        // Note: release builds must have the `versionName` set. However, the gradle ecosystem makes this hard to
+        // ergonomically validate (sometimes IDEs default to a release variant and mysteriously fail due to the
+        // validation, sometimes devs just need a release build and specifying project properties is annoying in IDEs),
+        // so instead we'll allow the `versionName` to silently default to an empty string.
         return if (project.hasProperty("versionName")) project.property("versionName") as String else ""
     }
 


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

This `versionName` check has been causing more headaches than value. I've added a note to `releaseVersionName(...)` that we aren't validating `versionName` for release builds anymore (and why), and removed the check.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
