### PR TITLE
For #7820: warm BrowsersCache on background thread.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -35,6 +35,7 @@ import org.mozilla.fenix.components.Components
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.session.NotificationSessionObserver
 import org.mozilla.fenix.session.VisibilityLifecycleCallback
+import org.mozilla.fenix.utils.BrowsersCache
 
 @SuppressLint("Registered")
 @Suppress("TooManyFunctions")
@@ -99,6 +100,7 @@ open class FenixApplication : LocaleAwareApplication() {
 
             setDayNightTheme()
             enableStrictMode()
+            warmBrowsersCache()
 
             // Enable the service-experiments component
             if (settings().isExperimentationEnabled && Config.channel.isReleaseOrBeta) {
@@ -250,6 +252,14 @@ open class FenixApplication : LocaleAwareApplication() {
                     settings.shouldUseLightTheme = true
                 }
             }
+        }
+    }
+
+    private fun warmBrowsersCache() {
+        // We avoid blocking the main thread for BrowsersCache on startup by loading it on
+        // background thread.
+        GlobalScope.launch(Dispatchers.Default) {
+            BrowsersCache.all(this@FenixApplication)
         }
     }
 


### PR DESCRIPTION
In an early iteration of his patch on a beta build, I saw no improvement over
6 runs (Pixel 2):
- Before: 401.5ms
- After: 402.17ms

This may be attributed to noise in startup performance. However,
BrowsersCache disappears from profiles completely and results in
theoretical performance gains.

When using the StartupTimeline class (not landed yet), I see a 27.75ms
runtime improvement on beta builds after this patch.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture