### PR TITLE
Update to Mozilla Android Components 31.0.0-SNAPSHOT..

### DIFF
--- a/app/src/migration/java/org/mozilla/fenix/MigratingFenixApplication.kt
+++ b/app/src/migration/java/org/mozilla/fenix/MigratingFenixApplication.kt
@@ -28,6 +28,7 @@ class MigratingFenixApplication : FenixApplication() {
                 this.components.addonUpdater
             )
             .migrateTelemetryIdentifiers()
+            .migrateSearchEngine(this.components.search.searchEngineManager)
             .build()
     }
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -32,7 +32,7 @@ object Versions {
     const val androidx_work = "2.2.0"
     const val google_material = "1.1.0-beta01"
 
-    const val mozilla_android_components = "30.0.0-SNAPSHOT"
+    const val mozilla_android_components = "31.0.0-SNAPSHOT"
     // Note that android-components also depends on application-services,
     // and in fact is our main source of appservices-related functionality.
     // The version number below tracks the application-services version


### PR DESCRIPTION
Updating to the latest snapshot version and enabling the default search engine migration: https://github.com/mozilla-mobile/android-components/issues/5818