### PR TITLE
Fix #7613 - Align radio buttons with the theme images

### DIFF
--- a/app/src/main/res/layout/onboarding_theme_picker.xml
+++ b/app/src/main/res/layout/onboarding_theme_picker.xml
@@ -52,12 +52,10 @@
         android:layout_height="wrap_content"
         android:contentDescription="@string/onboarding_theme_light_title"
         android:elevation="1dp"
-        app:layout_constraintBottom_toBottomOf="@+id/theme_light_image"
-        app:layout_constraintCircle="@id/theme_light_image"
-        app:layout_constraintCircleAngle="298"
-        app:layout_constraintCircleRadius="66dp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/description_text"
+        android:translationX="-7dp"
+        android:translationY="-8dp"
+        app:layout_constraintStart_toStartOf="@+id/theme_light_image"
+        app:layout_constraintTop_toTopOf="@+id/theme_light_image"
         app:onboardingKey="@string/pref_key_light_theme" />
 
     <ImageButton
@@ -80,12 +78,10 @@
         android:layout_height="wrap_content"
         android:contentDescription="@string/onboarding_theme_dark_title"
         android:elevation="1dp"
-        app:layout_constraintBottom_toBottomOf="@+id/theme_dark_image"
-        app:layout_constraintCircle="@id/theme_dark_image"
-        app:layout_constraintCircleAngle="298"
-        app:layout_constraintCircleRadius="66dp"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/description_text"
+        android:translationX="-7dp"
+        android:translationY="-8dp"
+        app:layout_constraintStart_toStartOf="@+id/theme_dark_image"
+        app:layout_constraintTop_toTopOf="@+id/theme_dark_image"
         app:onboardingKey="@string/pref_key_dark_theme" />
 
     <ImageButton


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR doesn't include tests as it encompasses just small layout changes.
- [x] **Screenshots**: This PR includes a screenshot showing the result (radio button for Light theme) vs current layout (radio buton for Dark theme.
- [x] **Accessibility**: The code in this PR follows [accessibility best practices]. (Brings no changes in this regard)

<img width="867" alt="Screenshot 2020-02-04 at 15 31 49" src="https://user-images.githubusercontent.com/11428869/73759154-32116280-4774-11ea-9c5b-e0335268d9a6.png">

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
