### PR TITLE
no issue - fixed alignment of open tabs header for RTL

### DIFF
--- a/app/src/main/res/layout/tab_header.xml
+++ b/app/src/main/res/layout/tab_header.xml
@@ -12,13 +12,12 @@
 
     <TextView
         android:id="@+id/header_text"
-        android:layout_width="0dp"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="4.5dp"
         android:text="@string/tab_header_label"
         android:textAppearance="@style/HeaderTextStyle"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@id/share_tabs_button"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
@@ -56,7 +55,6 @@
         android:src="@drawable/ic_menu"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/close_tabs_button"
         app:layout_constraintTop_toTopOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Fixed the alignment of the open tabs header for RTL languages

Before:

![Screenshot_20191019-233827](https://user-images.githubusercontent.com/1100614/67151779-f2a92e00-f2ca-11e9-8f4e-55d85a140acf.png)

After:

![Screenshot_20191019-233725](https://user-images.githubusercontent.com/1100614/67151782-fb99ff80-f2ca-11e9-8f3b-7a902286d93f.png)
