### PR TITLE
Issue #7633: Make megazord version mismatches a build-time error.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -523,6 +523,18 @@ dependencies {
         }
     }
 
+    // However, gradle's `replacedBy` does not take version information into account.
+    // If we have one version of the fenix megazord as a direct dependency
+    // and a different version of the full megazord as a transitive dependency via android-components,
+    // then the above rules will produce a version mismatch error at runtime.
+    // As a light hack, use a strict version dependency on one of the appservices components
+    // to turn that into a build-time failure.
+    implementation(Deps.appservices_native_support) {
+      version {
+        strictly Versions.mozilla_appservices
+      }
+    }
+
     testImplementation Deps.mockito_core
     androidTestImplementation Deps.mockito_android
     testImplementation Deps.mockk
@@ -629,11 +641,6 @@ def glean_android_components_tag = (
 ext.gleanGenerateMarkdownDocs = true
 ext.gleanDocsDirectory = "$rootDir/docs"
 apply from: 'https://github.com/mozilla-mobile/android-components/raw/' + glean_android_components_tag + '/components/service/glean/scripts/sdk_generator.gradle'
-
-// For production builds, the native code for all `org.mozilla.appservices` dependencies gets compiled together
-// into a single "megazord" build, and different megazords are published for different subsets of features.
-// Ref https://mozilla.github.io/application-services/docs/applications/consuming-megazord-libraries.html
-// Substitute all appservices dependencies with an appropriate megazord.
 
 afterEvaluate {
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -35,7 +35,7 @@ object Versions {
     // Note that android-components also depends on application-services,
     // and in fact is our main source of appservices-related functionality.
     // The version number below tracks the application-services version
-    // that we depend on directly for the fenix-megazord (and for it's
+    // that we depend on directly for the fenix-megazord (and for its
     // forUnitTest variant), and it's important that it be kept in
     // sync with the version used by android-components above.
     const val mozilla_appservices = "0.48.1"
@@ -199,6 +199,7 @@ object Deps {
     const val androidx_junit = "androidx.test.ext:junit:${Versions.androidx_test_ext}"
     const val androidx_test_core = "androidx.test:core:${Versions.androidx_testing}"
 
+    const val appservices_native_support = "org.mozilla.appservices:native-support:${Versions.mozilla_appservices}"
     const val fenix_megazord = "org.mozilla.appservices:fenix-megazord:${Versions.mozilla_appservices}"
     const val fenix_megazord_forUnitTests = "org.mozilla.appservices:fenix-megazord-forUnitTests:${Versions.mozilla_appservices}"
 


### PR DESCRIPTION
Connects to https://github.com/mozilla-mobile/fenix/issues/7633.

This is a proposal for avoiding "Incompatible megazord version" errors by failing at build time instead of runtime, by using gradle's support for strict version dependencies. With this change, attempting to use a newer android-components with an old application-services will result in a build-time error rather than a runtime crash.

Ideally I think this information would be published as part of the application-services dependency itself, so that consumers didn't have to do anything special to get this check. But it's not clear to me if gradle supports that and I don't want y'all to have to support through any more megazord version crashes in the leadup to the next release.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- ~~[ ] **Tests**: This PR includes thorough tests or an explanation of why it does not~~
  - It doesn't seem amenable to automated tests, but I did test it manually by changing `Versions.mozilla_appservices` and confirmed that it produces the expected build-time failure (and a pretty clear default error message IMHO).
- ~~[ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not~~
- ~~[ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features~~
