### PR TITLE
Fixes #5104: Changed empty_exception_container to match constraints.

### DIFF
--- a/app/src/main/res/layout/fragment_site_permissions_exceptions.xml
+++ b/app/src/main/res/layout/fragment_site_permissions_exceptions.xml
@@ -35,8 +35,9 @@
 
     <TextView
         android:id="@+id/empty_exception_container"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:gravity="center"
         android:text="@string/no_site_exceptions"
         android:textColor="?primaryText"
         android:textSize="20sp"

--- a/app/src/main/res/layout/fragment_site_permissions_exceptions.xml
+++ b/app/src/main/res/layout/fragment_site_permissions_exceptions.xml
@@ -12,7 +12,7 @@
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/exceptions"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
         android:visibility="gone"


### PR DESCRIPTION
The bug occurred because the activity/fragment is not recreated on
orientation change. A simple fix was to just set width and height to 0dp
to let it match constraints.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks.
- [x] **Tests**: This PR does not include thorough tests. Small UI change.
- [x] **Screenshots**: This PR includes videos ([before](https://user-images.githubusercontent.com/51314259/64257245-b34a9c00-cf2d-11e9-928d-59355797a1a7.gif) and [after](https://drive.google.com/open?id=1GUJXqH4tys0qkPPN7v18eCueCpsz7Tjf)) showing the view after orientation change.
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
