### PR TITLE
No issue: Remove useContentProcessHint from GV beta GeckoProvider

### DIFF
--- a/app/src/geckoBeta/java/org/mozilla/fenix/engine/GeckoProvider.kt
+++ b/app/src/geckoBeta/java/org/mozilla/fenix/engine/GeckoProvider.kt
@@ -45,7 +45,6 @@ object GeckoProvider {
 
         val runtimeSettings = builder
             .crashHandler(CrashHandlerService::class.java)
-            .useContentProcessHint(true)
             .telemetryDelegate(GeckoAdapter())
             .aboutConfigEnabled(Config.channel.isBeta)
             .debugLogging(Config.channel.isDebug)


### PR DESCRIPTION
since [we've updated gecko beta](https://github.com/mozilla-mobile/android-components/pull/6226) this needs to be updated 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture