### PR TITLE
🧊🎲 For #8535 #8498: Allow for multiple browsingModeListeners dispatch.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -174,7 +174,7 @@ open class HomeActivity : LocaleAwareAppCompatActivity() {
 
     final override fun onStop() {
         super.onStop()
-        browsingModeManager.unregisterBrowsingModeListener()
+        browsingModeManager.unregisterBrowsingModeListener(browsingModeListener)
     }
 
     final override fun onPause() {

--- a/app/src/main/java/org/mozilla/fenix/browser/browsingmode/BrowsingModeManager.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/browsingmode/BrowsingModeManager.kt
@@ -42,21 +42,21 @@ class DefaultBrowsingModeManager(
     private var _mode: BrowsingMode = BrowsingMode.Normal
 ) : BrowsingModeManager {
 
-    private var _browsingModeListener: BrowsingModeListener? = null
+    private val browsingModeListeners = mutableSetOf<BrowsingModeListener>()
 
     fun registerBrowsingModeListener(browsingModeListener: BrowsingModeListener) {
-        _browsingModeListener = browsingModeListener
+        browsingModeListeners.add(browsingModeListener)
     }
 
-    fun unregisterBrowsingModeListener() {
-        _browsingModeListener = null
+    fun unregisterBrowsingModeListener(browsingModeListener: BrowsingModeListener) {
+        browsingModeListeners.remove(browsingModeListener)
     }
 
     override var mode: BrowsingMode
         get() = _mode
         set(value) {
             _mode = value
-            _browsingModeListener?.onBrowsingModeChange(value)
+            browsingModeListeners.forEach { it.onBrowsingModeChange(value) }
             Settings.instance?.lastKnownMode = value
         }
 }


### PR DESCRIPTION
This is for when there are more than one activity instances during intent processing and handling deep links.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture