### PR TITLE
Fix missing Firebase token in nightly and production builds

### DIFF
--- a/taskcluster/fenix_taskgraph/transforms/build.py
+++ b/taskcluster/fenix_taskgraph/transforms/build.py
@@ -35,6 +35,7 @@ def add_shippable_secrets(config, tasks):
 
         if task.pop("include-shippable-secrets", False) and config.params["level"] == "3":
             build_type = task["attributes"]["build-type"]
+            gradle_build_type = task["run"]["gradle-build-type"]
             secret_index = 'project/mobile/fenix/{}'.format(build_type)
             secrets.extend([{
                 "key": key,
@@ -42,7 +43,7 @@ def add_shippable_secrets(config, tasks):
                 "path": target_file,
             } for key, target_file in (
                 ('adjust', '.adjust_token'),
-                ('firebase', 'app/src/{}/res/values/firebase.xml'.format(build_type)),
+                ('firebase', 'app/src/{}/res/values/firebase.xml'.format(gradle_build_type)),
                 ('digital_asset_links', '.digital_asset_links_token'),
                 ('leanplum', '.leanplum_token'),
                 ('sentry_dsn', '.sentry_token'),


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

Fixes a fallout of https://github.com/mozilla-mobile/fenix/pull/5488. 

Symptom: Push notifications are broken for every Fenix 2.Y.Z except 2.0.0. The APKs don't include some firebase tokens anymore. 

Root cause: The build task doesn't put the token file in the right directory anymore because of https://github.com/mozilla-mobile/fenix/pull/5488/files#diff-3a2aaafc93fc8bb53e2029001aa236aeR45. Because it's not in the right directory, it doesn't get baked in the final APK. 
The last working nightly was done [in this task](https://tools.taskcluster.net/groups/bwpDJ2a_SjmzOPbfQcjt1w/tasks/a2AArVSHQQCaceElg_8MnQ/details). The first broken one [was that one](https://tools.taskcluster.net/groups/bwpDJ2a_SjmzOPbfQcjt1w/tasks/a2AArVSHQQCaceElg_8MnQ/details). Note this difference in the command:

```diff
- automation/taskcluster/helper/get-secret.py -s project/mobile/fenix/nightly -k firebase -f app/src/fenixNightly/res/values/firebase.xml
+ automation/taskcluster/helper/get-secret.py -s project/mobile/fenix/nightly -k firebase -f app/src/nightly/res/values/firebase.xml 
```

This PR changes the nightly and the release graphs, this way: 

* nightly
```py
[
    "change",
    [
        "build-nightly",
        "task",
        "payload",
        "command",
        8
    ],
    [
        "taskcluster/scripts/get-secret.py -s project/mobile/fenix/nightly -k adjust -f .adjust_token && taskcluster/scripts/get-secret.py -s project/mobile/fenix/nightly -k firebase -f app/src/nightly/res/values/firebase.xml && taskcluster/scripts/get-secret.py -s project/mobile/fenix/nightly -k digital_asset_links -f .digital_asset_links_token && taskcluster/scripts/get-secret.py -s project/mobile/fenix/nightly -k leanplum -f .leanplum_token && taskcluster/scripts/get-secret.py -s project/mobile/fenix/nightly -k sentry_dsn -f .sentry_token && ./gradlew clean assembleGeckoNightlyFenixNightly '-PversionName=Nightly 191004 06:00'",
        "taskcluster/scripts/get-secret.py -s project/mobile/fenix/nightly -k adjust -f .adjust_token && taskcluster/scripts/get-secret.py -s project/mobile/fenix/nightly -k firebase -f app/src/fenixNightly/res/values/firebase.xml && taskcluster/scripts/get-secret.py -s project/mobile/fenix/nightly -k digital_asset_links -f .digital_asset_links_token && taskcluster/scripts/get-secret.py -s project/mobile/fenix/nightly -k leanplum -f .leanplum_token && taskcluster/scripts/get-secret.py -s project/mobile/fenix/nightly -k sentry_dsn -f .sentry_token && ./gradlew clean assembleGeckoNightlyFenixNightly '-PversionName=Nightly 191004 06:00'"
    ]
]
[
    "change",
    [
        "build-fennec-production",
        "task",
        "payload",
        "command",
        8
    ],
    [
        "taskcluster/scripts/get-secret.py -s project/mobile/fenix/fennec-production -k adjust -f .adjust_token && taskcluster/scripts/get-secret.py -s project/mobile/fenix/fennec-production -k firebase -f app/src/fennec-production/res/values/firebase.xml && taskcluster/scripts/get-secret.py -s project/mobile/fenix/fennec-production -k digital_asset_links -f .digital_asset_links_token && taskcluster/scripts/get-secret.py -s project/mobile/fenix/fennec-production -k leanplum -f .leanplum_token && taskcluster/scripts/get-secret.py -s project/mobile/fenix/fennec-production -k sentry_dsn -f .sentry_token && ./gradlew clean assembleGeckoBetaFennecProduction '-PversionName=Nightly 191004 06:00'",
        "taskcluster/scripts/get-secret.py -s project/mobile/fenix/fennec-production -k adjust -f .adjust_token && taskcluster/scripts/get-secret.py -s project/mobile/fenix/fennec-production -k firebase -f app/src/fennecProduction/res/values/firebase.xml && taskcluster/scripts/get-secret.py -s project/mobile/fenix/fennec-production -k digital_asset_links -f .digital_asset_links_token && taskcluster/scripts/get-secret.py -s project/mobile/fenix/fennec-production -k leanplum -f .leanplum_token && taskcluster/scripts/get-secret.py -s project/mobile/fenix/fennec-production -k sentry_dsn -f .sentry_token && ./gradlew clean assembleGeckoBetaFennecProduction '-PversionName=Nightly 191004 06:00'"
    ]
]
```

* beta

```py
[
    "change",
    [
        "build-production",
        "task",
        "payload",
        "command",
        8
    ],
    [
        "taskcluster/scripts/get-secret.py -s project/mobile/fenix/production -k adjust -f .adjust_token && taskcluster/scripts/get-secret.py -s project/mobile/fenix/production -k firebase -f app/src/production/res/values/firebase.xml && taskcluster/scripts/get-secret.py -s project/mobile/fenix/production -k digital_asset_links -f .digital_asset_links_token && taskcluster/scripts/get-secret.py -s project/mobile/fenix/production -k leanplum -f .leanplum_token && taskcluster/scripts/get-secret.py -s project/mobile/fenix/production -k sentry_dsn -f .sentry_token && ./gradlew clean assembleGeckoBetaFenixProduction -PversionName=2.1.0-beta.0",
        "taskcluster/scripts/get-secret.py -s project/mobile/fenix/production -k adjust -f .adjust_token && taskcluster/scripts/get-secret.py -s project/mobile/fenix/production -k firebase -f app/src/fenixProduction/res/values/firebase.xml && taskcluster/scripts/get-secret.py -s project/mobile/fenix/production -k digital_asset_links -f .digital_asset_links_token && taskcluster/scripts/get-secret.py -s project/mobile/fenix/production -k leanplum -f .leanplum_token && taskcluster/scripts/get-secret.py -s project/mobile/fenix/production -k sentry_dsn -f .sentry_token && ./gradlew clean assembleGeckoBetaFenixProduction -PversionName=2.1.0-beta.0"
    ]
]
```

* release

```py
[
    "change",
    [
        "build-production",
        "task",
        "payload",
        "command",
        8
    ],
    [
        "taskcluster/scripts/get-secret.py -s project/mobile/fenix/production -k adjust -f .adjust_token && taskcluster/scripts/get-secret.py -s project/mobile/fenix/production -k firebase -f app/src/production/res/values/firebase.xml && taskcluster/scripts/get-secret.py -s project/mobile/fenix/production -k digital_asset_links -f .digital_asset_links_token && taskcluster/scripts/get-secret.py -s project/mobile/fenix/production -k leanplum -f .leanplum_token && taskcluster/scripts/get-secret.py -s project/mobile/fenix/production -k sentry_dsn -f .sentry_token && ./gradlew clean assembleGeckoBetaFenixProduction -PversionName=2.1.0",
        "taskcluster/scripts/get-secret.py -s project/mobile/fenix/production -k adjust -f .adjust_token && taskcluster/scripts/get-secret.py -s project/mobile/fenix/production -k firebase -f app/src/fenixProduction/res/values/firebase.xml && taskcluster/scripts/get-secret.py -s project/mobile/fenix/production -k digital_asset_links -f .digital_asset_links_token && taskcluster/scripts/get-secret.py -s project/mobile/fenix/production -k leanplum -f .leanplum_token && taskcluster/scripts/get-secret.py -s project/mobile/fenix/production -k sentry_dsn -f .sentry_token && ./gradlew clean assembleGeckoBetaFenixProduction -PversionName=2.1.0"
    ]
]
```

### Testing

Except the diff in the task definitions showed above, I don't have any other way to test this patch out other than landing it and waiting to the next nightly to come up. I'll check the token are back.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
