### PR TITLE
No Issue: Updated About Settings Tests to check if a view is completely displayed.

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
@@ -17,6 +17,7 @@ import androidx.test.espresso.intent.Intents.intended
 import androidx.test.espresso.intent.matcher.IntentMatchers.toPackage
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.Visibility
+import androidx.test.espresso.matcher.ViewMatchers.isCompletelyDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.By
@@ -250,19 +251,19 @@ private fun assertRemoteDebug() {
 private fun assertAboutHeading(): ViewInteraction {
     TestHelper.scrollToElementByText("About")
     return onView(ViewMatchers.withText("About"))
-        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+        .check(matches(isCompletelyDisplayed()))
 }
 
 private fun assertRateOnGooglePlay(): ViewInteraction {
     TestHelper.scrollToElementByText("About Firefox Preview")
     return onView(ViewMatchers.withText("Rate on Google Play"))
-        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+        .check(matches(isCompletelyDisplayed()))
 }
 
 private fun assertAboutFirefoxPreview(): ViewInteraction {
     TestHelper.scrollToElementByText("About Firefox Preview")
     return onView(ViewMatchers.withText("About Firefox Preview"))
-        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+        .check(matches(isCompletelyDisplayed()))
 }
 
 fun swipeToBottom() = onView(ViewMatchers.withId(R.id.recycler_view)).perform(ViewActions.swipeUp())


### PR DESCRIPTION
Issue: https://console.firebase.google.com/u/0/project/moz-fenix/testlab/histories/bh.66b7091e15d53d45/matrices/5594099043841240865/executions/bs.f4119e7c0097182f/testcases/1/test-cases

When the recyclerview is scrolled to any of the items it should be fully visible to the user.