### PR TITLE
Fix 6048 - Improve alignment in Edit Bookmark screen

### DIFF
--- a/app/src/main/res/layout/fragment_edit_bookmark.xml
+++ b/app/src/main/res/layout/fragment_edit_bookmark.xml
@@ -14,12 +14,13 @@
         android:id="@+id/bookmark_name_label"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginStart="4dp"
         android:layout_marginTop="16dp"
+        android:labelFor="@id/bookmarkNameEdit"
         android:text="@string/bookmark_name_label"
         android:textAllCaps="true"
         android:textColor="?primaryText"
-        android:textSize="12sp"
-        android:labelFor="@id/bookmarkNameEdit" />
+        android:textSize="12sp" />
 
     <org.mozilla.fenix.utils.ClearableEditText
         android:id="@+id/bookmarkNameEdit"
@@ -39,12 +40,13 @@
         android:id="@+id/bookmarkUrlLabel"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginStart="4dp"
         android:layout_marginTop="8dp"
+        android:labelFor="@id/bookmarkUrlEdit"
         android:text="@string/bookmark_url_label"
-        android:textColor="?primaryText"
-        android:textSize="12sp"
         android:textAllCaps="true"
-        android:labelFor="@id/bookmarkUrlEdit" />
+        android:textColor="?primaryText"
+        android:textSize="12sp" />
 
     <org.mozilla.fenix.utils.ClearableEditText
         android:id="@+id/bookmarkUrlEdit"
@@ -64,17 +66,19 @@
         android:id="@+id/bookmark_folder_label"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginStart="4dp"
         android:layout_marginTop="8dp"
+        android:labelFor="@id/bookmarkParentFolderSelector"
         android:text="@string/bookmark_folder_label"
-        android:textColor="?primaryText"
-        android:textSize="12sp"
         android:textAllCaps="true"
-        android:labelFor="@id/bookmarkParentFolderSelector" />
+        android:textColor="?primaryText"
+        android:textSize="12sp" />
 
     <TextView
         android:id="@+id/bookmarkParentFolderSelector"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginStart="4dp"
         android:layout_marginTop="8dp"
         android:drawableStart="@drawable/ic_folder_icon"
         android:drawablePadding="10dp"


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

![Screenshot_20191122-110309](https://user-images.githubusercontent.com/46655/69445409-dfe5a700-0d17-11ea-9818-648023756ed5.png)


This PR addresses the issue by adjusting the positioning of the labels; I was unable to find a way to address the imaginary left/start padding of the input widgetry.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
