### PR TITLE
Use pinned Android Components Nightly version instead of snapshots.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     repositories {
         maven {
-            url "https://snapshots.maven.mozilla.org/maven2"
+            url "https://nightly.maven.mozilla.org/maven2"
         }
         maven {
             url "https://maven.mozilla.org/maven2"

--- a/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -89,7 +89,7 @@ class Core(private val context: Context) {
         )
     }
 
-    val sessionStorage: SessionStorage by lazy {
+    private val sessionStorage: SessionStorage by lazy {
         SessionStorage(context, engine = engine)
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ allprojects {
     repositories {
         google()
         maven {
-            url "https://snapshots.maven.mozilla.org/maven2"
+            url "https://nightly.maven.mozilla.org/maven2"
         }
         maven {
             url "https://maven.mozilla.org/maven2"

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+object AndroidComponents {
+    const val VERSION = "37.0.20200316130158"
+}
+

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -33,7 +33,7 @@ object Versions {
     const val google_material = "1.1.0"
     const val google_flexbox = "2.0.1"
 
-    const val mozilla_android_components = "37.0.0-SNAPSHOT"
+    const val mozilla_android_components = AndroidComponents.VERSION
 
     const val adjust = "4.18.3"
     const val installreferrer = "1.0"


### PR DESCRIPTION
With this patch we are stopping to use Android Components snapshots and instead pin a specific Nightly version. Nightly versions of AC get build automatically at the same time as snapshots and we can trigger them manually if needed.

We are currently setting up the automation to bump this version automatically by having @MickeyMoz open a PR. That's currently in review for Reference Browser and will then follow for Fenix. Until then (which should be next week!) I'll run the automation script manually.