### PR TITLE
For #7714: Align engine name to viewStart to support RTL layouts 

### DIFF
--- a/app/src/main/res/layout/search_engine_radio_button.xml
+++ b/app/src/main/res/layout/search_engine_radio_button.xml
@@ -37,6 +37,7 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/radio_button_padding_horizontal"
         android:layout_marginEnd="@dimen/radio_button_padding_horizontal"
+        android:textAlignment="viewStart"
         app:layout_constraintStart_toEndOf="@id/engine_icon"
         app:layout_constraintTop_toTopOf="@id/engine_icon"
         app:layout_constraintEnd_toEndOf="parent" />


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

![pass](https://user-images.githubusercontent.com/48995920/72448212-50acbb00-37bf-11ea-95d2-72b47991043d.png)
### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture