### PR TITLE
Closes #4982: Migrate Gecko files before initializing engine.

### DIFF
--- a/app/src/fennecProduction/java/org/mozilla/fenix/MigratingFenixApplication.kt
+++ b/app/src/fennecProduction/java/org/mozilla/fenix/MigratingFenixApplication.kt
@@ -4,25 +4,32 @@
 
 package org.mozilla.fenix
 
-import mozilla.components.support.ktx.android.content.isMainProcess
+import kotlinx.coroutines.runBlocking
 import mozilla.components.support.migration.FennecMigrator
 
 /**
  * An application class which knows how to migrate Fennec data.
  */
 class MigratingFenixApplication : FenixApplication() {
-    override fun setupApplication() {
-        super.setupApplication()
+    override fun setupInMainProcessOnly() {
+        migrateGeckoBlocking()
 
-        // Same check as is present in super.setupApplication:
-        if (!isMainProcess()) {
-            // If this is not the main process then do not continue with the migration here.
-            // Migration only needs to be done in our app's main process and should not be done in other processes like
-            // a GeckoView child process or the crash handling process. Most importantly we never want to end up in a
-            // situation where we create a GeckoRuntime from the Gecko child process.
-            return
+        super.setupInMainProcessOnly()
+
+        migrateDataAsynchronously()
+    }
+
+    private fun migrateGeckoBlocking() {
+        val migrator = FennecMigrator.Builder(this, this.components.analytics.crashReporter)
+            .migrateGecko()
+            .build()
+
+        runBlocking {
+            migrator.migrateAsync().await()
         }
+    }
 
+    private fun migrateDataAsynchronously() {
         val migrator = FennecMigrator.Builder(this, this.components.analytics.crashReporter)
             .migrateOpenTabs(this.components.core.sessionManager)
             .migrateHistory(this.components.core.historyStorage)

--- a/app/src/test/java/org/mozilla/fenix/TestApplication.kt
+++ b/app/src/test/java/org/mozilla/fenix/TestApplication.kt
@@ -10,6 +10,7 @@ class TestApplication : FenixApplication() {
 
     override val components = TestComponents(this)
 
-    override fun setupApplication() {
-    }
+    override fun setupInAllProcesses() = Unit
+
+    override fun setupInMainProcessOnly() = Unit
 }


### PR DESCRIPTION
This is the Fenix part of #4982 - for migrating Gecko internal files when updating from Fennec.

As part of this patch I restructured `onCreate()` in `FenixApplication` to call `setupInAllProcesses()` and `setupInMainProcessOnly()`.

I also moved more things to be only initialized in the main process. I do not think they are needed in other processes (which currently are only spawned by Gecko afaik).
- megazord setup and rust log initialization is only done in the main process now (@grigoryk can you confirm?)
- day/night theme is only setup in the main process now (others do not have any UI)
- Rx exception handler is only setup in the main process (Rx is only used in app code and that's only in the main process)
- strict mode is only setup in the main process (since we care about our own code here primarily).