### PR TITLE
For issue #8221: Fix crash in the AddonsManagementFragment when binding the RecyclerView after the fragment is not attached anymore

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/addons/AddonsManagementFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/addons/AddonsManagementFragment.kt
@@ -76,26 +76,26 @@ class AddonsManagementFragment : Fragment(R.layout.fragment_add_ons_management),
         lifecycleScope.launch(IO) {
             try {
                 val addons = requireContext().components.addonManager.getAddons()
-
                 lifecycleScope.launch(Dispatchers.Main) {
-                    val adapter = AddonsManagerAdapter(
-                        requireContext().components.addonCollectionProvider,
-                        this@AddonsManagementFragment,
-                        addons
-                    )
-                    view.add_ons_progress_bar.isVisible = false
-                    view.add_ons_empty_message.isVisible = false
+                    runIfFragmentIsAttached {
+                        val adapter = AddonsManagerAdapter(
+                            requireContext().components.addonCollectionProvider,
+                            this@AddonsManagementFragment,
+                            addons
+                        )
+                        view.add_ons_progress_bar.isVisible = false
+                        view.add_ons_empty_message.isVisible = false
 
-                    recyclerView.adapter = adapter
+                        recyclerView.adapter = adapter
+                    }
                 }
             } catch (e: AddonManagerException) {
                 lifecycleScope.launch(Dispatchers.Main) {
-                    showSnackBar(
-                        view,
-                        getString(R.string.mozac_feature_addons_failed_to_query_add_ons)
-                    )
-                    view.add_ons_progress_bar.isVisible = false
-                    view.add_ons_empty_message.isVisible = true
+                    runIfFragmentIsAttached {
+                        showSnackBar(view, getString(R.string.mozac_feature_addons_failed_to_query_add_ons))
+                        view.add_ons_progress_bar.isVisible = false
+                        view.add_ons_empty_message.isVisible = true
+                    }
                 }
             }
         }
@@ -165,13 +165,7 @@ class AddonsManagementFragment : Fragment(R.layout.fragment_add_ons_management),
             },
             onError = { _, _ ->
                 this@AddonsManagementFragment.view?.let { view ->
-                    showSnackBar(
-                        view,
-                        getString(
-                            R.string.mozac_feature_addons_failed_to_install,
-                            addon.translatedName
-                        )
-                    )
+                    showSnackBar(view, getString(R.string.mozac_feature_addons_failed_to_install, addon.translatedName))
                     addonProgressOverlay?.visibility = View.GONE
                     isInstallationInProgress = false
                 }


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture