### PR TITLE
Run migration in background service.

### DIFF
--- a/app/src/migration/AndroidManifest.xml
+++ b/app/src/migration/AndroidManifest.xml
@@ -12,6 +12,7 @@
     <application
         android:name="org.mozilla.fenix.MigratingFenixApplication"
         tools:replace="android:name">
+        <service android:name="org.mozilla.fenix.MigrationService" />
     </application>
 </manifest>
 

--- a/app/src/migration/java/org/mozilla/fenix/MigrationService.kt
+++ b/app/src/migration/java/org/mozilla/fenix/MigrationService.kt
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix
+
+import mozilla.components.support.migration.AbstractMigrationService
+
+/**
+ * Background service for running the migration from legacy Firefox for Android (Fennec).
+ */
+class MigrationService : AbstractMigrationService() {
+    override val migrator by lazy { getMigratorFromApplication() }
+}


### PR DESCRIPTION
In order to avoid a half done migration we are moving the migration to a background service (that is running in the "foreground").

This is the Fenix part of:
https://github.com/mozilla-mobile/android-components/issues/4879