### PR TITLE
Add support for application-services autoPublish local dev workflow.

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,11 +159,11 @@ Specify a relative path to your local `android-components` checkout via `autoPub
 If enabled, during a Fenix build android-components will be compiled and locally published if it has been modified,
 and published versions of android-components modules will be automatically used instead of whatever is declared in Dependencies.kt.
 
-### application-services composite builds
-Specify a relative path to your local `application-services` checkout via `substitutions.application-services.dir`.
+### application-services auto-publication workflow
+Specify a relative path to your local `application-services` checkout via `autoPublish.application-services.dir`.
 
-If enabled, a multi-project gradle build will be configured, and any application-services dependency will be substituted
-for the local version. Any changes to `application-services` will be automatically included in Fenix builds.
+If enabled, during a Fenix build application-services will be compiled and locally published,
+and published versions of application-services modules will be automatically used instead of whatever is declared in Dependencies.kt.
 
 ### GeckoView
 Specify a relative path to your local `mozilla-central` checkout via `dependencySubstitutions.geckoviewTopsrcdir`,

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -713,3 +713,8 @@ if (gradle.hasProperty('localProperties.autoPublish.android-components.dir')) {
     ext.acSrcDir = gradle."localProperties.autoPublish.android-components.dir"
     apply from: "../${acSrcDir}/substitute-local-ac.gradle"
 }
+
+if (gradle.hasProperty('localProperties.autoPublish.application-services.dir')) {
+    ext.appServicesSrcDir = gradle."localProperties.autoPublish.application-services.dir"
+    apply from: "../${appServicesSrcDir}/build-scripts/substitute-local-appservices.gradle"
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,19 +5,18 @@ def log(message) {
     logger.lifecycle("[settings] ${message}")
 }
 
-def runCmd(cmd, workingDir, successMessage) {
+def runCmd(cmd, workingDir, successMessage, captureStdout=true) {
     def proc = cmd.execute(null, new File(workingDir))
-    def standardOutput = new ByteArrayOutputStream()
-    def standardError = new ByteArrayOutputStream()
-    proc.consumeProcessOutput(standardOutput, standardError)
+    def standardOutput = captureStdout ? new ByteArrayOutputStream() : System.out
+    proc.consumeProcessOutput(standardOutput, System.err)
     proc.waitFor()
 
     if (proc.exitValue() != 0) {
-        throw new GradleException("Process '${cmd}' finished with non-zero exit value ${proc.exitValue()}:\n\nstdout:\n${standardOutput.toString()}\n\nstderr:\n${standardError.toString()}")
+        throw new GradleException("Process '${cmd}' finished with non-zero exit value ${proc.exitValue()}");
     } else {
         log(successMessage)
     }
-    return standardOutput
+    return captureStdout ? standardOutput : null
 }
 
 def gradlew = './gradlew'
@@ -29,7 +28,7 @@ if (System.properties['os.name'].toLowerCase().contains('windows')) {
 //////////////////////////////////////////////////////////////////////////
 
 Properties localProperties = null
-String settingAppServicesPath = "substitutions.application-services.dir"
+String settingAppServicesPath = "autoPublish.application-services.dir"
 String settingAndroidComponentsPath = "autoPublish.android-components.dir"
 
 if (file('local.properties').canRead()) {
@@ -48,10 +47,11 @@ if (localProperties != null) {
     String appServicesLocalPath = localProperties.getProperty(settingAppServicesPath)
 
     if (appServicesLocalPath != null) {
-        log("Enabling composite build with application-services modules from: $appServicesLocalPath")
-        includeBuild(appServicesLocalPath)
+        log("Enabling automatic publication of application-services from: $appServicesLocalPath")
+        def publishAppServicesCmd = ["./gradlew", "autoPublishForLocalDevelopment"]
+        runCmd(publishAppServicesCmd, appServicesLocalPath, "Published application-services for local development.", false)
     } else {
-        log("Disabled composite builds with application-services. Enable them by settings '$settingAppServicesPath' in local.properties")
+        log("Disabled auto-publication of application-services. Enable it by settings '$settingAppServicesPath' in local.properties")
     }
 
     String androidComponentsLocalPath = localProperties.getProperty(settingAndroidComponentsPath)
@@ -69,7 +69,7 @@ if (localProperties != null) {
         } else {
             log("android-components changed, publishing locally...")
             def publishAcCmd = ["${androidComponentsLocalPath}/${gradlew}", "publishToMavenLocal", "-Plocal=true"]
-            runCmd(publishAcCmd, androidComponentsLocalPath, "Published android-components.")
+            runCmd(publishAcCmd, androidComponentsLocalPath, "Published android-components.", false)
         }
     } else {
         log("Disabled auto-publication of android-components. Enable it by settings '$settingAndroidComponentsPath' in local.properties")


### PR DESCRIPTION
This is the consumer-side part of https://github.com/mozilla/application-services/pull/2690, which adds support for an auto-publish local development workflow in appservices. Draft for now while getting some initial feedback; /cc @grigoryk.

Fixes #8680.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- None of the PR checklist items seemed relevant because this is a build-system change, so I deleted them...

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.