### PR TITLE
No issue: Use SendTabFeature and FxaPushSupportFeature

### DIFF
--- a/app/src/test/java/org/mozilla/fenix/components/BackgroundServicesTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/BackgroundServicesTest.kt
@@ -15,7 +15,6 @@ import mozilla.components.concept.sync.AuthType
 import mozilla.components.concept.sync.OAuthAccount
 import mozilla.components.feature.push.AutoPushFeature
 import mozilla.components.feature.push.PushConfig
-import mozilla.components.feature.push.PushType
 import mozilla.components.service.fxa.DeviceConfig
 import mozilla.components.service.fxa.ServerConfig
 import mozilla.components.service.fxa.SyncConfig
@@ -74,53 +73,6 @@ class BackgroundServicesTest {
         every { context.isInExperiment(eq(Experiments.asFeatureSyncDisabled)) } returns true
         backgroundServices = TestableBackgroundServices(context)
         assertNull(backgroundServices.syncConfig)
-    }
-
-    @Test
-    fun `push account observer`() {
-        val push = mockk<AutoPushFeature>()
-        val observer = PushAccountObserver(push)
-        val registry = ObserverRegistry<AccountObserver>()
-        registry.register(observer)
-        val account = mockk<OAuthAccount>()
-
-        // Being explicit here (vs using 'any()') ensures that any change to which PushType variants
-        // are being subscribed/unsubscribed will break these tests, forcing developer to expand them.
-        every { push.subscribeForType(PushType.Services) } just Runs
-        every { push.unsubscribeForType(PushType.Services) } just Runs
-
-        // 'Existing' auth type doesn't trigger subscription - we're already subscribed.
-        registry.notifyObservers { onAuthenticated(account, AuthType.Existing) }
-        verify(exactly = 0) { push.subscribeForType(any()) }
-
-        // Every other auth type does.
-        registry.notifyObservers { onAuthenticated(account, AuthType.Signin) }
-        verify(exactly = 1) { push.subscribeForType(eq(PushType.Services)) }
-
-        registry.notifyObservers { onAuthenticated(account, AuthType.Signup) }
-        verify(exactly = 2) { push.subscribeForType(eq(PushType.Services)) }
-
-        registry.notifyObservers { onAuthenticated(account, AuthType.Recovered) }
-        verify(exactly = 3) { push.subscribeForType(eq(PushType.Services)) }
-
-        registry.notifyObservers { onAuthenticated(account, AuthType.Shared) }
-        verify(exactly = 4) { push.subscribeForType(eq(PushType.Services)) }
-
-        registry.notifyObservers { onAuthenticated(account, AuthType.Pairing) }
-        verify(exactly = 5) { push.subscribeForType(eq(PushType.Services)) }
-
-        registry.notifyObservers { onAuthenticated(account, AuthType.OtherExternal(null)) }
-        verify(exactly = 6) { push.subscribeForType(eq(PushType.Services)) }
-
-        registry.notifyObservers { onAuthenticated(account, AuthType.OtherExternal("someAction")) }
-        verify(exactly = 7) { push.subscribeForType(eq(PushType.Services)) }
-
-        // None of the above unsubscribed.
-        verify(exactly = 0) { push.unsubscribeForType(any()) }
-
-        // Finally, log-out should unsubscribe.
-        registry.notifyObservers { onLoggedOut() }
-        verify(exactly = 1) { push.unsubscribeForType(eq(PushType.Services)) }
     }
 
     @Test


### PR DESCRIPTION
This involves some push clean up for removing direct handling of push on the FxaAccountManager and now delegates that to FxaPushSupportFeature. The push "feature" Send Tab now no longer depends on push.

This is some pre-work to move push away from `Application.onCreate` initialization.

cc: @hawkinsw 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture