### PR TITLE
Closes #6937: Disable runStorageMaintenance during startup

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -131,11 +131,17 @@ open class FenixApplication : Application() {
 
         components.core.sessionManager.register(NotificationSessionObserver(this))
 
-        if ((System.currentTimeMillis() - settings().lastPlacesStorageMaintenance) > ONE_DAY_MILLIS) {
-            runStorageMaintenance()
-        }
+        // Storage maintenance disabled, for now, as it was interfering with background migrations.
+        // See https://github.com/mozilla-mobile/fenix/issues/7227 for context.
+        // if ((System.currentTimeMillis() - settings().lastPlacesStorageMaintenance) > ONE_DAY_MILLIS) {
+        //    runStorageMaintenance()
+        // }
     }
 
+    // See https://github.com/mozilla-mobile/fenix/issues/7227 for context.
+    // To re-enable this, we need to do so in a way that won't interfere with any startup operations
+    // which acquire reserved+ sqlite lock. Currently, Fennec migrations need to write to storage
+    // on startup, and since they run in a background service we can't simply order these operations.
     private fun runStorageMaintenance() {
         GlobalScope.launch(Dispatchers.IO) {
             // Bookmarks and history storage sit on top of the same db file so we only need to


### PR DESCRIPTION
This call will acquire a "write" lock at the storage layer (sqlite's reserved+),
which may interfere with migrations that run during startup as well (they need to
write to storage, and so also need to acquire a lock). If these operations clash,
we get a SQLITE_BUSY crash. For now, just disable the maintenance operation.

See https://github.com/mozilla-mobile/fenix/issues/7227 for context on re-enabling this.

---
<!-- Text above this line will be added to the commit once "bors" merges this PR -->

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
