### PR TITLE
Bug 7189 - Provide page title in website information dialog

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -155,6 +155,7 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
             BrowserFragmentDirections.actionBrowserFragmentToQuickSettingsSheetDialogFragment(
                 sessionId = session.id,
                 url = session.url,
+                title = session.title,
                 isSecured = session.securityInfo.secure,
                 sitePermissions = sitePermissions,
                 gravity = getAppropriateLayoutGravity()

--- a/app/src/main/java/org/mozilla/fenix/customtabs/ExternalAppBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/ExternalAppBrowserFragment.kt
@@ -161,6 +161,7 @@ class ExternalAppBrowserFragment : BaseBrowserFragment(), UserInteractionHandler
             .actionExternalAppBrowserFragmentToQuickSettingsSheetDialogFragment(
                 sessionId = session.id,
                 url = session.url,
+                title = session.title,
                 isSecured = session.securityInfo.secure,
                 sitePermissions = sitePermissions,
                 gravity = getAppropriateLayoutGravity()

--- a/app/src/main/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsFragmentStore.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsFragmentStore.kt
@@ -67,6 +67,7 @@ class QuickSettingsFragmentStore(
          *
          * @param context [Context] used for access to various Android resources.
          * @param websiteUrl [String] the URL of the current web page.
+         * @param websiteTitle [String] the title of the current web page.
          * @param isSecured [Boolean] whether the connection is secured (TLS) or not.
          * @param permissions [SitePermissions]? list of website permissions and their status.
          * @param settings [Settings] application settings.
@@ -75,12 +76,13 @@ class QuickSettingsFragmentStore(
         fun createStore(
             context: Context,
             websiteUrl: String,
+            websiteTitle: String,
             isSecured: Boolean,
             permissions: SitePermissions?,
             settings: Settings
         ) = QuickSettingsFragmentStore(
             QuickSettingsFragmentState(
-                webInfoState = createWebsiteInfoState(websiteUrl, isSecured),
+                webInfoState = createWebsiteInfoState(websiteUrl, websiteTitle, isSecured),
                 websitePermissionsState = createWebsitePermissionState(
                     context,
                     permissions,
@@ -101,13 +103,14 @@ class QuickSettingsFragmentStore(
         @VisibleForTesting
         fun createWebsiteInfoState(
             websiteUrl: String,
+            websiteTitle: String,
             isSecured: Boolean
         ): WebsiteInfoState {
             val (stringRes, iconRes, colorRes) = when (isSecured) {
                 true -> getSecuredWebsiteUiValues
                 false -> getInsecureWebsiteUiValues
             }
-            return WebsiteInfoState(websiteUrl, stringRes, iconRes, colorRes)
+            return WebsiteInfoState(websiteUrl, websiteTitle, stringRes, iconRes, colorRes)
         }
 
         /**
@@ -217,12 +220,14 @@ data class QuickSettingsFragmentState(
  * [State] to be rendered by [WebsiteInfoView] indicating whether the connection is secure or not.
  *
  * @param websiteUrl [String] the URL of the current web page.
+ * @param websiteTitle [String] the title of the current web page.
  * @param securityInfoRes [StringRes] for the connection description.
  * @param iconRes [DrawableRes] image indicating the connection status.
  * @param iconTintRes [ColorRes] icon color.
  */
 data class WebsiteInfoState(
     val websiteUrl: String,
+    val websiteTitle: String,
     @StringRes val securityInfoRes: Int,
     @DrawableRes val iconRes: Int,
     @ColorRes val iconTintRes: Int

--- a/app/src/main/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsSheetDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsSheetDialogFragment.kt
@@ -67,6 +67,7 @@ class QuickSettingsSheetDialogFragment : AppCompatDialogFragment() {
         quickSettingsStore = QuickSettingsFragmentStore.createStore(
             context = context,
             websiteUrl = args.url,
+            websiteTitle = args.title,
             isSecured = args.isSecured,
             permissions = args.sitePermissions,
             settings = Settings.getInstance(context)

--- a/app/src/main/java/org/mozilla/fenix/settings/quicksettings/WebsiteInfoView.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/quicksettings/WebsiteInfoView.kt
@@ -37,11 +37,16 @@ class WebsiteInfoView(
      */
     fun update(state: WebsiteInfoState) {
         bindUrl(state.websiteUrl)
+        bindTitle(state.websiteTitle)
         bindSecurityInfo(state.securityInfoRes, state.iconRes, state.iconTintRes)
     }
 
     private fun bindUrl(url: String) {
         view.url.text = url
+    }
+
+    private fun bindTitle(title: String) {
+        view.title.text = title
     }
 
     private fun bindSecurityInfo(

--- a/app/src/main/res/layout/quicksettings_website_info.xml
+++ b/app/src/main/res/layout/quicksettings_website_info.xml
@@ -13,6 +13,18 @@
     android:orientation="vertical">
 
     <TextView
+        android:id="@+id/title"
+        style="@style/QuickSettingsText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingTop="8dp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="" />
+
+    <TextView
         android:id="@+id/url"
         style="@style/QuickSettingsText"
         android:layout_width="match_parent"
@@ -21,7 +33,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        tools:text="https://wikipedia.org" />
+        tools:text="" />
 
     <TextView
         android:id="@+id/securityInfo"

--- a/app/src/main/res/layout/quicksettings_website_info.xml
+++ b/app/src/main/res/layout/quicksettings_website_info.xml
@@ -19,10 +19,7 @@
         android:layout_height="wrap_content"
         android:paddingTop="8dp"
         android:textStyle="bold"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:text="" />
+        tools:text="Wikipedia" />
 
     <TextView
         android:id="@+id/url"
@@ -30,19 +27,13 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:paddingTop="8dp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:text="" />
+        tools:text="https://wikipedia.org" />
 
     <TextView
         android:id="@+id/securityInfo"
         style="@style/QuickSettingsText.Icon"
         android:layout_width="match_parent"
         android:layout_height="@dimen/quicksettings_item_height"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/url"
         tools:drawableStart="@drawable/mozac_ic_lock"
         tools:drawableTint="@color/photonGreen50"
         tools:text="Secure connection" />

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -583,6 +583,9 @@
             android:name="sessionId"
             app:argType="string" />
         <argument
+            android:name="title"
+            app:argType="string" />
+        <argument
             android:name="url"
             app:argType="string" />
         <argument

--- a/app/src/test/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsFragmentStoreTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsFragmentStoreTest.kt
@@ -57,7 +57,7 @@ class QuickSettingsFragmentStoreTest {
         val permissions = mockk<SitePermissions>(relaxed = true)
 
         val store = QuickSettingsFragmentStore.createStore(
-            context, "url", true, permissions, settings
+            context, "url", "Hello", true, permissions, settings
         )
 
         assertAll {
@@ -71,9 +71,10 @@ class QuickSettingsFragmentStoreTest {
     @Test
     fun `createWebsiteInfoState constructs a WebsiteInfoState with the right values for a secure connection`() {
         val websiteUrl = "https://host.com/page1"
+        val websiteTitle = "Hello"
         val securedStatus = true
 
-        val state = QuickSettingsFragmentStore.createWebsiteInfoState(websiteUrl, securedStatus)
+        val state = QuickSettingsFragmentStore.createWebsiteInfoState(websiteUrl, websiteTitle, securedStatus)
 
         assertAll {
             assertThat(state).isNotNull()
@@ -87,9 +88,10 @@ class QuickSettingsFragmentStoreTest {
     @Test
     fun `createWebsiteInfoState constructs a WebsiteInfoState with the right values for an insecure connection`() {
         val websiteUrl = "https://host.com/page1"
+        val websiteTitle = "Hello"
         val securedStatus = false
 
-        val state = QuickSettingsFragmentStore.createWebsiteInfoState(websiteUrl, securedStatus)
+        val state = QuickSettingsFragmentStore.createWebsiteInfoState(websiteUrl, websiteTitle, securedStatus)
 
         assertAll {
             assertThat(state).isNotNull()

--- a/app/src/test/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsFragmentStoreTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsFragmentStoreTest.kt
@@ -79,6 +79,7 @@ class QuickSettingsFragmentStoreTest {
         assertAll {
             assertThat(state).isNotNull()
             assertThat(state.websiteUrl).isSameAs(websiteUrl)
+            assertThat(state.websiteTitle).isSameAs(websiteTitle)
             assertThat(state.securityInfoRes).isEqualTo(secureStringRes)
             assertThat(state.iconRes).isEqualTo(secureDrawableRes)
             assertThat(state.iconTintRes).isEqualTo(secureColorRes)
@@ -96,6 +97,7 @@ class QuickSettingsFragmentStoreTest {
         assertAll {
             assertThat(state).isNotNull()
             assertThat(state.websiteUrl).isSameAs(websiteUrl)
+            assertThat(state.websiteTitle).isSameAs(websiteTitle)
             assertThat(state.securityInfoRes).isEqualTo(insecureStringRes)
             assertThat(state.iconRes).isEqualTo(insecureDrawableRes)
             assertThat(state.iconTintRes).isEqualTo(insecureColorRes)


### PR DESCRIPTION
I took a few minutes to mock this one out.  Might need eyes from UX, but if undesired, please feel free to close.

![WebsiteTitle](https://user-images.githubusercontent.com/46655/71025514-ce03e380-20cc-11ea-84c6-3ab675654b67.png)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture