### PR TITLE
Issue #7203: Use app name 'Firefox Nightly' for fennecNightly build.

### DIFF
--- a/app/src/fennecNightly/values/static_strings.xml
+++ b/app/src/fennecNightly/values/static_strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<resources>
+    <!-- Name of the application -->
+    <string name="app_name" translatable="false">Firefox Nightly</string>
+</resources>


### PR DESCRIPTION
Using the app name "Firefox Nightly" for the fennecNightly build. This will make sure that "Firefox Nightly" users will still have a "Firefox Nightly" app after upgrading (and it does not turn into a "Firefox Preview").