### PR TITLE
For #5843 - Ensure tabs pending deletion are removed

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/PendingSessionDeletionManager.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/PendingSessionDeletionManager.kt
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.components
+
+import android.app.Activity
+import android.app.Application
+import android.content.Context
+import android.os.Bundle
+import org.mozilla.fenix.ext.settings
+
+class PendingSessionDeletionManager(application: Application) :
+    Application.ActivityLifecycleCallbacks {
+
+    private val sessionIdsPendingDeletion = mutableSetOf<String>()
+
+    init {
+        application.registerActivityLifecycleCallbacks(this)
+    }
+
+    fun addSession(sessionId: String) {
+        sessionIdsPendingDeletion.add(sessionId)
+    }
+
+    fun removeSession(sessionId: String) {
+        sessionIdsPendingDeletion.remove(sessionId)
+    }
+
+    fun getSessionsToDelete(context: Context): Set<String> {
+        return context.settings().preferences.getStringSet(
+            PREF_KEY,
+            setOf()
+        ) ?: setOf()
+    }
+
+    override fun onActivityPaused(activity: Activity?) {
+        activity?.settings()?.preferences?.edit()?.putStringSet(
+            PREF_KEY,
+            sessionIdsPendingDeletion
+        )?.apply()
+    }
+
+    override fun onActivityResumed(p0: Activity?) {
+        /* no-op */
+    }
+
+    override fun onActivityStarted(p0: Activity?) {
+        /* no-op */
+    }
+
+    override fun onActivityDestroyed(p0: Activity?) {
+        /* no-op */
+    }
+
+    override fun onActivitySaveInstanceState(p0: Activity?, p1: Bundle?) {
+        /* no-op */
+    }
+
+    override fun onActivityStopped(p0: Activity?) {
+        /* no-op */
+    }
+
+    override fun onActivityCreated(p0: Activity?, p1: Bundle?) {
+        /* no-op */
+    }
+
+    companion object {
+        private const val PREF_KEY = "pref_key_session_id_set_to_delete"
+    }
+}


### PR DESCRIPTION
Looking for feedback as a concept! 
Basically if the invoked deleted jobs are interrupted by the entire app being killed, we just want to shove the session ids we didn't end up deleting into prefs. On next app start, we will attempt to finish deleting them. Core probably isn't the best place for this, I tried HomeFragment and HomeActivity onCreate but it seems like some of the session ids have changed by then.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture