### PR TITLE
For #7511 - Override private customtab icon tint

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabsIntegration.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabsIntegration.kt
@@ -72,7 +72,13 @@ class CustomTabsIntegration(
         // See #5334
         if (isPrivate) {
             sessionManager.findSessionById(sessionId)?.apply {
-                customTabConfig = customTabConfig?.copy(toolbarColor = null)
+                val config = customTabConfig
+                customTabConfig = config?.copy(
+                    // Don't set toolbar background automatically
+                    toolbarColor = null,
+                    // Force tinting the action button
+                    actionButtonConfig = config.actionButtonConfig?.copy(tint = true)
+                )
             }
 
             toolbar.background = AppCompatResources.getDrawable(


### PR DESCRIPTION
This sets the `tint` flag so AC can add a tint later. That relies on code in master but seemingly not in the current AC version Fenix uses (or maybe Gradle sync wasn't working for me).

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture