### PR TITLE
Use same configuration for "forPerformanceTest" builds like we do for "fennec" flavor builds.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,6 +54,13 @@ android {
             manifestPlaceholders.isRaptorEnabled = "true"
             applicationIdSuffix ".fenix.performancetest"
             debuggable true
+            manifestPlaceholders = [
+                // Since we configure this build to behave like a "fennec" flavored build, we need
+                // to set a shared user id for the manifest. The actual values does not matter.
+                // However we pick a unique value to not "clash" with other Fenix/Fennec builds
+                // installed on the device.
+                "sharedUserId": "org.mozilla.fenix.performancetest.sharedID"
+            ]
         }
         fenixNightly releaseTemplate >> {
             applicationIdSuffix ".fenix.nightly"
@@ -169,6 +176,12 @@ android {
             manifest.srcFile "src/migration/AndroidManifest.xml"
         }
         fennecProduction {
+            java.srcDirs = ['src/migration/java']
+            manifest.srcFile "src/migration/AndroidManifest.xml"
+        }
+        forPerformanceTest {
+            // We want our performance test builds to use the same code as our "fennec" flavor builds
+            // since those builds will ship to our large user base.
             java.srcDirs = ['src/migration/java']
             manifest.srcFile "src/migration/AndroidManifest.xml"
         }


### PR DESCRIPTION
@mcomella If I remember correctly this is what we decided to do in Berlin.

With this patch a `forPerformancetest` build will use the same code/configuration as a Fennec / migration build of Fenix.

This allows us to:
* Test the performance of a configuration that ships to our large user base.
* Include the "Do we need to migrate?" code path into our performance testing (which needs to do some checks on app startup).