### PR TITLE
Bug 1619795: Cleanup.

### DIFF
--- a/taskcluster/ci/raptor/kind.yml
+++ b/taskcluster/ci/raptor/kind.yml
@@ -22,7 +22,6 @@ job-defaults:
         retrigger: true
     dependencies:
         geckoview-nightly: geckoview-nightly
-        linux64-minidump-stackwalk: toolchain-linux64-minidump-stackwalk
     notify:
         by-level:
             '3':

--- a/taskcluster/ci/toolchain/kind.yml
+++ b/taskcluster/ci/toolchain/kind.yml
@@ -13,7 +13,7 @@ jobs:
     linux64-minidump-stackwalk:
         description: "minidump_stackwalk toolchain"
         attributes:
-            toolchain-artifact: public/build/minidump_stackwalk.tar.gz
+            toolchain-artifact: public/build/minidump_stackwalk.tar.xz
         run:
             index-search:
                 - gecko.cache.level-3.toolchains.v3.linux64-minidump-stackwalk.latest


### PR DESCRIPTION
There were a couple of errors in the original pull request for this bug:
- The raptor tasks had duplicated dependencies.
- The filename of the minidump_stackwalk artifact was incorrect.