### PR TITLE
🎲 For #8637: Remove setActivityTheme outside activity lifecycle scope

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/theme/ThemeManager.kt
+++ b/app/src/main/java/org/mozilla/fenix/theme/ThemeManager.kt
@@ -112,8 +112,6 @@ class DefaultThemeManager(
             if (currentTheme != value) {
                 field = value
 
-                setActivityTheme(activity)
-
                 val intent = activity.intent ?: Intent().also { activity.intent = it }
                 intent.putExtra(HomeActivity.PRIVATE_BROWSING_MODE, value == BrowsingMode.Private)
 


### PR DESCRIPTION
Context: having activity instance referenced in outside object is generally fragile because activities get recreated all the time so the instance referenced may no longer be relevant.

Not only does `setActivityTheme(activity)` whenever the mode changes is dangerous for single activity framework, but also for deep link cases (i.e. custom tab) where there could be multiple activities. This call is also completely redundant and trivial because we recreate the activity shortly thereafter and would be correctly handled in onCreate (https://github.com/mozilla-mobile/fenix/blob/master/app/src/main/java/org/mozilla/fenix/HomeActivity.kt#L239)