### PR TITLE
Use createBlendModeColorFilterCompat 

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/collections/SaveCollectionListAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/collections/SaveCollectionListAdapter.kt
@@ -4,10 +4,11 @@
 
 package org.mozilla.fenix.collections
 
-import android.graphics.PorterDuff.Mode.SRC_IN
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.graphics.BlendModeColorFilterCompat.createBlendModeColorFilterCompat
+import androidx.core.graphics.BlendModeCompat.SRC_IN
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.android.synthetic.main.collections_list_item.view.*
 import mozilla.components.feature.tab.collections.TabCollection
@@ -52,11 +53,8 @@ class CollectionViewHolder(view: View) : RecyclerView.ViewHolder(view) {
     fun bind(collection: TabCollection) {
         itemView.collection_item.text = collection.title
         itemView.collection_description.text = collection.description(itemView.context)
-
-        itemView.collection_icon.setColorFilter(
-            collection.getIconColor(itemView.context),
-            SRC_IN
-        )
+        itemView.collection_icon.colorFilter =
+            createBlendModeColorFilterCompat(collection.getIconColor(itemView.context), SRC_IN)
     }
 
     companion object {

--- a/app/src/main/java/org/mozilla/fenix/ext/Toolbar.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/Toolbar.kt
@@ -5,13 +5,13 @@
 package org.mozilla.fenix.ext
 
 import android.graphics.ColorFilter
-import android.graphics.PorterDuff
-import android.graphics.PorterDuffColorFilter
 import android.widget.ActionMenuView
 import android.widget.ImageButton
 import androidx.annotation.ColorInt
 import androidx.appcompat.view.menu.ActionMenuItemView
 import androidx.appcompat.widget.Toolbar
+import androidx.core.graphics.BlendModeColorFilterCompat.createBlendModeColorFilterCompat
+import androidx.core.graphics.BlendModeCompat.SRC_IN
 import androidx.core.view.forEach
 
 /**
@@ -22,7 +22,7 @@ fun Toolbar.setToolbarColors(@ColorInt foreground: Int, @ColorInt background: In
         setBackgroundColor(background)
         setTitleTextColor(foreground)
 
-        val colorFilter = PorterDuffColorFilter(foreground, PorterDuff.Mode.SRC_IN)
+        val colorFilter = createBlendModeColorFilterCompat(foreground, SRC_IN)
         overflowIcon?.colorFilter = colorFilter
         forEach { child ->
             when (child) {
@@ -33,7 +33,7 @@ fun Toolbar.setToolbarColors(@ColorInt foreground: Int, @ColorInt background: In
     }
 }
 
-private fun themeActionMenuView(item: ActionMenuView, colorFilter: ColorFilter) {
+private fun themeActionMenuView(item: ActionMenuView, colorFilter: ColorFilter?) {
     item.forEach { innerChild ->
         if (innerChild is ActionMenuItemView) {
             innerChild.compoundDrawables.forEach { drawable ->

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/CollectionViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/CollectionViewHolder.kt
@@ -5,9 +5,10 @@
 package org.mozilla.fenix.home.sessioncontrol.viewholders
 
 import android.content.Context
-import android.graphics.PorterDuff.Mode.SRC_IN
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.graphics.BlendModeColorFilterCompat.createBlendModeColorFilterCompat
+import androidx.core.graphics.BlendModeCompat.SRC_IN
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.android.extensions.LayoutContainer
 import kotlinx.android.synthetic.main.collection_home_list_row.*
@@ -89,7 +90,7 @@ class CollectionViewHolder(
             view.collection_description.visibility = View.VISIBLE
         }
 
-        view.collection_icon.setColorFilter(
+        view.collection_icon.colorFilter = createBlendModeColorFilterCompat(
             collection.getIconColor(view.context),
             SRC_IN
         )

--- a/app/src/main/java/org/mozilla/fenix/share/viewholders/AccountDeviceViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/share/viewholders/AccountDeviceViewHolder.kt
@@ -5,10 +5,11 @@
 package org.mozilla.fenix.share.viewholders
 
 import android.content.Context
-import android.graphics.PorterDuff
 import android.view.View
 import androidx.annotation.VisibleForTesting
-import androidx.core.content.ContextCompat
+import androidx.core.content.ContextCompat.getColor
+import androidx.core.graphics.BlendModeColorFilterCompat.createBlendModeColorFilterCompat
+import androidx.core.graphics.BlendModeCompat.SRC_IN
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.android.synthetic.main.account_share_list_item.view.*
 import mozilla.components.concept.sync.DeviceType
@@ -51,8 +52,8 @@ class AccountDeviceViewHolder(
 
         itemView.deviceIcon.apply {
             setImageResource(drawableRes)
-            background.setColorFilter(ContextCompat.getColor(context, colorRes), PorterDuff.Mode.SRC_IN)
-            drawable.setTint(ContextCompat.getColor(context, R.color.device_foreground))
+            background.colorFilter = createBlendModeColorFilterCompat(getColor(context, colorRes), SRC_IN)
+            drawable.setTint(getColor(context, R.color.device_foreground))
         }
         itemView.isClickable = option != SyncShareOption.Offline
         itemView.deviceName.text = name

--- a/app/src/main/java/org/mozilla/fenix/utils/ClearableEditText.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/ClearableEditText.kt
@@ -6,13 +6,13 @@ package org.mozilla.fenix.utils
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.graphics.PorterDuff.Mode.SRC_IN
-import android.graphics.PorterDuffColorFilter
 import android.util.AttributeSet
 import android.view.MotionEvent
 import android.view.MotionEvent.ACTION_UP
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.appcompat.widget.AppCompatEditText
+import androidx.core.graphics.BlendModeColorFilterCompat.createBlendModeColorFilterCompat
+import androidx.core.graphics.BlendModeCompat.SRC_IN
 import mozilla.components.support.ktx.android.view.putCompoundDrawablesRelativeWithIntrinsicBounds
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.getColorFromAttr
@@ -46,10 +46,9 @@ class ClearableEditText @JvmOverloads constructor(
      * Displays a clear icon if text has been entered.
      */
     override fun onTextChanged(text: CharSequence?, start: Int, lengthBefore: Int, lengthAfter: Int) {
-        super.onTextChanged(text, start, lengthBefore, lengthAfter)
         val drawable = if (shouldShowClearButton(lengthAfter)) {
             AppCompatResources.getDrawable(context, R.drawable.ic_clear)?.apply {
-                colorFilter = PorterDuffColorFilter(context.getColorFromAttr(R.attr.primaryText), SRC_IN)
+                colorFilter = createBlendModeColorFilterCompat(context.getColorFromAttr(R.attr.primaryText), SRC_IN)
             }
         } else {
             null


### PR DESCRIPTION
`setColorFilter` and `PorterDuffColorFilter` are deprecated in Android Q. This makes it easier to switch to Q down the line.

`AwesomeBarView` also has some slight tweaks to better use kotlin functions.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture