### PR TITLE
Let push-apk not be blocked by the startup tests anymore

### DIFF
--- a/taskcluster/ci/push-apk/kind.yml
+++ b/taskcluster/ci/push-apk/kind.yml
@@ -11,7 +11,6 @@ transforms:
 
 kind-dependencies:
     - signing
-    - startup-test 
 
 primary-dependency: signing
 


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

The startup tests are failing for an unknown reason. Let's not make these test block the push-apk task. This way nightly users get updates. See original discussion at https://mozilla.slack.com/archives/CG2FGG1ST/p1575899222038400

Reverts https://github.com/mozilla-mobile/fenix/pull/6936

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
