### PR TITLE
Use Android Components 24.0.1 with Fenix 3.0.2

### DIFF
--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1058,7 +1058,7 @@
     <!-- Placeholder text shown in the Search String TextField before a user enters text -->
     <string name="search_add_custom_engine_search_string_hint">Řetězec používaný pro vyhledávání</string>
     <!-- Description text for the Search String TextField. The %s is part of the string -->
-    <string name="search_add_custom_engine_search_string_example">Dotaz nahraďte „% s“, Příklad: \nhttps://www.google.com/search?q=%s</string>
+    <string name="search_add_custom_engine_search_string_example">Dotaz nahraďte „%s“. Příklad: \nhttps://www.google.com/search?q=%s</string>
     <!-- Text for the button to learn more about adding a custom search engine -->
     <string name="search_add_custom_engine_learn_more_label">Zjistit více</string>
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -36,7 +36,7 @@ object Versions {
     const val androidx_work = "2.2.0"
     const val google_material = "1.1.0-beta01"
 
-    const val mozilla_android_components = "24.0.0"
+    const val mozilla_android_components = "24.0.1"
     // Note that android-components also depends on application-services,
     // and in fact is our main source of appservices-related functionality.
     // The version number below tracks the application-services version


### PR DESCRIPTION
Updating the release branch for Fenix 3.0.2 to use Android Components 24.0.1.