### PR TITLE
For #6993 Enable logo selection with Talkback on

### DIFF
--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -31,18 +31,22 @@
 
         <ImageView
             android:id="@+id/wordmark"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="80dp"
-            android:layout_marginStart="16dp"
-            android:layout_marginTop="60dp"
-            android:layout_marginBottom="32dp"
+            android:padding="5dp"
+            android:layout_marginStart="11dp"
+            android:layout_marginEnd="11dp"
+            android:layout_marginTop="55dp"
+            android:layout_marginBottom="27dp"
             android:adjustViewBounds="true"
             android:clickable="false"
             android:contentDescription="@string/app_name"
             android:focusable="false"
-            android:importantForAccessibility="no"
+            android:importantForAccessibility="yes"
             app:srcCompat="?fenixLogo"
+            android:scaleType="fitStart"
             app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
         <FrameLayout


### PR DESCRIPTION
Set important for importantForAccessibility to yes
Cleanup padding and margins to avoid Talkback rectangle overlapping logo
Adjust View size to adjust Talkback positioning, keeping alignment to start

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and passes detekt/ktlint checks (A pre-push hook is recommended)
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

<img src = https://user-images.githubusercontent.com/48995920/70429342-1134d580-1a81-11ea-9029-f334cf90742e.png width = 30%>


### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
