### PR TITLE
Closes #4976: Use dynamic launcher entry in manifest.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,12 +30,12 @@
         tools:ignore="UnusedAttribute">
 
         <!--
-          We inherited this entry (org.mozilla.gecko.App) from Fennec. We need to keep this as our
+          We inherited this entry (${applicationId}.App) from Fennec. We need to keep this as our
           main launcher to avoid launcher icons on the home screen disappearing for all our users
           on a Fennec build.
         -->
         <activity-alias
-            android:name="org.mozilla.gecko.App"
+            android:name="${applicationId}.App"
             android:targetActivity=".HomeActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
Fixing reopened #6872 

`org.mozilla.gecko.App` worked fine for local builds of Fennec. However Fennec's arcane build process turns that into a different value for our production builds (App ID + `.App`). This follows the same approach by using the manifest placeholder `${applicationId}`. Initially I wanted to just use `.App` like Fennec does in its manifest. But it turns out that Gradle and Fennec's build will turn that into different things in the final APK.

I tested this with re-signed Fennec production builds and it is now working for all fennec flavors of Fenix:

![migrating](https://user-images.githubusercontent.com/89638/70985742-e7049880-20bc-11ea-8c45-79f951ed6d17.png)
