### PR TITLE
Bug 1610725 - Support Action Tasks in CoT for Fenix. r=jlorenzo

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -63,11 +63,8 @@ tasks:
                           $if: 'tasks_for == "github-release"'
                           then: '${event.release.target_commitish}'
                           else:
-                              $if: 'tasks_for == "cron"'
+                              $if: 'tasks_for in ["action", "cron"]'
                               then: '${push.branch}'
-                              else:
-                                $if: 'tasks_for == "action"'
-                                then: ${parameters.head_ref}
               head_sha:
                   $if: 'tasks_for == "github-push"'
                   then: '${event.after}'
@@ -78,11 +75,9 @@ tasks:
                           $if: 'tasks_for == "github-release"'
                           then: '${event.release.tag_name}'
                           else:
-                              $if: 'tasks_for == "cron"'
+                              $if: 'tasks_for in ["action", "cron"]'
                               then: '${push.revision}'
-                              else:
-                                $if: 'tasks_for == "action"'
-                                then: ${parameters.head_rev}
+
 
               head_tag:
                   $if: 'tasks_for == "github-release"'


### PR DESCRIPTION
I think this should be all we need to support CoT for Fenix actions.

This patch removes `parameters` from the yml in favor of `push` based
on the taskgraph changes that need to happen.

@JohanLorenzo if any of my assumptions here as to what was required are incorrect please tell me, ideally with a link to taskcluster so I can see where I went wrong.

CC: @tomprince 