### PR TITLE
No Issue: Create a post-visual completeness executor

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -35,6 +35,7 @@ import org.mozilla.fenix.components.Components
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.session.NotificationSessionObserver
 import org.mozilla.fenix.session.VisibilityLifecycleCallback
+import org.mozilla.fenix.utils.OnVisualCompletenessExecutionQueue
 
 @SuppressLint("Registered")
 @Suppress("TooManyFunctions")
@@ -45,6 +46,8 @@ open class FenixApplication : LocaleAwareApplication() {
 
     var visibilityLifecycleCallback: VisibilityLifecycleCallback? = null
         private set
+
+    var isApplicationVisuallyComplete = false
 
     override fun onCreate() {
         super.onCreate()
@@ -142,6 +145,20 @@ open class FenixApplication : LocaleAwareApplication() {
         // if ((System.currentTimeMillis() - settings().lastPlacesStorageMaintenance) > ONE_DAY_MILLIS) {
         //    runStorageMaintenance()
         // }
+    }
+
+    // This method will be invoked when the application is visually complete. It *should* only be
+    // invoked once, but we will use a flag to make sure that we only execute operations a single
+    // time.
+    fun onApplicationVisuallyComplete() {
+        if (!isApplicationVisuallyComplete) {
+            logger.info("Fenix is visually complete.")
+
+            // Restart any Jobs that are waiting for visual completeness to run.
+            OnVisualCompletenessExecutionQueue.start()
+
+            isApplicationVisuallyComplete = true
+        }
     }
 
     // See https://github.com/mozilla-mobile/fenix/issues/7227 for context.

--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -14,12 +14,14 @@ import androidx.annotation.IdRes
 import androidx.annotation.VisibleForTesting
 import androidx.annotation.VisibleForTesting.PROTECTED
 import androidx.appcompat.widget.Toolbar
+import androidx.core.view.doOnPreDraw
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavDestination
 import androidx.navigation.NavDirections
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.NavigationUI
+import kotlinx.android.synthetic.main.activity_home.*
 import kotlinx.coroutines.launch
 import mozilla.components.browser.search.SearchEngine
 import mozilla.components.browser.session.Session
@@ -62,6 +64,8 @@ import org.mozilla.fenix.settings.about.AboutFragmentDirections
 import org.mozilla.fenix.theme.DefaultThemeManager
 import org.mozilla.fenix.theme.ThemeManager
 import org.mozilla.fenix.utils.BrowsersCache
+import org.mozilla.fenix.ext.application
+import org.mozilla.fenix.ext.asContext
 
 @SuppressWarnings("TooManyFunctions", "LargeClass")
 open class HomeActivity : LocaleAwareAppCompatActivity() {
@@ -110,6 +114,12 @@ open class HomeActivity : LocaleAwareAppCompatActivity() {
                 ?.also { components.analytics.metrics.track(Event.OpenedApp(it)) }
         }
         supportActionBar?.hide()
+
+        // Just before the root container is drawn for the first time, consider Fenix to be visually
+        // complete.
+        rootContainer.doOnPreDraw {
+            this.asContext.application.onApplicationVisuallyComplete()
+        }
     }
 
     @CallSuper

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
@@ -493,6 +493,7 @@ class GleanMetricsService(private val context: Context) : MetricsService {
         gleanInitializer = MainScope().launch {
             Glean.registerPings(Pings)
         }
+
         // setStartupMetrics is not a fast function. It does not need to be done before we can consider
         // ourselves initialized. So, let's do it, well, later.
         gleanSetStartupMetrics = MainScope().launch {

--- a/app/src/main/java/org/mozilla/fenix/ext/Activity.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/Activity.kt
@@ -5,6 +5,7 @@
 package org.mozilla.fenix.ext
 
 import android.app.Activity
+import android.content.Context
 import android.view.View
 import android.view.WindowManager
 
@@ -22,3 +23,9 @@ fun Activity.enterToImmersiveMode() {
             or View.SYSTEM_UI_FLAG_FULLSCREEN
             or View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY)
 }
+
+/**
+ * Get the Activity as a Context.
+ */
+val Activity.asContext
+    get() = this as Context

--- a/app/src/main/java/org/mozilla/fenix/utils/OnVisualCompletenessExecutionQueue.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/OnVisualCompletenessExecutionQueue.kt
@@ -1,0 +1,81 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.utils
+
+import kotlinx.coroutines.Job
+import mozilla.components.support.base.log.Log
+
+/**
+ * A queue of paused `Job`s whose execution is resumed when Fenix is visually complete.
+ *
+ * This queue contains paused `Job`s. Each Job in the queue will be restarted once Fenix
+ * is visually complete (as long as it has not be cancelled since it was added to the queue).
+ * Each Job will execute on the thread on which it was originally scheduled.
+ *
+ * This is threadsafe.
+ */
+object OnVisualCompletenessExecutionQueue {
+    internal var jobs = mutableListOf<Job>()
+    internal var hasExecuted = false
+    private const val visualCompletenessExecutionQueueLogTag = "OnVisualCompletenessExecutionQueue"
+
+    /**
+     * Add a paused Job to the queue
+     *
+     * Add a paused Job to the queue. If the job is not paused, it will *not* be added
+     * to the queue.
+     *
+     * @param j: The paused Job to add to the queue.
+     * @return true if [j] was added to the queue; false otherwise
+     */
+    @Synchronized
+    fun add(j: Job) {
+        if (hasExecuted) {
+            Log.log(
+                Log.Priority.WARN,
+                visualCompletenessExecutionQueueLogTag,
+                null,
+                "Queue already executed. Not adding the Job."
+            )
+            throw VisualCompletenessExecutionQueueException("Queue already executed.")
+        }
+        if (j.isActive || j.isCompleted) {
+            Log.log(
+                Log.Priority.WARN,
+                visualCompletenessExecutionQueueLogTag,
+                null,
+                "Not adding a Job that is active or complete."
+            )
+            throw VisualCompletenessExecutionQueueException("Job is active or complete.")
+        }
+        jobs.add(j)
+    }
+
+    /**
+     * Restart all paused jobs in the queue
+     *
+     * Restart all the paused jobs in the queue. When all the jobs have been started,
+     * clear the queue.
+     */
+    @Synchronized
+    fun start() {
+        jobs.forEach { if (!it.isCancelled) { it.start() } }
+        jobs.clear()
+        hasExecuted = true
+    }
+
+    /**
+     * Reset the state of the queue and clear its jobs
+     *
+     * This is for testing only.
+     */
+    @Synchronized
+    internal fun reset() {
+        jobs.clear()
+        hasExecuted = false
+    }
+}
+
+class VisualCompletenessExecutionQueueException(val failure: String) : Exception()

--- a/app/src/test/java/org/mozilla/fenix/utils/OnVisualCompletenessExecutionQueueTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/utils/OnVisualCompletenessExecutionQueueTest.kt
@@ -1,0 +1,90 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+@file:Suppress("DEPRECATION")
+
+package org.mozilla.fenix.utils
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineStart
+import org.junit.Assert
+import org.junit.Assert.assertTrue
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.fenix.TestApplication
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(application = TestApplication::class)
+class OnVisualCompletenessExecutionQueueTest {
+
+    @Test
+    fun `adding a paused Job to the queue succeeds`() {
+        OnVisualCompletenessExecutionQueue.reset()
+        OnVisualCompletenessExecutionQueue.add(CoroutineScope(Dispatchers.Default).launch(start = CoroutineStart.LAZY) {
+            // This is a do-nothing job!
+        })
+    }
+
+    @Test
+    fun `adding an active (or possibly complete) Job to the queue fails`() {
+        val invalidJob = "Job is active or complete."
+        OnVisualCompletenessExecutionQueue.reset()
+        try {
+            // Depending on how the scheduler goes, this job could be complete by the
+            // time that it is added to the queue.
+            OnVisualCompletenessExecutionQueue.add(CoroutineScope(Dispatchers.Default).launch {
+                // This is a do-nothing job!
+            })
+            Assert.fail("No exception was thrown")
+        } catch (ex: VisualCompletenessExecutionQueueException) {
+            assertEquals(invalidJob, ex.failure)
+        }
+    }
+
+    @Test
+    fun `adding a Job after queue execution fails`() {
+        val invalidQueue = "Queue already executed."
+        OnVisualCompletenessExecutionQueue.reset()
+        OnVisualCompletenessExecutionQueue.add(CoroutineScope(Dispatchers.Default).launch(start = CoroutineStart.LAZY) {
+            // This is a do-nothing job!
+        })
+
+        OnVisualCompletenessExecutionQueue.start()
+
+        try {
+            OnVisualCompletenessExecutionQueue.add(CoroutineScope(Dispatchers.Default).launch(start = CoroutineStart.LAZY) {
+                // This is a do-nothing job!
+            })
+            Assert.fail("No exception was thrown")
+        } catch (ex: VisualCompletenessExecutionQueueException) {
+            assertEquals(invalidQueue, ex.failure)
+        }
+    }
+
+    @Test
+    fun `after queue execution fails internal structures should be empty`() {
+        OnVisualCompletenessExecutionQueue.reset()
+        OnVisualCompletenessExecutionQueue.add(CoroutineScope(Dispatchers.Default).launch(start = CoroutineStart.LAZY) {
+            // This is a do-nothing job!
+        })
+
+        OnVisualCompletenessExecutionQueue.start()
+        assertTrue(OnVisualCompletenessExecutionQueue.jobs.size == 0)
+    }
+
+    @Test
+    fun `after queue execution fails hasExecuted flag should be false`() {
+        OnVisualCompletenessExecutionQueue.reset()
+        OnVisualCompletenessExecutionQueue.add(CoroutineScope(Dispatchers.Default).launch(start = CoroutineStart.LAZY) {
+            // This is a do-nothing job!
+        })
+
+        OnVisualCompletenessExecutionQueue.start()
+        assertTrue(OnVisualCompletenessExecutionQueue.hasExecuted)
+    }
+}


### PR DESCRIPTION
Create an object that will execute its enqueued, paused tasks
when Fenix is visually complete.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture