### PR TITLE
Closes #7450: Lazy storage initialization.

### DIFF
--- a/app/src/geckoBeta/java/org/mozilla/fenix/engine/GeckoProvider.kt
+++ b/app/src/geckoBeta/java/org/mozilla/fenix/engine/GeckoProvider.kt
@@ -23,7 +23,7 @@ object GeckoProvider {
     @Synchronized
     fun getOrCreateRuntime(
         context: Context,
-        storage: LoginsStorage
+        storage: Lazy<LoginsStorage>
     ): GeckoRuntime {
         if (runtime == null) {
             runtime = createRuntime(context, storage)
@@ -34,7 +34,7 @@ object GeckoProvider {
 
     private fun createRuntime(
         context: Context,
-        storage: LoginsStorage
+        storage: Lazy<LoginsStorage>
     ): GeckoRuntime {
         val builder = GeckoRuntimeSettings.Builder()
 

--- a/app/src/geckoNightly/java/org/mozilla/fenix/engine/GeckoProvider.kt
+++ b/app/src/geckoNightly/java/org/mozilla/fenix/engine/GeckoProvider.kt
@@ -22,7 +22,7 @@ object GeckoProvider {
     @Synchronized
     fun getOrCreateRuntime(
         context: Context,
-        storage: LoginsStorage
+        storage: Lazy<LoginsStorage>
     ): GeckoRuntime {
         if (runtime == null) {
             runtime = createRuntime(context, storage)
@@ -33,7 +33,7 @@ object GeckoProvider {
 
     private fun createRuntime(
         context: Context,
-        storage: LoginsStorage
+        storage: Lazy<LoginsStorage>
     ): GeckoRuntime {
         val builder = GeckoRuntimeSettings.Builder()
 

--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -151,6 +151,15 @@ open class FenixApplication : LocaleAwareApplication() {
         registerActivityLifecycleCallbacks(
             PerformanceActivityLifecycleCallbacks(components.performance.visualCompletenessTaskManager)
         )
+
+        components.performance.visualCompletenessTaskManager.add {
+            GlobalScope.launch(Dispatchers.IO) {
+                logger.info("Initializing storage after visual completeness...")
+                components.core.lazyHistoryStorage.value
+                components.core.lazyBookmarksStorage.value
+                components.core.lazyPasswordsStorage.value
+            }
+        }
     }
 
     // See https://github.com/mozilla-mobile/fenix/issues/7227 for context.

--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -331,7 +331,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Session
                     customTabId = customTabSessionId,
                     fragmentManager = parentFragmentManager,
                     loginValidationDelegate = DefaultLoginValidationDelegate(
-                        context.components.core.passwordsStorage
+                        context.components.core.lazyPasswordsStorage
                     ),
                     isSaveLoginEnabled = {
                         context.settings().shouldPromptToSaveLogins

--- a/app/src/main/java/org/mozilla/fenix/components/BackgroundServices.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/BackgroundServices.kt
@@ -46,9 +46,9 @@ class BackgroundServices(
     private val context: Context,
     private val push: Push,
     crashReporter: CrashReporter,
-    historyStorage: PlacesHistoryStorage,
-    bookmarkStorage: PlacesBookmarksStorage,
-    passwordsStorage: SyncableLoginsStorage
+    historyStorage: Lazy<PlacesHistoryStorage>,
+    bookmarkStorage: Lazy<PlacesBookmarksStorage>,
+    passwordsStorage: Lazy<SyncableLoginsStorage>
 ) {
     fun defaultDeviceName(context: Context): String =
         context.getString(

--- a/app/src/main/java/org/mozilla/fenix/components/Components.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Components.kt
@@ -33,9 +33,9 @@ class Components(private val context: Context) {
             context,
             push,
             analytics.crashReporter,
-            core.historyStorage,
-            core.bookmarksStorage,
-            core.passwordsStorage
+            core.lazyHistoryStorage,
+            core.lazyBookmarksStorage,
+            core.lazyPasswordsStorage
         )
     }
     val services by lazy { Services(context, backgroundServices.accountManager) }

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "37.0.20200318190037"
+    const val VERSION = "37.0.20200319130119"
 }


### PR DESCRIPTION
(requires https://github.com/mozilla-mobile/android-components/pull/6307)
Make sure that we actually lazily initialize our storage layers.

With this patch applied, storage layers (history, logins, bookmarks) will be initialized when first
accessed. We will no longer block GeckoEngine init, for example, on waiting for the logins storage
to initialize (which needs to access the costly securePrefStorage).
Similarly, BackgroundServices init will no longer require initialized instances of the storage
components - references to their "lazy wrappers" will suffice.

In practice, this changes when our storage layers are initialized in the following ways.
Currently, we will initialize everything on startup. This includes loading our megazord, as well.

With this change, init path depends on if the user is signed-into FxA or not.

If user is not an FxA user:
- on startup, none of the storage layers are initialized
- history storage will be initialized once, whenever:
  - first non-customTab page is loaded (access to the HistoryDelegate)
  - first interaction with the awesomebar
  - history UI is accessed
- bookmarks storage will be initialized once, whenever:
  - something is bookmarked, or we need to figure out if something's bookmarked
  - bookmarks UI is accessed
- logins storage will be initialized once, whenever:
  - first page is loaded with a login/password fields that can be autofilled
  - (or some other interaction by GV with the autofill/loginStorage delegates)
  - logins UI is accessed
- all of these storages will be initialized if the user logs into FxA and starts syncing data
  - except, if a storage is not chosen to be synced, it will not be initialized

If user is an FxA user:
- on startup, none of the storage layers are initialized
- sometime shortly after startup is complete, when a sync worker runs in the background, all storage
layers that are enabled to sync will be initialized.

This change also means that we delay loading the megazord until first access (as described above).

As an improvement over this, we can also kick-off a task to initialize our storage layers sometime shortly after startup, to improve performance of whatever ends up hitting the init path. That is, effectively we can switch everyone to the second category above (what happens currently to FxA users).



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture