### PR TITLE
Consolidate duplicate mock initialization in intent processor tests.

### DIFF
--- a/app/src/test/java/org/mozilla/fenix/home/intent/OpenBrowserIntentProcessorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/intent/OpenBrowserIntentProcessorTest.kt
@@ -21,11 +21,12 @@ import org.robolectric.annotation.Config
 @Config(application = TestApplication::class)
 class OpenBrowserIntentProcessorTest {
 
+    private val activity: HomeActivity = mockk(relaxed = true)
+    private val navController: NavController = mockk()
+    private val out: Intent = mockk(relaxed = true)
+
     @Test
     fun `do not process blank intents`() {
-        val activity: HomeActivity = mockk()
-        val navController: NavController = mockk()
-        val out: Intent = mockk()
         val processor = OpenBrowserIntentProcessor(activity) { null }
         processor.process(Intent(), navController, out)
 
@@ -36,9 +37,6 @@ class OpenBrowserIntentProcessorTest {
 
     @Test
     fun `do not process when open extra is false`() {
-        val activity: HomeActivity = mockk()
-        val navController: NavController = mockk()
-        val out: Intent = mockk()
         val intent = Intent().apply {
             putExtra(HomeActivity.OPEN_TO_BROWSER, false)
         }
@@ -52,9 +50,6 @@ class OpenBrowserIntentProcessorTest {
 
     @Test
     fun `process when open extra is true`() {
-        val activity: HomeActivity = mockk(relaxed = true)
-        val navController: NavController = mockk()
-        val out: Intent = mockk(relaxed = true)
         val intent = Intent().apply {
             putExtra(HomeActivity.OPEN_TO_BROWSER, true)
         }

--- a/app/src/test/java/org/mozilla/fenix/home/intent/SpeechProcessingIntentProcessorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/intent/SpeechProcessingIntentProcessorTest.kt
@@ -22,11 +22,12 @@ import org.robolectric.annotation.Config
 @Config(application = TestApplication::class)
 class SpeechProcessingIntentProcessorTest {
 
+    private val activity: HomeActivity = mockk(relaxed=true)
+    private val navController: NavController = mockk(relaxed=true)
+    private val out: Intent = mockk(relaxed=true)
+
     @Test
     fun `do not process blank intents`() {
-        val activity: HomeActivity = mockk()
-        val navController: NavController = mockk()
-        val out: Intent = mockk()
         val processor = SpeechProcessingIntentProcessor(activity)
         processor.process(Intent(), navController, out)
 
@@ -37,9 +38,6 @@ class SpeechProcessingIntentProcessorTest {
 
     @Test
     fun `do not process when open extra is false`() {
-        val activity: HomeActivity = mockk()
-        val navController: NavController = mockk()
-        val out: Intent = mockk()
         val intent = Intent().apply {
             putExtra(HomeActivity.OPEN_TO_BROWSER_AND_LOAD, false)
         }
@@ -53,9 +51,6 @@ class SpeechProcessingIntentProcessorTest {
 
     @Test
     fun `process when open extra is true`() {
-        val activity: HomeActivity = mockk(relaxed = true)
-        val navController: NavController = mockk()
-        val out: Intent = mockk(relaxed = true)
         val intent = Intent().apply {
             putExtra(HomeActivity.OPEN_TO_BROWSER_AND_LOAD, true)
         }
@@ -76,7 +71,6 @@ class SpeechProcessingIntentProcessorTest {
 
     @Test
     fun `reads the speech processing extra`() {
-        val activity: HomeActivity = mockk(relaxed = true)
         val intent = Intent().apply {
             putExtra(HomeActivity.OPEN_TO_BROWSER_AND_LOAD, true)
             putExtra(SPEECH_PROCESSING, "hello world")

--- a/app/src/test/java/org/mozilla/fenix/home/intent/SpeechProcessingIntentProcessorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/intent/SpeechProcessingIntentProcessorTest.kt
@@ -22,9 +22,9 @@ import org.robolectric.annotation.Config
 @Config(application = TestApplication::class)
 class SpeechProcessingIntentProcessorTest {
 
-    private val activity: HomeActivity = mockk(relaxed=true)
-    private val navController: NavController = mockk(relaxed=true)
-    private val out: Intent = mockk(relaxed=true)
+    private val activity: HomeActivity = mockk(relaxed = true)
+    private val navController: NavController = mockk(relaxed = true)
+    private val out: Intent = mockk(relaxed = true)
 
     @Test
     fun `do not process blank intents`() {

--- a/app/src/test/java/org/mozilla/fenix/home/intent/StartSearchIntentProcessorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/intent/StartSearchIntentProcessorTest.kt
@@ -23,11 +23,12 @@ import org.robolectric.annotation.Config
 @Config(application = TestApplication::class)
 class StartSearchIntentProcessorTest {
 
+    private val metrics: MetricController = mockk(relaxed = true)
+    private val navController: NavController = mockk(relaxed = true)
+    private val out: Intent = mockk(relaxed = true)
+
     @Test
     fun `do not process blank intents`() {
-        val metrics: MetricController = mockk()
-        val navController: NavController = mockk()
-        val out: Intent = mockk()
         StartSearchIntentProcessor(metrics).process(Intent(), navController, out)
 
         verify { metrics wasNot Called }
@@ -37,9 +38,6 @@ class StartSearchIntentProcessorTest {
 
     @Test
     fun `do not process when search extra is false`() {
-        val metrics: MetricController = mockk()
-        val navController: NavController = mockk()
-        val out: Intent = mockk()
         val intent = Intent().apply {
             removeExtra(HomeActivity.OPEN_TO_SEARCH)
         }
@@ -52,9 +50,6 @@ class StartSearchIntentProcessorTest {
 
     @Test
     fun `process search intents`() {
-        val metrics: MetricController = mockk(relaxed = true)
-        val navController: NavController = mockk(relaxed = true)
-        val out: Intent = mockk(relaxed = true)
         val intent = Intent().apply {
             putExtra(HomeActivity.OPEN_TO_SEARCH, StartSearchIntentProcessor.SEARCH_WIDGET)
         }


### PR DESCRIPTION
Moves mock initialization logic that's common to all the tests in a class to member variables instead of local.

Issue #4556

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
