### PR TITLE
Dismiss "migration notification" after leaving migration activity..

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/migration/MigrationProgressActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/migration/MigrationProgressActivity.kt
@@ -16,6 +16,7 @@ import androidx.recyclerview.widget.RecyclerView
 import kotlinx.android.synthetic.main.activity_migration.*
 import kotlinx.android.synthetic.main.migration_list_item.view.*
 import mozilla.components.support.migration.AbstractMigrationProgressActivity
+import mozilla.components.support.migration.AbstractMigrationService
 import mozilla.components.support.migration.Migration
 import mozilla.components.support.migration.Migration.Bookmarks
 import mozilla.components.support.migration.Migration.History
@@ -58,6 +59,8 @@ class MigrationProgressActivity : AbstractMigrationProgressActivity() {
 
         migration_button.apply {
             setOnClickListener {
+                AbstractMigrationService.dismissNotification(context)
+
                 finish()
                 overridePendingTransition(0, 0)
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -32,7 +32,7 @@ object Versions {
     const val androidx_work = "2.2.0"
     const val google_material = "1.1.0"
 
-    const val mozilla_android_components = "32.0.0-SNAPSHOT"
+    const val mozilla_android_components = "33.0.0-SNAPSHOT"
     // Note that android-components also depends on application-services,
     // and in fact is our main source of appservices-related functionality.
     // The version number below tracks the application-services version


### PR DESCRIPTION
For https://github.com/mozilla-mobile/android-components/issues/5886.

With this patch we will dismiss the "migration completed" notification once the users
clicks on the button in the migration activity.

Needs https://github.com/mozilla-mobile/android-components/pull/5927 in AC before it can land.