### PR TITLE
Match account problem styling between HomeMenu and BrowserMenu

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
@@ -29,6 +29,7 @@ import org.mozilla.fenix.ReleaseChannel
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.ext.asActivity
 import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.getColorFromAttr
 import org.mozilla.fenix.theme.ThemeManager
 import org.mozilla.fenix.utils.Settings
 
@@ -195,14 +196,14 @@ class DefaultToolbarMenu(
         label = context.getString(R.string.browser_menu_settings),
         startImageResource = R.drawable.ic_settings,
         iconTintColorResource = if (hasAccountProblem)
-            R.color.sync_error_text_color else
+            ThemeManager.resolveAttribute(R.attr.syncDisconnected, context) else
             primaryTextColor(),
         textColorResource = if (hasAccountProblem)
-            R.color.sync_error_text_color else
+            ThemeManager.resolveAttribute(R.attr.primaryText, context) else
             primaryTextColor(),
         highlight = BrowserMenuHighlight.HighPriority(
-            endImageResource = R.drawable.ic_alert,
-            backgroundTint = R.color.sync_error_background_color
+            endImageResource = R.drawable.ic_sync_disconnected,
+            backgroundTint = context.getColorFromAttr(R.attr.syncDisconnectedBackground)
         ),
         isHighlighted = { hasAccountProblem }
     ) {


### PR DESCRIPTION
The BrowserMenu still has the old styling from account problems, so I've made the HomeMenu and BrowserMenu match:

Before:

![Screenshot_20200228-162607](https://user-images.githubusercontent.com/46655/75566752-df933100-5a15-11ea-96c2-70c52ccd3e5a.png)


After:

![Screenshot_20200228-163121](https://user-images.githubusercontent.com/46655/75566769-e7eb6c00-5a15-11ea-8979-a4cdf6d38e6f.png)
![Screenshot_20200228-163043](https://user-images.githubusercontent.com/46655/75566772-eae65c80-5a15-11ea-9d99-7d944a936e4b.png)


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture