### PR TITLE
Clean up settings fragments

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/DataChoicesFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/DataChoicesFragment.kt
@@ -4,7 +4,6 @@
 
 package org.mozilla.fenix.settings
 
-import android.content.SharedPreferences
 import android.os.Bundle
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreference
@@ -20,36 +19,24 @@ import org.mozilla.fenix.ext.showToolbar
  */
 class DataChoicesFragment : PreferenceFragmentCompat() {
 
-    private val preferenceChangeListener =
-        SharedPreferences.OnSharedPreferenceChangeListener { sharedPreferences, key ->
-            when (key) {
-                getPreferenceKey(R.string.pref_key_telemetry) -> {
-                    if (sharedPreferences.getBoolean(key, requireContext().settings().isTelemetryEnabled)) {
-                        context?.components?.analytics?.metrics?.start()
-                    } else {
-                        context?.components?.analytics?.metrics?.stop()
-                    }
-                }
-            }
-        }
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        context?.let {
-            preferenceManager.sharedPreferences.registerOnSharedPreferenceChangeListener(preferenceChangeListener)
+
+        val context = requireContext()
+        preferenceManager.sharedPreferences.registerOnSharedPreferenceChangeListener(this) { sharedPreferences, key ->
+            if (key == getPreferenceKey(R.string.pref_key_telemetry)) {
+                if (sharedPreferences.getBoolean(key, context.settings().isTelemetryEnabled)) {
+                    context.components.analytics.metrics.start()
+                } else {
+                    context.components.analytics.metrics.stop()
+                }
+            }
         }
     }
 
     override fun onResume() {
         super.onResume()
         showToolbar(getString(R.string.preferences_data_collection))
-    }
-
-    override fun onDestroy() {
-        context?.let {
-            preferenceManager.sharedPreferences.unregisterOnSharedPreferenceChangeListener(preferenceChangeListener)
-        }
-        super.onDestroy()
     }
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {

--- a/app/src/main/java/org/mozilla/fenix/settings/OnSharedPreferenceChangeListener.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/OnSharedPreferenceChangeListener.kt
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.settings
+
+import android.content.SharedPreferences
+import androidx.lifecycle.Lifecycle.Event.ON_CREATE
+import androidx.lifecycle.Lifecycle.Event.ON_DESTROY
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.OnLifecycleEvent
+
+class OnSharedPreferenceChangeListener(
+    private val sharedPreferences: SharedPreferences,
+    private val listener: (SharedPreferences, String) -> Unit
+) : SharedPreferences.OnSharedPreferenceChangeListener, LifecycleObserver {
+
+    @OnLifecycleEvent(ON_CREATE)
+    fun onCreate() {
+        sharedPreferences.registerOnSharedPreferenceChangeListener(this)
+    }
+
+    @OnLifecycleEvent(ON_DESTROY)
+    fun onDestroy() {
+        sharedPreferences.unregisterOnSharedPreferenceChangeListener(this)
+    }
+
+    override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String) {
+        listener(sharedPreferences, key)
+    }
+}
+
+fun SharedPreferences.registerOnSharedPreferenceChangeListener(
+    owner: LifecycleOwner,
+    listener: (SharedPreferences, String) -> Unit
+) {
+    owner.lifecycle.addObserver(OnSharedPreferenceChangeListener(this, listener))
+}

--- a/app/src/main/java/org/mozilla/fenix/settings/ToolbarSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/ToolbarSettingsFragment.kt
@@ -5,16 +5,17 @@
 package org.mozilla.fenix.settings
 
 import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
 import androidx.preference.PreferenceFragmentCompat
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.getPreferenceKey
+import org.mozilla.fenix.ext.showToolbar
 
+/**
+ * Settings to adjust the position of the browser toolbar.
+ */
 class ToolbarSettingsFragment : PreferenceFragmentCompat() {
-    private lateinit var topPreference: RadioButtonPreference
-    private lateinit var bottomPreference: RadioButtonPreference
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         setPreferencesFromResource(R.xml.toolbar_preferences, rootKey)
@@ -22,16 +23,14 @@ class ToolbarSettingsFragment : PreferenceFragmentCompat() {
 
     override fun onResume() {
         super.onResume()
-        (activity as AppCompatActivity).title = getString(R.string.preferences_toolbar)
-        (activity as AppCompatActivity).supportActionBar?.show()
+        showToolbar(getString(R.string.preferences_toolbar))
 
-        setupClickListeners()
-        setupRadioGroups()
+        setupPreferences()
     }
 
-    private fun setupClickListeners() {
+    private fun setupPreferences() {
         val keyToolbarTop = getPreferenceKey(R.string.pref_key_toolbar_top)
-        topPreference = requireNotNull(findPreference(keyToolbarTop))
+        val topPreference = requireNotNull(findPreference<RadioButtonPreference>(keyToolbarTop))
         topPreference.onClickListener {
             requireContext().components.analytics.metrics.track(Event.ToolbarPositionChanged(
                 Event.ToolbarPositionChanged.Position.TOP
@@ -39,15 +38,13 @@ class ToolbarSettingsFragment : PreferenceFragmentCompat() {
         }
 
         val keyToolbarBottom = getPreferenceKey(R.string.pref_key_toolbar_bottom)
-        bottomPreference = requireNotNull(findPreference(keyToolbarBottom))
+        val bottomPreference = requireNotNull(findPreference<RadioButtonPreference>(keyToolbarBottom))
         bottomPreference.onClickListener {
             requireContext().components.analytics.metrics.track(Event.ToolbarPositionChanged(
                 Event.ToolbarPositionChanged.Position.BOTTOM
             ))
         }
-    }
 
-    private fun setupRadioGroups() {
         topPreference.addToRadioGroup(bottomPreference)
         bottomPreference.addToRadioGroup(topPreference)
     }

--- a/app/src/main/java/org/mozilla/fenix/settings/search/EditCustomSearchEngineFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/search/EditCustomSearchEngineFragment.kt
@@ -6,15 +6,13 @@ package org.mozilla.fenix.settings.search
 
 import android.net.Uri
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
-import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
-import androidx.navigation.fragment.navArgs
 import kotlinx.android.synthetic.main.custom_search_engine.*
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.Dispatchers.Main
@@ -26,12 +24,13 @@ import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.components.searchengine.CustomSearchEngineStore
 import org.mozilla.fenix.ext.increaseTapArea
 import org.mozilla.fenix.ext.requireComponents
+import org.mozilla.fenix.ext.showToolbar
 import org.mozilla.fenix.settings.SupportUtils
 import java.util.Locale
 
 class EditCustomSearchEngineFragment : Fragment(R.layout.fragment_add_search_engine) {
     private val engineIdentifier: String by lazy {
-        navArgs<EditCustomSearchEngineFragmentArgs>().value.searchEngineIdentifier
+        EditCustomSearchEngineFragmentArgs.fromBundle(requireArguments()).searchEngineIdentifier
     }
 
     private lateinit var searchEngine: SearchEngine
@@ -68,8 +67,7 @@ class EditCustomSearchEngineFragment : Fragment(R.layout.fragment_add_search_eng
 
     override fun onResume() {
         super.onResume()
-        (activity as AppCompatActivity).title = getString(R.string.search_engine_edit_custom_search_engine_title)
-        (activity as AppCompatActivity).supportActionBar?.show()
+        showToolbar(getString(R.string.search_engine_edit_custom_search_engine_title))
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {

--- a/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsDetailsExceptionsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsDetailsExceptionsFragment.kt
@@ -8,12 +8,13 @@ import android.content.DialogInterface
 import android.os.Bundle
 import androidx.appcompat.app.AlertDialog
 import androidx.lifecycle.lifecycleScope
-import androidx.navigation.Navigation
+import androidx.navigation.findNavController
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.Dispatchers.Main
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import mozilla.components.feature.sitepermissions.SitePermissions
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
@@ -47,28 +48,22 @@ class SitePermissionsDetailsExceptionsFragment : PreferenceFragmentCompat() {
             val context = requireContext()
             sitePermissions =
                 requireNotNull(context.components.core.permissionStorage.findSitePermissionsBy(sitePermissions.origin))
-            launch(Main) {
+            withContext(Main) {
                 bindCategoryPhoneFeatures()
             }
         }
     }
 
     private fun bindCategoryPhoneFeatures() {
-        val context = requireContext()
-
-        val cameraAction = CAMERA.getActionLabel(context, sitePermissions)
-        val locationAction = LOCATION.getActionLabel(context, sitePermissions)
-        val microphoneAction = MICROPHONE.getActionLabel(context, sitePermissions)
-        val notificationAction = NOTIFICATION.getActionLabel(context, sitePermissions)
-
-        initPhoneFeature(CAMERA, cameraAction)
-        initPhoneFeature(LOCATION, locationAction)
-        initPhoneFeature(MICROPHONE, microphoneAction)
-        initPhoneFeature(NOTIFICATION, notificationAction)
+        initPhoneFeature(CAMERA)
+        initPhoneFeature(LOCATION)
+        initPhoneFeature(MICROPHONE)
+        initPhoneFeature(NOTIFICATION)
         bindClearPermissionsButton()
     }
 
-    private fun initPhoneFeature(phoneFeature: PhoneFeature, summary: String) {
+    private fun initPhoneFeature(phoneFeature: PhoneFeature) {
+        val summary = phoneFeature.getActionLabel(requireContext(), sitePermissions)
         val keyPreference = phoneFeature.getPreferenceKey(requireContext())
         val cameraPhoneFeatures: Preference = requireNotNull(findPreference(keyPreference))
         cameraPhoneFeatures.summary = summary
@@ -103,8 +98,8 @@ class SitePermissionsDetailsExceptionsFragment : PreferenceFragmentCompat() {
     private fun clearSitePermissions() {
         lifecycleScope.launch(IO) {
             requireContext().components.core.permissionStorage.deleteSitePermissions(sitePermissions)
-            launch(Main) {
-                Navigation.findNavController(requireNotNull(view)).popBackStack()
+            withContext(Main) {
+                requireView().findNavController().popBackStack()
             }
         }
     }
@@ -115,6 +110,6 @@ class SitePermissionsDetailsExceptionsFragment : PreferenceFragmentCompat() {
                 phoneFeatureId = phoneFeature.id,
                 sitePermissions = sitePermissions
             )
-        Navigation.findNavController(view!!).navigate(directions)
+        requireView().findNavController().navigate(directions)
     }
 }


### PR DESCRIPTION
- Add lifecycle-aware `OnSharedPreferenceChangeListener` helper
- Remove unused `pref_key_telemetry` observer
- Remove extra functions in `SettingsFragment`

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
