### PR TITLE
For #6145: Switch drawableTint to appcompat version.

### DIFF
--- a/app/src/main/res/layout/component_collection_creation.xml
+++ b/app/src/main/res/layout/component_collection_creation.xml
@@ -18,7 +18,7 @@
         android:background="?android:attr/selectableItemBackgroundBorderless"
         android:drawableStart="@drawable/mozac_ic_back"
         android:drawablePadding="8dp"
-        android:drawableTint="@color/neutral_text"
+        app:drawableTint="@color/neutral_text"
         android:gravity="start|center_vertical"
         android:text="@string/create_collection_select_tabs"
         android:textAppearance="@style/HeaderTextStyle"

--- a/app/src/main/res/layout/component_collection_creation_name_collection.xml
+++ b/app/src/main/res/layout/component_collection_creation_name_collection.xml
@@ -18,7 +18,7 @@
         android:background="?android:attr/selectableItemBackgroundBorderless"
         android:drawableStart="@drawable/mozac_ic_back"
         android:drawablePadding="8dp"
-        android:drawableTint="@color/neutral_text"
+        app:drawableTint="@color/neutral_text"
         android:gravity="start|center_vertical"
         android:text="@string/create_collection_name_collection"
         android:textAppearance="@style/HeaderTextStyle"

--- a/app/src/main/res/layout/component_collection_creation_select_collection.xml
+++ b/app/src/main/res/layout/component_collection_creation_select_collection.xml
@@ -19,7 +19,7 @@
         android:drawableStart="@drawable/mozac_ic_back"
         android:drawablePadding="8dp"
         android:gravity="start|center_vertical"
-        android:drawableTint="@color/neutral_text"
+        app:drawableTint="@color/neutral_text"
         android:text="@string/create_collection_select_collection"
         android:textAppearance="@style/HeaderTextStyle"
         android:textColor="@color/neutral_text"

--- a/app/src/main/res/layout/fragment_add_new_device.xml
+++ b/app/src/main/res/layout/fragment_add_new_device.xml
@@ -45,7 +45,7 @@
                 android:drawableStart="@drawable/ic_info"
                 android:text="@string/sync_add_new_device_message"
                 android:drawablePadding="8dp"
-                android:drawableTint="@color/sync_error_text_color"
+                app:drawableTint="@color/sync_error_text_color"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:textColor="@color/sync_error_text_color"

--- a/app/src/main/res/layout/fragment_edit_bookmark.xml
+++ b/app/src/main/res/layout/fragment_edit_bookmark.xml
@@ -3,12 +3,12 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:layout_margin="16dp"
-    android:orientation="vertical">
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_margin="16dp"
+        android:orientation="vertical">
 
     <TextView
         android:id="@+id/bookmark_name_label"
@@ -78,9 +78,9 @@
         android:layout_marginTop="8dp"
         android:drawableStart="@drawable/ic_folder_icon"
         android:drawablePadding="10dp"
-        app:drawableTint="?primaryText"
         android:textColor="?secondaryText"
         android:textSize="16sp"
+        app:drawableTint="?primaryText"
         tools:text="Mobile Bookmarks" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/no_content_message.xml
+++ b/app/src/main/res/layout/no_content_message.xml
@@ -4,6 +4,7 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <LinearLayout
         xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
         xmlns:tools="http://schemas.android.com/tools" android:id="@+id/no_content_wrapper"
         android:background="@drawable/empty_session_control_background"
         android:layout_marginBottom="12dp"
@@ -16,7 +17,7 @@
             android:id="@+id/no_content_header"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:drawableTint="?primaryText"
+            app:drawableTint="?primaryText"
             android:drawablePadding="8dp"
             tools:text="@tools:sample/lorem"
             tools:drawableEnd="@drawable/ic_tab_collection"


### PR DESCRIPTION
The property android:drawableTint doesn't work on older Android devices,
so I switched to the appcompat version (app:drawableTint).

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks.
- [x] **Tests**: This PR does not include thorough tests. Small change.
- [x] **Screenshots**: This PR does not include screenshots.
- [x] **Accessibility**: The code in this PR does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
