### PR TITLE
Add a simple gradient to collection creation UI

### DIFF
--- a/app/src/main/res/drawable/simple_dark_grey_gradient.xml
+++ b/app/src/main/res/drawable/simple_dark_grey_gradient.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape>
+            <gradient
+                android:angle="90"
+                android:startColor="@color/dark_grey_90_gradient_start"
+                android:centerColor="@color/dark_grey_90_gradient_start"
+                android:endColor="@color/dark_grey_90_gradient_end"
+                android:type="linear" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/drawable/simple_dark_grey_gradient.xml
+++ b/app/src/main/res/drawable/simple_dark_grey_gradient.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item>
         <shape>

--- a/app/src/main/res/layout/component_collection_creation.xml
+++ b/app/src/main/res/layout/component_collection_creation.xml
@@ -115,6 +115,14 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <View
+        android:id="@+id/bottom_gradient"
+        android:layout_width="match_parent"
+        android:layout_height="102dp"
+        android:background="@drawable/simple_dark_grey_gradient"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:focusable="false"/>
+
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/bottom_button_bar_layout"
         android:layout_width="match_parent"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -21,6 +21,8 @@
     <color name="disabled_light_theme">#6620123A</color>
     <color name="scrimStart_light_theme">#F515141A</color>
     <color name="scrimEnd_light_theme">#F542414D</color>
+    <color name="dark_grey_90_gradient_start">#FF15141A</color>
+    <color name="dark_grey_90_gradient_end">#0015141A</color>
     <color name="collection_icon_color_violet_light_theme">#7542E5</color>
     <color name="collection_icon_color_blue_light_theme">#0250BB</color>
     <color name="collection_icon_color_pink_light_theme">#E31587</color>


### PR DESCRIPTION
Adds a simple gradient to collection creation.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->
Issue #6263 

Without Gradient | With Gradient 
--- | --- 
![before_gradient](https://user-images.githubusercontent.com/6266621/67999168-7fd87500-fc31-11e9-8de7-8251d5223eb1.png) | ![after_gradient](https://user-images.githubusercontent.com/6266621/67999171-8830b000-fc31-11e9-8a19-e5598580bce2.png)

I tried with `51dp` as well but it just didn't work at all so I went with `102dp`

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
