### PR TITLE
🎲 Add add top margin to No Bookmarks message

### DIFF
--- a/app/src/main/res/layout/component_bookmark.xml
+++ b/app/src/main/res/layout/component_bookmark.xml
@@ -25,6 +25,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
+            android:layout_marginTop="8dp"
             android:text="@string/bookmarks_empty_message"
             android:textColor="?secondaryText"
             android:textSize="16sp"


### PR DESCRIPTION
The No Bookmarks message is flush up against the top of the screen which looks bad.  I've added some top margin to pad it out.

![Screenshot_20200221-185351](https://user-images.githubusercontent.com/46655/75062969-6cd00600-54a9-11ea-889e-650523ccaba7.png)


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture