### PR TITLE
For issue #7636: After changing a tracking protection setting make sure to reload the selected session only when the EngineView is visible.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -144,6 +144,7 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
             (activity as HomeActivity).updateThemeForSession(it)
         }
         requireComponents.core.tabCollectionStorage.register(collectionStorageObserver, this)
+        reloadIfATrackingProtectionSettingHasChanged()
     }
 
     override fun onBackPressed(): Boolean {
@@ -194,6 +195,20 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
                 FenixSnackbar.makeWithToolbarPadding(view, Snackbar.LENGTH_SHORT)
                     .setText(view.context.getString(R.string.create_collection_tab_saved))
                     .show()
+            }
+        }
+    }
+
+    /**
+     * We need to make sure the EngineView is visible before reloading Fenix issue #7636
+     * https://github.com/mozilla-mobile/fenix/issues/7636 more related information
+     * https://bugzilla.mozilla.org/show_bug.cgi?id=1609701#cr-7
+     */
+    private fun reloadIfATrackingProtectionSettingHasChanged() {
+        context?.settings()?.shouldReload?.let {
+            if (it) {
+                requireComponents.useCases.sessionUseCases.reload.invoke()
+                context?.settings()?.shouldReload = false
             }
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/settings/TrackingProtectionFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/TrackingProtectionFragment.kt
@@ -143,7 +143,7 @@ class TrackingProtectionFragment : PreferenceFragmentCompat() {
         context?.components?.let {
             val policy = it.core.createTrackingProtectionPolicy()
             it.useCases.settingsUseCases.updateTrackingProtection.invoke(policy)
-            it.useCases.sessionUseCases.reload.invoke()
+            context?.settings()?.shouldReload = true
         }
     }
 

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -200,6 +200,14 @@ class Settings private constructor(
         default = false
     )
 
+    /**
+     * Indicates if we need to reload the selected session after a setting change.
+     */
+    var shouldReload by booleanPreference(
+        appContext.getPreferenceKey(R.string.pref_key_should_reload),
+        default = false
+    )
+
     val useStrictTrackingProtection by booleanPreference(
         appContext.getPreferenceKey(R.string.pref_key_tracking_protection_strict_default),
         true

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -104,6 +104,7 @@
     <string name="pref_key_dark_theme" translatable="false">pref_key_dark_theme</string>
     <string name="pref_key_auto_battery_theme" translatable="false">pref_key_auto_battery_theme</string>
     <string name="pref_key_follow_device_theme" translatable="false">pref_key_follow_device_theme</string>
+    <string name="pref_key_should_reload" translatable="false">pref_key_should_reload</string>
 
     <!-- Tracking Protection Settings -->
     <string name="pref_key_etp_learn_more" translatable="false">pref_key_etp_learn_more</string>


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture