### PR TITLE
For #8034: Create a post-visual completeness executor

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -37,6 +37,7 @@ import org.mozilla.fenix.components.Components
 import org.mozilla.fenix.components.metrics.MetricServiceType
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.session.NotificationSessionObserver
+import org.mozilla.fenix.session.PerformanceActivityLifecycleCallbacks
 import org.mozilla.fenix.session.VisibilityLifecycleCallback
 import org.mozilla.fenix.utils.BrowsersCache
 import org.mozilla.fenix.utils.Settings
@@ -143,6 +144,10 @@ open class FenixApplication : LocaleAwareApplication() {
         // if ((System.currentTimeMillis() - settings().lastPlacesStorageMaintenance) > ONE_DAY_MILLIS) {
         //    runStorageMaintenance()
         // }
+
+        registerActivityLifecycleCallbacks(
+            PerformanceActivityLifecycleCallbacks(components.performance.visualCompletenessTaskManager)
+        )
     }
 
     // See https://github.com/mozilla-mobile/fenix/issues/7227 for context.

--- a/app/src/main/java/org/mozilla/fenix/components/Components.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Components.kt
@@ -78,4 +78,5 @@ class Components(private val context: Context) {
     val publicSuffixList by lazy { PublicSuffixList(context) }
     val clipboardHandler by lazy { ClipboardHandler(context) }
     val migrationStore by lazy { MigrationStore() }
+    val performance by lazy { PerformanceComponent() }
 }

--- a/app/src/main/java/org/mozilla/fenix/components/PerformanceComponent.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/PerformanceComponent.kt
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.components
+
+import org.mozilla.fenix.utils.StartupTaskManager
+
+/**
+ * Component group for all functionality related to performance.
+ */
+class PerformanceComponent {
+    val visualCompletenessTaskManager by lazy { StartupTaskManager() }
+}

--- a/app/src/main/java/org/mozilla/fenix/perf/StartupTaskManager.kt
+++ b/app/src/main/java/org/mozilla/fenix/perf/StartupTaskManager.kt
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.utils
+
+import org.mozilla.gecko.util.ThreadUtils
+import java.lang.IllegalStateException
+
+typealias StartupTask = () -> Unit
+
+/**
+ * A queue of tasks that are performed at specific points during Fenix startup.
+ *
+ * This queue contains a list of startup tasks. Each task in the queue will be started once Fenix
+ * is visually complete.
+ *
+ * This class is not thread safe and should only be called from the main thread.
+ */
+class StartupTaskManager {
+    private var tasks = mutableListOf<StartupTask>()
+    private var hasStarted = false
+        private set
+
+    /**
+     * Add a task to the queue.
+     * Each task will execute on the main thread.
+     *
+     * @param task: The task to add to the queue.
+     */
+    @Synchronized
+    fun add(task: StartupTask) {
+        ThreadUtils.assertOnUiThread()
+        if (hasStarted) {
+            throw IllegalStateException("New tasks should not be added because queue already " +
+                    "started, and these newly added tasks will not execute.")
+        }
+
+        tasks.add(task)
+    }
+
+    /**
+     * Start all tasks in the queue. When all the tasks have been started,
+     * clear the queue.
+     */
+    fun start() {
+        ThreadUtils.assertOnUiThread()
+        hasStarted = true
+
+        tasks.forEach { it.invoke() }
+
+        // Anything captured by the lambda will remain captured if we hold on to these tasks,
+        // which takes up more memory than we need to.
+        tasks.clear()
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/session/PerformanceActivityLifecycleCallbacks.kt
+++ b/app/src/main/java/org/mozilla/fenix/session/PerformanceActivityLifecycleCallbacks.kt
@@ -1,0 +1,79 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.session
+
+import android.app.Activity
+import android.app.Application
+import android.os.Bundle
+import org.mozilla.fenix.HomeActivity
+import org.mozilla.fenix.IntentReceiverActivity
+import org.mozilla.fenix.browser.BrowserPerformanceTestActivity
+import org.mozilla.fenix.settings.account.AuthIntentReceiverActivity
+import org.mozilla.fenix.utils.StartupTaskManager
+import org.mozilla.fenix.widget.VoiceSearchActivity
+
+/**
+ * These callbacks handle binding performance code to the activity lifecycle.
+ */
+@SuppressWarnings("EmptyFunctionBlock")
+class PerformanceActivityLifecycleCallbacks(
+    private val visualCompletenessTaskManager: StartupTaskManager
+) : Application.ActivityLifecycleCallbacks {
+
+    override fun onActivityCreated(activity: Activity, bundle: Bundle?) {
+        ifNecessaryPostVisualCompleteness(activity)
+    }
+
+    /**
+     * Returns true if it is a terminal activity, or false if it
+     * an activity used in transition.
+     */
+    private fun isTransientActivity(activity: Activity): Boolean {
+        // These are the current list of non terminal activites.
+        // They have been whitelisted in case new activities are added to the application
+        // to ensure these new activities would not crash the application.
+        return isTransientActivityInMigrationVariant(activity) ||
+                (activity is IntentReceiverActivity) ||
+                (activity is VoiceSearchActivity) ||
+                (activity is AuthIntentReceiverActivity) ||
+                (activity is BrowserPerformanceTestActivity)
+    }
+
+    /**
+     * This starts the StartupTaskManager, eitther delayed or right away, if the activity is a
+     * terminal activity. If not, do nothing.
+     */
+    private fun ifNecessaryPostVisualCompleteness(activity: Activity) {
+        fun shouldStartVisualCompletenessQueueImmediately(): Boolean {
+            return !isTransientActivity(activity)
+        }
+
+        if (activity is HomeActivity) {
+            // We should delay the visualCompletenessTaskManager when reaching the HomeActivity
+            // to ensure all tasks are delayed until after visual completeness
+            activity.postVisualCompletenessQueue(visualCompletenessTaskManager)
+        } else if (shouldStartVisualCompletenessQueueImmediately()) {
+            // If we do not go through the home activity, we have to start the tasks
+            // immediately to avoid spending time implementing it.
+            visualCompletenessTaskManager.start()
+        }
+    }
+
+    override fun onActivityStarted(activity: Activity?) {}
+    override fun onActivityStopped(activity: Activity?) {}
+    override fun onActivityResumed(activity: Activity?) {}
+    override fun onActivityPaused(activity: Activity?) {}
+    override fun onActivitySaveInstanceState(activity: Activity?, bundle: Bundle?) {}
+    override fun onActivityDestroyed(activity: Activity?) {}
+
+    companion object {
+        /**
+         * The source files are different from migration and non migration variants.
+         * We use this property to extend the [isTransientActivity] implementation for the
+         * migration variants.
+         */
+        var isTransientActivityInMigrationVariant: (Activity) -> Boolean = { false }
+    }
+}

--- a/app/src/migration/java/org/mozilla/fenix/MigratingFenixApplication.kt
+++ b/app/src/migration/java/org/mozilla/fenix/MigratingFenixApplication.kt
@@ -7,11 +7,19 @@ package org.mozilla.fenix
 import android.content.Context
 import kotlinx.coroutines.runBlocking
 import mozilla.components.support.migration.FennecMigrator
+import org.mozilla.fenix.session.PerformanceActivityLifecycleCallbacks
 
 /**
  * An application class which knows how to migrate Fennec data.
  */
 class MigratingFenixApplication : FenixApplication() {
+
+    init {
+        PerformanceActivityLifecycleCallbacks.isTransientActivityInMigrationVariant = {
+            if (it is MigrationDecisionActivity) true else false
+        }
+    }
+
     val migrator by lazy {
         FennecMigrator.Builder(this, this.components.analytics.crashReporter)
             .migrateOpenTabs(this.components.core.sessionManager)


### PR DESCRIPTION
Create an object that will execute its enqueued, paused tasks
when Fenix is visually complete.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture