### PR TITLE
Enable Fennec settings (telemetry) migration

### DIFF
--- a/app/src/migration/java/org/mozilla/fenix/MigratingFenixApplication.kt
+++ b/app/src/migration/java/org/mozilla/fenix/MigratingFenixApplication.kt
@@ -14,6 +14,7 @@ import mozilla.components.support.migration.FennecMigrator
 class MigratingFenixApplication : FenixApplication() {
     val migrator by lazy {
         FennecMigrator.Builder(this, this.components.analytics.crashReporter)
+            .migrateSettings()
             .migrateOpenTabs(this.components.core.sessionManager)
             .migrateHistory(this.components.core.historyStorage)
             .migrateBookmarks(this.components.core.bookmarksStorage)


### PR DESCRIPTION
This simply turns on settings (currently, just telemetry) Fennec migration.
A-C side of this: https://github.com/mozilla-mobile/android-components/pull/5228