### PR TITLE
Use vector compat in TrackingProtectionPanelView.

### DIFF
--- a/app/src/main/res/layout/component_tracking_protection_panel.xml
+++ b/app/src/main/res/layout/component_tracking_protection_panel.xml
@@ -55,9 +55,9 @@
             style="@style/QuickSettingsText.Icon"
             android:layout_width="match_parent"
             android:layout_height="@dimen/tracking_protection_item_height"
-            android:drawableStart="@drawable/ic_cookies"
             android:text="@string/etp_cookies_title"
             android:visibility="gone"
+            app:drawableStartCompat="@drawable/ic_cookies"
             app:layout_constraintTop_toBottomOf="@id/blocking_header" />
 
         <TextView
@@ -65,9 +65,9 @@
             style="@style/QuickSettingsText.Icon"
             android:layout_width="match_parent"
             android:layout_height="@dimen/tracking_protection_item_height"
-            android:drawableStart="@drawable/ic_fingerprinters"
             android:text="@string/etp_fingerprinters_title"
             android:visibility="gone"
+            app:drawableStartCompat="@drawable/ic_fingerprinters"
             app:layout_constraintTop_toBottomOf="@id/cross_site_tracking" />
 
         <TextView
@@ -75,9 +75,9 @@
             style="@style/QuickSettingsText.Icon"
             android:layout_width="match_parent"
             android:layout_height="@dimen/tracking_protection_item_height"
-            android:drawableStart="@drawable/ic_cryptominers"
             android:text="@string/etp_cryptominers_title"
             android:visibility="gone"
+            app:drawableStartCompat="@drawable/ic_cryptominers"
             app:layout_constraintTop_toBottomOf="@id/fingerprinters" />
 
         <TextView
@@ -85,9 +85,9 @@
             style="@style/QuickSettingsText.Icon"
             android:layout_width="match_parent"
             android:layout_height="@dimen/tracking_protection_item_height"
-            android:drawableStart="@drawable/ic_social_media_trackers"
             android:text="@string/etp_social_media_trackers_title"
             android:visibility="gone"
+            app:drawableStartCompat="@drawable/ic_social_media_trackers"
             app:layout_constraintTop_toBottomOf="@id/cryptominers" />
 
         <TextView
@@ -95,9 +95,9 @@
             style="@style/QuickSettingsText.Icon"
             android:layout_width="match_parent"
             android:layout_height="@dimen/tracking_protection_item_height"
-            android:drawableStart="@drawable/ic_tracking_content"
             android:text="@string/etp_tracking_content_title"
             android:visibility="gone"
+            app:drawableStartCompat="@drawable/ic_tracking_content"
             app:layout_constraintTop_toBottomOf="@id/social_media_trackers" />
 
         <TextView
@@ -116,9 +116,9 @@
             style="@style/QuickSettingsText.Icon"
             android:layout_width="match_parent"
             android:layout_height="@dimen/tracking_protection_item_height"
-            android:drawableStart="@drawable/ic_fingerprinters"
             android:text="@string/etp_fingerprinters_title"
             android:visibility="gone"
+            app:drawableStartCompat="@drawable/ic_fingerprinters"
             app:layout_constraintTop_toBottomOf="@id/not_blocking_header" />
 
         <TextView
@@ -126,9 +126,9 @@
             style="@style/QuickSettingsText.Icon"
             android:layout_width="match_parent"
             android:layout_height="@dimen/tracking_protection_item_height"
-            android:drawableStart="@drawable/ic_cryptominers"
             android:text="@string/etp_cryptominers_title"
             android:visibility="gone"
+            app:drawableStartCompat="@drawable/ic_cryptominers"
             app:layout_constraintTop_toBottomOf="@id/fingerprinters_loaded" />
 
         <TextView
@@ -136,9 +136,9 @@
             style="@style/QuickSettingsText.Icon"
             android:layout_width="match_parent"
             android:layout_height="@dimen/tracking_protection_item_height"
-            android:drawableStart="@drawable/ic_social_media_trackers"
             android:text="@string/etp_social_media_trackers_title"
             android:visibility="gone"
+            app:drawableStartCompat="@drawable/ic_social_media_trackers"
             app:layout_constraintTop_toBottomOf="@id/cryptominers_loaded" />
 
         <TextView
@@ -146,9 +146,9 @@
             style="@style/QuickSettingsText.Icon"
             android:layout_width="match_parent"
             android:layout_height="@dimen/tracking_protection_item_height"
-            android:drawableStart="@drawable/ic_tracking_content"
             android:text="@string/etp_tracking_content_title"
             android:visibility="gone"
+            app:drawableStartCompat="@drawable/ic_tracking_content"
             app:layout_constraintTop_toBottomOf="@id/social_media_trackers_loaded" />
 
         <View
@@ -183,11 +183,11 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="20dp"
-            android:src="@drawable/mozac_ic_back"
             android:tint="?attr/primaryText"
             app:layout_constraintBottom_toBottomOf="@+id/category_description"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="@id/category_title" />
+            app:layout_constraintTop_toTopOf="@id/category_title"
+            app:srcCompat="@drawable/mozac_ic_back" />
 
         <TextView
             android:id="@+id/category_title"


### PR DESCRIPTION
Issue #5794 

Use vector compat for all vector drawables in TrackingProtectionPanelView.
(I forced it to show all the items in the screenshots below)

API 21 | API 29
--- | ---
![Screenshot (Oct 31, 2019 10_00_40 PM)](https://user-images.githubusercontent.com/1320020/67998051-430a7f00-fc2d-11e9-88dc-5a1a485d6822.png) | ![Screenshot (Oct 31, 2019 21_54_58)](https://user-images.githubusercontent.com/1320020/67998050-430a7f00-fc2d-11e9-90b4-5695a3f494ef.png)

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
