### PR TITLE
Bug 1600104 - part 2: Change FennecNightly signing format to have sha1 digest

### DIFF
--- a/taskcluster/ci/signing/kind.yml
+++ b/taskcluster/ci/signing/kind.yml
@@ -54,6 +54,12 @@ job-template:
                         '3': production-signing
                         default: dep-signing
                 default: dep-signing
+    signing-format:
+      by-build-type:
+          # Fennec nightly cannot have the sha256 checksums. For more details, see
+          # https://github.com/mozilla-releng/scriptworker-scripts/pull/102#issue-349016967
+          fennec-nightly: autograph_apk_fennec_sha1
+          default: autograph_apk
     index:
         by-build-type:
             (fennec-.+|nightly|performance-test|beta|production):

--- a/taskcluster/fenix_taskgraph/transforms/signing.py
+++ b/taskcluster/fenix_taskgraph/transforms/signing.py
@@ -18,7 +18,7 @@ transforms = TransformSequence()
 @transforms.add
 def resolve_keys(config, tasks):
     for task in tasks:
-        for key in ("index", "worker-type", "worker.signing-type"):
+        for key in ("index", "worker-type", "worker.signing-type", "signing-format"):
             resolve_keyed_by(
                 task,
                 key,
@@ -41,6 +41,7 @@ def set_signing_attributes(config, tasks):
 @transforms.add
 def set_signing_format(config, tasks):
     for task in tasks:
+        signing_format = task.pop("signing-format")
         for upstream_artifact in task["worker"]["upstream-artifacts"]:
-            upstream_artifact["formats"] = ["autograph_apk"]
+            upstream_artifact["formats"] = [signing_format]
         yield task


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

Fixes

```
signingscript.exceptions.SigningScriptError: No autograph config found with cert type project:mobile:fenix:releng:signing:cert:fennec-nightly-signing and formats ['autograph_apk']
```

https://treeherder.mozilla.org/logviewer.html#/jobs?job_id=280107229&repo=fenix&lineNumber=27

taskgraph-diff just highlighted this single change: 

```diff
diff --git a/Users/johanlorenzo/hg/build/braindump/taskcluster/taskgraph-diff/json/fenix-master/main-repo-cron-nightly.json b/Users/johanlorenzo/hg/build/braindump/taskcluster/taskgraph-diff/json/fenix-after/main-repo-cron-nightly.json
index 4455db1..b1fc8b6 100644
--- a/Users/johanlorenzo/hg/build/braindump/taskcluster/taskgraph-diff/json/fenix-master/main-repo-cron-nightly.json
+++ b/Users/johanlorenzo/hg/build/braindump/taskcluster/taskgraph-diff/json/fenix-after/main-repo-cron-nightly.json
@@ -1630,87 +1630,87 @@
                 "index": {
                     "rank": 0
                 },
                 "parent": "",
                 "treeherder": {
                     "collection": {
                         "opt": true
                     },
                     "groupName": "Nightly-related tasks with same APK configuration as Fennec",
                     "groupSymbol": "nightlyFennec",
                     "jobKind": "build",
                     "machine": {
                         "platform": "android-all"
                     },
                     "symbol": "Bs",
                     "tier": 2
                 },
                 "treeherder-platform": "android-all/opt"
             },
             "metadata": {
                 "description": "Sign Fenix ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=fenix&revision=841b06b02fc3a887fcea2a8b42dfbb9142f0bc52))",
                 "name": "signing-fennec-nightly",
                 "owner": "cron@noreply.mozilla.org",
                 "source": "https://github.com/mozilla-mobile/fenix/blob/841b06b02fc3a887fcea2a8b42dfbb9142f0bc52/taskcluster/ci/signing"
             },
             "payload": {
                 "maxRunTime": 600,
                 "upstreamArtifacts": [
                     {
                         "formats": [
-                            "autograph_apk"
+                            "autograph_apk_fennec_sha1"
                         ],
                         "paths": [
                             "public/build/arm64-v8a/geckoNightly/target.apk",
                             "public/build/armeabi-v7a/geckoNightly/target.apk",
                             "public/build/x86/geckoNightly/target.apk",
                             "public/build/x86_64/geckoNightly/target.apk"
                         ],
                         "taskId": {
                             "task-reference": "<build>"
                         },
                         "taskType": "build"
                     }
                 ]
             },
             "priority": "highest",
             "provisionerId": "scriptworker-k8s",
             "routes": [
                 "index.project.mobile.fenix.v2.fennec-nightly.2019.10.04.revision.841b06b02fc3a887fcea2a8b42dfbb9142f0bc52",
                 "index.project.mobile.fenix.v2.fennec-nightly.2019.10.04.latest",
                 "index.project.mobile.fenix.v2.fennec-nightly.latest",
                 "tc-treeherder.v2.fenix.841b06b02fc3a887fcea2a8b42dfbb9142f0bc52.0",
                 "checks"
             ],
             "scopes": [
                 "project:mobile:fenix:releng:signing:cert:fennec-nightly-signing",
-                "project:mobile:fenix:releng:signing:format:autograph_apk"
+                "project:mobile:fenix:releng:signing:format:autograph_apk_fennec_sha1"
             ],
             "tags": {
                 "createdForUser": "cron@noreply.mozilla.org",
                 "kind": "signing",
                 "label": "signing-fennec-nightly",
                 "os": "scriptworker",
                 "worker-implementation": "scriptworker"
             },
             "workerType": "mobile-3-signing"
         }
     },
     "signing-fennec-production": {
         "attributes": {
             "always_target": false,
             "apks": {
                 "arm64-v8a": "public/build/arm64-v8a/geckoBeta/target.apk",
                 "armeabi-v7a": "public/build/armeabi-v7a/geckoBeta/target.apk",
                 "x86": "public/build/x86/geckoBeta/target.apk",
                 "x86_64": "public/build/x86_64/geckoBeta/target.apk"
             },
             "build-type": "fennec-production",
             "kind": "signing",
             "nightly": true,
             "run_on_projects": [
                 "all"
             ],
             "run_on_tasks_for": [],
             "signed": true
         },
         "dependencies": {
```

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
