### PR TITLE
1592947: Use the Glean Gradle plugin

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,3 +1,19 @@
+// Allow installing Gradle plugins from the Mozilla Maven repositories
+buildscript {
+    repositories {
+        maven {
+            url "https://snapshots.maven.mozilla.org/maven2"
+        }
+        maven {
+            url "https://maven.mozilla.org/maven2"
+        }
+
+        dependencies {
+            classpath "org.mozilla.components:tooling-glean-gradle:${Versions.mozilla_android_components}"
+        }
+    }
+}
+
 plugins {
     id "com.jetbrains.python.envs" version "0.0.26"
 }
@@ -378,6 +394,11 @@ androidExtensions {
     experimental = true
 }
 
+// Generate Kotlin code and markdown docs for the Fenix Glean metrics.
+ext.gleanGenerateMarkdownDocs = true
+ext.gleanDocsDirectory = "$rootDir/docs"
+apply plugin: "org.mozilla.telemetry.glean-gradle-plugin"
+
 dependencies {
     geckoNightlyImplementation Deps.mozilla_browser_engine_gecko_nightly
     geckoBetaImplementation Deps.mozilla_browser_engine_gecko_beta
@@ -539,7 +560,7 @@ dependencies {
 
     // For the initial release of Glean 19, we require consumer applications to
     // depend on a separate library for unit tests. This will be removed in future releases.
-    testImplementation Deps.mozilla_service_glean_forUnitTests
+    testImplementation "org.mozilla.telemetry:glean-forUnitTests:${project.ext.glean_version}"
 }
 
 if (project.hasProperty("raptor")) {
@@ -627,17 +648,6 @@ task buildTranslationArray {
     def foundLocalesString = foundLocales.toString().replaceAll(',}','}')
     android.defaultConfig.buildConfigField "String[]", "SUPPORTED_LOCALE_ARRAY", foundLocalesString
 }
-
-def glean_android_components_tag = (
-        Versions.mozilla_android_components.endsWith('-SNAPSHOT') ?
-                'master' :
-                'v' + Versions.mozilla_android_components
-)
-
-// Generate markdown docs for the collected metrics.
-ext.gleanGenerateMarkdownDocs = true
-ext.gleanDocsDirectory = "$rootDir/docs"
-apply from: 'https://github.com/mozilla-mobile/android-components/raw/' + glean_android_components_tag + '/components/service/glean/scripts/sdk_generator.gradle'
 
 afterEvaluate {
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -34,8 +34,6 @@ object Versions {
 
     const val mozilla_android_components = "35.0.0-SNAPSHOT"
 
-    const val mozilla_glean = "25.0.0"
-
     const val adjust = "4.18.3"
     const val installreferrer = "1.0"
 
@@ -127,7 +125,6 @@ object Deps {
         "org.mozilla.components:service-sync-logins:${Versions.mozilla_android_components}"
     const val mozilla_service_firefox_accounts = "org.mozilla.components:service-firefox-accounts:${Versions.mozilla_android_components}"
     const val mozilla_service_glean = "org.mozilla.components:service-glean:${Versions.mozilla_android_components}"
-    const val mozilla_service_glean_forUnitTests = "org.mozilla.telemetry:glean-forUnitTests:${Versions.mozilla_glean}"
     const val mozilla_service_experiments = "org.mozilla.components:service-experiments:${Versions.mozilla_android_components}"
     const val mozilla_service_location = "org.mozilla.components:service-location:${Versions.mozilla_android_components}"
 


### PR DESCRIPTION
There are two things this solves:

1) Generating Kotlin code from `metrics.yaml` definition file is currently done by pulling a Groovy script directly from Github. When building against tagged versions of a-c this mostly works, but for snapshots, this occasionally has lead to a version mismatch between the Glean library (shipped through a-c) and the code generation script. Using this plugin means that the code generation script is shipped through the same Gradle/Maven mechanism as the a-c and Glean libraries, so the versions should always be in sync.

2) There is no longer a need to update the Glean version whenever the a-c version is updated. This has caused build breakage occasionally whenever a-c is updated.  Now, the Glean version is obtained through the plugin, so it should always be the one that correctly matches the version of android-components in use.  (Note the variable holding a version of Glean is removed here).

Lastly, a side benefit is that jumping around versions using things like `git bisect` should work correctly (though unfortunately not for retroactively for revisions prior to this PR).

This should remove the occasional breakage that comes from upgrading android-components and not also updating the glean version.

This seriously is the result of many months of getting all of the pieces below this in place so :tada: :party: etc.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture