### PR TITLE
Fixes #5085 - Use CustomTabWindowFeature

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -53,7 +53,6 @@ import mozilla.components.feature.session.SwipeRefreshFeature
 import mozilla.components.feature.sitepermissions.SitePermissions
 import mozilla.components.feature.sitepermissions.SitePermissionsFeature
 import mozilla.components.feature.sitepermissions.SitePermissionsRules
-import mozilla.components.feature.tabs.WindowFeature
 import mozilla.components.support.base.feature.BackHandler
 import mozilla.components.support.base.feature.PermissionsFeature
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
@@ -103,7 +102,6 @@ abstract class BaseBrowserFragment : Fragment(), BackHandler, SessionManager.Obs
     protected val readerViewFeature = ViewBoundFeatureWrapper<ReaderViewFeature>()
 
     private val sessionFeature = ViewBoundFeatureWrapper<SessionFeature>()
-    private val windowFeature = ViewBoundFeatureWrapper<WindowFeature>()
     private val contextMenuFeature = ViewBoundFeatureWrapper<ContextMenuFeature>()
     private val downloadsFeature = ViewBoundFeatureWrapper<DownloadsFeature>()
     private val appLinksFeature = ViewBoundFeatureWrapper<AppLinksFeature>()
@@ -238,15 +236,6 @@ abstract class BaseBrowserFragment : Fragment(), BackHandler, SessionManager.Obs
                     engineView = view.engineView,
                     useCases = context.components.useCases.contextMenuUseCases,
                     customTabId = customTabSessionId
-                ),
-                owner = this,
-                view = view
-            )
-
-            windowFeature.set(
-                feature = WindowFeature(
-                    store = store,
-                    tabsUseCases = context.components.useCases.tabsUseCases
                 ),
                 owner = this,
                 view = view

--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -22,18 +22,19 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.Observer
 import androidx.transition.TransitionInflater
 import com.google.android.material.snackbar.Snackbar
-import kotlinx.android.synthetic.main.fragment_browser.view.browserLayout
-import kotlinx.android.synthetic.main.fragment_browser.view.readerViewControlsBar
-import kotlinx.android.synthetic.main.fragment_home.bottom_bar
-import kotlinx.android.synthetic.main.tracking_protection_onboarding_popup.view.onboarding_message
+import kotlinx.android.synthetic.main.fragment_browser.view.*
+import kotlinx.android.synthetic.main.fragment_home.*
+import kotlinx.android.synthetic.main.tracking_protection_onboarding_popup.view.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.components.browser.session.Session
 import mozilla.components.feature.contextmenu.ContextMenuCandidate
 import mozilla.components.feature.readerview.ReaderViewFeature
 import mozilla.components.feature.session.TrackingProtectionUseCases
 import mozilla.components.feature.sitepermissions.SitePermissions
+import mozilla.components.feature.tabs.WindowFeature
 import mozilla.components.lib.state.ext.consumeFrom
 import mozilla.components.support.base.feature.BackHandler
+import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
 import org.jetbrains.anko.dimen
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
@@ -54,8 +55,10 @@ import org.mozilla.fenix.mvi.getManagedEmitter
  * Fragment used for browsing the web within the main app.
  */
 @ExperimentalCoroutinesApi
-@Suppress("TooManyFunctions", "LargeClass")
+@Suppress("TooManyFunctions")
 class BrowserFragment : BaseBrowserFragment(), BackHandler {
+
+    private val windowFeature = ViewBoundFeatureWrapper<WindowFeature>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -96,6 +99,15 @@ class BrowserFragment : BaseBrowserFragment(), BackHandler {
                         context.components.analytics.metrics.track(Event.ReaderModeAvailable)
                     }
                 },
+                owner = this,
+                view = view
+            )
+
+            windowFeature.set(
+                feature = WindowFeature(
+                    store = context.components.core.store,
+                    tabsUseCases = context.components.useCases.tabsUseCases
+                ),
                 owner = this,
                 view = view
             )

--- a/app/src/main/java/org/mozilla/fenix/customtabs/ExternalAppBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/ExternalAppBrowserFragment.kt
@@ -16,6 +16,7 @@ import mozilla.components.browser.session.Session
 import mozilla.components.concept.engine.manifest.WebAppManifestParser
 import mozilla.components.concept.engine.manifest.getOrNull
 import mozilla.components.feature.contextmenu.ContextMenuCandidate
+import mozilla.components.feature.customtabs.CustomTabWindowFeature
 import mozilla.components.feature.pwa.ext.getTrustedScope
 import mozilla.components.feature.pwa.ext.trustedOrigins
 import mozilla.components.feature.pwa.feature.ManifestUpdateFeature
@@ -45,6 +46,7 @@ class ExternalAppBrowserFragment : BaseBrowserFragment(), BackHandler {
     private val args by navArgs<ExternalAppBrowserFragmentArgs>()
 
     private val customTabsIntegration = ViewBoundFeatureWrapper<CustomTabsIntegration>()
+    private val windowFeature = ViewBoundFeatureWrapper<CustomTabWindowFeature>()
     private val hideToolbarFeature = ViewBoundFeatureWrapper<WebAppHideToolbarFeature>()
 
     @Suppress("LongMethod")
@@ -70,6 +72,16 @@ class ExternalAppBrowserFragment : BaseBrowserFragment(), BackHandler {
                     ),
                     owner = this,
                     view = view)
+
+                windowFeature.set(
+                    feature = CustomTabWindowFeature(
+                        activity,
+                        components.core.store,
+                        customTabSessionId
+                    ),
+                    owner = this,
+                    view = view
+                )
 
                 hideToolbarFeature.set(
                     feature = WebAppHideToolbarFeature(


### PR DESCRIPTION
Opens _blank links in new custom tab. Bringing this PR back after playing around with it.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

Currently this PR will show the "Open in normal/private mode" popup when opening a window. mozilla-mobile/android-components#5061 will fix that.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
