### PR TITLE
For issue #8809 Notification permissions can't be disabled/re-enabled unless you restart the browser...

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/PermissionStorage.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/PermissionStorage.kt
@@ -9,13 +9,14 @@ import androidx.paging.DataSource
 import mozilla.components.feature.sitepermissions.SitePermissions
 import mozilla.components.feature.sitepermissions.SitePermissions.Status
 import mozilla.components.feature.sitepermissions.SitePermissionsStorage
+import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.test.Mockable
 
 @Mockable
 class PermissionStorage(private val context: Context) {
 
     private val permissionsStorage by lazy {
-        SitePermissionsStorage(context)
+        SitePermissionsStorage(context, context.components.core.engine)
     }
 
     fun addSitePermissionException(


### PR DESCRIPTION
This requires a new version of AC that includes https://github.com/mozilla-mobile/android-components/pull/6323
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture