### PR TITLE
For #1741: Passes 'showDescription' boolean to SearchSuggestionProvider

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarView.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarView.kt
@@ -164,7 +164,8 @@ class AwesomeBarView(
                 fetchClient = components.core.client,
                 mode = SearchSuggestionProvider.Mode.MULTIPLE_SUGGESTIONS,
                 limit = 3,
-                icon = searchDrawable.toBitmap()
+                icon = searchDrawable.toBitmap(),
+                showDescription = false
             )
 
         shortcutsEnginePickerProvider =


### PR DESCRIPTION
Change required for removing description from search suggestion. Implemented
in AC (https://github.com/mozilla-mobile/android-components/pull/5890)



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR does not include thorough tests.
- [x] **Screenshots**: This PR includes screenshots of the changes made.
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).

**Screenshot before**             |  **Screenshot after**
:-------------------------:|:-------------------------:
<img src="https://user-images.githubusercontent.com/52956363/74256634-57661980-4cfc-11ea-9d7f-aabe564ecb40.png" width="300"> | <img src="https://user-images.githubusercontent.com/52956363/74256661-61881800-4cfc-11ea-87fa-ed362d0bcaa1.png" width="300">

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture