### PR TITLE
Make nimbledroid not depend on a real token on staging releases

### DIFF
--- a/automation/taskcluster/upload_apk_nimbledroid.py
+++ b/automation/taskcluster/upload_apk_nimbledroid.py
@@ -38,5 +38,9 @@ token_file = sys.argv[2]
 with open(token_file) as f:
 	key = f.read()
 
+if key.rstrip() == '--':
+	print('Nimbledroid key "--" detected. Not uploading anything to the service.')
+	sys.exit(0)
+
 with open(apk_path) as apk_file:
 	uploadApk({'apk': apk_file}, key)

--- a/taskcluster/ci/nimbledroid/kind.yml
+++ b/taskcluster/ci/nimbledroid/kind.yml
@@ -5,6 +5,7 @@
 loader: taskgraph.loader.transform:loader
 
 transforms:
+    - fenix_taskgraph.transforms.nimbledroid:transforms
     - taskgraph.transforms.job:transforms
     - taskgraph.transforms.task:transforms
 
@@ -18,9 +19,17 @@ job-defaults:
         using: run-commands
         use-caches: false
         secrets:
-            - name: project/mobile/fenix/nimbledroid
-              key: api_key
-              path: .nimbledroid_token
+            by-level:
+                '3':
+                    - name: project/mobile/fenix/nimbledroid
+                      key: api_key
+                      path: .nimbledroid_token
+                default: []
+        pre-commands:
+            by-level:
+              '3': []
+              default:
+                - [echo, '--', '>', .nimbledroid_token]
     run-on-tasks-for: []
     treeherder:
         kind: test
@@ -39,16 +48,15 @@ jobs:
             signing: signing-nightly
         run:
             commands:
-            - [wget, {artifact-reference: '<signing/public/build/armeabi-v7a/geckoNightly/target.apk>'}, '-O', target.apk]
-            - [python, automation/taskcluster/upload_apk_nimbledroid.py, target.apk, .nimbledroid_token]
-
+                - [wget, {artifact-reference: '<signing/public/build/armeabi-v7a/geckoNightly/target.apk>'}, '-O', target.apk]
+                - [python, automation/taskcluster/upload_apk_nimbledroid.py, target.apk, .nimbledroid_token]
         treeherder:
             symbol: nightly(nimbledroid)
-    
+
     production:
         attributes:
             release-type: production
-        dependencies: 
+        dependencies:
             signing: signing-production
         run:
             commands:
@@ -60,7 +68,7 @@ jobs:
     beta:
         attributes:
             release-type: beta
-        dependencies: 
+        dependencies:
             signing: signing-beta
         run:
             commands:
@@ -68,4 +76,3 @@ jobs:
                 - [python, automation/taskcluster/upload_apk_nimbledroid.py, target.apk, .nimbledroid_token]
         treeherder:
             symbol: beta(nimbledroid)
-            

--- a/taskcluster/fenix_taskgraph/job.py
+++ b/taskcluster/fenix_taskgraph/job.py
@@ -32,6 +32,7 @@ gradlew_schema = Schema({
 
 run_commands_schema = Schema({
     Required("using"): "run-commands",
+    Optional("pre-commands"): [[text_type]],
     Required("commands"): [[taskref_or_string]],
     Required("workdir"): text_type,
     Optional("use-caches"): bool,
@@ -42,7 +43,8 @@ run_commands_schema = Schema({
 @run_job_using("docker-worker", "run-commands", schema=run_commands_schema)
 def configure_run_commands_schema(config, job, taskdesc):
     run = job["run"]
-    pre_commands = [
+    pre_commands = run.pop("pre-commands", [])
+    pre_commands += [
         _generate_secret_command(secret) for secret in run.get("secrets", [])
     ]
     all_commands = pre_commands + run.pop("commands", [])

--- a/taskcluster/fenix_taskgraph/transforms/nimbledroid.py
+++ b/taskcluster/fenix_taskgraph/transforms/nimbledroid.py
@@ -1,0 +1,28 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+"""
+Apply some defaults and minor modifications to the jobs defined in the nimbledroid
+kind.
+"""
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+from taskgraph.transforms.base import TransformSequence
+from taskgraph.util.schema import resolve_keyed_by
+
+
+transforms = TransformSequence()
+
+
+@transforms.add
+def resolve_keys(config, tasks):
+    for task in tasks:
+        for key in ("run.secrets", "run.pre-commands"):
+            resolve_keyed_by(
+                task,
+                key,
+                item_name=task["name"],
+                level=config.params["level"]
+            )
+        yield task


### PR DESCRIPTION
Hey @kglazko! 

I remember we talked about making the nimbledroid task easier to use when doing staging nighlies/releases. I found a way that still kicks off the task, but doesn't interact with the Nimbledroid service. How does it look to you?


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture