### PR TITLE
For #7124 - Remove top/buttom toolbar assumptions

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -596,9 +596,10 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Session
     protected abstract fun getEngineMargins(): Pair<Int, Int>
 
     /**
-     * Returns the layout [android.view.Gravity] for the quick settings dialog.
+     * Returns the layout [android.view.Gravity] for the quick settings and ETP dialog.
      */
-    protected abstract fun getAppropriateLayoutGravity(): Int
+    protected fun getAppropriateLayoutGravity(): Int =
+        if (context?.settings()?.shouldUseBottomToolbar == true) Gravity.BOTTOM else Gravity.TOP
 
     protected fun updateLayoutMargins(inFullScreen: Boolean) {
         view?.swipeRefresh?.apply {

--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -593,7 +593,13 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Session
     /**
      * Returns the top and bottom margins.
      */
-    protected abstract fun getEngineMargins(): Pair<Int, Int>
+    private fun getEngineMargins(): Pair<Int, Int> =
+        if (context?.settings()?.shouldUseBottomToolbar == true) {
+            val toolbarSize = resources.getDimensionPixelSize(R.dimen.browser_toolbar_height)
+            0 to toolbarSize
+        } else {
+            0 to 0
+        }
 
     /**
      * Returns the layout [android.view.Gravity] for the quick settings and ETP dialog.

--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -6,7 +6,6 @@ package org.mozilla.fenix.browser
 
 import android.content.Context
 import android.os.Bundle
-import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -195,8 +194,6 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
         val toolbarSize = resources.getDimensionPixelSize(R.dimen.browser_toolbar_height)
         return 0 to toolbarSize
     }
-
-    override fun getAppropriateLayoutGravity() = Gravity.BOTTOM
 
     private fun themeReaderViewControlsForPrivateMode(view: View) = with(view) {
         listOf(

--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -190,11 +190,6 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
         }
     }
 
-    override fun getEngineMargins(): Pair<Int, Int> {
-        val toolbarSize = resources.getDimensionPixelSize(R.dimen.browser_toolbar_height)
-        return 0 to toolbarSize
-    }
-
     private fun themeReaderViewControlsForPrivateMode(view: View) = with(view) {
         listOf(
             R.id.mozac_feature_readerview_font_size_decrease,

--- a/app/src/main/java/org/mozilla/fenix/customtabs/ExternalAppBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/ExternalAppBrowserFragment.kt
@@ -71,7 +71,8 @@ class ExternalAppBrowserFragment : BaseBrowserFragment(), UserInteractionHandler
                         isPrivate = (activity as HomeActivity).browsingModeManager.mode.isPrivate
                     ),
                     owner = this,
-                    view = view)
+                    view = view
+                )
 
                 windowFeature.set(
                     feature = CustomTabWindowFeature(
@@ -184,11 +185,6 @@ class ExternalAppBrowserFragment : BaseBrowserFragment(), UserInteractionHandler
                     )
             nav(R.id.externalAppBrowserFragment, directions)
         }
-    }
-
-    override fun getEngineMargins(): Pair<Int, Int> {
-        // Since the top toolbar is dynamic we don't want any margins
-        return 0 to 0
     }
 
     override fun getContextMenuCandidates(

--- a/app/src/main/java/org/mozilla/fenix/customtabs/ExternalAppBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/ExternalAppBrowserFragment.kt
@@ -5,7 +5,6 @@
 package org.mozilla.fenix.customtabs
 
 import android.content.Context
-import android.view.Gravity
 import android.view.View
 import androidx.navigation.fragment.navArgs
 import kotlinx.android.synthetic.main.component_browser_top_toolbar.*
@@ -204,6 +203,4 @@ class ExternalAppBrowserFragment : BaseBrowserFragment(), UserInteractionHandler
             null
         )
     )
-
-    override fun getAppropriateLayoutGravity() = Gravity.TOP
 }


### PR DESCRIPTION
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

It looks like we missed these assumptions when adding the top/bottom toolbar changes. We can no longer assume Custom Tabs always have a top toolbar and Normal Browsing always has a bottom toolbar.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
