### PR TITLE
Closes #6172 - Convert waitNotNull into extension function for UI tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/ext/WaitNotNull.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/ext/WaitNotNull.kt
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.helpers.ext
+
+import androidx.test.uiautomator.SearchCondition
+import androidx.test.uiautomator.UiDevice
+import org.junit.Assert.assertNotNull
+import org.mozilla.fenix.helpers.TestAssetHelper
+
+/**
+ * Blocks the test for [waitTime] miliseconds before continuing.
+ *
+ * Will cause the test to fail is the condition is not met before the timeout.
+ */
+fun UiDevice.waitNotNull(
+    searchCondition: SearchCondition<*>,
+    waitTime: Long = TestAssetHelper.waitingTimeShort
+) = assertNotNull(wait(searchCondition, waitTime))

--- a/app/src/androidTest/java/org/mozilla/fenix/syncintegration/SyncIntegrationTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/syncintegration/SyncIntegrationTest.kt
@@ -27,7 +27,7 @@ import androidx.test.uiautomator.Until
 import org.hamcrest.Matchers.allOf
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.TestAssetHelper
-import org.junit.Assert.assertNotNull
+import org.mozilla.fenix.helpers.ext.waitNotNull
 
 @Suppress("RECEIVER_NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS")
 class SyncIntegrationTest {
@@ -111,7 +111,7 @@ class SyncIntegrationTest {
     }
 
     fun tapOnSignIn() {
-        assertNotNull(mDevice.wait(Until.findObjects(By.text("Sign in")), TestAssetHelper.waitingTimeShort))
+        mDevice.waitNotNull(Until.findObjects(By.text("Sign in")))
         // Let's tap on enter, sometimes depending on the device the sign in button is
         // hidden by the keyboard
         mDevice.pressEnter()
@@ -133,7 +133,7 @@ class SyncIntegrationTest {
     }
 
     fun seeBookmark() {
-        assertNotNull(mDevice.wait(Until.findObjects(By.text("Bookmark")), TestAssetHelper.waitingTime))
+        mDevice.waitNotNull(Until.findObjects(By.text("Bookmark")), TestAssetHelper.waitingTime)
         val bookmarkButton = mDevice.findObject(By.text("Bookmark"))
         bookmarkButton.click()
     }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
@@ -5,7 +5,6 @@
 package org.mozilla.fenix.ui
 
 import androidx.test.uiautomator.UiDevice
-import org.junit.Assert.assertNotNull
 import org.junit.Rule
 import org.junit.Test
 import org.junit.Ignore
@@ -13,6 +12,7 @@ import org.mozilla.fenix.helpers.HomeActivityTestRule
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.Until
+import org.mozilla.fenix.helpers.ext.waitNotNull
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.ui.robots.PRIVATE_SESSION_MESSAGE
 import org.mozilla.fenix.ui.robots.homeScreen
@@ -122,7 +122,7 @@ class HomeScreenTest {
         homeScreen {
             // To deal with the race condition where multiple "add tab" buttons are present,
             // we need to wait until previous HomeFragment View objects are gone.
-            assertNotNull(mDevice.wait(Until.gone(By.text(PRIVATE_SESSION_MESSAGE)), waitingTime))
+            mDevice.waitNotNull(Until.gone(By.text(PRIVATE_SESSION_MESSAGE)), waitingTime)
             verifyHomeScreen()
             verifyNavigationToolbar()
             verifyHomePrivateBrowsingButton()

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
@@ -9,12 +9,12 @@ import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.Until
 import okhttp3.mockwebserver.MockWebServer
-import org.junit.Assert.assertNotNull
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
+import org.mozilla.fenix.helpers.ext.waitNotNull
 import org.mozilla.fenix.helpers.HomeActivityTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.ui.robots.homeScreen
@@ -76,7 +76,7 @@ class TabbedBrowsingTest {
 
         homeScreen {
             // Timing issue on slow devices on Firebase
-            assertNotNull(mDevice.wait(Until.findObjects(By.res("org.mozilla.fenix.debug:id/item_tab")), TestAssetHelper.waitingTime))
+            mDevice.waitNotNull(Until.findObjects(By.res("org.mozilla.fenix.debug:id/item_tab")), TestAssetHelper.waitingTime)
             verifyExistingTabList()
 
         }.openTabsListThreeDotMenu {
@@ -106,7 +106,7 @@ class TabbedBrowsingTest {
             verifyTabCounter("1")
         }.openHomeScreen {
             // Timing issue on slow devices on Firebase
-            assertNotNull(mDevice.wait(Until.findObjects(By.res("org.mozilla.fenix.debug:id/item_tab")), TestAssetHelper.waitingTime))
+            mDevice.waitNotNull(Until.findObjects(By.res("org.mozilla.fenix.debug:id/item_tab")), TestAssetHelper.waitingTime)
             verifyExistingTabList()
             verifyShareTabsButton(true)
             verifyCloseTabsButton(true)
@@ -135,7 +135,7 @@ class TabbedBrowsingTest {
 
         homeScreen {
             // Timing issue on slow devices on Firebase
-            assertNotNull(mDevice.wait(Until.findObjects(By.res("org.mozilla.fenix.debug:id/item_tab")), TestAssetHelper.waitingTime))
+            mDevice.waitNotNull(Until.findObjects(By.res("org.mozilla.fenix.debug:id/item_tab")), TestAssetHelper.waitingTime)
             verifyExistingTabList()
         }.openTabsListThreeDotMenu {
             verifyCloseAllTabsButton()

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -15,17 +15,17 @@ import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.Until
 import org.hamcrest.CoreMatchers.containsString
-import org.junit.Assert.assertNotNull
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.helpers.click
+import org.mozilla.fenix.helpers.ext.waitNotNull
 
 class BrowserRobot {
 
     fun verifyHelpUrl() {
         val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
         val redirectUrl = "https://support.mozilla.org/"
-        assertNotNull(mDevice.wait(Until.findObject(By.res("org.mozilla.fenix.debug:id/mozac_browser_toolbar_url_view")), TestAssetHelper.waitingTime))
+        mDevice.waitNotNull(Until.findObject(By.res("org.mozilla.fenix.debug:id/mozac_browser_toolbar_url_view")), TestAssetHelper.waitingTime)
         onView(withId(R.id.mozac_browser_toolbar_url_view))
             .check(matches(withText(containsString(redirectUrl))))
     }
@@ -33,7 +33,7 @@ class BrowserRobot {
     fun verifyWhatsNewURL() {
         val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
         val redirectUrl = "https://support.mozilla.org/"
-        assertNotNull(mDevice.wait(Until.findObject(By.res("org.mozilla.fenix.debug:id/mozac_browser_toolbar_url_view")), TestAssetHelper.waitingTime))
+        mDevice.waitNotNull(Until.findObject(By.res("org.mozilla.fenix.debug:id/mozac_browser_toolbar_url_view")), TestAssetHelper.waitingTime)
         onView(withId(R.id.mozac_browser_toolbar_url_view))
             .check(matches(withText(containsString(redirectUrl))))
     }
@@ -43,7 +43,7 @@ class BrowserRobot {
     */
     fun verifyPageContent(expectedText: String) {
         val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-        assertNotNull(mDevice.wait(Until.findObject(By.text(expectedText)), TestAssetHelper.waitingTime))
+        mDevice.waitNotNull(Until.findObject(By.text(expectedText)), TestAssetHelper.waitingTime)
     }
 
     fun verifyTabCounter(expectedText: String) {
@@ -67,19 +67,19 @@ class BrowserRobot {
 
             tabsCounter().click()
 
-            assertNotNull(mDevice.wait(
+            mDevice.waitNotNull(
                 Until.findObject(By.res("org.mozilla.fenix.debug:id/header_text")),
                 TestAssetHelper.waitingTime
-            ))
+            )
 
             HomeScreenRobot().interact()
             return HomeScreenRobot.Transition()
         }
 
         fun openQuickActionBar(interact: QuickActionBarRobot.() -> Unit): QuickActionBarRobot.Transition {
-            assertNotNull(mDevice.wait(Until.gone(By.res("org.mozilla.fenix.debug:id/quick_action_sheet")),
+            mDevice.waitNotNull(Until.gone(By.res("org.mozilla.fenix.debug:id/quick_action_sheet")),
                 TestAssetHelper.waitingTime
-            ))
+            )
             quickActionBarHandle().click()
 
             QuickActionBarRobot().interact()

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/FindInPageRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/FindInPageRobot.kt
@@ -17,10 +17,10 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.Until
-import org.junit.Assert.assertNotNull
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.click
+import org.mozilla.fenix.helpers.ext.waitNotNull
 
 /**
  * Implementation of Robot Pattern for the find in page UI.
@@ -34,15 +34,15 @@ class FindInPageRobot {
     fun verifyFindInPageCloseButton() = assertFindInPageCloseButton()!!
 
     fun enterFindInPageQuery(expectedText: String) {
-        assertNotNull(mDevice.wait(Until.findObject(By.res("org.mozilla.fenix.debug:id/find_in_page_query_text")), waitingTime))
+        mDevice.waitNotNull(Until.findObject(By.res("org.mozilla.fenix.debug:id/find_in_page_query_text")), waitingTime)
         findInPageQuery().perform(clearText())
-        assertNotNull(mDevice.wait(Until.gone(By.res("org.mozilla.fenix.debug:id/find_in_page_result_text")), waitingTime))
+        mDevice.waitNotNull(Until.gone(By.res("org.mozilla.fenix.debug:id/find_in_page_result_text")), waitingTime)
         findInPageQuery().perform(typeText(expectedText))
-        assertNotNull(mDevice.wait(Until.findObject(By.res("org.mozilla.fenix.debug:id/find_in_page_result_text")), waitingTime))
+        mDevice.waitNotNull(Until.findObject(By.res("org.mozilla.fenix.debug:id/find_in_page_result_text")), waitingTime)
     }
 
     fun verifyFindNextInPageResult(ratioCounter: String) {
-        assertNotNull(mDevice.wait(Until.findObject(By.text(ratioCounter)), waitingTime))
+        mDevice.waitNotNull(Until.findObject(By.text(ratioCounter)), waitingTime)
         val element = mDevice.findObject(By.text(ratioCounter))
         findInPageResult().check(matches(withText((ratioCounter))))
         findInPageNextButton().click()
@@ -50,7 +50,7 @@ class FindInPageRobot {
     }
 
     fun verifyFindPrevInPageResult(ratioCounter: String) {
-        assertNotNull(mDevice.wait(Until.findObject(By.text(ratioCounter)), waitingTime))
+        mDevice.waitNotNull(Until.findObject(By.text(ratioCounter)), waitingTime)
         val element = mDevice.findObject(By.text(ratioCounter))
         findInPageResult().check(matches(withText((ratioCounter))))
         findInPagePrevButton().click()

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/LibraryRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/LibraryRobot.kt
@@ -18,10 +18,10 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.Until
 import org.hamcrest.CoreMatchers.allOf
-import org.junit.Assert.assertNotNull
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.helpers.click
+import org.mozilla.fenix.helpers.ext.waitNotNull
 
 /**
  * Implementation of Robot Pattern for the your library menu.
@@ -52,7 +52,7 @@ class LibraryRobot {
         }
 
         fun openBookmarks(interact: BookmarksRobot.() -> Unit): BookmarksRobot.Transition {
-            assertNotNull(mDevice.wait(Until.findObject(By.text("Bookmarks")), TestAssetHelper.waitingTime))
+            mDevice.waitNotNull(Until.findObject(By.text("Bookmarks")), TestAssetHelper.waitingTime)
             bookmarksButton().click()
 
             BookmarksRobot().interact()
@@ -60,7 +60,7 @@ class LibraryRobot {
         }
 
         fun openHistory(interact: HistoryRobot.() -> Unit): HistoryRobot.Transition {
-            assertNotNull(mDevice.wait(Until.findObject(By.text("History")), TestAssetHelper.waitingTime))
+            mDevice.waitNotNull(Until.findObject(By.text("History")), TestAssetHelper.waitingTime)
             historyButton().click()
 
             HistoryRobot().interact()

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NavigationToolbarRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NavigationToolbarRobot.kt
@@ -18,7 +18,7 @@ import androidx.test.uiautomator.Until
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.click
-import org.junit.Assert.assertNotNull
+import org.mozilla.fenix.helpers.ext.waitNotNull
 
 /**
  * Implementation of Robot Pattern for the URL toolbar.
@@ -29,7 +29,7 @@ class NavigationToolbarRobot {
         val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
 
         fun enterURLAndEnterToBrowser(url: Uri, interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
-            assertNotNull(mDevice.wait(Until.findObject(By.res("org.mozilla.fenix.debug:id/toolbar")), waitingTime))
+            mDevice.waitNotNull(Until.findObject(By.res("org.mozilla.fenix.debug:id/toolbar")), waitingTime)
             urlBar().click()
             awesomeBar().perform(replaceText(url.toString()), pressImeActionButton())
 
@@ -38,7 +38,7 @@ class NavigationToolbarRobot {
         }
 
         fun openThreeDotMenu(interact: ThreeDotMenuMainRobot.() -> Unit): ThreeDotMenuMainRobot.Transition {
-            assertNotNull(mDevice.wait(Until.findObject(By.descContains("Menu")), waitingTime))
+            mDevice.waitNotNull(Until.findObject(By.descContains("Menu")), waitingTime)
             threeDotButton().click()
 
             ThreeDotMenuMainRobot().interact()
@@ -46,7 +46,7 @@ class NavigationToolbarRobot {
         }
 
         fun openNewTabAndEnterToBrowser(url: Uri, interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
-            assertNotNull(mDevice.wait(Until.findObject(By.descContains("Add tab")), waitingTime))
+            mDevice.waitNotNull(Until.findObject(By.descContains("Add tab")), waitingTime)
             newTab().click()
             awesomeBar().perform(replaceText(url.toString()), pressImeActionButton())
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SearchRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SearchRobot.kt
@@ -27,9 +27,9 @@ import androidx.test.uiautomator.Until
 import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.CoreMatchers.startsWith
 import org.hamcrest.Matchers
-import org.junit.Assert.assertNotNull
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.TestAssetHelper
+import org.mozilla.fenix.helpers.ext.waitNotNull
 
 /**
  * Implementation of Robot Pattern for the search fragment.
@@ -65,7 +65,7 @@ class SearchRobot {
     }
 
     fun clickDuckDuckGoResult() {
-        assertNotNull(mDevice.wait(Until.findObjects(By.text("DuckDuckGo")), TestAssetHelper.waitingTime))
+        mDevice.waitNotNull(Until.findObjects(By.text("DuckDuckGo")), TestAssetHelper.waitingTime)
         awesomeBar().perform(RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click()))
     }
 
@@ -101,29 +101,29 @@ private fun awesomeBar() = onView(withId(R.id.awesomeBar))
 private fun browserToolbarEditView() = onView(Matchers.allOf(withId(R.id.mozac_browser_toolbar_edit_url_view)))
 
 private fun duckDuckGoEngineButton(): ViewInteraction {
-    assertNotNull(mDevice.wait(Until.findObject(By.text("DuckDuckGo")), TestAssetHelper.waitingTime))
+    mDevice.waitNotNull(Until.findObject(By.text("DuckDuckGo")), TestAssetHelper.waitingTime)
     return onView(Matchers.allOf(withText("DuckDuckGo")))
 }
 
 private fun denyPermissionButton(): UiObject {
-    assertNotNull(mDevice.wait(Until.findObjects(By.text("Deny")), TestAssetHelper.waitingTime))
+    mDevice.waitNotNull(Until.findObjects(By.text("Deny")), TestAssetHelper.waitingTime)
     return mDevice.findObject(UiSelector().text("Deny"))
 }
 
 private fun allowPermissionButton(): UiObject {
-    assertNotNull(mDevice.wait(Until.findObjects(By.text("Allow")), TestAssetHelper.waitingTime))
+    mDevice.waitNotNull(Until.findObjects(By.text("Allow")), TestAssetHelper.waitingTime)
     return mDevice.findObject(UiSelector().text("Allow"))
 }
 
 private fun scanButton(): ViewInteraction {
-    assertNotNull(mDevice.wait(Until.findObject(By.res("org.mozilla.fenix.debug:id/search_scan_button")), TestAssetHelper.waitingTime))
+    mDevice.waitNotNull(Until.findObject(By.res("org.mozilla.fenix.debug:id/search_scan_button")), TestAssetHelper.waitingTime)
     return onView(allOf(withId(R.id.searchScanButton)))
 }
 
 private fun clearButton() = onView(withId(R.id.mozac_browser_toolbar_clear_view))
 
 private fun assertDuckDuckGoURL() {
-    assertNotNull(mDevice.wait(Until.findObject(By.textContains("https://duckduckgo.com/?q=mozilla")), TestAssetHelper.waitingTime))
+    mDevice.waitNotNull(Until.findObject(By.textContains("https://duckduckgo.com/?q=mozilla")), TestAssetHelper.waitingTime)
     onView(allOf(withText(startsWith("https://duckduckgo.com"))))
         .check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuMainRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuMainRobot.kt
@@ -18,10 +18,10 @@ import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.Until
 import org.hamcrest.Matchers.allOf
-import org.junit.Assert.assertNotNull
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.click
+import org.mozilla.fenix.helpers.ext.waitNotNull
 import org.mozilla.fenix.share.ShareFragment
 
 /**
@@ -39,7 +39,7 @@ class ThreeDotMenuMainRobot {
     fun verifyShareButton() = assertShareButton()
     fun clickShareButton() {
         shareButton().click()
-        assertNotNull(mDevice.wait(Until.findObject(By.text("SHARE A LINK")), waitingTime))
+        mDevice.waitNotNull(Until.findObject(By.text("SHARE A LINK")), waitingTime)
     }
 
     fun verifyShareTabButton() = assertShareTabButton()
@@ -55,7 +55,7 @@ class ThreeDotMenuMainRobot {
         private val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
 
         fun openSettings(interact: SettingsRobot.() -> Unit): SettingsRobot.Transition {
-            assertNotNull(mDevice.wait(Until.findObject(By.text("Settings")), waitingTime))
+            mDevice.waitNotNull(Until.findObject(By.text("Settings")), waitingTime)
             settingsButton().click()
 
             SettingsRobot().interact()
@@ -63,7 +63,7 @@ class ThreeDotMenuMainRobot {
         }
 
         fun openLibrary(interact: LibraryRobot.() -> Unit): LibraryRobot.Transition {
-            assertNotNull(mDevice.wait(Until.findObject(By.text("Your Library")), waitingTime))
+            mDevice.waitNotNull(Until.findObject(By.text("Your Library")), waitingTime)
             libraryButton().click()
 
             LibraryRobot().interact()
@@ -71,7 +71,7 @@ class ThreeDotMenuMainRobot {
         }
 
         fun openHelp(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
-            assertNotNull(mDevice.wait(Until.findObject(By.text("Help")), waitingTime))
+            mDevice.waitNotNull(Until.findObject(By.text("Help")), waitingTime)
             helpButton().click()
 
             BrowserRobot().interact()
@@ -79,7 +79,7 @@ class ThreeDotMenuMainRobot {
         }
 
         fun goForward(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
-            assertNotNull(mDevice.wait(Until.findObject(By.desc("Forward")), waitingTime))
+            mDevice.waitNotNull(Until.findObject(By.desc("Forward")), waitingTime)
             forwardButton().click()
 
             BrowserRobot().interact()
@@ -87,7 +87,7 @@ class ThreeDotMenuMainRobot {
         }
 
         fun goBack(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
-            assertNotNull(mDevice.wait(Until.findObject(By.desc("Back")), waitingTime))
+            mDevice.waitNotNull(Until.findObject(By.desc("Back")), waitingTime)
             backButton().click()
 
             BrowserRobot().interact()
@@ -95,7 +95,7 @@ class ThreeDotMenuMainRobot {
         }
 
         fun refreshPage(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
-            assertNotNull(mDevice.wait(Until.findObject(By.desc("Refresh")), waitingTime))
+            mDevice.waitNotNull(Until.findObject(By.desc("Refresh")), waitingTime)
             refreshButton().click()
 
             BrowserRobot().interact()
@@ -103,7 +103,7 @@ class ThreeDotMenuMainRobot {
         }
 
         fun closeAllTabs(interact: HomeScreenRobot.() -> Unit): HomeScreenRobot.Transition {
-            assertNotNull(mDevice.wait(Until.findObject(By.text("Close all tabs")), waitingTime))
+            mDevice.waitNotNull(Until.findObject(By.text("Close all tabs")), waitingTime)
             closeAllTabsButton().click()
 
             HomeScreenRobot().interact()
@@ -111,7 +111,7 @@ class ThreeDotMenuMainRobot {
         }
 
         fun openFindInPage(interact: FindInPageRobot.() -> Unit): FindInPageRobot.Transition {
-            assertNotNull(mDevice.wait(Until.findObject(By.text("Find in page")), waitingTime))
+            mDevice.waitNotNull(Until.findObject(By.text("Find in page")), waitingTime)
             findInPageButton().click()
 
             FindInPageRobot().interact()
@@ -119,7 +119,7 @@ class ThreeDotMenuMainRobot {
         }
 
         fun openWhatsNew(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
-            assertNotNull(mDevice.wait(Until.findObject(By.text("What's New")), waitingTime))
+            mDevice.waitNotNull(Until.findObject(By.text("What's New")), waitingTime)
             whatsNewButton().click()
 
             BrowserRobot().interact()

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/screenshots/MenuScreenShotTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/screenshots/MenuScreenShotTest.kt
@@ -19,13 +19,13 @@
 // import okhttp3.mockwebserver.MockWebServer
 // import org.hamcrest.Matchers
 // import org.junit.After
-// import org.junit.Assert.assertNotNull
 // import org.junit.Before
 // import org.junit.Rule
 // import org.junit.Test
 // import org.mozilla.fenix.HomeActivity
 // import org.mozilla.fenix.R
 // import org.mozilla.fenix.helpers.AndroidAssetDispatcher
+// import org.mozilla.fenix.helpers.ext.waitNotNull
 // import org.mozilla.fenix.helpers.HomeActivityTestRule
 // import org.mozilla.fenix.helpers.TestAssetHelper
 // import org.mozilla.fenix.helpers.click
@@ -168,22 +168,22 @@
 //                 .instance(1)
 //                 .className(ImageView::class.java)).click()
 //         // Homescreen with visited tabs
-//         assertNotNull(device.wait(Until.findObjects(By.text("Save to collection")), TestAssetHelper.waitingTimeShort))
+//         mDevice.waitNotNull(device.wait(Until.findObjects(By.text("Save to collection")))
 //         openTabsMenu()
 //         Screengrab.screenshot("open-tabs-menu")
 //         device.pressBack()
-//         assertNotNull(device.wait(Until.findObjects(By.text("Save to collection")), TestAssetHelper.waitingTimeShort))
+//         mDevice.waitNotNull(Until.findObjects(By.text("Save to collection")))
 //         Screengrab.screenshot("save-collection-button")
 //
 //         // Save a collection
 //         saveToCollectionButton()
 //         Screengrab.screenshot("save-collection-view")
-//         assertNotNull(device.wait(Until.findObject(By.res("org.mozilla.fenix.debug:id/name_collection_edittext")), TestAssetHelper.waitingTimeShort))
+//         mDevice.waitNotNull(Until.findObject(By.res("org.mozilla.fenix.debug:id/name_collection_edittext")))
 //         nameCollectionTextBox().perform(replaceText("CollectionName"),
 //                 pressImeActionButton())
 //
 //         // Homescreen after saving one collection
-//         assertNotNull(device.wait(Until.findObject(By.res("org.mozilla.fenix.debug:id/collection_title")), TestAssetHelper.waitingTimeShort))
+//         mDevice.waitNotNull(Until.findObject(By.res("org.mozilla.fenix.debug:id/collection_title")))
 //         Screengrab.screenshot("saved-tab")
 //
 //         // Open Collection menu
@@ -197,7 +197,7 @@
 //         navigationToolbar {
 //         }.enterURLAndEnterToBrowser(defaultWebPage.url) {
 //         }
-//         assertNotNull(device.wait(Until.findObjects(By.res("org.mozilla.fenix.debug:id/quick_action_sheet_handle")), TestAssetHelper.waitingTimeShort))
+//         mDevice.waitNotNull(Until.findObjects(By.res("org.mozilla.fenix.debug:id/quick_action_sheet_handle")))
 //         openQuickActionMenu()
 //         Screengrab.screenshot("browser-tab-share-bookmark")
 //         // Open Browser tab menu
@@ -210,7 +210,7 @@
 //         device.findObject(UiSelector()
 //                 .instance(1)
 //                 .className(ImageView::class.java)).click()
-//         assertNotNull(device.wait(Until.findObjects(By.res("org.mozilla.fenix.debug:id/close_tab_button")), TestAssetHelper.waitingTimeShort))
+//         mDevice.waitNotNull(Until.findObjects(By.res("org.mozilla.fenix.debug:id/close_tab_button")))
 //         closeTabButton()
 //         Screengrab.screenshot("remove-tab")
 //     }


### PR DESCRIPTION
#6172 

From previous re-factor

> It occurs to me that we could make this easier to reuse with an extension function. Something like the following:
> 
> ```kotlin
>     /**
>      * Blocks the test for [waitTime] miliseconds before continuing.
>      *
>      * Will cause the test to fail is the condition is not met before the timeout.
>      */
>     fun UiDevice.waitNotNull(
>         searchCondition: SearchCondition<*>,
>         waitTime: Long = TestAssetHelper.waitingTimeShort
>     ) = assertNotNull(wait(searchCondition, waitTime))
> ```
> 
> Which would update L113 to look like `mDevice.waitNotNull(Until.findObjects(By.text("Sign in")))`, or (if we wanted to use a different timeout) `mDevice.waitNotNull(Until.findObjects(By.text("Sign in")), TestAssetHelper.waitingTimeShort)`
