### PR TITLE
Bug 1623601 - Add visual metrics tasks to nightly browsertime tests.

### DIFF
--- a/taskcluster/fenix_taskgraph/target_tasks.py
+++ b/taskcluster/fenix_taskgraph/target_tasks.py
@@ -56,6 +56,6 @@ def target_tasks_raptor(full_task_graph, parameters, graph_config):
 @_target_task('browsertime')
 def target_tasks_raptor(full_task_graph, parameters, graph_config):
     def filter(task, parameters):
-        return task.kind == 'browsertime'
+        return task.kind == 'browsertime' or task.kind == 'visual-metrics'
 
     return [l for l, t in full_task_graph.tasks.iteritems() if filter(t, parameters)]

--- a/taskcluster/fenix_taskgraph/target_tasks.py
+++ b/taskcluster/fenix_taskgraph/target_tasks.py
@@ -56,6 +56,6 @@ def target_tasks_raptor(full_task_graph, parameters, graph_config):
 @_target_task('browsertime')
 def target_tasks_raptor(full_task_graph, parameters, graph_config):
     def filter(task, parameters):
-        return task.kind == 'browsertime' or task.kind == 'visual-metrics'
+        return task.kind in ('browsertime', 'visual-metrics')
 
     return [l for l, t in full_task_graph.tasks.iteritems() if filter(t, parameters)]


### PR DESCRIPTION
This patch adds the visual-metrics tasks to the nightly browsertime cron tests. They are currently being removed because they don't have a `browsertime` kind.