### PR TITLE
Fix #7928: Add padding to checkbox

### DIFF
--- a/app/src/main/res/layout/checkbox_left_preference.xml
+++ b/app/src/main/res/layout/checkbox_left_preference.xml
@@ -12,7 +12,7 @@
     android:focusable="true"
     android:gravity="center_vertical"
     android:paddingStart="8dp"
-    android:paddingBottom="8dp"
+    android:minHeight="?android:attr/listPreferredItemHeight"
     android:paddingEnd="?android:attr/scrollbarSize">
 
     <LinearLayout


### PR DESCRIPTION
Fixes #7928: add `android:minHeight="?android:attr/listPreferredItemHeight" `.

Note: app/src/main/res/layout/checkbox_left_preference.xml is now completely identical to app/src/main/res/layout/delete_browsing_category_checkbox.xml. Can one of these files be deleted?
### Screenshots:
#### Before:
![grafik](https://user-images.githubusercontent.com/44171190/76078274-93f6ff00-5fa2-11ea-909f-0dfc9582d02a.png)
(This looks even worse with rounded screen corners)
#### After:
![grafik](https://user-images.githubusercontent.com/44171190/76078134-585c3500-5fa2-11ea-9b5b-81a1399b9267.png)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture