### PR TITLE
Use Mozilla Android Components 27.0.2 with Fenix 3.1.

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -31,7 +31,7 @@ object Versions {
     const val androidx_work = "2.2.0"
     const val google_material = "1.1.0-beta01"
 
-    const val mozilla_android_components = "27.0.0"
+    const val mozilla_android_components = "27.0.3"
     // Note that android-components also depends on application-services,
     // and in fact is our main source of appservices-related functionality.
     // The version number below tracks the application-services version


### PR DESCRIPTION
Updating the 3.1 release branch to use Mozilla Android Components 27.0.2.