### PR TITLE
Add mark-as-shipped task

### DIFF
--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -54,6 +54,11 @@ workers:
             implementation: scriptworker-pushapk
             os: scriptworker
             worker-type: 'mobile-{level}-pushapk'
+        ship-it:
+            provisioner: scriptworker-k8s
+            implementation: scriptworker-shipit
+            os: scriptworker
+            worker-type: 'mobile-{level}-shipit'
         t-bitbar.*:
             provisioner: proj-autophone
             implementation: generic-worker

--- a/taskcluster/ci/mark-as-shipped/kind.yml
+++ b/taskcluster/ci/mark-as-shipped/kind.yml
@@ -1,0 +1,32 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+loader: fenix_taskgraph.loader.multi_dep:loader
+
+transforms:
+    - fenix_taskgraph.transforms.multi_dep:transforms
+    - fenix_taskgraph.transforms.mark_as_shipped:transforms
+    - taskgraph.transforms.task:transforms
+
+kind-dependencies:
+    - push-apk
+
+primary-dependency: push-apk
+
+group-by: build-type
+
+only-for-build-types:
+    - beta
+    - production
+
+job-template:
+    description: Mark Fenix as shipped in ship-it
+    worker-type: ship-it
+    scopes:
+        - project:releng:ship-it:action:mark-as-shipped
+    worker: {}
+
+    treeherder:
+        job-symbol: mark-shipped
+        kind: build

--- a/taskcluster/fenix_taskgraph/transforms/mark_as_shipped.py
+++ b/taskcluster/fenix_taskgraph/transforms/mark_as_shipped.py
@@ -1,0 +1,28 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+"""
+Apply some defaults and minor modifications to the jobs defined in the build
+kind.
+"""
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+from taskgraph.transforms.base import TransformSequence
+from taskgraph.util.schema import resolve_keyed_by
+
+
+transforms = TransformSequence()
+
+
+@transforms.add
+def make_task_description(config, jobs):
+    for job in jobs:
+        product = "Fenix"
+        version = config.params['release_version'] or "{ver}"
+        job['worker']['release-name'] = '{product}-{version}-build{build_number}'.format(
+            product=product,
+            version=version,
+            build_number=config.params.get('build_number', 1)
+        )
+        yield job

--- a/taskcluster/fenix_taskgraph/worker_types.py
+++ b/taskcluster/fenix_taskgraph/worker_types.py
@@ -94,3 +94,26 @@ def build_push_apk_payload(config, task, task_def):
             scope_prefix, worker["product"], ":dep" if worker["dep"] else ""
         )
     )
+
+
+@payload_builder(
+    "scriptworker-shipit",
+    schema={
+        Required("upstream-artifacts"): [
+            {
+                Required("taskId"): taskref_or_string,
+                Required("taskType"): text_type,
+                Required("paths"): [text_type],
+            }
+        ],
+        Required("release-name"): text_type,
+    },
+)
+def build_push_apk_payload(config, task, task_def):
+    worker = task["worker"]
+
+    task_def["tags"]["worker-implementation"] = "scriptworker"
+
+    task_def['payload'] = {
+        'release_name': worker['release-name']
+    }


### PR DESCRIPTION
For ship-it based Fenix releases, we'll need to have a task to say, that yes, we did finish shipping.

The dependency on pushapk makes sense in this regard. Though I have not yet fully tested this code locally, I suspect it should be good as-is, I still want @JohanLorenzo  to :+1: first