### PR TITLE
Publish gradle reports as artifacts

### DIFF
--- a/taskcluster/ci/test/kind.yml
+++ b/taskcluster/ci/test/kind.yml
@@ -41,6 +41,11 @@ jobs:
                 - name: project/mobile/fenix/public-tokens
                   key: codecov
                   path: .cc_token
+        worker:
+            artifacts:
+                - name: public/reports/index.html
+                  path: /builds/worker/checkouts/src/app/build/reports/tests/testGeckoNightlyDebugUnitTest/index.html
+                  type: file
     ui:
         attributes:
             build-type: debug


### PR DESCRIPTION
---
As requested [here](https://mozilla.slack.com/archives/CG2FGG1ST/p1573841677196700).
[This](https://firefox-ci-tc.services.mozilla.com/tasks/Vnnh3-3BSyqUzAzikn1C7Q) is what a task with the associated reports would look like (click the artifacts dropdown).

@JohanLorenzo I'm not sure if there's a better approach here - I think that the reports should be accessible, but it's really difficult choosing the right report in taskcluster when there's hundreds in this list, as shown in that last link^. We can do a zip-and-artifact technique, but I'm not sure if that's a good call. What do you think?

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
