### PR TITLE
AboutPageAdapter doesn't use notifyDataSetChanged()

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/about/AboutFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/about/AboutFragment.kt
@@ -64,7 +64,7 @@ class AboutFragment : Fragment(), AboutPageListener {
         }
 
         populateAboutHeader()
-        aboutPageAdapter.updateData(populateAboutList())
+        aboutPageAdapter.submitList(populateAboutList())
     }
 
     private fun populateAboutHeader() {

--- a/app/src/main/java/org/mozilla/fenix/settings/about/AboutPageAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/about/AboutPageAdapter.kt
@@ -6,33 +6,33 @@ package org.mozilla.fenix.settings.about
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import androidx.annotation.VisibleForTesting
-import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
 import org.mozilla.fenix.settings.about.viewholders.AboutItemViewHolder
 
-class AboutPageAdapter(private val listener: AboutPageListener) : RecyclerView.Adapter<AboutItemViewHolder>() {
-
-    @VisibleForTesting
-    var aboutList: List<AboutPageItem>? = null
-
-    fun updateData(items: List<AboutPageItem>) {
-        this.aboutList = items
-        notifyDataSetChanged()
-    }
+class AboutPageAdapter(private val listener: AboutPageListener) :
+    ListAdapter<AboutPageItem, AboutItemViewHolder>(DiffCallback) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AboutItemViewHolder {
         val view = LayoutInflater.from(parent.context)
             .inflate(AboutItemViewHolder.LAYOUT_ID, parent, false)
-
         return AboutItemViewHolder(view, listener)
     }
 
-    override fun getItemCount(): Int = aboutList?.size ?: 0
-
     override fun onBindViewHolder(holder: AboutItemViewHolder, position: Int) {
-        (aboutList?.get(position) as AboutPageItem.Item).also {
-            holder.bind(it)
-        }
+        holder.bind(getItem(position) as AboutPageItem.Item)
+    }
+
+    private object DiffCallback : DiffUtil.ItemCallback<AboutPageItem>() {
+
+        override fun areItemsTheSame(oldItem: AboutPageItem, newItem: AboutPageItem) =
+            oldItem === newItem
+
+        override fun areContentsTheSame(oldItem: AboutPageItem, newItem: AboutPageItem) =
+            when (oldItem) {
+                is AboutPageItem.Item ->
+                    newItem is AboutPageItem.Item && oldItem.title == newItem.title
+            }
     }
 }
 

--- a/app/src/test/java/org/mozilla/fenix/settings/about/AboutPageAdapterTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/about/AboutPageAdapterTest.kt
@@ -39,20 +39,6 @@ class AboutPageAdapterTest {
     private val listener: AboutPageListener = mockk(relaxed = true)
 
     @Test
-    fun `updateData should set the new data and call notifyDataSetChanged()`() {
-        val adapter = spyk(AboutPageAdapter(listener), recordPrivateCalls = true)
-        every { adapter.notifyDataSetChanged() } just Runs
-
-        adapter.updateData(aboutList)
-
-        // Wasn't able to test in verify block the 'adapter.aboutList' setter from the updateData method
-        assertThat(adapter.aboutList).isEqualTo(aboutList)
-        verify {
-            adapter.notifyDataSetChanged()
-        }
-    }
-
-    @Test
     fun `getItemCount on a default instantiated Adapter should return 0`() {
         val adapter = AboutPageAdapter(listener)
 
@@ -63,7 +49,7 @@ class AboutPageAdapterTest {
     fun `getItemCount after updateData() call should return the correct list size`() {
         val adapter = AboutPageAdapter(listener)
 
-        adapter.updateData(aboutList)
+        adapter.submitList(aboutList)
 
         assertThat(adapter.itemCount).isEqualTo(2)
     }
@@ -93,9 +79,9 @@ class AboutPageAdapterTest {
         } returns viewHolder
         every { viewHolder.bind(any()) } just Runs
 
-        adapter.updateData(aboutList)
+        adapter.submitList(aboutList)
         adapter.bindViewHolder(viewHolder, 1)
 
-        verify { viewHolder.bind(adapter.aboutList?.get(1) as AboutPageItem.Item) }
+        verify { viewHolder.bind(aboutList[1] as AboutPageItem.Item) }
     }
 }


### PR DESCRIPTION
We make the AboutPageAdapter inherit from a ListAdapter so that we don't use notifyDataSetChanged().



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture