### PR TITLE
Remove @UseExperimental for usages of the flow api.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/addons/AddonsManagementFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/addons/AddonsManagementFragment.kt
@@ -17,7 +17,6 @@ import kotlinx.android.synthetic.main.fragment_add_ons_management.view.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Dispatchers.IO
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
@@ -57,7 +56,6 @@ class AddonsManagementFragment : Fragment(R.layout.fragment_add_ons_management),
         showToolbar(getString(R.string.preferences_addons))
     }
 
-    @UseExperimental(ExperimentalCoroutinesApi::class)
     override fun onStart() {
         super.onStart()
         findPreviousDialogFragment()?.let { dialog ->

--- a/app/src/main/java/org/mozilla/fenix/addons/InstalledAddonDetailsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/addons/InstalledAddonDetailsFragment.kt
@@ -15,7 +15,6 @@ import androidx.navigation.Navigation
 import androidx.navigation.findNavController
 import kotlinx.android.synthetic.main.fragment_installed_add_on_details.view.*
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.map
@@ -51,7 +50,6 @@ class InstalledAddonDetailsFragment : Fragment() {
         }
     }
 
-    @UseExperimental(ExperimentalCoroutinesApi::class)
     override fun onStart() {
         super.onStart()
         scope = requireContext().components.core.store.flowScoped { flow ->

--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -474,6 +474,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Session
                         requireComponents.core.engine,
                         requireComponents.core.sessionManager,
                         requireComponents.backgroundServices.accountManager,
+                        requireComponents.backgroundServices.serverConfig,
                         setOf(FxaCapability.CHOOSE_WHAT_TO_SYNC)
                     ),
                     owner = this,

--- a/app/src/main/java/org/mozilla/fenix/components/BackgroundServices.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/BackgroundServices.kt
@@ -58,7 +58,7 @@ class BackgroundServices(
             Build.MODEL
         )
 
-    private val serverConfig = FxaServer.config(context)
+    val serverConfig = FxaServer.config(context)
     private val deviceConfig = DeviceConfig(
         name = defaultDeviceName(context),
         type = DeviceType.MOBILE,

--- a/app/src/main/java/org/mozilla/fenix/migration/MigrationTelemetryListener.kt
+++ b/app/src/main/java/org/mozilla/fenix/migration/MigrationTelemetryListener.kt
@@ -4,7 +4,6 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix
 
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.collect
 import mozilla.components.lib.state.ext.flowScoped
 import mozilla.components.support.base.log.logger.Logger
@@ -17,7 +16,6 @@ class MigrationTelemetryListener(
     private val metrics: MetricController,
     private val store: MigrationStore
 ) {
-    @UseExperimental(ExperimentalCoroutinesApi::class)
     fun start() {
         // Observe for migration completed.
         store.flowScoped { flow ->

--- a/app/src/test/java/org/mozilla/fenix/AppRequestInterceptorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/AppRequestInterceptorTest.kt
@@ -11,7 +11,6 @@ import assertk.assertions.isEqualTo
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
-import kotlinx.coroutines.ObsoleteCoroutinesApi
 import mozilla.components.browser.errorpages.ErrorPages
 import mozilla.components.browser.errorpages.ErrorType
 import mozilla.components.concept.engine.request.RequestInterceptor
@@ -25,7 +24,6 @@ import org.mozilla.fenix.ext.isOnline
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
-@UseExperimental(ObsoleteCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
 @Config(application = TestApplication::class)
 class AppRequestInterceptorTest {

--- a/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarControllerTest.kt
@@ -20,7 +20,6 @@ import io.mockk.verify
 import io.mockk.verifyOrder
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.newSingleThreadContext
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.resetMain
@@ -62,7 +61,6 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 @ExperimentalCoroutinesApi
-@UseExperimental(ObsoleteCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
 @Config(application = TestApplication::class)
 class DefaultBrowserToolbarControllerTest {

--- a/app/src/test/java/org/mozilla/fenix/home/DefaultSessionControlControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/DefaultSessionControlControllerTest.kt
@@ -13,7 +13,6 @@ import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.MainScope
-import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.newSingleThreadContext
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
@@ -36,7 +35,6 @@ import org.mozilla.fenix.settings.SupportUtils
 import mozilla.components.feature.tab.collections.Tab as ComponentTab
 
 @ExperimentalCoroutinesApi
-@UseExperimental(ObsoleteCoroutinesApi::class)
 class DefaultSessionControlControllerTest {
 
     private val mainThreadSurrogate = newSingleThreadContext("UI thread")

--- a/app/src/test/java/org/mozilla/fenix/settings/deletebrowsingdata/DefaultDeleteBrowsingDataControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/deletebrowsingdata/DefaultDeleteBrowsingDataControllerTest.kt
@@ -13,7 +13,6 @@ import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.newSingleThreadContext
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runBlockingTest
@@ -28,7 +27,6 @@ import org.mozilla.fenix.ext.components
 import org.robolectric.annotation.Config
 
 @ExperimentalCoroutinesApi
-@UseExperimental(ObsoleteCoroutinesApi::class)
 @RunWith(AndroidJUnit4::class)
 @Config(application = TestApplication::class)
 class DefaultDeleteBrowsingDataControllerTest {

--- a/app/src/test/java/org/mozilla/fenix/settings/deletebrowsingdata/DeleteAndQuitTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/deletebrowsingdata/DeleteAndQuitTest.kt
@@ -13,7 +13,6 @@ import io.mockk.verify
 import io.mockk.verifyOrder
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.newSingleThreadContext
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runBlockingTest
@@ -37,7 +36,6 @@ import org.mozilla.fenix.utils.Settings
 import org.robolectric.annotation.Config
 
 @ExperimentalCoroutinesApi
-@UseExperimental(ObsoleteCoroutinesApi::class)
 @RunWith(AndroidJUnit4::class)
 @Config(application = TestApplication::class)
 class DeleteAndQuitTest {

--- a/app/src/test/java/org/mozilla/fenix/settings/quicksettings/DefaultQuickSettingsControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/quicksettings/DefaultQuickSettingsControllerTest.kt
@@ -21,7 +21,6 @@ import io.mockk.slot
 import io.mockk.verify
 import io.mockk.verifyOrder
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestCoroutineScope
 import mozilla.components.browser.session.Session
@@ -43,7 +42,6 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 @ExperimentalCoroutinesApi
-@UseExperimental(ObsoleteCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
 @Config(application = TestApplication::class)
 class DefaultQuickSettingsControllerTest {

--- a/app/src/test/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsFragmentStoreTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsFragmentStoreTest.kt
@@ -38,7 +38,6 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
-@UseExperimental(kotlinx.coroutines.ObsoleteCoroutinesApi::class)
 @Config(application = TestApplication::class)
 class QuickSettingsFragmentStoreTest {
     private val context = spyk(testContext)

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "37.0.20200317130045"
+    const val VERSION = "37.0.20200318130133"
 }


### PR DESCRIPTION
As a result of updating the [AC coroutines version to 1.3.5 ](https://github.com/mozilla-mobile/android-components/pull/6285) the [@UseExperimental(ExperimentalCoroutinesApi::class)](https://github.com/Kotlin/kotlinx.coroutines/releases/tag/1.3.0) for using `flow` is not needed anymore. This requires the latest version of AC
