### PR TITLE
For #7847: Improve startup performance of the Fenix wrapper around Glean

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
@@ -5,9 +5,6 @@
 package org.mozilla.fenix.components.metrics
 
 import android.content.Context
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.MainScope
-import kotlinx.coroutines.launch
 import mozilla.components.service.glean.Glean
 import mozilla.components.service.glean.private.NoExtraKeys
 import mozilla.components.support.base.log.logger.Logger
@@ -509,12 +506,6 @@ class GleanMetricsService(private val context: Context) : MetricsService {
 
     private val logger = Logger("GleanMetricsService")
     private var initialized = false
-    /*
-     * We need to keep an eye on when we are done starting so that we don't
-     * accidentally stop ourselves before we've ever started.
-     */
-    private lateinit var gleanInitializer: Job
-    private lateinit var gleanSetStartupMetrics: Job
 
     private val activationPing = ActivationPing(context)
 
@@ -526,17 +517,22 @@ class GleanMetricsService(private val context: Context) : MetricsService {
         if (initialized) return
         initialized = true
 
+        // The code below doesn't need to execute immediately, so we'll add them to the visual
+        // completeness task queue to be run later.
+        val taskManager = context.components.performance.visualCompletenessTaskManager
+
         // We have to initialize Glean *on* the main thread, because it registers lifecycle
         // observers. However, the activation ping must be sent *off* of the main thread,
         // because it calls Google ad APIs that must be called *off* of the main thread.
         // These two things actually happen in parallel, but that should be ok because Glean
         // can handle events being recorded before it's initialized.
-        gleanInitializer = MainScope().launch {
+        taskManager.add {
             Glean.registerPings(Pings)
         }
+
         // setStartupMetrics is not a fast function. It does not need to be done before we can consider
         // ourselves initialized. So, let's do it, well, later.
-        gleanSetStartupMetrics = MainScope().launch {
+        taskManager.add {
             setStartupMetrics()
         }
     }
@@ -575,8 +571,6 @@ class GleanMetricsService(private val context: Context) : MetricsService {
     }
 
     override fun stop() {
-        gleanInitializer.cancel()
-        gleanSetStartupMetrics.cancel()
         Glean.setUploadEnabled(false)
     }
 


### PR DESCRIPTION
This should address #7847. I'm not quite sure what I should do about cancelling the callbacks we're deferring until visual completeness, so I removed that for now. I think we probably want to add it back in, so let me know if you have any ideas. Based on my tests, this shaves about 38ms off our app-link startup time (for some reason, I can't get numbers for regular startup...).

@emalysz Am I using the visual completeness manager correctly here? I didn't see any uses of it yet in the tree, so I just made an educated guess as to what the right way here is (Kotlin isn't my strongest language).