### PR TITLE
Added OnCheckListener to checkboxes: DeleteBrowsingDataFragment

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/deletebrowsingdata/DeleteBrowsingDataFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/deletebrowsingdata/DeleteBrowsingDataFragment.kt
@@ -51,11 +51,22 @@ class DeleteBrowsingDataFragment : Fragment(R.layout.fragment_delete_browsing_da
             })
         }
 
+        getCheckboxes().forEach {
+            it.onCheckListener = { _ -> updateDeleteButton() }
+        }
+
         getCheckboxes().forEach { it.isChecked = true }
 
         view.delete_data?.setOnClickListener {
             askToDelete()
         }
+    }
+
+    private fun updateDeleteButton() {
+        val enabled = getCheckboxes().any { it.isChecked }
+
+        view?.delete_data?.isEnabled = enabled
+        view?.delete_data?.alpha = if (enabled) ENABLED_ALPHA else DISABLED_ALPHA
     }
 
     override fun onResume() {


### PR DESCRIPTION
Added OnCheckListener to all checkboxes ,when there are no items checked delete button will be disabled

Closes #5465

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

Screen shot (gif): https://drive.google.com/file/d/18Kq8Op-EXQ-infpHs8Q2mYhG_2do-jrg/view?usp=sharing