### PR TITLE
Bump a-s dependency to 0.48.3.

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -39,7 +39,7 @@ object Versions {
     // that we depend on directly for the fenix-megazord (and for it's
     // forUnitTest variant), and it's important that it be kept in
     // sync with the version used by android-components above.
-    const val mozilla_appservices = "0.48.2"
+    const val mozilla_appservices = "0.48.3"
 
     const val mozilla_glean = "23.0.0"
 


### PR DESCRIPTION
Changelog: https://github.com/mozilla/application-services/releases/tag/v0.48.3

Ref: mozilla-mobile/android-components#5703

@grigoryk @ekager r?


