### PR TITLE
Issue #5183: Initialize megazord asynchronously

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -13,11 +13,12 @@ import androidx.annotation.CallSuper
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.content.getSystemService
 import io.reactivex.plugins.RxJavaPlugins
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.async
-import kotlinx.coroutines.launch
 import mozilla.appservices.Megazord
 import mozilla.components.concept.push.PushProcessor
 import mozilla.components.service.experiments.Experiments
@@ -75,19 +76,24 @@ open class FenixApplication : Application() {
 
     @CallSuper
     open fun setupInMainProcessOnly() {
-        setupMegazord()
+        run {
+            // Attention: Do not invoke any code from a-s in this scope.
+            val megazordSetup = setupMegazord()
 
-        // We want rust logging to go through the log sinks.
-        // This has to happen after initializing the megazord.
-        RustLog.enable()
+            setDayNightTheme()
+            registerRxExceptionHandling()
+            enableStrictMode()
 
-        setDayNightTheme()
+            // Make sure the engine is initialized and ready to use.
+            components.core.engine.warmUp()
 
-        registerRxExceptionHandling()
-        enableStrictMode()
-
-        // Make sure the engine is initialized and ready to use.
-        components.core.engine.warmUp()
+            // Just to make sure it is impossible for any application-services pieces
+            // to invoke parts of itself that require complete megazord initialization
+            // before that process completes, we wait here, if necessary.
+            if (!megazordSetup.isCompleted) {
+                runBlocking { megazordSetup.await(); }
+            }
+        }
 
         // We want to call this function as early as possible, but only once and
         // on the main process, as it uses Gecko to fetch experiments from the server.
@@ -205,11 +211,15 @@ open class FenixApplication : Application() {
      * - https://github.com/mozilla/application-services/blob/master/docs/design/megazords.md
      * - https://mozilla.github.io/application-services/docs/applications/consuming-megazord-libraries.html
      */
-    private fun setupMegazord() {
-        // Note: This must be called as soon as possible
+    private fun setupMegazord(): Deferred<Unit> {
+        // Note: Megazord.init() must be called as soon as possible ...
         Megazord.init()
-        // This (and enabling RustLog) may be delayed if needed for performance reasons
-        RustHttpConfig.setClient(lazy { components.core.client })
+
+        return GlobalScope.async(Dispatchers.IO) {
+            // ... but RustHttpConfig.setClient() and RustLog.enable() can be called later.
+            RustHttpConfig.setClient(lazy { components.core.client })
+            RustLog.enable()
+        }
     }
 
     override fun onTrimMemory(level: Int) {


### PR DESCRIPTION
Thanks to the work of the team at application-services, it is possible
to asynchronously initialize the Http client and logger used by megazord
Use that power to hide the time necessary to complete this initialization
within the time that it takes to warmup the gecko runtime.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
