### PR TITLE
Closes #8544: Activity should be reused when opening intents from other apps

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -108,7 +108,14 @@
             android:taskAffinity=""
             android:windowSoftInputMode="adjustResize|stateAlwaysHidden" />
 
-        <activity android:name=".IntentReceiverActivity" android:theme="@style/Theme.Transparent">
+        <activity
+            android:name=".IntentReceiverActivity"
+            android:theme="@style/Theme.Transparent"
+            android:relinquishTaskIdentity="true"
+            android:taskAffinity=""
+            android:exported="true"
+            android:excludeFromRecents="true" >
+
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 

--- a/app/src/main/java/org/mozilla/fenix/IntentReceiverActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/IntentReceiverActivity.kt
@@ -57,6 +57,15 @@ class IntentReceiverActivity : Activity() {
                 modeDependentProcessors +
                 NewTabShortcutIntentProcessor()
 
+        // Explicitly remove the new task and clear task flags (Our browser activity is a single
+        // task activity and we never want to start a second task here).
+        intent.flags = intent.flags and Intent.FLAG_ACTIVITY_NEW_TASK.inv()
+        intent.flags = intent.flags and Intent.FLAG_ACTIVITY_CLEAR_TASK.inv()
+
+        // IntentReceiverActivity is started with the "excludeFromRecents" flag (set in manifest). We
+        // do not want to propagate this flag from the intent receiver activity to the browser.
+        intent.flags = intent.flags and Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS.inv()
+
         // Call process for side effects, short on the first that returns true
         intentProcessors.any { it.process(intent) }
 
@@ -66,8 +75,8 @@ class IntentReceiverActivity : Activity() {
         intent.setClassName(applicationContext, intentProcessorType.activityClassName)
         intent.putExtra(HomeActivity.OPEN_TO_BROWSER, intentProcessorType.shouldOpenToBrowser(intent))
 
-        // finish() before starting another activity. Don't keep this on the activities back stack.
-        finish()
         startActivity(intent)
+        // must finish() after starting the other activity
+        finish()
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -191,7 +191,6 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Session
                 },
                 openInFenixIntent = Intent(context, IntentReceiverActivity::class.java).apply {
                     action = Intent.ACTION_VIEW
-                    flags = Intent.FLAG_ACTIVITY_NEW_TASK
                 },
                 bookmarkTapped = { lifecycleScope.launch { bookmarkTapped(it) } },
                 scope = lifecycleScope,


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture