### PR TITLE
ui-tests-homescreen-fix-to-enable.

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
@@ -7,7 +7,6 @@ package org.mozilla.fenix.ui
 import androidx.test.uiautomator.UiDevice
 import org.junit.Rule
 import org.junit.Test
-import org.junit.Ignore
 import org.mozilla.fenix.helpers.HomeActivityTestRule
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.By
@@ -51,12 +50,17 @@ class HomeScreenTest {
             verifyNoCollectionsTextIsNotShown()
             verifyHomeToolbar()
             verifyHomeComponent()
+
+            // Verify Top Sites
+            verifyExistingTopSitesList()
+            verifyExistingTopSitesTabs("Wikipedia")
+            verifyExistingTopSitesTabs("YouTube")
+            verifyExistingTopSitesTabs("Top Articles")
         }
     }
 
     @Test
-    @Ignore("Temp disable flakey test - see: https://github.com/mozilla-mobile/fenix/issues/5462")
-    fun firstRunHomeScreenItemsTest() {
+    fun firstRunScreenTest() {
         homeScreen {
             verifyHomeScreen()
             verifyNavigationToolbar()
@@ -65,39 +69,59 @@ class HomeScreenTest {
             verifyHomeWordmark()
 
             verifyWelcomeHeader()
-
+            // Sign in to Firefox
             verifyGetTheMostHeader()
             verifyAccountsSignInButton()
+
+            // Intro to other sections
             verifyGetToKnowHeader()
 
-            swipeUpToDismissFirstRun()
+            // See What's new
+            scrollToElementByText("See what’s new")
+            verifyWhatsNewHeader()
+            verifyWhatsNewLink()
 
-            verifyChooseThemeHeader()
-            verifyChooseThemeText()
-            verifyLightThemeToggle()
-            verifyLightThemeDescription()
-            verifyDarkThemeToggle()
-            verifyDarkThemeDescription()
-            verifyAutomaticThemeToggle()
-            verifyAutomaticThemeDescription()
-
+            // Protect yourself
+            scrollToElementByText("Protect yourself")
             verifyProtectYourselfHeader()
             verifyTrackingProtectionToggle()
             verifyProtectYourselfText()
 
+            /* Check disable due to Firebase failures on Pixel 2 API 28
+            // Choose your theme
+            verifyChooseThemeHeader()
+            verifyChooseThemeText()
+            verifyDarkThemeDescription()
+            verifyDarkThemeToggle()
+            verifyLightThemeDescription()
+            verifyLightThemeToggle()
+
+            // Browse privately
+            scrollToElementByText("Open Settings")
             verifyBrowsePrivatelyHeader()
             verifyBrowsePrivatelyText()
+             */
+
+            swipeToBottom()
+
+            // Take a position
+            scrollToElementByText("Take a position")
+            verifyTakePositionHeader()
+            verifyTakePositionElements()
+
+            // Your privacy
+            scrollToElementByText("Your privacy")
             verifyYourPrivacyHeader()
             verifyYourPrivacyText()
-
             verifyPrivacyNoticeButton()
+
+            // Start Browsing
+            swipeToBottom()
             verifyStartBrowsingButton()
         }
     }
 
     @Test
-    @Ignore("Temp disable broken test - see:  https://github.com/mozilla-mobile/fenix/issues/5050")
-
     fun privateModeScreenItemsTest() {
         homeScreen { }.dismissOnboarding()
         homeScreen { }.togglePrivateBrowsingMode()
@@ -114,9 +138,10 @@ class HomeScreenTest {
             verifyPrivateSessionMessage(visible = true)
             verifyHomeToolbar()
             verifyHomeComponent()
+        }.openCommonMythsLink {
+            verifyUrl("common-myths-about-private-browsing")
+            mDevice.pressBack()
         }
-
-        homeScreen { }.addNewTab()
 
         homeScreen {
             // To deal with the race condition where multiple "add tab" buttons are present,

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -32,6 +32,7 @@ import org.junit.Assert.assertTrue
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.helpers.Constants.LongClickDuration
+import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.click
 import org.mozilla.fenix.helpers.ext.waitNotNull
@@ -54,8 +55,9 @@ class BrowserRobot {
             Until.findObject(By.res("org.mozilla.fenix.debug:id/mozac_browser_toolbar_url_view")),
             waitingTime
         )
+        TestAssetHelper.waitingTime
         onView(withId(R.id.mozac_browser_toolbar_url_view))
-            .check(matches(withText(containsString(url))))
+                .check(matches(withText(containsString(url))))
     }
 
     fun verifyHelpUrl() {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
@@ -82,14 +82,27 @@ class HomeScreenRobot {
     fun verifyTrackingProtectionToggle() = assertTrackingProtectionToggle()
     fun verifyProtectYourselfText() = assertProtectYourselfText()
 
+    // What's new elements
+    fun verifyWhatsNewHeader() = assertWhatsNewHeather()
+    fun verifyWhatsNewLink() = assertWhatsNewLink()
+
+    // Browse privately
     fun verifyBrowsePrivatelyHeader() = assertBrowsePrivatelyHeader()
     fun verifyBrowsePrivatelyText() = assertBrowsePrivatelyText()
+
+    // Take a position
+    fun verifyTakePositionHeader() = assertTakePositionheader()
+    fun verifyTakePositionElements() {
+        assertTakePositionBottomRadioButton()
+        assertTakePositionTopRadioButton()
+    }
+
+    // Your privacy
     fun verifyYourPrivacyHeader() = assertYourPrivacyHeader()
     fun verifyYourPrivacyText() = assertYourPrivacyText()
     fun verifyPrivacyNoticeButton() = assertPrivacyNoticeButton()
     fun verifyStartBrowsingButton() = assertStartBrowsingButton()
 
-    // Private mode elements
     fun verifyPrivateSessionHeader() = assertPrivateSessionHeader()
 
     fun verifyPrivateSessionMessage(visible: Boolean = true) = assertPrivateSessionMessage(visible)
@@ -153,7 +166,7 @@ class HomeScreenRobot {
             .perform(click())
     }
 
-    fun swipeToBottom() = onView(withId(R.id.sessionControlRecyclerView)).perform(ViewActions.swipeUp())
+    fun swipeToBottom() = onView(withId(R.id.homeLayout)).perform(ViewActions.swipeUp())
 
     fun swipeToTop() = onView(withId(R.id.sessionControlRecyclerView)).perform(ViewActions.swipeDown())
 
@@ -260,6 +273,14 @@ class HomeScreenRobot {
             onView(withText("Open in private tab"))
                 .check((matches(withEffectiveVisibility(Visibility.VISIBLE))))
                 .perform(click())
+
+            BrowserRobot().interact()
+            return BrowserRobot.Transition()
+        }
+
+        fun openCommonMythsLink(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
+            onView(withId(R.id.private_session_common_myths))
+                    .perform(click())
 
             BrowserRobot().interact()
             return BrowserRobot.Transition()
@@ -389,7 +410,7 @@ private fun assertChooseThemeHeader() =
         .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
 private fun assertChooseThemeText() =
-    onView(allOf(withText("Try dark theme: easier on your battery and your eyes.")))
+    onView(allOf(withText("Save some battery and your eyesight by enabling dark mode.")))
         .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
 private fun assertLightThemeToggle() =
@@ -409,7 +430,7 @@ private fun assertDarkThemeDescription() =
         .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
 private fun assertAutomaticThemeToggle() =
-    onView(ViewMatchers.withResourceName("theme_automatic_radio_button"))
+    onView(withId(R.id.theme_automatic_radio_button))
         .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
 private fun assertAutomaticThemeDescription() =
@@ -429,7 +450,7 @@ private fun assertProtectYourselfText() {
     onView(
         allOf(
             withText(
-                "Firefox Preview blocks ad trackers that follow you around the web."
+                "Firefox Preview helps stop websites from tracking you online."
             )
         )
     )
@@ -441,7 +462,7 @@ private fun assertBrowsePrivatelyHeader() =
         .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
 private fun assertBrowsePrivatelyText() =
-    onView(allOf(withText(containsString("private browsing is just a tap away."))))
+    onView(allOf(withText(containsString("Update your private browsing settings."))))
         .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
 private fun assertYourPrivacyHeader() =
@@ -462,8 +483,25 @@ private fun assertPrivacyNoticeButton() =
     onView(allOf(withText("Read our privacy notice")))
         .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
+// What's new elements
+private fun assertWhatsNewHeather() = onView(allOf(withText("See what’s new")))
+        .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+
+private fun assertWhatsNewLink() = onView(allOf(withText("Get answers here")))
+        .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+
 private fun assertStartBrowsingButton() =
     onView(allOf(withText("Start browsing")))
+        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+
+// Take a position
+private fun assertTakePositionheader() = onView(allOf(withText("Take a position")))
+        .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+
+private fun assertTakePositionTopRadioButton() = onView(ViewMatchers.withResourceName("toolbar_top_radio_button"))
+        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+
+private fun assertTakePositionBottomRadioButton() = onView(ViewMatchers.withResourceName("toolbar_bottom_radio_button"))
         .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
 // Private mode elements
@@ -482,9 +520,10 @@ private fun assertPrivateSessionMessage(visible: Boolean) =
             if (visible) matches(withEffectiveVisibility(Visibility.VISIBLE)) else doesNotExist()
         )
 
-private fun assertShareTabsButton(visible: Boolean) =
-    onView(allOf(withId(R.id.share_tabs_button), isDisplayed()))
-        .check(matches(withEffectiveVisibility(visibleOrGone(visible))))
+private fun assertShareTabsButton(visible: Boolean) = onView(allOf(withId(R.id.share_tabs_button)))
+        .check(
+                if (visible) matches(withEffectiveVisibility(Visibility.VISIBLE)) else matches(withEffectiveVisibility(Visibility.INVISIBLE))
+        )
 
 private fun assertCloseTabsButton(title: String) =
     onView(allOf(withId(R.id.close_tab_button), withContentDescription("Close tab $title")))


### PR DESCRIPTION
This PR tries to enable to disabled tests for Homescreen. There are some changes needed in the First Run view to update the tests according to the new view.
It also adds checks for the Top Sites added to the view.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture