### PR TITLE
No Issue: Add a custom Detekt plugin to flag the use of banned methods

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,6 +9,7 @@ apply plugin: 'jacoco'
 apply from: "$project.rootDir/automation/gradle/versionCode.gradle"
 apply plugin: 'androidx.navigation.safeargs.kotlin'
 apply plugin: 'com.google.android.gms.oss-licenses-plugin'
+apply plugin: 'io.gitlab.arturbosch.detekt'
 
 
 import com.android.build.OutputFile
@@ -362,6 +363,12 @@ androidExtensions {
 }
 
 dependencies {
+
+
+        detekt project(":mozilla-detekt-rules")
+        detekt "io.gitlab.arturbosch.detekt:detekt-cli:${Versions.detekt}"
+
+
     geckoNightlyImplementation Deps.mozilla_browser_engine_gecko_nightly
     geckoBetaImplementation Deps.mozilla_browser_engine_gecko_beta
 
@@ -693,4 +700,53 @@ if (gradle.hasProperty('localProperties.dependencySubstitutions.geckoviewTopsrcd
 if (gradle.hasProperty('localProperties.autoPublish.android-components.dir')) {
     ext.acSrcDir = gradle."localProperties.autoPublish.android-components.dir"
     apply from: "../${acSrcDir}/substitute-local-ac.gradle"
+}
+
+task detektWithAndroidContext() {
+
+    setGroup("verification")
+    setDescription("Run Detekt with a symbol-resolving Android   classpath in order to perform more precise checking.")
+
+    // Only execute these behaviors when the configuration phase of the gradle build lifecycle is complete.
+    doLast {
+        // Create a new Detekt task.
+        def t = this.project.tasks.create("testing", io.gitlab.arturbosch.detekt.Detekt)
+        // Configure that task according to our site specifications
+        t.configure {
+            def projectDir = this.project.getProjectDir().toString()
+
+            // Collect a classpath that uses each of the available variants. This classpath includes all the Android
+            // project's dependencies. This is only available after the configuration phase of the gradle build
+            // lifecycle is complete.
+            def fs = files()
+            android.applicationVariants.each {
+                // Check each element of the classpath to see if it exists before adding it to the list.
+                fs += it.javaCompile.classpath.filter { it.exists() }
+            }
+            // Set a classpath that includes the Android-specific classpath that we just built.
+            classpath.setFrom(fs)
+
+            // Replicate standard detekt configuration closure items.
+
+            // Put the equivalent to the 'input =' value from the detekt configuration closure here.
+            setSource(files("$projectDir/src/"))
+            // This include is the default for Detekt. It must be set explicitly because it does not
+            // get set here automatically like it does when the 'input =' line is set in the
+            // detekt configuration closure.
+            include("**/*.kt", "**/*.kts")
+            config.setFrom(files("$projectDir/config/detekt.yml"))
+            jvmTarget = "1.8"
+            reports {
+                html {
+                    enabled = true
+                    destination = file("$projectDir/build/reports/detekt.html")
+                }
+                xml {
+                    enabled = false
+                }
+            }
+        }
+        // Finally, call check on the Detekt task in order to execute.
+        t.check()
+    }
 }

--- a/app/config/detekt.yml
+++ b/app/config/detekt.yml
@@ -1,5 +1,8 @@
-autoCorrect: true
-failFast: false
+config:
+  validation: false
+
+formatting:
+  autoCorrect: true
 
 build:
   maxIssues: 0
@@ -26,13 +29,6 @@ console-reports:
   #  - 'NotificationReport'
   #  - 'FindingsReport'
   #  - 'BuildFailureReport'
-
-output-reports:
-  active: true
-  exclude:
-  #  - 'HtmlOutputReport'
-    - 'PlainOutputReport'
-    - 'XmlOutputReport'
 
 comments:
   active: true
@@ -114,6 +110,9 @@ mozilla-detekt-rules:
     # with the debuggable flag or not. Use a check for different build variants,
     # instead.
     bannedProperties: "BuildConfig.DEBUG"
+  MozillaBannedMethodInvocation:
+    active: true
+    bannedMethods: ".*action[a-zA-Z]+FragmentToBrowserFragment.*"
 
 empty-blocks:
   active: true

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
 }
 
 plugins {
-    id("io.gitlab.arturbosch.detekt").version("1.0.0-RC16")
+    id("io.gitlab.arturbosch.detekt").version("1.3.1")
 }
 
 allprojects {
@@ -48,10 +48,9 @@ task clean(type: Delete) {
 
 detekt {
     // The version number is duplicated, please refer to plugins block for more details
-    version = "1.0.0-RC16"
+    version = "1.3.1"
     input = files("$projectDir/app/src")
-    config = files("$projectDir/config/detekt.yml")
-    filters = ".*test.*,.*/resources/.*,.*/tmp/.*"
+    config = files("$projectDir/app/config/detekt.yml")
 
     reports {
         html {

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -11,7 +11,7 @@ object Versions {
     const val leanplum = "5.2.3"
     const val osslicenses_plugin = "0.9.5"
     const val osslicenses_library = "17.0.0"
-    const val detekt = "1.0.0-RC16"
+    const val detekt = "1.3.1"
 
     const val androidx_appcompat = "1.1.0"
     const val androidx_biometric = "1.0.1"

--- a/mozilla-detekt-rules/src/main/java/org/mozilla/fenix/detektrules/CustomRulesetConsoleReport.kt
+++ b/mozilla-detekt-rules/src/main/java/org/mozilla/fenix/detektrules/CustomRulesetConsoleReport.kt
@@ -6,7 +6,7 @@ import io.gitlab.arturbosch.detekt.api.Detektion
 class CustomRulesetConsoleReport : ConsoleReport() {
     override fun render(detektion: Detektion): String? {
         return detektion.findings["mozilla-detekt-rules"]?.fold("") { output, finding ->
-            output + finding.locationAsString + ": " + finding.messageOrDescription()
+            output + finding.location.compactWithSignature() + ": " + finding.messageOrDescription()
         }
     }
 }

--- a/mozilla-detekt-rules/src/main/java/org/mozilla/fenix/detektrules/CustomRulesetProvider.kt
+++ b/mozilla-detekt-rules/src/main/java/org/mozilla/fenix/detektrules/CustomRulesetProvider.kt
@@ -11,10 +11,16 @@ import io.gitlab.arturbosch.detekt.api.RuleSetProvider
 class CustomRulesetProvider : RuleSetProvider {
     override val ruleSetId: String = "mozilla-detekt-rules"
 
-    override fun instance(config: Config): RuleSet = RuleSet(
-        ruleSetId,
-        listOf(
-            MozillaBannedPropertyAccess(config)
+    override fun instance(config: Config): RuleSet {
+        val providerList = listOf(
+            MozillaBannedPropertyAccess(config),
+            MozillaBannedMethodInvocation(config)
         )
-    )
+        providerList.forEach { it.configure() }
+        return RuleSet(
+            ruleSetId,
+            providerList.filter { it.validate() }
+        )
+    }
 }
+

--- a/mozilla-detekt-rules/src/main/java/org/mozilla/fenix/detektrules/MozillaBannedMethodInvocation.kt
+++ b/mozilla-detekt-rules/src/main/java/org/mozilla/fenix/detektrules/MozillaBannedMethodInvocation.kt
@@ -1,0 +1,166 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.detektrules
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Severity
+import org.jetbrains.kotlin.psi.KtQualifiedExpression
+import org.jetbrains.kotlin.psi.KtCallElement
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtElement
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
+import org.jetbrains.kotlin.com.intellij.openapi.util.Key
+import java.util.regex.PatternSyntaxException
+
+class MozillaBannedMethodInvocation(config: Config = Config.empty) : MozillaRule(config) {
+    companion object {
+        const val DESCR = "Invoking banned method"
+    }
+
+    val checkedMethodKey = Key<Boolean>("CheckedMethod")
+
+    override val issue = Issue(
+        "MozillaBannedMethodInvocation",
+        Severity.Defect,
+        DESCR,
+        Debt.FIVE_MINS
+    )
+
+    private lateinit var banned: MutableList<Regex>
+    private var configOk = true
+
+    override fun validate(): Boolean {
+        return configOk
+    }
+
+    override fun configure() {
+        // Initialize the banned list from the user-specified configuration.
+        configOk = true
+        banned = mutableListOf()
+        val bannedMethodInvocationsList = valueOrDefault("bannedMethods", "").replace(" ", "")
+        if (!bannedMethodInvocationsList.contentEquals("")) {
+            bannedMethodInvocationsList.split(",").forEach {
+                try {
+                    val r = Regex(
+                        it,
+                        RegexOption.DOT_MATCHES_ALL
+                    )
+                    banned.add(r)
+
+                } catch (pse: PatternSyntaxException) {
+                    // Log a warning here about an invalid regular expression.
+                    MozillaLogger.logInfo("MozillaBannedMethodInvocation: " +
+                            "$it is an invalid description of a banned method. " +
+                            "It will not be used.")
+                    // It is just this method description that will not be included. Others might still be valid.
+                    configOk = true
+                }
+            }
+        }
+    }
+
+    /**
+     * Issue a CodeSmell report if the invoked method matches a banned method
+     *
+     * If a method is invoked that is banned, issue a CodeSmell report.
+     *
+     * @param possiblyBannedMethodInvocation The invoked method to compare against the banned list
+     * @param expression The expression from where this invocation came. It is used to provide context to the report.
+     *
+     * @return None
+     */
+    private fun reportIfBanned(
+        possiblyBannedMethodInvocation: CharSequence,
+        expression: KtExpression
+    ) {
+        banned.filter { it.matches(possiblyBannedMethodInvocation) }.map {
+            CodeSmell(
+                issue,
+                Entity.from(expression),
+                "Using $possiblyBannedMethodInvocation is not allowed because invoking " +
+                        "${it.pattern} is against Mozilla policy. " +
+                        "See 'mozilla-detekt-rules' stanza in 'config/detekt.yml' for more information.\n"
+            )
+        }.forEach { report(it) }
+    }
+
+    override fun visitQualifiedExpression(expression: KtQualifiedExpression) {
+        var possiblyBannedMethodInvocation: String? = null
+
+        // Separate the call (the selector) from the receiver. We store this so
+        // we can later mark it as checked if we actually checked.
+        var callDescendant: KtElement? = null
+        if (expression.selectorExpression != null && expression.selectorExpression is KtCallElement) {
+            callDescendant = expression.selectorExpression
+        }
+
+        // All we know at this point is that this expression is a simple qualified expression.
+        // There are two ways to determine if this is a function call:
+
+        // 1. If there is a binding context and the expression resolves to a function
+        // call in that context, we know it is a function call.
+        if (bindingContext != BindingContext.EMPTY) {
+            possiblyBannedMethodInvocation =
+                expression.getResolvedCall(bindingContext)?.resultingDescriptor?.fqNameOrNull()
+                    ?.asString()
+        }
+
+        // 2. If the selector is a function call, then we know it is a function call.
+        // Note: We do not want to override what we found above, if anything. Also, we
+        // only have to check a single selector because chained method invocations will
+        // result in multiple calls to this function.
+        if (callDescendant != null &&
+            (possiblyBannedMethodInvocation == null || possiblyBannedMethodInvocation == "")
+        ) {
+            // In order to create the literal against which we will check for a match in the banned list,
+            // we have to recreate from the receiver and the selector. This is necessary for handling
+            // chained method invocations.
+            possiblyBannedMethodInvocation =
+                expression.receiverExpression.node.chars.toString() + "." + callDescendant.node.chars.toString()
+        }
+
+        // If either of those two cases is true, then we will check to see if invoking this
+        // function is banned. Mark that we have checked this function here so that we do not
+        // recheck when visitCallExpression() is invoked on this expression.
+        if (possiblyBannedMethodInvocation != null) {
+            callDescendant?.putUserData(checkedMethodKey, true)
+            reportIfBanned(possiblyBannedMethodInvocation, expression)
+        }
+
+        // Visit our children after we do our work. This makes it possible to qualified function
+        // invocations before checking the function itself later. We always prefer checking the
+        // most fully-qualified name against the banned list.
+        super.visitQualifiedExpression(expression)
+    }
+
+    override fun visitCallExpression(expression: KtCallExpression) {
+        super.visitCallExpression(expression)
+
+        // Check first to see if this expression has already been checked!
+        if (expression.getUserData(checkedMethodKey) == true) return
+
+        // Start by assuming that we will check whether the string of characters
+        // represented by this expression (which is a function call), is banned.
+        var possiblyBannedMethodInvocation = expression.node.chars.toString()
+
+        // If we can resolve this function call into it's fully-qualified name,
+        // then let's do that and use that as the basis for the comparison. Remember,
+        // we always prefer checking whether the most fully-qualified name is banned.
+        if (bindingContext != BindingContext.EMPTY) {
+            val resolvedCall = expression.getResolvedCall(bindingContext)
+            possiblyBannedMethodInvocation =
+                resolvedCall?.resultingDescriptor?.fqNameOrNull()?.asString()
+                    ?: possiblyBannedMethodInvocation
+        }
+        reportIfBanned(possiblyBannedMethodInvocation, expression)
+    }
+}

--- a/mozilla-detekt-rules/src/main/java/org/mozilla/fenix/detektrules/MozillaBannedPropertyAccess.kt
+++ b/mozilla-detekt-rules/src/main/java/org/mozilla/fenix/detektrules/MozillaBannedPropertyAccess.kt
@@ -9,11 +9,10 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Debt
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.Severity
 import org.jetbrains.kotlin.psi.*
 
-class MozillaBannedPropertyAccess(config: Config = Config.empty) : Rule(config) {
+class MozillaBannedPropertyAccess(config: Config = Config.empty) : MozillaRule(config) {
     override val issue = Issue(
         "MozillaBannedPropertyAccess",
         Severity.Defect,

--- a/mozilla-detekt-rules/src/main/java/org/mozilla/fenix/detektrules/MozillaLogger.kt
+++ b/mozilla-detekt-rules/src/main/java/org/mozilla/fenix/detektrules/MozillaLogger.kt
@@ -1,0 +1,14 @@
+package org.mozilla.fenix.detektrules
+
+object MozillaLogger {
+    fun logError(msg: String) {
+        System.err.println(msg)
+    }
+
+    private fun logNonError(msg: String) {
+        System.out.println(msg)
+    }
+
+    fun logWarning(msg: String) = logNonError(msg)
+    fun logInfo(msg: String) = logNonError(msg)
+}

--- a/mozilla-detekt-rules/src/main/java/org/mozilla/fenix/detektrules/MozillaRule.kt
+++ b/mozilla-detekt-rules/src/main/java/org/mozilla/fenix/detektrules/MozillaRule.kt
@@ -1,0 +1,23 @@
+package org.mozilla.fenix.detektrules
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Rule
+
+abstract class MozillaRule(config: Config = Config.empty): Rule(config) {
+    /**
+     * Validate this rule's configuration
+     *
+     * Check whether or not this custom Detekt rule's configuration is valid. This is
+     * called after the rule is configured.
+     *
+     * [MozillaRule]s with invalid configurations are not activated.
+     *
+     * @return A [Boolean]indicating whether the configuration is valid or not. Invalid
+     * configurations will de-activate the rule.
+     */
+    open fun validate(): Boolean = true
+
+    open fun configure(): Unit {
+
+    }
+}

--- a/mozilla-detekt-rules/src/main/resources/config.yml
+++ b/mozilla-detekt-rules/src/main/resources/config.yml
@@ -1,3 +1,6 @@
   MozillaBannedPropertyAccess:
     active: true
     bannedProperties: "Sample.Banned"
+  MozillaBannedMethodInvocation:
+    active: true
+    bannedMethods: ".*Foo\\.bannedMethodX.*, .*Foo\\.bannedMethodY.*, .*forbidden.*, .*[mMisconfigured.*"

--- a/mozilla-detekt-rules/src/test/java/org/mozilla/fenix/detektrules/MozillaBannedMethodInvocationTest.kt
+++ b/mozilla-detekt-rules/src/test/java/org/mozilla/fenix/detektrules/MozillaBannedMethodInvocationTest.kt
@@ -1,0 +1,227 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.detektrules
+
+import io.gitlab.arturbosch.detekt.test.lint
+import io.gitlab.arturbosch.detekt.api.YamlConfig
+import io.gitlab.arturbosch.detekt.test.KtTestCompiler
+import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.Arguments.arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
+
+internal class MozillaBannedMethodInvocationTest {
+    @Test
+    internal fun `match of banned method qualified invocation should warn`() {
+        var rule = MozillaBannedMethodInvocation(YamlConfig.loadResource(this.javaClass.getResource("/config.yml")))
+        rule.configure()
+        rule.validate()
+
+        val contextualFindings =
+            rule.compileAndLintWithContext(
+                KtTestCompiler.createEnvironment().env,
+                NONCOMPLIANT_QUALIFIED_INVOCATION.trimIndent()
+            )
+        assertThat(contextualFindings).hasSize(1)
+        assertThat(contextualFindings[0].issue.description).isEqualTo(MozillaBannedMethodInvocation.DESCR)
+
+        val contextFreeFindings =
+            rule.lint(
+                NONCOMPLIANT_QUALIFIED_INVOCATION.trimIndent()
+            )
+        assertThat(contextFreeFindings).hasSize(1)
+        assertThat(contextFreeFindings[0].issue.description).isEqualTo(MozillaBannedMethodInvocation.DESCR)
+    }
+
+    @Test
+    internal fun `match of chained banned method qualified invocation through allowed method qualified invocation should warn if there is a context`() {
+        var rule = MozillaBannedMethodInvocation(YamlConfig.loadResource(this.javaClass.getResource("/config.yml")))
+        rule.configure()
+        rule.validate()
+
+        val contextualFindings =
+            rule.compileAndLintWithContext(
+                KtTestCompiler.createEnvironment().env,
+                NONCOMPLIANT_CHAINED_QUALIFIED_INVOCATION.trimIndent()
+            )
+        assertThat(contextualFindings).hasSize(1)
+        assertThat(contextualFindings[0].issue.description).isEqualTo(MozillaBannedMethodInvocation.DESCR)
+
+        // This will not warn because "Foo.allowedMethod().bannedMethodY()" will be checked literally
+        // because there is no resolution context to determine that bannedMethodY is actually
+        // TestFoo.Foo.bannedMethodY. Our regular expression does not match in this case.
+        val contextFreeFindings =
+            rule.lint(
+                NONCOMPLIANT_CHAINED_QUALIFIED_INVOCATION.trimIndent()
+            )
+        assertThat(contextFreeFindings).hasSize(0)
+    }
+
+    @Test
+    internal fun `match of banned method direct invocation should warn`() {
+        var rule = MozillaBannedMethodInvocation(YamlConfig.loadResource(this.javaClass.getResource("/config.yml")))
+        rule.configure()
+        rule.validate()
+
+        val contextualFindings =
+            rule.compileAndLintWithContext(
+                KtTestCompiler.createEnvironment().env,
+                NONCOMPLIANT_DIRECT_INVOCATION.trimIndent()
+            )
+        assertThat(contextualFindings).hasSize(1)
+        assertThat(contextualFindings[0].issue.description).isEqualTo(MozillaBannedMethodInvocation.DESCR)
+
+        val contextFreeFindings =
+            rule.lint(
+                NONCOMPLIANT_DIRECT_INVOCATION.trimIndent()
+            )
+        assertThat(contextFreeFindings).hasSize(1)
+    }
+
+    @DisplayName("compliant ")
+    @MethodSource("compliantProvider")
+    @ParameterizedTest(name = "{1} should not warn")
+    internal fun testCompliantWhen(source: String) {
+        var rule = MozillaBannedMethodInvocation(YamlConfig.loadResource(this.javaClass.getResource("/config.yml")))
+        rule.configure()
+        rule.validate()
+
+        val findings =
+            rule.compileAndLintWithContext(
+                KtTestCompiler.createEnvironment().env,
+                source
+            )
+        assertThat(findings).isEmpty()
+    }
+
+    companion object {
+        @JvmStatic
+        fun compliantProvider(): Stream<Arguments> =
+            Stream.of(
+                arguments(COMPLIANT_QUALIFIED_INVOCATION, "Allowed qualified method invocation"),
+                arguments(COMPLIANT_DIRECT_INVOCATION, "Allowed direct method invocation"),
+                arguments(COMPLIANT_MISCONFIGURED_INVOCATION, "match of misconfigured banned method direct invocation")
+            )
+    }
+}
+
+const val NONCOMPLIANT_QUALIFIED_INVOCATION = """
+        class TestFoo {
+            lateinit var x: String
+            object Foo {
+                val property: Boolean = false
+                fun bannedMethodX(): Boolean {
+                    return false
+                }
+                fun bannedMethodY(): Boolean {
+                    return false
+                }
+                fun allowedMethod(): Foo {
+                    return this
+                }
+            }
+            init {
+                if (Foo.bannedMethodX()) {
+                    x = "banned"
+                }
+                if (Foo.property) {
+                    x = "banned"
+                }
+            }
+        }
+        """
+const val NONCOMPLIANT_CHAINED_QUALIFIED_INVOCATION = """
+        class TestFoo {
+            lateinit var x: String
+            object Foo {
+                val property: Boolean = false
+                fun bannedMethodX(): Boolean {
+                    return false
+                }
+                fun bannedMethodY(): Boolean {
+                    return false
+                }
+                fun allowedMethod(): Foo {
+                    return this
+                }
+            }
+            init {
+                if (Foo.allowedMethod().bannedMethodY()) {
+                    x = "banned"
+                }
+                if (Foo.property) {
+                    x = "banned"
+                }
+            }
+        }
+        """
+const val COMPLIANT_QUALIFIED_INVOCATION = """
+        class TestFoo {
+            lateinit var x: String
+            object Foo {
+                val property: Boolean = false
+                fun bannedMethodX(): Boolean {
+                    return false
+                }
+                fun bannedMethodY(): Boolean {
+                    return false
+                }
+                fun allowedMethod(): Foo {
+                    return this
+                }
+            }
+            init {
+                if (Foo.allowedMethod()) {
+                    x = "banned"
+                }
+                if (Foo.property) {
+                    x = "banned"
+                }
+            }
+        }
+        """
+const val NONCOMPLIANT_DIRECT_INVOCATION = """
+        var x: String = ""
+        fun forbidden(): Boolean {
+            return true
+        }
+        fun doer() {
+            if (forbidden()) {
+                x = "allowed"
+            }
+        }
+        fun doer() {
+            if (allowed()) {
+                x = "allowed"
+            }
+        }
+        """
+const val COMPLIANT_DIRECT_INVOCATION = """
+        var x: String = ""
+        fun allowed(): Boolean {
+            return true
+        }
+        fun doer() {
+            if (allowed()) {
+                x = "allowed"
+            }
+        }
+        """
+const val COMPLIANT_MISCONFIGURED_INVOCATION = """
+        var x: String = ""
+        fun misconfigured(): Boolean {
+            return true
+        }
+        fun doer() {
+            if (misconfigured()) {
+                x = "allowed"
+            }
+        }
+        """


### PR DESCRIPTION
This custom Detekt plugin allows us to search Fenix for the use of
methods that we deem objectionable, in some way. The configuration
for this plugin is a comma-separated list of regular expressions that
describe the methods that are not allowed to be used.

![Screenshot from 2020-01-31 04-15-29](https://user-images.githubusercontent.com/8715530/73527047-5bcb3200-43e0-11ea-82c8-6a0c82834958.png)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture