### PR TITLE
Fix for #5695 - Migration steps' status displayed before the migration completed 

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/migration/MigrationProgressActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/migration/MigrationProgressActivity.kt
@@ -102,7 +102,13 @@ internal fun MigrationResults.toItemList() = filterKeys {
         type,
         status.success
     )
-}
+}.toMutableList()
+    .plus(
+        whiteList
+            .filterKeys { !this.containsKey(it) }
+            .keys
+            .map { MigrationItem(it, false) }
+    ).sortedBy { it.migration.javaClass.simpleName }
 
 internal data class MigrationItem(val migration: Migration, val status: Boolean)
 


### PR DESCRIPTION
The migration steps' status was already being shown as succeeded instead of showing an "unchecked" list of steps.
These changes will make the steps being "checked" only after the migration completed by starting
with an "unchecked" list.

- [x] **Tests**: This is already covered by tests.
- [x] **Screenshots**: This PR isn't adding any new visual changes just behavioral.
- [x] **Accessibility**: The code in this PR does not include any **new** user facing features.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture