### PR TITLE
For #8056: remove Experiments.initialize from FenixApplication

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -20,7 +20,6 @@ import kotlinx.coroutines.runBlocking
 import mozilla.appservices.Megazord
 import mozilla.components.browser.session.Session
 import mozilla.components.concept.push.PushProcessor
-import mozilla.components.service.experiments.Experiments
 import mozilla.components.service.glean.Glean
 import mozilla.components.service.glean.config.Configuration
 import mozilla.components.service.glean.net.ConceptFetchHttpUploader
@@ -107,16 +106,6 @@ open class FenixApplication : LocaleAwareApplication() {
             setDayNightTheme()
             enableStrictMode()
             warmBrowsersCache()
-
-            // Enable the service-experiments component
-            if (settings().isExperimentationEnabled && Config.channel.isReleaseOrBeta) {
-                Experiments.initialize(
-                    applicationContext,
-                    mozilla.components.service.experiments.Configuration(
-                        httpClient = lazy(LazyThreadSafetyMode.NONE) { components.core.client }
-                    )
-                )
-            }
 
             // Make sure the engine is initialized and ready to use.
             components.core.engine.warmUp()


### PR DESCRIPTION
Experiments will not be used before GA and are thus being removed
for performance wins.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture