### PR TITLE
Resolves #7285: Meaningful name for tracking options

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -916,9 +916,9 @@
     <!-- Text displayed that links to website about enhanced tracking protection -->
     <string name="preference_enhanced_tracking_protection_explanation_learn_more">Weitere Informationen</string>
     <!-- Preference for enhanced tracking protection for the standard protection settings -->
-    <string name="preference_enhanced_tracking_protection_standard_option">Standard</string>
+    <string name="preference_enhanced_tracking_protection_standard_option">Einfach</string>
     <!-- Preference for enhanced tracking protection for the standard protection settings -->
-    <string name="preference_enhanced_tracking_protection_standard">Standard (empfohlen)</string>
+    <string name="preference_enhanced_tracking_protection_standard">Einfach (empfohlen)</string>
     <!-- Preference description for enhanced tracking protection for the standard protection settings -->
     <string name="preference_enhanced_tracking_protection_standard_description">Ausgewogen für Schutz und Leistung.</string>
     <!-- Preference description for enhanced tracking protection for the standard protection settings -->

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -901,9 +901,9 @@
     <!-- Text displayed that links to website about enhanced tracking protection -->
     <string name="preference_enhanced_tracking_protection_explanation_learn_more">Läs mer</string>
     <!-- Preference for enhanced tracking protection for the standard protection settings -->
-    <string name="preference_enhanced_tracking_protection_standard_option">Standard</string>
+    <string name="preference_enhanced_tracking_protection_standard_option">Grundläggande</string>
     <!-- Preference for enhanced tracking protection for the standard protection settings -->
-    <string name="preference_enhanced_tracking_protection_standard">Standard (rekommenderas)</string>
+    <string name="preference_enhanced_tracking_protection_standard">Grundläggande (rekommenderas)</string>
     <!-- Preference description for enhanced tracking protection for the standard protection settings -->
     <string name="preference_enhanced_tracking_protection_standard_description">Balanserad för skydd och prestanda.</string>
     <!-- Preference description for enhanced tracking protection for the standard protection settings -->


### PR DESCRIPTION
# Details

The name wasn't found to be meaningful in the tracking protection settings for both **German** and the **Swedish** languages as well.

Hence changed German setting to `Einfach` and Swedish setting to `Grundläggande` for the first option in tracking protection.

![fenix_pr1-min](https://user-images.githubusercontent.com/13200018/71305361-b6906780-23f8-11ea-8b88-67fe446ff925.png)


To test the same simply change the system language to German/Swedish and notice the difference.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture