### PR TITLE
For #7253 - Replace anko setters

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/TabInCollectionViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/TabInCollectionViewHolder.kt
@@ -13,7 +13,6 @@ import kotlinx.android.extensions.LayoutContainer
 import kotlinx.android.synthetic.main.tab_in_collection.*
 import mozilla.components.feature.tab.collections.TabCollection
 import mozilla.components.support.ktx.android.util.dpToFloat
-import org.jetbrains.anko.backgroundColor
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.getColorFromAttr
@@ -77,7 +76,7 @@ class TabInCollectionViewHolder(
             view.background = AppCompatResources.getDrawable(view.context, R.drawable.rounded_bottom_corners)
             divider_line.visibility = View.GONE
         } else {
-            view.backgroundColor = view.context.getColorFromAttr(R.attr.above)
+            view.setBackgroundColor(view.context.getColorFromAttr(R.attr.above))
             divider_line.visibility = View.VISIBLE
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/TabViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/TabViewHolder.kt
@@ -14,7 +14,6 @@ import kotlinx.android.extensions.LayoutContainer
 import kotlinx.android.synthetic.main.tab_list_row.*
 import mozilla.components.feature.media.state.MediaState
 import mozilla.components.support.ktx.android.util.dpToFloat
-import org.jetbrains.anko.imageBitmap
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.components
@@ -123,7 +122,7 @@ class TabViewHolder(
         if (icon == null) {
             favicon_image.context.components.core.icons.loadIntoView(favicon_image, url)
         } else {
-            favicon_image.imageBitmap = icon
+            favicon_image.setImageBitmap(icon)
         }
     }
 

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/selectfolder/SelectBookmarkFolderAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/selectfolder/SelectBookmarkFolderAdapter.kt
@@ -15,7 +15,6 @@ import kotlinx.android.extensions.LayoutContainer
 import mozilla.components.concept.storage.BookmarkNode
 import mozilla.components.concept.storage.BookmarkNodeType
 import mozilla.components.support.ktx.android.util.dpToPx
-import org.jetbrains.anko.image
 import org.mozilla.fenix.R
 import org.mozilla.fenix.library.LibrarySiteItemView
 import org.mozilla.fenix.library.bookmarks.BookmarksSharedViewModel
@@ -72,12 +71,15 @@ class SelectBookmarkFolderAdapter(private val sharedViewModel: BookmarksSharedVi
 
         fun bind(folder: BookmarkNodeWithDepth, selected: Boolean, onSelect: (BookmarkNode) -> Unit) {
             view.changeSelected(selected)
-            view.iconView.image = AppCompatResources.getDrawable(
-                containerView.context,
-                R.drawable.ic_folder_icon
-            )?.apply {
-                setTint(ContextCompat.getColor(containerView.context, R.color.primary_text_light_theme))
-            }
+            view.iconView.setImageDrawable(
+                AppCompatResources.getDrawable(
+                    containerView.context,
+                    R.drawable.ic_folder_icon
+                )?.apply {
+                    setTint(ContextCompat.getColor(containerView.context,
+                        R.color.primary_text_light_theme))
+                }
+            )
             view.titleView.text = folder.node.title
             view.setOnClickListener {
                 onSelect(folder.node)

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/viewholders/BookmarkFolderViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/viewholders/BookmarkFolderViewHolder.kt
@@ -8,7 +8,6 @@ import android.view.View
 import androidx.core.content.ContextCompat
 import androidx.appcompat.content.res.AppCompatResources
 import mozilla.components.concept.storage.BookmarkNode
-import org.jetbrains.anko.image
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.hideAndDisable
 import org.mozilla.fenix.ext.showAndEnable
@@ -44,12 +43,19 @@ class BookmarkFolderViewHolder(
         }
 
         containerView.changeSelected(item in selectionHolder.selectedItems)
-        containerView.iconView.image = AppCompatResources.getDrawable(
-            containerView.context,
-            R.drawable.ic_folder_icon
-        )?.apply {
-            setTint(ContextCompat.getColor(containerView.context, R.color.primary_text_light_theme))
-        }
+        containerView.iconView.setImageDrawable(
+            AppCompatResources.getDrawable(
+                containerView.context,
+                R.drawable.ic_folder_icon
+            )?.apply {
+                setTint(
+                    ContextCompat.getColor(
+                        containerView.context,
+                        R.color.primary_text_light_theme
+                    )
+                )
+            }
+        )
         containerView.titleView.text = item.title
     }
 }


### PR DESCRIPTION
Replace anko setters for the following:
* Setting favicons in open tabs
* Setting the folder icon when viewing bookmarks
* Setting the folder icons when creating a folder and selecting where to put it

Tested by setting break points to each of the setter changes to make sure each was triggered.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture