### PR TITLE
Use new WindowFeature API after browser-state migration 

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -46,7 +46,7 @@ import mozilla.components.feature.session.FullScreenFeature
 import mozilla.components.feature.session.SessionFeature
 import mozilla.components.feature.session.SessionUseCases
 import mozilla.components.feature.session.SwipeRefreshFeature
-import mozilla.components.feature.session.WindowFeature
+import mozilla.components.feature.tabs.WindowFeature
 import mozilla.components.feature.sitepermissions.SitePermissions
 import mozilla.components.feature.sitepermissions.SitePermissionsFeature
 import mozilla.components.feature.sitepermissions.SitePermissionsRules
@@ -246,7 +246,10 @@ abstract class BaseBrowserFragment : Fragment(), BackHandler, SessionManager.Obs
             )
 
             windowFeature.set(
-                feature = WindowFeature(sessionManager),
+                feature = WindowFeature(
+                    store = store,
+                    tabsUseCases = context.components.useCases.tabsUseCases
+                ),
                 owner = this,
                 view = view
             )


### PR DESCRIPTION
This is preparing for incoming API breakage in A-C 20.0.0-SNAPSHOT once this A-C PR lands: https://github.com/mozilla-mobile/android-components/pull/4901 