### PR TITLE
NOISSUE - Updated misspelled variable name in Custom tab Doorhanger

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/quicksettings/WebsitePermissionsView.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/quicksettings/WebsitePermissionsView.kt
@@ -62,7 +62,7 @@ class WebsitePermissionsView(
         // If more permissions are added into this View we can display them into a list
         // and also use DiffUtil to only update one item in case of a permission change
         bindPermission(state.camera,
-                Pair(view.findViewById(R.id.cameraLabel), view.findViewById(R.id.camerStatus)))
+                Pair(view.findViewById(R.id.cameraLabel), view.findViewById(R.id.cameraStatus)))
         bindPermission(state.location,
                 Pair(view.findViewById(R.id.locationLabel), view.findViewById(R.id.locationStatus)))
         bindPermission(state.microphone,

--- a/app/src/main/res/layout/quicksettings_permissions.xml
+++ b/app/src/main/res/layout/quicksettings_permissions.xml
@@ -12,7 +12,7 @@
     android:layout_height="wrap_content">
 
     <TextView
-        android:id="@+id/camerStatus"
+        android:id="@+id/cameraStatus"
         style="@style/QuickSettingsText.PermissionItemEnd"
         android:layout_width="wrap_content"
         android:layout_height="@dimen/quicksettings_item_height"
@@ -32,7 +32,7 @@
         android:text="@string/preference_phone_feature_camera"
         android:visibility="gone"
         app:layout_constraintBottom_toTopOf="@id/microphoneLabel"
-        app:layout_constraintEnd_toStartOf="@id/camerStatus"
+        app:layout_constraintEnd_toStartOf="@id/cameraStatus"
         app:layout_constraintStart_toStartOf="parent"
         tools:visibility="visible" />
 


### PR DESCRIPTION
The ID of the camera status variable was named camerStatus instead of cameraStatus.