### PR TITLE
Revert "Update Application Services to 0.44.0" commit to fix imcompatible megazord version crash

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -43,7 +43,7 @@ object Versions {
     // that we depend on directly for the fenix-megazord (and for it's
     // forUnitTest variant), and it's important that it be kept in
     // sync with the version used by android-components above.
-    const val mozilla_appservices = "0.44.0"
+    const val mozilla_appservices = "0.42.2"
 
     const val mozilla_glean = "19.0.0"
 


### PR DESCRIPTION
---

I'm getting below error messages while I was trying to deploy into device so I wanted to create this PR to solve crash

```
12-03 08:35:07.594 1398-1461/org.mozilla.fenix.debug E/AndroidRuntime: FATAL EXCEPTION: DefaultDispatcher-worker-5
    Process: org.mozilla.fenix.debug, PID: 1398
    java.lang.ExceptionInInitializerError
        at mozilla.appservices.places.LibPlacesFFI.<clinit>(LibPlacesFFI.kt)
        at mozilla.appservices.places.PlacesApi.<init>(PlacesConnection.kt:35)
        at mozilla.components.browser.storage.sync.RustPlacesConnection.init(Connection.kt:65)
        at mozilla.components.browser.storage.sync.PlacesStorage$places$2.invoke(PlacesStorage.kt:35)
        at mozilla.components.browser.storage.sync.PlacesStorage$places$2.invoke(PlacesStorage.kt:26)
        at kotlin.SynchronizedLazyImpl.getValue(LazyJVM.kt:74)
        at mozilla.components.browser.storage.sync.PlacesStorage.getPlaces$browser_storage_sync_release(PlacesStorage.kt)
        at mozilla.components.browser.storage.sync.PlacesStorage$runMaintenance$2.invokeSuspend(PlacesStorage.kt:47)
        at mozilla.components.browser.storage.sync.PlacesStorage$runMaintenance$2.invoke(PlacesStorage.kt)
        at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:91)
        at kotlinx.coroutines.BuildersKt__Builders_commonKt.withContext(Builders.common.kt:156)
        at kotlinx.coroutines.BuildersKt.withContext(Unknown Source)
        at mozilla.components.browser.storage.sync.PlacesStorage.runMaintenance$suspendImpl(PlacesStorage.kt:46)
        at mozilla.components.browser.storage.sync.PlacesStorage.runMaintenance(PlacesStorage.kt)
        at org.mozilla.fenix.FenixApplication$runStorageMaintenance$1.invokeSuspend(FenixApplication.kt:143)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.DispatchedTask.run(Dispatched.kt:241)
        at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:594)
        at kotlinx.coroutines.scheduling.CoroutineScheduler.access$runSafely(CoroutineScheduler.kt:60)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:740)
     Caused by: mozilla.appservices.support.native.IncompatibleMegazordVersion: Incompatible megazord version: library "places" was compiled expecting app-services version "0.42.2", but the megazord "fenix" provides version "0.44.0"

```
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
