### PR TITLE
No issue: Fixes breakage with unused import in 4a2cb91

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
@@ -6,7 +6,6 @@
 
 package org.mozilla.fenix.ui.robots
 
-import androidx.preference.R
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions


### PR DESCRIPTION
https://github.com/mozilla-mobile/fenix/commit/4a2cb91ad903a68ff4fae3a1cd6f2722647c3e6d
```Kotlin
[task 2019-12-16T15:22:18.848Z] > Task :app:compileGeckoBetaDebugAndroidTestKotlin FAILED
[task 2019-12-16T15:22:18.849Z] e: /builds/worker/checkouts/src/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt: (9, 28): Conflicting import, imported name 'R' is ambiguous
[task 2019-12-16T15:22:18.850Z] e: /builds/worker/checkouts/src/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt: (23, 26): Conflicting import, imported name 'R' is ambiguous
[task 2019-12-16T15:22:18.851Z] e: /builds/worker/checkouts/src/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt: (166, 32): Unresolved reference: R
[task 2019-12-16T15:22:18.852Z] e: /builds/worker/checkouts/src/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt: (247, 50): Unresolved reference: R
