### PR TITLE
Closes #8541: Close find bar when entering fullscreen

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -836,6 +836,8 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Session
 
     private fun fullScreenChanged(inFullScreen: Boolean) {
         if (inFullScreen) {
+            // Close find in page bar if opened
+            findInPageIntegration.onBackPressed()
             FenixSnackbar.make(
                     view = view!!,
                     duration = Snackbar.LENGTH_SHORT,


### PR DESCRIPTION
Closes #8541: Calls `findInPageIntegration.onBackPressed()` when entering fullscreen. I'm not sure if this is the right way to do it. I have not added a test, please let me know how I could add one if this is needed.
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture