### PR TITLE
For #4021:  Provide tab title during share

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/share/ShareController.kt
+++ b/app/src/main/java/org/mozilla/fenix/share/ShareController.kt
@@ -7,6 +7,7 @@ package org.mozilla.fenix.share
 import android.content.Context
 import android.content.Intent
 import android.content.Intent.ACTION_SEND
+import android.content.Intent.EXTRA_SUBJECT
 import android.content.Intent.EXTRA_TEXT
 import android.content.Intent.FLAG_ACTIVITY_NEW_TASK
 import android.net.Uri
@@ -80,6 +81,7 @@ class DefaultShareController(
     override fun handleShareToApp(app: AppShareOption) {
         val intent = Intent(ACTION_SEND).apply {
             putExtra(EXTRA_TEXT, getShareText())
+            putExtra(EXTRA_SUBJECT, shareData.map { it.title }.joinToString(", "))
             type = "text/plain"
             flags = FLAG_ACTIVITY_NEW_TASK
             setClassName(app.packageName, app.activityName)
@@ -161,8 +163,8 @@ class DefaultShareController(
     }
 
     @VisibleForTesting
-    fun getShareText() = shareData.joinToString("\n") { data ->
-        listOfNotNull(data.url, data.text).joinToString(" ")
+    fun getShareText() = shareData.joinToString("\n\n") { data ->
+        listOfNotNull(data.title, data.url).joinToString(" ")
     }
 
     // Navigation between app fragments uses ShareTab as arguments. SendTabUseCases uses TabData.

--- a/app/src/test/java/org/mozilla/fenix/share/ShareControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/share/ShareControllerTest.kt
@@ -57,7 +57,7 @@ class ShareControllerTest {
         TabData("title0", "url0"),
         TabData("title1", "url1")
     )
-    private val textToShare = "${shareData[0].url}\n${shareData[1].url}"
+    private val textToShare = "${shareData[0].title} ${shareData[0].url}\n\n${shareData[1].title} ${shareData[1].url}"
     private val sendTabUseCases = mockk<SendTabUseCases>(relaxed = true)
     private val snackbar = mockk<FenixSnackbar>(relaxed = true)
     private val navController = mockk<NavController>(relaxed = true)


### PR DESCRIPTION
This PR concatenates tab titles for the email subject and places titles before URLs in the email body:

<img width="407" alt="ShareTabs" src="https://user-images.githubusercontent.com/46655/72473730-f0148280-37ac-11ea-9450-2b908abf73ed.png">

And to Google Drive:

<img width="603" alt="SavedToDrive" src="https://user-images.githubusercontent.com/46655/72476122-04a74980-37b2-11ea-8258-1b368637ad52.png">



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture