### PR TITLE
Simplify intent handling and handle manifest file not existing in FennecWebAppIntentProcessor

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/IntentProcessors.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/IntentProcessors.kt
@@ -70,7 +70,7 @@ class IntentProcessors(
             ),
             WebAppIntentProcessor(sessionManager, sessionUseCases.loadUrl, manifestStorage),
             FennecBookmarkShortcutsIntentProcessor(sessionManager, sessionUseCases.loadUrl),
-            FennecWebAppIntentProcessor(sessionManager, sessionUseCases.loadUrl, manifestStorage)
+            FennecWebAppIntentProcessor(context, sessionManager, sessionUseCases.loadUrl, manifestStorage)
         )
     }
 


### PR DESCRIPTION
This series of patches addresses https://github.com/mozilla-mobile/android-components/issues/5974.

The first patch simplifies the Intent handling in IntentReceiverActivity and removes the need to process() and then match() on every intent processor. A successful process() means that we already matched. Doing this in two steps caused issues when the process() failed but later the simple check in match() returned true.

The second patch makes FennecWebAppIntentProcessor handle a situation where we can't read a manifest file. In that situation we open the URL just as a custom tab.