### PR TITLE
Fix #3122 - Hide the "Bookmark saved" Snackbar when user closes BrowserFragment

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -295,8 +295,8 @@ class BrowserFragment : BaseBrowserFragment(), BackHandler {
                 )
                 requireComponents.analytics.metrics.track(Event.AddBookmark)
 
-                view?.let {
-                    FenixSnackbar.make(it.rootView, Snackbar.LENGTH_LONG)
+                view?.let { view ->
+                    FenixSnackbar.make(view, Snackbar.LENGTH_LONG)
                         .setAnchorView(browserToolbarView.view)
                         .setAction(getString(R.string.edit_bookmark_snackbar_action)) {
                             nav(


### PR DESCRIPTION
Previously the Snackbar was being inflated in the parent of this Fragment so
surviving it being closed.
Tying the Snackbar with the Fragment from which it is shown ensures it will be
effectively hidden whenever the user navigates from the Fragment.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks.
- [x] **Tests**: This PR does not include tests as it only comprises of a small modification in a not yet tested component.
- [x] **Video showcasing the solution**: https://drive.google.com/file/d/19x_6OyvIzr-O2fM9idV6FXXT41S_WGF_/
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
