### PR TITLE
Update the Lifecycle dependency to 2.2.0-rc02

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -24,7 +24,7 @@ object Versions {
     const val androidx_preference = "1.1.0"
     const val androidx_legacy = "1.0.0"
     const val androidx_annotation = "1.1.0"
-    const val androidx_lifecycle = "2.2.0-beta01"
+    const val androidx_lifecycle = "2.2.0-rc02"
     const val androidx_fragment = "1.2.0-beta02"
     const val androidx_navigation = "2.2.0-beta01"
     const val androidx_recyclerview = "1.1.0-beta04"


### PR DESCRIPTION
The changelog [lives here](https://developer.android.com/jetpack/androidx/releases/lifecycle#2.2.0-rc02).
This is another attempt to fix the oddities being detected by Glean in Fenix: 'baseline' ping are not being sent for a certain subset of users, 'metrics' pings are.

Other fixes that we tried before (proguard rules, using legacy classes from the Lifecycle library) made things better, but the problem doesn't appear to be fixed yet, on Nightly.

Updating to this newer would help due to this specific fix:

> "Fixed a bug in the proguard setup of the library that affected devices running API 28+ if the target API is below 29. (b/142778206)"

cc @liuche @sblatz @mdboom 

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
