### PR TITLE
For #1718: Sets accessibility users to top toolbar by default

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/RadioButtonPreference.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/RadioButtonPreference.kt
@@ -92,6 +92,11 @@ open class RadioButtonPreference @JvmOverloads constructor(
         }
     }
 
+    fun setCheckedWithoutClickListener(isChecked: Boolean) {
+        updateRadioValue(isChecked)
+        toggleRadioGroups()
+    }
+
     private fun updateRadioValue(isChecked: Boolean) {
         persistBoolean(isChecked)
         radioButton?.isChecked = isChecked

--- a/app/src/main/java/org/mozilla/fenix/settings/ToolbarSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/ToolbarSettingsFragment.kt
@@ -10,6 +10,7 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.getPreferenceKey
+import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.showToolbar
 
 /**
@@ -44,6 +45,9 @@ class ToolbarSettingsFragment : PreferenceFragmentCompat() {
                 Event.ToolbarPositionChanged.Position.BOTTOM
             ))
         }
+
+        topPreference.setCheckedWithoutClickListener(!requireContext().settings().shouldUseBottomToolbar)
+        bottomPreference.setCheckedWithoutClickListener(requireContext().settings().shouldUseBottomToolbar)
 
         topPreference.addToRadioGroup(bottomPreference)
         bottomPreference.addToRadioGroup(topPreference)

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.fenix.utils
 
+import android.accessibilityservice.AccessibilityServiceInfo.CAPABILITY_CAN_PERFORM_GESTURES
 import android.app.Application
 import android.content.Context
 import android.content.Context.MODE_PRIVATE
@@ -206,9 +207,7 @@ class Settings private constructor(
 
     val shouldUseFixedTopToolbar: Boolean
         get() {
-            val accessibilityManager =
-                appContext.getSystemService(Context.ACCESSIBILITY_SERVICE) as? AccessibilityManager
-            return accessibilityManager?.isTouchExplorationEnabled ?: false
+            return touchExplorationIsEnabled || switchServiceIsEnabled
         }
 
     var shouldDeleteBrowsingDataOnQuit by booleanPreference(
@@ -218,8 +217,36 @@ class Settings private constructor(
 
     var shouldUseBottomToolbar by booleanPreference(
         appContext.getPreferenceKey(R.string.pref_key_toolbar_bottom),
-        default = true
+        // Default accessibility users to top toolbar
+        default = !touchExplorationIsEnabled && !switchServiceIsEnabled
     )
+
+    /**
+     * Check each active accessibility service to see if it can perform gestures, if any can,
+     * then it is *likely* a switch service is enabled. We are assuming this to be the case based on #7486
+     */
+    private val switchServiceIsEnabled: Boolean
+        get() {
+            val accessibilityManager =
+                appContext.getSystemService(Context.ACCESSIBILITY_SERVICE) as? AccessibilityManager
+
+            accessibilityManager?.getEnabledAccessibilityServiceList(0)?.let { activeServices ->
+                for (service in activeServices) {
+                    if (service.capabilities.and(CAPABILITY_CAN_PERFORM_GESTURES) == 1) {
+                        return true
+                    }
+                }
+            }
+
+            return false
+        }
+
+    private val touchExplorationIsEnabled: Boolean
+        get() {
+            val accessibilityManager =
+                appContext.getSystemService(Context.ACCESSIBILITY_SERVICE) as? AccessibilityManager
+            return accessibilityManager?.isTouchExplorationEnabled ?: false
+        }
 
     val toolbarSettingString: String
         get() = when {

--- a/app/src/main/res/xml/toolbar_preferences.xml
+++ b/app/src/main/res/xml/toolbar_preferences.xml
@@ -4,11 +4,9 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
     <org.mozilla.fenix.settings.RadioButtonPreference
-        android:defaultValue="false"
         android:key="@string/pref_key_toolbar_top"
         android:title="@string/preference_top_toolbar" />
     <org.mozilla.fenix.settings.RadioButtonPreference
-        android:defaultValue="true"
         android:key="@string/pref_key_toolbar_bottom"
         android:title="@string/preference_bottom_toolbar" />
 </PreferenceScreen>


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture