### PR TITLE
UI Sync Int Tests fix TPS preference

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,6 +9,7 @@ pipeline {
     }
     stages {
         stage('test') {
+        when { branch 'master' }
             steps {
                 dir('app/src/androidTest/java/org/mozilla/fenix/syncIntegration') {
                     sh 'pipenv install'
@@ -21,6 +22,7 @@ pipeline {
     post {
         always {
             script {
+                 if (env.BRANCH_NAME == 'master') {
                  publishHTML(target: [
                      allowMissing: false,
                      alwaysLinkToLastBuild: true,
@@ -28,13 +30,18 @@ pipeline {
                      reportDir: '/Users/synctesting/.jenkins/workspace/fenix/app/src/androidTest/java/org/mozilla/fenix/syncintegration/results',
                      reportFiles: 'index.html',
                      reportName: 'HTML Report'])
+                 }
             }
         }
 
         failure {
-            slackSend(
-                color: 'danger',
-                message: "FAILED: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})")
+            script {
+                if (env.BRANCH_NAME == 'master') {
+                    slackSend(
+                        color: 'danger',
+                        message: "FAILED: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})")
+                }
+            }
         }
 
         fixed {

--- a/app/src/androidTest/java/org/mozilla/fenix/AppRequestInterceptor.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/AppRequestInterceptor.kt
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix
+
+import android.content.Context
+import mozilla.components.concept.engine.EngineSession
+import mozilla.components.concept.engine.request.RequestInterceptor
+import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ui.robots.appContext
+
+/**
+ * This class overrides the application's request interceptor to
+ * deactivate the FxA web channel
+ * which is not supported on the staging servers.
+*/
+
+class AppRequestInterceptor(private val context: Context) : RequestInterceptor {
+    override fun onLoadRequest(
+        engineSession: EngineSession,
+        uri: String,
+        hasUserGesture: Boolean,
+        isSameDomain: Boolean
+    ): RequestInterceptor.InterceptionResponse? {
+        return appContext.components.services.accountsAuthFeature.interceptor.onLoadRequest(
+            engineSession, uri, hasUserGesture, isSameDomain)
+    }
+}

--- a/app/src/androidTest/java/org/mozilla/fenix/syncintegration/SyncIntegrationTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/syncintegration/SyncIntegrationTest.kt
@@ -62,6 +62,8 @@ class SyncIntegrationTest {
     fun checkHistoryFromDesktopTest() {
         signInFxSync()
         tapReturnToPreviousApp()
+        // Let's wait until homescreen is shown to go to three dot menu
+        mDevice.waitNotNull(Until.findObjects(By.text("Open tabs")), TestAssetHelper.waitingTime)
         homeScreen {
         }.openThreeDotMenu {
         }.openHistory { }
@@ -82,7 +84,7 @@ class SyncIntegrationTest {
     @Test
     fun checkAccountSettings() {
         signInFxSync()
-        mDevice.waitNotNull(Until.findObjects(By.text("Settings")), TestAssetHelper.waitingTime)
+        mDevice.waitNotNull(Until.findObjects(By.text("Account")), TestAssetHelper.waitingTime)
 
         goToAccountSettings()
         // This function to be added to the robot once the status of checkboxes can be checked
@@ -207,8 +209,7 @@ class SyncIntegrationTest {
     }
 
     fun historyAfterSyncIsShown() {
-        val historyEntry = mDevice.findObject(By.text("http://www.example.com/"))
-        historyEntry.isEnabled()
+        mDevice.waitNotNull(Until.findObjects(By.text("http://www.example.com/")), TestAssetHelper.waitingTime)
     }
 
     fun bookmarkAfterSyncIsShown() {
@@ -217,7 +218,12 @@ class SyncIntegrationTest {
     }
 
     fun tapReturnToPreviousApp() {
+        mDevice.waitNotNull(Until.findObjects(By.text("Save")), TestAssetHelper.waitingTime)
         mDevice.waitNotNull(Until.findObjects(By.text("Settings")), TestAssetHelper.waitingTime)
+
+        // Wait until the Settings shows the account synced
+        mDevice.waitNotNull(Until.findObjects(By.text("Account")), TestAssetHelper.waitingTime)
+        // Go to Homescreen
         mDevice.pressBack()
     }
 

--- a/app/src/androidTest/java/org/mozilla/fenix/syncintegration/conftest.py
+++ b/app/src/androidTest/java/org/mozilla/fenix/syncintegration/conftest.py
@@ -93,7 +93,7 @@ def tps_profile(pytestconfig, tps_addon, tps_config, tps_log, fxa_urls):
         # 'devtools.debugger.remote-enabled': True,
         'engine.bookmarks.repair.enabled': False,
         'extensions.autoDisableScopes': 10,
-        'extensions.legacy.enabled': True,
+        'extensions.experiments.enabled': True,
         'extensions.update.enabled': False,
         'extensions.update.notifyUser': False,
         # While this line is commented prod is launched instead of stage

--- a/app/src/androidTest/java/org/mozilla/fenix/syncintegration/test_integration.py
+++ b/app/src/androidTest/java/org/mozilla/fenix/syncintegration/test_integration.py
@@ -1,7 +1,6 @@
 import os
 import sys
 
-
 def test_sync_account_settings(tps, gradlewbuild):
     gradlewbuild.test('checkAccountSettings')
 
@@ -9,15 +8,24 @@ def test_sync_history_from_desktop(tps, gradlewbuild):
     os.chdir('app/src/androidTest/java/org/mozilla/fenix/syncintegration/')
     tps.run('test_history.js')
     gradlewbuild.test('checkHistoryFromDesktopTest')
-
+'''
 def test_sync_bookmark_from_desktop(tps, gradlewbuild):
+    os.chdir('app/src/androidTest/java/org/mozilla/fenix/syncintegration/')
     tps.run('test_bookmark.js')
     gradlewbuild.test('checkBookmarkFromDesktopTest')
 
-def test_sync_logins_from_device(tps, gradlewbuild):
+def test_sync_logins_from_desktop(tps, gradlewbuild):
+    os.chdir('app/src/androidTest/java/org/mozilla/fenix/syncintegration/')
     tps.run('test_logins.js')
     gradlewbuild.test('checkLoginsFromDesktopTest')
 
 def test_sync_bookmark_from_device(tps, gradlewbuild):
+    os.chdir('app/src/androidTest/java/org/mozilla/fenix/syncintegration/')
     gradlewbuild.test('checkBookmarkFromDeviceTest')
-    tps.run('test_bookmark_desktop.js')
+    tps.run('app/src/androidTest/java/org/mozilla/fenix/syncintegration/test_bookmark_desktop.js')
+
+def test_sync_history_from_device(tps, gradlewbuild):
+    os.chdir('app/src/androidTest/java/org/mozilla/fenix/syncintegration/')
+    gradlewbuild.test('checkHistoryFromDeviceTest')
+    tps.run('app/src/androidTest/java/org/mozilla/fenix/syncintegration/test_history_desktop.js')
+'''


### PR DESCRIPTION
Sync integration tests were failing due to [Bug 1610758](https://bugzilla.mozilla.org/show_bug.cgi?id=1610758) This PR fixes that

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture