### PR TITLE
For #4994: Hide add folder option when in Desktop Bookmarks folder.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkAdapter.kt
@@ -25,7 +25,7 @@ class BookmarkAdapter(val emptyView: View, val interactor: BookmarkViewInteracto
     RecyclerView.Adapter<BookmarkNodeViewHolder>(), SelectionHolder<BookmarkNode> {
 
     private var tree: List<BookmarkNode> = listOf()
-    private var mode: BookmarkFragmentState.Mode = BookmarkFragmentState.Mode.Normal
+    private var mode: BookmarkFragmentState.Mode = BookmarkFragmentState.Mode.Normal()
     override val selectedItems: Set<BookmarkNode> get() = mode.selectedItems
     private var isFirstRun = true
 

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragment.kt
@@ -154,8 +154,10 @@ class BookmarkFragment : LibraryPageFragment<BookmarkNode>(), UserInteractionHan
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         when (val mode = bookmarkStore.state.mode) {
-            BookmarkFragmentState.Mode.Normal -> {
-                inflater.inflate(R.menu.bookmarks_menu, menu)
+            is BookmarkFragmentState.Mode.Normal -> {
+                if (mode.showMenu) {
+                    inflater.inflate(R.menu.bookmarks_menu, menu)
+                }
             }
             is BookmarkFragmentState.Mode.Selecting -> {
                 if (mode.selectedItems.any { it.type != BookmarkNodeType.ITEM }) {

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkView.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkView.kt
@@ -100,7 +100,7 @@ class BookmarkView(
     val view: View = LayoutInflater.from(container.context)
         .inflate(R.layout.component_bookmark, container, true)
 
-    private var mode: BookmarkFragmentState.Mode = BookmarkFragmentState.Mode.Normal
+    private var mode: BookmarkFragmentState.Mode = BookmarkFragmentState.Mode.Normal()
     private var tree: BookmarkNode? = null
     private var canGoBack = false
 

--- a/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkAdapterTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkAdapterTest.kt
@@ -46,12 +46,12 @@ internal class BookmarkAdapterTest {
                 )
             )
         )
-        bookmarkAdapter.updateData(tree, BookmarkFragmentState.Mode.Normal)
-        bookmarkAdapter.updateData(null, BookmarkFragmentState.Mode.Normal)
+        bookmarkAdapter.updateData(tree, BookmarkFragmentState.Mode.Normal())
+        bookmarkAdapter.updateData(null, BookmarkFragmentState.Mode.Normal())
         verifyOrder {
-            bookmarkAdapter.updateData(tree, BookmarkFragmentState.Mode.Normal)
+            bookmarkAdapter.updateData(tree, BookmarkFragmentState.Mode.Normal())
             bookmarkAdapter.notifyItemRangeInserted(0, 3)
-            bookmarkAdapter.updateData(null, BookmarkFragmentState.Mode.Normal)
+            bookmarkAdapter.updateData(null, BookmarkFragmentState.Mode.Normal())
             bookmarkAdapter.notifyItemRangeRemoved(0, 3)
         }
     }

--- a/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkFragmentInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkFragmentInteractorTest.kt
@@ -87,7 +87,7 @@ class BookmarkFragmentInteractorTest {
 
     @Test
     fun `switch between bookmark selection modes`() {
-        interactor.onSelectionModeSwitch(BookmarkFragmentState.Mode.Normal)
+        interactor.onSelectionModeSwitch(BookmarkFragmentState.Mode.Normal())
 
         verify {
             bookmarkController.handleSelectionModeSwitch()

--- a/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkFragmentStoreTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkFragmentStoreTest.kt
@@ -21,7 +21,7 @@ class BookmarkFragmentStoreTest {
         val initialState = BookmarkFragmentState(null)
         val store = BookmarkFragmentStore(initialState)
 
-        assertThat(BookmarkFragmentState(null, BookmarkFragmentState.Mode.Normal)).isEqualTo(store.state)
+        assertThat(BookmarkFragmentState(null, BookmarkFragmentState.Mode.Normal())).isEqualTo(store.state)
 
         store.dispatch(BookmarkFragmentAction.Change(tree)).join()
 
@@ -34,7 +34,7 @@ class BookmarkFragmentStoreTest {
         val initialState = BookmarkFragmentState(tree)
         val store = BookmarkFragmentStore(initialState)
 
-        assertThat(BookmarkFragmentState(tree, BookmarkFragmentState.Mode.Normal)).isEqualTo(store.state)
+        assertThat(BookmarkFragmentState(tree, BookmarkFragmentState.Mode.Normal())).isEqualTo(store.state)
 
         store.dispatch(BookmarkFragmentAction.Change(newTree)).join()
 
@@ -47,7 +47,7 @@ class BookmarkFragmentStoreTest {
         val initialState = BookmarkFragmentState(tree)
         val store = BookmarkFragmentStore(initialState)
 
-        assertThat(BookmarkFragmentState(tree, BookmarkFragmentState.Mode.Normal)).isEqualTo(store.state)
+        assertThat(BookmarkFragmentState(tree, BookmarkFragmentState.Mode.Normal())).isEqualTo(store.state)
 
         store.dispatch(BookmarkFragmentAction.Change(tree)).join()
 
@@ -77,7 +77,7 @@ class BookmarkFragmentStoreTest {
 
         store.dispatch(BookmarkFragmentAction.Deselect(childItem)).join()
 
-        assertThat(BookmarkFragmentState(tree, BookmarkFragmentState.Mode.Normal)).isEqualTo(store.state)
+        assertThat(BookmarkFragmentState(tree, BookmarkFragmentState.Mode.Normal())).isEqualTo(store.state)
     }
 
     @Test
@@ -102,7 +102,7 @@ class BookmarkFragmentStoreTest {
 
     @Test
     fun `deselecting while not in selecting mode does nothing`() = runBlocking {
-        val initialState = BookmarkFragmentState(tree, BookmarkFragmentState.Mode.Normal)
+        val initialState = BookmarkFragmentState(tree, BookmarkFragmentState.Mode.Normal())
         val store = BookmarkFragmentStore(initialState)
 
         store.dispatch(BookmarkFragmentAction.Deselect(item)).join()
@@ -117,12 +117,12 @@ class BookmarkFragmentStoreTest {
 
         store.dispatch(BookmarkFragmentAction.DeselectAll).join()
 
-        assertThat(initialState.copy(mode = BookmarkFragmentState.Mode.Normal)).isEqualTo(store.state)
+        assertThat(initialState.copy(mode = BookmarkFragmentState.Mode.Normal())).isEqualTo(store.state)
     }
 
     @Test
     fun `deselect all bookmarks when none are selected`() = runBlocking {
-        val initialState = BookmarkFragmentState(tree, BookmarkFragmentState.Mode.Normal)
+        val initialState = BookmarkFragmentState(tree, BookmarkFragmentState.Mode.Normal())
         val store = BookmarkFragmentStore(initialState)
 
         store.dispatch(BookmarkFragmentAction.DeselectAll)
@@ -139,7 +139,7 @@ class BookmarkFragmentStoreTest {
 
         store.state.run {
             assertThat(newTree).isEqualTo(tree)
-            assertThat(BookmarkFragmentState.Mode.Normal).isEqualTo(mode)
+            assertThat(BookmarkFragmentState.Mode.Normal()).isEqualTo(mode)
         }
     }
 
@@ -167,6 +167,17 @@ class BookmarkFragmentStoreTest {
         assertFalse(store.state.isLoading)
     }
 
+    @Test
+    fun `switching to Desktop Bookmarks folder sets showMenu state to false`() = runBlocking {
+        val initialState = BookmarkFragmentState(tree)
+        val store = BookmarkFragmentStore(initialState)
+
+        store.dispatch(BookmarkFragmentAction.Change(rootFolder)).join()
+
+        assertThat(rootFolder).isEqualTo(store.state.tree)
+        assertThat(BookmarkFragmentState.Mode.Normal(false)).isEqualTo(store.state.mode)
+    }
+
     private val item = BookmarkNode(BookmarkNodeType.ITEM, "456", "123", 0, "Mozilla", "http://mozilla.org", null)
     private val separator = BookmarkNode(BookmarkNodeType.SEPARATOR, "789", "123", 1, null, null, null)
     private val subfolder = BookmarkNode(BookmarkNodeType.FOLDER, "987", "123", 0, "Subfolder", null, listOf())
@@ -190,5 +201,14 @@ class BookmarkFragmentStoreTest {
         "Mobile",
         null,
         listOf(separator, subfolder)
+    )
+    private val rootFolder = BookmarkNode(
+        BookmarkNodeType.FOLDER,
+        "root________",
+        null,
+        0,
+        "Desktop Bookmarks",
+        null,
+        listOf(subfolder)
     )
 }


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

Fixes #4994 

There were two possible solutions:
1. Create a new BookmarkFragmentState.Mode for Desktop Bookmarks (aka Root folder), but I don't think that is the purpose of BookmarkFragmentState.Mode classes (?)
2. Add a showMenu (default true) option in BookmarkFragmentState.Mode.Normal, set that to true if the folder guid is "root________", and then check that when creating the OptionsMenu in BookmarkFragment to determine whether to inflate an options menu or not.

I went with (2). Open to other suggestions though.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture


![Fenix-Fix-Desktop-Add-Folder-Menu-1](https://user-images.githubusercontent.com/436057/70688540-08f6b900-1c80-11ea-80e8-de31be69a22e.gif)

