### PR TITLE
For #8016 - Prevent duplicate domains from displaying in the collection description on the home screen

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/TabCollectionStorage.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/TabCollectionStorage.kt
@@ -104,5 +104,7 @@ fun TabCollection.description(context: Context): String {
             } else {
                 it
             }
-        }.joinToString(", ")
+        }
+        .distinct()
+        .joinToString(", ")
 }


### PR DESCRIPTION
There's no need to show a domain more than once, especially with limited space

Before:

![Screenshot_20200131-115927](https://user-images.githubusercontent.com/46655/73534918-a7063480-4422-11ea-81dd-33e290876beb.png)


After:



![Screenshot_20200131-120021](https://user-images.githubusercontent.com/46655/73534913-a4a3da80-4422-11ea-9745-cf3a24ed7399.png)


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture