### PR TITLE
For #7862: Correct "Learn more" arrow icon direction in ETP settings for RTL layouts

### DIFF
--- a/app/src/main/res/drawable/ic_arrowhead_right.xml
+++ b/app/src/main/res/drawable/ic_arrowhead_right.xml
@@ -4,6 +4,7 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
+    android:autoMirrored="true"
     android:viewportWidth="7"
     android:viewportHeight="13">
     <path


### PR DESCRIPTION
For #7862 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: The change is only within `.xml`
- [x] **Screenshots**: 
<img src="https://user-images.githubusercontent.com/26433289/73360546-350fdd00-42b4-11ea-8835-b1ff89b836b4.png" width="350"/>

- [x] **Accessibility**: 
<img src="https://user-images.githubusercontent.com/26433289/73360804-c1ba9b00-42b4-11ea-9806-a4f12494ae3e.png" width="350"/>

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture