### PR TITLE
Closes #7217 - Fix Truncated Text in Tracking Protection Info

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/trackingprotection/SwitchWithDescription.kt
+++ b/app/src/main/java/org/mozilla/fenix/trackingprotection/SwitchWithDescription.kt
@@ -11,8 +11,6 @@ import androidx.appcompat.content.res.AppCompatResources
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.withStyledAttributes
 import kotlinx.android.synthetic.main.switch_with_description.view.*
-import kotlinx.android.synthetic.main.tracking_protection_category.view.switchItemDescription
-import kotlinx.android.synthetic.main.tracking_protection_category.view.switchItemTitle
 import mozilla.components.support.ktx.android.view.putCompoundDrawablesRelativeWithIntrinsicBounds
 import org.mozilla.fenix.R
 
@@ -36,13 +34,13 @@ class SwitchWithDescription @JvmOverloads constructor(
                     id
                 )
             )
-            switchItemTitle.text = resources.getString(
+            trackingProtectionCategoryTitle.text = resources.getString(
                 getResourceId(
                     R.styleable.SwitchWithDescription_switchTitle,
                     R.string.preference_enhanced_tracking_protection
                 )
             )
-            switchItemDescription.text = resources.getString(
+            trackingProtectionCategoryItemDescription.text = resources.getString(
                 getResourceId(
                     R.styleable.SwitchWithDescription_switchDescription,
                     R.string.preference_enhanced_tracking_protection_explanation

--- a/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionCategoryItem.kt
+++ b/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionCategoryItem.kt
@@ -30,14 +30,14 @@ class TrackingProtectionCategoryItem @JvmOverloads constructor(
                 R.styleable.TrackingProtectionCategory_categoryItemIcon,
                 R.drawable.ic_cryptominers
             )
-            switchIcon?.background = resources.getDrawable(id, context.theme)
-            switchItemTitle?.text = resources.getString(
+            trackingProtectionCategoryIcon?.background = resources.getDrawable(id, context.theme)
+            trackingProtectionCategoryTitle?.text = resources.getString(
                 getResourceId(
                     R.styleable.TrackingProtectionCategory_categoryItemTitle,
                     R.string.etp_cookies_title
                 )
             )
-            switchItemDescription?.text = resources.getString(
+            trackingProtectionCategoryItemDescription?.text = resources.getString(
                 getResourceId(
                     R.styleable.TrackingProtectionCategory_categoryItemDescription,
                     R.string.etp_cookies_description

--- a/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionPanelView.kt
+++ b/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionPanelView.kt
@@ -162,7 +162,7 @@ class TrackingProtectionPanelView(
     }
 
     private fun bindTrackingProtectionInfo(isTrackingProtectionOn: Boolean) {
-        trackingProtectionSwitch.switchItemDescription.text =
+        trackingProtectionSwitch.trackingProtectionCategoryItemDescription.text =
             view.context.getString(if (isTrackingProtectionOn) R.string.etp_panel_on else R.string.etp_panel_off)
         trackingProtectionSwitch.switch_widget.isChecked = isTrackingProtectionOn
         trackingProtectionSwitch.switch_widget.jumpDrawablesToCurrentState()

--- a/app/src/main/res/layout/switch_with_description.xml
+++ b/app/src/main/res/layout/switch_with_description.xml
@@ -10,7 +10,7 @@
 
     <TextView
         android:layout_marginTop="4dp"
-        android:id="@+id/switchItemTitle"
+        android:id="@+id/trackingProtectionCategoryTitle"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="48dp"
@@ -18,7 +18,7 @@
         android:clickable="false"
         android:textAppearance="@style/ListItemTextStyle"
         android:textSize="16sp"
-        app:layout_constraintBottom_toTopOf="@+id/switchItemDescription"
+        app:layout_constraintBottom_toTopOf="@+id/trackingProtectionCategoryItemDescription"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0"
         app:layout_constraintStart_toStartOf="parent"
@@ -27,17 +27,17 @@
         tools:text="@tools:sample/lorem" />
 
     <TextView
-        android:id="@+id/switchItemDescription"
+        android:id="@+id/trackingProtectionCategoryItemDescription"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:clickable="false"
         android:textColor="?attr/secondaryText"
         android:layout_marginBottom="4dp"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="@id/switchItemTitle"
+        app:layout_constraintEnd_toEndOf="@id/trackingProtectionCategoryTitle"
         app:layout_constraintHorizontal_bias="0.5"
-        app:layout_constraintStart_toStartOf="@id/switchItemTitle"
-        app:layout_constraintTop_toBottomOf="@+id/switchItemTitle"
+        app:layout_constraintStart_toStartOf="@id/trackingProtectionCategoryTitle"
+        app:layout_constraintTop_toBottomOf="@+id/trackingProtectionCategoryTitle"
         app:layout_constraintVertical_chainStyle="packed"
         tools:text="@tools:sample/lorem" />
 
@@ -48,7 +48,7 @@
         android:layout_marginStart="@dimen/library_item_icon_margin_horizontal"
         android:layout_marginEnd="@dimen/library_item_icon_margin_horizontal"
         app:drawableStartCompat="@drawable/ic_tracking_protection"
-        app:layout_constraintBottom_toBottomOf="@id/switchItemDescription"
+        app:layout_constraintBottom_toBottomOf="@id/trackingProtectionCategoryItemDescription"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="@id/switchItemTitle" />
+        app:layout_constraintTop_toTopOf="@id/trackingProtectionCategoryTitle" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/tracking_protection_category.xml
+++ b/app/src/main/res/layout/tracking_protection_category.xml
@@ -10,7 +10,7 @@
     tools:parentTag="androidx.constraintlayout.widget.ConstraintLayout">
 
     <ImageView
-        android:id="@+id/switchIcon"
+        android:id="@+id/trackingProtectionCategoryIcon"
         android:layout_width="24dp"
         android:layout_height="24dp"
         android:layout_marginStart="@dimen/library_item_icon_margin_horizontal"
@@ -24,23 +24,24 @@
         app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
-        android:id="@+id/switchItemTitle"
-        android:layout_width="wrap_content"
+        android:id="@+id/trackingProtectionCategoryTitle"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/library_item_icon_margin_horizontal"
         android:layout_marginTop="12dp"
-        android:layout_marginEnd="@dimen/library_item_icon_margin_horizontal"
+        android:layout_marginEnd="16dp"
         android:clickable="false"
         android:textAppearance="@style/ListItemTextStyle"
         android:textSize="16sp"
-        app:layout_constraintBottom_toTopOf="@+id/switchItemDescription"
+        app:layout_constraintBottom_toTopOf="@+id/trackingProtectionCategoryItemDescription"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.5"
-        app:layout_constraintStart_toEndOf="@id/switchIcon"
+        app:layout_constraintStart_toEndOf="@id/trackingProtectionCategoryIcon"
         app:layout_constraintTop_toTopOf="parent"
         tools:text="@tools:sample/lorem" />
 
     <TextView
-        android:id="@+id/switchItemDescription"
+        android:id="@+id/trackingProtectionCategoryItemDescription"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/library_item_icon_margin_horizontal"
@@ -51,7 +52,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.5"
-        app:layout_constraintStart_toEndOf="@id/switchIcon"
-        app:layout_constraintTop_toBottomOf="@+id/switchItemTitle"
+        app:layout_constraintStart_toEndOf="@id/trackingProtectionCategoryIcon"
+        app:layout_constraintTop_toBottomOf="@+id/trackingProtectionCategoryTitle"
         tools:text="@tools:sample/lorem/random" />
 </merge>

--- a/app/src/main/res/layout/tracking_protection_category.xml
+++ b/app/src/main/res/layout/tracking_protection_category.xml
@@ -29,7 +29,7 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/library_item_icon_margin_horizontal"
         android:layout_marginTop="12dp"
-        android:layout_marginEnd="16dp"
+        android:layout_marginEnd="@dimen/library_item_icon_margin_horizontal"
         android:clickable="false"
         android:textAppearance="@style/ListItemTextStyle"
         android:textSize="16sp"


### PR DESCRIPTION
* Allow tracking protection titles to wrap instead of being cut off
* Refactor view ids to match the layout
* Fixes: #7217

<p align="center">
	<img width=400px src="https://user-images.githubusercontent.com/9855136/71314429-24d72900-23fd-11ea-83a4-807ca53e41d7.png" alt="Logo">
</p>

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture