### PR TITLE
No issue: Disable UI test createBookmarkFolderTest for intermittent failure

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
@@ -95,6 +95,7 @@ class BookmarksTest {
         }
     }
 
+    @Ignore("Intermittent failure on Nexus 6: https://github.com/mozilla-mobile/fenix/issues/8772")
     @Test
     fun createBookmarkFolderTest() {
         homeScreen {


### PR DESCRIPTION
https://console.firebase.google.com/u/1/project/moz-fenix/testlab/histories/bh.66b7091e15d53d45/matrices/9186111130315338273

Intermittent failure on Nexus 6.