### PR TITLE
Update IntentProcessor implementation to comply with new interface

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/customtabs/FennecWebAppIntentProcessor.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/FennecWebAppIntentProcessor.kt
@@ -43,7 +43,7 @@ class FennecWebAppIntentProcessor(
     /**
      * Returns true if this intent should launch a progressive web app created in Fennec.
      */
-    override fun matches(intent: Intent) =
+    private fun matches(intent: Intent) =
         intent.toSafeIntent().action == ACTION_FENNEC_WEBAPP
 
     /**

--- a/app/src/main/java/org/mozilla/fenix/home/intent/FennecBookmarkShortcutsIntentProcessor.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/intent/FennecBookmarkShortcutsIntentProcessor.kt
@@ -27,7 +27,7 @@ class FennecBookmarkShortcutsIntentProcessor(
     /**
      * Returns true if this Intent is of a Fennec pinned shortcut.
      */
-    override fun matches(intent: Intent): Boolean {
+    private fun matches(intent: Intent): Boolean {
         return intent.toSafeIntent().action == ACTION_FENNEC_HOMESCREEN_SHORTCUT
     }
 

--- a/app/src/main/java/org/mozilla/fenix/shortcut/NewTabShortcutIntentProcessor.kt
+++ b/app/src/main/java/org/mozilla/fenix/shortcut/NewTabShortcutIntentProcessor.kt
@@ -17,7 +17,7 @@ class NewTabShortcutIntentProcessor : IntentProcessor {
     /**
      * Returns true if this intent processor will handle the intent.
      */
-    override fun matches(intent: Intent): Boolean {
+    private fun matches(intent: Intent): Boolean {
         val safeIntent = SafeIntent(intent)
         return safeIntent.action == ACTION_OPEN_TAB || safeIntent.action == ACTION_OPEN_PRIVATE_TAB
     }

--- a/app/src/test/java/org/mozilla/fenix/IntentReceiverActivityTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/IntentReceiverActivityTest.kt
@@ -40,9 +40,7 @@ class IntentReceiverActivityTest {
         intent.flags = FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY
 
         `when`(testContext.components.intentProcessors.intentProcessor.process(intent)).thenReturn(true)
-        `when`(testContext.components.intentProcessors.intentProcessor.matches(intent)).thenReturn(true)
         `when`(testContext.components.intentProcessors.customTabIntentProcessor.process(intent)).thenReturn(false)
-        `when`(testContext.components.intentProcessors.customTabIntentProcessor.matches(intent)).thenReturn(false)
         val activity = Robolectric.buildActivity(IntentReceiverActivity::class.java, intent).get()
         activity.processIntent(intent)
 
@@ -155,7 +153,6 @@ class IntentReceiverActivityTest {
 
         val intent = Intent()
         `when`(testContext.components.intentProcessors.customTabIntentProcessor.process(intent)).thenReturn(true)
-        `when`(testContext.components.intentProcessors.customTabIntentProcessor.matches(intent)).thenReturn(true)
 
         val activity = Robolectric.buildActivity(IntentReceiverActivity::class.java, intent).get()
         activity.processIntent(intent)
@@ -176,7 +173,6 @@ class IntentReceiverActivityTest {
 
         val intent = Intent()
         `when`(testContext.components.intentProcessors.privateCustomTabIntentProcessor.process(intent)).thenReturn(true)
-        `when`(testContext.components.intentProcessors.privateCustomTabIntentProcessor.matches(intent)).thenReturn(true)
 
         val activity = Robolectric.buildActivity(IntentReceiverActivity::class.java, intent).get()
         activity.processIntent(intent)

--- a/app/src/test/java/org/mozilla/fenix/components/IntentProcessorTypeTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/IntentProcessorTypeTest.kt
@@ -103,7 +103,6 @@ class IntentProcessorTypeTest {
     @Test
     fun `get type for generic intent processor`() {
         val processor = object : IntentProcessor {
-            override fun matches(intent: Intent) = true
             override suspend fun process(intent: Intent) = true
         }
         val type = testContext.components.intentProcessors.getType(processor)

--- a/app/src/test/java/org/mozilla/fenix/home/intent/FennecBookmarkShortcutsIntentProcessorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/intent/FennecBookmarkShortcutsIntentProcessorTest.kt
@@ -38,23 +38,12 @@ class FennecBookmarkShortcutsIntentProcessorTest {
     private val loadUrlUseCase = mockk<SessionUseCases.DefaultLoadUrlUseCase>(relaxed = true)
 
     @Test
-    fun `only match Fennec pinned shortcut Intents`() {
-        val processor = FennecBookmarkShortcutsIntentProcessor(sessionManager, loadUrlUseCase)
-
-        assertAll {
-            assertThat(processor.matches(Intent(ACTION_FENNEC_HOMESCREEN_SHORTCUT))).isTrue()
-            assertThat(processor.matches(Intent("ShouldNotMatch"))).isFalse()
-            assertThat(processor.matches(Intent())).isFalse()
-        }
-    }
-
-    @Test
     fun `do not process blank Intents`() = runBlocking {
         val processor = FennecBookmarkShortcutsIntentProcessor(sessionManager, loadUrlUseCase)
         val fennecShortcutsIntent = Intent(ACTION_FENNEC_HOMESCREEN_SHORTCUT)
         fennecShortcutsIntent.data = Uri.parse("http://mozilla.org")
 
-        val wasEmptyIntentProcessed = processor.matches(Intent())
+        val wasEmptyIntentProcessed = processor.process(Intent())
 
         assertThat(wasEmptyIntentProcessed).isFalse()
         verify {


### PR DESCRIPTION
We changed the Fenix implementation in https://github.com/mozilla-mobile/fenix/pull/8823. And removed `matches()` from the interface in AC in https://github.com/mozilla-mobile/android-components/issues/6097. Now we can remove the `override` keyword from the `IntentProcessor` implementations living in Fenix.