### PR TITLE
For #6294 - When only one tab is being saved to collection, add it to selected tabs

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/collections/CollectionCreationFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/collections/CollectionCreationFragment.kt
@@ -47,8 +47,7 @@ class CollectionCreationFragment : DialogFragment() {
         val sessionManager = requireComponents.core.sessionManager
         val publicSuffixList = requireComponents.publicSuffixList
         val tabs = sessionManager.getTabs(args.tabIds, publicSuffixList)
-        val selectedTabs = sessionManager.getTabs(args.selectedTabIds, publicSuffixList)
-            .toSet()
+        val selectedTabs = if (tabs.size == 1) setOf(tabs.first()) else emptySet()
         val tabCollections = requireComponents.core.tabCollectionStorage.cachedTabCollections
         val selectedTabCollection = args.selectedTabCollectionId
             .let { id -> tabCollections.firstOrNull { it.id == id } }


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

This change looks like it was missed in the Collections Migration: https://github.com/mozilla-mobile/fenix/pull/5911/files#diff-ada8c7e16acf189d16082c66263daf35L25

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
