### PR TITLE
Fixes #8491: Changed toolbar background for PBM when is set to top

### DIFF
--- a/app/src/main/res/drawable/private_home_bottom_bar_background_gradient_top.xml
+++ b/app/src/main/res/drawable/private_home_bottom_bar_background_gradient_top.xml
@@ -6,12 +6,7 @@
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
 <item>
     <shape>
-        <gradient
-            android:angle="45"
-            android:startColor="#7529A7"
-            android:centerColor="#492E85"
-            android:endColor="#383372"
-            android:type="linear" />
+        <solid android:color="@color/toolbar_end_gradient_private_theme"/>
     </shape>
 </item>
 <item android:top="-2dp" android:left="-2dp" android:right="-2dp">


### PR DESCRIPTION
This change was required so that the background of the toolbar match the
homeFragment gradient



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR does not include thorough tests. Just a small UI change.
- [x] **Screenshots**: This PR includes screenshots of the changes made.
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/52956363/77157278-b6604080-6aa9-11ea-956a-78d6e8861440.png" width="300px" /></td>
    <td><img src="https://user-images.githubusercontent.com/52956363/77157318-c6782000-6aa9-11ea-8bf8-bf5c834bd8ee.png" width="300px" /></td>
  </tr>
</table>