### PR TITLE
Test that 'baseline' pings are sent by Fenix

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -494,6 +494,8 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     }
 
+    androidTestImplementation Deps.androidx_junit
+    androidTestImplementation Deps.androidx_work_testing
     androidTestImplementation Deps.mockwebserver
     testImplementation Deps.mozilla_support_test
     testImplementation Deps.androidx_junit

--- a/app/src/androidTest/java/org/mozilla/fenix/glean/BaselinePingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/glean/BaselinePingTest.kt
@@ -1,0 +1,107 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.glean
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.rule.ActivityTestRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import androidx.test.uiautomator.UiDevice
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import mozilla.components.service.glean.Glean
+import mozilla.components.service.glean.config.Configuration
+import mozilla.components.service.glean.testing.GleanTestLocalServer
+import org.json.JSONObject
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.BeforeClass
+import org.mozilla.fenix.HomeActivity
+import org.mozilla.fenix.helpers.HomeActivityTestRule
+import org.mozilla.fenix.helpers.MockWebServerHelper
+import java.util.concurrent.TimeUnit
+
+@RunWith(AndroidJUnit4::class)
+class BaselinePingTest {
+    private val server = MockWebServerHelper.createAlwaysOkMockWebServer()
+
+    @get:Rule
+    val activityRule: ActivityTestRule<HomeActivity> = HomeActivityTestRule()
+
+    @get:Rule
+    val gleanRule = GleanTestLocalServer(ApplicationProvider.getApplicationContext(), server.port)
+
+    companion object {
+        @BeforeClass
+        @JvmStatic
+        fun setupOnce() {
+            // Fenix does not initialize the Glean SDK in tests/debug builds, but this test
+            // requires Glean to be initialized so we need to do it manually. Additionally,
+            // we need to do this on the main thread, as the Glean SDK requires it.
+            GlobalScope.launch(Dispatchers.Main.immediate) {
+                Glean.initialize(
+                    ApplicationProvider.getApplicationContext(),
+                    true,
+                    Configuration()
+                )
+            }
+        }
+    }
+
+    private fun waitForPingContent(
+        pingName: String,
+        maxAttempts: Int = 3
+    ): JSONObject? {
+        var attempts = 0
+        do {
+            attempts += 1
+            val request = server.takeRequest(20L, TimeUnit.SECONDS)
+            val docType = request.path.split("/")[3]
+            if (pingName == docType) {
+                return JSONObject(request.body.readUtf8())
+            }
+        } while (attempts < maxAttempts)
+
+        return null
+    }
+
+    @Test
+    fun validateBaselinePing() {
+        // Wait for the app to be idle/ready.
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+        device.waitForIdle()
+
+        // Wait for 1 second: this should guarantee we have some valid duration in the
+        // ping.
+        Thread.sleep(1000)
+
+        // Move it to background.
+        device.pressHome()
+
+        // Validate the received data.
+        val baselinePing = waitForPingContent("baseline")!!
+        assertEquals("baseline", baselinePing.getJSONObject("ping_info")["ping_type"])
+
+        val metrics = baselinePing.getJSONObject("metrics")
+
+        // Make sure we have a 'duration' field with a reasonable value: it should be >= 1, since
+        // we slept for 1000ms.
+        val timespans = metrics.getJSONObject("timespan")
+        assertTrue(timespans.getJSONObject("glean.baseline.duration").getLong("value") >= 1L)
+
+        // Make sure there's no errors.
+        val errors = metrics.optJSONObject("labeled_counter")?.keys()
+        errors?.forEach {
+            assertFalse(it.startsWith("glean.error."))
+        }
+    }
+}

--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/MockWebServer.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/MockWebServer.kt
@@ -32,6 +32,20 @@ object MockWebServerHelper {
         }
         return uris
     }
+
+    /**
+     * Create a mock webserver that accepts all requests and replies with "OK".
+     * @return a [MockWebServer] instance
+     */
+    fun createAlwaysOkMockWebServer(): MockWebServer {
+        return MockWebServer().apply {
+            setDispatcher(object : Dispatcher() {
+                override fun dispatch(request: RecordedRequest): MockResponse {
+                    return MockResponse().setBody("OK")
+                }
+            })
+        }
+    }
 }
 
 /**


### PR DESCRIPTION
This is an initial instrumented test for Fenix that checks if a 'baseline' ping is generated when
going to background.

~~**Note**: this won't work until Fenix is a new A-C snapshot which contains the latest updates from mozilla/glean#634 and mozilla-mobile/android-components#5549~~


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture