### PR TITLE
Closes mozilla-mobile#4558 Change height of bookmark linearlayout

### DIFF
--- a/app/src/main/res/layout/fragment_bookmark.xml
+++ b/app/src/main/res/layout/fragment_bookmark.xml
@@ -11,6 +11,6 @@
     <LinearLayout
         android:id="@+id/bookmarkLayout"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:orientation="vertical" />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
Bookmark sign in button was not visible because of 'match_parent' height of the layout.

<img src="https://user-images.githubusercontent.com/50130354/67361875-176f0100-f56a-11e9-89ee-dd7ba6f4a8b5.png" width="270" height="480">

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
