### PR TITLE
For #4487 Set activity title only once in Bookmark fragment

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragment.kt
@@ -120,7 +120,6 @@ class BookmarkFragment : LibraryPageFragment<BookmarkNode>(), BackHandler {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        activity?.title = getString(R.string.library_bookmarks)
         setHasOptionsMenu(true)
     }
 

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkView.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkView.kt
@@ -150,7 +150,7 @@ class BookmarkView(
 
     private fun setUiForNormalMode(root: BookmarkNode?) {
         super.setUiForNormalMode(
-            if (BookmarkRoot.Mobile.matches(root)) context.getString(R.string.library_bookmarks) else root?.title,
+            if (BookmarkRoot.Mobile.id == root?.guid) context.getString(R.string.library_bookmarks) else root?.title,
             view.bookmark_list
         )
     }

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -255,7 +255,6 @@
     <fragment
         android:id="@+id/bookmarkFragment"
         android:name="org.mozilla.fenix.library.bookmarks.BookmarkFragment"
-        android:label="@string/library_bookmarks"
         tools:layout="@layout/fragment_bookmark">
         <argument
             android:name="currentRoot"


### PR DESCRIPTION
Removed label from nav_graph that caused label to be set for each navigation
Removed title setting in onCreate() called for each navigation
Changed logic for checking current root when setting UI for normal mode

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
