### PR TITLE
Fix #7980 - MigrationStore's COMPLETE action now redirects to MigrationProgressActivity 

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/migration/MigrationProgressActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/migration/MigrationProgressActivity.kt
@@ -22,6 +22,7 @@ import mozilla.components.support.migration.Migration.History
 import mozilla.components.support.migration.Migration.Logins
 import mozilla.components.support.migration.Migration.Settings
 import mozilla.components.support.migration.MigrationResults
+import mozilla.components.support.migration.state.MigrationAction
 import mozilla.components.support.migration.state.MigrationProgress
 import mozilla.components.support.migration.state.MigrationStore
 import org.mozilla.fenix.HomeActivity
@@ -62,6 +63,7 @@ class MigrationProgressActivity : AbstractMigrationProgressActivity() {
 
                 // If we received a user-initiated intent, throw this back to the intent receiver.
                 if (intent.hasExtra(HomeActivity.OPEN_TO_BROWSER)) {
+                    store.dispatch(MigrationAction.Clear)
                     intent.setClassName(applicationContext, IntentReceiverActivity::class.java.name)
                     startActivity(intent)
                 }

--- a/app/src/migration/java/org/mozilla/fenix/MigrationDecisionActivity.kt
+++ b/app/src/migration/java/org/mozilla/fenix/MigrationDecisionActivity.kt
@@ -24,8 +24,8 @@ class MigrationDecisionActivity : Activity() {
         val intent = if (intent != null) intent else Intent()
 
         val activity = when (store.state.progress) {
-            MigrationProgress.COMPLETED, MigrationProgress.NONE -> HomeActivity::class.java
-            MigrationProgress.MIGRATING -> MigrationProgressActivity::class.java
+            MigrationProgress.NONE -> HomeActivity::class.java
+            MigrationProgress.MIGRATING, MigrationProgress.COMPLETED -> MigrationProgressActivity::class.java
         }
 
         intent.setClass(applicationContext, activity)


### PR DESCRIPTION
In order to ensure that the user's migration screen is not being bypassed by mistake, we handle the
migration's store COMPLETED state the same way we handle the MIGRATING state.

We can do this because we can treat the initial state (NONE) as being either a fresh start of the
app, either the user's intention of starting the home activity.

Before this change, if the app was being open from the shortcut after the migration was complete,
the user would have been encountered the home activity instead of the migration one.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This is already covered by tests.
- [x] **Screenshots**: This PR isn't adding any new visual changes just behavioral.
- [x] **Accessibility**: The code in this PR does not include any user facing features.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture