### PR TITLE
Fixes #3743 - Separate onboarding adapter

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/ext/Session.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/Session.kt
@@ -13,14 +13,13 @@ import org.mozilla.fenix.home.sessioncontrol.Tab
 fun Session.toTab(context: Context, selected: Boolean? = null, mediaState: MediaState? = null): Tab =
     this.toTab(context.components.publicSuffixList, selected, mediaState)
 
-fun Session.toTab(publicSuffixList: PublicSuffixList, selected: Boolean? = null, mediaState: MediaState? = null): Tab {
-    return Tab(
-        this.id,
-        this.url,
-        this.url.urlToTrimmedHost(publicSuffixList),
-        this.title,
-        selected,
-        mediaState,
-        this.icon
+fun Session.toTab(publicSuffixList: PublicSuffixList, selected: Boolean? = null, mediaState: MediaState? = null) =
+    Tab(
+        sessionId = id,
+        url = url,
+        hostname = url.urlToTrimmedHost(publicSuffixList),
+        title = title,
+        selected = selected ?: false,
+        mediaState = mediaState,
+        icon = icon
     )
-}

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/OnboardingAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/OnboardingAdapter.kt
@@ -1,0 +1,90 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.home.sessioncontrol
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.annotation.LayoutRes
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import io.reactivex.Observer
+import org.mozilla.fenix.home.OnboardingState
+import org.mozilla.fenix.home.sessioncontrol.viewholders.onboarding.OnboardingAutomaticSignInViewHolder
+import org.mozilla.fenix.home.sessioncontrol.viewholders.onboarding.OnboardingFinishViewHolder
+import org.mozilla.fenix.home.sessioncontrol.viewholders.onboarding.OnboardingHeaderViewHolder
+import org.mozilla.fenix.home.sessioncontrol.viewholders.onboarding.OnboardingManualSignInViewHolder
+import org.mozilla.fenix.home.sessioncontrol.viewholders.onboarding.OnboardingPrivacyNoticeViewHolder
+import org.mozilla.fenix.home.sessioncontrol.viewholders.onboarding.OnboardingPrivateBrowsingViewHolder
+import org.mozilla.fenix.home.sessioncontrol.viewholders.onboarding.OnboardingSectionHeaderViewHolder
+import org.mozilla.fenix.home.sessioncontrol.viewholders.onboarding.OnboardingThemePickerViewHolder
+import org.mozilla.fenix.home.sessioncontrol.viewholders.onboarding.OnboardingTrackingProtectionViewHolder
+
+sealed class OnboardingItem(@LayoutRes val viewType: Int) {
+    object OnboardingHeader : OnboardingItem(OnboardingHeaderViewHolder.LAYOUT_ID)
+    data class OnboardingSectionHeader(
+        val labelBuilder: (Context) -> String
+    ) : OnboardingItem(OnboardingSectionHeaderViewHolder.LAYOUT_ID)
+    object OnboardingManualSignIn : OnboardingItem(OnboardingManualSignInViewHolder.LAYOUT_ID)
+    data class OnboardingAutomaticSignIn(
+        val state: OnboardingState.SignedOutCanAutoSignIn
+    ) : OnboardingItem(OnboardingAutomaticSignInViewHolder.LAYOUT_ID)
+    object OnboardingThemePicker : OnboardingItem(OnboardingThemePickerViewHolder.LAYOUT_ID)
+    object OnboardingTrackingProtection : OnboardingItem(OnboardingTrackingProtectionViewHolder.LAYOUT_ID)
+    object OnboardingPrivateBrowsing : OnboardingItem(OnboardingPrivateBrowsingViewHolder.LAYOUT_ID)
+    object OnboardingPrivacyNotice : OnboardingItem(OnboardingPrivacyNoticeViewHolder.LAYOUT_ID)
+    object OnboardingFinish : OnboardingItem(OnboardingFinishViewHolder.LAYOUT_ID)
+}
+
+/**
+ * Adapter to display onboarding views.
+ */
+class OnboardingAdapter(
+    private val actionEmitter: Observer<SessionControlAction>
+) : ListAdapter<OnboardingItem, RecyclerView.ViewHolder>(OnboardingItemDiffCallback) {
+
+    // This method triggers the ComplexMethod lint error when in fact it's quite simple.
+    @SuppressWarnings("ComplexMethod")
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        val view = LayoutInflater.from(parent.context).inflate(viewType, parent, false)
+        return when (viewType) {
+            OnboardingHeaderViewHolder.LAYOUT_ID -> OnboardingHeaderViewHolder(view)
+            OnboardingSectionHeaderViewHolder.LAYOUT_ID -> OnboardingSectionHeaderViewHolder(view)
+            OnboardingManualSignInViewHolder.LAYOUT_ID -> OnboardingManualSignInViewHolder(view)
+            OnboardingAutomaticSignInViewHolder.LAYOUT_ID -> OnboardingAutomaticSignInViewHolder(view)
+            OnboardingThemePickerViewHolder.LAYOUT_ID -> OnboardingThemePickerViewHolder(view)
+            OnboardingTrackingProtectionViewHolder.LAYOUT_ID -> OnboardingTrackingProtectionViewHolder(view)
+            OnboardingPrivateBrowsingViewHolder.LAYOUT_ID -> OnboardingPrivateBrowsingViewHolder(view)
+            OnboardingPrivacyNoticeViewHolder.LAYOUT_ID -> OnboardingPrivacyNoticeViewHolder(view)
+            OnboardingFinishViewHolder.LAYOUT_ID -> OnboardingFinishViewHolder(view, actionEmitter)
+            else -> throw IllegalStateException()
+        }
+    }
+
+    override fun getItemViewType(position: Int) = getItem(position).viewType
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        val item = getItem(position)
+        when (holder) {
+            is OnboardingSectionHeaderViewHolder -> holder.bind(
+                (item as OnboardingItem.OnboardingSectionHeader).labelBuilder
+            )
+            is OnboardingManualSignInViewHolder -> holder.bind()
+            is OnboardingAutomaticSignInViewHolder -> holder.bind(
+                (item as OnboardingItem.OnboardingAutomaticSignIn).state.withAccount
+            )
+        }
+    }
+
+    private object OnboardingItemDiffCallback : DiffUtil.ItemCallback<OnboardingItem>() {
+        override fun areItemsTheSame(oldItem: OnboardingItem, newItem: OnboardingItem) =
+            oldItem::class == newItem::class
+
+        @Suppress("DiffUtilEquals")
+        override fun areContentsTheSame(oldItem: OnboardingItem, newItem: OnboardingItem) =
+            oldItem == newItem
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlComponent.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlComponent.kt
@@ -4,7 +4,6 @@
 
 package org.mozilla.fenix.home.sessioncontrol
 
-import android.content.Context
 import android.graphics.Bitmap
 import android.view.View
 import android.view.ViewGroup
@@ -13,7 +12,6 @@ import io.reactivex.Observer
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.feature.media.state.MediaState
-import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.home.Mode
 import org.mozilla.fenix.mvi.Action
 import org.mozilla.fenix.mvi.ActionBusFactory
@@ -51,13 +49,10 @@ data class Tab(
     val url: String,
     val hostname: String,
     val title: String,
-    val selected: Boolean? = null,
+    val selected: Boolean = false,
     var mediaState: MediaState? = null,
     val icon: Bitmap? = null
 )
-
-fun List<Tab>.toSessionBundle(context: Context): MutableList<Session> =
-    this.toSessionBundle(context.components.core.sessionManager)
 
 fun List<Tab>.toSessionBundle(sessionManager: SessionManager): MutableList<Session> {
     val sessionBundle = mutableListOf<Session>()

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/TabViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/TabViewHolder.kt
@@ -95,7 +95,7 @@ class TabViewHolder(
         updateTitle(tab.title)
         updateHostname(tab.hostname)
         updateFavIcon(tab.url, tab.icon)
-        updateSelected(tab.selected ?: false)
+        updateSelected(tab.selected)
         updatePlayPauseButton(tab.mediaState ?: MediaState.None)
         item_tab.transitionName = "$TAB_ITEM_TRANSITION_NAME${tab.sessionId}"
         updateCloseButtonDescription(tab.title)

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -47,6 +47,7 @@
     <dimen name="design_quick_action_sheet_peek_height_min">64dp</dimen>
 
     <dimen name="onboarding_header_icon_height_width">32dp</dimen>
+    <dimen name="tab_swipe_delete_icon_margin">32dp</dimen>
 
     <!-- Bottom Sheet Fragment card -->
     <dimen name="bottom_sheet_corner_radius">8dp</dimen>


### PR DESCRIPTION
Refactors the onboarding screen to be a separate view. Long-term this may be changed into a linear layout too.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
