### PR TITLE
More options for history items.

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/HistoryTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/HistoryTest.kt
@@ -81,6 +81,77 @@ class HistoryTest {
     }
 
     @Test
+    fun copyHistoryItemURLTest() {
+        val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(firstWebPage.url) {
+            verifyPageContent("Page content: 1")
+        }.openThreeDotMenu {
+        }.openLibrary {
+        }.openHistory {
+        }.openThreeDotMenu {
+        }.clickCopy {
+            verifyCopySnackBarText()
+        }
+    }
+
+    @Test
+    fun shareHistoryItemTest() {
+        val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(firstWebPage.url) {
+            verifyPageContent("Page content: 1")
+        }.openThreeDotMenu {
+        }.openLibrary {
+        }.openHistory {
+        }.openThreeDotMenu {
+        }.clickShare {
+            verifyShareOverlay()
+            verifyShareTabFavicon()
+            verifyShareTabTitle()
+            verifyShareTabUrl()
+        }
+    }
+
+    @Test
+    fun openHistoryItemInNewTabTest() {
+        val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(firstWebPage.url) {
+            verifyPageContent("Page content: 1")
+        }.openThreeDotMenu {
+        }.openLibrary {
+        }.openHistory {
+        }.openThreeDotMenu {
+        }.clickOpenInNormalTab {
+            verifyPageContent(firstWebPage.content)
+        }.openHomeScreen {
+            verifyOpenTabsHeader()
+        }
+    }
+
+    @Test
+    fun openHistoryItemInNewPrivateTabTest() {
+        val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(firstWebPage.url) {
+            verifyPageContent("Page content: 1")
+        }.openThreeDotMenu {
+        }.openLibrary {
+        }.openHistory {
+        }.openThreeDotMenu {
+        }.clickOpenInPrivateTab {
+            verifyPageContent(firstWebPage.content)
+        }.openHomeScreen {
+            verifyPrivateSessionHeader()
+        }
+    }
+
+    @Test
     fun deleteHistoryItemTest() {
         val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
@@ -90,8 +161,8 @@ class HistoryTest {
         }.openThreeDotMenu {
         }.openLibrary {
         }.openHistory {
-            openOverflowMenu()
-            clickThreeDotMenuDelete()
+        }.openThreeDotMenu {
+        }.clickDelete {
             verifyEmptyHistoryView()
         }
     }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HistoryRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HistoryRobot.kt
@@ -55,6 +55,8 @@ class HistoryRobot {
 
     fun verifyTestPageUrl(expectedUrl: Uri) = assertPageUrl(expectedUrl)
 
+    fun verifyCopySnackBarText() = assertCopySnackBarText()
+
     fun verifyDeleteConfirmationMessage() = assertDeleteConfirmationMessage()
 
     fun verifyHomeScreen() = HomeScreenRobot().verifyHomeScreen()
@@ -66,11 +68,7 @@ class HistoryRobot {
             ),
             waitingTime
         )
-        overflowMenu().click()
-    }
-
-    fun clickThreeDotMenuDelete() {
-        threeDotMenuDeleteButton().click()
+        threeDotMenu().click()
     }
 
     fun clickDeleteHistoryButton() {
@@ -92,6 +90,15 @@ class HistoryRobot {
             HistoryRobot().interact()
             return Transition()
         }
+
+        fun openThreeDotMenu(interact: ThreeDotMenuHistoryItemRobot.() -> Unit):
+            ThreeDotMenuHistoryItemRobot.Transition {
+
+            threeDotMenu().click()
+
+            ThreeDotMenuHistoryItemRobot().interact()
+            return ThreeDotMenuHistoryItemRobot.Transition()
+        }
     }
 }
 
@@ -106,9 +113,9 @@ private fun testPageTitle() = onView(allOf(withId(R.id.title), withText("Test_Pa
 
 private fun pageUrl() = onView(withId(R.id.url))
 
-private fun overflowMenu() = onView(withId(R.id.overflow_menu))
+private fun threeDotMenu() = onView(withId(R.id.overflow_menu))
 
-private fun threeDotMenuDeleteButton() = onView(withId(R.id.simple_text))
+private fun snackBarText() = onView(withId(R.id.snackbar_text))
 
 private fun deleteAllHistoryButton() = onView(withId(R.id.delete_button))
 
@@ -143,3 +150,5 @@ private fun assertDeleteConfirmationMessage() =
     onView(withText("This will delete all of your browsing data."))
         .inRoot(isDialog())
         .check(matches(isDisplayed()))
+
+private fun assertCopySnackBarText() = snackBarText().check(matches(withText("URL copied")))

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuHistoryItemRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuHistoryItemRobot.kt
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.ui.robots
+
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.uiautomator.By
+import androidx.test.uiautomator.Until
+import org.mozilla.fenix.R
+import org.mozilla.fenix.helpers.TestAssetHelper
+import org.mozilla.fenix.helpers.click
+import org.mozilla.fenix.helpers.ext.waitNotNull
+
+/**
+ * Implementation of Robot Pattern for the History three dot menu.
+ */
+class ThreeDotMenuHistoryItemRobot {
+
+    class Transition {
+
+        fun clickCopy(interact: HistoryRobot.() -> Unit): HistoryRobot.Transition {
+            copyButton().click()
+            HistoryRobot().interact()
+            return HistoryRobot.Transition()
+        }
+
+        fun clickShare(interact: LibrarySubMenusMultipleSelectionToolbarRobot.() -> Unit):
+            LibrarySubMenusMultipleSelectionToolbarRobot.Transition {
+
+            shareButton().click()
+
+            mDevice.waitNotNull(
+                Until.findObject(
+                    By.text("ALL ACTIONS")
+                ), TestAssetHelper.waitingTime
+            )
+
+            LibrarySubMenusMultipleSelectionToolbarRobot().interact()
+            return LibrarySubMenusMultipleSelectionToolbarRobot.Transition()
+        }
+
+        fun clickOpenInNormalTab(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
+            openInNewNormalTabButton().click()
+            BrowserRobot().interact()
+            return BrowserRobot.Transition()
+        }
+
+        fun clickOpenInPrivateTab(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
+            openInNewPrivateTabButton().click()
+            BrowserRobot().interact()
+            return BrowserRobot.Transition()
+        }
+
+        fun clickDelete(interact: HistoryRobot.() -> Unit): HistoryRobot.Transition {
+            deleteButton().click()
+            HistoryRobot().interact()
+            return HistoryRobot.Transition()
+        }
+    }
+}
+
+private fun copyButton() = onView(withText(R.string.history_menu_copy_button))
+
+private fun shareButton() = onView(withText(R.string.history_menu_share_button))
+
+private fun openInNewNormalTabButton() =
+    onView(withText(R.string.history_menu_open_in_new_tab_button))
+
+private fun openInNewPrivateTabButton() =
+    onView(withText(R.string.history_menu_open_in_private_tab_button))
+
+private fun deleteButton() = onView(withText(R.string.history_delete_item))

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryInteractor.kt
@@ -4,10 +4,13 @@
 
 package org.mozilla.fenix.library.history
 
+import org.mozilla.fenix.browser.browsingmode.BrowsingMode
+
 /**
  * Interactor for the history screen
  * Provides implementations for the HistoryViewInteractor
  */
+@SuppressWarnings("TooManyFunctions")
 class HistoryInteractor(
     private val historyController: HistoryController
 ) : HistoryViewInteractor {
@@ -29,6 +32,22 @@ class HistoryInteractor(
 
     override fun onModeSwitched() {
         historyController.handleModeSwitched()
+    }
+
+    override fun onCopyPressed(item: HistoryItem) {
+        historyController.handleCopyUrl(item)
+    }
+
+    override fun onSharePressed(item: HistoryItem) {
+        historyController.handleShare(item)
+    }
+
+    override fun onOpenInNormalTab(item: HistoryItem) {
+        historyController.handleOpen(item, BrowsingMode.Normal)
+    }
+
+    override fun onOpenInPrivateTab(item: HistoryItem) {
+        historyController.handleOpen(item, BrowsingMode.Private)
     }
 
     override fun onDeleteAll() {

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryItemMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryItemMenu.kt
@@ -16,13 +16,29 @@ class HistoryItemMenu(
     private val onItemTapped: (Item) -> Unit = {}
 ) : LibraryItemMenu {
     sealed class Item {
+        object Copy : Item()
+        object Share : Item()
+        object OpenInNewTab : Item()
+        object OpenInPrivateTab : Item()
         object Delete : Item()
     }
 
     override val menuBuilder by lazy { BrowserMenuBuilder(menuItems) }
 
     private val menuItems by lazy {
-        listOf(
+        listOfNotNull(
+            SimpleBrowserMenuItem(context.getString(R.string.history_menu_copy_button)) {
+                onItemTapped.invoke(Item.Copy)
+            },
+            SimpleBrowserMenuItem(context.getString(R.string.history_menu_share_button)) {
+                onItemTapped.invoke(Item.Share)
+            },
+            SimpleBrowserMenuItem(context.getString(R.string.history_menu_open_in_new_tab_button)) {
+                onItemTapped.invoke(Item.OpenInNewTab)
+            },
+            SimpleBrowserMenuItem(context.getString(R.string.history_menu_open_in_private_tab_button)) {
+                onItemTapped.invoke(Item.OpenInPrivateTab)
+            },
             SimpleBrowserMenuItem(
                 context.getString(R.string.history_delete_item),
                 textColorResource = ThemeManager.resolveAttribute(R.attr.destructive, context)

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryView.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryView.kt
@@ -34,6 +34,34 @@ interface HistoryViewInteractor : SelectionInteractor<HistoryItem> {
     fun onModeSwitched()
 
     /**
+     * Copies the URL of a history item to the copy-paste buffer.
+     *
+     * @param item the history item to copy the URL from
+     */
+    fun onCopyPressed(item: HistoryItem)
+
+    /**
+     * Opens the share sheet for a history item.
+     *
+     * @param item the history item to share
+     */
+    fun onSharePressed(item: HistoryItem)
+
+    /**
+     * Opens a history item in a new tab.
+     *
+     * @param item the history item to open in a new tab
+     */
+    fun onOpenInNormalTab(item: HistoryItem)
+
+    /**
+     * Opens a history item in a private tab.
+     *
+     * @param item the history item to open in a private tab
+     */
+    fun onOpenInPrivateTab(item: HistoryItem)
+
+    /**
      * Called when delete all is tapped
      */
     fun onDeleteAll()

--- a/app/src/main/java/org/mozilla/fenix/library/history/viewholders/HistoryListItemViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/viewholders/HistoryListItemViewHolder.kt
@@ -11,6 +11,7 @@ import kotlinx.android.synthetic.main.library_site_item.view.*
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.hideAndDisable
 import org.mozilla.fenix.ext.showAndEnable
+import org.mozilla.fenix.lib.Do
 import org.mozilla.fenix.library.SelectionHolder
 import org.mozilla.fenix.library.history.HistoryFragmentState
 import org.mozilla.fenix.library.history.HistoryInteractor
@@ -98,7 +99,12 @@ class HistoryListItemViewHolder(
     private fun setupMenu() {
         val historyMenu = HistoryItemMenu(itemView.context) {
             val item = this.item ?: return@HistoryItemMenu
-            when (it) {
+
+            Do exhaustive when (it) {
+                HistoryItemMenu.Item.Copy -> historyInteractor.onCopyPressed(item)
+                HistoryItemMenu.Item.Share -> historyInteractor.onSharePressed(item)
+                HistoryItemMenu.Item.OpenInNewTab -> historyInteractor.onOpenInNormalTab(item)
+                HistoryItemMenu.Item.OpenInPrivateTab -> historyInteractor.onOpenInPrivateTab(item)
                 HistoryItemMenu.Item.Delete -> historyInteractor.onDeleteSome(setOf(item))
             }
         }

--- a/app/src/main/res/layout/fragment_history.xml
+++ b/app/src/main/res/layout/fragment_history.xml
@@ -2,9 +2,11 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<LinearLayout
+
+<FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/historyLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"/>
+    tools:context="org.mozilla.fenix.library.history.HistoryFragment" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -452,6 +452,14 @@
     <string name="history_delete_all_dialog">Are you sure you want to clear your history?</string>
     <!-- Text for positive action to delete history in deleting history dialog -->
     <string name="history_clear_dialog">Clear</string>
+    <!-- History overflow menu copy button -->
+    <string name="history_menu_copy_button">Copy</string>
+    <!-- History overflow menu share button -->
+    <string name="history_menu_share_button">Share</string>
+    <!-- History overflow menu open in new tab button -->
+    <string name="history_menu_open_in_new_tab_button">Open in new tab</string>
+    <!-- History overflow menu open in private tab button -->
+    <string name="history_menu_open_in_private_tab_button">Open in private tab</string>
     <!-- Text for the button to delete a single history item -->
     <string name="history_delete_item">Delete</string>
     <!-- History multi select title in app bar

--- a/app/src/test/java/org/mozilla/fenix/library/history/HistoryInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/history/HistoryInteractorTest.kt
@@ -1,0 +1,124 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+   License, v. 2.0. If a copy of the MPL was not distributed with this
+   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.library.history
+
+import assertk.assertThat
+import assertk.assertions.isTrue
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verifyAll
+import org.junit.Test
+import org.mozilla.fenix.browser.browsingmode.BrowsingMode
+
+class HistoryInteractorTest {
+    private val historyItem = HistoryItem(0, "title", "url", 0.toLong())
+    val controller: HistoryController = mockk(relaxed = true)
+    val interactor = HistoryInteractor(controller)
+
+    @Test
+    fun onOpen() {
+        interactor.open(historyItem)
+
+        verifyAll {
+            controller.handleOpen(historyItem)
+        }
+    }
+
+    @Test
+    fun onSelect() {
+        interactor.select(historyItem)
+
+        verifyAll {
+            controller.handleSelect(historyItem)
+        }
+    }
+
+    @Test
+    fun onDeselect() {
+        interactor.deselect(historyItem)
+
+        verifyAll {
+            controller.handleDeselect(historyItem)
+        }
+    }
+
+    @Test
+    fun onBackPressed() {
+        every {
+            controller.handleBackPressed()
+        } returns true
+
+        val backpressHandled = interactor.onBackPressed()
+
+        verifyAll {
+            controller.handleBackPressed()
+        }
+        assertThat(backpressHandled).isTrue()
+    }
+
+    @Test
+    fun onModeSwitched() {
+        interactor.onModeSwitched()
+
+        verifyAll {
+            controller.handleModeSwitched()
+        }
+    }
+
+    @Test
+    fun onCopyPressed() {
+        interactor.onCopyPressed(historyItem)
+
+        verifyAll {
+            controller.handleCopyUrl(historyItem)
+        }
+    }
+
+    @Test
+    fun onSharePressed() {
+        interactor.onSharePressed(historyItem)
+
+        verifyAll {
+            controller.handleShare(historyItem)
+        }
+    }
+
+    @Test
+    fun onOpenInNormalTab() {
+        interactor.onOpenInNormalTab(historyItem)
+
+        verifyAll {
+            controller.handleOpen(historyItem, BrowsingMode.Normal)
+        }
+    }
+
+    @Test
+    fun onOpenInPrivateTab() {
+        interactor.onOpenInPrivateTab(historyItem)
+
+        verifyAll {
+            controller.handleOpen(historyItem, BrowsingMode.Private)
+        }
+    }
+
+    @Test
+    fun onDeleteAll() {
+        interactor.onDeleteAll()
+
+        verifyAll {
+            controller.handleDeleteAll()
+        }
+    }
+
+    @Test
+    fun onDeleteSome() {
+        val items = setOf(historyItem)
+
+        interactor.onDeleteSome(items)
+        verifyAll {
+            controller.handleDeleteSome(items)
+        }
+    }
+}


### PR DESCRIPTION
Add new menu actions for a history item:
  - Copy url
  - Share to another FXA device
  - Open in new tab
  - Open in private tab

and unit tests for them.

Video showing the new options being used - https://drive.google.com/file/d/1uJbzJk2YBNHMOI509WB8i9_SV1mGCjUo


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests.
- [x] **Screenshots**: This PR includes a video showing the changes.
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md)

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture