### PR TITLE
For #4107 Make home screen fullscreen

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -13,6 +13,8 @@ import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.Window
+import android.view.WindowManager
 import android.widget.Button
 import android.widget.LinearLayout
 import android.widget.PopupWindow
@@ -210,7 +212,26 @@ class HomeFragment : Fragment() {
 
         activity.themeManager.applyStatusBarTheme(activity)
 
+        setFragmentFullScreen(this.activity?.window, view.homeLayout)
+
         return view
+    }
+
+    private fun setFragmentFullScreen(window: Window?, homeScreen: View) {
+
+        window?.decorView?.setOnApplyWindowInsetsListener { _, insets ->
+
+            homeScreen.setPadding(
+                homeScreen.paddingLeft,
+                homeScreen.paddingTop + insets.stableInsetTop,
+                homeScreen.paddingRight,
+                homeScreen.paddingBottom + insets.stableInsetBottom
+            )
+
+            window.decorView.setOnApplyWindowInsetsListener(null)
+
+            insets.consumeSystemWindowInsets()
+        }
     }
 
     @ExperimentalCoroutinesApi
@@ -249,7 +270,7 @@ class HomeFragment : Fragment() {
                 if (menu == null) {
                     menu = homeMenu?.menuBuilder?.build(requireContext())?.show(
                         anchor = it,
-                        orientation = BrowserMenu.Orientation.DOWN,
+                        orientation = BrowserMenu.Orientation.UP,
                         onDismiss = { menu = null }
                     )
                 } else {
@@ -438,6 +459,8 @@ class HomeFragment : Fragment() {
 
     override fun onResume() {
         super.onResume()
+        this.activity?.window?.setFlags(WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
+            WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS)
         hideToolbar()
     }
 
@@ -770,6 +793,11 @@ class HomeFragment : Fragment() {
 
             it.toTab(requireContext(), it == selected, mediaState)
         }
+    }
+
+    override fun onPause() {
+        this.activity?.window?.clearFlags(WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS)
+        super.onPause()
     }
 
     companion object {

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -140,7 +140,7 @@
         <!-- Drawables -->
         <item name="fenixLogo">@drawable/ic_logo_wordmark_private</item>
         <item name="homeBackground">@drawable/private_home_background_gradient</item>
-        <item name="bottomBarBackground">@drawable/private_home_bottom_bar_background_gradient</item>
+        <item name="bottomBarBackground">@android:color/transparent</item>
         <item name="privateBrowsingButtonBackground">@color/primary_text_private_theme</item>
         <item name="privateBrowsingButtonAccent">@color/above_private_theme</item>
         <item name="shieldLottieFile">@raw/shield_json_dark</item>


### PR DESCRIPTION
Add/Remove fullscreen flags in home fragment's onResume / onPause
Change homeLayout padding to include system bars height (status&navigation).
Change homeMenu orientation to UP to properly display menu.
Change home bottomBar background to transparent.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features
<img src = https://user-images.githubusercontent.com/48995920/70072497-ca1d8f00-15ff-11ea-84f5-ecd2170fe63a.png width = 40%>

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
