### PR TITLE
Make 'Redirect to Sync' home menu item go directly to the 'Reconnect to Sync' / error screen

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -623,7 +623,7 @@ class HomeFragment : Fragment() {
                     hideOnboardingIfNeeded()
                     nav(
                         R.id.homeFragment,
-                        HomeFragmentDirections.actionGlobalTurnOnSync()
+                        HomeFragmentDirections.actionHomeFragmentToAccountProblemFragment()
                     )
                 }
             }

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -63,6 +63,9 @@
             android:id="@+id/action_homeFragment_to_turnOnSyncFragment"
             app:destination="@+id/turnOnSyncFragment" />
         <action
+            android:id="@+id/action_homeFragment_to_accountProblemFragment"
+            app:destination="@id/accountProblemFragment" />
+        <action
             android:id="@+id/action_homeFragment_to_searchFragment"
             app:destination="@id/searchFragment"
             app:enterAnim="@anim/fade_in"


### PR DESCRIPTION

![Reconnect](https://user-images.githubusercontent.com/46655/75564796-6940ff80-5a12-11ea-8bc1-0aa6ce3a3022.gif)




### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture