### PR TITLE
Bump a-s dependency to 0.48.2 

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -38,7 +38,7 @@ object Versions {
     // that we depend on directly for the fenix-megazord (and for it's
     // forUnitTest variant), and it's important that it be kept in
     // sync with the version used by android-components above.
-    const val mozilla_appservices = "0.48.1"
+    const val mozilla_appservices = "0.48.2"
 
     const val mozilla_glean = "23.0.0"
 


### PR DESCRIPTION
Changelog: https://github.com/mozilla/application-services/releases/tag/v0.48.2

Ref: https://github.com/mozilla-mobile/android-components/pull/5558

@grigoryk @ekager r?