### PR TITLE
Fix #8631 - Persist the same activity for http/s schemes after migration

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -35,6 +35,10 @@
 
           Note that `fennec*` build types override the targetActivity property in the Manifest
           inside their source set.
+
+          Fennec's activity set to handle http/s schemes.
+          Need to also use it in Fenix to keep the previously default app status after migration.
+          Also the Fennec declared entry for homescreen pinned shortcuts.
         -->
         <activity-alias
             android:name="${applicationId}.App"
@@ -43,6 +47,14 @@
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="http" />
+                <data android:scheme="https" />
             </intent-filter>
 
             <meta-data
@@ -122,12 +134,7 @@
 
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
-
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
                 <category android:name="mozilla.components.pwa.category.SHORTCUT" />
-                <data android:scheme="http" />
-                <data android:scheme="https" />
             </intent-filter>
 
             <intent-filter>


### PR DESCRIPTION
Most of the times setting an application as default does not restrict it's
activities so that only that initial one can handle a specific Intent.
If that activity is renamed/deleted or it's intent filter is now declared for
another, normally, the same application will remain set as default.

IRL we saw that Huawei imposes strict restrictions regarding the default apps
settings, such that any changes in preferred activities would result in
dropping the current default app to let the user pick again a default one.

To protect against such edgecases and keep the default app status previously set
for Fennec we'll keep the same Fennec component declared in Fenix's manifest
as the activity set to handle http/s schemes.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR does not includes tests. Can only be manually tested.
- [x] **Screenshots**: This PR includes a video showing the issue being fixed.
https://drive.google.com/file/d/1ZaTT2uS_XITCFqJfE9KsUq5fsVTi2bQR/view?usp=sharing
(the Fennec -> Fenix update starts at around 00:45)
- [x] **Accessibility**: The code in this PR follows does not include any user facing features.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture