### PR TITLE
For #5334: fix ETP shield coloring on custom private tabs

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabsIntegration.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabsIntegration.kt
@@ -8,8 +8,6 @@ import android.app.Activity
 import android.view.View
 import android.view.ViewGroup.MarginLayoutParams
 import androidx.appcompat.content.res.AppCompatResources
-import com.airbnb.lottie.LottieCompositionFactory
-import com.airbnb.lottie.LottieDrawable
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.browser.toolbar.display.DisplayToolbar
@@ -19,7 +17,6 @@ import mozilla.components.support.base.feature.UserInteractionHandler
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.toolbar.ToolbarMenu
 import org.mozilla.fenix.ext.settings
-import org.mozilla.fenix.theme.ThemeManager
 
 class CustomTabsIntegration(
     sessionManager: SessionManager,
@@ -43,37 +40,30 @@ class CustomTabsIntegration(
             }
         }
 
-        val task = LottieCompositionFactory
-            .fromRawRes(
+        val uncoloredEtpShield = AppCompatResources.getDrawable(
+            activity,
+            R.drawable.ic_tracking_protection_enabled
+        )!!
+
+        toolbar.display.icons = toolbar.display.icons.copy(
+            // Custom private tab backgrounds have bad contrast against the colored shield
+            trackingProtectionTrackersBlocked = uncoloredEtpShield,
+            trackingProtectionNothingBlocked = uncoloredEtpShield,
+            trackingProtectionException = AppCompatResources.getDrawable(
                 activity,
-                ThemeManager.resolveAttribute(R.attr.shieldLottieFile, activity)
+                R.drawable.ic_tracking_protection_disabled
+            )!!
+        )
+
+        toolbar.display.displayIndicatorSeparator = false
+        if (activity.settings().shouldUseTrackingProtection) {
+            toolbar.display.indicators = listOf(
+                DisplayToolbar.Indicators.SECURITY,
+                DisplayToolbar.Indicators.TRACKING_PROTECTION
             )
-        task.addListener { result ->
-            val lottieDrawable = LottieDrawable()
-            lottieDrawable.composition = result
-
-            toolbar.display.displayIndicatorSeparator = false
-            if (activity.settings().shouldUseTrackingProtection) {
-                toolbar.display.indicators = listOf(
-                    DisplayToolbar.Indicators.SECURITY,
-                    DisplayToolbar.Indicators.TRACKING_PROTECTION
-                )
-            } else {
-                toolbar.display.indicators = listOf(
-                    DisplayToolbar.Indicators.SECURITY
-                )
-            }
-
-            toolbar.display.icons = toolbar.display.icons.copy(
-                trackingProtectionTrackersBlocked = lottieDrawable,
-                trackingProtectionNothingBlocked = AppCompatResources.getDrawable(
-                    activity,
-                    R.drawable.ic_tracking_protection_enabled
-                )!!,
-                trackingProtectionException = AppCompatResources.getDrawable(
-                    activity,
-                    R.drawable.ic_tracking_protection_disabled
-                )!!
+        } else {
+            toolbar.display.indicators = listOf(
+                DisplayToolbar.Indicators.SECURITY
             )
         }
 


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### Screenshots
<img width="464" alt="Screen Shot 2019-12-06 at 11 30 16 AM" src="https://user-images.githubusercontent.com/13170306/70350679-03cae180-181c-11ea-84a1-9e68680d8294.png">


### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
