### PR TITLE
Closes #6937 - Explicit ordering for migration and db operations in onCreate

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -74,8 +74,12 @@ open class FenixApplication : Application() {
         Log.addSink(AndroidLogSink())
     }
 
-    @CallSuper
     open fun setupInMainProcessOnly() {
+        setupOperationsNotInvolvingStorageLayers()
+        setupOperationsThatAccessStorageLayers()
+    }
+
+    protected fun setupOperationsNotInvolvingStorageLayers() {
         run {
             // Attention: Do not invoke any code from a-s in this scope.
             val megazordSetup = setupMegazord()
@@ -130,7 +134,9 @@ open class FenixApplication : Application() {
         registerActivityLifecycleCallbacks(visibilityLifecycleCallback)
 
         components.core.sessionManager.register(NotificationSessionObserver(this))
+    }
 
+    protected fun setupOperationsThatAccessStorageLayers() {
         if ((System.currentTimeMillis() - settings().lastPlacesStorageMaintenance) > ONE_DAY_MILLIS) {
             runStorageMaintenance()
         }


### PR DESCRIPTION
This patch adds an explicit order for migration logic and runMaintanence call.
Ordering these operations makes sure they won't run concurrently, thus avoiding
potential for SQLITE_BUSY errors.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
