### PR TITLE
Add secret menu to use custom FxA/Sync server

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/FxaServer.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/FxaServer.kt
@@ -7,6 +7,7 @@ import android.content.Context
 import mozilla.components.service.fxa.ServerConfig
 import mozilla.components.service.fxa.ServerConfig.Server
 import org.mozilla.fenix.FeatureFlags
+import org.mozilla.fenix.ext.settings
 
 /**
  * Utility to configure Firefox Account servers.
@@ -24,6 +25,11 @@ object FxaServer {
     }
 
     fun config(context: Context): ServerConfig {
-        return ServerConfig(Server.RELEASE, CLIENT_ID, redirectUrl(context))
+        val serverOverride = context.settings().overrideFxAServer
+        val tokenServerOverride = context.settings().overrideSyncTokenServer.ifEmpty { null }
+        if (serverOverride.isEmpty()) {
+            return ServerConfig(Server.RELEASE, CLIENT_ID, redirectUrl(context), tokenServerOverride)
+        }
+        return ServerConfig(serverOverride, CLIENT_ID, redirectUrl(context), tokenServerOverride)
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -187,6 +187,8 @@ class Settings private constructor(
                 (trackingProtectionOnboardingCount < trackingProtectionOnboardingMaximumCount &&
                 !trackingProtectionOnboardingShownThisSession)
 
+    var showSecretDebugMenuThisSession = false
+
     val shouldShowSecurityPinWarningSync: Boolean
         get() = loginsSecureWarningSyncCount < showLoginsSecureWarningSyncMaxCount
 
@@ -596,5 +598,15 @@ class Settings private constructor(
     var openLinksInExternalApp by booleanPreference(
         appContext.getPreferenceKey(R.string.pref_key_open_links_in_external_app),
         default = false
+    )
+
+    var overrideFxAServer by stringPreference(
+        appContext.getPreferenceKey(R.string.pref_key_override_fxa_server),
+        default = ""
+    )
+
+    var overrideSyncTokenServer by stringPreference(
+        appContext.getPreferenceKey(R.string.pref_key_override_sync_tokenserver),
+        default = ""
     )
 }

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -38,6 +38,8 @@
     <string name="pref_key_account" translatable="false">pref_key_account</string>
     <string name="pref_key_sign_in" translatable="false">pref_key_sign_in</string>
     <string name="pref_key_account_auth_error" translatable="false">pref_key_account_auth_error</string>
+    <string name="pref_key_override_fxa_server" translatable="false">pref_key_override_fxa_server</string>
+    <string name="pref_key_override_sync_tokenserver" translatable="false">pref_key_override_sync_tokenserver</string>
     <string name="pref_key_private_mode" translatable="false">pref_key_private_mode</string>
     <string name="pref_key_customize" translatable="false">pref_key_customize</string>
     <string name="pref_key_toolbar" translatable="false">pref_key_toolbar</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -200,6 +200,12 @@
     <string name="preferences_add_private_browsing_shortcut">Add private browsing shortcut</string>
     <!-- Preference for accessibility -->
     <string name="preferences_accessibility">Accessibility</string>
+    <!-- Preference to override the Firefox Account server -->
+    <string name="preferences_override_fxa_server">Custom Firefox Account server</string>
+    <!-- Preference to override the Sync token server -->
+    <string name="preferences_override_sync_tokenserver">Custom Sync server</string>
+    <!-- Toast shown after updating the FxA/Sync server override preferences -->
+    <string name="toast_override_fxa_sync_server_done">Firefox Account/Sync server modified. Quitting the application to apply changes…</string>
     <!-- Preference category for account information -->
     <string name="preferences_category_account">Account</string>
     <!-- Preference shown on banner to sign into account -->
@@ -1050,6 +1056,10 @@
     <string name="about_licensing_information">Licensing information</string>
     <!-- About page link text to open a screen with libraries that are used -->
     <string name="about_other_open_source_libraries">Libraries that we use</string>
+    <!-- Toast shown to the user when they are activating the secret dev menu
+        The first parameter is number of long clicks left to enable the menu -->
+    <string name="about_debug_menu_toast_progress">Debug menu: %1$d click(s) left to enable</string>
+    <string name="about_debug_menu_toast_done">Debug menu enabled</string>
 
     <!-- Content description of the tab counter toolbar button when one tab is open -->
     <string name="tab_counter_content_description_one_tab">1 tab</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -29,6 +29,20 @@
             android:key="@string/pref_key_account_auth_error"/>
     </androidx.preference.PreferenceCategory>
 
+    <androidx.preference.EditTextPreference
+        android:key="@string/pref_key_override_fxa_server"
+        android:title="@string/preferences_override_fxa_server"
+        android:inputType="textUri"
+        app:iconSpaceReserved="false"
+        app:isPreferenceVisible="false"/>
+
+    <androidx.preference.EditTextPreference
+        android:key="@string/pref_key_override_sync_tokenserver"
+        android:title="@string/preferences_override_sync_tokenserver"
+        android:inputType="textUri"
+        app:iconSpaceReserved="false"
+        app:isPreferenceVisible="false"/>
+
     <androidx.preference.PreferenceCategory
         android:title="@string/preferences_category_general"
         app:iconSpaceReserved="false">


### PR DESCRIPTION
Fixes https://github.com/mozilla-mobile/fenix/issues/3762.
Fixes https://github.com/mozilla/application-services/issues/2651.

You need to click 5 times the Firefox Preview logo in the "About Firefox Preview" setting page to activate the secret menu. This will add a new menu under "Turn on Sync" where you can specify a different content server URL.

Because re-creating a `FxAccountManager` instance would involve an insane refactoring (and plenty of bugs), we help the user by killing the app for them when they change that setting.

⚠️ Note that this menu is **not intended for end-users** but for QA only. ⚠️