### PR TITLE
For #5334 - Override custom tab styling in private mode

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabsIntegration.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabsIntegration.kt
@@ -70,6 +70,10 @@ class CustomTabsIntegration(
         // If in private mode, override toolbar background to use private color
         // See #5334
         if (isPrivate) {
+            sessionManager.findSessionById(sessionId)?.apply {
+                customTabConfig = customTabConfig?.copy(toolbarColor = null)
+            }
+
             toolbar.background = AppCompatResources.getDrawable(
                 activity,
                 R.drawable.toolbar_background


### PR DESCRIPTION

<img width="772" alt="image" src="https://user-images.githubusercontent.com/1250545/71221410-6216ac00-2281-11ea-9c0e-84d72b6022ec.png">