### PR TITLE
Fennec home screen bookmarks: Select new tab..

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/intent/FennecBookmarkShortcutsIntentProcessor.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/intent/FennecBookmarkShortcutsIntentProcessor.kt
@@ -42,7 +42,7 @@ class FennecBookmarkShortcutsIntentProcessor(
         return if (!url.isNullOrEmpty() && matches(intent)) {
             val session = Session(url, private = false, source = Session.Source.HOME_SCREEN)
 
-            sessionManager.add(session)
+            sessionManager.add(session, selected = true)
             loadUrlUseCase(url, session, EngineSession.LoadUrlFlags.external())
             intent.action = ACTION_VIEW
             intent.putSessionId(session.id)

--- a/app/src/test/java/org/mozilla/fenix/home/intent/FennecBookmarkShortcutsIntentProcessorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/intent/FennecBookmarkShortcutsIntentProcessorTest.kt
@@ -82,7 +82,7 @@ class FennecBookmarkShortcutsIntentProcessorTest {
             assertThat(fennecShortcutsIntent.getSessionId()).isEqualTo(expectedSession.id)
         }
         verifyAll {
-            sessionManager.add(expectedSession)
+            sessionManager.add(expectedSession, true)
             loadUrlUseCase(testUrl, expectedSession, EngineSession.LoadUrlFlags.external())
         }
     }


### PR DESCRIPTION
Fix for https://github.com/mozilla-mobile/android-components/issues/5623. When opening a home screen shortcut that was created by Fennec then we are opening a new tab but we were not selecting it - so the new tab was opened in the background.