### PR TITLE
For #6835 Align Home and Browser toolbar elements to perfectly overlap

### DIFF
--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -77,7 +77,10 @@
                 android:transitionName="toolbar_wrapper_transition"
                 android:layout_width="0dp"
                 android:layout_height="40dp"
-                android:layout_margin="8dp"
+                android:layout_marginEnd="0dp"
+                android:layout_marginStart="8dp"
+                android:layout_marginTop="8dp"
+                android:layout_marginBottom="8dp"
                 android:background="@drawable/home_search_background_normal"
                 android:clickable="true"
                 android:contentDescription="@string/search_hint"
@@ -91,7 +94,7 @@
                     android:id="@+id/search_engine_icon"
                     android:layout_width="24dp"
                     android:layout_height="24dp"
-                    android:layout_marginStart="12dp"
+                    android:layout_marginStart="8dp"
                     android:layout_gravity="start|center_vertical"
                     android:clickable="false"
                     android:focusable="false"
@@ -113,8 +116,8 @@
 
             <ImageButton
                 android:id="@+id/add_tab_button"
-                android:layout_width="40dp"
-                android:layout_height="40dp"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
                 android:background="?android:attr/selectableItemBackgroundBorderless"
                 android:contentDescription="@string/add_tab"
                 android:src="@drawable/ic_new"
@@ -125,9 +128,8 @@
 
             <ImageButton
                 android:id="@+id/menuButton"
-                android:layout_width="40dp"
-                android:layout_height="40dp"
-                android:layout_marginEnd="6dp"
+                android:layout_width="36dp"
+                android:layout_height="48dp"
                 android:background="?android:attr/selectableItemBackgroundBorderless"
                 android:contentDescription="@string/content_description_menu"
                 android:src="@drawable/ic_menu"


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

![2](https://user-images.githubusercontent.com/48995920/69957479-72056080-150b-11ea-9ea9-281c9b6da092.png)
![1](https://user-images.githubusercontent.com/48995920/69957480-729df700-150b-11ea-9443-669afe381dfc.png)
![imgonline-com-ua-Piconpic-MbadokdQXFe](https://user-images.githubusercontent.com/48995920/69957463-6b76e900-150b-11ea-9481-82676087fc24.jpg)


### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
