### PR TITLE
Fix for A-C 23.0.0: onDownloadCompleted renamed to onDownloadStopped

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -263,7 +263,7 @@ abstract class BaseBrowserFragment : Fragment(), BackHandler, SessionManager.Obs
                 }
             )
 
-            downloadFeature.onDownloadCompleted = { download, _, downloadJobStatus ->
+            downloadFeature.onDownloadStopped = { download, _, downloadJobStatus ->
                 // If the download is just paused, don't show any in-app notification
                 if (downloadJobStatus == AbstractFetchDownloadService.DownloadJobStatus.COMPLETED ||
                     downloadJobStatus == AbstractFetchDownloadService.DownloadJobStatus.FAILED) {


### PR DESCRIPTION
This is to fix master after a breaking change landed in A-C.