### PR TITLE
Fix 3809 - Show entire URL in security info view

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/quicksettings/WebsiteInfoView.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/quicksettings/WebsiteInfoView.kt
@@ -11,10 +11,8 @@ import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.core.content.ContextCompat
-import androidx.core.net.toUri
 import kotlinx.android.extensions.LayoutContainer
 import kotlinx.android.synthetic.main.quicksettings_website_info.view.*
-import mozilla.components.support.ktx.android.net.hostWithoutCommonPrefixes
 import mozilla.components.support.ktx.android.view.putCompoundDrawablesRelativeWithIntrinsicBounds
 import org.mozilla.fenix.R
 
@@ -42,7 +40,7 @@ class WebsiteInfoView(
     }
 
     private fun bindUrl(url: String) {
-        view.url.text = url.toUri().hostWithoutCommonPrefixes
+        view.url.text = url
     }
 
     private fun bindSecurityInfo(

--- a/app/src/main/res/layout/quicksettings_website_info.xml
+++ b/app/src/main/res/layout/quicksettings_website_info.xml
@@ -16,7 +16,7 @@
         android:id="@+id/url"
         style="@style/QuickSettingsText"
         android:layout_width="match_parent"
-        android:layout_height="@dimen/quicksettings_item_height"
+        android:layout_height="wrap_content"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"

--- a/app/src/main/res/layout/quicksettings_website_info.xml
+++ b/app/src/main/res/layout/quicksettings_website_info.xml
@@ -17,6 +17,7 @@
         style="@style/QuickSettingsText"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:paddingTop="8dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"


### PR DESCRIPTION
Shows the full URL when clicking on the security icon

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

<img width="362" alt="FullUrl" src="https://user-images.githubusercontent.com/46655/68979365-eed1d400-07c2-11ea-97ca-044f9d88b8c9.png">


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.
