### PR TITLE
No issue: Fix dynamic theming to accommodate lazily inflated readerview

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -194,9 +194,9 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
             R.id.mozac_feature_readerview_font_size_decrease,
             R.id.mozac_feature_readerview_font_size_increase
         ).map {
-            findViewById<Button>(it)
+            findViewById<Button?>(it)
         }.forEach {
-            it.setTextColor(
+            it?.setTextColor(
                 ContextCompat.getColorStateList(
                     context,
                     R.color.readerview_private_button_color
@@ -208,9 +208,9 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
             R.id.mozac_feature_readerview_font_serif,
             R.id.mozac_feature_readerview_font_sans_serif
         ).map {
-            findViewById<RadioButton>(it)
+            findViewById<RadioButton?>(it)
         }.forEach {
-            it.setTextColor(
+            it?.setTextColor(
                 ContextCompat.getColorStateList(
                     context,
                     R.color.readerview_private_radio_color


### PR DESCRIPTION
Perf fix in https://github.com/mozilla-mobile/android-components/pull/5494
caused UI test failure/crashes so this is a followup fix

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture