### PR TITLE
Split android-test build job into 2 so it can be signed with 2...

### DIFF
--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -45,7 +45,7 @@ jobs:
         treeherder:
             symbol: debug(B)
 
-    android-test:
+    android-test-debug:
         attributes:
             code-review: true
         run-on-tasks-for: [github-pull-request, github-push]
@@ -56,7 +56,26 @@ jobs:
             # 2 differences here: "androidTest/" is added and "{gradle_build_type}" is forced to "debug"
             path: '/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/{geckoview_engine}/debug/{fileName}'
         treeherder:
-            symbol: androidTest(B)
+            symbol: debug(Bat)
+
+    # android-test-nightly, while still being a debug build, is meant to be signed with the nightly
+    # key. The Firebase testing infrastructure requires both the androidTest APK and the APK under
+    # test to be signed with the same key. Thus, the nightly APK being signed with nightly means
+    # we need an androidTest APK with the same signature.
+    #
+    # TODO: See if we can tweak the signing kind to make 2 signing jobs out of a single `android-test`
+    # job.
+    android-test-nightly:
+        attributes:
+            nightly: true
+        run:
+            geckoview-engine: geckoNightly
+            gradle-build-type: androidTest
+        apk-artifact-template:
+            # 2 differences here: "androidTest/" is added and "{gradle_build_type}" is forced to "debug"
+            path: '/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/{geckoview_engine}/debug/{fileName}'
+        treeherder:
+            symbol: nightly(Bat)
 
     performance-test:
         run:

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -2,7 +2,6 @@
 trust-domain: mobile
 treeherder:
     group-names:
-        'androidTest': 'Tasks related to the androidTest APK'
         'beta': 'Nightly-related tasks'
         'debug': 'Builds made for testing'
         'forPerformanceTest': 'Builds made for Raptor and other performance tests'

--- a/taskcluster/ci/signing/kind.yml
+++ b/taskcluster/ci/signing/kind.yml
@@ -16,7 +16,7 @@ job-template:
     description: Sign Fenix
     worker-type:
         by-build-type:
-            (fennec-production|nightly|beta|production):
+            (fennec-production|nightly|beta|production|android-test-nightly):
                 by-level:
                     '3': signing
                     default: dep-signing
@@ -29,6 +29,10 @@ job-template:
                         '3': fennec-production-signing
                         default: dep-signing
                 nightly:
+                    by-level:
+                        '3': nightly-signing
+                        default: dep-signing
+                android-test-nightly:
                     by-level:
                         '3': nightly-signing
                         default: dep-signing
@@ -49,7 +53,10 @@ job-template:
             default: {}
     run-on-tasks-for: []
     treeherder:
-        job-symbol: Bs
+        job-symbol:
+            by-build-type:
+                android-test.+: Bats
+                default: Bs
         kind: build
         platform: android-all/opt
         tier: 2

--- a/taskcluster/ci/ui-test/kind.yml
+++ b/taskcluster/ci/ui-test/kind.yml
@@ -10,13 +10,13 @@ transforms:
     - taskgraph.transforms.task:transforms
 
 jobs:
-    x86:
+    x86-debug:
         attributes:
             build-type: debug
             code-review: true
         dependencies:
             signing: signing-debug
-            signing-android-test: signing-android-test
+            signing-android-test: signing-android-test-debug
         description: Test Fenix
         include-pull-request-number: true
         run-on-tasks-for: [github-pull-request, github-push]

--- a/taskcluster/fenix_taskgraph/transforms/single_dep.py
+++ b/taskcluster/fenix_taskgraph/transforms/single_dep.py
@@ -8,6 +8,7 @@ Apply some defaults and minor modifications to the single_dep jobs.
 from __future__ import absolute_import, print_function, unicode_literals
 
 from taskgraph.transforms.base import TransformSequence
+from taskgraph.util.schema import resolve_keyed_by
 from taskgraph.util.treeherder import inherit_treeherder_from_dep, join_symbol
 
 
@@ -30,6 +31,21 @@ def build_name_and_attributes(config, tasks):
 
 def _get_dependent_job_name_without_its_kind(dependent_job):
     return dependent_job.label[len(dependent_job.kind) + 1:]
+
+
+@transforms.add
+def resolve_keys(config, tasks):
+    for task in tasks:
+        resolve_keyed_by(
+            task,
+            "treeherder.job-symbol",
+            item_name=task["name"],
+            **{
+                'build-type': task["attributes"]["build-type"],
+                'level': config.params["level"],
+            }
+        )
+        yield task
 
 
 @transforms.add


### PR DESCRIPTION
... different keys

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

This fixes https://github.com/mozilla-mobile/fenix/pull/6569#discussion_r350054573. Here's what taskgraph-diff generates:

cron nightly:

```py
[
    "add", 
    "", 
    [
        [
            "signing-android-test-nightly", 
            {
                "attributes": {
                    "always_target": false, 
                    "apks": {
                        "noarch": "public/build/noarch/geckoNightly/target.apk"
                    }, 
                    "build-type": "android-test-nightly", 
                    "kind": "signing", 
                    "nightly": true, 
                    "run_on_projects": [
                        "all"
                    ], 
                    "run_on_tasks_for": [], 
                    "signed": true
                }, 
                "dependencies": {
                    "build": "build-android-test-nightly"
                }, 
                "kind": "signing", 
                "label": "signing-android-test-nightly", 
                "optimization": null, 
                "soft_dependencies": [], 
                "task": {
                    "created": {
                        "relative-datestamp": "0 seconds"
                    }, 
                    "deadline": {
                        "relative-datestamp": "1 day"
                    }, 
                    "expires": {
                        "relative-datestamp": "1 year"
                    }, 
                    "extra": {
                        "index": {
                            "rank": 0
                        }, 
                        "parent": "", 
                        "treeherder": {
                            "collection": {
                                "opt": true
                            }, 
                            "groupName": "Nightly-related tasks", 
                            "groupSymbol": "nightly", 
                            "jobKind": "build", 
                            "machine": {
                                "platform": "android-all"
                            }, 
                            "symbol": "Bats", 
                            "tier": 2
                        }, 
                        "treeherder-platform": "android-all/opt"
                    }, 
                    "metadata": {
                        "description": "Sign Fenix ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=fenix&revision=841b06b02fc3a887fcea2a8b42dfbb9142f0bc52))", 
                        "name": "signing-android-test-nightly", 
                        "owner": "cron@noreply.mozilla.org", 
                        "source": "https://github.com/mozilla-mobile/fenix/blob/841b06b02fc3a887fcea2a8b42dfbb9142f0bc52/taskcluster/ci/signing"
                    }, 
                    "payload": {
                        "maxRunTime": 600, 
                        "upstreamArtifacts": [
                            {
                                "formats": [
                                    "autograph_apk"
                                ], 
                                "paths": [
                                    "public/build/noarch/geckoNightly/target.apk"
                                ], 
                                "taskId": {
                                    "task-reference": "<build>"
                                }, 
                                "taskType": "build"
                            }
                        ]
                    }, 
                    "priority": "highest", 
                    "provisionerId": "scriptworker-k8s", 
                    "routes": [
                        "tc-treeherder.v2.fenix.841b06b02fc3a887fcea2a8b42dfbb9142f0bc52.0", 
                        "checks"
                    ], 
                    "scopes": [
                        "project:mobile:fenix:releng:signing:cert:nightly-signing", 
                        "project:mobile:fenix:releng:signing:format:autograph_apk"
                    ], 
                    "tags": {
                        "createdForUser": "cron@noreply.mozilla.org", 
                        "kind": "signing", 
                        "label": "signing-android-test-nightly", 
                        "os": "scriptworker", 
                        "worker-implementation": "scriptworker"
                    }, 
                    "workerType": "mobile-3-signing"
                }
            }
        ], 
        [
            "build-android-test-nightly", 
            {
                "attributes": {
                    "always_target": false, 
                    "apks": {
                        "noarch": "public/build/noarch/geckoNightly/target.apk"
                    }, 
                    "build-type": "android-test-nightly", 
                    "kind": "build", 
                    "nightly": true, 
                    "run_on_projects": [
                        "all"
                    ], 
                    "run_on_tasks_for": []
                }, 
                "dependencies": {
                    "docker-image": "build-docker-image-base"
                }, 
                "kind": "build", 
                "label": "build-android-test-nightly", 
                "optimization": null, 
                "soft_dependencies": [], 
                "task": {
                    "created": {
                        "relative-datestamp": "0 seconds"
                    }, 
                    "deadline": {
                        "relative-datestamp": "1 day"
                    }, 
                    "expires": {
                        "relative-datestamp": "1 year"
                    }, 
                    "extra": {
                        "chainOfTrust": {
                            "inputs": {
                                "docker-image": {
                                    "task-reference": "<docker-image>"
                                }
                            }
                        }, 
                        "index": {
                            "rank": 1570168853
                        }, 
                        "parent": "", 
                        "treeherder": {
                            "collection": {
                                "opt": true
                            }, 
                            "groupName": "Nightly-related tasks", 
                            "groupSymbol": "nightly", 
                            "jobKind": "build", 
                            "machine": {
                                "platform": "android-all"
                            }, 
                            "symbol": "Bat", 
                            "tier": 1
                        }, 
                        "treeherder-platform": "android-all/opt"
                    }, 
                    "metadata": {
                        "description": "Build Fenix from source code. ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=fenix&revision=841b06b02fc3a887fcea2a8b42dfbb9142f0bc52))", 
                        "name": "build-android-test-nightly", 
                        "owner": "cron@noreply.mozilla.org", 
                        "source": "https://github.com/mozilla-mobile/fenix/blob/841b06b02fc3a887fcea2a8b42dfbb9142f0bc52/taskcluster/ci/build"
                    }, 
                    "payload": {
                        "artifacts": {
                            "public/build/noarch/geckoNightly/target.apk": {
                                "expires": {
                                    "relative-datestamp": "1 year"
                                }, 
                                "path": "/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/geckoNightly/debug/app-geckoNightly-debug-androidTest.apk", 
                                "type": "file"
                            }
                        }, 
                        "command": [
                            "/usr/local/bin/run-task", 
                            "--mobile-checkout=/builds/worker/checkouts/src/", 
                            "--task-cwd", 
                            "/builds/worker/checkouts/src", 
                            "--fetch-hgfingerprint", 
                            "--", 
                            "bash", 
                            "-cx", 
                            "echo '\"--\"' '>' .adjust_token && echo '\"\"' '>' .digital_asset_links_token && echo '\"-:-\"' '>' .leanplum_token && echo '\"https://fake@sentry.prod.mozaws.net/368\"' '>' .sentry_token && ./gradlew clean assembleAndroidTest"
                        ], 
                        "env": {
                            "ANDROID_SDK_ROOT": "/builds/worker/android-sdk-linux", 
                            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store", 
                            "MOBILE_BASE_REPOSITORY": "https://github.com/mozilla-mobile/fenix", 
                            "MOBILE_HEAD_REF": "master", 
                            "MOBILE_HEAD_REPOSITORY": "https://github.com/mozilla-mobile/fenix", 
                            "MOBILE_HEAD_REV": "841b06b02fc3a887fcea2a8b42dfbb9142f0bc52", 
                            "MOBILE_REPOSITORY_TYPE": "git", 
                            "MOZ_AUTOMATION": "1", 
                            "MOZ_SCM_LEVEL": "3", 
                            "REPOSITORIES": "{\"mobile\": \"Fenix\"}", 
                            "SCCACHE_DISABLE": "1", 
                            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts", 
                            "VCS_PATH": "/builds/worker/checkouts/src"
                        }, 
                        "features": {
                            "chainOfTrust": true, 
                            "taskclusterProxy": true
                        }, 
                        "image": {
                            "path": "public/image.tar.zst", 
                            "taskId": {
                                "task-reference": "<docker-image>"
                            }, 
                            "type": "task-image"
                        }, 
                        "maxRunTime": 7200, 
                        "onExitStatus": {
                            "purgeCaches": [
                                72
                            ], 
                            "retry": [
                                72
                            ]
                        }
                    }, 
                    "priority": "highest", 
                    "provisionerId": "mobile-3", 
                    "routes": [
                        "tc-treeherder.v2.fenix.841b06b02fc3a887fcea2a8b42dfbb9142f0bc52.0", 
                        "checks"
                    ], 
                    "scopes": [], 
                    "tags": {
                        "createdForUser": "cron@noreply.mozilla.org", 
                        "kind": "build", 
                        "label": "build-android-test-nightly", 
                        "os": "linux", 
                        "worker-implementation": "docker-worker"
                    }, 
                    "workerType": "b-linux"
                }
            }
        ]
    ]
]

```

push:

```py
[
    "add", 
    "", 
    [
        [
            "build-android-test-debug",
            {
              # ...
            }
        ], 
        [
            "ui-test-x86-debug", 
            {
              # ...
            }
        ], 
        [
            "signing-android-test-debug", 
            {
              # ...
            }
        ]
    ]
]
[
    "remove", 
    "", 
    [
        [
            "signing-android-test", 
            {
              # ...
            }
        ], 
        [
            "build-android-test", 
            {
              # ...
            }
        ], 
        [
            "ui-test-x86", 
            {
              # ...
            }
        ]
    ]
]
```

pull request:

```py
[
    "change", 
    [
        "pr-complete", 
        "soft_dependencies", 
        0
    ], 
    [
        "lint-ktlint", 
        "ui-test-x86-debug"
    ]
]
[
    "change", 
    [
        "pr-complete", 
        "soft_dependencies", 
        1
    ], 
    [
        "lint-detekt", 
        "lint-ktlint"
    ]
]
[
    "change", 
    [
        "pr-complete", 
        "soft_dependencies", 
        2
    ], 
    [
        "build-debug", 
        "lint-detekt"
    ]
]
[
    "change", 
    [
        "pr-complete", 
        "soft_dependencies", 
        3
    ], 
    [
        "lint-lint", 
        "build-debug"
    ]
]
[
    "change", 
    [
        "pr-complete", 
        "soft_dependencies", 
        4
    ], 
    [
        "test-debug", 
        "build-android-test-debug"
    ]
]
[
    "change", 
    [
        "pr-complete", 
        "soft_dependencies", 
        5
    ], 
    [
        "lint-compare-locales", 
        "lint-lint"
    ]
]
[
    "change", 
    [
        "pr-complete", 
        "soft_dependencies", 
        6
    ], 
    [
        "build-android-test", 
        "test-debug"
    ]
]
[
    "change", 
    [
        "pr-complete", 
        "soft_dependencies", 
        7
    ], 
    [
        "ui-test-x86", 
        "lint-compare-locales"
    ]
]
[
    "add", 
    "", 
    [
        [
            "build-android-test-debug", 
            {
                # ...
            }
        ], 
        [
            "ui-test-x86-debug", 
            {
                # ...
            }
        ], 
        [
            "signing-android-test-debug", 
            {
                # ...
            }
        ]
    ]
]
[
    "remove", 
    "", 
    [
        [
            "signing-android-test", 
            {
                # ...
            }
        ], 
        [
            "build-android-test", 
            {
                # ...
            }
        ], 
        [
            "ui-test-x86", 
            {
                # ...
            }
        ]
    ]
]

```

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
