### PR TITLE
Closes #7761: Makes the Parent Folder Selector height 48dp

### DIFF
--- a/app/src/main/res/layout/fragment_edit_bookmark.xml
+++ b/app/src/main/res/layout/fragment_edit_bookmark.xml
@@ -3,23 +3,23 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
-        xmlns:tools="http://schemas.android.com/tools"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_margin="16dp"
-        android:orientation="vertical">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_margin="16dp"
+    android:orientation="vertical">
 
     <ProgressBar
         android:id="@+id/progress_bar_bookmark"
         style="@style/Widget.AppCompat.ProgressBar.Horizontal"
-        android:indeterminate="true"
         android:layout_width="match_parent"
         android:layout_height="8dp"
+        android:indeterminate="true"
         android:translationY="-3dp"
         android:visibility="gone"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
         android:id="@+id/bookmark_name_label"
@@ -88,13 +88,14 @@
     <TextView
         android:id="@+id/bookmarkParentFolderSelector"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="48dp"
         android:layout_marginStart="4dp"
         android:layout_marginTop="8dp"
-        app:drawableStartCompat="@drawable/ic_folder_icon"
         android:drawablePadding="10dp"
+        android:gravity="center_vertical"
         android:textColor="?secondaryText"
         android:textSize="16sp"
+        app:drawableStartCompat="@drawable/ic_folder_icon"
         app:drawableTint="?primaryText"
         tools:text="Mobile Bookmarks" />
 


### PR DESCRIPTION
- This change makes the folder easier to click and follows accessibility guidelines
- Doesn't need tests because it is a UI only change
- Before and After screenshots below
![Before](https://user-images.githubusercontent.com/10077686/77186934-10f99c80-6aaa-11ea-982a-c0a143cb3fe0.png)
![After](https://user-images.githubusercontent.com/10077686/77186935-11923300-6aaa-11ea-97d7-11bec4c8356e.png)




### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture