### PR TITLE
For #4064: Update R8/ProGuard config for new Kotlin coroutines library

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -33,14 +33,17 @@
 
 ####################################################################################################
 # Force removal of slow Dispatchers.Main ServiceLoader
-#
-# Please remove these rules when Android Gradle Plugin 3.6+ & coroutines 1.3.0+ are both in use
 ####################################################################################################
-# Ensure the custom, fast service loader implementation is removed.
--assumevalues class kotlinx.coroutines.internal.MainDispatcherLoader {
-  boolean FAST_SERVICE_LOADER_ENABLED return false;
+# Allow R8 to optimize away the FastServiceLoader.
+# Together with ServiceLoader optimization in R8
+# this results in direct instantiation when loading Dispatchers.Main
+-assumenosideeffects class kotlinx.coroutines.internal.MainDispatcherLoader {
+    boolean FAST_SERVICE_LOADER_ENABLED return false;
 }
--checkdiscard class kotlinx.coroutines.internal.FastServiceLoader
+
+-assumenosideeffects class kotlinx.coroutines.internal.FastServiceLoader {
+    boolean ANDROID_DETECTED return true;
+}
 
 ####################################################################################################
 # Mozilla Application Services


### PR DESCRIPTION
This is a Proguard/R8 config fix for performance as recommended in the examples for the new coroutines update.
---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
