### PR TITLE
Allow fragment to go back when all unsupported add-ons are removed

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/addons/NotYetSupportedAddonFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/addons/NotYetSupportedAddonFragment.kt
@@ -9,6 +9,7 @@ import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.LinearLayoutManager
 import kotlinx.android.synthetic.main.fragment_not_yet_supported_addons.view.*
@@ -28,17 +29,20 @@ class NotYetSupportedAddonFragment :
     Fragment(R.layout.fragment_not_yet_supported_addons), UnsupportedAddonsAdapterDelegate {
 
     private val args by navArgs<NotYetSupportedAddonFragmentArgs>()
+    private var unsupportedAddonsAdapter: UnsupportedAddonsAdapter? = null
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        unsupportedAddonsAdapter = UnsupportedAddonsAdapter(
+            addonManager = requireContext().components.addonManager,
+            unsupportedAddonsAdapterDelegate = this@NotYetSupportedAddonFragment,
+            addons = args.addons.toList()
+        )
+
         view.unsupported_add_ons_list.apply {
             layoutManager = LinearLayoutManager(requireContext())
-            adapter = UnsupportedAddonsAdapter(
-                addonManager = requireContext().components.addonManager,
-                unsupportedAddonsAdapterDelegate = this@NotYetSupportedAddonFragment,
-                addons = args.addons.toList()
-            )
+            adapter = unsupportedAddonsAdapter
         }
 
         view.learn_more_label.setOnClickListener {
@@ -55,6 +59,10 @@ class NotYetSupportedAddonFragment :
     override fun onUninstallError(addonId: String, throwable: Throwable) {
         this@NotYetSupportedAddonFragment.view?.let { view ->
             showSnackBar(view, getString(R.string.mozac_feature_addons_failed_to_remove, ""))
+        }
+
+        if (unsupportedAddonsAdapter?.itemCount == 0) {
+            findNavController().popBackStack()
         }
     }
 


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture