### PR TITLE
Add tests for About Firefox Preview screen

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAboutTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAboutTest.kt
@@ -77,7 +77,6 @@ class SettingsAboutTest {
         // Verify Android "Open with Google Play Store" sub menu
     }
 
-    @Ignore("This is a stub test, ignore for now")
     @Test
     fun verifyAboutFirefoxPreview() {
         // Open 3dot (main) menu
@@ -89,5 +88,17 @@ class SettingsAboutTest {
         // "Firefox Preview is produced by Mozilla"
         // Day, Date, timestamp
         // "Open source libraries we use"
+        homeScreen {
+        }.openThreeDotMenu {
+        }.openSettings {
+            // ABOUT
+            verifyAboutFirefoxPreview()
+        }.openAboutFirefoxPreview {
+            verifyBuildNo()
+            verifyProducedBy()
+            verifyTimeStamp()
+            verifyOpenSourceLibraries()
+        }
+
     }
 }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
@@ -104,6 +104,15 @@ class SettingsRobot {
             SettingsSubMenuDefaultBrowserRobot().interact()
             return SettingsSubMenuDefaultBrowserRobot.Transition()
         }
+
+        fun openAboutFirefoxPreview(interact: SettingsSubMenuAboutRobot.() -> Unit): SettingsSubMenuAboutRobot.Transition {
+            mDevice.waitForIdle()
+            fun aboutFirefoxPreviewButton() = onView(ViewMatchers.withText("About Firefox Preview"))
+            aboutFirefoxPreviewButton().click()
+
+            SettingsSubMenuAboutRobot().interact()
+            return SettingsSubMenuAboutRobot.Transition()
+        }
     }
 }
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAboutRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAboutRobot.kt
@@ -6,17 +6,30 @@
 
 package org.mozilla.fenix.ui.robots
 
-import androidx.test.espresso.Espresso
+import androidx.core.content.pm.PackageInfoCompat
+import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import org.hamcrest.CoreMatchers
+import org.hamcrest.CoreMatchers.containsString
+import org.hamcrest.CoreMatchers.startsWith
+import org.mozilla.fenix.BuildConfig
+import org.mozilla.geckoview.BuildConfig as GeckoViewBuildConfig
+
 
 /**
  * Implementation of Robot Pattern for the settings search sub menu.
  */
 class SettingsSubMenuAboutRobot {
+
+    fun verifyBuildNo() = assertBuildNo()
+    fun verifyProducedBy() = assertProducedBy()
+    fun verifyTimeStamp() = assertTimestamp()
+    fun verifyOpenSourceLibraries() = assertOpenSourceLibraries()
 
     class Transition {
         val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
@@ -32,4 +45,39 @@ class SettingsSubMenuAboutRobot {
 }
 
 private fun goBackButton() =
-    Espresso.onView(CoreMatchers.allOf(ViewMatchers.withContentDescription("Navigate up")))
+    onView(CoreMatchers.allOf(ViewMatchers.withContentDescription("Navigate up")))
+
+private fun assertBuildNo() {
+    val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
+    val versionCode = PackageInfoCompat.getLongVersionCode(packageInfo).toString()
+
+    val buildNo = "${packageInfo.versionName} (Build #$versionCode)\n"
+
+    val componentsVersion = "${mozilla.components.Build.version}, ${mozilla.components.Build.gitHash}"
+    val geckoVersion = GeckoViewBuildConfig.MOZ_APP_VERSION + "-" + GeckoViewBuildConfig.MOZ_APP_BUILDID
+
+    onView(ViewMatchers.withText(startsWith(buildNo)))
+        .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+    onView(ViewMatchers.withText(containsString(componentsVersion)))
+        .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+    onView(ViewMatchers.withText(containsString(geckoVersion)))
+        .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+}
+
+private fun assertProducedBy() {
+    onView(ViewMatchers.withText("Firefox Preview is produced by Mozilla."))
+        .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+}
+
+private fun assertTimestamp() {
+    val buildDate = BuildConfig.BUILD_DATE
+    onView(ViewMatchers.withText(buildDate))
+        .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+}
+
+private fun assertOpenSourceLibraries() {
+    onView(ViewMatchers.withText("Open source libraries we use"))
+        .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+}


### PR DESCRIPTION
Add tests for Three Dots > Settings > About Firefox Preview screen. Part of an Outreachy application.
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
