### PR TITLE
Fix sync test after changes in the syntaxt to check the elements

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/syncintegration/SyncIntegrationTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/syncintegration/SyncIntegrationTest.kt
@@ -97,7 +97,7 @@ class SyncIntegrationTest {
     }
 
     fun tapOnContinueButton() {
-        val continueButton = mDevice.findObject(By.res("org.mozilla.fenix.debug:id/submit-btn"))
+        val continueButton = mDevice.findObject(By.res("submit-btn"))
         continueButton.clickAndWait(Until.newWindow(), TestAssetHelper.waitingTime)
     }
 


### PR DESCRIPTION
After PR #6084 landed tests started to fail. The way the `Continue`button is checked with that new syntax does not work in that case. This PR is to revert that change and have the tests working again