### PR TITLE
For perf-frontend-issues#50: instrument imperfect reportFullyDrawn.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -53,6 +53,7 @@ import org.mozilla.fenix.library.bookmarks.BookmarkFragmentDirections
 import org.mozilla.fenix.library.history.HistoryFragmentDirections
 import org.mozilla.fenix.onboarding.FenixOnboarding
 import org.mozilla.fenix.perf.HotStartPerformanceMonitor
+import org.mozilla.fenix.perf.Performance
 import org.mozilla.fenix.search.SearchFragmentDirections
 import org.mozilla.fenix.settings.DefaultBrowserSettingsFragmentDirections
 import org.mozilla.fenix.settings.SettingsFragmentDirections
@@ -92,6 +93,7 @@ open class HomeActivity : LocaleAwareAppCompatActivity() {
 
         setupThemeAndBrowsingMode(getModeFromIntentOrLastKnown(intent))
         setContentView(R.layout.activity_home)
+        Performance.instrumentColdStartupToHomescreenTime(this)
         setupToolbarAndNavigation()
 
         if (intent.getBooleanExtra(EXTRA_FINISH_ONBOARDING, false)) {

--- a/app/src/main/java/org/mozilla/fenix/perf/Performance.kt
+++ b/app/src/main/java/org/mozilla/fenix/perf/Performance.kt
@@ -4,9 +4,37 @@
 
 package org.mozilla.fenix.perf
 
+import androidx.core.view.doOnPreDraw
+import kotlinx.android.synthetic.main.activity_home.*
+import org.mozilla.fenix.HomeActivity
+
 /**
  * A collection of objects related to app performance.
  */
 object Performance {
     const val TAG = "FenixPerf"
+
+    /**
+     * Instruments cold startup time for use with our internal measuring system, FNPRMS. This may
+     * also appear in Google Play Vitals dashboards.
+     *
+     * This will need to be rewritten if any parts of the UI are changed to be displayed
+     * asynchronously.
+     *
+     * In the current implementation, we only intend to instrument cold startup to the homescreen.
+     * To save implementation time, we ignore the fact that the RecyclerView draws twice if the user
+     * has tabs, collections, etc. open: the "No tabs" placeholder and a tab list. This
+     * instrumentation will only capture the "No tabs" draw.
+     */
+    fun instrumentColdStartupToHomescreenTime(activity: HomeActivity) {
+        // For greater accuracy, we could add an onDrawListener instead of a preDrawListener but:
+        // - single use onDrawListeners are not built-in and it's non-trivial to write one
+        // - the difference is timing is minimal (< 7ms on Pixel 2)
+        // - if we compare against another app using a preDrawListener, it should be comparable
+        //
+        // Unfortunately, this is tightly coupled to the root view of HomeActivity's view hierarchy
+        activity.rootContainer.doOnPreDraw {
+            activity.reportFullyDrawn()
+        }
+    }
 }

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -7,6 +7,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
+    android:id="@+id/rootContainer"
     tools:context=".HomeActivity">
 
     <androidx.appcompat.widget.Toolbar


### PR DESCRIPTION
We don't capture the second RV draw yet. Unfortunately, I don't know if
it's the best use of my time to capture that as well.

Random thoughts on `reportFullyDrawn`:
* It is expected to be called when content is drawn; i.e. it will not automatically attach it’s own onDrawListener for the next drawn frame.
  * Determined because calling it in onCreate has a big difference in results than calling it in a onPreDrawListener set in onCreate
* When instrumented correctly, it produces different results when launching via the homescreen icon and launching via the command line.
  * When launching with the homescreen icon, it will take longer than “Displayed” time and sometimes “Displayed” is not shown at all
  * When launching via the command line, “Displayed”
* Appears it can be used to measure warm start (i.e. swipe away app in recent app switcher); not sure about hot start


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture