### PR TITLE
Closes #8316: Disable animations for instrumented tests

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -150,6 +150,7 @@ android {
     testOptions {
         execution 'ANDROIDX_TEST_ORCHESTRATOR'
         unitTests.includeAndroidResources = true
+        animationsDisabled = true
     }
 
     flavorDimensions "engine"


### PR DESCRIPTION
https://google.github.io/android-gradle-dsl/current/com.android.build.gradle.internal.dsl.TestOptions.html#com.android.build.gradle.internal.dsl.TestOptions:animationsDisabled

```Gradle
android {
  testOptions {
            animationsDisabled = true
  }
}
```

_If you set this property to true, running instrumented tests with Gradle from the command line executes am instrument with the --no-window-animation flag. By default, this property is set to false._

Might help with intermittent flakiness.
