### PR TITLE
Fix for #8430 - Migration progress bar too close to the text

### DIFF
--- a/app/src/main/res/layout/activity_migration.xml
+++ b/app/src/main/res/layout/activity_migration.xml
@@ -104,9 +104,9 @@
         style="@style/Widget.AppCompat.ProgressBar"
         android:layout_width="@dimen/migration_progress_size"
         android:layout_height="@dimen/migration_progress_size"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:layout_marginBottom="8dp"
+        android:layout_marginStart="@dimen/migration_progress_margin_start"
+        android:layout_marginTop="@dimen/migration_progress_margin_vertical"
+        android:layout_marginBottom="@dimen/migration_progress_margin_vertical"
         app:layout_constraintBottom_toBottomOf="@+id/migration_button"
         app:layout_constraintStart_toStartOf="@+id/migration_button"
         app:layout_constraintTop_toTopOf="@+id/migration_button" />

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -112,5 +112,7 @@
     <dimen name="migration_description_text_size">16sp</dimen>
     <dimen name="migration_welcome_title_text_size">20sp</dimen>
     <dimen name="migration_progress_size">24dp</dimen>
+    <dimen name="migration_progress_margin_vertical">8dp</dimen>
+    <dimen name="migration_progress_margin_start">4dp</dimen>
 
 </resources>


### PR DESCRIPTION
Reduced the margin start value of the progress bar in order to leave more space between it and the
text.

Moved hardcoded margin values into dimens resources.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This is already covered by tests
- [x] **Screenshots**: 
<img width="462" alt="image" src="https://user-images.githubusercontent.com/20266431/74528130-253cfd80-4f30-11ea-8d33-d74def6ec5bb.png">
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) 

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture