### PR TITLE
Issue #8291: Speculatively create content process in search fragment

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
@@ -84,8 +84,10 @@ class SearchFragment : Fragment(), UserInteractionHandler {
             requireComponents.search.provider.getDefaultEngine(requireContext())
         )
 
+        val isPrivate = (activity as HomeActivity).browsingModeManager.mode.isPrivate
+
         val showSearchSuggestions =
-            if ((activity as HomeActivity).browsingModeManager.mode.isPrivate) {
+            if (isPrivate) {
                 requireContext().settings().shouldShowSearchSuggestions &&
                         requireContext().settings().shouldShowSearchSuggestionsInPrivate
             } else {
@@ -127,7 +129,7 @@ class SearchFragment : Fragment(), UserInteractionHandler {
             view.toolbar_component_wrapper,
             searchInteractor,
             historyStorageProvider(),
-            (activity as HomeActivity).browsingModeManager.mode.isPrivate,
+            isPrivate,
             requireComponents.core.engine
         )
 
@@ -135,6 +137,7 @@ class SearchFragment : Fragment(), UserInteractionHandler {
             .findViewById<InlineAutocompleteEditText>(R.id.mozac_browser_toolbar_edit_url_view)
         urlView?.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
 
+        requireComponents.core.engine.speculativeCreateSession(isPrivate)
         startPostponedEnterTransition()
         return view
     }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -32,7 +32,7 @@ object Versions {
     const val androidx_work = "2.2.0"
     const val google_material = "1.1.0"
 
-    const val mozilla_android_components = "35.0.0-SNAPSHOT"
+    const val mozilla_android_components = "36.0.0-SNAPSHOT"
 
     const val adjust = "4.18.3"
     const val installreferrer = "1.0"


### PR DESCRIPTION
Requires: https://github.com/mozilla-mobile/android-components/pull/6165 

Summary: This makes sure we have an engine (gecko) session ready when the user enters a search term or a URL. 

NB: The reason this is needed in Fenix (and not R-B) is due to the different UI implemenations. R-B opens the tab (and creates an engine session) before the toolbar and awesomebar are displayed. In Fenix, the new tab is opened after the user "hits enter" in the toolbar of the search fragment.