### PR TITLE
For #8116: Attach add-on snackbar to activity rootView

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/addons/AddonsManagementFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/addons/AddonsManagementFragment.kt
@@ -30,6 +30,7 @@ import mozilla.components.feature.addons.ui.PermissionsDialogFragment
 import mozilla.components.feature.addons.ui.translatedName
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.getRootView
 import org.mozilla.fenix.ext.showToolbar
 
 /**
@@ -173,8 +174,9 @@ class AddonsManagementFragment : Fragment(R.layout.fragment_add_ons_management),
             addon,
             onSuccess = {
                 this@AddonsManagementFragment.view?.let { view ->
+                    val rootView = activity?.getRootView() ?: view
                     showSnackBar(
-                        view,
+                        rootView,
                         getString(
                             R.string.mozac_feature_addons_successfully_installed,
                             it.translatedName
@@ -187,7 +189,11 @@ class AddonsManagementFragment : Fragment(R.layout.fragment_add_ons_management),
             },
             onError = { _, _ ->
                 this@AddonsManagementFragment.view?.let { view ->
-                    showSnackBar(view, getString(R.string.mozac_feature_addons_failed_to_install, addon.translatedName))
+                    val rootView = activity?.getRootView() ?: view
+                    showSnackBar(
+                        rootView,
+                        getString(R.string.mozac_feature_addons_failed_to_install, addon.translatedName)
+                    )
                     addonProgressOverlay?.visibility = View.GONE
                     isInstallationInProgress = false
                 }


### PR DESCRIPTION
We show Snackbar with `activity.getRootView()` in `EditBookmarkFragment`, `BrowserToolbarController` and `ShareFragment`. 

This persists the `snackbar.show()` visibility across different fragment transition (i.e. backPress). This, however, still requires the `snackbark.show()` to be executed (which happens in the callback). So, if we decide to backpress before the callback, the snackbar will not show. This seems to be the consistent behaviour across fenix UX AFAIK :).