### PR TITLE
Prepare to use minidump_stackwalk toolchain artifact rather than tooltool package

### DIFF
--- a/taskcluster/ci/raptor/kind.yml
+++ b/taskcluster/ci/raptor/kind.yml
@@ -8,6 +8,7 @@ transforms:
 
 kind-dependencies:
     - signing
+    - toolchain
 
 only-for-build-types:
     - performance-test
@@ -19,6 +20,7 @@ only-for-abis:
 job-defaults:
     dependencies:
         geckoview-nightly: geckoview-nightly
+        linux64-minidump-stackwalk: toolchain-linux64-minidump-stackwalk
     notify:
         by-level:
             '3':
@@ -76,6 +78,9 @@ job-defaults:
             - '--binary=org.mozilla.fenix.performancetest'
             - '--activity=org.mozilla.fenix.browser.BrowserPerformanceTestActivity'
             - '--download-symbols=ondemand'
+    fetches:
+        linux64-minidump-stackwalk:
+            - artifact: minidump_stackwalk.tar.xz
 
 jobs:
     tp6m-1-cold:

--- a/taskcluster/ci/toolchain/kind.yml
+++ b/taskcluster/ci/toolchain/kind.yml
@@ -1,0 +1,11 @@
+---
+loader: taskgraph.loader.transform:loader
+transforms:
+    - taskgraph.transforms.index_search:transforms
+    - taskgraph.transforms.task:transforms
+
+jobs:
+    linux64-minidump-stackwalk:
+        description: "minidump_stackwalk toolchain"
+        index-search:
+            - gecko.cache.level-3.toolchains.v3.linux64-minidump-stackwalk.latest


### PR DESCRIPTION
Bug 1525218 is changing mozilla-central to use minidump_stackwalk toolchain artifacts instead of tooltool packages, and both fenix and reference-browser broke when that landed because the new mozharness code expected the toolchain artifacts that their taskgraph doesn't know about. This is about adding them.