### PR TITLE
Update Mozilla Android Components to 28.0.0-SNAPSHOT

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/Config.kt
+++ b/app/src/main/java/org/mozilla/fenix/Config.kt
@@ -5,7 +5,7 @@
 package org.mozilla.fenix
 
 enum class ReleaseChannel {
-    FenixDebug, FenixNightly, FenixBeta, FenixProduction, FennecProduction;
+    FenixDebug, FenixNightly, FenixBeta, FenixProduction, FennecProduction, FennecBeta, FennecNightly;
 
     val isReleased: Boolean
         get() = when (this) {
@@ -27,12 +27,15 @@ enum class ReleaseChannel {
         get() = when (this) {
             FenixProduction -> true
             FenixBeta -> true
+            FennecProduction -> true
+            FennecBeta -> true
             else -> false
         }
 
     val isNightlyOrDebug: Boolean
         get() = when (this) {
             FenixNightly -> true
+            FennecNightly -> true
             FenixDebug -> true
             else -> false
         }
@@ -45,6 +48,8 @@ object Config {
         "fenixNightly" -> ReleaseChannel.FenixNightly
         "debug" -> ReleaseChannel.FenixDebug
         "fennecProduction" -> ReleaseChannel.FennecProduction
+        "fennecBeta" -> ReleaseChannel.FennecBeta
+        "fennecNightly" -> ReleaseChannel.FennecNightly
 
         // Builds for local performance analysis, recording benchmarks, automation, etc.
         // This should be treated like a released channel because we want to test

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/ActivationPing.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/ActivationPing.kt
@@ -166,7 +166,7 @@ class ActivationPing(private val context: Context) {
             }
 
             Logger.info("ActivationPing - generating ping (has `identifier`: ${hashedId != null})")
-            Pings.activation.send()
+            Pings.activation.submit()
             markAsTriggered()
         }
     }

--- a/app/src/migration/java/org/mozilla/fenix/MigratingFenixApplication.kt
+++ b/app/src/migration/java/org/mozilla/fenix/MigratingFenixApplication.kt
@@ -7,6 +7,7 @@ package org.mozilla.fenix
 import android.content.Context
 import kotlinx.coroutines.runBlocking
 import mozilla.components.support.migration.FennecMigrator
+import mozilla.components.support.migration.state.MigrationStore
 
 /**
  * An application class which knows how to migrate Fennec data.
@@ -26,12 +27,14 @@ class MigratingFenixApplication : FenixApplication() {
             .build()
     }
 
+    val migrationStore by lazy { MigrationStore() }
+
     override fun setupInMainProcessOnly() {
         migrateGeckoBlocking()
 
         super.setupInMainProcessOnly()
 
-        migrator.startMigrationServiceIfNeeded(MigrationService::class.java)
+        migrator.startMigrationIfNeeded(migrationStore, MigrationService::class.java)
     }
 
     private fun migrateGeckoBlocking() {
@@ -47,4 +50,8 @@ class MigratingFenixApplication : FenixApplication() {
 
 fun Context.getMigratorFromApplication(): FennecMigrator {
     return (applicationContext as MigratingFenixApplication).migrator
+}
+
+fun Context.getMigrationStoreFromApplication(): MigrationStore {
+    return (applicationContext as MigratingFenixApplication).migrationStore
 }

--- a/app/src/migration/java/org/mozilla/fenix/MigrationService.kt
+++ b/app/src/migration/java/org/mozilla/fenix/MigrationService.kt
@@ -5,10 +5,12 @@
 package org.mozilla.fenix
 
 import mozilla.components.support.migration.AbstractMigrationService
+import mozilla.components.support.migration.state.MigrationStore
 
 /**
  * Background service for running the migration from legacy Firefox for Android (Fennec).
  */
 class MigrationService : AbstractMigrationService() {
     override val migrator by lazy { getMigratorFromApplication() }
+    override val store: MigrationStore by lazy { getMigrationStoreFromApplication() }
 }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -31,16 +31,16 @@ object Versions {
     const val androidx_work = "2.2.0"
     const val google_material = "1.1.0-beta01"
 
-    const val mozilla_android_components = "27.0.0-SNAPSHOT"
+    const val mozilla_android_components = "28.0.0-SNAPSHOT"
     // Note that android-components also depends on application-services,
     // and in fact is our main source of appservices-related functionality.
     // The version number below tracks the application-services version
     // that we depend on directly for the fenix-megazord (and for it's
     // forUnitTest variant), and it's important that it be kept in
     // sync with the version used by android-components above.
-    const val mozilla_appservices = "0.44.0"
+    const val mozilla_appservices = "0.47.0"
 
-    const val mozilla_glean = "22.1.0"
+    const val mozilla_glean = "23.0.0"
 
     const val adjust = "4.18.3"
     const val installreferrer = "1.0"

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -38,7 +38,7 @@ object Versions {
     // that we depend on directly for the fenix-megazord (and for it's
     // forUnitTest variant), and it's important that it be kept in
     // sync with the version used by android-components above.
-    const val mozilla_appservices = "0.47.0"
+    const val mozilla_appservices = "0.44.0"
 
     const val mozilla_glean = "23.0.0"
 


### PR DESCRIPTION
Working off https://github.com/mozilla-mobile/fenix/pull/7538, we need to downgrade to 0.44.0 for app services as well.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture