### PR TITLE
Closes #7762: Initialize Glean later in Fennec builds....

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/Config.kt
+++ b/app/src/main/java/org/mozilla/fenix/Config.kt
@@ -57,6 +57,9 @@ enum class ReleaseChannel {
 
     val isFennec: Boolean
         get() = this in fennecChannels
+
+    val isFenix: Boolean
+        get() = !isFennec
 }
 
 object Config {

--- a/app/src/migration/java/org/mozilla/fenix/MigratingFenixApplication.kt
+++ b/app/src/migration/java/org/mozilla/fenix/MigratingFenixApplication.kt
@@ -38,6 +38,10 @@ class MigratingFenixApplication : FenixApplication() {
         // These migrations need to run before regular initialization happens.
         migrateBlocking()
 
+        // Now that we have migrated from Fennec whether the user wants to enable telemetry we can
+        // initialize Glean
+        initializeGlean()
+
         // Fenix application initialization can happen now.
         super.setupInMainProcessOnly()
 


### PR DESCRIPTION
PR #7857 was a quick fix that unblocked telemetry collection from `fenix` builds and fixed the telemetry ID reset. This is now fixing the same issues for `fennec` builds.

We are now avoiding setting `uploadEnabled` to `false` in Glean by splitting the initialization: For `fenix` builds we do it immediately and set the flag based on the user setting. For `fennec` builds we do it a bit later once we have migrated the setting from Fennec to honor the user's choice.