### PR TITLE
Closes #7788: Route search widget intents through IntentReceiverActivity

### DIFF
--- a/app/src/main/java/org/mozilla/gecko/search/SearchWidgetProvider.kt
+++ b/app/src/main/java/org/mozilla/gecko/search/SearchWidgetProvider.kt
@@ -20,6 +20,7 @@ import androidx.annotation.Dimension.DP
 import androidx.appcompat.widget.AppCompatDrawableManager
 import androidx.core.graphics.drawable.toBitmap
 import org.mozilla.fenix.HomeActivity
+import org.mozilla.fenix.IntentReceiverActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.home.intent.StartSearchIntentProcessor
@@ -104,7 +105,7 @@ class SearchWidgetProvider : AppWidgetProvider() {
     }
 
     private fun createTextSearchIntent(context: Context): PendingIntent {
-        return Intent(context, HomeActivity::class.java)
+        return Intent(context, IntentReceiverActivity::class.java)
             .let { intent ->
                 intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
                 intent.putExtra(HomeActivity.OPEN_TO_SEARCH, StartSearchIntentProcessor.SEARCH_WIDGET)


### PR DESCRIPTION
This re-routes the search widget intents to go through IntentReceiverActivity so that it get's processed by the MigrationIntentProcessor.

Filed https://github.com/mozilla-mobile/fenix/issues/7791 as a follow-up since there is a lot of duplication for intent processing that can be done in one place.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture