### PR TITLE
Issue #7818: Use different target activities for launcher activity alias (fenix vs. fennec).

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,16 +31,14 @@
 
         <!--
           We inherited this entry (${applicationId}.App) from Fennec. We need to keep this as our
-          main launcher to avoid launcher icons on the home screen disappearing for all our users
-          on a Fennec build.
+          main launcher to avoid launcher icons on the home screen disappearing for all our users.
 
-          !!HERE BE DRAGONS!!
-          We need the targetActivity to be IntentReceiverActivity so that we can check if we have
-          a migration in progress. If not, the HomeActivity is invoked.
+          Note that `fennec*` build types override the targetActivity property in the Manifest
+          inside their source set.
         -->
         <activity-alias
             android:name="${applicationId}.App"
-            android:targetActivity=".IntentReceiverActivity">
+            android:targetActivity=".HomeActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/migration/AndroidManifest.xml
+++ b/app/src/migration/AndroidManifest.xml
@@ -12,7 +12,19 @@
     <application
         android:name="org.mozilla.fenix.MigratingFenixApplication"
         tools:replace="android:name">
+
+        <!-- Overriding the alias of the main manifest to route app launches through our
+             MigrationDecisionActivity which will show the migration screen before launching
+             into the app if needed. -->
+        <activity-alias
+            android:name="${applicationId}.App"
+            android:targetActivity="org.mozilla.fenix.MigrationDecisionActivity"
+            tools:replace="android:targetActivity"/>
+
+        <activity
+            android:name="org.mozilla.fenix.MigrationDecisionActivity"
+            android:exported="false" />
+
         <service android:name="org.mozilla.fenix.MigrationService" />
     </application>
 </manifest>
-

--- a/app/src/migration/java/org/mozilla/fenix/MigrationDecisionActivity.kt
+++ b/app/src/migration/java/org/mozilla/fenix/MigrationDecisionActivity.kt
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import mozilla.components.support.migration.state.MigrationProgress
+import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.migration.MigrationProgressActivity
+
+/**
+ * The purpose of this activity, when launched, is to decide whether we want to show the migration
+ * screen ([MigrationProgressActivity]) or launch the browser normally ([HomeActivity]).
+ */
+class MigrationDecisionActivity : Activity() {
+    private val store by lazy { components.migrationStore }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val intent = if (intent != null) intent else Intent()
+
+        val activity = when (store.state.progress) {
+            MigrationProgress.COMPLETED, MigrationProgress.NONE -> HomeActivity::class.java
+            MigrationProgress.MIGRATING -> MigrationProgressActivity::class.java
+        }
+
+        intent.setClass(applicationContext, activity)
+        intent.putExtra(HomeActivity.OPEN_TO_BROWSER, false)
+
+        startActivity(intent)
+        finish()
+
+        // We are disabling animations here when switching activities because this results in a
+        // perceived faster launch. This activity will start immediately with a solid background
+        // and then we switch to the actual activity without an animation. This visually looks like
+        // a faster start than launching this activity invisibly and switching to the actual
+        // activity after that.
+        overridePendingTransition(0, 0)
+    }
+}


### PR DESCRIPTION
(Proposal for regression described in #7818. See issue for more details).

* With this patch fenix build variants will launch HomeActivity directly from the launcher.
  This will get rid of the performance regression outlined in #7818.

* Fennec build variants will launch into MigrationDecisionActivity which will show the
  migration UI or launch normally into the app. This is faster than going through
  IntentReceiverActivity (measured and perceived).