### PR TITLE
No Issue: Add a coroutine scope to MetricController

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/metrics/AdjustMetricsService.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/AdjustMetricsService.kt
@@ -11,12 +11,13 @@ import android.util.Log
 import com.adjust.sdk.Adjust
 import com.adjust.sdk.AdjustConfig
 import com.adjust.sdk.LogLevel
+import kotlinx.coroutines.CoroutineScope
 import org.mozilla.fenix.BuildConfig
 import org.mozilla.fenix.Config
 import org.mozilla.fenix.ext.settings
 
 class AdjustMetricsService(private val application: Application) : MetricsService {
-    override fun start() {
+    override fun start(scope: CoroutineScope) {
         if ((BuildConfig.ADJUST_TOKEN.isNullOrEmpty())) {
             Log.i(LOGTAG, "No adjust token defined")
 

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
@@ -5,6 +5,7 @@
 package org.mozilla.fenix.components.metrics
 
 import android.content.Context
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.MainScope
@@ -474,7 +475,7 @@ class GleanMetricsService(private val context: Context) : MetricsService {
 
     private val activationPing = ActivationPing(context)
 
-    override fun start() {
+    override fun start(scope: CoroutineScope) {
         Glean.setUploadEnabled(true)
 
         if (initialized) return

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/LeanplumMetricsService.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/LeanplumMetricsService.kt
@@ -10,6 +10,7 @@ import com.leanplum.Leanplum
 import com.leanplum.LeanplumActivityHelper
 import com.leanplum.annotations.Parser
 import com.leanplum.internal.LeanplumInternal
+import kotlinx.coroutines.CoroutineScope
 import org.mozilla.fenix.BuildConfig
 import org.mozilla.fenix.ext.settings
 import java.util.UUID.randomUUID
@@ -53,7 +54,7 @@ class LeanplumMetricsService(private val application: Application) : MetricsServ
 
     private val token = Token(LeanplumId, LeanplumToken)
 
-    override fun start() {
+    override fun start(scope: CoroutineScope) {
         when (token.type) {
             Token.Type.Production -> Leanplum.setAppIdForProductionMode(token.id, token.token)
             Token.Type.Development -> Leanplum.setAppIdForDevelopmentMode(token.id, token.token)


### PR DESCRIPTION
The scope is managed by the lifetime of the controller and
passed to each `ServiceController`. `ServiceController`s can use
that scope to launch asynchronous tasks with the reassurance
that they will be GC'd and canceled appropriately.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture