### PR TITLE
For #5872 & #6075: Set TabHeader buttons to invisible instead of gone.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/TabHeaderViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/TabHeaderViewHolder.kt
@@ -7,6 +7,7 @@ package org.mozilla.fenix.home.sessioncontrol.viewholders
 import android.content.Context
 import android.view.View
 import android.widget.PopupWindow
+import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
 import io.reactivex.Observer
@@ -81,8 +82,8 @@ class TabHeaderViewHolder(
         val headerTextResourceId =
             if (isPrivate) R.string.tabs_header_private_title else R.string.tab_header_label
         view.header_text.text = view.context.getString(headerTextResourceId)
-        view.share_tabs_button.isVisible = isPrivate && hasTabs
-        view.close_tabs_button.isVisible = isPrivate && hasTabs
+        view.share_tabs_button.isInvisible = !isPrivate || !hasTabs
+        view.close_tabs_button.isInvisible = !isPrivate || !hasTabs
         view.tabs_overflow_button.isVisible = !isPrivate && hasTabs
     }
 


### PR DESCRIPTION
At least one button has to be invisible instead of gone to keep layout height.
Tabs overflow button kept gone to avoid empty space on view end in private mode.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
