### PR TITLE
For #7524: Remove DeviceConstellation polling from on Resume!! 

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -128,7 +128,6 @@ open class HomeActivity : LocaleAwareAppCompatActivity() {
                 // If we're authenticated, kick-off a sync and a device state refresh.
                 accountManager.authenticatedAccount()?.let {
                     accountManager.syncNowAsync(SyncReason.Startup, debounce = true)
-                    it.deviceConstellation().pollForEventsAsync().await()
                 }
             }
         }


### PR DESCRIPTION
@grigoryk @rfk let's start with just removing the device constellation polling, and if we see the numbers fall, we can consider continuing with removing/moving the `accountManager.syncNowAsync` as well.