### PR TITLE
For #7661: Add variant-specific schemas for deep links

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,9 +29,12 @@ android {
         vectorDrawables.useSupportLibrary = true
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments clearPackageData: 'true'
-        manifestPlaceholders.isRaptorEnabled = "false"
         resValue "bool", "IS_DEBUG", "false"
         buildConfigField "boolean", "USE_RELEASE_VERSIONING", "false"
+        manifestPlaceholders = [
+                "isRaptorEnabled": "false",
+                "deepLinkScheme": "fenix"
+        ]
     }
 
     def releaseTemplate = {
@@ -58,10 +61,12 @@ android {
         fenixNightly releaseTemplate >> {
             applicationIdSuffix ".fenix.nightly"
             buildConfigField "boolean", "USE_RELEASE_VERSIONING", "true"
+            manifestPlaceholders = ["deepLinkScheme": "fenix-nightly"]
         }
         fenixBeta releaseTemplate >> {
             applicationIdSuffix ".fenix.beta"
             buildConfigField "boolean", "USE_RELEASE_VERSIONING", "true"
+            manifestPlaceholders = ["deepLinkScheme": "fenix-beta"]
         }
         fenixProduction releaseTemplate >> {
             applicationIdSuffix ".fenix"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -77,23 +77,23 @@
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <category android:name="android.intent.category.DEFAULT" />
-                <data android:scheme="fenix"
+                <data android:scheme="${deepLinkScheme}"
                     android:host="home"/>
-                <data android:scheme="fenix"
+                <data android:scheme="${deepLinkScheme}"
                       android:host="settings"/>
-                <data android:scheme="fenix"
+                <data android:scheme="${deepLinkScheme}"
                     android:host="turn_on_sync"/>
-                <data android:scheme="fenix"
+                <data android:scheme="${deepLinkScheme}"
                     android:host="settings_search_engine"/>
-                <data android:scheme="fenix"
+                <data android:scheme="${deepLinkScheme}"
                     android:host="settings_accessibility"/>
-                <data android:scheme="fenix"
+                <data android:scheme="${deepLinkScheme}"
                     android:host="settings_delete_browsing_data"/>
-                <data android:scheme="fenix"
+                <data android:scheme="${deepLinkScheme}"
                     android:host="enable_private_browsing"/>
-                <data android:scheme="fenix"
+                <data android:scheme="${deepLinkScheme}"
                     android:host="open"/>
-                <data android:scheme="fenix"
+                <data android:scheme="${deepLinkScheme}"
                     android:host="make_default_browser"/>
             </intent-filter>
         </activity>

--- a/app/src/main/java/org/mozilla/fenix/home/intent/DeepLinkIntentProcessor.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/intent/DeepLinkIntentProcessor.kt
@@ -24,7 +24,8 @@ class DeepLinkIntentProcessor(
 ) : HomeIntentProcessor {
 
     override fun process(intent: Intent, navController: NavController, out: Intent): Boolean {
-        return if (intent.scheme == "fenix") {
+        val scheme = intent.scheme?.contains("fenix") ?: return false
+        return if (scheme) {
             intent.data?.let { handleDeepLink(it, navController) }
             true
         } else {

--- a/app/src/test/java/org/mozilla/fenix/home/intent/DeepLinkIntentProcessorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/intent/DeepLinkIntentProcessorTest.kt
@@ -59,6 +59,15 @@ class DeepLinkIntentProcessorTest {
     }
 
     @Test
+    fun `return true if scheme is a fenix variant`() {
+        assertTrue(processor.process(testIntent("fenix-beta://test"), navController, out))
+
+        verify { activity wasNot Called }
+        verify { navController wasNot Called }
+        verify { out wasNot Called }
+    }
+
+    @Test
     fun `process home deep link`() {
         assertTrue(processor.process(testIntent("fenix://home"), navController, out))
 


### PR DESCRIPTION
In order to target specific variants of Fenix, we're adding schemas that
are specific that app in order to avoid collisions with the other
variants and with other forks of fenix that may have the same schemas.

The current schema for variants:
 - Fenix Nightly: `fenix-nightly://`
 - Fenix Beta: `fenix-beta://`
 - Everything else: `fenix://`

Fixes issue #7661.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture