### PR TITLE
Closes #7414 

### DIFF
--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -31,7 +31,7 @@
     <color name="toolbar_divider_color_normal_theme">@color/toolbar_divider_color_dark_theme</color>
     <color name="fill_link_from_clipboard_normal_theme">@color/accent_on_dark_background_normal_theme</color>
     <color name="menu_category_normal_theme">@color/primary_text_normal_theme</color>
-    <color name="about_content_text_normal_theme">@color/about_content_text_dark_theme</color>
+
 
 
     <!-- Collection icons-->

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -33,7 +33,7 @@
     <color name="toolbar_end_gradient_light_theme">@color/foundation_light_theme</color>
     <color name="toolbar_divider_color_light_theme">#CDCCCF</color>
     <color name="fill_link_from_clipboard_light_theme">@color/accent_light_theme</color>
-    <color name="about_content_text_light_theme">#232749</color>
+
 
     <!-- Dark theme color palette -->
     <color name="primary_text_dark_theme">#FBFBFE</color>
@@ -63,7 +63,7 @@
     <color name="toolbar_end_gradient_dark_theme">@color/foundation_dark_theme</color>
     <color name="toolbar_divider_color_dark_theme">@color/neutral_faded_dark_theme</color>
     <color name="fill_link_from_clipboard_dark_theme">@color/accent_on_dark_background_normal_theme</color>
-    <color name="about_content_text_dark_theme">#FBFBFE</color>
+
 
     <!-- Private theme color palette -->
     <color name="primary_text_private_theme">#FBFBFE</color>
@@ -119,7 +119,6 @@
     <color name="toolbar_divider_color_normal_theme">@color/toolbar_divider_color_light_theme</color>
     <color name="fill_link_from_clipboard_normal_theme">@color/fill_link_from_clipboard_light_theme</color>
     <color name="menu_category_normal_theme">@color/accent_light_theme</color>
-    <color name="about_content_text_normal_theme">@color/about_content_text_light_theme</color>
 
     <!-- Bookmark buttons -->
     <color name="bookmark_favicon_background">#DFDFE3</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -371,7 +371,7 @@
     </style>
 
     <style name="AboutHeaderContentText" parent="TextAppearance.MaterialComponents.Subtitle1">
-        <item name="android:textColor">@color/about_content_text_normal_theme</item>
+        <item name="android:textColor">?primaryText</item>
         <item name="android:lineSpacingExtra">@dimen/about_header_text_line_spacing_extra</item>
     </style>
 


### PR DESCRIPTION
- changed AboutHeaderContentText color to primarytext color 
- removed futile code of aboutText color in both light and dark theme

screenshot of dark theme(private mode)
![dark](https://user-images.githubusercontent.com/45488611/72009110-3df42c80-327b-11ea-8ae4-314583347baf.jpeg)

screenshot of light theme(private mode)
![light](https://user-images.githubusercontent.com/45488611/72009154-56fcdd80-327b-11ea-8b48-05cbb2c571ce.jpeg)



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture