### PR TITLE
MigrationPushRenewer: Remove ExperimentalCoroutinesApi.

### DIFF
--- a/app/src/migration/java/org/mozilla/fenix/MigrationPushRenewer.kt
+++ b/app/src/migration/java/org/mozilla/fenix/MigrationPushRenewer.kt
@@ -4,7 +4,6 @@
 
 package org.mozilla.fenix
 
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.collect
 import mozilla.components.concept.push.PushProcessor
 import mozilla.components.lib.state.ext.flowScoped
@@ -19,7 +18,6 @@ class MigrationPushRenewer(
     private val service: PushProcessor?,
     private val store: MigrationStore
 ) {
-    @UseExperimental(ExperimentalCoroutinesApi::class)
     fun start() {
         // Observe for migration completed.
         store.flowScoped { flow ->


### PR DESCRIPTION
This is in our migration code, which PR #9211 seem to have missed.