### PR TITLE
For #5733 - Private mode notification - wrong home screen

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -86,7 +86,7 @@ open class HomeActivity : AppCompatActivity() {
     final override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val mode = getPrivateModeFromIntent()
+        val mode = getPrivateModeFromIntent(intent)
 
         components.publicSuffixList.prefetch()
         setupThemeAndBrowsingMode(mode)
@@ -150,6 +150,7 @@ open class HomeActivity : AppCompatActivity() {
 
         val intentProcessors = listOf(CrashReporterIntentProcessor()) + externalSourceIntentProcessors
         intentProcessors.any { it.process(intent, navHost.navController, this.intent) }
+        browsingModeManager.mode = getPrivateModeFromIntent(intent)
     }
 
     /**
@@ -192,7 +193,7 @@ open class HomeActivity : AppCompatActivity() {
      * External sources such as 3rd party links and shortcuts use this function to enter
      * private mode directly before the content view is created.
      */
-    private fun getPrivateModeFromIntent(): BrowsingMode {
+    private fun getPrivateModeFromIntent(intent: Intent?): BrowsingMode {
         intent?.toSafeIntent()?.let {
             if (it.hasExtra(PRIVATE_BROWSING_MODE)) {
                 val startPrivateMode = it.getBooleanExtra(PRIVATE_BROWSING_MODE, false)

--- a/app/src/main/java/org/mozilla/fenix/session/SessionNotificationService.kt
+++ b/app/src/main/java/org/mozilla/fenix/session/SessionNotificationService.kt
@@ -18,9 +18,8 @@ import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.support.utils.ThreadUtils
-
-import org.mozilla.fenix.R
 import org.mozilla.fenix.HomeActivity
+import org.mozilla.fenix.R
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.metrics
@@ -104,6 +103,7 @@ class SessionNotificationService : Service() {
     private fun createOpenActionIntent(): PendingIntent {
         val intent = Intent(this, HomeActivity::class.java)
         intent.putExtra(HomeActivity.EXTRA_OPENED_FROM_NOTIFICATION, true)
+        intent.putExtra(HomeActivity.PRIVATE_BROWSING_MODE, true)
 
         return PendingIntent.getActivity(this, 1, intent, PendingIntent.FLAG_UPDATE_CURRENT)
     }


### PR DESCRIPTION

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR doesn't include tests, small fix
- [x] **Screenshots**: This PR includes video of the fix
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) 

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

[Video with fix, open notification from private in background, normal in background and normal](https://drive.google.com/file/d/1QyBO9KH80jjFRjsicx1vOQepZNAXPDaa/view)