### PR TITLE
For #7207 - Use accessible color for about links in dark mode

### DIFF
--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -13,6 +13,7 @@
     <color name="accent_normal_theme">@color/accent_dark_theme</color>
     <color name="accent_bright_normal_theme">@color/accent_bright_dark_theme</color>
     <color name="accent_high_contrast_normal_theme">@color/accent_high_contrast_dark_theme</color>
+    <color name="about_link_normal_theme">@color/about_link_dark_theme</color>
     <color name="tab_ring_normal_theme">@color/tab_ring_dark_theme</color>
     <color name="neutral_normal_theme">@color/neutral_dark_theme</color>
     <color name="neutral_faded_normal_theme">@color/neutral_faded_dark_theme</color>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -9,6 +9,7 @@
     <attr name="contrastText" format="reference" />
     <attr name="accent" format="reference" />
     <attr name="accentBright" format="reference" />
+    <attr name="aboutLink" format="reference" />
     <attr name="accentHighContrast" format="reference" />
     <attr name="accentUsedOnDarkBackground" format="reference" />
     <attr name="tabRing" format="reference" />

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -12,6 +12,7 @@
     <color name="above_light_theme">#FFF</color>
     <color name="accent_light_theme">#312A65</color>
     <color name="accent_bright_light_theme">#592ACB</color>
+    <color name="about_link_normal_theme">#592ACB</color>
     <color name="accent_high_contrast_light_theme">@color/accent_light_theme</color>
     <color name="tab_ring_light_theme">@color/accent_light_theme</color>
     <color name="neutral_light_theme">@color/photonGrey30</color>
@@ -44,6 +45,7 @@
     <color name="above_dark_theme">#32313C</color>
     <color name="accent_dark_theme">#9059FF</color>
     <color name="accent_bright_dark_theme">#592ACB</color>
+    <color name="about_link_dark_theme">#AB71FF</color>
     <color name="accent_high_contrast_dark_theme">#AB71FF</color>
     <color name="tab_ring_dark_theme">@color/accent_dark_theme</color>
     <color name="neutral_dark_theme">@color/photonGrey20</color>
@@ -74,6 +76,7 @@
     <color name="above_private_theme">#291D4F</color>
     <color name="accent_private_theme">#9059FF</color>
     <color name="accent_bright_private_theme">#592ACB</color>
+    <color name="about_link_private_theme">#AB71FF</color>
     <color name="accent_high_contrast_private_theme">#AA71FF</color>
     <color name="tab_ring_private_theme">#F565FF</color>
     <color name="neutral_private_theme">@color/photonGrey20</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -33,6 +33,7 @@
         <item name="contrastText">@color/contrast_text_normal_theme</item>
         <item name="accent">@color/accent_normal_theme</item>
         <item name="accentBright">@color/accent_bright_normal_theme</item>
+        <item name="aboutLink">@color/about_link_normal_theme</item>
         <item name="accentHighContrast">@color/accent_high_contrast_normal_theme</item>
         <item name="foundation">@color/foundation_normal_theme</item>
         <item name="above">@color/above_normal_theme</item>
@@ -120,6 +121,7 @@
         <item name="contrastText">@color/contrast_text_private_theme</item>
         <item name="accent">@color/accent_private_theme</item>
         <item name="accentBright">@color/accent_bright_private_theme</item>
+        <item name="aboutLink">@color/about_link_private_theme</item>
         <item name="accentHighContrast">@color/accent_high_contrast_private_theme</item>
         <item name="foundation">@color/foundation_private_theme</item>
         <item name="above">@color/above_private_theme</item>
@@ -368,7 +370,7 @@
     <style name="ShareDialogStyle" parent="DialogStyleBase"/>
 
     <style name="AboutItemText" parent="TextAppearance.MaterialComponents.Body2">
-        <item name="android:textColor">?accentBright</item>
+        <item name="android:textColor">?aboutLink</item>
         <item name="android:textSize">@dimen/about_items_text_size</item>
         <item name="android:paddingStart">@dimen/about_list_item_text_padding</item>
         <item name="android:paddingEnd">@dimen/about_list_item_text_padding</item>


### PR DESCRIPTION
Supercedes https://github.com/mozilla-mobile/fenix/pull/7550 by @KaairaGupta -- thank you for getting this one started!

![Screenshot_20200207-223450](https://user-images.githubusercontent.com/46655/74071385-5ade6580-49c9-11ea-91c0-b2b90f823188.png)

Uses colors approved by @brampitoyo in previous PR.