### PR TITLE
For #2570: Hide 3-dots menu for all library items when in select mode.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/LibraryPageView.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/LibraryPageView.kt
@@ -8,16 +8,12 @@ import android.content.Context
 import android.view.ViewGroup
 import androidx.appcompat.widget.Toolbar
 import androidx.core.content.ContextCompat
-import androidx.core.view.children
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.library_site_item.view.*
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.asActivity
 import org.mozilla.fenix.ext.getColorFromAttr
-import org.mozilla.fenix.ext.hideAndDisable
 import org.mozilla.fenix.ext.setToolbarColors
-import org.mozilla.fenix.ext.showAndEnable
 
 open class LibraryPageView(
     override val containerView: ViewGroup
@@ -35,9 +31,7 @@ open class LibraryPageView(
             backgroundColor = context.getColorFromAttr(R.attr.foundation)
         )
         libraryItemsList.setItemViewCacheSize(0)
-        libraryItemsList.children.forEach { item ->
-            item.overflow_menu.showAndEnable()
-        }
+        libraryItemsList.adapter?.notifyItemRangeChanged(0, libraryItemsList.childCount)
     }
 
     protected fun setUiForSelectingMode(
@@ -50,9 +44,7 @@ open class LibraryPageView(
             backgroundColor = context.getColorFromAttr(R.attr.accentHighContrast)
         )
         libraryItemsList.setItemViewCacheSize(0)
-        libraryItemsList.children.forEach { item ->
-            item.overflow_menu.hideAndDisable()
-        }
+        libraryItemsList.adapter?.notifyItemRangeChanged(0, libraryItemsList.childCount)
     }
 
     private fun updateToolbar(title: String?, foregroundColor: Int, backgroundColor: Int) {


### PR DESCRIPTION
Used notifyItemRangeChanged to redraw already drawn items.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
