### PR TITLE
Issue #5194: Reuse Fennec taskAffinity flag.

### DIFF
--- a/app/src/migration/AndroidManifest.xml
+++ b/app/src/migration/AndroidManifest.xml
@@ -19,10 +19,12 @@
         <activity-alias
             android:name="${applicationId}.App"
             android:targetActivity="org.mozilla.fenix.MigrationDecisionActivity"
-            tools:replace="android:targetActivity"/>
+            android:taskAffinity="${applicationId}.BROWSER"
+            tools:replace="android:targetActivity" />
 
         <activity
             android:name="org.mozilla.fenix.MigrationDecisionActivity"
+            android:taskAffinity="${applicationId}.BROWSER"
             android:exported="false" />
 
         <service android:name="org.mozilla.fenix.MigrationService" />


### PR DESCRIPTION
Reusing the same taskAffinity makes sure that we are launching into a potentially already
existing task from Fennec. Without that we may spawn a new task and will show up twice
in "Recent apps" - with one entry still having a fennec screenshot.