### PR TITLE
Use ManifestUpdateFeature

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/Components.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Components.kt
@@ -27,7 +27,7 @@ class Components(private val context: Context) {
             core.store,
             core.engine.settings,
             search.searchEngineManager,
-            core.client
+            core.webAppShortcutManager
         )
     }
     val intentProcessors by lazy {

--- a/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -30,13 +30,14 @@ import mozilla.components.feature.customtabs.store.CustomTabsServiceStore
 import mozilla.components.feature.media.MediaFeature
 import mozilla.components.feature.media.RecordingDevicesNotificationFeature
 import mozilla.components.feature.media.state.MediaStateMachine
+import mozilla.components.feature.pwa.ManifestStorage
+import mozilla.components.feature.pwa.WebAppShortcutManager
 import mozilla.components.feature.session.HistoryDelegate
 import mozilla.components.feature.webcompat.WebCompatFeature
 import mozilla.components.service.sync.logins.AsyncLoginsStorageAdapter
 import mozilla.components.service.sync.logins.SyncableLoginsStore
 import org.mozilla.fenix.AppRequestInterceptor
 import org.mozilla.fenix.FeatureFlags
-import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.test.Mockable
 import java.io.File
@@ -141,7 +142,19 @@ class Core(private val context: Context) {
      * Icons component for loading, caching and processing website icons.
      */
     val icons by lazy {
-        BrowserIcons(context, context.components.core.client)
+        BrowserIcons(context, client)
+    }
+
+    /**
+     * Shortcut component for managing shortcuts on the device home screen.
+     */
+    val webAppShortcutManager by lazy {
+        WebAppShortcutManager(
+            context,
+            client,
+            webAppManifestStorage,
+            supportWebApps = FeatureFlags.progressiveWebApps
+        )
     }
 
     /**
@@ -155,6 +168,8 @@ class Core(private val context: Context) {
     val tabCollectionStorage by lazy { TabCollectionStorage(context, sessionManager) }
 
     val permissionStorage by lazy { PermissionStorage(context) }
+
+    val webAppManifestStorage by lazy { ManifestStorage(context) }
 
     val loginsStorage by lazy {
         SyncableLoginsStore(

--- a/app/src/main/java/org/mozilla/fenix/components/UseCases.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/UseCases.kt
@@ -9,16 +9,15 @@ import mozilla.components.browser.search.SearchEngineManager
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.Settings
-import mozilla.components.concept.fetch.Client
 import mozilla.components.feature.app.links.AppLinksUseCases
 import mozilla.components.feature.contextmenu.ContextMenuUseCases
 import mozilla.components.feature.downloads.DownloadsUseCases
+import mozilla.components.feature.pwa.WebAppShortcutManager
 import mozilla.components.feature.pwa.WebAppUseCases
 import mozilla.components.feature.search.SearchUseCases
 import mozilla.components.feature.session.SessionUseCases
 import mozilla.components.feature.session.SettingsUseCases
 import mozilla.components.feature.tabs.TabsUseCases
-import org.mozilla.fenix.FeatureFlags.progressiveWebApps
 import org.mozilla.fenix.test.Mockable
 
 /**
@@ -32,7 +31,7 @@ class UseCases(
     private val store: BrowserStore,
     private val engineSettings: Settings,
     private val searchEngineManager: SearchEngineManager,
-    private val httpClient: Client
+    private val shortcutManager: WebAppShortcutManager
 ) {
     /**
      * Use cases that provide engine interactions for a given browser session.
@@ -57,7 +56,7 @@ class UseCases(
     val appLinksUseCases by lazy { AppLinksUseCases(context.applicationContext) }
 
     val webAppUseCases by lazy {
-        WebAppUseCases(context, sessionManager, httpClient, supportWebApps = progressiveWebApps)
+        WebAppUseCases(context, sessionManager, shortcutManager)
     }
 
     val downloadUseCases by lazy { DownloadsUseCases(store) }

--- a/app/src/main/java/org/mozilla/fenix/customtabs/ExternalAppBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/ExternalAppBrowserFragment.kt
@@ -18,6 +18,7 @@ import mozilla.components.concept.engine.manifest.getOrNull
 import mozilla.components.feature.contextmenu.ContextMenuCandidate
 import mozilla.components.feature.pwa.ext.getTrustedScope
 import mozilla.components.feature.pwa.ext.trustedOrigins
+import mozilla.components.feature.pwa.feature.ManifestUpdateFeature
 import mozilla.components.feature.pwa.feature.WebAppActivityFeature
 import mozilla.components.feature.pwa.feature.WebAppHideToolbarFeature
 import mozilla.components.feature.pwa.feature.WebAppSiteControlsFeature
@@ -26,6 +27,7 @@ import mozilla.components.feature.sitepermissions.SitePermissions
 import mozilla.components.lib.state.ext.consumeFrom
 import mozilla.components.support.base.feature.BackHandler
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
+import mozilla.components.support.ktx.android.arch.lifecycle.addObservers
 import org.mozilla.fenix.R
 import org.mozilla.fenix.browser.BaseBrowserFragment
 import org.mozilla.fenix.browser.CustomTabContextMenuCandidate
@@ -86,10 +88,18 @@ class ExternalAppBrowserFragment : BaseBrowserFragment(), BackHandler {
                 )
 
                 if (manifest != null) {
-                    activity.lifecycle.addObserver(
+                    activity.lifecycle.addObservers(
                         WebAppActivityFeature(
                             activity,
                             components.core.icons,
+                            manifest
+                        ),
+                        ManifestUpdateFeature(
+                            activity.applicationContext,
+                            requireComponents.core.sessionManager,
+                            requireComponents.core.webAppManifestStorage,
+                            requireComponents.core.webAppManifestStorage,
+                            customTabSessionId,
                             manifest
                         )
                     )

--- a/app/src/main/java/org/mozilla/fenix/customtabs/ExternalAppBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/ExternalAppBrowserFragment.kt
@@ -97,7 +97,7 @@ class ExternalAppBrowserFragment : BaseBrowserFragment(), BackHandler {
                         ManifestUpdateFeature(
                             activity.applicationContext,
                             requireComponents.core.sessionManager,
-                            requireComponents.core.webAppManifestStorage,
+                            requireComponents.core.webAppShortcutManager,
                             requireComponents.core.webAppManifestStorage,
                             customTabSessionId,
                             manifest

--- a/app/src/test/java/org/mozilla/fenix/components/TestComponents.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/TestComponents.kt
@@ -24,7 +24,7 @@ class TestComponents(private val context: Context) : Components(context) {
             core.store,
             core.engine.settings,
             search.searchEngineManager,
-            core.client
+            core.webAppShortcutManager
         )
     }
     override val intentProcessors by lazy {

--- a/app/src/test/java/org/mozilla/fenix/components/TestCore.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/TestCore.kt
@@ -9,12 +9,12 @@ import io.mockk.mockk
 import mozilla.components.browser.engine.gecko.GeckoEngine
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.state.store.BrowserStore
-import mozilla.components.concept.fetch.Client
+import mozilla.components.feature.pwa.WebAppShortcutManager
 
 class TestCore(context: Context) : Core(context) {
 
     override val engine = mockk<GeckoEngine>(relaxed = true)
     override val sessionManager = SessionManager(engine)
-    override val client = mockk<Client>()
     override val store = mockk<BrowserStore>()
+    override val webAppShortcutManager = mockk<WebAppShortcutManager>()
 }


### PR DESCRIPTION
Use new feature to update the stored web app manifest when PWAs are launched. Replaces the deprecated WebAppUseCases constructor.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
