### PR TITLE
For #2570: Hide 3-dots menu for all library items when in select mode.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/LibraryPageView.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/LibraryPageView.kt
@@ -30,8 +30,7 @@ open class LibraryPageView(
             foregroundColor = context.getColorFromAttr(R.attr.primaryText),
             backgroundColor = context.getColorFromAttr(R.attr.foundation)
         )
-        libraryItemsList.setItemViewCacheSize(0)
-        libraryItemsList.adapter?.notifyItemRangeChanged(0, libraryItemsList.childCount)
+        libraryItemsList.adapter?.notifyDataSetChanged()
     }
 
     protected fun setUiForSelectingMode(
@@ -43,8 +42,7 @@ open class LibraryPageView(
             foregroundColor = ContextCompat.getColor(context, R.color.white_color),
             backgroundColor = context.getColorFromAttr(R.attr.accentHighContrast)
         )
-        libraryItemsList.setItemViewCacheSize(0)
-        libraryItemsList.adapter?.notifyItemRangeChanged(0, libraryItemsList.childCount)
+        libraryItemsList.adapter?.notifyDataSetChanged()
     }
 
     private fun updateToolbar(title: String?, foregroundColor: Int, backgroundColor: Int) {


### PR DESCRIPTION
notifyDataSetChanged to avoid not displayed( but already created) items not being redrawn

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
