### PR TITLE
For #6179 - Changed positioning of private mode icons in tab header

### DIFF
--- a/app/src/main/res/layout/tab_header.xml
+++ b/app/src/main/res/layout/tab_header.xml
@@ -30,7 +30,6 @@
         android:src="@drawable/ic_hollow_share"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/close_tabs_button"
-        app:layout_constraintStart_toEndOf="@+id/header_text"
         app:layout_constraintTop_toTopOf="parent" />
 
     <ImageButton
@@ -43,7 +42,6 @@
         android:tint="?primaryText"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/tabs_overflow_button"
-        app:layout_constraintStart_toEndOf="@+id/share_tabs_button"
         app:layout_constraintTop_toTopOf="parent" />
 
     <ImageButton


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR is a small xml change
- [x] **Screenshots**: This PR includes screenshots of fix
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md)

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

<img src="https://user-images.githubusercontent.com/1709373/67304486-94fc2800-f4fc-11e9-83c8-6a58d286d4e0.png" width="256px">

