### PR TITLE
Issue #6898: Allow empty adjust token for fennecNightly builds.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/metrics/AdjustMetricsService.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/AdjustMetricsService.kt
@@ -13,14 +13,15 @@ import com.adjust.sdk.AdjustConfig
 import com.adjust.sdk.LogLevel
 import org.mozilla.fenix.BuildConfig
 import org.mozilla.fenix.Config
+import org.mozilla.fenix.ReleaseChannel
 import org.mozilla.fenix.ext.settings
 
 class AdjustMetricsService(private val application: Application) : MetricsService {
     override fun start() {
-        if ((BuildConfig.ADJUST_TOKEN.isNullOrEmpty())) {
+        if ((BuildConfig.ADJUST_TOKEN.isNullOrBlank())) {
             Log.i(LOGTAG, "No adjust token defined")
 
-            if (Config.channel.isReleased) {
+            if (Config.channel.isReleased && Config.channel != ReleaseChannel.FennecNightly) {
                 throw IllegalStateException("No adjust token defined for release build")
             }
 


### PR DESCRIPTION
Firefox for Android Nightly builds do not use Adjust. With this change we allow `fennecNightly` builds to also have no adjust token.