### PR TITLE
Bug 1619795: Make it easier to specify paths of toolchain artifacts

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -8,7 +8,7 @@ tasks:
     - $let:
           taskgraph:
               branch: taskgraph
-              revision: 7a51e874018f13aa236f5dc64ae7bbcaf942fcf3
+              revision: 932b4cf48cc785c31b03f0b9f2cba654bc67bc00
           trustDomain: mobile
       in:
           $let:

--- a/taskcluster/ci/geckoview/kind.yml
+++ b/taskcluster/ci/geckoview/kind.yml
@@ -1,11 +1,17 @@
 ---
 loader: taskgraph.loader.transform:loader
 transforms:
-    - taskgraph.transforms.index_search:transforms
+    - taskgraph.transforms.job:transforms
     - taskgraph.transforms.task:transforms
+
+job-defaults:
+    worker-type: always-optimized
+    run:
+        using: index-search
 
 jobs:
     nightly:
         description: "upstream nightly job"
-        index-search:
-            - gecko.v2.mozilla-central.nightly.latest.mobile.android-x86_64-opt
+        run:
+            index-search:
+                - gecko.v2.mozilla-central.nightly.latest.mobile.android-x86_64-opt

--- a/taskcluster/ci/raptor/kind.yml
+++ b/taskcluster/ci/raptor/kind.yml
@@ -79,8 +79,8 @@ job-defaults:
             - '--activity=org.mozilla.fenix.browser.BrowserPerformanceTestActivity'
             - '--download-symbols=ondemand'
     fetches:
-        linux64-minidump-stackwalk:
-            - artifact: minidump_stackwalk.tar.xz
+        toolchain:
+            - linux64-minidump-stackwalk
 
 jobs:
     tp6m-1-cold:

--- a/taskcluster/ci/toolchain/kind.yml
+++ b/taskcluster/ci/toolchain/kind.yml
@@ -1,11 +1,19 @@
 ---
 loader: taskgraph.loader.transform:loader
 transforms:
-    - taskgraph.transforms.index_search:transforms
+    - taskgraph.transforms.job:transforms
     - taskgraph.transforms.task:transforms
+
+job-defaults:
+    worker-type: always-optimized
+    run:
+        using: index-search
 
 jobs:
     linux64-minidump-stackwalk:
         description: "minidump_stackwalk toolchain"
-        index-search:
-            - gecko.cache.level-3.toolchains.v3.linux64-minidump-stackwalk.latest
+        attributes:
+            toolchain-artifact: public/build/minidump_stackwalk.tar.gz
+        run:
+            index-search:
+                - gecko.cache.level-3.toolchains.v3.linux64-minidump-stackwalk.latest


### PR DESCRIPTION
This updates taskgraph to allow specifying `toolchain-artifact` on toolchain tasks, to support the mozilla-central ffmpeg task which has an artifact at `public/` instead of `public/build/`.