### PR TITLE
Swap AVD (x86) Nexus 6 (API 25) with a Nexus6P (API 27)

### DIFF
--- a/automation/taskcluster/androidTest/flank-x86.yml
+++ b/automation/taskcluster/androidTest/flank-x86.yml
@@ -41,8 +41,8 @@ gcloud:
    - package org.mozilla.fenix.ui
 
   device:
-   - model: Nexus6 
-     version: 25
+   - model: Nexus6P
+     version: 27
    - model: Pixel2 
      version: 28
 


### PR DESCRIPTION
The Nexus 6 (x86 AVD) on API 25 is causing too many instablility issues. Let’s see what happens with a Nexus 6P on API 27.