### PR TITLE
sync-integration-history-bookmark-fenix-desktop

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/syncintegration/test_bookmark_desktop.js
+++ b/app/src/androidTest/java/org/mozilla/fenix/syncintegration/test_bookmark_desktop.js
@@ -1,0 +1,25 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
+/*
+ * The list of phases mapped to their corresponding profiles.  The object
+ * here must be in strict JSON format, as it will get parsed by the Python
+ * testrunner (no single quotes, extra comma's, etc).
+ */
+EnableEngines(["bookmarks"]);
+
+var phases = { "phase1": "profile1" };
+
+
+// expected bookmark state
+var bookmarksExpected = {
+"mobile": [{
+  uri: "http://www.example.com/",
+  title: "Example Domain"}]
+};
+
+// sync and verify bookmarks
+Phase("phase1", [
+  [Sync],
+  [Bookmarks.verify, bookmarksExpected],
+]);

--- a/app/src/androidTest/java/org/mozilla/fenix/syncintegration/test_history_desktop.js
+++ b/app/src/androidTest/java/org/mozilla/fenix/syncintegration/test_history_desktop.js
@@ -1,0 +1,28 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
+/*
+ * The list of phases mapped to their corresponding profiles.  The object
+ * here must be in strict JSON format, as it will get parsed by the Python
+ * testrunner (no single quotes, extra comma's, etc).
+ */
+EnableEngines(["history"]);
+
+var phases = { "phase1": "profile1" };
+
+
+// expected history state
+var historyExpected = [
+    { uri: "http://www.example.com/",
+      visits: [
+        { type: 1 },
+        { type: 2 }
+      ]
+    }
+];
+
+// sync and verify history
+Phase("phase1", [
+  [Sync],
+  [History.verify, historyExpected]
+]);

--- a/app/src/androidTest/java/org/mozilla/fenix/syncintegration/test_integration.py
+++ b/app/src/androidTest/java/org/mozilla/fenix/syncintegration/test_integration.py
@@ -10,12 +10,14 @@ def test_sync_history_from_desktop(tps, gradlewbuild):
     tps.run('test_history.js')
     gradlewbuild.test('checkHistoryFromDesktopTest')
 
-def test_sync_bookmark_from_device(tps, gradlewbuild):
-    os.chdir('app/src/androidTest/java/org/mozilla/fenix/syncintegration/')
+def test_sync_bookmark_from_desktop(tps, gradlewbuild):
     tps.run('test_bookmark.js')
     gradlewbuild.test('checkBookmarkFromDesktopTest')
 
 def test_sync_logins_from_device(tps, gradlewbuild):
-    os.chdir('app/src/androidTest/java/org/mozilla/fenix/syncintegration/')
     tps.run('test_logins.js')
     gradlewbuild.test('checkLoginsFromDesktopTest')
+
+def test_sync_bookmark_from_device(tps, gradlewbuild):
+    gradlewbuild.test('checkBookmarkFromDeviceTest')
+    tps.run('test_bookmark_desktop.js')

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
@@ -146,6 +146,14 @@ class SettingsRobot {
             SettingsSubMenuLoginsAndPasswordRobot().interact()
             return SettingsSubMenuLoginsAndPasswordRobot.Transition()
         }
+
+        fun openTurnOnSyncMenu(interact: SettingsTurnOnSyncRobot.() -> Unit): SettingsTurnOnSyncRobot.Transition {
+            fun turnOnSyncButton() = onView(ViewMatchers.withText("Turn on Sync"))
+            turnOnSyncButton().click()
+
+            SettingsTurnOnSyncRobot().interact()
+            return SettingsTurnOnSyncRobot.Transition()
+        }
     }
 }
 


### PR DESCRIPTION
This PR adds two tests so that the sync tests environment is complete in both ways Fenix <-> Desktop.
- One test saves a Bookmark on Fenix and sign in. Then, it checks that the bookmark appears for the same FxA on Desktop
- The other tests creates history by visiting a webiste and sign in on Fenix. Then with same FxA the history is checked on Desktop


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture