### PR TITLE
Closes #4976: Reuse Fennec launcher entry in manifest.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,17 +28,31 @@
         android:theme="@style/NormalTheme"
         android:usesCleartextTraffic="true"
         tools:ignore="UnusedAttribute">
-        <activity
-            android:name=".HomeActivity"
-            android:configChanges="keyboard|keyboardHidden|mcc|mnc|orientation|screenSize|locale|layoutDirection|smallestScreenSize|screenLayout"
-            android:launchMode="singleTask"
-            android:windowSoftInputMode="adjustResize">
+
+        <!--
+          We inherited this entry (org.mozilla.gecko.App) from Fennec. We need to keep this as our
+          main launcher to avoid launcher icons on the home screen disappearing for all our users
+          on a Fennec build.
+        -->
+        <activity-alias
+            android:name="org.mozilla.gecko.App"
+            android:targetActivity=".HomeActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
 
+            <meta-data
+                android:name="android.app.shortcuts"
+                android:resource="@xml/shortcuts" />
+        </activity-alias>
+
+        <activity
+            android:name=".HomeActivity"
+            android:configChanges="keyboard|keyboardHidden|mcc|mnc|orientation|screenSize|locale|layoutDirection|smallestScreenSize|screenLayout"
+            android:launchMode="singleTask"
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.BROWSABLE" />
@@ -62,10 +76,6 @@
                 <data android:scheme="fenix"
                     android:host="make_default_browser"/>
             </intent-filter>
-
-            <meta-data
-                android:name="android.app.shortcuts"
-                android:resource="@xml/shortcuts" />
         </activity>
 
         <activity


### PR DESCRIPTION
With this patch Fennec users, who upgrade to Fenix, will not lose Firefox launcher icons they
have added to their home screen.

A side effect of this change is that the launcher entry for existing Fenix users may disappear
from the home screen for existing Firefox Preview users and they will have to re-add it.
Since the Preview audience is more accepting of breaking changes and since that group is
way smaller than the millions of Fennec users, I think that this is an acceptable breaking
change. I looked into supporting multiple launcher entries in parallel, but that got quite
complex with multiple build types and multiple manifest files. Especially if we decide
to keep a Firefox Preview build around (e.g. org.mozilla.fenix) then it would be good to
unify on a single launcher and do that as early as possible.
