### PR TITLE
Fix Issue #7366: Reference local android-components gradlew correctly

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -54,7 +54,7 @@ if (localProperties != null) {
     if (androidComponentsLocalPath != null) {
         log("Enabling automatic publication of android-components from: $androidComponentsLocalPath")
         log("Determining if android-components are up-to-date...")
-        def compileAcCmd = ["${androidComponentsLocalPath}/gradlew", "compileReleaseKotlin"]
+        def compileAcCmd = ["./gradlew", "compileReleaseKotlin"]
         def compileOutput = runCmd(compileAcCmd, androidComponentsLocalPath, "Compiled android-components.")
         // This is somewhat brittle: parse last line of gradle output, to fish out how many tasks were executed.
         // One executed task means gradle didn't do any work other than executing the top-level 'compile' task.


### PR DESCRIPTION
In `settings.gradle` when Fenix determines whether there is an
overriding local android-components it calls `gradlew` from the
`autoPublish.android-components.dir` directory. It sets the current
working directory (cwd) to `autoPublish.android-components.dir` and then
invokes `<autoPublish.android-components.dir>/gradlew`. The proper
behavior is to invoke `./gradlew` because the cwd is already set properly.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture