### PR TITLE
WIP: Refactor BackgroundServices to remove push.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -103,7 +103,7 @@ open class FenixApplication : Application() {
             components.analytics.metrics.start()
         }
 
-        setupPush()
+        setupPushFeature()
 
         visibilityLifecycleCallback = VisibilityLifecycleCallback(getSystemService())
         registerActivityLifecycleCallbacks(visibilityLifecycleCallback)
@@ -166,18 +166,18 @@ open class FenixApplication : Application() {
         }
     }
 
-    private fun setupPush() {
+    private fun setupPushFeature() {
         // Sets the PushFeature as the singleton instance for push messages to go to.
-        // We need the push feature setup here to deliver messages in the case where the service
+        // We need the pushFeature feature setup here to deliver messages in the case where the service
         // starts up the app first.
-        components.backgroundServices.push?.let { autoPushFeature ->
-            Logger.info("AutoPushFeature is configured, initializing it...")
+        components.pushDispatcher.pushDispatcher?.let { pushDispatcher ->
+            Logger.info("Push dispatcher is configured, initializing it...")
 
-            // Install the AutoPush singleton to receive messages.
-            PushProcessor.install(autoPushFeature)
+            // Install the AutoPushFeature singleton to receive messages.
+            PushProcessor.install(pushDispatcher)
 
             // Initialize the service. This could potentially be done in a coroutine in the future.
-            autoPushFeature.initialize()
+            pushDispatcher.initialize()
         }
     }
 

--- a/app/src/main/java/org/mozilla/fenix/components/AccountManagerDispatchee.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/AccountManagerDispatchee.kt
@@ -1,0 +1,36 @@
+package org.mozilla.fenix.components
+
+import mozilla.components.concept.sync.DevicePushSubscription
+import mozilla.components.feature.push.AutoPushFeature
+import mozilla.components.feature.push.AutoPushSubscription
+import mozilla.components.service.fxa.manager.FxaAccountManager
+import org.mozilla.fenix.components.push.Dispatchee
+
+class AccountManagerDispatchee(private val accountManager: Lazy<FxaAccountManager>) :
+    Dispatchee {
+    var registered = false
+    override fun onServiceTypeEvent(message: String, dispatcher: AutoPushFeature) {
+        if (!registered) {
+            accountManager.value.register(PushAccountObserver(dispatcher))
+            registered = true
+        }
+        accountManager.value.authenticatedAccount()?.deviceConstellation()
+            ?.processRawEventAsync(message)
+    }
+
+    override fun onServiceTypeSubscriptionAvailable(subscription: AutoPushSubscription, dispatcher: AutoPushFeature) {
+        if (!registered) {
+            accountManager.value.register(PushAccountObserver(dispatcher))
+            registered = true
+        }
+        accountManager.value.authenticatedAccount()
+            ?.deviceConstellation()
+            ?.setDevicePushSubscriptionAsync(
+                DevicePushSubscription(
+                    endpoint = subscription.endpoint,
+                    publicKey = subscription.publicKey,
+                    authKey = subscription.authKey
+                )
+            )
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/components/Components.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Components.kt
@@ -6,6 +6,7 @@ package org.mozilla.fenix.components
 
 import android.content.Context
 import mozilla.components.lib.publicsuffixlist.PublicSuffixList
+import org.mozilla.fenix.components.push.Dispatcher
 import org.mozilla.fenix.test.Mockable
 import org.mozilla.fenix.utils.ClipboardHandler
 
@@ -22,6 +23,12 @@ class Components(private val context: Context) {
             core.bookmarksStorage,
             core.passwordsStorage,
             core.getSecureAbove22Preferences()
+        )
+    }
+    val pushDispatcher by lazy {
+        Dispatcher(
+            context,
+            listOf(AccountManagerDispatchee(lazy { backgroundServices.accountManager }))
         )
     }
     val services by lazy { Services(context, backgroundServices.accountManager) }

--- a/app/src/main/java/org/mozilla/fenix/components/push/Dispatchee.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/push/Dispatchee.kt
@@ -1,0 +1,16 @@
+package org.mozilla.fenix.components.push
+
+import mozilla.components.feature.push.AutoPushFeature
+import mozilla.components.feature.push.AutoPushSubscription
+
+interface Dispatchee {
+    /*
+    When the push dispatcher gets a message with a Service type, this method is invoked.
+     */
+    fun onServiceTypeEvent(message: String, dispatcher: AutoPushFeature)
+    /*
+    When the push dispatcher gets a subscription available notification with a Service type,
+    this method is invoked.
+     */
+    fun onServiceTypeSubscriptionAvailable(subscription: AutoPushSubscription, dispatcher: AutoPushFeature)
+}

--- a/app/src/main/java/org/mozilla/fenix/components/push/Dispatcher.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/push/Dispatcher.kt
@@ -1,0 +1,69 @@
+package org.mozilla.fenix.components.push
+
+import android.content.Context
+import androidx.annotation.VisibleForTesting
+import mozilla.components.concept.push.Bus
+import mozilla.components.feature.push.AutoPushFeature
+import mozilla.components.feature.push.AutoPushSubscription
+import mozilla.components.feature.push.PushConfig
+import mozilla.components.feature.push.PushSubscriptionObserver
+import mozilla.components.feature.push.PushType
+import mozilla.components.support.base.log.logger.Logger
+import org.mozilla.fenix.R
+import org.mozilla.fenix.components.FirebasePush
+import org.mozilla.fenix.test.Mockable
+
+@Mockable
+class Dispatcher(private val context: Context, private val dispatchees: List<Dispatchee>) {
+    val pushDispatcher by lazy { makePushConfig()?.let { makePush(it) } }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    fun makePush(pushConfig: PushConfig): AutoPushFeature {
+        var apf = AutoPushFeature(
+            context = context,
+            service = FirebasePush(),
+            config = pushConfig
+        )
+        /*
+        Tell the dispatchee about an event of Service type.
+         */
+        apf.registerForPushMessages(
+            PushType.Services,
+            object : Bus.Observer<PushType, String> {
+                override fun onEvent(type: PushType, message: String) {
+                    for (dispatchee in dispatchees) {
+                        dispatchee.onServiceTypeEvent(message, apf)
+                    }
+                }
+            }
+        )
+        /*
+        Tell the dispatchee about a subscription available of Service type.
+         */
+        apf.registerForSubscriptions(object : PushSubscriptionObserver {
+            override fun onSubscriptionAvailable(subscription: AutoPushSubscription) {
+                if (subscription.type == PushType.Services) {
+                    for (dispatchee in dispatchees) {
+                        dispatchee.onServiceTypeSubscriptionAvailable(subscription, apf)
+                    }
+                }
+            }
+        })
+        return apf
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    fun makePushConfig(): PushConfig? {
+        val logger = Logger("PushConfig")
+        val projectIdKey = context.getString(R.string.pref_key_push_project_id)
+        val resId = context.resources.getIdentifier(projectIdKey, "string", context.packageName)
+        if (resId == 0) {
+            logger.warn("No firebase configuration found; cannot support push service.")
+            return null
+        }
+
+        logger.debug("Creating push configuration for autopush.")
+        val projectId = context.resources.getString(resId)
+        return PushConfig(projectId)
+    }
+}

--- a/app/src/test/java/org/mozilla/fenix/components/BackgroundServicesTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/BackgroundServicesTest.kt
@@ -14,7 +14,6 @@ import mozilla.components.concept.sync.AccountObserver
 import mozilla.components.concept.sync.AuthType
 import mozilla.components.concept.sync.OAuthAccount
 import mozilla.components.feature.push.AutoPushFeature
-import mozilla.components.feature.push.PushConfig
 import mozilla.components.feature.push.PushType
 import mozilla.components.service.fxa.DeviceConfig
 import mozilla.components.service.fxa.ServerConfig
@@ -33,16 +32,13 @@ import org.mozilla.fenix.isInExperiment
 class BackgroundServicesTest {
     class TestableBackgroundServices(
         val context: Context
-    ) : BackgroundServices(context, mockk(), mockk(), mockk(), mockk(), mockk()) {
+    ) : BackgroundServices(context, mockk(), mockk(), mockk(), mockk(), mockk(), mockk()) {
         override fun makeAccountManager(
             context: Context,
             serverConfig: ServerConfig,
             deviceConfig: DeviceConfig,
             syncConfig: SyncConfig?
         ) = mockk<FxaAccountManager>(relaxed = true)
-
-        override fun makePushConfig() = mockk<PushConfig>(relaxed = true)
-        override fun makePush(pushConfig: PushConfig) = mockk<AutoPushFeature>(relaxed = true)
     }
 
     @Test


### PR DESCRIPTION
Make push its own component so that it can be accessed without having to instantiate every background service. This will result in a significant savings at startup. 

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
