### PR TITLE
Fixes #6341: Initialize 'selectedTabs' based on opened/selected tabs.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/collections/CollectionCreationFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/collections/CollectionCreationFragment.kt
@@ -47,7 +47,12 @@ class CollectionCreationFragment : DialogFragment() {
         val sessionManager = requireComponents.core.sessionManager
         val publicSuffixList = requireComponents.publicSuffixList
         val tabs = sessionManager.getTabs(args.tabIds, publicSuffixList)
-        val selectedTabs = if (tabs.size == 1) setOf(tabs.first()) else emptySet()
+        val selectedTabs = if (args.selectedTabIds != null) {
+            sessionManager.getTabs(args.selectedTabIds, publicSuffixList).toSet()
+        } else {
+            if (tabs.size == 1) setOf(tabs.first()) else emptySet()
+        }
+
         val tabCollections = requireComponents.core.tabCollectionStorage.cachedTabCollections
         val selectedTabCollection = args.selectedTabCollectionId
             .let { id -> tabCollections.firstOrNull { it.id == id } }


### PR DESCRIPTION
The problem was that the parameter 'selectedTabIds' was not taken into account
when initializing the variable 'selectedTabs'. So I made the initialization
based on both the selected tab and the number of open tabs.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks.
- [x] **Tests**: This PR does not include thorough tests.
- [x] **Screenshots**: This PR includes a [video](https://drive.google.com/open?id=1TNTK6Pj4EZXRuFMyjVm7zBhqZLZT8hdD) showing that the tab is checked when creating a collection.
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
