### PR TITLE
Issue #5208: Use new tab/collection restore API.

### DIFF
--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "38.0.20200326130056"
+    const val VERSION = "38.0.20200326160141"
 }


### PR DESCRIPTION
This will fix restoring the "engine state" of tabs from tab collections (scroll state, history etc).

This first requires the following AC patch to land and be available in an AC nightly release:
https://github.com/mozilla-mobile/android-components/pull/6381