### PR TITLE
Update to AC 19.0.0-SNAPSHOT and use new toolbar API.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -487,6 +487,10 @@ dependencies {
     androidTestImplementation Deps.mockito_android
     testImplementation Deps.mockk
     testImplementation Deps.assertk
+
+    // For the initial release of Glean 19, we require consumer applications to
+    // depend on a separate library for unit tests. This will be removed in future releases.
+    testImplementation Deps.mozilla_service_glean_forUnitTests
 }
 
 if (project.hasProperty("raptor")) {

--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -221,11 +221,11 @@ abstract class BaseBrowserFragment : Fragment(), BackHandler, SessionManager.Obs
                 view = view
             )
 
-            browserToolbarView.view.setOnSiteSecurityClickedListener {
+            browserToolbarView.view.display.setOnSiteSecurityClickedListener {
                 showQuickSettingsDialog()
             }
 
-            browserToolbarView.view.setOnTrackingProtectionClickedListener {
+            browserToolbarView.view.display.setOnTrackingProtectionClickedListener {
                 context.metrics.track(Event.TrackingProtectionIconPressed)
                 showTrackingProtectionPanel()
             }

--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -379,7 +379,7 @@ class BrowserFragment : BaseBrowserFragment(), BackHandler {
             val tpIcon =
                 browserToolbarView
                     .view
-                    .findViewById<AppCompatImageView>(R.id.mozac_browser_toolbar_tracking_protection_icon_view)
+                    .findViewById<AppCompatImageView>(R.id.mozac_browser_toolbar_tracking_protection_indicator)
 
             // Measure layout view
             val spec = View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED)

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarIntegration.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarIntegration.kt
@@ -85,7 +85,6 @@ class ToolbarIntegration(
                         trackingProtectionNothingBlocked = AppCompatResources.getDrawable(
                             context,
                             R.drawable.ic_tracking_protection_enabled
-
                         )!!,
                         trackingProtectionException = AppCompatResources.getDrawable(
                             context,

--- a/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabsIntegration.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabsIntegration.kt
@@ -14,6 +14,7 @@ import com.airbnb.lottie.LottieCompositionFactory
 import com.airbnb.lottie.LottieDrawable
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.toolbar.BrowserToolbar
+import mozilla.components.browser.toolbar.display.DisplayToolbar
 import mozilla.components.feature.customtabs.CustomTabsToolbarFeature
 import mozilla.components.support.base.feature.BackHandler
 import mozilla.components.support.base.feature.LifecycleAwareFeature
@@ -63,17 +64,26 @@ class CustomTabsIntegration(
         task.addListener { result ->
             val lottieDrawable = LottieDrawable()
             lottieDrawable.composition = result
-            toolbar.displayTrackingProtectionIcon =
-                activity.settings().shouldUseTrackingProtection && FeatureFlags.etpCategories
-            toolbar.displaySeparatorView = false
 
-            toolbar.setTrackingProtectionIcons(
-                iconOnNoTrackersBlocked = AppCompatResources.getDrawable(
+            toolbar.display.displayIndicatorSeparator = false
+            if (activity.settings().shouldUseTrackingProtection && FeatureFlags.etpCategories) {
+                toolbar.display.indicators = listOf(
+                    DisplayToolbar.Indicators.SECURITY,
+                    DisplayToolbar.Indicators.TRACKING_PROTECTION
+                )
+            } else {
+                toolbar.display.indicators = listOf(
+                    DisplayToolbar.Indicators.SECURITY
+                )
+            }
+
+            toolbar.display.icons = toolbar.display.icons.copy(
+                trackingProtectionTrackersBlocked = lottieDrawable,
+                trackingProtectionNothingBlocked = AppCompatResources.getDrawable(
                     activity,
                     R.drawable.ic_tracking_protection_enabled
                 )!!,
-                iconOnTrackersBlocked = lottieDrawable,
-                iconDisabledForSite = AppCompatResources.getDrawable(
+                trackingProtectionException = AppCompatResources.getDrawable(
                     activity,
                     R.drawable.ic_tracking_protection_disabled
                 )!!

--- a/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
@@ -9,7 +9,6 @@ import android.content.Context
 import android.content.DialogInterface
 import android.graphics.Typeface.BOLD
 import android.graphics.Typeface.ITALIC
-import android.graphics.drawable.BitmapDrawable
 import android.os.Bundle
 import android.text.style.StyleSpan
 import android.view.LayoutInflater
@@ -30,7 +29,6 @@ import mozilla.components.support.base.feature.BackHandler
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
 import mozilla.components.support.ktx.android.content.hasCamera
 import mozilla.components.support.ktx.android.content.isPermissionGranted
-import org.jetbrains.anko.backgroundDrawable
 import org.mozilla.fenix.BrowserDirection
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
@@ -193,7 +191,6 @@ class SearchFragment : Fragment(), BackHandler {
         consumeFrom(searchStore) {
             awesomeBarView.update(it)
             toolbarView.update(it)
-            updateSearchEngineIcon(it)
             updateSearchWithLabel(it)
             updateClipboardSuggestion(it, requireContext().components.clipboardHandler.url)
         }
@@ -243,14 +240,6 @@ class SearchFragment : Fragment(), BackHandler {
             }
             else -> false
         }
-    }
-
-    private fun updateSearchEngineIcon(searchState: SearchFragmentState) {
-        val searchIcon = searchState.searchEngineSource.searchEngine.icon
-        val draw = BitmapDrawable(resources, searchIcon)
-        val iconSize = resources.getDimension(R.dimen.preference_icon_drawable_size).toInt()
-        draw.setBounds(0, 0, iconSize, iconSize)
-        searchEngineIcon?.backgroundDrawable = draw
     }
 
     private fun updateSearchWithLabel(searchState: SearchFragmentState) {

--- a/app/src/main/java/org/mozilla/fenix/search/toolbar/ToolbarView.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/toolbar/ToolbarView.kt
@@ -4,6 +4,8 @@
 
 package org.mozilla.fenix.search.toolbar
 
+import android.graphics.Bitmap
+import android.graphics.drawable.BitmapDrawable
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -77,16 +79,20 @@ class ToolbarView(
 
             layoutParams.height = CoordinatorLayout.LayoutParams.MATCH_PARENT
 
-            hint = context.getString(R.string.search_hint)
+            edit.hint = context.getString(R.string.search_hint)
 
-            textColor = container.context.getColorFromAttr(R.attr.primaryText)
-
-            hintColor = container.context.getColorFromAttr(R.attr.secondaryText)
-
-            suggestionBackgroundColor = ContextCompat.getColor(
-                container.context,
-                R.color.suggestion_highlight_color
+            edit.colors = edit.colors.copy(
+                text = container.context.getColorFromAttr(R.attr.primaryText),
+                hint = container.context.getColorFromAttr(R.attr.secondaryText),
+                suggestionBackground = ContextCompat.getColor(
+                    container.context,
+                    R.color.suggestion_highlight_color
+                ),
+                clear = container.context.getColorFromAttr(R.attr.primaryText)
             )
+
+            edit.setUrlBackground(
+                ContextCompat.getDrawable(container.context, R.drawable.search_url_background))
 
             private = isPrivate
 
@@ -122,6 +128,18 @@ class ToolbarView(
             view.editMode()
             isInitialized = true
         }
+
+        val iconSize = container.resources.getDimensionPixelSize(R.dimen.preference_icon_drawable_size)
+
+        val scaledIcon = Bitmap.createScaledBitmap(
+            searchState.searchEngineSource.searchEngine.icon,
+            iconSize,
+            iconSize,
+            true)
+
+        val icon = BitmapDrawable(container.resources, scaledIcon)
+
+        view.edit.setIcon(icon, searchState.searchEngineSource.searchEngine.name)
     }
 
     companion object {

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -14,23 +14,13 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/toolbar_wrapper"
         android:layout_width="0dp"
-        android:layout_height="40dp"
-        android:layout_margin="8dp"
-        android:background="@drawable/search_url_background"
+        android:layout_height="56dp"
+        android:layout_margin="0dp"
         android:outlineProvider="paddedBounds"
         android:transitionName="toolbar_wrapper_transition"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
-
-        <ImageView
-            android:id="@+id/searchEngineIcon"
-            android:layout_width="24dp"
-            android:layout_height="24dp"
-            android:layout_margin="12dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
 
         <FrameLayout
             android:id="@+id/toolbar_component_wrapper"
@@ -38,7 +28,7 @@
             android:layout_height="0dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@id/searchEngineIcon"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -52,7 +52,7 @@
     <dimen name="bottom_sheet_top_padding">8dp</dimen>
 
     <!-- Browser Toolbar -->
-    <dimen name="browser_toolbar_height">57dp</dimen>
+    <dimen name="browser_toolbar_height">56dp</dimen>
     <dimen name="toolbar_and_qab_height">67dp</dimen>
 
     <!-- SignIn Component -->

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -35,7 +35,7 @@ object Versions {
     const val androidx_work = "2.2.0"
     const val google_material = "1.1.0-beta01"
 
-    const val mozilla_android_components = "18.0.0-SNAPSHOT"
+    const val mozilla_android_components = "19.0.0-SNAPSHOT"
     // Note that android-components also depends on application-services,
     // and in fact is our main source of appservices-related functionality.
     // The version number below tracks the application-services version

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -44,6 +44,8 @@ object Versions {
     // sync with the version used by android-components above.
     const val mozilla_appservices = "0.42.0"
 
+    const val mozilla_glean = "19.0.0"
+
     const val autodispose = "1.1.0"
     const val adjust = "4.11.4"
     const val installreferrer = "1.0"
@@ -137,6 +139,7 @@ object Deps {
     const val mozilla_service_firefox_accounts = "org.mozilla.components:service-firefox-accounts:${Versions.mozilla_android_components}"
     const val mozilla_service_fretboard = "org.mozilla.components:service-fretboard:${Versions.mozilla_android_components}"
     const val mozilla_service_glean = "org.mozilla.components:service-glean:${Versions.mozilla_android_components}"
+    const val mozilla_service_glean_forUnitTests = "org.mozilla.telemetry:glean-forUnitTests:${Versions.mozilla_glean}"
     const val mozilla_service_experiments = "org.mozilla.components:service-experiments:${Versions.mozilla_android_components}"
 
     const val mozilla_ui_colors = "org.mozilla.components:ui-colors:${Versions.mozilla_android_components}"


### PR DESCRIPTION
The change hasn't landed in AC yet. However in 18.0.0 we are going to land a toolbar refactoring (which is now using ConstraintLayout internally, yay!) and with that we are changing the API. This patch migrates Fenix to use that new API.