### PR TITLE
For #6593 & #6594 - bookmark keyboard visibility

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
@@ -98,6 +98,19 @@ class BookmarksTest {
             addNewFolderName(bookmarksFolderName)
             saveNewFolder()
             verifyFolderTitle(bookmarksFolderName)
+            verifyKeyboardHidden()
+        }
+    }
+
+    @Test
+    fun cancelCreateBookmarkFolderTest() {
+        homeScreen {
+        }.openThreeDotMenu {
+        }.openBookmarks {
+            clickAddFolderButton()
+            addNewFolderName(bookmarksFolderName)
+            navigateUp()
+            verifyKeyboardHidden()
         }
     }
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
@@ -127,7 +127,7 @@ class BookmarksTest {
         }.openThreeDotMenu {
         }.clickEdit {
             verifyEditBookmarksView()
-            verifyBoomarkNameEditBox()
+            verifyBookmarkNameEditBox()
             verifyBookmarkURLEditBox()
             verifyParentFolderSelector()
             navigateUp()

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
@@ -95,6 +95,7 @@ class BookmarksTest {
         }.openThreeDotMenu {
         }.openBookmarks {
             clickAddFolderButton()
+            verifyKeyboardVisible()
             addNewFolderName(bookmarksFolderName)
             saveNewFolder()
             verifyFolderTitle(bookmarksFolderName)

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BookmarksRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BookmarksRobot.kt
@@ -6,7 +6,9 @@
 
 package org.mozilla.fenix.ui.robots
 
+import android.content.Context
 import android.net.Uri
+import android.view.inputmethod.InputMethodManager
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.typeText
 import androidx.test.espresso.assertion.ViewAssertions.matches
@@ -16,10 +18,14 @@ import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withParent
 import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
 import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.containsString
+import org.junit.Assert
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.click
+import java.io.IOException
 
 /**
  * Implementation of Robot Pattern for the bookmarks menu.
@@ -50,6 +56,10 @@ class BookmarksRobot {
 
     fun verifyHomeScreen() = HomeScreenRobot().verifyHomeScreen()
 
+    fun verifyKeyboardHidden() = assertKeyboardVisibility(isExpectedToBeVisible = false)
+
+    fun verifyKeyboardVisible() = assertKeyboardVisibility(isExpectedToBeVisible = true)
+
     fun clickAddFolderButton() {
         addFolderButton().click()
     }
@@ -68,11 +78,11 @@ class BookmarksRobot {
     }
 
     class Transition {
-        fun goBack(interact: BookmarksRobot.() -> Unit): BookmarksRobot.Transition {
+        fun goBack(interact: BookmarksRobot.() -> Unit): Transition {
             goBackButton().click()
 
             BookmarksRobot().interact()
-            return BookmarksRobot.Transition()
+            return Transition()
         }
 
         fun openThreeDotMenu(interact: ThreeDotMenuBookmarksRobot.() -> Unit): ThreeDotMenuBookmarksRobot.Transition {
@@ -155,3 +165,11 @@ private fun assertBookmarkFolderSelector() =
 private fun assertBookmarkURLEditBox() =
     onView(withId(R.id.bookmarkUrlEdit))
         .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+
+private fun assertKeyboardVisibility(isExpectedToBeVisible: Boolean) =
+    Assert.assertEquals(
+        isExpectedToBeVisible,
+        UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+            .executeShellCommand("dumpsys input_method | grep mInputShown")
+            .contains("mInputShown=true")
+    )

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BookmarksRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BookmarksRobot.kt
@@ -6,9 +6,7 @@
 
 package org.mozilla.fenix.ui.robots
 
-import android.content.Context
 import android.net.Uri
-import android.view.inputmethod.InputMethodManager
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.typeText
 import androidx.test.espresso.assertion.ViewAssertions.matches
@@ -25,7 +23,6 @@ import org.hamcrest.Matchers.containsString
 import org.junit.Assert
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.click
-import java.io.IOException
 
 /**
  * Implementation of Robot Pattern for the bookmarks menu.

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BookmarksRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BookmarksRobot.kt
@@ -48,7 +48,7 @@ class BookmarksRobot {
 
     fun verifyEditBookmarksView() = assertEditBookmarksView()
 
-    fun verifyBoomarkNameEditBox() = assertBookmarkNameEditBox()
+    fun verifyBookmarkNameEditBox() = assertBookmarkNameEditBox()
 
     fun verifyBookmarkURLEditBox() = assertBookmarkURLEditBox()
 

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/addfolder/AddBookmarkFolderFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/addfolder/AddBookmarkFolderFragment.kt
@@ -77,6 +77,11 @@ class AddBookmarkFolderFragment : Fragment(R.layout.fragment_edit_bookmark) {
         }
     }
 
+    override fun onPause() {
+        super.onPause()
+        bookmarkNameEdit.hideKeyboard()
+    }
+
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         inflater.inflate(R.menu.bookmarks_add_folder, menu)
     }

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/addfolder/AddBookmarkFolderFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/addfolder/AddBookmarkFolderFragment.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import mozilla.appservices.places.BookmarkRoot
 import mozilla.components.support.ktx.android.view.hideKeyboard
+import mozilla.components.support.ktx.android.view.showKeyboard
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.nav
@@ -49,6 +50,7 @@ class AddBookmarkFolderFragment : Fragment(R.layout.fragment_edit_bookmark) {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         bookmarkUrlLabel.visibility = GONE
         bookmarkUrlEdit.visibility = GONE
+        bookmarkNameEdit.showKeyboard()
     }
 
     override fun onResume() {


### PR DESCRIPTION
I know that it was said

> - Every PR must have exactly one issue associated with it.

But both of them were so simple and needed the same new test helper that I hope that no one will mind that I put them together in a single PR.

![i6593-i6594 (1)](https://user-images.githubusercontent.com/36203921/68999604-755ce300-08a1-11ea-9afe-390216ef0e0b.gif)


---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
