### PR TITLE
For#6430 Private browsing hint width should not exceed screen dimensions

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -99,6 +99,7 @@ import org.mozilla.fenix.share.ShareTab
 import org.mozilla.fenix.utils.FragmentPreDrawManager
 import org.mozilla.fenix.utils.allowUndo
 import org.mozilla.fenix.whatsnew.WhatsNew
+import kotlin.math.min
 
 @SuppressWarnings("TooManyFunctions", "LargeClass")
 class HomeFragment : Fragment() {
@@ -614,10 +615,13 @@ class HomeFragment : Fragment() {
         context?.let {
             val layout = LayoutInflater.from(it)
                 .inflate(R.layout.pbm_shortcut_popup, null)
-            val trackingOnboarding =
+            val privateBrowsingRecommend =
                 PopupWindow(
                     layout,
-                    (resources.displayMetrics.widthPixels / CFR_WIDTH_DIVIDER).toInt(),
+                    min(
+                        (resources.displayMetrics.widthPixels / CFR_WIDTH_DIVIDER).toInt(),
+                        (resources.displayMetrics.heightPixels / CFR_WIDTH_DIVIDER).toInt()
+                    ),
                     LinearLayout.LayoutParams.WRAP_CONTENT,
                     true
                 )
@@ -625,19 +629,20 @@ class HomeFragment : Fragment() {
                 setOnClickListener {
                     context.metrics.track(Event.PrivateBrowsingAddShortcutCFR)
                     PrivateShortcutCreateManager.createPrivateShortcut(context)
-                    trackingOnboarding.dismiss()
+                    privateBrowsingRecommend.dismiss()
                 }
             }
             layout.findViewById<Button>(R.id.cfr_neg_button).apply {
                 setOnClickListener {
                     context.metrics.track(Event.PrivateBrowsingCancelCFR)
-                    trackingOnboarding.dismiss()
+                    privateBrowsingRecommend.dismiss()
                 }
             }
             // We want to show the popup only after privateBrowsingButton is available.
             // Otherwise, we will encounter an activity token error.
             privateBrowsingButton.post {
-                trackingOnboarding.showAsDropDown(privateBrowsingButton, 0, CFR_Y_OFFSET, Gravity.TOP or Gravity.END)
+                privateBrowsingRecommend.showAsDropDown(
+                    privateBrowsingButton, 0, CFR_Y_OFFSET, Gravity.TOP or Gravity.END)
             }
         }
     }


### PR DESCRIPTION
Renamed ambiguous pop-up window name.
Adjusted code to match max line length.
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
