### PR TITLE
Android manifest: Export shortcut target activity.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -57,7 +57,8 @@
         -->
         <activity-alias
             android:name="org.mozilla.gecko.BrowserApp"
-            android:targetActivity=".IntentReceiverActivity">
+            android:targetActivity=".IntentReceiverActivity"
+            android:exported="true">
         </activity-alias>
 
         <activity


### PR DESCRIPTION
Fixing https://github.com/mozilla-mobile/android-components/issues/5608

The launcher on older versions of Android will not launch shortcuts from Fennec if the target activity is not exported.

