### PR TITLE
Update Application Services to 0.44.0..

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -43,7 +43,7 @@ object Versions {
     // that we depend on directly for the fenix-megazord (and for it's
     // forUnitTest variant), and it's important that it be kept in
     // sync with the version used by android-components above.
-    const val mozilla_appservices = "0.42.2"
+    const val mozilla_appservices = "0.44.0"
 
     const val mozilla_glean = "19.0.0"
 


### PR DESCRIPTION
A-C is bumping the dependency version in https://github.com/mozilla-mobile/android-components/pull/5131.