### PR TITLE
Update mockwebserver to 3.14.7 and enable tests 

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
@@ -11,7 +11,6 @@ import mozilla.appservices.places.BookmarkRoot
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.ext.bookmarkStorage
@@ -95,7 +94,6 @@ class BookmarksTest {
         }
     }
 
-    @Ignore("Intermittent failure on Nexus 6: https://github.com/mozilla-mobile/fenix/issues/8772")
     @Test
     fun createBookmarkFolderTest() {
         homeScreen {
@@ -271,7 +269,6 @@ class BookmarksTest {
         }
     }
 
-    @Ignore("Temp disable: Nexus 6 failures - issue: https://github.com/mozilla-mobile/fenix/issues/7417")
     @Test
     fun deleteMultipleSelectionTest() {
         val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
@@ -318,7 +315,6 @@ class BookmarksTest {
         }
     }
 
-    @Ignore("Temp disable: Nexus 6 failures - issue: https://github.com/mozilla-mobile/fenix/issues/7417")
     @Test
     fun multipleBookmarkDeletions() {
         homeScreen {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/CollectionTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/CollectionTest.kt
@@ -14,7 +14,6 @@ import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.Until
 import okhttp3.mockwebserver.MockWebServer
-import org.junit.Ignore
 import org.junit.Before
 import org.junit.After
 import org.junit.Test
@@ -55,7 +54,6 @@ class CollectionTest {
     }
 
     @Test
-    @Ignore("Temp disable test - see: https://github.com/mozilla-mobile/fenix/issues/5793")
     // open a webpage, and add currently opened tab to existing collection
     fun addTabToCollectionTest() {
         val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
@@ -122,7 +120,6 @@ class CollectionTest {
     }
 
     @Test
-    @Ignore("Temp disable test - see: https://github.com/mozilla-mobile/fenix/issues/5793")
     // Rename Collection from the Homescreen
     fun renameCollectionTest() {
 
@@ -144,7 +141,6 @@ class CollectionTest {
     }
 
     @Test
-    @Ignore("Temp disable test - see: https://github.com/mozilla-mobile/fenix/issues/5793")
     // Delete Collection from the Homescreen
     fun deleteCollectionTest() {
 
@@ -166,7 +162,6 @@ class CollectionTest {
     }
 
     @Test
-    @Ignore("Temp disable test - see: https://github.com/mozilla-mobile/fenix/issues/5793")
     fun createCollectionTest() {
         val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
         val secondWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 2)

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/ContextMenusTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/ContextMenusTest.kt
@@ -9,7 +9,6 @@ import androidx.test.uiautomator.UiDevice
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
@@ -53,7 +52,6 @@ class ContextMenusTest {
     }
 
     @Test
-    @Ignore("Disabling because of intermittent failures https://github.com/mozilla-mobile/fenix/issues/8663")
     fun verifyContextOpenLinkNewTab() {
         val pageLinks =
             TestAssetHelper.getGenericAsset(mockWebServer, 4)
@@ -98,7 +96,6 @@ class ContextMenusTest {
         }
     }
 
-    @Ignore("Intermittent failure - https://github.com/mozilla-mobile/fenix/issues/8832")
     @Test
     fun verifyContextCopyLink() {
         val pageLinks =
@@ -135,7 +132,6 @@ class ContextMenusTest {
         }
     }
 
-    @Ignore("Temp disable intermittent failure - https://github.com/mozilla-mobile/fenix/issues/7687")
     @Test
     fun verifyContextOpenImageNewTab() {
         val pageLinks =
@@ -155,7 +151,6 @@ class ContextMenusTest {
         }
     }
 
-    @Ignore("Temp disable intermittent failure - https://github.com/mozilla-mobile/fenix/issues/7687")
     @Test
     fun verifyContextCopyImageLocation() {
         val pageLinks =
@@ -176,7 +171,6 @@ class ContextMenusTest {
         }
     }
 
-    @Ignore("Temp disable intermittent failure - https://github.com/mozilla-mobile/fenix/issues/7666")
     @Test
     fun verifyContextSaveImage() {
         val pageLinks =
@@ -201,7 +195,6 @@ class ContextMenusTest {
         }
     }
 
-    @Ignore("Temp disable intermittent failure - https://github.com/mozilla-mobile/fenix/issues/7693")
     @Test
     fun verifyContextMixedVariations() {
         val pageLinks =

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/DownloadTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/DownloadTest.kt
@@ -73,7 +73,6 @@ class DownloadTest {
     }
 
     @Test
-    @Ignore("Temp disable flakey test - see: https://github.com/mozilla-mobile/fenix/issues/7303")
     fun testDownloadPrompt() {
         homeScreen { }.dismissOnboarding()
 
@@ -91,7 +90,6 @@ class DownloadTest {
     }
 
     @Test
-    @Ignore("Temp disable flakey test - see: https://github.com/mozilla-mobile/fenix/issues/5462")
     fun testDownloadNotification() {
         homeScreen { }.dismissOnboarding()
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/NavigationToolbarTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/NavigationToolbarTest.kt
@@ -9,7 +9,6 @@ import androidx.test.uiautomator.UiDevice
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
@@ -124,7 +123,6 @@ class NavigationToolbarTest {
         }
     }
 
-    @Ignore("Temp disable broken test - see:  https://github.com/mozilla-mobile/fenix/issues/5534")
     @Test
     fun findInPageTest() {
         val loremIpsumWebPage = TestAssetHelper.getLoremIpsumAsset(mockWebServer)

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/ReaderViewTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/ReaderViewTest.kt
@@ -9,7 +9,6 @@ import androidx.test.uiautomator.UiDevice
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
@@ -166,7 +165,6 @@ class ReaderViewTest {
     }
 
     @Test
-    @Ignore("Intermittent failure. Fix in https://github.com/mozilla-mobile/fenix/issues/9188")
     fun verifyReaderViewAppearanceFontToggle() {
         val readerViewPage =
             TestAssetHelper.getLoremIpsumAsset(mockWebServer)

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SearchTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SearchTest.kt
@@ -61,7 +61,6 @@ class SearchTest {
     }
 
     @Test
-    @Ignore("Temp disable flakey test - see: https://github.com/mozilla-mobile/fenix/issues/5462")
     fun shortcutSearchEngineSettingsTest() {
         homeScreen {
         }.openSearch {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsBasicsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsBasicsTest.kt
@@ -12,7 +12,6 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.Ignore
 import org.mozilla.fenix.FenixApplication
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
@@ -107,7 +106,6 @@ class SettingsBasicsTest {
         }
     }
 
-    @Ignore("This test works locally, fails on firebase. https://github.com/mozilla-mobile/fenix/issues/8174")
     @Test
     fun toggleSearchSuggestions() {
         // Goes through the settings and changes the search suggestion toggle, then verifies it changes.
@@ -126,7 +124,6 @@ class SettingsBasicsTest {
         }
     }
 
-    @Ignore("Currently failing on firebase: https://github.com/mozilla-mobile/fenix/issues/8747")
     @Test
     fun toggleShowVisitedSitesAndBookmarks() {
         // Bookmarks a few websites, toggles the history and bookmarks setting to off, then verifies if the visited and bookmarked websites do not show in the suggestions.

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsPrivacyTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsPrivacyTest.kt
@@ -141,7 +141,6 @@ class SettingsPrivacyTest {
     }
 
     @Test
-    @Ignore("Passes locally, fails on CI. Fix in https://github.com/mozilla-mobile/fenix/issues/9189")
     fun saveLoginFromPromptTest() {
         val saveLoginTest =
             TestAssetHelper.getSaveLoginAsset(mockWebServer)
@@ -167,7 +166,6 @@ class SettingsPrivacyTest {
     }
 
     @Test
-    @Ignore("Passes locally, fails on CI. Fix in https://github.com/mozilla-mobile/fenix/issues/9189")
     fun doNotSaveLoginFromPromptTest() {
         val saveLoginTest = TestAssetHelper.getSaveLoginAsset(mockWebServer)
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -45,7 +45,7 @@ object Versions {
     const val assertk = "0.19"
 
     const val espresso_version = "3.2.0"
-    const val mockwebserver = "3.11.0"
+    const val mockwebserver = "3.14.7"
     const val orchestrator = "1.3.0-alpha02"
     const val tools_test_rules = "1.3.0-alpha02"
     const val tools_test_runner = "1.3.0-alpha02"


### PR DESCRIPTION
not ready for merging want to run this through Firebase several times to see if updating Mockwebserver helps with any of the flaky tests.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture