### PR TITLE
Bug 1616641 - let fennec-nightly tasks ride along vanilla fenix nightlies

### DIFF
--- a/.cron.yml
+++ b/.cron.yml
@@ -12,12 +12,6 @@ jobs:
       when:
           - {hour: 6, minute: 0}
           - {hour: 18, minute: 0}
-    - name: fennec-nightly
-      job:
-          type: decision-task
-          treeherder-symbol: N-fennec
-          target-tasks-method: fennec-nightly
-      when: []  # Force hook only
     - name: fennec-beta
       job:
           type: decision-task

--- a/taskcluster/fenix_taskgraph/target_tasks.py
+++ b/taskcluster/fenix_taskgraph/target_tasks.py
@@ -30,23 +30,13 @@ def target_tasks_nightly(full_task_graph, parameters, graph_config):
     """Select the set of tasks required for a nightly build."""
 
     def filter(task, parameters):
-        return (
-            task.attributes.get("nightly", False) and
-            not _filter_fennec("nightly", task, parameters)
-        )
+        return task.attributes.get("nightly", False)
 
     return [l for l, t in full_task_graph.tasks.iteritems() if filter(t, parameters)]
 
 
 def _filter_fennec(fennec_type, task, parameters):
     return task.attributes.get("build-type", "") == "fennec-{}".format(fennec_type)
-
-
-@_target_task("fennec-nightly")
-def target_tasks_fennec_nightly(full_task_graph, parameters, graph_config):
-    """Select the set of tasks required for a nightly build signed with the fennec key."""
-
-    return [l for l, t in full_task_graph.tasks.iteritems() if _filter_fennec("nightly", t, parameters)]
 
 
 @_target_task("fennec-beta")


### PR DESCRIPTION
We no longer need standalone `fennec-nightly` graphs. Hence we remove their graph definitions and let those tasks ride along the vanilla fenix nightlies. 

Moreover, we want the fennec-nightly push-apk job to push to `beta` track directly, rather than `alpha` track so that Fenix folks have one less thing to take care of, now that we're 100% migrated on Fenix nightly. That change is tracked in https://github.com/mozilla-releng/scriptworker-scripts/pull/148