### PR TITLE
For #7679 - Locale menu checkmark dissapearing

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/advanced/LocaleManagerExtension.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/advanced/LocaleManagerExtension.kt
@@ -47,3 +47,7 @@ fun LocaleManager.getSelectedLocale(
         supportedMatch ?: defaultLocale
     }
 }
+
+fun LocaleManager.isDefaultLocaleSelected(context: Context): Boolean {
+    return getCurrentLocale(context) == null
+}

--- a/app/src/test/java/org/mozilla/fenix/settings/advanced/LocaleAdapterTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/advanced/LocaleAdapterTest.kt
@@ -1,0 +1,48 @@
+package org.mozilla.fenix.settings.advanced
+
+import android.content.Context
+import android.view.View
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import mozilla.components.support.locale.LocaleManager
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.util.Locale
+
+class LocaleAdapterTest {
+
+    private val selectedLocale = Locale("en", "UK")
+    private val view: View = mockk(relaxed = true)
+    private val context: Context = mockk(relaxed = true)
+
+    private val localeViewHolder: BaseLocaleViewHolder =
+        object : BaseLocaleViewHolder(view, selectedLocale) {
+
+            override fun bind(locale: Locale) {
+                // not required
+            }
+        }
+
+    @Before
+    fun setup() {
+        every { view.context } returns context
+    }
+
+    @Test
+    fun `verify selected locale checker returns true`() {
+        mockkStatic("org.mozilla.fenix.settings.advanced.LocaleManagerExtensionKt")
+        every { LocaleManager.isDefaultLocaleSelected(context) } returns false
+
+        assertTrue(localeViewHolder.isCurrentLocaleSelected(selectedLocale, isDefault = false))
+    }
+
+    @Test
+    fun `verify default locale checker returns true`() {
+        mockkStatic("org.mozilla.fenix.settings.advanced.LocaleManagerExtensionKt")
+        every { LocaleManager.isDefaultLocaleSelected(context) } returns true
+
+        assertTrue(localeViewHolder.isCurrentLocaleSelected(selectedLocale, isDefault = true))
+    }
+}

--- a/app/src/test/java/org/mozilla/fenix/settings/advanced/LocaleManagerExtensionTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/advanced/LocaleManagerExtensionTest.kt
@@ -11,6 +11,7 @@ import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import mozilla.components.support.locale.LocaleManager
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -40,6 +41,27 @@ class LocaleManagerExtensionTest {
 
         assertEquals(expectedSize, list.size)
         assertTrue(list.isNotEmpty())
+    }
+
+    @Test
+    @Config(qualifiers = "en-rUS")
+    fun `default locale selected`() {
+        val context: Context = mockk()
+        mockkObject(LocaleManager)
+        every { LocaleManager.getCurrentLocale(context) } returns null
+
+        assertTrue(LocaleManager.isDefaultLocaleSelected(context))
+    }
+
+    @Test
+    @Config(qualifiers = "en-rUS")
+    fun `custom locale selected`() {
+        val context: Context = mockk()
+        mockkObject(LocaleManager)
+        val selectedLocale = Locale("en", "UK")
+        every { LocaleManager.getCurrentLocale(context) } returns selectedLocale
+
+        assertFalse(LocaleManager.isDefaultLocaleSelected(context))
     }
 
     @Test


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

[**Video with fix**. Note: the order of the locale list changes on re-entry because it's sorted alphabetically by the name in that specific language](https://drive.google.com/file/d/1PI0cVHZqJNP6IwH5bdFpJFYoFVkoK4jv/view?usp=sharing)