### PR TITLE
Use new MemoryConsumer.onTrimMemory() API.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -220,8 +220,10 @@ open class FenixApplication : LocaleAwareApplication() {
 
     override fun onTrimMemory(level: Int) {
         super.onTrimMemory(level)
+
         runOnlyInMainProcess {
-            components.core.sessionManager.onLowMemory()
+            components.core.icons.onTrimMemory(level)
+            components.core.sessionManager.onTrimMemory(level)
         }
     }
 


### PR DESCRIPTION
The latest snapshot (currently building) comes with an updated API. Instead of `onLowMemory()` we now support `onTrimMemory(level)` from Android's `ComponentCallbacks2`. This allows us to make better decisions based on the `level`. In addition to that I also added the call to `BrowserIcons` which also supports trimming its memory usage if needed.