### PR TITLE
Closes #5305: Update list of tabs after onboarding screen was dismissed.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -487,7 +487,9 @@ class HomeFragment : Fragment() {
     private fun hideOnboarding() {
         onboarding.finish()
         homeFragmentStore.dispatch(
-            HomeFragmentAction.ModeChange(currentMode.getCurrentMode()))
+            HomeFragmentAction.ModeChange(
+                mode = currentMode.getCurrentMode(),
+                tabs = getListOfSessions().toTabs()))
     }
 
     private fun setupHomeMenu() {

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragmentStore.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragmentStore.kt
@@ -57,7 +57,7 @@ sealed class HomeFragmentAction : Action {
         HomeFragmentAction()
     data class CollectionExpanded(val collection: TabCollection, val expand: Boolean) : HomeFragmentAction()
     data class CollectionsChange(val collections: List<TabCollection>) : HomeFragmentAction()
-    data class ModeChange(val mode: Mode) : HomeFragmentAction()
+    data class ModeChange(val mode: Mode, val tabs: List<Tab> = emptyList()) : HomeFragmentAction()
     data class TabsChange(val tabs: List<Tab>) : HomeFragmentAction()
 }
 
@@ -83,7 +83,7 @@ private fun homeFragmentStateReducer(
             state.copy(expandedCollections = newExpandedCollection)
         }
         is HomeFragmentAction.CollectionsChange -> state.copy(collections = action.collections)
-        is HomeFragmentAction.ModeChange -> state.copy(mode = action.mode, tabs = emptyList())
+        is HomeFragmentAction.ModeChange -> state.copy(mode = action.mode, tabs = action.tabs)
         is HomeFragmentAction.TabsChange -> state.copy(tabs = action.tabs)
     }
 }


### PR DESCRIPTION
Fix for https://github.com/mozilla-mobile/android-components/issues/5305.

Whenever we dismiss the onboarding screen (by clicking on "Start browsing") we end up on the home screen with an empty list of tabs. Usually that is no problem. However if we migrated from Fennec then we may already have some tabs that we inherited from Fennec. Those tabs didn't show up until you did something that caused the home screen to reload (e.g. going to another screen and back).

This is a quick fix and updates the list of tabs when we dismiss the onboarding screen. Eventually we may just want to listen to `BrowserStore` and always display the tabs in it without keeping a separate copy that we only update sometimes.