### PR TITLE
Issue 7445 - Modified Onboarding Card Colors

### DIFF
--- a/app/src/main/res/drawable/ic_onboarding_avatar_anonymous.xml
+++ b/app/src/main/res/drawable/ic_onboarding_avatar_anonymous.xml
@@ -3,43 +3,14 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:aapt="http://schemas.android.com/aapt"
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
     android:viewportHeight="24">
   <path
-      android:pathData="M17.6655,14.2092C16.1843,12.4998 14.1333,14.8 11.9997,14.8C9.8675,14.8 7.8151,12.4998 6.3339,14.2092C5.9139,14.6936 5.8803,15.3992 6.2401,15.9284C7.4959,17.7764 9.5959,19 11.9997,19C14.4035,19 16.5035,17.7764 17.7593,15.9284C18.1205,15.3992 18.0855,14.6936 17.6655,14.2092M16.25,9.25C16.25,6.9026 14.3474,5 12,5C9.6526,5 7.75,6.9026 7.75,9.25C7.75,11.5974 9.6526,13.5 12,13.5C14.3474,13.5 16.25,11.5974 16.25,9.25Z">
-    <aapt:attr name="android:fillColor">
-      <gradient 
-          android:startY="21.265238"
-          android:startX="10.078417"
-          android:endY="-6.155523"
-          android:endX="18.457676"
-          android:type="linear">
-        <item android:offset="0" android:color="#00B3F4"/>
-        <item android:offset="0.16" android:color="#07B8ED"/>
-        <item android:offset="0.41" android:color="#1AC6D8"/>
-        <item android:offset="0.7" android:color="#39DCB7"/>
-        <item android:offset="0.76" android:color="#3FE1B0"/>
-      </gradient>
-    </aapt:attr>
-  </path>
+      android:fillColor="@android:color/white"
+      android:pathData="M17.6655,14.2092C16.1843,12.4998 14.1333,14.8 11.9997,14.8C9.8675,14.8 7.8151,12.4998 6.3339,14.2092C5.9139,14.6936 5.8803,15.3992 6.2401,15.9284C7.4959,17.7764 9.5959,19 11.9997,19C14.4035,19 16.5035,17.7764 17.7593,15.9284C18.1205,15.3992 18.0855,14.6936 17.6655,14.2092M16.25,9.25C16.25,6.9026 14.3474,5 12,5C9.6526,5 7.75,6.9026 7.75,9.25C7.75,11.5974 9.6526,13.5 12,13.5C14.3474,13.5 16.25,11.5974 16.25,9.25Z" />
   <path
-      android:pathData="M12,22C6.4772,22 2,17.5228 2,12C2,6.4772 6.4772,2 12,2C17.5228,2 22,6.4772 22,12C21.9939,17.5203 17.5203,21.9939 12,22L12,22ZM12,4C7.5817,4 4,7.5817 4,12C4,16.4183 7.5817,20 12,20C16.4183,20 20,16.4183 20,12C19.995,7.5838 16.4162,4.005 12,4Z">
-    <aapt:attr name="android:fillColor">
-      <gradient
-          android:startY="25.236055"
-          android:startX="7.735972"
-          android:endY="-13.936461"
-          android:endX="26.325832"
-          android:type="linear">
-        <item android:offset="0" android:color="#00B3F4"/>
-        <item android:offset="0.16" android:color="#07B8ED"/>
-        <item android:offset="0.41" android:color="#1AC6D8"/>
-        <item android:offset="0.7" android:color="#39DCB7"/>
-        <item android:offset="0.76" android:color="#3FE1B0"/>
-      </gradient>
-    </aapt:attr>
-  </path>
+      android:fillColor="@android:color/white"
+      android:pathData="M12,22C6.4772,22 2,17.5228 2,12C2,6.4772 6.4772,2 12,2C17.5228,2 22,6.4772 22,12C21.9939,17.5203 17.5203,21.9939 12,22L12,22ZM12,4C7.5817,4 4,7.5817 4,12C4,16.4183 7.5817,20 12,20C16.4183,20 20,16.4183 20,12C19.995,7.5838 16.4162,4.005 12,4Z" />
 </vector>

--- a/app/src/main/res/layout/onboarding_automatic_signin.xml
+++ b/app/src/main/res/layout/onboarding_automatic_signin.xml
@@ -33,7 +33,7 @@
         android:padding="10dp"
         android:text="@string/onboarding_firefox_account_auto_signin_confirm"
         android:textAllCaps="false"
-        android:textColor="?neutral"
+        android:textColor="@color/onboarding_card_button_text_dark"
         android:textSize="14sp"
         android:textStyle="bold"
         app:backgroundTint="@color/onboarding_card_button_background_dark" />

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -209,8 +209,9 @@
 
     <!-- Onboarding colors -->
     <color name="onboarding_card_background_dark">#20123A</color>
-    <color name="onboarding_card_primary_text_dark">#3FE1B0</color>
-    <color name="onboarding_card_button_background_dark">#312A65</color>
+    <color name="onboarding_card_primary_text_dark">#FFFFFF</color>
+    <color name="onboarding_card_button_background_dark">#F9F9FB</color>
+    <color name="onboarding_card_button_text_dark">#312A65</color>
 
     <!-- Share UI -->
     <color name="default_share_background">#E3E2E3</color>


### PR DESCRIPTION
https://github.com/mozilla-mobile/fenix/issues/7445

I wasn't able to find the source of the regression. From the git history, it looked like the incorrect colors were added when sign-in cards were introduced. 

According to the design, the background color for the "Yes, sign me in" button is different from the "Sign into Firefox" button color. So I made the call and went with the latter color for consistency. Here's the [Abstract](https://app.goabstract.com/share/9507950f-cabb-415d-b4fa-1e9ee5229621?mode=design&sha=cf4d6e8baf5e4e3bb504ab793a2e94571e1b043d).

Screenshots with both sign-in cards _manually forced_ to show up at the same time:

<img width="461" alt="Screen Shot 2020-01-02 at 1 32 11 PM" src="https://user-images.githubusercontent.com/1782266/71694629-9485d600-2d64-11ea-9ba8-6af19ede4cc8.png">
<img width="461" alt="Scre†en Shot 2020-01-02 at 1 33 16 PM" src="https://user-images.githubusercontent.com/1782266/71694632-9780c680-2d64-11ea-8b3f-d7db69c9e9df.png">

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture