### PR TITLE
For #8568 - Refocus URL editText in SearchFragment onResume.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
@@ -27,6 +27,7 @@ import kotlinx.android.synthetic.main.search_suggestions_onboarding.view.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.components.concept.storage.HistoryStorage
 import mozilla.components.feature.qr.QrFeature
+import mozilla.components.feature.qr.QrFragment
 import mozilla.components.lib.state.ext.consumeFrom
 import mozilla.components.support.base.feature.UserInteractionHandler
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
@@ -278,6 +279,31 @@ class SearchFragment : Fragment(), UserInteractionHandler {
 
         permissionDidUpdate = false
         hideToolbar()
+
+        if (!isQrFragmentVisible()) {
+            refocusUrlView()
+        }
+    }
+
+    /**
+     * Refocus URL editText. Needed after the user brings back the app
+     * into the foreground.
+     * See https://github.com/mozilla-mobile/fenix/issues/6290
+     **/
+    private fun refocusUrlView() {
+        val urlView = toolbarView.view
+            .findViewById<InlineAutocompleteEditText>(R.id.mozac_browser_toolbar_edit_url_view)
+        if (!urlView.hasFocus()) {
+            urlView.requestFocus()
+        }
+    }
+
+    /**
+     * Check to see if QrFragment exists & is visible.
+     * */
+    private fun isQrFragmentVisible(): Boolean {
+        val foundQrFragment = parentFragmentManager.fragments.firstOrNull { it is QrFragment }
+        return foundQrFragment != null && foundQrFragment.isVisible
     }
 
     override fun onPause() {


### PR DESCRIPTION
For [#8568](https://github.com/mozilla-mobile/fenix/issues/8568)
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR doesn't include any tests because it's only a minor change.
- [x] **Screenshots**: This PR includes GIFs.
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

![url_edittext_onresume](https://user-images.githubusercontent.com/60002907/74937020-ee655c80-53f3-11ea-96f7-a8fc268de178.gif)
