### PR TITLE
Closes #5170. Add button to move tabs from and to private mode.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserInteractor.kt
@@ -20,6 +20,10 @@ open class BrowserInteractor(
         browserToolbarController.handleToolbarPasteAndGo(text)
     }
 
+    override fun onBrowserToolbarMoveTab() {
+        browserToolbarController.handleToolbarMoveTab()
+    }
+
     override fun onBrowserToolbarClicked() {
         browserToolbarController.handleToolbarClick()
     }

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt
@@ -50,6 +50,7 @@ interface BrowserToolbarController {
     fun handleToolbarItemInteraction(item: ToolbarMenu.Item)
     fun handleToolbarClick()
     fun handleTabCounterClick()
+    fun handleToolbarMoveTab()
 }
 
 @Suppress("LargeClass")
@@ -95,6 +96,15 @@ class DefaultBrowserToolbarController(
 
         activity.components.core.sessionManager.selectedSession?.searchTerms = text
         activity.components.useCases.searchUseCases.defaultSearch.invoke(text)
+    }
+
+    override fun handleToolbarMoveTab() {
+        val session = currentSession ?: return
+        if (browsingModeManager.mode.isPrivate)
+            activity.components.useCases.tabsUseCases.addTab(session.url)
+        else
+            activity.components.useCases.tabsUseCases.addPrivateTab(session.url)
+        activity.components.useCases.tabsUseCases.removeTab(session.id)
     }
 
     override fun handleToolbarClick() {

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarView.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarView.kt
@@ -39,6 +39,7 @@ interface BrowserToolbarViewInteractor {
     fun onBrowserToolbarClicked()
     fun onBrowserToolbarMenuItemTapped(item: ToolbarMenu.Item)
     fun onTabCounterClicked()
+    fun onBrowserToolbarMoveTab()
 }
 
 class BrowserToolbarView(
@@ -90,6 +91,16 @@ class BrowserToolbarView(
             customView.paste_and_go.isVisible =
                 !clipboard.text.isNullOrEmpty() && !isCustomTabSession
 
+            val session = if (isCustomTabSession) customTabSession else selectedSession
+            if (session != null) {
+                customView.move_tab.isVisible = true
+                customView.move_tab.text = view.context.resources.getString(
+                    if (session.private) R.string.browser_toolbar_long_press_popup_make_tab_non_private
+                    else R.string.browser_toolbar_long_press_popup_make_tab_private)
+            } else {
+                customView.move_tab.isVisible = false
+            }
+
             customView.copy.setOnClickListener {
                 popupWindow.dismiss()
                 if (isCustomTabSession) {
@@ -112,6 +123,11 @@ class BrowserToolbarView(
             customView.paste_and_go.setOnClickListener {
                 popupWindow.dismiss()
                 interactor.onBrowserToolbarPasteAndGo(clipboard.text!!)
+            }
+
+            customView.move_tab.setOnClickListener {
+                popupWindow.dismiss()
+                interactor.onBrowserToolbarMoveTab()
             }
 
             popupWindow.showAsDropDown(

--- a/app/src/main/res/layout/browser_toolbar_popup_window.xml
+++ b/app/src/main/res/layout/browser_toolbar_popup_window.xml
@@ -43,4 +43,14 @@
         android:textAllCaps="false"
         android:textColor="?primaryText"
         android:text="@string/browser_toolbar_long_press_popup_paste_and_go"/>
+    <Button
+        android:id="@+id/move_tab"
+        android:background="?selectableItemBackground"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:paddingStart="12dp"
+        android:paddingEnd="12dp"
+        android:textAllCaps="false"
+        android:textColor="?primaryText"
+        android:text="@string/browser_toolbar_long_press_popup_make_tab_private"/>
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -964,6 +964,10 @@
     <string name="browser_toolbar_long_press_popup_copy">Copy</string>
     <!-- Paste & go the text in the clipboard. '&amp;' is replaced with the ampersand symbol: & -->
     <string name="browser_toolbar_long_press_popup_paste_and_go">Paste &amp; Go</string>
+    <!-- Move a normal tab to private mode -->
+    <string name="browser_toolbar_long_press_popup_make_tab_private">As Private</string>
+    <!-- Move a private tab to normal mode -->
+    <string name="browser_toolbar_long_press_popup_make_tab_non_private">As Normal</string>
     <!-- Paste the text in the clipboard -->
     <string name="browser_toolbar_long_press_popup_paste">Paste</string>
     <!-- Snackbar message shown after an URL has been copied to clipboard. -->


### PR DESCRIPTION
This PR adds a button to swap a tab between private and non-private mode. The button can be accessed via the long-press menu on the tab's toolbar, next to its copy/paste actions, as per request in issue #5170.

As seen on the below screenshots, I had to pick very short labels to make sure the buttons don't overflow on two lines, making the whole overlay look odd. I believe this is not an ideal situation and may need changes in terms of UX. I'm also not sure concerning a11y, however I integrated the feature taking the same steps as the paste&go feature found in the same location.
If you have a suggestion on where to best place the button I'm happy to adapt the PR accordingly.

![Screenshot_1577995299](https://user-images.githubusercontent.com/4313751/71689927-873c0c00-2da3-11ea-817b-a7d6bbad0ed8.png)
![Screenshot_1577995288](https://user-images.githubusercontent.com/4313751/71689928-873c0c00-2da3-11ea-8c61-cb65a6bad4e1.png)


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture