### PR TITLE
Add "Not yet supported" addon fragment 

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/addons/AddonsManagementFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/addons/AddonsManagementFragment.kt
@@ -8,7 +8,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.annotation.StringRes
 import androidx.fragment.app.Fragment
 import androidx.navigation.Navigation
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -22,7 +21,7 @@ import mozilla.components.feature.addons.AddonManagerException
 import mozilla.components.feature.addons.ui.AddonsManagerAdapter
 import mozilla.components.feature.addons.ui.AddonsManagerAdapterDelegate
 import mozilla.components.feature.addons.ui.PermissionsDialogFragment
-import mozilla.components.feature.addons.ui.translate
+import mozilla.components.feature.addons.ui.translatedName
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.showToolbar
@@ -72,6 +71,10 @@ class AddonsManagementFragment : Fragment(), AddonsManagerAdapterDelegate {
         showPermissionDialog(addon)
     }
 
+    override fun onNotYetSupportedSectionClicked(unsupportedAddons: ArrayList<Addon>) {
+        showNotYetSupportedAddonFragment(unsupportedAddons)
+    }
+
     private fun bindRecyclerView(view: View) {
         recyclerView = view.findViewById(R.id.add_ons_list)
         recyclerView.layoutManager = LinearLayoutManager(requireContext())
@@ -89,7 +92,7 @@ class AddonsManagementFragment : Fragment(), AddonsManagerAdapterDelegate {
                 }
             } catch (e: AddonManagerException) {
                 scope.launch(Dispatchers.Main) {
-                    showSnackBar(view, "Failed to query Add-ons!")
+                    showSnackBar(view, getString(R.string.mozac_feature_addons_failed_to_query_add_ons))
                 }
             }
         }
@@ -107,6 +110,14 @@ class AddonsManagementFragment : Fragment(), AddonsManagerAdapterDelegate {
         val directions =
             AddonsManagementFragmentDirections.actionAddonsManagementFragmentToAddonDetailsFragment(
                 addon
+            )
+        Navigation.findNavController(requireView()).navigate(directions)
+    }
+
+    private fun showNotYetSupportedAddonFragment(unsupportedAddons: ArrayList<Addon>) {
+        val directions =
+            AddonsManagementFragmentDirections.actionAddonsManagementFragmentToNotYetSupportedAddonFragment(
+                unsupportedAddons.toTypedArray()
             )
         Navigation.findNavController(requireView()).navigate(directions)
     }
@@ -136,7 +147,13 @@ class AddonsManagementFragment : Fragment(), AddonsManagerAdapterDelegate {
             addon,
             onSuccess = {
                 this@AddonsManagementFragment.view?.let { view ->
-                    showSnackBar(view, "Successfully installed: ${it.translatableName.translate()}")
+                    showSnackBar(
+                        view,
+                        getString(
+                            R.string.mozac_feature_addons_successfully_installed,
+                            it.translatedName
+                        )
+                    )
                     bindRecyclerView(view)
                 }
 
@@ -144,7 +161,7 @@ class AddonsManagementFragment : Fragment(), AddonsManagerAdapterDelegate {
             },
             onError = { _, _ ->
                 this@AddonsManagementFragment.view?.let { view ->
-                    showSnackBar(view, "Failed to install: ${addon.translatableName.translate()}")
+                    showSnackBar(view, getString(R.string.mozac_feature_addons_failed_to_install, addon.translatedName))
                 }
                 addonProgressOverlay.visibility = View.GONE
             }
@@ -154,6 +171,4 @@ class AddonsManagementFragment : Fragment(), AddonsManagerAdapterDelegate {
     companion object {
         private const val PERMISSIONS_DIALOG_FRAGMENT_TAG = "ADDONS_PERMISSIONS_DIALOG_FRAGMENT"
     }
-
-    private inner class Section(@StringRes val title: Int)
 }

--- a/app/src/main/java/org/mozilla/fenix/addons/InstalledAddonDetailsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/addons/InstalledAddonDetailsFragment.kt
@@ -17,6 +17,7 @@ import mozilla.components.feature.addons.ui.translate
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.showToolbar
+import mozilla.components.feature.addons.ui.translatedName
 
 /**
  * An activity to show the details of a installed add-on.
@@ -60,13 +61,13 @@ class InstalledAddonDetailsFragment : Fragment() {
                     onSuccess = {
                         showSnackBar(
                             view,
-                            "Successfully enabled ${addon.translatableName.translate()}"
+                            getString(R.string.mozac_feature_addons_successfully_enabled, addon.translatedName)
                         )
                     },
                     onError = {
                         showSnackBar(
                             view,
-                            "Failed to enable ${addon.translatableName.translate()}"
+                            getString(R.string.mozac_feature_addons_failed_to_enable, addon.translatedName)
                         )
                     }
                 )
@@ -76,13 +77,13 @@ class InstalledAddonDetailsFragment : Fragment() {
                     onSuccess = {
                         showSnackBar(
                             view,
-                            "Successfully disabled ${addon.translatableName.translate()}"
+                            getString(R.string.mozac_feature_addons_successfully_disabled, addon.translatedName)
                         )
                     },
                     onError = {
                         showSnackBar(
                             view,
-                            "Failed to disable ${addon.translatableName.translate()}"
+                            getString(R.string.mozac_feature_addons_failed_to_disable, addon.translatedName)
                         )
                     }
                 )
@@ -129,12 +130,18 @@ class InstalledAddonDetailsFragment : Fragment() {
                 onSuccess = {
                     showSnackBar(
                         view,
-                        "Successfully uninstalled ${addon.translatableName.translate()}"
+                        getString(R.string.mozac_feature_addons_successfully_uninstalled, addon.translatedName)
                     )
                     view.findNavController().popBackStack()
                 },
                 onError = { _, _ ->
-                    showSnackBar(view, "Failed to uninstall ${addon.translatableName.translate()}")
+                    showSnackBar(
+                        view,
+                        getString(
+                            R.string.mozac_feature_addons_failed_to_uninstall,
+                            addon.translatedName
+                        )
+                    )
                 }
             )
         }

--- a/app/src/main/java/org/mozilla/fenix/addons/NotYetSupportedAddonFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/addons/NotYetSupportedAddonFragment.kt
@@ -1,0 +1,65 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.addons
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import mozilla.components.feature.addons.Addon
+import mozilla.components.feature.addons.ui.UnsupportedAddonsAdapter
+import mozilla.components.feature.addons.ui.UnsupportedAddonsAdapterDelegate
+import org.mozilla.fenix.R
+import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.showToolbar
+
+/**
+ * Fragment for displaying and managing add-ons that are not yet supported by the browser.
+ */
+class NotYetSupportedAddonFragment : Fragment(), UnsupportedAddonsAdapterDelegate {
+    private val addons: List<Addon> by lazy {
+        NotYetSupportedAddonFragmentArgs.fromBundle(requireNotNull(arguments)).addons.toList()
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_not_yet_supported_addons, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val recyclerView: RecyclerView = view.findViewById(R.id.unsupported_add_ons_list)
+        recyclerView.layoutManager = LinearLayoutManager(requireContext())
+        recyclerView.adapter = UnsupportedAddonsAdapter(
+            addonManager = requireContext().components.addonManager,
+            unsupportedAddonsAdapterDelegate = this@NotYetSupportedAddonFragment,
+            unsupportedAddons = addons
+        )
+    }
+
+    override fun onResume() {
+        super.onResume()
+        showToolbar(getString(R.string.mozac_feature_addons_unsupported_section))
+    }
+
+    override fun onUninstallError(addonId: String, throwable: Throwable) {
+        this@NotYetSupportedAddonFragment.view?.let { view ->
+            showSnackBar(view, getString(R.string.mozac_feature_addons_failed_to_remove, ""))
+        }
+    }
+
+    override fun onUninstallSuccess() {
+        this@NotYetSupportedAddonFragment.view?.let { view ->
+            showSnackBar(view, getString(R.string.mozac_feature_addons_successfully_removed, ""))
+        }
+    }
+}

--- a/app/src/main/res/layout/fragment_not_yet_supported_addons.xml
+++ b/app/src/main/res/layout/fragment_not_yet_supported_addons.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?android:attr/selectableItemBackground"
+        android:orientation="horizontal"
+        android:padding="16dp"
+        android:text="@string/mozac_feature_addons_not_yet_supported_caption" />
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@color/photonGrey30" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/unsupported_add_ons_list"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".BrowserActivity"/>
+</LinearLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -716,6 +716,9 @@
         <action
             android:id="@+id/action_addonsManagementFragment_to_installedAddonDetails"
             app:destination="@id/installedAddonDetailsFragment" />
+        <action
+            android:id="@+id/action_addonsManagementFragment_to_notYetSupportedAddonFragment"
+            app:destination="@id/notYetSupportedAddonFragment" />
     </fragment>
     <fragment
         android:id="@+id/addonDetailsFragment"
@@ -741,6 +744,14 @@
         <argument
             android:name="addon"
             app:argType="mozilla.components.feature.addons.Addon" />
+    </fragment>
+    <fragment
+        android:id="@+id/notYetSupportedAddonFragment"
+        android:name="org.mozilla.fenix.addons.NotYetSupportedAddonFragment"
+        android:label="NotYetSupportedAddonFragment" >
+        <argument
+            android:name="addons"
+            app:argType="mozilla.components.feature.addons.Addon[]" />
     </fragment>
     <fragment
         android:id="@+id/addonInternalSettingsFragment"


### PR DESCRIPTION
This imports AC's [NotYetSupportedAddonActivity](https://github.com/mozilla-mobile/android-components/blob/ba0ab51d6de733c27d235e8863a9a5733654fd14/samples/browser/src/main/java/org/mozilla/samples/browser/addons/NotYetSupportedAddonActivity.kt) to Fenix.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture