### PR TITLE
For #4064: Replace prerelease R8 with improved Kotlin coroutines library

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -368,6 +368,7 @@ dependencies {
 
     implementation Deps.kotlin_stdlib
     implementation Deps.kotlin_coroutines
+    implementation Deps.kotlin_coroutines_android
     testImplementation Deps.kotlin_coroutines_test
     implementation Deps.androidx_appcompat
     implementation Deps.androidx_constraintlayout

--- a/build.gradle
+++ b/build.gradle
@@ -2,14 +2,10 @@
 
 buildscript {
     repositories {
-        // remove next line after Android Gradle Plugin 3.6.0+ is stable
-        maven { url "http://storage.googleapis.com/r8-releases/raw/master"}
         google()
         jcenter()
     }
     dependencies {
-        // remove next line after Android Gradle Plugin 3.6.0+ is stable
-        classpath Deps.tools_newestR8
         classpath Deps.tools_androidgradle
         classpath Deps.tools_kotlingradle
         classpath Deps.androidx_safeargs

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -4,9 +4,8 @@
 
 object Versions {
     const val kotlin = "1.3.30"
-    const val coroutines = "1.3.1"
+    const val coroutines = "1.3.3"
     const val android_gradle_plugin = "3.5.0"
-    const val newest_r8 = "ceaee94e172c6c057cc05e646f5324853fc5d4c5"
     const val rxAndroid = "2.1.0"
     const val rxKotlin = "2.3.0"
     const val rxBindings = "3.0.0-alpha2"
@@ -72,7 +71,6 @@ object Versions {
 @Suppress("unused")
 object Deps {
     const val tools_androidgradle = "com.android.tools.build:gradle:${Versions.android_gradle_plugin}"
-    const val tools_newestR8 = "com.android.tools:r8:${Versions.newest_r8}"
     const val tools_kotlingradle = "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.kotlin}"
     const val kotlin_stdlib = "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${Versions.kotlin}"
     const val kotlin_coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.coroutines}"


### PR DESCRIPTION
There are no UI changes here. The only change is replacing the pre-release R8 version with a newer Kotlin coroutines library that no longer uses slow ServiceLoaders on the Main thread.
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
