### PR TITLE
Add toolbar helpers

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -15,7 +15,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.CallSuper
-import androidx.appcompat.app.AppCompatActivity
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
@@ -79,6 +78,7 @@ import org.mozilla.fenix.downloads.DownloadService
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.enterToImmersiveMode
 import org.mozilla.fenix.ext.getRootView
+import org.mozilla.fenix.ext.hideToolbar
 import org.mozilla.fenix.ext.metrics
 import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.requireComponents
@@ -461,7 +461,7 @@ abstract class BaseBrowserFragment : Fragment(), BackHandler, SessionManager.Obs
             components.core.engine.settings.preferredColorScheme = preferredColorScheme
             components.useCases.sessionUseCases.reload()
         }
-        (activity as AppCompatActivity).supportActionBar?.hide()
+        hideToolbar()
 
         assignSitePermissionsRules()
     }

--- a/app/src/main/java/org/mozilla/fenix/crashes/CrashReporterFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/crashes/CrashReporterFragment.kt
@@ -6,13 +6,13 @@ package org.mozilla.fenix.crashes
 
 import android.os.Bundle
 import android.view.View
-import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import kotlinx.android.synthetic.main.fragment_crash_reporter.*
 import mozilla.components.lib.crash.Crash
 import org.mozilla.fenix.R
+import org.mozilla.fenix.ext.hideToolbar
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.settings
 
@@ -47,6 +47,6 @@ class CrashReporterFragment : Fragment(R.layout.fragment_crash_reporter) {
 
     override fun onResume() {
         super.onResume()
-        (activity as AppCompatActivity).supportActionBar?.hide()
+        hideToolbar()
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/exceptions/ExceptionsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/exceptions/ExceptionsFragment.kt
@@ -9,7 +9,6 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import kotlinx.android.synthetic.main.fragment_exceptions.view.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -20,6 +19,7 @@ import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.StoreProvider
 import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.showToolbar
 import org.mozilla.fenix.settings.SupportUtils
 
 /**
@@ -34,8 +34,7 @@ class ExceptionsFragment : Fragment() {
 
     override fun onResume() {
         super.onResume()
-        activity?.title = getString(R.string.preference_exceptions)
-        (activity as AppCompatActivity).supportActionBar?.show()
+        showToolbar(getString(R.string.preference_exceptions))
     }
 
     override fun onCreateView(

--- a/app/src/main/java/org/mozilla/fenix/ext/Fragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/Fragment.kt
@@ -6,6 +6,7 @@ package org.mozilla.fenix.ext
 
 import androidx.annotation.IdRes
 import androidx.annotation.StringRes
+import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.navigation.NavDirections
 import androidx.navigation.NavOptions
@@ -32,3 +33,20 @@ fun Fragment.nav(@IdRes id: Int?, directions: NavDirections, options: NavOptions
 }
 
 fun Fragment.getPreferenceKey(@StringRes resourceId: Int): String = getString(resourceId)
+
+/**
+ * Displays the activity toolbar with the given [title].
+ * Throws if the fragment is not attached to an [AppCompatActivity].
+ */
+fun Fragment.showToolbar(title: String) {
+    (requireActivity() as AppCompatActivity).title = title
+    (requireActivity() as AppCompatActivity).supportActionBar?.show()
+}
+
+/**
+ * Hides the activity toolbar.
+ * Throws if the fragment is not attached to an [AppCompatActivity].
+ */
+fun Fragment.hideToolbar() {
+    (requireActivity() as AppCompatActivity).supportActionBar?.hide()
+}

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -18,7 +18,6 @@ import android.widget.LinearLayout
 import android.widget.PopupWindow
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
-import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.widget.ConstraintLayout.LayoutParams.PARENT_ID
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
@@ -72,6 +71,7 @@ import org.mozilla.fenix.components.PrivateShortcutCreateManager
 import org.mozilla.fenix.components.TabCollectionStorage
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.hideToolbar
 import org.mozilla.fenix.ext.metrics
 import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.requireComponents
@@ -330,7 +330,7 @@ class HomeFragment : Fragment() {
             )
         )
 
-        (activity as AppCompatActivity).supportActionBar?.hide()
+        hideToolbar()
 
         requireComponents.backgroundServices.accountManager.register(currentMode, owner = this)
         requireComponents.backgroundServices.accountManager.register(object : AccountObserver {

--- a/app/src/main/java/org/mozilla/fenix/library/LibraryFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/LibraryFragment.kt
@@ -19,6 +19,7 @@ import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.setToolbarColors
+import org.mozilla.fenix.ext.showToolbar
 
 /**
  * Displays buttons to navigate to library sections, such as bookmarks and history.
@@ -69,15 +70,13 @@ class LibraryFragment : Fragment(R.layout.fragment_library) {
     }
 
     private fun initToolbar() {
-        val activity = activity as? AppCompatActivity
-        val toolbar = activity?.findViewById<Toolbar>(R.id.navigationToolbar)
-        context?.let { context ->
+        (activity as? AppCompatActivity)?.let { activity ->
+            val toolbar = activity.findViewById<Toolbar>(R.id.navigationToolbar)
             toolbar?.setToolbarColors(
-                foreground = context.getColorFromAttr(R.attr.primaryText),
-                background = context.getColorFromAttr(R.attr.foundation)
+                foreground = activity.getColorFromAttr(R.attr.primaryText),
+                background = activity.getColorFromAttr(R.attr.foundation)
             )
+            showToolbar(getString(R.string.library_title))
         }
-        activity?.title = getString(R.string.library_title)
-        activity?.supportActionBar?.show()
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/library/LibraryPageFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/LibraryPageFragment.kt
@@ -8,6 +8,7 @@ import androidx.fragment.app.Fragment
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.hideToolbar
 
 abstract class LibraryPageFragment<T> : Fragment() {
 
@@ -24,6 +25,6 @@ abstract class LibraryPageFragment<T> : Fragment() {
         }
 
         (activity as HomeActivity).browsingModeManager.mode = BrowsingMode.fromBoolean(private)
-        (activity as HomeActivity).supportActionBar?.hide()
+        hideToolbar()
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/addfolder/AddBookmarkFolderFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/addfolder/AddBookmarkFolderFragment.kt
@@ -10,7 +10,6 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.View.GONE
-import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.ViewModelProvider
@@ -28,6 +27,7 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.requireComponents
+import org.mozilla.fenix.ext.showToolbar
 import org.mozilla.fenix.library.bookmarks.BookmarksSharedViewModel
 
 /**
@@ -55,9 +55,7 @@ class AddBookmarkFolderFragment : Fragment(R.layout.fragment_edit_bookmark) {
 
     override fun onResume() {
         super.onResume()
-        (activity as AppCompatActivity).title =
-            getString(R.string.bookmark_add_folder_fragment_label)
-        (activity as AppCompatActivity).supportActionBar?.show()
+        showToolbar(getString(R.string.bookmark_add_folder_fragment_label))
 
         lifecycleScope.launch(Main) {
             sharedViewModel.selectedFolder = withContext(IO) {

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/selectfolder/SelectBookmarkFolderFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/selectfolder/SelectBookmarkFolderFragment.kt
@@ -11,7 +11,6 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
-import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.ViewModelProvider
@@ -30,6 +29,7 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.requireComponents
+import org.mozilla.fenix.ext.showToolbar
 import org.mozilla.fenix.library.bookmarks.BookmarksSharedViewModel
 import org.mozilla.fenix.library.bookmarks.DesktopFolders
 import org.mozilla.fenix.library.bookmarks.SignInView
@@ -57,8 +57,7 @@ class SelectBookmarkFolderFragment : Fragment() {
 
     override fun onResume() {
         super.onResume()
-        activity?.title = getString(R.string.bookmark_select_folder_fragment_label)
-        (activity as? AppCompatActivity)?.supportActionBar?.show()
+        showToolbar(getString(R.string.bookmark_select_folder_fragment_label))
 
         val accountManager = requireComponents.backgroundServices.accountManager
         sharedViewModel.observeAccountManager(accountManager, owner = this)

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragment.kt
@@ -14,7 +14,6 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.MenuRes
 import androidx.appcompat.app.AlertDialog
-import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Observer
 import androidx.lifecycle.lifecycleScope
 import kotlinx.android.synthetic.main.fragment_history.view.*
@@ -34,6 +33,7 @@ import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.requireComponents
+import org.mozilla.fenix.ext.showToolbar
 import org.mozilla.fenix.library.LibraryPageFragment
 import org.mozilla.fenix.share.ShareTab
 
@@ -122,10 +122,7 @@ class HistoryFragment : LibraryPageFragment<HistoryItem>(), BackHandler {
 
     override fun onResume() {
         super.onResume()
-        (activity as AppCompatActivity).apply {
-            title = getString(R.string.library_history)
-            supportActionBar?.show()
-        }
+        showToolbar(getString(R.string.library_history))
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {

--- a/app/src/main/java/org/mozilla/fenix/logins/SavedLoginSiteInfoFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/logins/SavedLoginSiteInfoFragment.kt
@@ -8,7 +8,6 @@ import android.os.Bundle
 import android.text.InputType
 import android.view.View
 import android.view.WindowManager
-import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.snackbar.Snackbar
@@ -17,6 +16,7 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.showToolbar
 
 class SavedLoginSiteInfoFragment : Fragment(R.layout.fragment_saved_login_site_info) {
     private val safeArguments get() = requireNotNull(arguments)
@@ -97,7 +97,6 @@ class SavedLoginSiteInfoFragment : Fragment(R.layout.fragment_saved_login_site_i
             WindowManager.LayoutParams.FLAG_SECURE,
             WindowManager.LayoutParams.FLAG_SECURE
         )
-        activity?.title = savedLoginItem.url
-        (activity as AppCompatActivity).supportActionBar?.show()
+        showToolbar(savedLoginItem.url)
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/logins/SavedLoginsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/logins/SavedLoginsFragment.kt
@@ -9,7 +9,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
-import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
@@ -25,6 +24,7 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.components.StoreProvider
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.showToolbar
 
 class SavedLoginsFragment : Fragment() {
     private lateinit var savedLoginsStore: SavedLoginsFragmentStore
@@ -37,8 +37,7 @@ class SavedLoginsFragment : Fragment() {
             WindowManager.LayoutParams.FLAG_SECURE,
             WindowManager.LayoutParams.FLAG_SECURE
         )
-        activity?.title = getString(R.string.preferences_passwords_saved_logins)
-        (activity as AppCompatActivity).supportActionBar?.show()
+        showToolbar(getString(R.string.preferences_passwords_saved_logins))
     }
 
     override fun onCreateView(

--- a/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
@@ -16,7 +16,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.ViewStub
 import androidx.appcompat.app.AlertDialog
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
@@ -38,6 +37,7 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.components.StoreProvider
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.getSpannable
+import org.mozilla.fenix.ext.hideToolbar
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.search.awesomebar.AwesomeBarView
 import org.mozilla.fenix.search.toolbar.ToolbarView
@@ -261,7 +261,7 @@ class SearchFragment : Fragment(), BackHandler {
         updateClipboardSuggestion(searchStore.state, requireContext().components.clipboardHandler.url)
 
         permissionDidUpdate = false
-        (activity as AppCompatActivity).supportActionBar?.hide()
+        hideToolbar()
     }
 
     override fun onPause() {

--- a/app/src/main/java/org/mozilla/fenix/settings/AccessibilityFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/AccessibilityFragment.kt
@@ -5,13 +5,13 @@
 package org.mozilla.fenix.settings
 
 import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreference
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.getPreferenceKey
 import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.ext.showToolbar
 
 /**
  * Displays font size controls for accessibility.
@@ -22,8 +22,7 @@ import org.mozilla.fenix.ext.settings
 class AccessibilityFragment : PreferenceFragmentCompat() {
     override fun onResume() {
         super.onResume()
-        (activity as AppCompatActivity).title = getString(R.string.preferences_accessibility)
-        (activity as AppCompatActivity).supportActionBar?.show()
+        showToolbar(getString(R.string.preferences_accessibility))
 
         val forceZoomPreference = findPreference<SwitchPreference>(
             getPreferenceKey(R.string.pref_key_accessibility_force_enable_zoom)

--- a/app/src/main/java/org/mozilla/fenix/settings/DataChoicesFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/DataChoicesFragment.kt
@@ -6,7 +6,6 @@ package org.mozilla.fenix.settings
 
 import android.content.SharedPreferences
 import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreference
 import org.mozilla.fenix.Config
@@ -14,6 +13,7 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.getPreferenceKey
 import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.ext.showToolbar
 
 /**
  * Lets the user toggle telemetry on/off.
@@ -42,8 +42,7 @@ class DataChoicesFragment : PreferenceFragmentCompat() {
 
     override fun onResume() {
         super.onResume()
-        (activity as AppCompatActivity).title = getString(R.string.preferences_data_collection)
-        (activity as AppCompatActivity).supportActionBar?.show()
+        showToolbar(getString(R.string.preferences_data_collection))
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/org/mozilla/fenix/settings/DefaultBrowserSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/DefaultBrowserSettingsFragment.kt
@@ -10,7 +10,6 @@ import android.os.Build
 import android.os.Build.VERSION.SDK_INT
 import android.os.Bundle
 import android.provider.Settings.ACTION_MANAGE_DEFAULT_APPS_SETTINGS
-import androidx.appcompat.app.AppCompatActivity
 import androidx.preference.CheckBoxPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
@@ -21,6 +20,7 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.getPreferenceKey
 import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.ext.showToolbar
 
 /**
  * Lets the user control their default browser preferences
@@ -61,9 +61,7 @@ class DefaultBrowserSettingsFragment : PreferenceFragmentCompat() {
 
     override fun onResume() {
         super.onResume()
-        (activity as AppCompatActivity).title =
-            getString(R.string.preferences_set_as_default_browser)
-        (activity as AppCompatActivity).supportActionBar?.show()
+        showToolbar(getString(R.string.preferences_set_as_default_browser))
 
         updatePreferences()
     }

--- a/app/src/main/java/org/mozilla/fenix/settings/LoginsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/LoginsFragment.kt
@@ -14,7 +14,6 @@ import android.os.Build
 import android.os.Build.VERSION_CODES.M
 import android.os.Bundle
 import androidx.appcompat.app.AlertDialog
-import androidx.appcompat.app.AppCompatActivity
 import androidx.biometric.BiometricManager
 import androidx.biometric.BiometricPrompt
 import androidx.lifecycle.lifecycleScope
@@ -34,6 +33,7 @@ import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.getPreferenceKey
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.ext.showToolbar
 import java.util.concurrent.Executors
 
 @Suppress("TooManyFunctions")
@@ -85,8 +85,7 @@ class LoginsFragment : PreferenceFragmentCompat(), AccountObserver {
 
     override fun onResume() {
         super.onResume()
-        activity?.title = getString(R.string.preferences_passwords_logins_and_passwords)
-        (activity as AppCompatActivity).supportActionBar?.show()
+        showToolbar(getString(R.string.preferences_passwords_logins_and_passwords))
 
         val savedLoginsKey = getPreferenceKey(R.string.pref_key_saved_logins)
         findPreference<Preference>(savedLoginsKey)?.setOnPreferenceClickListener {

--- a/app/src/main/java/org/mozilla/fenix/settings/PairFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/PairFragment.kt
@@ -9,7 +9,6 @@ import android.os.Bundle
 import android.os.VibrationEffect
 import android.os.Vibrator
 import android.view.View
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.getSystemService
 import androidx.core.text.HtmlCompat
 import androidx.fragment.app.Fragment
@@ -21,6 +20,7 @@ import mozilla.components.support.base.feature.BackHandler
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.requireComponents
+import org.mozilla.fenix.ext.showToolbar
 
 class PairFragment : Fragment(R.layout.fragment_pair), BackHandler {
 
@@ -74,8 +74,7 @@ class PairFragment : Fragment(R.layout.fragment_pair), BackHandler {
 
     override fun onResume() {
         super.onResume()
-        (activity as AppCompatActivity).title = getString(R.string.sync_scan_code)
-        (activity as AppCompatActivity).supportActionBar?.show()
+        showToolbar(getString(R.string.sync_scan_code))
     }
 
     override fun onBackPressed(): Boolean {

--- a/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
@@ -10,7 +10,6 @@ import android.content.Intent
 import android.content.SharedPreferences
 import android.net.Uri
 import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.Navigation
 import androidx.navigation.fragment.findNavController
@@ -59,6 +58,7 @@ import org.mozilla.fenix.ext.getPreferenceKey
 import org.mozilla.fenix.ext.metrics
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.ext.showToolbar
 import org.mozilla.fenix.settings.account.AccountAuthErrorPreference
 import org.mozilla.fenix.settings.account.AccountPreference
 import org.mozilla.fenix.utils.ItsNotBrokenSnack
@@ -112,8 +112,7 @@ class SettingsFragment : PreferenceFragmentCompat(), AccountObserver {
     override fun onResume() {
         super.onResume()
 
-        (activity as AppCompatActivity).title = getString(R.string.settings_title)
-        (activity as AppCompatActivity).supportActionBar?.show()
+        showToolbar(getString(R.string.settings_title))
 
         val trackingProtectionPreference =
             findPreference<Preference>(getPreferenceKey(pref_key_tracking_protection_settings))

--- a/app/src/main/java/org/mozilla/fenix/settings/ThemeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/ThemeFragment.kt
@@ -8,12 +8,12 @@ import android.annotation.SuppressLint
 import android.os.Build
 import android.os.Build.VERSION.SDK_INT
 import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.preference.PreferenceFragmentCompat
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.getPreferenceKey
 import org.mozilla.fenix.ext.requireComponents
+import org.mozilla.fenix.ext.showToolbar
 
 class ThemeFragment : PreferenceFragmentCompat() {
     private lateinit var radioLightTheme: RadioButtonPreference
@@ -27,8 +27,7 @@ class ThemeFragment : PreferenceFragmentCompat() {
 
     override fun onResume() {
         super.onResume()
-        (activity as AppCompatActivity).title = getString(R.string.preferences_theme)
-        (activity as AppCompatActivity).supportActionBar?.show()
+        showToolbar(getString(R.string.preferences_theme))
         setupPreferences()
     }
 

--- a/app/src/main/java/org/mozilla/fenix/settings/TrackingProtectionFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/TrackingProtectionFragment.kt
@@ -5,7 +5,6 @@
 package org.mozilla.fenix.settings
 
 import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.findNavController
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
@@ -19,6 +18,7 @@ import org.mozilla.fenix.ext.getPreferenceKey
 import org.mozilla.fenix.ext.metrics
 import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.ext.showToolbar
 
 /**
  * Displays the toggle for tracking protection and a button to open
@@ -41,8 +41,7 @@ class TrackingProtectionFragment : PreferenceFragmentCompat() {
 
     override fun onResume() {
         super.onResume()
-        activity?.title = getString(R.string.preference_enhanced_tracking_protection)
-        (activity as AppCompatActivity).supportActionBar?.show()
+        showToolbar(getString(R.string.preference_enhanced_tracking_protection))
 
         // Tracking Protection Switch
         val trackingProtectionKey = getPreferenceKey(R.string.pref_key_tracking_protection)

--- a/app/src/main/java/org/mozilla/fenix/settings/account/AccountProblemFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/account/AccountProblemFragment.kt
@@ -5,7 +5,6 @@
 package org.mozilla.fenix.settings.account
 
 import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.preference.Preference
@@ -19,6 +18,7 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.getPreferenceKey
 import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.requireComponents
+import org.mozilla.fenix.ext.showToolbar
 
 class AccountProblemFragment : PreferenceFragmentCompat(), AccountObserver {
 
@@ -42,8 +42,7 @@ class AccountProblemFragment : PreferenceFragmentCompat(), AccountObserver {
 
     override fun onResume() {
         super.onResume()
-        (activity as AppCompatActivity).title = getString(R.string.sync_reconnect)
-        (activity as AppCompatActivity).supportActionBar?.show()
+        showToolbar(getString(R.string.sync_reconnect))
 
         val accountManager = requireComponents.backgroundServices.accountManager
         accountManager.register(this, owner = this)

--- a/app/src/main/java/org/mozilla/fenix/settings/account/AccountSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/account/AccountSettingsFragment.kt
@@ -14,7 +14,6 @@ import android.text.InputFilter
 import android.text.format.DateUtils
 import android.view.View
 import androidx.appcompat.app.AlertDialog
-import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.preference.CheckBoxPreference
@@ -43,6 +42,7 @@ import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.getPreferenceKey
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.ext.showToolbar
 
 @SuppressWarnings("TooManyFunctions", "LargeClass")
 class AccountSettingsFragment : PreferenceFragmentCompat() {
@@ -73,8 +73,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat() {
 
     override fun onResume() {
         super.onResume()
-        (activity as AppCompatActivity).title = getString(R.string.preferences_account_settings)
-        (activity as AppCompatActivity).supportActionBar?.show()
+        showToolbar(getString(R.string.preferences_account_settings))
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/org/mozilla/fenix/settings/account/TurnOnSyncFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/account/TurnOnSyncFragment.kt
@@ -8,7 +8,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.text.HtmlCompat
 import androidx.fragment.app.Fragment
 import androidx.navigation.findNavController
@@ -21,6 +20,7 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.requireComponents
+import org.mozilla.fenix.ext.showToolbar
 
 @SuppressWarnings("TooManyFunctions")
 class TurnOnSyncFragment : Fragment(), AccountObserver {
@@ -58,8 +58,7 @@ class TurnOnSyncFragment : Fragment(), AccountObserver {
         }
 
         requireComponents.backgroundServices.accountManager.register(this, owner = this)
-        (activity as AppCompatActivity).title = getString(R.string.preferences_sync)
-        (activity as AppCompatActivity).supportActionBar?.show()
+        showToolbar(getString(R.string.preferences_sync))
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {

--- a/app/src/main/java/org/mozilla/fenix/settings/deletebrowsingdata/DeleteBrowsingDataFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/deletebrowsingdata/DeleteBrowsingDataFragment.kt
@@ -8,7 +8,6 @@ import android.content.DialogInterface
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AlertDialog
-import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.lifecycle.lifecycleScope
@@ -24,6 +23,7 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.requireComponents
+import org.mozilla.fenix.ext.showToolbar
 
 @SuppressWarnings("TooManyFunctions")
 class DeleteBrowsingDataFragment : Fragment(R.layout.fragment_delete_browsing_data) {
@@ -71,10 +71,7 @@ class DeleteBrowsingDataFragment : Fragment(R.layout.fragment_delete_browsing_da
 
     override fun onResume() {
         super.onResume()
-        (activity as AppCompatActivity).apply {
-            title = getString(R.string.preferences_delete_browsing_data)
-            supportActionBar?.show()
-        }
+        showToolbar(getString(R.string.preferences_delete_browsing_data))
 
         getCheckboxes().forEach {
             it.visibility = View.VISIBLE

--- a/app/src/main/java/org/mozilla/fenix/settings/deletebrowsingdata/DeleteBrowsingDataOnQuitFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/deletebrowsingdata/DeleteBrowsingDataOnQuitFragment.kt
@@ -5,7 +5,6 @@
 package org.mozilla.fenix.settings.deletebrowsingdata
 
 import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
 import androidx.preference.CheckBoxPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
@@ -13,6 +12,7 @@ import androidx.preference.SwitchPreference
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.getPreferenceKey
 import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.ext.showToolbar
 import org.mozilla.fenix.settings.SharedPreferenceUpdater
 
 class DeleteBrowsingDataOnQuitFragment : PreferenceFragmentCompat() {
@@ -36,8 +36,7 @@ class DeleteBrowsingDataOnQuitFragment : PreferenceFragmentCompat() {
     @Suppress("ComplexMethod")
     override fun onResume() {
         super.onResume()
-        activity?.title = getString(R.string.preferences_delete_browsing_data_on_quit)
-        (activity as AppCompatActivity).supportActionBar?.show()
+        showToolbar(getString(R.string.preferences_delete_browsing_data_on_quit))
 
         // Delete Browsing Data on Quit Switch
         val deleteOnQuitPref = findPreference<SwitchPreference>(

--- a/app/src/main/java/org/mozilla/fenix/settings/search/SearchEngineFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/search/SearchEngineFragment.kt
@@ -5,7 +5,6 @@
 package org.mozilla.fenix.settings.search
 
 import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.fragment.findNavController
 import androidx.preference.Preference
 import androidx.preference.CheckBoxPreference
@@ -14,6 +13,7 @@ import androidx.preference.SwitchPreference
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.getPreferenceKey
 import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.ext.showToolbar
 import org.mozilla.fenix.settings.SharedPreferenceUpdater
 
 class SearchEngineFragment : PreferenceFragmentCompat() {
@@ -24,8 +24,7 @@ class SearchEngineFragment : PreferenceFragmentCompat() {
 
     override fun onResume() {
         super.onResume()
-        (activity as AppCompatActivity).title = getString(R.string.preferences_search)
-        (activity as AppCompatActivity).supportActionBar?.show()
+        showToolbar(getString(R.string.preferences_search))
 
         val searchSuggestionsPreference =
             findPreference<SwitchPreference>(getPreferenceKey(R.string.pref_key_show_search_suggestions))?.apply {

--- a/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsDetailsExceptionsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsDetailsExceptionsFragment.kt
@@ -7,7 +7,6 @@ package org.mozilla.fenix.settings.sitepermissions
 import android.content.DialogInterface
 import android.os.Bundle
 import androidx.appcompat.app.AlertDialog
-import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.Navigation
 import androidx.preference.Preference
@@ -19,13 +18,13 @@ import mozilla.components.feature.sitepermissions.SitePermissions
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.getPreferenceKey
+import org.mozilla.fenix.ext.showToolbar
 import org.mozilla.fenix.settings.PhoneFeature
 import org.mozilla.fenix.settings.PhoneFeature.CAMERA
 import org.mozilla.fenix.settings.PhoneFeature.LOCATION
 import org.mozilla.fenix.settings.PhoneFeature.MICROPHONE
 import org.mozilla.fenix.settings.PhoneFeature.NOTIFICATION
 
-@SuppressWarnings("TooManyFunctions")
 class SitePermissionsDetailsExceptionsFragment : PreferenceFragmentCompat() {
     private lateinit var sitePermissions: SitePermissions
 
@@ -43,10 +42,7 @@ class SitePermissionsDetailsExceptionsFragment : PreferenceFragmentCompat() {
 
     override fun onResume() {
         super.onResume()
-        (activity as AppCompatActivity).apply {
-            title = sitePermissions.origin
-            supportActionBar?.show()
-        }
+        showToolbar(sitePermissions.origin)
         lifecycleScope.launch(IO) {
             val context = requireContext()
             sitePermissions =

--- a/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsFragment.kt
@@ -5,7 +5,6 @@
 package org.mozilla.fenix.settings.sitepermissions
 
 import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.Navigation
 import androidx.preference.Preference
 import androidx.preference.Preference.OnPreferenceClickListener
@@ -14,6 +13,7 @@ import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.getPreferenceKey
 import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.ext.showToolbar
 import org.mozilla.fenix.settings.PhoneFeature
 
 @SuppressWarnings("TooManyFunctions")
@@ -21,8 +21,7 @@ class SitePermissionsFragment : PreferenceFragmentCompat() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        (activity as AppCompatActivity).title = getString(R.string.preferences_site_permissions)
-        (activity as AppCompatActivity).supportActionBar?.show()
+        showToolbar(getString(R.string.preferences_site_permissions))
     }
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {

--- a/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsManageExceptionsPhoneFeatureFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsManageExceptionsPhoneFeatureFragment.kt
@@ -15,7 +15,6 @@ import android.view.ViewGroup
 import android.widget.Button
 import android.widget.RadioButton
 import androidx.appcompat.app.AlertDialog
-import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.Dispatchers.IO
@@ -26,6 +25,7 @@ import mozilla.components.feature.sitepermissions.SitePermissions.Status.BLOCKED
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.ext.showToolbar
 import org.mozilla.fenix.settings.PhoneFeature
 import org.mozilla.fenix.settings.initBlockedByAndroidView
 import org.mozilla.fenix.settings.setStartCheckedIndicator
@@ -50,8 +50,7 @@ class SitePermissionsManageExceptionsPhoneFeatureFragment : Fragment() {
             .fromBundle(requireArguments())
             .sitePermissions
 
-        (activity as AppCompatActivity).title = phoneFeature.getLabel(requireContext())
-        (activity as AppCompatActivity).supportActionBar?.show()
+        showToolbar(phoneFeature.getLabel(requireContext()))
     }
 
     override fun onCreateView(

--- a/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsManagePhoneFeatureFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsManagePhoneFeatureFragment.kt
@@ -19,7 +19,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.RadioButton
-import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import mozilla.components.feature.sitepermissions.SitePermissionsRules
 import mozilla.components.feature.sitepermissions.SitePermissionsRules.Action.ASK_TO_ALLOW
@@ -27,6 +26,7 @@ import mozilla.components.feature.sitepermissions.SitePermissionsRules.Action.BL
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.ext.showToolbar
 import org.mozilla.fenix.settings.PhoneFeature
 import org.mozilla.fenix.settings.initBlockedByAndroidView
 import org.mozilla.fenix.settings.setStartCheckedIndicator
@@ -45,8 +45,7 @@ class SitePermissionsManagePhoneFeatureFragment : Fragment() {
             .fromBundle(requireArguments())
             .permission.toPhoneFeature()
 
-        (activity as AppCompatActivity).title = phoneFeature.getLabel(requireContext())
-        (activity as AppCompatActivity).supportActionBar?.show()
+        showToolbar(phoneFeature.getLabel(requireContext()))
         settings = requireContext().settings()
     }
 

--- a/app/src/main/java/org/mozilla/fenix/share/AddNewDeviceFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/share/AddNewDeviceFragment.kt
@@ -7,10 +7,10 @@ package org.mozilla.fenix.share
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AlertDialog
-import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import kotlinx.android.synthetic.main.fragment_add_new_device.*
 import org.mozilla.fenix.R
+import org.mozilla.fenix.ext.showToolbar
 import org.mozilla.fenix.settings.SupportUtils
 
 /**
@@ -20,8 +20,7 @@ class AddNewDeviceFragment : Fragment(R.layout.fragment_add_new_device) {
 
     override fun onResume() {
         super.onResume()
-        (activity as AppCompatActivity).title = getString(R.string.sync_add_new_device_title)
-        (activity as AppCompatActivity).supportActionBar?.show()
+        showToolbar(getString(R.string.sync_add_new_device_title))
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionBlockingFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionBlockingFragment.kt
@@ -6,12 +6,12 @@ package org.mozilla.fenix.trackingprotection
 
 import android.os.Bundle
 import android.view.View
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.navArgs
 import kotlinx.android.synthetic.main.fragment_tracking_protection_blocking.*
 import org.mozilla.fenix.R
+import org.mozilla.fenix.ext.showToolbar
 
 class TrackingProtectionBlockingFragment :
     Fragment(R.layout.fragment_tracking_protection_blocking) {
@@ -26,8 +26,7 @@ class TrackingProtectionBlockingFragment :
 
     override fun onResume() {
         super.onResume()
-        (activity as AppCompatActivity).title = getTitle()
-        (activity as AppCompatActivity).supportActionBar?.show()
+        showToolbar(getTitle())
     }
 
     private fun getTitle(): String {


### PR DESCRIPTION
Adds helper function for displaying the toolbar/action bar with a title.
I chose to throw if the cast fails because we usually already do that, and it's probably a failure state if the fragment is attached to something unexpected.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
