### PR TITLE
Closes #6411: Upgrade Mozilla Application Services to 0.42.2

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -42,7 +42,7 @@ object Versions {
     // that we depend on directly for the fenix-megazord (and for it's
     // forUnitTest variant), and it's important that it be kept in
     // sync with the version used by android-components above.
-    const val mozilla_appservices = "0.42.0"
+    const val mozilla_appservices = "0.42.2"
 
     const val mozilla_glean = "19.0.0"
 


### PR DESCRIPTION
This is to fix Nightly which broke because A-S was upgraded in A-C, but not in Fenix:


```kotlin
 Caused by: mozilla.appservices.support.native.IncompatibleMegazordVersion: Incompatible megazord version: library "viaduct" was compiled expecting app-services version "0.42.2", but the megazord "fenix" provides version "0.42.0"
        at mozilla.appservices.support.native.HelpersKt.lookupMegazordLibrary(Helpers.kt:13)
        at mozilla.appservices.support.native.HelpersKt.findMegazordLibraryName(Helpers.kt:4)
        at mozilla.appservices.httpconfig.LibViaduct$Companion$INSTANCE$1.invoke(LibViaduct.kt:3)
        at mozilla.appservices.httpconfig.LibViaduct$Companion$INSTANCE$1.invoke(LibViaduct.kt:1)
```