### PR TITLE
Update to AC 29.0.0-SNAPSHOT and fix breaking changes

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/AppRequestInterceptor.kt
+++ b/app/src/main/java/org/mozilla/fenix/AppRequestInterceptor.kt
@@ -65,7 +65,7 @@ class AppRequestInterceptor(private val context: Context) : RequestInterceptor {
 
         context.components.analytics.metrics.track(Event.ErrorPageVisited(improvedErrorType))
 
-        return RequestInterceptor.ErrorResponse(
+        return RequestInterceptor.ErrorResponse.Content(
             ErrorPages.createErrorPage(
                 context,
                 improvedErrorType,

--- a/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -58,4 +58,9 @@ object FeatureFlags {
      * Enables the new language picker
      */
     val fenixLanguagePicker = Config.channel.isNightlyOrDebug
+
+    /**
+     * Enables deleting individual tracking protection exceptions.
+     */
+    val deleteIndividualTrackingProtectionExceptions = Config.channel.isNightlyOrDebug
 }

--- a/app/src/main/java/org/mozilla/fenix/exceptions/ExceptionsAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/exceptions/ExceptionsAdapter.kt
@@ -9,6 +9,7 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import mozilla.components.concept.engine.content.blocking.TrackingProtectionException
 import org.mozilla.fenix.exceptions.viewholders.ExceptionsDeleteButtonViewHolder
 import org.mozilla.fenix.exceptions.viewholders.ExceptionsHeaderViewHolder
 import org.mozilla.fenix.exceptions.viewholders.ExceptionsListItemViewHolder
@@ -16,7 +17,7 @@ import org.mozilla.fenix.exceptions.viewholders.ExceptionsListItemViewHolder
 sealed class AdapterItem {
     object DeleteButton : AdapterItem()
     object Header : AdapterItem()
-    data class Item(val item: ExceptionsItem) : AdapterItem()
+    data class Item(val item: TrackingProtectionException) : AdapterItem()
 }
 
 /**
@@ -31,7 +32,7 @@ class ExceptionsAdapter(
      * Change the list of items that are displayed.
      * Header and footer items are added to the list as well.
      */
-    fun updateData(exceptions: List<ExceptionsItem>) {
+    fun updateData(exceptions: List<TrackingProtectionException>) {
         val adapterItems = mutableListOf<AdapterItem>()
         adapterItems.add(AdapterItem.Header)
         exceptions.mapTo(adapterItems) { AdapterItem.Item(it) }

--- a/app/src/main/java/org/mozilla/fenix/exceptions/ExceptionsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/exceptions/ExceptionsFragment.kt
@@ -16,6 +16,7 @@ import mozilla.components.concept.engine.content.blocking.TrackingProtectionExce
 import mozilla.components.feature.session.TrackingProtectionUseCases
 import mozilla.components.lib.state.ext.consumeFrom
 import org.mozilla.fenix.BrowserDirection
+import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.StoreProvider
@@ -76,8 +77,10 @@ class ExceptionsFragment : Fragment() {
     }
 
     private fun deleteOneItem(item: TrackingProtectionException) {
-        // We can't currently delete one item in this Exceptions list with a URL with the GV API
-        // See https://github.com/mozilla-mobile/android-components/issues/4699
+        // This feature hasn't been uplifted yet.
+        if (FeatureFlags.deleteIndividualTrackingProtectionExceptions) {
+            trackingProtectionUseCases.removeAllExceptions()
+        }
         Log.e("Remove one exception", "$item")
         reloadExceptions()
     }

--- a/app/src/main/java/org/mozilla/fenix/exceptions/ExceptionsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/exceptions/ExceptionsFragment.kt
@@ -12,6 +12,7 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import kotlinx.android.synthetic.main.fragment_exceptions.view.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import mozilla.components.concept.engine.content.blocking.TrackingProtectionException
 import mozilla.components.feature.session.TrackingProtectionUseCases
 import mozilla.components.lib.state.ext.consumeFrom
 import org.mozilla.fenix.BrowserDirection
@@ -74,7 +75,7 @@ class ExceptionsFragment : Fragment() {
         reloadExceptions()
     }
 
-    private fun deleteOneItem(item: ExceptionsItem) {
+    private fun deleteOneItem(item: TrackingProtectionException) {
         // We can't currently delete one item in this Exceptions list with a URL with the GV API
         // See https://github.com/mozilla-mobile/android-components/issues/4699
         Log.e("Remove one exception", "$item")
@@ -92,8 +93,7 @@ class ExceptionsFragment : Fragment() {
 
     private fun reloadExceptions() {
         trackingProtectionUseCases.fetchExceptions { resultList ->
-            val exceptionsList = resultList.map { ExceptionsItem(it) }
-            exceptionsStore.dispatch(ExceptionsFragmentAction.Change(exceptionsList))
+            exceptionsStore.dispatch(ExceptionsFragmentAction.Change(resultList))
         }
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/exceptions/ExceptionsFragmentStore.kt
+++ b/app/src/main/java/org/mozilla/fenix/exceptions/ExceptionsFragmentStore.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.fenix.exceptions
 
+import mozilla.components.concept.engine.content.blocking.TrackingProtectionException
 import mozilla.components.lib.state.Action
 import mozilla.components.lib.state.State
 import mozilla.components.lib.state.Store
@@ -12,7 +13,7 @@ import mozilla.components.lib.state.Store
  * Class representing an exception item
  * @property url Host of the exception
  */
-data class ExceptionsItem(val url: String)
+data class ExceptionItem(override val url: String) : TrackingProtectionException
 
 /**
  * The [Store] for holding the [ExceptionsFragmentState] and applying [ExceptionsFragmentAction]s.
@@ -24,14 +25,14 @@ class ExceptionsFragmentStore(initialState: ExceptionsFragmentState) :
  * Actions to dispatch through the `ExceptionsStore` to modify `ExceptionsState` through the reducer.
  */
 sealed class ExceptionsFragmentAction : Action {
-    data class Change(val list: List<ExceptionsItem>) : ExceptionsFragmentAction()
+    data class Change(val list: List<TrackingProtectionException>) : ExceptionsFragmentAction()
 }
 
 /**
  * The state for the Exceptions Screen
  * @property items List of exceptions to display
  */
-data class ExceptionsFragmentState(val items: List<ExceptionsItem>) : State
+data class ExceptionsFragmentState(val items: List<TrackingProtectionException>) : State
 
 /**
  * The ExceptionsState Reducer.

--- a/app/src/main/java/org/mozilla/fenix/exceptions/ExceptionsInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/exceptions/ExceptionsInteractor.kt
@@ -4,13 +4,15 @@
 
 package org.mozilla.fenix.exceptions
 
+import mozilla.components.concept.engine.content.blocking.TrackingProtectionException
+
 /**
  * Interactor for the exceptions screen
  * Provides implementations for the ExceptionsViewInteractor
  */
 class ExceptionsInteractor(
     private val learnMore: () -> Unit,
-    private val deleteOne: (ExceptionsItem) -> Unit,
+    private val deleteOne: (TrackingProtectionException) -> Unit,
     private val deleteAll: () -> Unit
 ) : ExceptionsViewInteractor {
     override fun onLearnMore() {
@@ -21,7 +23,7 @@ class ExceptionsInteractor(
         deleteAll.invoke()
     }
 
-    override fun onDeleteOne(item: ExceptionsItem) {
+    override fun onDeleteOne(item: TrackingProtectionException) {
         deleteOne.invoke(item)
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/exceptions/ExceptionsView.kt
+++ b/app/src/main/java/org/mozilla/fenix/exceptions/ExceptionsView.kt
@@ -14,6 +14,7 @@ import androidx.core.view.isVisible
 import androidx.recyclerview.widget.LinearLayoutManager
 import kotlinx.android.extensions.LayoutContainer
 import kotlinx.android.synthetic.main.component_exceptions.view.*
+import mozilla.components.concept.engine.content.blocking.TrackingProtectionException
 import org.mozilla.fenix.R
 
 /**
@@ -34,7 +35,7 @@ interface ExceptionsViewInteractor {
     /**
      * Called whenever one exception item is deleted
      */
-    fun onDeleteOne(item: ExceptionsItem)
+    fun onDeleteOne(item: TrackingProtectionException)
 }
 
 /**

--- a/app/src/main/java/org/mozilla/fenix/exceptions/viewholders/ExceptionsListItemViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/exceptions/viewholders/ExceptionsListItemViewHolder.kt
@@ -7,9 +7,9 @@ package org.mozilla.fenix.exceptions.viewholders
 import android.view.View
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.android.synthetic.main.exception_item.view.*
+import mozilla.components.concept.engine.content.blocking.TrackingProtectionException
 import org.mozilla.fenix.R
 import org.mozilla.fenix.exceptions.ExceptionsInteractor
-import org.mozilla.fenix.exceptions.ExceptionsItem
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.loadIntoView
 
@@ -25,7 +25,7 @@ class ExceptionsListItemViewHolder(
     private val url = view.domainView
     private val deleteButton = view.delete_exception
 
-    private var item: ExceptionsItem? = null
+    private var item: TrackingProtectionException? = null
 
     init {
         deleteButton.setOnClickListener {
@@ -35,7 +35,7 @@ class ExceptionsListItemViewHolder(
         }
     }
 
-    fun bind(item: ExceptionsItem) {
+    fun bind(item: TrackingProtectionException) {
         this.item = item
         url.text = item.url
         updateFavIcon(item.url)

--- a/app/src/main/java/org/mozilla/fenix/exceptions/viewholders/ExceptionsListItemViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/exceptions/viewholders/ExceptionsListItemViewHolder.kt
@@ -5,9 +5,11 @@
 package org.mozilla.fenix.exceptions.viewholders
 
 import android.view.View
+import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.android.synthetic.main.exception_item.view.*
 import mozilla.components.concept.engine.content.blocking.TrackingProtectionException
+import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.R
 import org.mozilla.fenix.exceptions.ExceptionsInteractor
 import org.mozilla.fenix.ext.components
@@ -38,6 +40,7 @@ class ExceptionsListItemViewHolder(
     fun bind(item: TrackingProtectionException) {
         this.item = item
         url.text = item.url
+        deleteButton.isVisible = FeatureFlags.deleteIndividualTrackingProtectionExceptions
         updateFavIcon(item.url)
     }
 

--- a/app/src/test/java/org/mozilla/fenix/AppRequestInterceptorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/AppRequestInterceptorTest.kt
@@ -113,7 +113,9 @@ class AppRequestInterceptorTest {
     }
 
     private fun createActualErrorPage(error: ErrorType): String {
-        return interceptor.onErrorRequest(session = mockk(), errorType = error, uri = null)?.data!!
+        val errorPage = interceptor.onErrorRequest(session = mockk(), errorType = error, uri = null)
+                as RequestInterceptor.ErrorResponse.Content
+        return errorPage.data
     }
 
     private fun createExpectedErrorPage(error: ErrorType, @RawRes html: Int, @RawRes css: Int): String {

--- a/app/src/test/java/org/mozilla/fenix/exceptions/ExceptionsFragmentStoreTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/exceptions/ExceptionsFragmentStoreTest.kt
@@ -14,7 +14,7 @@ class ExceptionsFragmentStoreTest {
     fun onChange() = runBlocking {
         val initialState = emptyDefaultState()
         val store = ExceptionsFragmentStore(initialState)
-        val newExceptionsItem = ExceptionsItem("URL")
+        val newExceptionsItem = ExceptionItem("URL")
 
         store.dispatch(ExceptionsFragmentAction.Change(listOf(newExceptionsItem))).join()
         assertNotSame(initialState, store.state)

--- a/app/src/test/java/org/mozilla/fenix/exceptions/ExceptionsInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/exceptions/ExceptionsInteractorTest.kt
@@ -5,6 +5,7 @@
 package org.mozilla.fenix.exceptions
 
 import io.mockk.mockk
+import mozilla.components.concept.engine.content.blocking.TrackingProtectionException
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -36,8 +37,8 @@ class ExceptionsInteractorTest {
 
     @Test
     fun onDeleteOne() {
-        var exceptionsItemReceived: ExceptionsItem? = null
-        val exceptionsItem = ExceptionsItem("url")
+        var exceptionsItemReceived: TrackingProtectionException? = null
+        val exceptionsItem = ExceptionItem("url")
         val interactor = ExceptionsInteractor(
             mockk(),
             { exceptionsItemReceived = exceptionsItem },

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -32,7 +32,7 @@ object Versions {
     const val androidx_work = "2.2.0"
     const val google_material = "1.1.0-beta01"
 
-    const val mozilla_android_components = "28.0.0-SNAPSHOT"
+    const val mozilla_android_components = "29.0.0-SNAPSHOT"
     // Note that android-components also depends on application-services,
     // and in fact is our main source of appservices-related functionality.
     // The version number below tracks the application-services version


### PR DESCRIPTION
Switched to using the new interface `TrackingProtectionException` everywhere, which `ExceptionItem` now implements.

Was already in here cutting the beta build, so opened a PR against master too.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture