### PR TITLE
Fixes #6408: Pop stack to homeFragment when opening bookmarks from homeFragment 

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/LibraryPageFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/LibraryPageFragment.kt
@@ -16,7 +16,9 @@ abstract class LibraryPageFragment<T> : Fragment() {
     abstract val selectedItems: Set<T>
 
     protected fun close() {
-        findNavController().popBackStack(R.id.libraryFragment, true)
+        if (!findNavController().popBackStack(R.id.libraryFragment, true)) {
+            findNavController().popBackStack(R.id.homeFragment, false)
+        }
     }
 
     protected fun openItemsInNewTab(private: Boolean = false, toUrl: (T) -> String?) {


### PR DESCRIPTION
When bookmark fragment is opened from homeFragment, libraryFragment does not
exists so the popBackStack(R.id.libraryFragment, true) would have failed. So
the solution for this was to pop back stack to homeFragment when the
bookmarks/history fragments are opened from homeFragment.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks.
- [x] **Tests**: This PR does not include thorough tests.
- [x] **Screenshots**: This PR includes a [video](https://drive.google.com/open?id=1QXu-SWCRKZKF1ETmLMESLel4uS7JhM7X) showing the close button functionality from bookmarks.
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
