### PR TITLE
Fix for #8426 - Migration steps displayed in a different order than specs

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/migration/MigrationProgressActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/migration/MigrationProgressActivity.kt
@@ -91,29 +91,23 @@ class MigrationProgressActivity : AbstractMigrationProgressActivity() {
 }
 
 // These are the only items we want to show migrating in the UI.
-internal val whiteList = mapOf(
-    Bookmarks to R.string.preferences_sync_bookmarks,
+internal val whiteList = linkedMapOf(
+    Settings to R.string.settings_title,
     History to R.string.preferences_sync_history,
-    Logins to R.string.migration_text_passwords,
-    Settings to R.string.settings_title
+    Bookmarks to R.string.preferences_sync_bookmarks,
+    Logins to R.string.migration_text_passwords
 )
 
-internal fun MigrationResults.toItemList() = filterKeys {
-    whiteList.keys.contains(it)
-}.map { (type, status) ->
-    MigrationItem(
-        type,
-        status.success
-    )
-}.toMutableList()
-    .plus(
-        whiteList
-            .filterKeys { !this.containsKey(it) }
-            .keys
-            .map { MigrationItem(it, false) }
-    ).sortedBy { it.migration.javaClass.simpleName }
+internal fun MigrationResults.toItemList() = whiteList.keys
+    .map {
+        if (containsKey(it)) {
+            MigrationItem(it, getValue(it).success)
+        } else {
+            MigrationItem(it)
+        }
+    }
 
-internal data class MigrationItem(val migration: Migration, val status: Boolean)
+internal data class MigrationItem(val migration: Migration, val status: Boolean = false)
 
 internal class MigrationStatusAdapter :
     ListAdapter<MigrationItem, MigrationStatusAdapter.ViewHolder>(DiffCallback) {


### PR DESCRIPTION
Changed the order of the whitelisted migrations in order to respect the UI specifications.

Now using linked hash map instead of hash map for the whitelisted migrations so we can preserve the
order of the steps upon status changing in the migration process.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This is already covered by tests
- [x] **Screenshots**: 
![device-2020-02-14-115649](https://user-images.githubusercontent.com/20266431/74520942-3b8f8d00-4f21-11ea-8d25-e7901a7db479.png)
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md)
### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture