### PR TITLE
For #7996: Private mode doesn't play nicely with sites added to home screen

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/customtabs/ExternalAppBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/ExternalAppBrowserFragment.kt
@@ -70,7 +70,7 @@ class ExternalAppBrowserFragment : BaseBrowserFragment(), UserInteractionHandler
                         activity = activity,
                         engineLayout = view.swipeRefresh,
                         onItemTapped = { browserInteractor.onBrowserToolbarMenuItemTapped(it) },
-                        isPrivate = (activity as HomeActivity).browsingModeManager.mode.isPrivate,
+                        isPrivate = it.private,
                         shouldReverseItems = !activity.settings().shouldUseBottomToolbar
                     ),
                     owner = this,
@@ -122,7 +122,13 @@ class ExternalAppBrowserFragment : BaseBrowserFragment(), UserInteractionHandler
                             requireComponents.core.sessionManager,
                             requireComponents.useCases.sessionUseCases.reload,
                             customTabSessionId,
-                            manifest
+                            manifest,
+                            WebAppSiteControlsBuilder(
+                                requireComponents.core.sessionManager,
+                                requireComponents.useCases.sessionUseCases.reload,
+                                customTabSessionId,
+                                manifest
+                            )
                         )
                     )
                 } else {

--- a/app/src/main/java/org/mozilla/fenix/customtabs/WebAppSiteControlsBuilder.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/WebAppSiteControlsBuilder.kt
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.customtabs
+
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import androidx.core.app.NotificationCompat
+import mozilla.components.browser.session.Session
+import mozilla.components.browser.session.SessionManager
+import mozilla.components.concept.engine.manifest.WebAppManifest
+import mozilla.components.feature.pwa.feature.SiteControlsBuilder
+import mozilla.components.feature.session.SessionUseCases
+import org.mozilla.fenix.R
+
+class WebAppSiteControlsBuilder(
+    private val sessionManager: SessionManager,
+    reloadUrlUseCase: SessionUseCases.ReloadUrlUseCase,
+    private val sessionId: String,
+    private val manifest: WebAppManifest
+) : SiteControlsBuilder {
+
+    private val inner = SiteControlsBuilder.CopyAndRefresh(reloadUrlUseCase)
+
+    override fun buildNotification(
+        context: Context,
+        builder: NotificationCompat.Builder,
+        channelId: String
+    ) {
+        inner.buildNotification(context, builder, channelId)
+
+        val isPrivateSession = sessionManager.findSessionById(sessionId)?.private ?: false
+
+        if (!isPrivateSession) { return }
+
+        builder.setSmallIcon(R.drawable.ic_pbm_notification)
+        builder.setContentTitle(context.getString(R.string.pwa_site_controls_title_private, manifest.name))
+    }
+
+    override fun getFilter() = inner.getFilter()
+
+    override fun onReceiveBroadcast(context: Context, session: Session, intent: Intent) = inner.onReceiveBroadcast(context, session, intent)
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -444,6 +444,8 @@
     <string name="collection_open_tabs">Open tabs</string>
     <!-- Text for the menu button to remove a top site -->
     <string name="remove_top_site">Remove</string>
+    <!-- Postfix for private WebApp titles, placeholder is replaced with app name -->
+    <string name="pwa_site_controls_title_private">%1$s (Private Mode)</string>
 
     <!-- History -->
     <!-- Text for the button to clear all history -->


### PR DESCRIPTION
Site Controls Notification should reflect the browsing mode of the current web app session.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not

![Screenshot_20200229-180019](https://user-images.githubusercontent.com/4500858/75611762-a47c2500-5b1d-11ea-8e4c-1e3d0492a5c9.png)

- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

I was only able to test this by removing the `return` statement in the notification builder, as there is currently no way to start PWAs in private mode. https://github.com/mozilla-mobile/android-components/blob/0dd4e8df2229c44e076554c73542d560e05a04e9/components/feature/pwa/src/main/java/mozilla/components/feature/pwa/intent/WebAppIntentProcessor.kt#L48

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture