### PR TITLE
Add ETP settings accessibility labels 

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/RadioButtonInfoPreference.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/RadioButtonInfoPreference.kt
@@ -19,6 +19,7 @@ class RadioButtonInfoPreference @JvmOverloads constructor(
 ) : RadioButtonPreference(context, attrs) {
     private var infoClickListener: (() -> Unit)? = null
     private var infoView: ImageView? = null
+    var contentDescription: String? = null
 
     fun onInfoClickListener(listener: (() -> Unit)) {
         infoClickListener = listener
@@ -65,6 +66,7 @@ class RadioButtonInfoPreference @JvmOverloads constructor(
             infoClickListener?.invoke()
         }
         infoView?.alpha = if (isEnabled) FULL_ALPHA else HALF_ALPHA
+        contentDescription?.let { infoView?.contentDescription = it }
     }
 
     companion object {

--- a/app/src/main/java/org/mozilla/fenix/settings/TrackingProtectionFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/TrackingProtectionFragment.kt
@@ -89,6 +89,8 @@ class TrackingProtectionFragment : PreferenceFragmentCompat() {
     private fun bindStrict() {
         val keyStrict = getString(R.string.pref_key_tracking_protection_strict_default)
         radioStrict = requireNotNull(findPreference(keyStrict))
+        radioStrict.contentDescription =
+            getString(R.string.preference_enhanced_tracking_protection_strict_info_button)
         radioStrict.onPreferenceChangeListener = object : SharedPreferenceUpdater() {
             override fun onPreferenceChange(preference: Preference, newValue: Any?): Boolean {
                 if (newValue == true) {
@@ -114,6 +116,8 @@ class TrackingProtectionFragment : PreferenceFragmentCompat() {
     private fun bindStandard() {
         val keyStandard = getString(R.string.pref_key_tracking_protection_standard_option)
         radioStandard = requireNotNull(findPreference(keyStandard))
+        radioStandard.contentDescription =
+            getString(R.string.preference_enhanced_tracking_protection_standard_info_button)
         radioStandard.onPreferenceChangeListener = object : SharedPreferenceUpdater() {
             override fun onPreferenceChange(preference: Preference, newValue: Any?): Boolean {
                 if (newValue == true) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -870,6 +870,8 @@
     <string name="preference_enhanced_tracking_protection_standard_description">Balanced for protection and performance.</string>
     <!-- Preference description for enhanced tracking protection for the standard protection settings -->
     <string name="preference_enhanced_tracking_protection_standard_description_2">Pages will load normally, but block fewer trackers.</string>
+    <!--  Accessibility text for the Standard protection information icon  -->
+    <string name="preference_enhanced_tracking_protection_standard_info_button">What\'s blocked by standard tracking protection</string>
     <!-- Preference for enhanced tracking protection for the strict protection settings -->
     <string name="preference_enhanced_tracking_protection_strict">Strict</string>
     <!-- Preference for enhanced tracking protection for the strict protection settings, default setting -->
@@ -880,6 +882,8 @@
     <string name="preference_enhanced_tracking_protection_strict_recommended">Strict (recommended)</string>
     <!-- Preference description for enhanced tracking protection for the strict protection settings -->
     <string name="preference_enhanced_tracking_protection_strict_description">Stronger protection, but may cause some sites or content to break.</string>
+    <!--  Accessibility text for the Strict protection information icon  -->
+    <string name="preference_enhanced_tracking_protection_strict_info_button">What\'s blocked by strict tracking protection</string>
     <!-- Header for categories that are being blocked by current Enhanced Tracking Protection settings -->
     <string name="enhanced_tracking_protection_blocked">Blocked</string>
     <!-- Header for categories that are being not being blocked by current Enhanced Tracking Protection settings -->


### PR DESCRIPTION
Issue #5621

Add contentDescriptions to RadioButtonInfoPreference and implement accessibility strings.
The `?.let` check is to ensure that a contentDescription set in xml does not get overridden

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

Before this would just say "Unlabelled, button"

I enabled Talk Back with the developer toggle of displaying the text on screen for this Demo GIF: (And put it in this table for readability) | ![fenix_etp_demo](https://user-images.githubusercontent.com/6266621/68003277-fdf14780-fc42-11e9-8434-86026194fd74.gif)
--- | ---


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
