### PR TITLE
Closes #7294: Fix parameterized message in search engine ↩️

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/search/AddSearchEngineFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/search/AddSearchEngineFragment.kt
@@ -193,7 +193,7 @@ class AddSearchEngineFragment : Fragment(), CompoundButton.OnCheckedChangeListen
             when (result) {
                 SearchStringValidator.Result.CannotReach -> {
                     custom_search_engine_search_string_field.error = resources
-                        .getString(R.string.search_add_custom_engine_error_cannot_reach)
+                        .getString(R.string.search_add_custom_engine_error_cannot_reach, name)
                 }
                 SearchStringValidator.Result.Success -> {
                     CustomSearchEngineStore.addSearchEngine(

--- a/app/src/main/java/org/mozilla/fenix/settings/search/EditCustomSearchEngineFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/search/EditCustomSearchEngineFragment.kt
@@ -137,7 +137,7 @@ class EditCustomSearchEngineFragment : Fragment(R.layout.fragment_add_search_eng
             when (result) {
                 SearchStringValidator.Result.CannotReach -> {
                     custom_search_engine_search_string_field.error = resources
-                        .getString(R.string.search_add_custom_engine_error_cannot_reach)
+                        .getString(R.string.search_add_custom_engine_error_cannot_reach, name)
                 }
                 SearchStringValidator.Result.Success -> {
                     CustomSearchEngineStore.updateSearchEngine(


### PR DESCRIPTION
The string resource `R.string.search_add_custom_engine_error_cannot_reach` contained a parameterized variable that wasn't assigned when used.

For #7294

<img width="400" alt="Screen Shot 2019-12-19 at 3 54 59 PM" src="https://user-images.githubusercontent.com/9855136/71218962-5b376b80-2278-11ea-81c6-39a4116b377b.png">

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture