### PR TITLE
For #8898 Show round progress bar only on end side

### DIFF
--- a/app/src/main/res/drawable/progress_gradient.xml
+++ b/app/src/main/res/drawable/progress_gradient.xml
@@ -12,7 +12,11 @@
     <item android:id="@android:id/progress">
         <scale android:scaleWidth="100%">
             <shape>
-                <corners android:radius="8dp" />
+                <corners
+                    android:bottomLeftRadius="0dp"
+                    android:bottomRightRadius="8dp"
+                    android:topLeftRadius="0dp"
+                    android:topRightRadius="8dp"/>
                 <gradient
                     android:angle="45"
                     android:centerColor="#F10366"


### PR DESCRIPTION
This will auto-mirror on RTL so it will also show at progressbar end

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.


![progress](https://user-images.githubusercontent.com/48995920/75683806-707d3d00-5ca0-11ea-8706-e09ba69af809.png)

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture