### PR TITLE
Hide extra share item in custom tab menu

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabToolbarMenu.kt
@@ -15,6 +15,7 @@ import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.toolbar.ToolbarMenu
+import org.mozilla.fenix.ext.primaryLocale
 import org.mozilla.fenix.theme.ThemeManager
 
 class CustomTabToolbarMenu(
@@ -23,6 +24,10 @@ class CustomTabToolbarMenu(
     private val sessionId: String?,
     private val onItemTapped: (ToolbarMenu.Item) -> Unit = {}
 ) : ToolbarMenu {
+
+    private val appName = context.getString(R.string.app_name)
+    private val primaryTextColor = ThemeManager.resolveAttribute(R.attr.primaryText, context)
+
     override val menuBuilder by lazy { BrowserMenuBuilder(menuItems) }
 
     private val session: Session?
@@ -32,7 +37,7 @@ class CustomTabToolbarMenu(
         val back = BrowserMenuItemToolbar.TwoStateButton(
             primaryImageResource = mozilla.components.ui.icons.R.drawable.mozac_ic_back,
             primaryContentDescription = context.getString(R.string.browser_menu_back),
-            primaryImageTintResource = primaryTextColor(),
+            primaryImageTintResource = primaryTextColor,
             isInPrimaryState = {
                 session?.canGoBack ?: true
             },
@@ -48,7 +53,7 @@ class CustomTabToolbarMenu(
         val forward = BrowserMenuItemToolbar.TwoStateButton(
             primaryImageResource = mozilla.components.ui.icons.R.drawable.mozac_ic_forward,
             primaryContentDescription = context.getString(R.string.browser_menu_forward),
-            primaryImageTintResource = primaryTextColor(),
+            primaryImageTintResource = primaryTextColor,
             isInPrimaryState = {
                 session?.canGoForward ?: true
             },
@@ -64,13 +69,13 @@ class CustomTabToolbarMenu(
         val refresh = BrowserMenuItemToolbar.TwoStateButton(
             primaryImageResource = mozilla.components.ui.icons.R.drawable.mozac_ic_refresh,
             primaryContentDescription = context.getString(R.string.browser_menu_refresh),
-            primaryImageTintResource = primaryTextColor(),
+            primaryImageTintResource = primaryTextColor,
             isInPrimaryState = {
                 session?.loading == false
             },
             secondaryImageResource = mozilla.components.ui.icons.R.drawable.mozac_ic_stop,
             secondaryContentDescription = context.getString(R.string.browser_menu_stop),
-            secondaryImageTintResource = primaryTextColor(),
+            secondaryImageTintResource = primaryTextColor,
             disableInSecondaryState = false
         ) {
             if (session?.loading == true) {
@@ -99,10 +104,12 @@ class CustomTabToolbarMenu(
     private val share = BrowserMenuImageText(
         label = context.getString(R.string.browser_menu_share),
         imageResource = R.drawable.mozac_ic_share,
-        textColorResource = primaryTextColor(),
-        iconTintColorResource = primaryTextColor()
+        textColorResource = primaryTextColor,
+        iconTintColorResource = primaryTextColor
     ) {
         onItemTapped.invoke(ToolbarMenu.Item.Share)
+    }.apply {
+        visible = { session?.customTabConfig?.showShareMenuItem ?: true }
     }
 
     private val desktopMode = BrowserMenuSwitch(
@@ -115,29 +122,22 @@ class CustomTabToolbarMenu(
     private val findInPage = BrowserMenuImageText(
         label = context.getString(R.string.browser_menu_find_in_page),
         imageResource = R.drawable.mozac_ic_search,
-        iconTintColorResource = primaryTextColor()
+        iconTintColorResource = primaryTextColor
     ) {
         onItemTapped.invoke(ToolbarMenu.Item.FindInPage)
     }
 
     private val openInFenix = SimpleBrowserMenuItem(
-        label = {
-            val appName = context.getString(R.string.app_name)
-            context.getString(R.string.browser_menu_open_in_fenix, appName)
-        }(),
-        textColorResource = primaryTextColor()
+        label = context.getString(R.string.browser_menu_open_in_fenix, appName),
+        textColorResource = primaryTextColor
     ) {
         onItemTapped.invoke(ToolbarMenu.Item.OpenInFenix)
     }
 
     private val poweredBy = SimpleBrowserMenuItem(
-        label = {
-            val appName = context.getString(R.string.app_name)
-            context.getString(R.string.browser_menu_powered_by, appName).toUpperCase()
-        }(),
+        label = context.getString(R.string.browser_menu_powered_by, appName)
+            .toUpperCase(context.resources.configuration.primaryLocale),
         textSize = ToolbarMenu.CAPTION_TEXT_SIZE,
-        textColorResource = primaryTextColor()
+        textColorResource = primaryTextColor
     )
-
-    private fun primaryTextColor() = ThemeManager.resolveAttribute(R.attr.primaryText, context)
 }

--- a/app/src/main/java/org/mozilla/fenix/ext/Resources.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/Resources.kt
@@ -12,6 +12,7 @@ import android.text.SpannableString
 import android.text.Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
 import androidx.annotation.StringRes
 import java.util.Formatter
+import java.util.Locale
 import kotlin.collections.ArrayList
 import kotlin.collections.HashMap
 
@@ -21,17 +22,17 @@ fun Resources.getSpannable(@StringRes id: Int, spanParts: List<Pair<Any, Iterabl
     val resultCreator = SpannableStringCreator()
     Formatter(
         SpannableAppendable(resultCreator, spanParts),
-        getLocale(configuration)
+        configuration.primaryLocale
     ).format(getString(id), *spanParts.map { it.first }.toTypedArray())
     return resultCreator.toSpannableString()
 }
 
-private fun getLocale(configuration: Configuration) =
+val Configuration.primaryLocale: Locale get() =
     if (SDK_INT >= Build.VERSION_CODES.N) {
-        configuration.locales[0]
+        locales[0]
     } else {
         @Suppress("Deprecation")
-        configuration.locale
+        locale
     }
 
 class SpannableStringCreator {


### PR DESCRIPTION
In custom tabs where the app provides its own share button, hide our share button.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture