### PR TITLE
For #373: Implement LeanPlum push messaging

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -374,8 +374,10 @@ dependencies {
     implementation Deps.androidx_coordinatorlayout
 
     implementation Deps.sentry
-    implementation Deps.leanplum
     implementation Deps.osslicenses_library
+
+    implementation Deps.leanplum_core
+    implementation Deps.leanplum_fcm
 
     implementation Deps.mozilla_concept_engine
     implementation Deps.mozilla_concept_push

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -221,7 +221,7 @@
                 android:exported="false" />
 
         <service
-            android:name=".components.FirebasePush"
+            android:name=".components.FirebasePushService"
             android:exported="false">
             <intent-filter>
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />

--- a/app/src/main/java/org/mozilla/fenix/components/BackgroundServices.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/BackgroundServices.kt
@@ -87,7 +87,7 @@ class BackgroundServices(
             syncPeriodInMinutes = 240L) // four hours
     }
 
-    val pushService by lazy { FirebasePush() }
+    val pushService by lazy { FirebasePushService() }
 
     val push by lazy { makePushConfig()?.let { makePush(it) } }
 

--- a/app/src/main/java/org/mozilla/fenix/components/FirebasePush.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/FirebasePush.kt
@@ -1,9 +1,0 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
-package org.mozilla.fenix.components
-
-import mozilla.components.lib.push.firebase.AbstractFirebasePushService
-
-class FirebasePush : AbstractFirebasePushService()

--- a/app/src/main/java/org/mozilla/fenix/components/FirebasePushService.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/FirebasePushService.kt
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.components
+
+import android.annotation.SuppressLint
+import com.google.firebase.messaging.RemoteMessage
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.leanplum.LeanplumPushFirebaseMessagingService
+import mozilla.components.concept.push.PushService
+import mozilla.components.lib.push.firebase.AbstractFirebasePushService
+import mozilla.components.feature.push.AutoPushFeature
+
+/**
+ * A wrapper class that only exists to delegate to [FirebaseMessagingService] instances.
+ *
+ * Implementation notes:
+ *
+ * This was a doozy...
+ *
+ * With Firebase Cloud Messaging, we've been given some tight constraints in order to get this to
+ * work:
+ *  - We want to have multiple FCM message receivers for AutoPush and LeanPlum (for now), however
+ *  there can only be one registered [FirebaseMessagingService] in the AndroidManifest.
+ *  - The [LeanplumPushFirebaseMessagingService] does not function as expected unless it's the
+ *  inherited service that receives the messages.
+ *  - The [AutoPushService] is not strongly tied to being the inherited service, but the
+ *  [AutoPushFeature] requires a reference to the push instance as a [PushService].
+ *
+ * We tried creating an empty [FirebaseMessagingService] that can hold a list of the services
+ * for delegating, but the [LeanplumPushFirebaseMessagingService] tries to get a reference to the
+ * Application Context, however,since the FCM service runs in a background process that gives a
+ * nullptr. Within LeanPlum, this is something that is probably provided internally.
+ *
+ * We tried to pass in an instance of the [AbstractFirebasePushService] to [FirebasePushService]
+ * through the constructor and delegate the implementation of a [PushService] to that, but alas,
+ * the service requires you to have an empty default constructor in order for the OS to do the
+ * initialization. For this reason, we created a singleton instance of the AutoPush instance since
+ * that lets us easily delegate the implementation to that, as well as make invocations when FCM
+ * receives new messages.
+ */
+class FirebasePushService : LeanplumPushFirebaseMessagingService(),
+    PushService by AutoPushService {
+
+    override fun onNewToken(newToken: String) {
+        AutoPushService.onNewToken(newToken)
+        super.onNewToken(newToken)
+    }
+
+    override fun onMessageReceived(remoteMessage: RemoteMessage?) {
+        AutoPushService.onMessageReceived(remoteMessage)
+        super.onMessageReceived(remoteMessage)
+    }
+}
+
+/**
+ * A singleton instance of the FirebasePushService needed for communicating between FCM and the
+ * [AutoPushFeature].
+ */
+@SuppressLint("MissingFirebaseInstanceTokenRefresh") // Implemented internally.
+object AutoPushService : AbstractFirebasePushService()

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -153,7 +153,8 @@ object Deps {
     const val sentry = "io.sentry:sentry-android:${Versions.sentry}"
     const val leakcanary = "com.squareup.leakcanary:leakcanary-android:${Versions.leakcanary}"
 
-    const val leanplum = "com.leanplum:leanplum-core:${Versions.leanplum}"
+    const val leanplum_core = "com.leanplum:leanplum-core:${Versions.leanplum}"
+    const val leanplum_fcm = "com.leanplum:leanplum-fcm:${Versions.leanplum}"
 
     const val androidx_annotation = "androidx.annotation:annotation:${Versions.androidx_annotation}"
     const val androidx_biometric = "androidx.biometric:biometric:${Versions.androidx_biometric}"


### PR DESCRIPTION
Also closes #6250, since we rely solely on the SDK itself to consume the
messages straight from FCM.

I tried to write some tests, but I wasn't able to figure out how to mock the `LeanplumPushFirebaseMessagingService` invocations being called via super.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture