### PR TITLE
For #6073: Add collapsing/expanding section in History window after pressing section header

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryAdapter.kt
@@ -10,6 +10,7 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.paging.PagedListAdapter
 import androidx.recyclerview.widget.DiffUtil
+import kotlinx.android.synthetic.main.history_list_item.view.*
 import org.mozilla.fenix.R
 import org.mozilla.fenix.library.SelectionHolder
 import org.mozilla.fenix.library.history.viewholders.HistoryListItemViewHolder
@@ -18,6 +19,8 @@ import java.util.Date
 
 enum class HistoryItemTimeGroup {
     Today, ThisWeek, ThisMonth, Older;
+
+    var groupVisible = true
 
     fun humanReadable(context: Context): String = when (this) {
         Today -> context.getString(R.string.history_24_hours)
@@ -29,7 +32,8 @@ enum class HistoryItemTimeGroup {
 
 class HistoryAdapter(
     private val historyInteractor: HistoryInteractor
-) : PagedListAdapter<HistoryItem, HistoryListItemViewHolder>(historyDiffCallback), SelectionHolder<HistoryItem> {
+) : PagedListAdapter<HistoryItem, HistoryListItemViewHolder>(historyDiffCallback),
+    SelectionHolder<HistoryItem> {
 
     private var mode: HistoryFragmentState.Mode = HistoryFragmentState.Mode.Normal
     override val selectedItems get() = mode.selectedItems
@@ -53,8 +57,12 @@ class HistoryAdapter(
 
         val previousHeader = previous?.let(::timeGroupForHistoryItem)
         val currentHeader = timeGroupForHistoryItem(current)
-        val timeGroup = if (currentHeader != previousHeader) currentHeader else null
-        holder.bind(current, timeGroup, position == 0, mode)
+        val timeGroup = if (currentHeader != previousHeader) currentHeader else previousHeader
+
+        holder.bind(
+            current, timeGroup, position == 0, mode,
+            this, currentHeader != previousHeader
+        )
     }
 
     companion object {

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryAdapter.kt
@@ -10,7 +10,6 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.paging.PagedListAdapter
 import androidx.recyclerview.widget.DiffUtil
-import kotlinx.android.synthetic.main.history_list_item.view.*
 import org.mozilla.fenix.R
 import org.mozilla.fenix.library.SelectionHolder
 import org.mozilla.fenix.library.history.viewholders.HistoryListItemViewHolder

--- a/app/src/main/java/org/mozilla/fenix/library/history/viewholders/HistoryListItemViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/viewholders/HistoryListItemViewHolder.kt
@@ -12,11 +12,7 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.hideAndDisable
 import org.mozilla.fenix.ext.showAndEnable
 import org.mozilla.fenix.library.SelectionHolder
-import org.mozilla.fenix.library.history.HistoryInteractor
-import org.mozilla.fenix.library.history.HistoryItem
-import org.mozilla.fenix.library.history.HistoryItemMenu
-import org.mozilla.fenix.library.history.HistoryItemTimeGroup
-import org.mozilla.fenix.library.history.HistoryFragmentState
+import org.mozilla.fenix.library.history.*
 
 class HistoryListItemViewHolder(
     view: View,
@@ -43,17 +39,24 @@ class HistoryListItemViewHolder(
         item: HistoryItem,
         timeGroup: HistoryItemTimeGroup?,
         showDeleteButton: Boolean,
-        mode: HistoryFragmentState.Mode
+        mode: HistoryFragmentState.Mode,
+        adapter: HistoryAdapter?,
+        firstInGroup: Boolean
     ) {
         this.item = item
+
+        if (timeGroup != null && !timeGroup.groupVisible) {
+            itemView.history_layout.visibility = View.GONE
+        } else {
+            itemView.history_layout.visibility = View.VISIBLE
+        }
 
         itemView.history_layout.titleView.text = item.title
         itemView.history_layout.urlView.text = item.url
 
         toggleDeleteButton(showDeleteButton, mode === HistoryFragmentState.Mode.Normal)
 
-        val headerText = timeGroup?.humanReadable(itemView.context)
-        toggleHeader(headerText)
+        toggleHeader(firstInGroup, timeGroup, adapter)
 
         itemView.history_layout.setSelectionInteractor(item, selectionHolder, historyInteractor)
         itemView.history_layout.changeSelected(item in selectionHolder.selectedItems)
@@ -65,10 +68,22 @@ class HistoryListItemViewHolder(
         }
     }
 
-    private fun toggleHeader(headerText: String?) {
-        if (headerText != null) {
+    private fun toggleHeader(
+        firstInGroup: Boolean,
+        timeGroup: HistoryItemTimeGroup?,
+        adapter: HistoryAdapter?
+    ) {
+        if (firstInGroup) {
+            val headerText = timeGroup?.humanReadable(itemView.context)
+
             itemView.header_title.visibility = View.VISIBLE
             itemView.header_title.text = headerText
+            itemView.header_title.setOnClickListener {
+                if (timeGroup != null) {
+                    timeGroup.groupVisible = !timeGroup.groupVisible
+                }
+                adapter?.notifyDataSetChanged()
+            }
         } else {
             itemView.header_title.visibility = View.GONE
         }


### PR DESCRIPTION
1. Adds groupVisible for the HistoryItemTimeGroup
2. Adds OnClickListener for the header_title for the HistoryListItem inside HistoryListItemViewHolder - it's changing groupVisible and forcing refreshing from HistoryAdapter
3. Adds necessary changes in HistoryAdapter

Change doesn't modify screen view in this meaning, that it's adding new graphic elements or is changing some fonts - screenshots and accessibility notes are the most probably not necessary

Tests are also not added

Closes #6073:Adding collapsing/expanding sections in history window

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture