### PR TITLE
Bug 1600104 - Enable Fennec{Nightly,Beta} builds on CI

### DIFF
--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -95,17 +95,6 @@ jobs:
         treeherder:
             symbol: nightly(B)
 
-    fennec-production:
-        attributes:
-            nightly: true
-        include-nightly-version: true
-        include-shippable-secrets: true
-        run:
-            geckoview-engine: geckoBeta
-            gradle-build-type: fennecProduction
-        treeherder:
-            symbol: nightlyFennec(B)
-
     beta:
         attributes:
             release-type: beta
@@ -129,3 +118,40 @@ jobs:
         run-on-tasks-for: [github-release]
         treeherder:
             symbol: production(B)
+
+    fennec-nightly:
+        attributes:
+            nightly: true
+        include-nightly-version: true
+        include-shippable-secrets: true
+        run:
+            geckoview-engine: geckoNightly
+            gradle-build-type: fennecNightly
+        treeherder:
+            symbol: nightlyFennec(B)
+
+    fennec-beta:
+        attributes:
+            # TODO replace `nightly: true` by `release-type: beta` once the data migration
+            # testing is over
+            nightly: true
+        include-release-version: true
+        include-shippable-secrets: true
+        run:
+            geckoview-engine: geckoBeta
+            gradle-build-type: fennecBeta
+        treeherder:
+            symbol: betaFennec(B)
+
+    fennec-production:
+        attributes:
+            # TODO replace `nightly: true` by `release-type: production` once the data migration
+            # testing is over
+            nightly: true
+        include-release-version: true
+        include-shippable-secrets: true
+        run:
+            geckoview-engine: geckoBeta
+            gradle-build-type: fennecProduction
+        treeherder:
+            symbol: productionFennec(B)

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -2,13 +2,15 @@
 trust-domain: mobile
 treeherder:
     group-names:
-        'beta': 'Nightly-related tasks'
+        'beta': 'Beta-related tasks'
+        'betaFennec': 'Beta-related tasks with same APK configuration as Fennec'
         'debug': 'Builds made for testing'
         'forPerformanceTest': 'Builds made for Raptor and other performance tests'
         'I': 'Docker Image Builds'
         'nightly': 'Nightly-related tasks'
         'nightlyFennec': 'Nightly-related tasks with same APK configuration as Fennec'
         'production': 'Release-related tasks'
+        'productionFennec': 'Production-related tasks with same APK configuration as Fennec'
         'Rap': 'Raptor tests'
         'Rap-P': 'Raptor power tests'
 

--- a/taskcluster/ci/signing/kind.yml
+++ b/taskcluster/ci/signing/kind.yml
@@ -12,11 +12,12 @@ transforms:
 kind-dependencies:
     - build
 
+
 job-template:
     description: Sign Fenix
     worker-type:
         by-build-type:
-            (fennec-production|nightly|beta|production|android-test-nightly):
+            (fennec-.+|nightly|beta|production|android-test-nightly):
                 by-level:
                     '3': signing
                     default: dep-signing
@@ -24,9 +25,13 @@ job-template:
     worker:
         signing-type:
             by-build-type:
-                fennec-production:
+                fennec-(beta|production):
                     by-level:
                         '3': fennec-production-signing
+                        default: dep-signing
+                fennec-nightly:
+                    by-level:
+                        '3': fennec-nightly-signing
                         default: dep-signing
                 nightly:
                     by-level:
@@ -48,7 +53,7 @@ job-template:
                 default: dep-signing
     index:
         by-build-type:
-            (fennec-production|nightly|performance-test|beta|production):
+            (fennec-.+|nightly|performance-test|beta|production):
                 type: signing
             default: {}
     run-on-tasks-for: []


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

Here's what taskgraph-diff outputs: See https://github.com/mozilla-mobile/fenix/pull/6856#issuecomment-561168633 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
