### PR TITLE
For issue #8097: Run add-ons callbacks only when the fragment is attached.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/addons/AddonsManagementFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/addons/AddonsManagementFragment.kt
@@ -9,12 +9,13 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.Navigation
 import androidx.recyclerview.widget.LinearLayoutManager
 import kotlinx.android.synthetic.main.fragment_add_ons_management.*
 import kotlinx.android.synthetic.main.fragment_add_ons_management.view.*
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.launch
 import mozilla.components.feature.addons.Addon
 import mozilla.components.feature.addons.AddonManagerException
@@ -31,7 +32,6 @@ import org.mozilla.fenix.ext.showToolbar
  */
 @Suppress("TooManyFunctions")
 class AddonsManagementFragment : Fragment(), AddonsManagerAdapterDelegate {
-    private val scope = CoroutineScope(Dispatchers.IO)
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -77,11 +77,11 @@ class AddonsManagementFragment : Fragment(), AddonsManagerAdapterDelegate {
     private fun bindRecyclerView(view: View) {
         val recyclerView = view.add_ons_list
         recyclerView.layoutManager = LinearLayoutManager(requireContext())
-        scope.launch {
+        lifecycleScope.launch(IO) {
             try {
                 val addons = requireContext().components.addonManager.getAddons()
 
-                scope.launch(Dispatchers.Main) {
+                lifecycleScope.launch(Dispatchers.Main) {
                     val adapter = AddonsManagerAdapter(
                         requireContext().components.addonCollectionProvider,
                         this@AddonsManagementFragment,
@@ -90,7 +90,7 @@ class AddonsManagementFragment : Fragment(), AddonsManagerAdapterDelegate {
                     recyclerView.adapter = adapter
                 }
             } catch (e: AddonManagerException) {
-                scope.launch(Dispatchers.Main) {
+                lifecycleScope.launch(Dispatchers.Main) {
                     showSnackBar(view, getString(R.string.mozac_feature_addons_failed_to_query_add_ons))
                 }
             }
@@ -153,15 +153,14 @@ class AddonsManagementFragment : Fragment(), AddonsManagerAdapterDelegate {
                         )
                     )
                     bindRecyclerView(view)
+                    addonProgressOverlay?.visibility = View.GONE
                 }
-
-                addonProgressOverlay?.visibility = View.GONE
             },
             onError = { _, _ ->
                 this@AddonsManagementFragment.view?.let { view ->
                     showSnackBar(view, getString(R.string.mozac_feature_addons_failed_to_install, addon.translatedName))
+                    addonProgressOverlay?.visibility = View.GONE
                 }
-                addonProgressOverlay?.visibility = View.GONE
             }
         )
     }

--- a/app/src/main/java/org/mozilla/fenix/addons/Extensions.kt
+++ b/app/src/main/java/org/mozilla/fenix/addons/Extensions.kt
@@ -5,6 +5,7 @@
 package org.mozilla.fenix.addons
 
 import android.view.View
+import androidx.fragment.app.Fragment
 import org.mozilla.fenix.components.FenixSnackbar
 import java.text.NumberFormat
 import java.util.Locale
@@ -28,4 +29,15 @@ internal fun showSnackBar(view: View, text: String) {
     FenixSnackbar.make(view, FenixSnackbar.LENGTH_SHORT)
         .setText(text)
         .show()
+}
+
+/**
+ * Run the [block] only if the [Fragment] is attached.
+ *
+ * @param block A callback to be executed if the container [Fragment] is attached.
+ */
+internal inline fun Fragment.runIfFragmentIsAttached(block: () -> Unit) {
+    context?.let {
+        block()
+    }
 }

--- a/app/src/main/java/org/mozilla/fenix/addons/InstalledAddonDetailsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/addons/InstalledAddonDetailsFragment.kt
@@ -62,36 +62,56 @@ class InstalledAddonDetailsFragment : Fragment() {
                 requireContext().components.addonManager.enableAddon(
                     addon,
                     onSuccess = {
-                        switch.setState(true)
-                        this.addon = it
-                        showSnackBar(
-                            view,
-                            getString(R.string.mozac_feature_addons_successfully_enabled, addon.translatedName)
-                        )
+                        runIfFragmentIsAttached {
+                            switch.setState(true)
+                            this.addon = it
+                            showSnackBar(
+                                view,
+                                getString(
+                                    R.string.mozac_feature_addons_successfully_enabled,
+                                    addon.translatedName
+                                )
+                            )
+                        }
                     },
                     onError = {
-                        showSnackBar(
-                            view,
-                            getString(R.string.mozac_feature_addons_failed_to_enable, addon.translatedName)
-                        )
+                        runIfFragmentIsAttached {
+                            showSnackBar(
+                                view,
+                                getString(
+                                    R.string.mozac_feature_addons_failed_to_enable,
+                                    addon.translatedName
+                                )
+                            )
+                        }
                     }
                 )
             } else {
                 requireContext().components.addonManager.disableAddon(
                     addon,
                     onSuccess = {
-                        switch.setState(false)
-                        this.addon = it
-                        showSnackBar(
-                            view,
-                            getString(R.string.mozac_feature_addons_successfully_disabled, addon.translatedName)
-                        )
+                        runIfFragmentIsAttached {
+                            switch.setState(false)
+                            this.addon = it
+                            showSnackBar(
+                                view,
+                                getString(
+                                    R.string.mozac_feature_addons_successfully_disabled,
+                                    addon.translatedName
+                                )
+                            )
+                        }
                     },
                     onError = {
-                        showSnackBar(
-                            view,
-                            getString(R.string.mozac_feature_addons_failed_to_disable, addon.translatedName)
-                        )
+                        runIfFragmentIsAttached {
+                            showSnackBar(
+                                view,
+                                getString(
+                                    R.string.mozac_feature_addons_failed_to_disable,
+                                    addon.translatedName
+                                )
+                            )
+                        }
                     }
                 )
             }
@@ -136,20 +156,27 @@ class InstalledAddonDetailsFragment : Fragment() {
             requireContext().components.addonManager.uninstallAddon(
                 addon,
                 onSuccess = {
-                    showSnackBar(
-                        view,
-                        getString(R.string.mozac_feature_addons_successfully_uninstalled, addon.translatedName)
-                    )
-                    view.findNavController().popBackStack()
+                    runIfFragmentIsAttached {
+                        showSnackBar(
+                            view,
+                            getString(
+                                R.string.mozac_feature_addons_successfully_uninstalled,
+                                addon.translatedName
+                            )
+                        )
+                        view.findNavController().popBackStack()
+                    }
                 },
                 onError = { _, _ ->
-                    showSnackBar(
-                        view,
-                        getString(
-                            R.string.mozac_feature_addons_failed_to_uninstall,
-                            addon.translatedName
+                    runIfFragmentIsAttached {
+                        showSnackBar(
+                            view,
+                            getString(
+                                R.string.mozac_feature_addons_failed_to_uninstall,
+                                addon.translatedName
+                            )
                         )
-                    )
+                    }
                 }
             )
         }


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture