### PR TITLE
Implement new feature-tabs API..

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/search/SearchController.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchController.kt
@@ -34,6 +34,7 @@ interface SearchController {
     fun handleSearchShortcutEngineSelected(searchEngine: SearchEngine)
     fun handleClickSearchEngineSettings()
     fun handleExistingSessionSelected(session: Session)
+    fun handleExistingSessionSelected(tabId: String)
     fun handleSearchShortcutsButtonClicked()
 }
 
@@ -150,5 +151,12 @@ class DefaultSearchController(
         (context as HomeActivity).openToBrowser(
             from = BrowserDirection.FromSearch
         )
+    }
+
+    override fun handleExistingSessionSelected(tabId: String) {
+        val session = context.components.core.sessionManager.findSessionById(tabId)
+        if (session != null) {
+            handleExistingSessionSelected(session)
+        }
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/search/SearchInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchInteractor.kt
@@ -52,4 +52,8 @@ class SearchInteractor(
     override fun onExistingSessionSelected(session: Session) {
         searchController.handleExistingSessionSelected(session)
     }
+
+    override fun onExistingSessionSelected(tabId: String) {
+        searchController.handleExistingSessionSelected(tabId)
+    }
 }

--- a/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarView.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarView.kt
@@ -70,6 +70,11 @@ interface AwesomeBarInteractor {
     fun onExistingSessionSelected(session: Session)
 
     /**
+     * Called whenever an existing session is selected from the sessionSuggestionProvider
+     */
+    fun onExistingSessionSelected(tabId: String)
+
+    /**
      * Called whenever the Shortcuts button is clicked
      */
     fun onSearchShortcutsButtonClicked()
@@ -119,6 +124,10 @@ class AwesomeBarView(
     private val selectTabUseCase = object : TabsUseCases.SelectTabUseCase {
         override fun invoke(session: Session) {
             interactor.onExistingSessionSelected(session)
+        }
+
+        override fun invoke(tabId: String) {
+            interactor.onExistingSessionSelected(tabId)
         }
     }
 


### PR DESCRIPTION
We migrated `feature-tabs`, `concept-tabstray` and `browser-tabstraty` to no longer depend on `browser-session`. This also needs a small change in Fenix (Introducing an additional method in `TabsUseCases.SelectTabUseCase`).