### PR TITLE
Change type for OnboardingAutomaticSignIn

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlAdapter.kt
@@ -96,11 +96,9 @@ sealed class AdapterItem(@LayoutRes val viewType: Int) {
     ) : AdapterItem(OnboardingSectionHeaderViewHolder.LAYOUT_ID) {
         override fun sameAs(other: AdapterItem) = other is OnboardingSectionHeader && labelBuilder == other.labelBuilder
     }
-    data class OnboardingManualSignIn(
-        val state: OnboardingState
-    ) : AdapterItem(OnboardingManualSignInViewHolder.LAYOUT_ID)
+    object OnboardingManualSignIn : AdapterItem(OnboardingManualSignInViewHolder.LAYOUT_ID)
     data class OnboardingAutomaticSignIn(
-        val state: OnboardingState
+        val state: OnboardingState.SignedOutCanAutoSignIn
     ) : AdapterItem(OnboardingAutomaticSignInViewHolder.LAYOUT_ID)
     object OnboardingThemePicker : AdapterItem(OnboardingThemePickerViewHolder.LAYOUT_ID)
     object OnboardingTrackingProtection : AdapterItem(OnboardingTrackingProtectionViewHolder.LAYOUT_ID)
@@ -197,9 +195,8 @@ class SessionControlAdapter(
                 (item as AdapterItem.OnboardingSectionHeader).labelBuilder
             )
             is OnboardingManualSignInViewHolder -> holder.bind()
-            is OnboardingAutomaticSignInViewHolder -> holder.bind((
-                (item as AdapterItem.OnboardingAutomaticSignIn).state
-                    as OnboardingState.SignedOutCanAutoSignIn).withAccount
+            is OnboardingAutomaticSignInViewHolder -> holder.bind(
+                (item as AdapterItem.OnboardingAutomaticSignIn).state.withAccount
             )
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlView.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlView.kt
@@ -89,7 +89,7 @@ private fun onboardingAdapterItems(onboardingState: OnboardingState): List<Adapt
     items.addAll(when (onboardingState) {
         OnboardingState.SignedOutNoAutoSignIn -> {
             listOf(
-                AdapterItem.OnboardingManualSignIn(onboardingState)
+                AdapterItem.OnboardingManualSignIn
             )
         }
         is OnboardingState.SignedOutCanAutoSignIn -> {


### PR DESCRIPTION
When @daphliu and I mocked state for screenshots in #7471, we found that `OnboardingAutomaticSignIn` can take any `OnboardingState` but crashes unless the state is `SignedOutCanAutoSignIn`. 

This PR changes the types so that only valid states can be used.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [/] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not _(no visual changes)_
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture