### PR TITLE
For #8358 - Make sure we don't cancel toolbar editing more than once.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/search/toolbar/ToolbarView.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/toolbar/ToolbarView.kt
@@ -80,6 +80,7 @@ class ToolbarView(
         .findViewById(R.id.toolbar)
 
     private var isInitialized = false
+    private var hasBeenCanceled = false
 
     init {
         view.apply {
@@ -120,7 +121,10 @@ class ToolbarView(
 
             setOnEditListener(object : mozilla.components.concept.toolbar.Toolbar.OnEditListener {
                 override fun onCancelEditing(): Boolean {
-                    interactor.onEditingCanceled()
+                    // For some reason, this can be triggered twice on one back press. This only leads to
+                    // navigateUp, so let's make sure we only call it once
+                    if (!hasBeenCanceled) interactor.onEditingCanceled()
+                    hasBeenCanceled = true
                     // We need to return false to not show display mode
                     return false
                 }


### PR DESCRIPTION
TBH I still don't know why exactly this is happening. I traced it into AC where `setOnDispatchKeyEventPreImeListener` is being dispatched twice for one back press. I already spent like an hour or two on this, so I'm more concerned rn about getting a fix in than why this started happening randomly. My guess would be either some lifecycle changes or maybe a dependency update. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture