### PR TITLE
For #5382: Fix cron jobs which were not scheduled anymore

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -14,21 +14,22 @@ tasks:
           $let:
               # Github events have this stuff in different places...
               ownerEmail:
-                  $if: 'event.sender.login == "bors[bot]"'
-                  then: 'skaspari+mozlando@mozilla.com'   # It must match what's in bors.toml
-                  else: 
-                      $if: 'tasks_for == "github-push"'
-                      then: '${event.pusher.email}'
-                      # Assume Pull Request
+                  $if: 'tasks_for in ["cron", "action"]'
+                  then: '${tasks_for}@noreply.mozilla.org'
+                  else:
+                      $if: 'event.sender.login == "bors[bot]"'
+                      then: 'skaspari+mozlando@mozilla.com'   # It must match what's in bors.toml
                       else:
-                          $if: 'tasks_for == "github-pull-request"'
-                          then: '${event.pull_request.user.login}@users.noreply.github.com'
+                          $if: 'tasks_for == "github-push"'
+                          then: '${event.pusher.email}'
+                          # Assume Pull Request
                           else:
-                              $if: 'tasks_for == "github-release"'
-                              then: '${event.sender.login}@users.noreply.github.com'
+                              $if: 'tasks_for == "github-pull-request"'
+                              then: '${event.pull_request.user.login}@users.noreply.github.com'
                               else:
-                                  $if: 'tasks_for in ["cron", "action"]'
-                                  then: '${tasks_for}@noreply.mozilla.org'
+                                  $if: 'tasks_for == "github-release"'
+                                  then: '${event.sender.login}@users.noreply.github.com'
+
               baseRepoUrl:
                   $if: 'tasks_for in ["github-push", "github-release"]'
                   then: '${event.repository.html_url}'


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

#5929 regressed the cron jobs. For instance, nightly couldn't be scheduled anymore because:

```
[task 2019-10-11T12:42:17.210Z] InterpreterError: InterpreterError at template.tasks[0]: unknown context value event
```

https://tools.taskcluster.net/groups/ZA-ncp5qTXmVI4iQ9O11gg/tasks/ZA-ncp5qTXmVI4iQ9O11gg/runs/0/logs/public%2Flogs%2Flive_backing.log#L103

That problem doesn't exist in a-c thanks to this patch.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
