### PR TITLE
🎲 Bug 1613416 - Hide "Report site issue" button in Fenix Production.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
@@ -22,7 +22,9 @@ import mozilla.components.browser.menu.item.BrowserMenuItemToolbar
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.storage.BookmarksStorage
+import org.mozilla.fenix.Config
 import org.mozilla.fenix.R
+import org.mozilla.fenix.ReleaseChannel
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.theme.ThemeManager
@@ -132,6 +134,10 @@ class DefaultToolbarMenu(
             context.components.browsingModeManager.mode == BrowsingMode.Normal
         val shouldDeleteDataOnQuit = Settings.getInstance(context)
             .shouldDeleteBrowsingDataOnQuit
+        val shouldShowWebcompatReporter = Config.channel !in setOf(
+            ReleaseChannel.FenixProduction,
+            ReleaseChannel.FennecProduction
+        )
 
         // Predicates that need to be repeatedly called as the session changes
         fun shouldShowAddToHomescreen(): Boolean =
@@ -154,7 +160,7 @@ class DefaultToolbarMenu(
             findInPage,
             privateTab,
             newTab,
-            reportIssue,
+            if (shouldShowWebcompatReporter) reportIssue else null,
             if (shouldShowSaveToCollection) saveToCollection else null,
             if (shouldDeleteDataOnQuit) deleteDataOnQuit else null,
             readerMode.apply { visible = ::shouldShowReaderMode },


### PR DESCRIPTION
@denschub 
> This is for [Bugzilla Bug 1613416](https://bugzilla.mozilla.org/show_bug.cgi?id=1613416). We are a bit worried that we'll receive too many issues from the Fenix release population, so we'll go the Desktop-route and have the reporter only enabled in prerelease builds of Fenix. For now, at least.
>
> I'm honestly not 100% sure how to test this change. There is a test for the button's handler in `app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt`, which should be working either way, but the ReleaseChannel-based switch is untested. I'm happy to add tests if someone nudges me into the right direction.