### PR TITLE
Closes #7254 - Replace Anko applyConstraintSet

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -18,7 +18,11 @@ import android.widget.LinearLayout
 import android.widget.PopupWindow
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
-import androidx.constraintlayout.widget.ConstraintLayout.LayoutParams.PARENT_ID
+import androidx.constraintlayout.widget.ConstraintSet
+import androidx.constraintlayout.widget.ConstraintSet.BOTTOM
+import androidx.constraintlayout.widget.ConstraintSet.TOP
+import androidx.constraintlayout.widget.ConstraintSet.START
+import androidx.constraintlayout.widget.ConstraintSet.END
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Lifecycle
@@ -53,11 +57,6 @@ import mozilla.components.feature.media.ext.getSession
 import mozilla.components.feature.media.state.MediaState
 import mozilla.components.feature.media.state.MediaStateMachine
 import mozilla.components.feature.tab.collections.TabCollection
-import org.jetbrains.anko.constraint.layout.ConstraintSetBuilder.Side.BOTTOM
-import org.jetbrains.anko.constraint.layout.ConstraintSetBuilder.Side.END
-import org.jetbrains.anko.constraint.layout.ConstraintSetBuilder.Side.START
-import org.jetbrains.anko.constraint.layout.ConstraintSetBuilder.Side.TOP
-import org.jetbrains.anko.constraint.layout.applyConstraintSet
 import org.mozilla.fenix.BrowserDirection
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
@@ -197,16 +196,13 @@ class HomeFragment : Fragment() {
 
         sessionControlView = SessionControlView(homeFragmentStore, view.homeLayout, sessionControlInteractor)
 
-        view.homeLayout.applyConstraintSet {
-            sessionControlView.view {
-                connect(
-                    TOP to BOTTOM of view.wordmark_spacer,
-                    START to START of PARENT_ID,
-                    END to END of PARENT_ID,
-                    BOTTOM to TOP of view.bottom_bar
-                )
-            }
-        }
+        val constraintSet = ConstraintSet()
+        constraintSet.clone(view.homeLayout)
+        constraintSet.connect(sessionControlView.view.id, TOP, view.wordmark_spacer.id, BOTTOM)
+        constraintSet.connect(sessionControlView.view.id, START, ConstraintSet.PARENT_ID, START)
+        constraintSet.connect(sessionControlView.view.id, END, ConstraintSet.PARENT_ID, END)
+        constraintSet.connect(sessionControlView.view.id, BOTTOM, view.bottom_bar.id, TOP)
+        constraintSet.applyTo(view.homeLayout)
 
         activity.themeManager.applyStatusBarTheme(activity)
 

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -197,12 +197,14 @@ class HomeFragment : Fragment() {
         sessionControlView = SessionControlView(homeFragmentStore, view.homeLayout, sessionControlInteractor)
 
         val constraintSet = ConstraintSet()
-        constraintSet.clone(view.homeLayout)
-        constraintSet.connect(sessionControlView.view.id, TOP, view.wordmark_spacer.id, BOTTOM)
-        constraintSet.connect(sessionControlView.view.id, START, ConstraintSet.PARENT_ID, START)
-        constraintSet.connect(sessionControlView.view.id, END, ConstraintSet.PARENT_ID, END)
-        constraintSet.connect(sessionControlView.view.id, BOTTOM, view.bottom_bar.id, TOP)
-        constraintSet.applyTo(view.homeLayout)
+        constraintSet.apply {
+            clone(view.homeLayout)
+            connect(sessionControlView.view.id, TOP, view.wordmark_spacer.id, BOTTOM)
+            connect(sessionControlView.view.id, START, ConstraintSet.PARENT_ID, START)
+            connect(sessionControlView.view.id, END, ConstraintSet.PARENT_ID, END)
+            connect(sessionControlView.view.id, BOTTOM, view.bottom_bar.id, TOP)
+            applyTo(view.homeLayout)
+        }
 
         activity.themeManager.applyStatusBarTheme(activity)
 

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -23,6 +23,7 @@ import androidx.constraintlayout.widget.ConstraintSet.BOTTOM
 import androidx.constraintlayout.widget.ConstraintSet.TOP
 import androidx.constraintlayout.widget.ConstraintSet.START
 import androidx.constraintlayout.widget.ConstraintSet.END
+import androidx.constraintlayout.widget.ConstraintSet.PARENT_ID
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Lifecycle
@@ -196,12 +197,11 @@ class HomeFragment : Fragment() {
 
         sessionControlView = SessionControlView(homeFragmentStore, view.homeLayout, sessionControlInteractor)
 
-        val constraintSet = ConstraintSet()
-        constraintSet.apply {
+        ConstraintSet().apply {
             clone(view.homeLayout)
             connect(sessionControlView.view.id, TOP, view.wordmark_spacer.id, BOTTOM)
-            connect(sessionControlView.view.id, START, ConstraintSet.PARENT_ID, START)
-            connect(sessionControlView.view.id, END, ConstraintSet.PARENT_ID, END)
+            connect(sessionControlView.view.id, START, PARENT_ID, START)
+            connect(sessionControlView.view.id, END, PARENT_ID, END)
             connect(sessionControlView.view.id, BOTTOM, view.bottom_bar.id, TOP)
             applyTo(view.homeLayout)
         }

--- a/app/src/main/java/org/mozilla/fenix/search/SearchLayouts.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchLayouts.kt
@@ -6,14 +6,13 @@ package org.mozilla.fenix.search
 
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.constraintlayout.widget.ConstraintLayout.LayoutParams.PARENT_ID
-import androidx.constraintlayout.widget.ConstraintLayout.LayoutParams.UNSET
+import androidx.constraintlayout.widget.ConstraintLayout.LayoutParams.TOP
+import androidx.constraintlayout.widget.ConstraintLayout.LayoutParams.BOTTOM
+import androidx.constraintlayout.widget.ConstraintSet
 import androidx.recyclerview.widget.LinearLayoutManager
 import kotlinx.android.synthetic.main.component_awesomebar.*
 import kotlinx.android.synthetic.main.fragment_search.*
 import mozilla.components.support.base.log.logger.Logger
-import org.jetbrains.anko.constraint.layout.ConstraintSetBuilder.Side.BOTTOM
-import org.jetbrains.anko.constraint.layout.ConstraintSetBuilder.Side.TOP
-import org.jetbrains.anko.constraint.layout.applyConstraintSet
 import org.mozilla.fenix.Experiments.AATestDescriptor
 import org.mozilla.fenix.isInExperiment
 
@@ -32,54 +31,43 @@ internal fun SearchFragment.layoutComponents(layout: ConstraintLayout) {
 
 internal fun SearchFragment.setInExperimentConstraints(layout: ConstraintLayout) {
     Logger.debug("Loading in experiment constraints")
-    layout.applyConstraintSet {
-        toolbar_wrapper {
-            connect(
-                TOP to TOP of UNSET,
-                BOTTOM to TOP of pillWrapper
-            )
-        }
-        awesomeBar {
-            connect(
-                TOP to TOP of PARENT_ID,
-                BOTTOM to TOP of toolbar_wrapper
-            )
-        }
+
+    ConstraintSet().apply {
+        clone(layout)
+
+        // Move the search bar to the bottom of the layout
+        clear(toolbar_wrapper.id, TOP)
+        connect(toolbar_wrapper.id, BOTTOM, pillWrapper.id, TOP)
+
+        connect(awesomeBar.id, TOP, PARENT_ID, TOP)
+        connect(awesomeBar.id, BOTTOM, toolbar_wrapper.id, TOP)
         (awesomeBar.layoutManager as? LinearLayoutManager)?.reverseLayout = true
-        pillWrapper {
-            connect(
-                BOTTOM to BOTTOM of PARENT_ID
-            )
-        }
+
+        connect(pillWrapper.id, BOTTOM, PARENT_ID, BOTTOM)
+
+        applyTo(layout)
     }
 }
 
 internal fun SearchFragment.setOutOfExperimentConstraints(layout: ConstraintLayout) {
     Logger.debug("Loading out of experiment constraints")
-    layout.applyConstraintSet {
-        toolbar_wrapper {
-            connect(
-                TOP to TOP of PARENT_ID,
-                BOTTOM to TOP of UNSET
-            )
-        }
-        fill_link_from_clipboard {
-            connect(
-                TOP to BOTTOM of toolbar_wrapper
-            )
-        }
-        awesomeBar {
-            connect(
-                TOP to TOP of UNSET,
-                TOP to BOTTOM of search_with_shortcuts,
-                BOTTOM to TOP of pillWrapper
-            )
-        }
+
+    ConstraintSet().apply {
+        clone(layout)
+
+        // Move the search bar to the top of the layout
+        connect(toolbar_wrapper.id, TOP, PARENT_ID, TOP)
+        clear(toolbar_wrapper.id, BOTTOM)
+
+        connect(fill_link_from_clipboard.id, TOP, toolbar_wrapper.id, BOTTOM)
+
+        clear(awesomeBar.id, TOP)
+        connect(awesomeBar.id, TOP, search_with_shortcuts.id, BOTTOM)
+        connect(awesomeBar.id, BOTTOM, pillWrapper.id, TOP)
         (awesomeBar.layoutManager as? LinearLayoutManager)?.reverseLayout = false
-        pillWrapper {
-            connect(
-                BOTTOM to BOTTOM of PARENT_ID
-            )
-        }
+
+        connect(pillWrapper.id, BOTTOM, PARENT_ID, BOTTOM)
+
+        applyTo(layout)
     }
 }


### PR DESCRIPTION
* Anko has been deprecated and will not be continued

Replace `applyConstraintSet` which creates and applies `ConstraintSet` to the `ConstraintLayout`.

After replacing `applyConstraintSet`, the home screen should not have changed visually and work the same as before.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture