### PR TITLE
For #7041 - Respect current mode when opening library items 

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkController.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkController.kt
@@ -56,7 +56,7 @@ class DefaultBookmarkController(
     private val services: Services = activity.components.services
 
     override fun handleBookmarkTapped(item: BookmarkNode) {
-        openInNewTab(item.url!!, true, BrowserDirection.FromBookmarks, BrowsingMode.Normal)
+        openInNewTab(item.url!!, true, BrowserDirection.FromBookmarks, activity.browsingModeManager.mode)
     }
 
     override fun handleBookmarkExpand(folder: BookmarkNode) {

--- a/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkControllerTest.kt
@@ -107,7 +107,7 @@ class BookmarkControllerTest {
     }
 
     @Test
-    fun `handleBookmarkTapped should respect browsing mode`(){
+    fun `handleBookmarkTapped should respect browsing mode`() {
         // if in normal mode, should be in normal mode
         every { homeActivity.browsingModeManager.mode } returns BrowsingMode.Normal
 

--- a/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkControllerTest.kt
@@ -22,6 +22,7 @@ import io.mockk.verifyOrder
 import mozilla.appservices.places.BookmarkRoot
 import mozilla.components.concept.storage.BookmarkNode
 import mozilla.components.concept.storage.BookmarkNodeType
+import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import org.mozilla.fenix.BrowserDirection
@@ -101,9 +102,23 @@ class BookmarkControllerTest {
 
         verifyOrder {
             invokePendingDeletion.invoke()
-            homeActivity.browsingModeManager.mode = BrowsingMode.Normal
             homeActivity.openToBrowserAndLoad(item.url!!, true, BrowserDirection.FromBookmarks)
         }
+    }
+
+    @Test
+    fun `handleBookmarkTapped should respect browsing mode`(){
+        // if in normal mode, should be in normal mode
+        every { homeActivity.browsingModeManager.mode } returns BrowsingMode.Normal
+
+        controller.handleBookmarkTapped(item)
+        Assert.assertEquals(BrowsingMode.Normal.isPrivate, homeActivity.browsingModeManager.mode.isPrivate)
+
+        // if in private mode, should be in private mode
+        every { homeActivity.browsingModeManager.mode } returns BrowsingMode.Private
+
+        controller.handleBookmarkTapped(item)
+        Assert.assertEquals(BrowsingMode.Private.isPrivate, homeActivity.browsingModeManager.mode.isPrivate)
     }
 
     @Test

--- a/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkControllerTest.kt
@@ -22,7 +22,7 @@ import io.mockk.verifyOrder
 import mozilla.appservices.places.BookmarkRoot
 import mozilla.components.concept.storage.BookmarkNode
 import mozilla.components.concept.storage.BookmarkNodeType
-import org.junit.Assert
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.mozilla.fenix.BrowserDirection
@@ -112,13 +112,13 @@ class BookmarkControllerTest {
         every { homeActivity.browsingModeManager.mode } returns BrowsingMode.Normal
 
         controller.handleBookmarkTapped(item)
-        Assert.assertEquals(BrowsingMode.Normal.isPrivate, homeActivity.browsingModeManager.mode.isPrivate)
+        assertEquals(BrowsingMode.Normal, homeActivity.browsingModeManager.mode)
 
         // if in private mode, should be in private mode
         every { homeActivity.browsingModeManager.mode } returns BrowsingMode.Private
 
         controller.handleBookmarkTapped(item)
-        Assert.assertEquals(BrowsingMode.Private.isPrivate, homeActivity.browsingModeManager.mode.isPrivate)
+        assertEquals(BrowsingMode.Private, homeActivity.browsingModeManager.mode)
     }
 
     @Test

--- a/app/src/test/java/org/mozilla/fenix/library/history/HistoryControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/history/HistoryControllerTest.kt
@@ -146,25 +146,4 @@ class HistoryControllerTest {
         controller.handleDeleteSome(setOf(historyItem, newHistoryItem))
         assertEquals(itemsToDelete, setOf(historyItem, newHistoryItem))
     }
-
-    @Test
-    fun `openHistoryItem respects browsing mode`() {
-        val homeActivity = mockk<HomeActivity>()
-
-        every { homeActivity.browsingModeManager.mode } returns BrowsingMode.Private
-        DefaultHistoryController(
-            mockk(),
-            {
-                homeActivity.openToBrowserAndLoad(
-                    mockk(),
-                    true,
-                    BrowserDirection.FromHistory
-                )
-            },
-            mockk(),
-            mockk(),
-            mockk()
-        )
-        assertEquals(BrowsingMode.Private.isPrivate, homeActivity.browsingModeManager.mode.isPrivate)
-    }
 }

--- a/app/src/test/java/org/mozilla/fenix/library/history/HistoryControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/history/HistoryControllerTest.kt
@@ -12,9 +12,6 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import org.mozilla.fenix.BrowserDirection
-import org.mozilla.fenix.HomeActivity
-import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 
 class HistoryControllerTest {
 

--- a/app/src/test/java/org/mozilla/fenix/library/history/HistoryControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/history/HistoryControllerTest.kt
@@ -148,7 +148,7 @@ class HistoryControllerTest {
     }
 
     @Test
-    fun `openHistoryItem respects browsing mode`(){
+    fun `openHistoryItem respects browsing mode`() {
         val homeActivity = mockk<HomeActivity>()
 
         every { homeActivity.browsingModeManager.mode } returns BrowsingMode.Private

--- a/app/src/test/java/org/mozilla/fenix/library/history/HistoryControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/history/HistoryControllerTest.kt
@@ -12,6 +12,9 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import org.mozilla.fenix.BrowserDirection
+import org.mozilla.fenix.HomeActivity
+import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 
 class HistoryControllerTest {
 
@@ -142,5 +145,26 @@ class HistoryControllerTest {
             )
         controller.handleDeleteSome(setOf(historyItem, newHistoryItem))
         assertEquals(itemsToDelete, setOf(historyItem, newHistoryItem))
+    }
+
+    @Test
+    fun `openHistoryItem respects browsing mode`(){
+        val homeActivity = mockk<HomeActivity>()
+
+        every { homeActivity.browsingModeManager.mode } returns BrowsingMode.Private
+        DefaultHistoryController(
+            mockk(),
+            {
+                homeActivity.openToBrowserAndLoad(
+                    mockk(),
+                    true,
+                    BrowserDirection.FromHistory
+                )
+            },
+            mockk(),
+            mockk(),
+            mockk()
+        )
+        assertEquals(BrowsingMode.Private.isPrivate, homeActivity.browsingModeManager.mode.isPrivate)
     }
 }


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

BrowsingMode is respected in private mode, written test case around the same as well to be confident. 

Added fix for opening links via bookmarks