### PR TITLE
Closes #8162: Add shortcuts.xml for fennecBeta variant..

### DIFF
--- a/app/src/fennecBeta/res/xml/shortcuts.xml
+++ b/app/src/fennecBeta/res/xml/shortcuts.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+    <shortcut
+        android:shortcutId="open_new_tab"
+        android:enabled="true"
+        android:icon="@drawable/ic_static_shortcut_tab"
+        android:shortcutShortLabel="@string/home_screen_shortcut_open_new_tab_2"
+        android:shortcutLongLabel="@string/home_screen_shortcut_open_new_tab_2">
+        <intent
+            android:action="org.mozilla.fenix.OPEN_TAB"
+            android:targetPackage="org.mozilla.firefox_beta"
+            android:targetClass="org.mozilla.fenix.IntentReceiverActivity" />
+    </shortcut>
+    <shortcut
+        android:shortcutId="open_new_private_tab"
+        android:enabled="true"
+        android:icon="@drawable/ic_static_shortcut_private_tab"
+        android:shortcutShortLabel="@string/home_screen_shortcut_open_new_private_tab_2"
+        android:shortcutLongLabel="@string/home_screen_shortcut_open_new_private_tab_2">
+        <intent
+            android:action="org.mozilla.fenix.OPEN_PRIVATE_TAB"
+            android:targetPackage="org.mozilla.firefox_beta"
+            android:targetClass="org.mozilla.fenix.IntentReceiverActivity" />
+    </shortcut>
+</shortcuts>


### PR DESCRIPTION
Like we did for `fennecNightly` before, now for `fennecBeta`: We have override versions for all our build variants since those files contain the package name. So we needed one for the `fennecBeta` variant too. Tested that now shortcuts are working when using a `fennecBeta` build.