### PR TITLE
Issue #7863: Ensure parent process triggers speculative connect

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarView.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarView.kt
@@ -213,7 +213,8 @@ class BrowserToolbarView(
                     components.core.sessionManager,
                     sessionId = null,
                     isPrivate = sessionManager.selectedSession?.private ?: false,
-                    interactor = interactor
+                    interactor = interactor,
+                    engine = components.core.engine
                 )
             }
         }

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarIntegration.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarIntegration.kt
@@ -12,6 +12,7 @@ import mozilla.components.browser.domains.autocomplete.DomainAutocompleteProvide
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.browser.toolbar.display.DisplayToolbar
+import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.storage.HistoryStorage
 import mozilla.components.feature.toolbar.ToolbarAutocompleteFeature
 import mozilla.components.feature.toolbar.ToolbarFeature
@@ -72,7 +73,8 @@ class DefaultToolbarIntegration(
     sessionManager: SessionManager,
     sessionId: String? = null,
     isPrivate: Boolean,
-    interactor: BrowserToolbarViewInteractor
+    interactor: BrowserToolbarViewInteractor,
+    engine: Engine
 ) : ToolbarIntegration(
     context = context,
     toolbar = toolbar,
@@ -135,7 +137,11 @@ class DefaultToolbarIntegration(
         }
         toolbar.addBrowserAction(tabsAction)
 
-        ToolbarAutocompleteFeature(toolbar).apply {
+        val engineForSpeculativeConnects = if (!isPrivate) engine else null
+        ToolbarAutocompleteFeature(
+            toolbar,
+            engineForSpeculativeConnects
+        ).apply {
             addDomainProvider(domainAutocompleteProvider)
             if (context.settings().shouldShowHistorySuggestions) {
                 addHistoryStorageProvider(historyStorage)

--- a/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
@@ -127,7 +127,8 @@ class SearchFragment : Fragment(), UserInteractionHandler {
             view.toolbar_component_wrapper,
             searchInteractor,
             historyStorageProvider(),
-            (activity as HomeActivity).browsingModeManager.mode.isPrivate
+            (activity as HomeActivity).browsingModeManager.mode.isPrivate,
+            requireComponents.core.engine
         )
 
         val urlView = toolbarView.view
@@ -307,6 +308,10 @@ class SearchFragment : Fragment(), UserInteractionHandler {
         fill_link_from_clipboard.visibility = visibility
         divider_line.visibility = visibility
         clipboard_url.text = clipboardUrl
+
+        if (clipboardUrl != null && !((activity as HomeActivity).browsingModeManager.mode.isPrivate)) {
+            requireComponents.core.engine.speculativeConnect(clipboardUrl)
+        }
     }
 
     override fun onRequestPermissionsResult(

--- a/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarView.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarView.kt
@@ -141,6 +141,7 @@ class AwesomeBarView(
         val draw = getDrawable(context, R.drawable.ic_link)!!
         draw.colorFilter = createBlendModeColorFilterCompat(primaryTextColor, SRC_IN)
 
+        val engineForSpeculativeConnects = if (!isBrowsingModePrivate()) components.core.engine else null
         sessionProvider =
             SessionSuggestionProvider(
                 context.resources,
@@ -154,14 +155,16 @@ class AwesomeBarView(
             HistoryStorageSuggestionProvider(
                 components.core.historyStorage,
                 loadUrlUseCase,
-                components.core.icons
+                components.core.icons,
+                engineForSpeculativeConnects
             )
 
         bookmarksStorageSuggestionProvider =
             BookmarksStorageSuggestionProvider(
                 components.core.bookmarksStorage,
                 loadUrlUseCase,
-                components.core.icons
+                components.core.icons,
+                engineForSpeculativeConnects
             )
 
         val searchDrawable = getDrawable(context, R.drawable.ic_search)!!
@@ -176,7 +179,8 @@ class AwesomeBarView(
                 mode = SearchSuggestionProvider.Mode.MULTIPLE_SUGGESTIONS,
                 limit = 3,
                 icon = searchDrawable.toBitmap(),
-                showDescription = false
+                showDescription = false,
+                engine = engineForSpeculativeConnects
             )
 
         shortcutsEnginePickerProvider =
@@ -344,6 +348,8 @@ class AwesomeBarView(
             val draw = getDrawable(context, R.drawable.ic_search)
             draw?.colorFilter = createBlendModeColorFilterCompat(primaryTextColor, SRC_IN)
 
+            val engineForSpeculativeConnects = if (!isBrowsingModePrivate()) components.core.engine else null
+
             SearchSuggestionProvider(
                 components.search.provider.installedSearchEngines(context).list.find { it.name == engine.name }
                     ?: components.search.provider.getDefaultEngine(context),
@@ -351,7 +357,8 @@ class AwesomeBarView(
                 components.core.client,
                 limit = 3,
                 mode = SearchSuggestionProvider.Mode.MULTIPLE_SUGGESTIONS,
-                icon = draw?.toBitmap()
+                icon = draw?.toBitmap(),
+                engine = engineForSpeculativeConnects
             )
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarView.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarView.kt
@@ -145,7 +145,7 @@ class AwesomeBarView(
         sessionProvider =
             SessionSuggestionProvider(
                 context.resources,
-                components.core.sessionManager,
+                components.core.store,
                 selectTabUseCase,
                 components.core.icons,
                 excludeSelectedSession = true

--- a/app/src/main/java/org/mozilla/fenix/search/toolbar/ToolbarView.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/toolbar/ToolbarView.kt
@@ -22,6 +22,7 @@ import kotlinx.android.extensions.LayoutContainer
 import mozilla.components.browser.domains.autocomplete.ShippedDomainsProvider
 import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.browser.toolbar.behavior.BrowserToolbarBottomBehavior
+import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.storage.HistoryStorage
 import mozilla.components.feature.toolbar.ToolbarAutocompleteFeature
 import mozilla.components.support.ktx.android.content.getColorFromAttr
@@ -63,7 +64,8 @@ class ToolbarView(
     private val container: ViewGroup,
     private val interactor: ToolbarInteractor,
     private val historyStorage: HistoryStorage?,
-    private val isPrivate: Boolean
+    private val isPrivate: Boolean,
+    engine: Engine
 ) : LayoutContainer {
 
     override val containerView: View?
@@ -137,7 +139,11 @@ class ToolbarView(
             })
         }
 
-        ToolbarAutocompleteFeature(view).apply {
+        val engineForSpeculativeConnects = if (!isPrivate) engine else null
+        ToolbarAutocompleteFeature(
+            view,
+            engineForSpeculativeConnects
+        ).apply {
             addDomainProvider(ShippedDomainsProvider().also { it.initialize(view.context) })
             historyStorage?.also(::addHistoryStorageProvider)
         }


### PR DESCRIPTION
Small change to the views to make sure we pass along the engine for speculative connects in the toolbar and awesomebar. We only want to issue speculative connect calls for regular (!private) tabs.

We already have speculative connect calls for custom tabs and when opening links through intents.

This needs https://github.com/mozilla-mobile/android-components/pull/6111 to land.