### PR TITLE
For #6322 - UI tests for Account Settings View

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/syncintegration/SyncIntegrationTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/syncintegration/SyncIntegrationTest.kt
@@ -18,6 +18,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.helpers.HomeActivityTestRule
 import org.mozilla.fenix.ui.robots.homeScreen
+import org.mozilla.fenix.ui.robots.accountSettings
 
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
@@ -27,6 +28,7 @@ import androidx.test.uiautomator.Until
 import org.hamcrest.Matchers.allOf
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.TestAssetHelper
+
 import org.mozilla.fenix.helpers.ext.waitNotNull
 
 @Suppress("RECEIVER_NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS")
@@ -56,6 +58,27 @@ class SyncIntegrationTest {
         }.openThreeDotMenu {
         }.openBookmarks { }
         bookmarkAfterSyncIsShown()
+    }
+
+    @Test
+    fun checkAccountSettings() {
+        signInFxSync()
+        mDevice.waitNotNull(Until.findObjects(By.text("Settings")), TestAssetHelper.waitingTime)
+
+        goToAccountSettings()
+        // This function to be added to the robot once the status of checkboxes can be checked
+        // currently is not possible to select each one (History/Bookmark) and verify its status
+        // verifyCheckBoxesSelected()
+        // Then select/unselect each one and verify again that its status is correct
+        accountSettings {
+            verifyBookmarksCheckbox()
+            verifyHistoryCheckbox()
+            verifySignOutButton()
+            verifyDeviceName()
+        }.disconnectAccount {
+            sleep(TestAssetHelper.waitingTime)
+            verifySettingsView()
+        }
     }
 
     /* These tests will be running in the future
@@ -155,9 +178,15 @@ class SyncIntegrationTest {
         sleep(TestAssetHelper.waitingTimeShort)
         tapOnSignIn()
     }
+
+    fun goToAccountSettings() {
+        enterAccountSettings()
+        mDevice.waitNotNull(Until.findObjects(By.text("Device name")), TestAssetHelper.waitingTime)
+    }
 }
 
 fun settingsAccount() = onView(allOf(withText("Turn on Sync"))).perform(click())
 fun tapInToolBar() = onView(withId(org.mozilla.fenix.R.id.toolbar_wrapper))
 fun awesomeBar() = onView(withId(org.mozilla.fenix.R.id.mozac_browser_toolbar_edit_url_view))
 fun useEmailInsteadButton() = onView(withId(R.id.signInEmailButton)).perform(click())
+fun enterAccountSettings() = onView(withId(R.id.email)).perform(click())

--- a/app/src/androidTest/java/org/mozilla/fenix/syncintegration/SyncIntegrationTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/syncintegration/SyncIntegrationTest.kt
@@ -70,13 +70,14 @@ class SyncIntegrationTest {
         // currently is not possible to select each one (History/Bookmark) and verify its status
         // verifyCheckBoxesSelected()
         // Then select/unselect each one and verify again that its status is correct
+        // See issue #6544
         accountSettings {
             verifyBookmarksCheckbox()
             verifyHistoryCheckbox()
             verifySignOutButton()
             verifyDeviceName()
         }.disconnectAccount {
-            sleep(TestAssetHelper.waitingTime)
+            mDevice.waitNotNull(Until.findObjects(By.text("Settings")), TestAssetHelper.waitingTime)
             verifySettingsView()
         }
     }
@@ -160,7 +161,7 @@ class SyncIntegrationTest {
     }
 
     fun tapReturnToPreviousApp() {
-        sleep(TestAssetHelper.waitingTime)
+        mDevice.waitNotNull(Until.findObjects(By.text("Settings")), TestAssetHelper.waitingTime)
         mDevice.pressBack()
     }
 

--- a/app/src/androidTest/java/org/mozilla/fenix/syncintegration/test_integration.py
+++ b/app/src/androidTest/java/org/mozilla/fenix/syncintegration/test_integration.py
@@ -2,7 +2,11 @@ import os
 import sys
 
 
+def test_sync_account_settings(tps, gradlewbuild):
+    gradlewbuild.test('checkAccountSettings')
+
 def test_sync_history_from_desktop(tps, gradlewbuild):
+    os.chdir('app/src/androidTest/java/org/mozilla/fenix/syncintegration/')
     tps.run('test_history.js')
     gradlewbuild.test('checkHistoryFromDesktopTest')
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/AccountSettingsRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/AccountSettingsRobot.kt
@@ -1,0 +1,63 @@
+package org.mozilla.fenix.ui.robots
+
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.assertion.ViewAssertions
+import androidx.test.espresso.matcher.ViewMatchers
+import org.hamcrest.CoreMatchers
+import org.mozilla.fenix.R
+import org.mozilla.fenix.helpers.click
+
+/**
+ * Implementation of Robot Pattern for the URL toolbar.
+ */
+class AccountSettingsRobot {
+    fun verifyBookmarksCheckbox() = assertBookmarksCheckbox()
+
+    fun verifyHistoryCheckbox() = assertHistoryCheckbox()
+
+    fun verifySignOutButton() = assertSignOutButton()
+    fun verifyDeviceName() = assertDeviceName()
+
+    class Transition {
+
+        fun disconnectAccount(interact: SettingsRobot.() -> Unit): SettingsRobot.Transition {
+            signOutButton().click()
+            disconnectButton().click()
+
+            SettingsRobot().interact()
+            return SettingsRobot.Transition()
+        }
+    }
+}
+
+fun accountSettings(interact: AccountSettingsRobot.() -> Unit): AccountSettingsRobot.Transition {
+    AccountSettingsRobot().interact()
+    return AccountSettingsRobot.Transition()
+}
+
+private fun bookmarksCheckbox() = Espresso.onView(CoreMatchers.allOf(ViewMatchers.withText("Bookmarks")))
+private fun historyCheckbox() = Espresso.onView(CoreMatchers.allOf(ViewMatchers.withText("History")))
+
+private fun signOutButton() = Espresso.onView(CoreMatchers.allOf(ViewMatchers.withText("Sign out")))
+private fun deviceName() = Espresso.onView(CoreMatchers.allOf(ViewMatchers.withText("Device name")))
+
+private fun disconnectButton() = Espresso.onView(CoreMatchers.allOf(ViewMatchers.withId(R.id.signOutDisconnect)))
+
+private fun assertBookmarksCheckbox() = bookmarksCheckbox().check(
+        ViewAssertions.matches(
+                ViewMatchers.withEffectiveVisibility(
+                        ViewMatchers.Visibility.VISIBLE
+                )
+        )
+)
+
+private fun assertHistoryCheckbox() = historyCheckbox().check(
+        ViewAssertions.matches(
+                ViewMatchers.withEffectiveVisibility(
+                        ViewMatchers.Visibility.VISIBLE
+                )
+        )
+)
+
+private fun assertSignOutButton() = signOutButton().check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+private fun assertDeviceName() = deviceName().check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))


### PR DESCRIPTION
Fixes #6322. This PR tries to add a new test for checking the options in that menu are correct.
This test will run as part as the syncintegration test suite not regularly with the other ui tests due to the need to sign in using a verified stage account.

<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
