### PR TITLE
Closes #8066: disable failing UI Bookmarks tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
@@ -11,6 +11,7 @@ import mozilla.appservices.places.BookmarkRoot
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.ext.bookmarkStorage
@@ -269,6 +270,7 @@ class BookmarksTest {
         }
     }
 
+    @Ignore("Temp disable: Nexus 6 failures - issue: https://github.com/mozilla-mobile/fenix/issues/7417")
     @Test
     fun deleteMultipleSelectionTest() {
         val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
@@ -315,6 +317,7 @@ class BookmarksTest {
         }
     }
 
+    @Ignore("Temp disable: Nexus 6 failures - issue: https://github.com/mozilla-mobile/fenix/issues/7417")
     @Test
     fun multipleBookmarkDeletions() {
         homeScreen {


### PR DESCRIPTION
See https://github.com/mozilla-mobile/fenix/issues/7417