### PR TITLE
Open "migration FAQ" when selecting "What's new" in a Fennec build..

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/Config.kt
+++ b/app/src/main/java/org/mozilla/fenix/Config.kt
@@ -5,7 +5,15 @@
 package org.mozilla.fenix
 
 enum class ReleaseChannel {
-    FenixDebug, FenixNightly, FenixBeta, FenixProduction, FennecProduction, FennecBeta, FennecNightly;
+    FenixDebug,
+
+    FenixNightly,
+    FenixBeta,
+    FenixProduction,
+
+    FennecProduction,
+    FennecBeta,
+    FennecNightly;
 
     val isReleased: Boolean
         get() = when (this) {
@@ -39,6 +47,9 @@ enum class ReleaseChannel {
             FenixDebug -> true
             else -> false
         }
+
+    val isFennec: Boolean
+        get() = this in fennecChannels
 }
 
 object Config {
@@ -62,3 +73,9 @@ object Config {
         }
     }
 }
+
+private val fennecChannels: List<ReleaseChannel> = listOf(
+    ReleaseChannel.FennecNightly,
+    ReleaseChannel.FennecBeta,
+    ReleaseChannel.FennecProduction
+)

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -536,10 +536,7 @@ class HomeFragment : Fragment() {
                     WhatsNew.userViewedWhatsNew(context)
                     context.metrics.track(Event.WhatsNewTapped(Event.WhatsNewTapped.Source.HOME))
                     (activity as HomeActivity).openToBrowserAndLoad(
-                        searchTermOrURL = SupportUtils.getSumoURLForTopic(
-                            context,
-                            SupportUtils.SumoTopic.WHATS_NEW
-                        ),
+                        searchTermOrURL = SupportUtils.getWhatsNewUrl(context),
                         newTab = true,
                         from = BrowserDirection.FromHome
                     )

--- a/app/src/main/java/org/mozilla/fenix/settings/SupportUtils.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SupportUtils.kt
@@ -10,6 +10,7 @@ import androidx.browser.customtabs.CustomTabsIntent
 import androidx.core.net.toUri
 import mozilla.components.support.ktx.android.content.appVersionName
 import org.mozilla.fenix.BuildConfig
+import org.mozilla.fenix.Config
 import org.mozilla.fenix.IntentReceiverActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.getColorFromAttr
@@ -32,7 +33,8 @@ object SupportUtils {
         SEND_TABS("send-tab-preview"),
         SET_AS_DEFAULT_BROWSER("set-firefox-preview-default"),
         SEARCH_SUGGESTION("how-search-firefox-preview"),
-        CUSTOM_SEARCH_ENGINES("custom-search-engines")
+        CUSTOM_SEARCH_ENGINES("custom-search-engines"),
+        UPGRADE_FAQ("firefox-preview-upgrade-faqs")
     }
 
     /**
@@ -63,6 +65,12 @@ object SupportUtils {
 
     fun getPrivacyNoticeUrl(locale: Locale = Locale.getDefault()) =
         "https://www.mozilla.org/${getLanguageTag(locale)}/privacy/firefox/"
+
+    fun getWhatsNewUrl(context: Context) = if (Config.channel.isFennec) {
+        getGenericSumoURLForTopic(SumoTopic.UPGRADE_FAQ)
+    } else {
+        getSumoURLForTopic(context, SumoTopic.WHATS_NEW)
+    }
 
     fun createCustomTabIntent(context: Context, url: String): Intent = CustomTabsIntent.Builder()
         .setInstantAppsEnabled(false)


### PR DESCRIPTION
This is the Fenix part of https://github.com/mozilla-mobile/android-components/issues/5481.

For Fennec builds we want to send users that click on "What's new?" to the migration FAQ page on SUMO.