### PR TITLE
Fix for #8533 - Migration screen's buttons in the wrong place

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/migration/MigrationProgressActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/migration/MigrationProgressActivity.kt
@@ -57,7 +57,12 @@ class MigrationProgressActivity : AbstractMigrationProgressActivity() {
             text = context.getString(R.string.migration_title, appName)
         }
 
-        migration_button.apply {
+        migration_button_text_view.text = getString(R.string.migration_updating_app_button_text, appName)
+    }
+
+    override fun onMigrationCompleted(results: MigrationResults) {
+        // Enable clicking the finish button
+        migration_button_text_view.apply {
             setOnClickListener {
                 AbstractMigrationService.dismissNotification(context)
 
@@ -71,18 +76,10 @@ class MigrationProgressActivity : AbstractMigrationProgressActivity() {
                     startActivity(intent)
                 }
             }
-            text = getString(R.string.migration_updating_app_button_text, appName)
-        }
-    }
-
-    override fun onMigrationCompleted(results: MigrationResults) {
-        // Enable clicking the finish button
-        migration_button.apply {
-            isEnabled = true
             text = getString(R.string.migration_update_app_button, getString(R.string.app_name))
-            setBackgroundResource(R.drawable.button_background)
             setTextColor(ContextCompat.getColor(context, R.color.white_color))
         }
+        migration_button.setBackgroundResource(R.drawable.button_background)
         migration_button_progress_bar.visibility = View.INVISIBLE
         // Keep the results list up-to-date.
         statusAdapter.submitList(results.toItemList())

--- a/app/src/main/res/layout/activity_migration.xml
+++ b/app/src/main/res/layout/activity_migration.xml
@@ -15,34 +15,17 @@
         android:layout_marginStart="@dimen/migration_margin_horizontal_large"
         android:importantForAccessibility="no"
         app:layout_constraintBottom_toBottomOf="@+id/migration_welcome_title"
-        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="@+id/migration_welcome_title"
-        app:srcCompat="@drawable/ic_firefox" />
-
-    <androidx.appcompat.widget.AppCompatTextView
-        android:id="@+id/migration_description"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/migration_margin_horizontal_large"
-        android:layout_marginTop="@dimen/migration_margin_vertical"
-        android:layout_marginEnd="@dimen/migration_margin_horizontal_large"
-        android:fontFamily="sans-serif-light"
-        android:text="@string/migration_description"
-        android:textColor="@color/text_scale_example_text_color"
-        android:textSize="@dimen/migration_description_text_size"
-        android:textStyle="bold"
-        app:layout_constraintBottom_toTopOf="@+id/guideline_vertical_center"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.0"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/migration_welcome_title" />
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toLeftOf="@id/migration_welcome_title"
+        app:srcCompat="@drawable/ic_firefox"/>
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/migration_welcome_title"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
-        android:layout_marginTop="@dimen/migration_margin_vertical_small"
+        android:layout_marginTop="@dimen/migration_margin"
         android:layout_marginEnd="@dimen/migration_margin_horizontal_large"
         android:fontFamily="sans-serif-medium"
         android:maxLines="2"
@@ -51,65 +34,76 @@
         android:textSize="@dimen/migration_welcome_title_text_size"
         android:textStyle="bold"
         app:layout_constraintBottom_toTopOf="@+id/migration_description"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/migration_firefox_logo"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_chainStyle="packed"
-        tools:text="Welcome to the all-new Firefox Preview" />
+        app:layout_constraintLeft_toRightOf="@id/migration_firefox_logo"
+        app:layout_constraintRight_toRightOf="parent"
+        tools:text="Welcome to the all-new Firefox Preview"
+        app:layout_constraintVertical_chainStyle="spread"/>
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/migration_description"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/migration_margin_horizontal_large"
+        android:layout_marginTop="@dimen/migration_margin"
+        android:layout_marginEnd="@dimen/migration_margin_horizontal_large"
+        android:fontFamily="sans-serif-light"
+        android:text="@string/migration_description"
+        android:textColor="@color/text_scale_example_text_color"
+        android:textSize="@dimen/migration_description_text_size"
+        android:textStyle="bold"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/migration_status_list"
+        app:layout_constraintTop_toBottomOf="@+id/migration_welcome_title" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/migration_status_list"
         android:layout_width="wrap_content"
-        android:layout_height="0dp"
+        android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/migration_margin_horizontal_large"
-        android:layout_marginTop="@dimen/migration_margin_vertical_small"
+        android:layout_marginTop="@dimen/migration_margin"
         android:layout_marginEnd="@dimen/migration_margin_horizontal_large"
-        android:layout_marginBottom="@dimen/migration_margin_vertical_small"
+        android:layout_marginBottom="@dimen/migration_margin"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintBottom_toTopOf="@+id/migration_button"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/guideline_vertical_center"
+        app:layout_constraintTop_toBottomOf="@+id/migration_description"
         tools:itemCount="5"
         tools:listitem="@layout/migration_list_item" />
 
-    <androidx.appcompat.widget.AppCompatButton
+    <LinearLayout
         android:id="@+id/migration_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/migration_margin_horizontal_large"
-        android:layout_marginEnd="@dimen/migration_margin_horizontal_large"
-        android:layout_marginBottom="@dimen/migration_margin_vertical"
-        android:background="@drawable/button_background_grey"
-        android:enabled="false"
-        android:minWidth="200dp"
-        android:paddingStart="@dimen/migration_button_padding"
-        android:paddingEnd="@dimen/migration_button_padding"
-        android:text="@string/migration_updating_app_button_text"
-        android:textAllCaps="false"
-        android:textColor="@color/button_text_color"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        tools:text="Updating Firefox…" />
+        app:layout_constraintTop_toBottomOf="@id/migration_status_list"
+        android:gravity="center"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        android:background="@drawable/button_background_grey"
+        android:orientation="horizontal">
 
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guideline_vertical_center"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.5" />
+        <ProgressBar
+            android:id="@+id/migration_button_progress_bar"
+            style="@style/Widget.AppCompat.ProgressBar"
+            android:layout_width="@dimen/migration_progress_size"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/migration_margin"
+            android:layout_marginEnd="@dimen/migration_progress_margin_start"/>
 
-    <ProgressBar
-        android:id="@+id/migration_button_progress_bar"
-        style="@style/Widget.AppCompat.ProgressBar"
-        android:layout_width="@dimen/migration_progress_size"
-        android:layout_height="@dimen/migration_progress_size"
-        android:layout_marginStart="@dimen/migration_progress_margin_start"
-        android:layout_marginTop="@dimen/migration_progress_margin_vertical"
-        android:layout_marginBottom="@dimen/migration_progress_margin_vertical"
-        app:layout_constraintBottom_toBottomOf="@+id/migration_button"
-        app:layout_constraintStart_toStartOf="@+id/migration_button"
-        app:layout_constraintTop_toTopOf="@+id/migration_button" />
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/migration_button_text_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/migration_progress_margin_compound"
+            android:background="@android:color/transparent"
+            android:text="@string/migration_updating_app_button_text"
+            android:textAllCaps="false"
+            android:textStyle="bold"
+            android:textColor="@color/button_text_color"
+            tools:text="Updating Firefox…" />
+
+    </LinearLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>
-

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -104,15 +104,14 @@
     <dimen name="locale_item_subtitle_size">12sp</dimen>
 
     <!--Migration Activity-->
-    <dimen name="migration_button_padding">32dp</dimen>
     <dimen name="migration_margin_horizontal_large">24dp</dimen>
-    <dimen name="migration_margin_vertical">16dp</dimen>
-    <dimen name="migration_margin_vertical_small">8dp</dimen>
+    <dimen name="migration_margin">16dp</dimen>
     <dimen name="migration_firefox_logo_size">48dp</dimen>
     <dimen name="migration_description_text_size">16sp</dimen>
     <dimen name="migration_welcome_title_text_size">20sp</dimen>
     <dimen name="migration_progress_size">24dp</dimen>
-    <dimen name="migration_progress_margin_vertical">8dp</dimen>
+    <dimen name="migration_progress_margin">8dp</dimen>
     <dimen name="migration_progress_margin_start">4dp</dimen>
+    <dimen name="migration_progress_margin_compound">44dp</dimen>
 
 </resources>


### PR DESCRIPTION
Made a small refactor on the migration screen layout in order to correctly position the elements.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This is already covered by tests
- [x] **Screenshots**: 
<img width="496" alt="image" src="https://user-images.githubusercontent.com/20266431/74854734-6413ee80-5348-11ea-83ba-62ab611e1e82.png">

- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) 
<img width="497" alt="image" src="https://user-images.githubusercontent.com/20266431/74854794-7857eb80-5348-11ea-84b7-e4eaad8afe42.png">
### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture