### PR TITLE
Issue 6274: Asynchronously load the search fragment and its components

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -41,12 +41,16 @@ import androidx.transition.TransitionInflater
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.fragment_home.*
 import kotlinx.android.synthetic.main.fragment_home.view.*
+import kotlinx.android.synthetic.main.fragment_home.view.toolbar_wrapper
+import kotlinx.android.synthetic.main.fragment_search.view.*
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.Dispatchers.Main
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.delay
 import mozilla.appservices.places.BookmarkRoot
 import mozilla.components.browser.menu.BrowserMenu
 import mozilla.components.browser.session.Session
@@ -80,6 +84,8 @@ import org.mozilla.fenix.home.sessioncontrol.SessionControlInteractor
 import org.mozilla.fenix.home.sessioncontrol.SessionControlView
 import org.mozilla.fenix.home.sessioncontrol.viewholders.CollectionViewHolder
 import org.mozilla.fenix.onboarding.FenixOnboarding
+import org.mozilla.fenix.search.SearchFragment
+import org.mozilla.fenix.search.toolbar.ToolbarView
 import org.mozilla.fenix.settings.SupportUtils
 import org.mozilla.fenix.settings.deletebrowsingdata.deleteAndQuit
 import org.mozilla.fenix.utils.FragmentPreDrawManager
@@ -208,6 +214,22 @@ class HomeFragment : Fragment() {
 
         activity.themeManager.applyStatusBarTheme(activity)
 
+        MainScope().launch(Dispatchers.IO) {
+            container?.apply {
+                // Use a WaitableAsyncInflater in order to share the results with the SearchFragment
+                // later, but get the results immediately ...
+                val searchFragmentView = SearchFragment.WaitableSearchFragmentInflater.get(
+                    this.context,
+                    this,
+                    false
+                )
+                // ... they are needed right here because the toolbar has to be inflated with a very
+                // specific context or it won't appear.
+                ToolbarView.WaitableToolBarInflater.inflate(
+                    this.context, searchFragmentView.toolbar_component_wrapper, true
+                )
+            }
+        }
         return view
     }
 

--- a/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
@@ -45,6 +45,7 @@ import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.search.awesomebar.AwesomeBarView
 import org.mozilla.fenix.search.toolbar.ToolbarView
 import org.mozilla.fenix.settings.SupportUtils
+import org.mozilla.fenix.utils.WaitableAsyncInflater
 
 @Suppress("TooManyFunctions", "LargeClass")
 class SearchFragment : Fragment(), UserInteractionHandler {
@@ -80,7 +81,7 @@ class SearchFragment : Fragment(), UserInteractionHandler {
             ?.let(SearchFragmentArgs.Companion::fromBundle)
             ?.let { it.pastedText }
 
-        val view = inflater.inflate(R.layout.fragment_search, container, false)
+        val view = WaitableSearchFragmentInflater.get(context!!, container!!)
         val url = session?.url.orEmpty()
         val currentSearchEngine = SearchEngineSource.Default(
             requireComponents.search.provider.getDefaultEngine(requireContext())
@@ -349,6 +350,7 @@ class SearchFragment : Fragment(), UserInteractionHandler {
     }
 
     companion object {
+        var WaitableSearchFragmentInflater = WaitableAsyncInflater(R.layout.fragment_search)
         private const val SHARED_TRANSITION_MS = 200L
         private const val REQUEST_CODE_CAMERA_PERMISSIONS = 1
     }

--- a/app/src/main/java/org/mozilla/fenix/search/toolbar/ToolbarView.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/toolbar/ToolbarView.kt
@@ -6,7 +6,6 @@ package org.mozilla.fenix.search.toolbar
 
 import android.graphics.Bitmap
 import android.graphics.drawable.BitmapDrawable
-import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
@@ -29,6 +28,7 @@ import org.mozilla.fenix.ext.getColorFromAttr
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.search.SearchFragmentState
 import org.mozilla.fenix.theme.ThemeManager
+import org.mozilla.fenix.utils.WaitableAsyncInflater
 
 /**
  * Interface for the Toolbar Interactor. This interface is implemented by objects that want
@@ -75,9 +75,10 @@ class ToolbarView(
         else -> R.layout.component_browser_top_toolbar
     }
 
-    val view: BrowserToolbar = LayoutInflater.from(container.context)
-        .inflate(toolbarLayout, container, true)
-        .findViewById(R.id.toolbar)
+    val view by lazy {
+        ToolbarView.WaitableToolBarInflater.get(container.context, container)
+            .findViewById<BrowserToolbar>(R.id.toolbar)
+    }
 
     private var isInitialized = false
 
@@ -166,6 +167,9 @@ class ToolbarView(
 
     companion object {
         private const val TOOLBAR_ELEVATION_IN_DP = 16
+        // TODO
+        // Take into account the fact that the choice of layout is dynamic.
+        var WaitableToolBarInflater = WaitableAsyncInflater(R.layout.component_browser_top_toolbar)
     }
 }
 

--- a/app/src/main/java/org/mozilla/fenix/utils/WaitableAsyncInflater.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/WaitableAsyncInflater.kt
@@ -1,0 +1,83 @@
+package org.mozilla.fenix.utils
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+/**
+ * Wrapper around an asynchronous layout inflater that gives callers the ability to
+ * synchronously access the inflated view, whether the asynchronous inflation is
+ * complete or in progress.
+ *
+ * A WaitiableAsyncInflater is a wrapper around an asynchronous layout inflater upon which
+ * a caller can invoke get() to obtain the inflated view. If the inflation already happened
+ * and the view is created by the time the call to get() happens, the view is returned
+ * immediately. If the inflation is in progress asynchronously at the time of the get()
+ * call, the function waits for inflation to complete and then returns the view. If the
+ * inflation has not yet started by the time of the get() call, the inflation happens
+ * synchronously and the view is returned.
+ *
+ * Users invoke inflate() when they simply want to start the inflation asynchronously and
+ * are not interested in the view itself.
+ *
+ * This class is thread safe.
+ */
+class WaitableAsyncInflater(val resId: Int) {
+
+    var asyncInflationStarted = false
+    var condition = Object()
+    var view: View? = null
+    val scope = CoroutineScope(Dispatchers.IO)
+
+    private fun startAsynchronousInflation(context: Context, group: ViewGroup, attachToRoot: Boolean = false) {
+        scope.launch {
+            view = LayoutInflater.from(context).inflate(resId, group, attachToRoot)
+            synchronized(condition) {
+                condition.notifyAll()
+            }
+        }
+        asyncInflationStarted = true
+    }
+
+    private fun doSynchronousInflation(context: Context, group: ViewGroup, attachToRoot: Boolean = false) {
+        val inflater = LayoutInflater.from(context)
+        view = inflater.inflate(resId, group, attachToRoot)
+    }
+
+    /**
+     * TODO
+     *
+     * In this documentation, be sure to mention that *it is assumed* that the view can be inflated
+     * off the MT.
+     */
+    @Synchronized
+    fun inflate(context: Context, group: ViewGroup, attachToRoot: Boolean = false) {
+        if (view == null && !asyncInflationStarted) {
+            startAsynchronousInflation(context, group, attachToRoot)
+        }
+    }
+
+    /**
+     * TODO
+     */
+    @Synchronized
+    fun get(context: Context, group: ViewGroup, attachToRoot: Boolean = false): View {
+        if (view == null && !asyncInflationStarted) {
+            // When there is neither a view already created nor an asynchronous inflation in progress
+            // do the inflation on demand.
+            doSynchronousInflation(context, group, attachToRoot)
+        } else {
+            // Otherwise, potentially wait for the view to be created.
+            while (view == null) {
+                synchronized(condition) {
+                    condition.wait()
+                }
+            }
+        }
+        return view!!
+    }
+}


### PR DESCRIPTION
WIP as it stands. Undocumented, for now. 

NB: There are three *long* inflations that happen when the Search Bar is first displayed. This WIP only removes the first of those three. However, I do see a noticeable performance improvement and this framework seems to be applicable to the other two long inflations. If you think what is proposed here is a sane idea, we can move forward on applying this tool to the other two. Until then, I want to ask for your feedback!

Here is the idea:
1. Create a thing called a `WaitableAsyncInflater`.
2. Use that to asynchronously pre-inflate the search fragment (and its components) when the Home Fragment is created.
3. Get the pre-created view when the Search Bar is displayed.

A `WaitiableAsyncInflater` is a wrapper around an asynchronous layout inflater upon which a caller can invoke `get()` to obtain the inflated view. If the inflation already happened and the view is created by the time the call to `get()` happens, the view is returned immediately. If the inflation is in progress asynchronously at the time of the `get()` call, the function waits for inflation to complete and then returns the view. If the inflation has not yet started by the time of the `get()` call, the inflation happens synchronously and the view is returned. 

Users invoke `inflate()` when they simply want to start the layout asynchronously and are not interested in the view that is actually inflated. 

I wonder if this is a sane approach? I am sharing this with you early to get your feedback on both 

1. the method and
2. the perceived decrease in latency for loading the search fragment the first time.
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture