### PR TITLE
For #5063: Added parameter customTabSessionId into ContextMenuFeature

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -243,7 +243,8 @@ abstract class BaseBrowserFragment : Fragment(), BackHandler, SessionManager.Obs
                         )
                     ),
                     engineView = view.engineView,
-                    useCases = context.components.useCases.contextMenuUseCases
+                    useCases = context.components.useCases.contextMenuUseCases,
+                    customTabId = customTabSessionId
                 ),
                 owner = this,
                 view = view


### PR DESCRIPTION
Added parameter customTabSessionId into ContextMenuFeature in
BaseBrowserFragment in order to show the context menu in a custom tab.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks
- [x] **Tests**: This PR does not includes tests.
- [x] **Screenshots**: This PR does not includes screenshots.
- [x] **Accessibility**: The code in this PR does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
