### PR TITLE
Use consistent verbiage with regard to opened tabs

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
@@ -203,7 +203,7 @@ private fun assertAddTabButton() =
         .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
 private fun assertNoTabsOpenedHeader() =
-    onView(CoreMatchers.allOf(ViewMatchers.withText("No tabs opened")))
+    onView(CoreMatchers.allOf(ViewMatchers.withText("No open tabs")))
         .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
 private fun assertNoTabsOpenedText() {

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlUIView.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlUIView.kt
@@ -20,7 +20,7 @@ import org.mozilla.fenix.mvi.UIView
 
 val noTabMessage = AdapterItem.NoContentMessage(
     R.drawable.ic_tabs,
-    R.string.no_open_tabs_header,
+    R.string.no_open_tabs_header_2,
     R.string.no_open_tabs_description
 )
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,7 +15,7 @@
     <!-- Placeholder text shown in the search bar before a user enters text -->
     <string name="search_hint">Search or enter address</string>
     <!-- No Open Tabs Message Header -->
-    <string name="no_open_tabs_header">No tabs opened</string>
+    <string name="no_open_tabs_header_2">No open tabs</string>
     <!-- No Open Tabs Message Description -->
     <string name="no_open_tabs_description">Your open tabs will be shown here.</string>
 


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

This is just an idea but I'm finding the "tab opened" / "open tabs" language to be inconsistent.

<img width="335" alt="TabLanguage" src="https://user-images.githubusercontent.com/46655/68620666-a26d5800-0493-11ea-82d6-7243ecd04d10.png">


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
