### PR TITLE
Update to Mozilla Android Components 18.0.0-SNAPSHOT.

### DIFF
--- a/app/src/test/java/org/mozilla/fenix/components/metrics/BreadcrumbRecorderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/metrics/BreadcrumbRecorderTest.kt
@@ -25,6 +25,9 @@ internal class BreadcrumbRecorderTest {
     @Test
     fun `ensure crash reporter recordCrashBreadcrumb is called`() {
         val service = object : CrashReporterService {
+            override fun report(throwable: Throwable) {
+            }
+
             override fun report(crash: Crash.UncaughtExceptionCrash) {
             }
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -35,14 +35,14 @@ object Versions {
     const val androidx_work = "2.2.0"
     const val google_material = "1.1.0-beta01"
 
-    const val mozilla_android_components = "16.0.0"
+    const val mozilla_android_components = "18.0.0-SNAPSHOT"
     // Note that android-components also depends on application-services,
     // and in fact is our main source of appservices-related functionality.
     // The version number below tracks the application-services version
     // that we depend on directly for the fenix-megazord (and for it's
     // forUnitTest variant), and it's important that it be kept in
     // sync with the version used by android-components above.
-    const val mozilla_appservices = "0.40.0"
+    const val mozilla_appservices = "0.41.0"
 
     const val autodispose = "1.1.0"
     const val adjust = "4.11.4"


### PR DESCRIPTION
We haven't updated in a while and therefore some fixes didn't make it into Fenix (Nightly) yet.