### PR TITLE
AboutFragment: Use SupportUtils.getWhatsNewUrl().

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/about/AboutFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/about/AboutFragment.kt
@@ -102,7 +102,7 @@ class AboutFragment : Fragment(), AboutPageListener {
             AboutPageItem.Item(
                 AboutItem.ExternalLink(
                     WHATS_NEW,
-                    SupportUtils.getSumoURLForTopic(context, SupportUtils.SumoTopic.WHATS_NEW)
+                    SupportUtils.getWhatsNewUrl(context)
                 ), getString(R.string.about_whats_new, getString(R.string.app_name))
             ),
             AboutPageItem.Item(


### PR DESCRIPTION
In PR #7592 I missed that there is a second entry point to "What's new?" from the "about" screen.