### PR TITLE
For #4824 - Fixes onboarding telemetry events from being sent a…

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -263,7 +263,7 @@ class HomeFragment : Fragment() {
             view.resources.getDimensionPixelSize(R.dimen.search_bar_search_engine_icon_padding)
         view.toolbar_wrapper.setOnClickListener {
             invokePendingDeleteJobs()
-            onboarding.finish()
+            hideOnboardingIfNeeded()
             val directions = HomeFragmentDirections.actionHomeFragmentToSearchFragment(
                 sessionId = null
             )
@@ -277,7 +277,7 @@ class HomeFragment : Fragment() {
 
         view.add_tab_button.setOnClickListener {
             invokePendingDeleteJobs()
-            onboarding.finish()
+            hideOnboardingIfNeeded()
             val directions = HomeFragmentDirections.actionHomeFragmentToSearchFragment(
                 sessionId = null
             )

--- a/app/src/main/java/org/mozilla/fenix/onboarding/FenixOnboarding.kt
+++ b/app/src/main/java/org/mozilla/fenix/onboarding/FenixOnboarding.kt
@@ -8,6 +8,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.core.content.edit
 import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.components.metrics.Event
 
 class FenixOnboarding(context: Context) {
     private val metrics = context.components.analytics.metrics
@@ -22,9 +23,7 @@ class FenixOnboarding(context: Context) {
 
     fun finish() {
         onboardingPrefs.onboardedVersion = CURRENT_ONBOARDING_VERSION
-
-        // To be fixed in #4824
-        // metrics.track(Event.DismissedOnboarding)
+        metrics.track(Event.DismissedOnboarding)
     }
 
     fun userHasBeenOnboarded() = onboardingPrefs.onboardedVersion == CURRENT_ONBOARDING_VERSION


### PR DESCRIPTION
Summary of bug finding: when onboarding was completed, onboarding telementry events were fired whenever a user tapped on the "add tab" button or the toolbar wrapper. This fixes #4824 by checking if the user has completed their onboarding process. I felt that tests and screenshots were unnecessary for such a small unit of work which is why I didn't write/take any.  

### Pull Request checklist
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture