### PR TITLE
For #5711 - Onboarding colours have contrast issues.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingManualSignInViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingManualSignInViewHolder.kt
@@ -6,6 +6,7 @@ package org.mozilla.fenix.home.sessioncontrol.viewholders.onboarding
 
 import android.view.View
 import androidx.appcompat.content.res.AppCompatResources
+import androidx.core.content.ContextCompat
 import androidx.navigation.Navigation
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.android.synthetic.main.onboarding_manual_signin.view.*
@@ -25,6 +26,7 @@ class OnboardingManualSignInViewHolder(private val view: View) : RecyclerView.Vi
         val appName = view.context.getString(R.string.app_name)
         view.header_text.text = view.context.getString(R.string.onboarding_firefox_account_header, appName)
         val icon = AppCompatResources.getDrawable(view.context, R.drawable.ic_onboarding_firefox_accounts)
+        icon?.setTint(ContextCompat.getColor(view.context, R.color.white_color))
         view.header_text.putCompoundDrawablesRelativeWithIntrinsicBounds(start = icon)
     }
 

--- a/app/src/main/res/drawable/onboarding_card_background_dark.xml
+++ b/app/src/main/res/drawable/onboarding_card_background_dark.xml
@@ -4,7 +4,12 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
-    <stroke android:width="1dp" android:color="?neutralFaded" />
-    <solid android:color="@color/onboarding_card_background_dark" />
+    <stroke
+        android:width="1dp"
+        android:color="?neutralFaded" />
+    <gradient
+        android:angle="45"
+        android:endColor="@color/accent_high_contrast_dark_theme"
+        android:startColor="@color/accent_bright_dark_theme" />
     <corners android:radius="8dp" />
 </shape>

--- a/app/src/main/res/layout/onboarding_manual_signin.xml
+++ b/app/src/main/res/layout/onboarding_manual_signin.xml
@@ -17,8 +17,9 @@
         android:layout_height="wrap_content"
         android:layout_marginBottom="14dp"
         android:drawablePadding="12dp"
+        android:drawableTint="@color/white_color"
         android:textAppearance="@style/Header16TextStyle"
-        android:textColor="@color/onboarding_card_primary_text_dark"
+        android:textColor="@color/neutral_text"
         tools:text="@string/onboarding_firefox_account_header" />
 
     <Button
@@ -33,8 +34,8 @@
         android:padding="10dp"
         android:text="@string/onboarding_firefox_account_sign_in"
         android:textAllCaps="false"
-        android:textColor="?neutral"
+        android:textColor="@color/button_text_color"
         android:textSize="14sp"
         android:textStyle="bold"
-        app:backgroundTint="@color/onboarding_card_button_background_dark" />
+        app:backgroundTint="@color/foundation_light_theme" />
 </LinearLayout>


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

I had to change the tint of the drawables programmatically since I wasn't sure if I should create a new drawable entirely for the circular arrows. 

![Screenshot_1574455572](https://user-images.githubusercontent.com/27742105/69459413-89339980-0d26-11ea-8b9c-cd0fe54ddb3a.png)
![Screenshot_1574455575](https://user-images.githubusercontent.com/27742105/69459414-89339980-0d26-11ea-92ee-04b9314450bd.png)



### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
