### PR TITLE
Fixes #9243: Remove tabs fade in animation when pressing on Save to Collection

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/collections/CollectionCreationView.kt
+++ b/app/src/main/java/org/mozilla/fenix/collections/CollectionCreationView.kt
@@ -148,10 +148,6 @@ class CollectionCreationView(
             interactor.close()
         }
 
-        TransitionManager.beginDelayedTransition(
-            view.collection_constraint_layout,
-            transition
-        )
         val constraint = selectTabsConstraints
         constraint.applyTo(view.collection_constraint_layout)
 


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR does not include thorough tests.
- [x] **Screenshots**: This PR includes a [video](https://drive.google.com/file/d/1_GX4Wv82KR1fOA8hh3QDS0mDwOswp6fu/view?usp=sharing) of the changes made.
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture