### PR TITLE
Issue #6196: Make initialization of Glean metrics faster

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
@@ -6,9 +6,8 @@ package org.mozilla.fenix.components.metrics
 
 import android.content.Context
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.MainScope
 import mozilla.components.service.glean.BuildConfig
 import mozilla.components.service.glean.Glean
 import mozilla.components.service.glean.config.Configuration
@@ -416,7 +415,8 @@ class GleanMetricsService(private val context: Context) : MetricsService {
      * We need to keep an eye on when we are done starting so that we don't
      * accidentally stop ourselves before we've ever started.
      */
-    private lateinit var starter: Job
+    private lateinit var gleanInitializer: Job
+    private lateinit var gleanSetStartupMetrics: Job
 
     private val activationPing = ActivationPing(context)
 
@@ -431,7 +431,7 @@ class GleanMetricsService(private val context: Context) : MetricsService {
         // because it calls Google ad APIs that must be called *off* of the main thread.
         // These two things actually happen in parallel, but that should be ok because Glean
         // can handle events being recorded before it's initialized.
-        starter = MainScope().launch {
+        gleanInitializer = MainScope().launch {
             Glean.registerPings(Pings)
             Glean.initialize(context,
                 Configuration(channel = BuildConfig.BUILD_TYPE,
@@ -439,8 +439,11 @@ class GleanMetricsService(private val context: Context) : MetricsService {
                         lazy(LazyThreadSafetyMode.NONE) { context.components.core.client }
                     )))
         }
-
-        setStartupMetrics()
+        // setStartupMetrics is not a fast function. It does not need to be done before we can consider
+        // ourselves initialized. So, let's do it, well, later.
+        gleanSetStartupMetrics = MainScope().launch {
+            setStartupMetrics()
+        }
 
         context.settings().totalUriCount = 0
     }
@@ -472,10 +475,8 @@ class GleanMetricsService(private val context: Context) : MetricsService {
     }
 
     override fun stop() {
-        /*
-         * We cannot stop until we're done starting.
-         */
-        runBlocking { starter.join(); }
+        gleanInitializer.cancel()
+        gleanSetStartupMetrics.cancel()
         Glean.setUploadEnabled(false)
     }
 


### PR DESCRIPTION
setStartupMetrics is very expensive and does not need to be
done synchronously at the time the Glean Metrics Service is
initialized.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
