### PR TITLE
For #6086: Add setting for blocking screen locking

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -9,6 +9,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.util.AttributeSet
 import android.view.View
+import android.view.WindowManager
 import androidx.annotation.CallSuper
 import androidx.annotation.IdRes
 import androidx.annotation.VisibleForTesting
@@ -93,6 +94,10 @@ open class HomeActivity : LocaleAwareAppCompatActivity() {
         setupThemeAndBrowsingMode(mode)
 
         setContentView(R.layout.activity_home)
+
+        if (!applicationContext.settings().shouldAllowForScreenLock) {
+            window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        }
 
         setupToolbarAndNavigation()
 

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -179,6 +179,11 @@ class Settings private constructor(
         default = true
     )
 
+    val shouldAllowForScreenLock by booleanPreference(
+        appContext.getPreferenceKey(R.string.pref_key_screen_lock),
+        true
+    )
+
     val shouldUseDarkTheme by booleanPreference(
         appContext.getPreferenceKey(R.string.pref_key_dark_theme),
         default = false

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -129,5 +129,7 @@
 
     <string name="pref_key_total_uri" translatable="false">pref_key_total_uri</string>
 
+    <string name="pref_key_screen_lock" translatable="false">pref_key_screen_lock</string>
+
     <string name="pref_key_encryption_key_generated" translatable="false">pref_key_encryption_key_generated</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -729,6 +729,9 @@
     <!-- Summary for Accessibility Text Automatic Size Scaling Preference -->
     <string name="preference_accessibility_auto_size_summary">Font size will match your Android settings. Disable to manage font size here.</string>
 
+    <!-- Title for Screen blocking preference -->
+    <string name="preference_screen_lock">Allow for screen locking</string>
+
     <!-- Title for the Delete browsing data preference -->
     <string name="preferences_delete_browsing_data">Delete browsing data</string>
     <!-- Title for the tabs item in Delete browsing data -->

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -54,6 +54,11 @@
         <androidx.preference.Preference
             android:key="@string/pref_key_toolbar"
             android:title="@string/preferences_toolbar" />
+
+        <androidx.preference.SwitchPreference
+            android:defaultValue="true"
+            android:key="@string/pref_key_screen_lock"
+            android:title="@string/preference_screen_lock" />
     </androidx.preference.PreferenceCategory>
 
     <androidx.preference.PreferenceCategory


### PR DESCRIPTION

Adds new setting for blocking screen locking. 

![Screenshot_1578406021](https://user-images.githubusercontent.com/24834168/71902123-b1a21680-3161-11ea-898d-bbcac2f0c726.png)

Tests were not created

Closes #6086:Adding screen timeout option

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture