### PR TITLE
For #8824: Reset isInstallationInProgress in correct lifecycle

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/addons/AddonsManagementFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/addons/AddonsManagementFragment.kt
@@ -105,6 +105,7 @@ class AddonsManagementFragment : Fragment(R.layout.fragment_add_ons_management),
                             this@AddonsManagementFragment,
                             addons
                         )
+                        isInstallationInProgress = false
                         view.add_ons_progress_bar.isVisible = false
                         view.add_ons_empty_message.isVisible = false
 
@@ -115,6 +116,7 @@ class AddonsManagementFragment : Fragment(R.layout.fragment_add_ons_management),
                 lifecycleScope.launch(Dispatchers.Main) {
                     runIfFragmentIsAttached {
                         showSnackBar(view, getString(R.string.mozac_feature_addons_failed_to_query_add_ons))
+                        isInstallationInProgress = false
                         view.add_ons_progress_bar.isVisible = false
                         view.add_ons_empty_message.isVisible = true
                     }


### PR DESCRIPTION
`bindRecyclerView()` gets called in `onViewCreate` **and** whenever there is a change in `extensions`.

Because we wait for all `pendingAddonActions` in `AddonManager.getAddons()`, we should set `isInstallationInProgress = false` as the initial UI state when we are successfully able to get add-ons list and bind to the `RecyclerView`

