### PR TITLE
For #7075 Update passwords preference visibility and description string 

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
@@ -158,8 +158,8 @@ private fun assertEnhancedTrackingProtectionValue() = onView(ViewMatchers.withTe
     .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
 private fun assertLoginsButton() {
-    TestHelper.scrollToElementByText("Passwords")
-    onView(ViewMatchers.withText("Passwords"))
+    TestHelper.scrollToElementByText("Logins and passwords")
+    onView(ViewMatchers.withText("Logins and passwords"))
         .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 }
 

--- a/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
@@ -109,6 +109,7 @@ class SettingsFragment : PreferenceFragmentCompat(), AccountObserver {
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         setPreferencesFromResource(R.xml.preferences, rootKey)
+        updatePreferenceVisibilityForFeatureFlags()
     }
 
     override fun onResume() {
@@ -167,8 +168,6 @@ class SettingsFragment : PreferenceFragmentCompat(), AccountObserver {
             context!!,
             requireComponents.backgroundServices.accountManager.accountProfile()
         )
-
-        updatePreferenceVisibilityForFeatureFlags()
     }
 
     private fun updatePreferenceVisibilityForFeatureFlags() {

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -67,7 +67,7 @@
             app:isPreferenceVisible="false"
             android:icon="@drawable/ic_login"
             android:key="@string/pref_key_passwords"
-            android:title="@string/preferences_passwords" />
+            android:title="@string/preferences_passwords_logins_and_passwords" />
         <androidx.preference.Preference
             android:icon="@drawable/ic_private_browsing"
             android:key="@string/pref_key_add_private_browsing_shortcut"


### PR DESCRIPTION
Set visibility for feature flags before settings screen it's displayed.
Change string for preference to match existing header string.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
