### PR TITLE
For #5972 - Fixes bugs when launching in private mode on Android 5

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -131,62 +131,6 @@
                 android:resource="@mipmap/ic_launcher" />
         </activity>
 
-        <!-- Launch in private mode alias -->
-        <activity-alias
-            android:name="org.mozilla.fenix.alias.IntentReceiverActivity"
-            android:label="@string/app_name_private_2"
-            android:icon="@mipmap/ic_launcher_private"
-            android:roundIcon="@mipmap/ic_launcher_private_round"
-            android:targetActivity=".IntentReceiverActivity">
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-
-                <data android:scheme="http" />
-                <data android:scheme="https" />
-            </intent-filter>
-
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-
-                <category android:name="android.intent.category.BROWSABLE" />
-                <category android:name="android.intent.category.DEFAULT" />
-
-                <data android:scheme="http" />
-                <data android:scheme="https" />
-                <data android:mimeType="text/html" />
-                <data android:mimeType="text/plain" />
-                <data android:mimeType="application/xhtml+xml" />
-            </intent-filter>
-
-            <intent-filter>
-                <action android:name="android.intent.action.SEND" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <data android:mimeType="text/plain" />
-            </intent-filter>
-
-            <intent-filter>
-                <action android:name="android.intent.action.ASSIST" />
-                <category android:name="android.intent.category.DEFAULT" />
-            </intent-filter>
-
-            <intent-filter>
-                <action android:name="android.nfc.action.NDEF_DISCOVERED"/>
-                <category android:name="android.intent.category.DEFAULT" />
-                <data android:scheme="http" />
-                <data android:scheme="https" />
-            </intent-filter>
-
-            <meta-data
-                android:name="com.android.systemui.action_assist_icon"
-                android:resource="@mipmap/ic_launcher_private" />
-            <meta-data
-                android:name="org.mozilla.fenix.LAUNCH_PRIVATE_LINK"
-                android:value="true" />
-        </activity-alias>
-
         <activity android:name=".widget.VoiceSearchActivity" />
 
         <activity

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -310,8 +310,9 @@ class HomeFragment : Fragment() {
         super.onDestroyView()
     }
 
-    override fun onResume() {
-        super.onResume()
+    override fun onStart() {
+        super.onStart()
+        subscribeToTabCollections()
 
         getAutoDisposeObservable<SessionControlAction>()
             .subscribe {
@@ -354,11 +355,6 @@ class HomeFragment : Fragment() {
             !PrivateShortcutCreateManager.doesPrivateBrowsingPinnedShortcutExist(context)) {
             recommendPrivateBrowsingShortcut()
         }
-    }
-
-    override fun onStart() {
-        super.onStart()
-        subscribeToTabCollections()
 
         // We only want this observer live just before we navigate away to the collection creation screen
         requireComponents.core.tabCollectionStorage.unregister(collectionStorageObserver)
@@ -602,9 +598,9 @@ class HomeFragment : Fragment() {
         }
     }
 
-    override fun onPause() {
+    override fun onStop() {
         invokePendingDeleteJobs()
-        super.onPause()
+        super.onStop()
         val homeViewModel: HomeScreenViewModel by activityViewModels {
             ViewModelProvider.NewInstanceFactory() // this is a workaround for #4652
         }


### PR DESCRIPTION
There are some issues on Android 5 using activity-aliases so we took that out. In the process of testing opening new links in private mode we noticed the HomeFragment wasn't getting an onResume call when navigating from the browserFragment back to the homeFragment after opening an intent link. Moving that logic to onStart/onStop fixed it.