### PR TITLE
For #7431: Remove extra share button

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabToolbarMenu.kt
@@ -7,12 +7,12 @@ package org.mozilla.fenix.customtabs
 import android.content.Context
 import android.graphics.Typeface
 import mozilla.components.browser.menu.BrowserMenuBuilder
+import mozilla.components.browser.menu.item.BrowserMenuCategory
 import mozilla.components.browser.menu.item.BrowserMenuDivider
+import mozilla.components.browser.menu.item.BrowserMenuImageSwitch
 import mozilla.components.browser.menu.item.BrowserMenuImageText
 import mozilla.components.browser.menu.item.BrowserMenuItemToolbar
 import mozilla.components.browser.menu.item.SimpleBrowserMenuItem
-import mozilla.components.browser.menu.item.BrowserMenuImageSwitch
-import mozilla.components.browser.menu.item.BrowserMenuCategory
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import org.mozilla.fenix.R
@@ -90,7 +90,6 @@ class CustomTabToolbarMenu(
         val menuItems = listOf(
             poweredBy,
             BrowserMenuDivider(),
-            share,
             desktopMode,
             findInPage,
             openInFenix,
@@ -98,15 +97,6 @@ class CustomTabToolbarMenu(
             menuToolbar
         )
         if (shouldReverseItems) { menuItems.reversed() } else { menuItems }
-    }
-
-    private val share = BrowserMenuImageText(
-        label = context.getString(R.string.browser_menu_share),
-        imageResource = R.drawable.mozac_ic_share,
-        textColorResource = primaryTextColor(),
-        iconTintColorResource = primaryTextColor()
-    ) {
-        onItemTapped.invoke(ToolbarMenu.Item.Share)
     }
 
     private val desktopMode = BrowserMenuImageSwitch(

--- a/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabsIntegration.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabsIntegration.kt
@@ -99,22 +99,15 @@ class CustomTabsIntegration(
         menuBuilder = customTabToolbarMenu.menuBuilder,
         menuItemIndex = START_OF_MENU_ITEMS_INDEX,
         window = activity.window,
+        shareListener = { onItemTapped.invoke(ToolbarMenu.Item.Share) },
         closeListener = { activity.finish() }
     )
 
-    override fun start() {
-        feature.start()
-    }
-
-    override fun stop() {
-        feature.stop()
-    }
-
-    override fun onBackPressed(): Boolean {
-        return feature.onBackPressed()
-    }
+    override fun start() = feature.start()
+    override fun stop() = feature.stop()
+    override fun onBackPressed() = feature.onBackPressed()
 
     companion object {
-        const val START_OF_MENU_ITEMS_INDEX = 2
+        private const val START_OF_MENU_ITEMS_INDEX = 2
     }
 }


### PR DESCRIPTION
AC already provides a share button in the toolbar unless the custom tab app offers a custom share option. Fenix's menu option will _always_ be a duplicate.

Additionally I've tweaked the default share button so that it uses the custom share sheet. This is the best fix for #7431 we can get since other menu options are controlled by the calling app.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture