### PR TITLE
For #9422: Align widget text to viewStart to support RTL layouts

### DIFF
--- a/app/src/main/res/layout/search_widget_large.xml
+++ b/app/src/main/res/layout/search_widget_large.xml
@@ -3,12 +3,12 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
-<RelativeLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        android:layout_width="match_parent"
-        android:layout_height="50dp"
-        android:background="@drawable/rounded_white_corners"
-        android:layout_gravity="center">
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="50dp"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:background="@drawable/rounded_white_corners"
+    android:layout_gravity="center">
 
     <ImageView
             android:id="@+id/button_search_widget_new_tab_icon"
@@ -24,11 +24,13 @@
             android:layout_width="match_parent"
             android:layout_height="32dp"
             android:gravity="center_vertical"
+            android:textAlignment="viewStart"
             android:textSize="15sp"
             android:textColor="@color/search_widget_text"
             android:letterSpacing="-0.025"
             android:layout_marginStart="9dp"
-            android:layout_marginTop="9dp"/>
+            android:layout_marginTop="9dp"
+            tools:ignore="RtlCompat" />
 
     <ImageButton
             android:id="@+id/button_search_widget_voice"

--- a/app/src/main/res/layout/search_widget_large.xml
+++ b/app/src/main/res/layout/search_widget_large.xml
@@ -1,44 +1,43 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- This Source Code Form is subject to the terms of the Mozilla Public
+<?xml version="1.0" encoding="utf-8"?><!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="50dp"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:background="@drawable/rounded_white_corners"
-    android:layout_gravity="center">
+    android:layout_gravity="center"
+    android:background="@drawable/rounded_white_corners">
 
     <ImageView
-            android:id="@+id/button_search_widget_new_tab_icon"
-            android:layout_width="50dp"
-            android:contentDescription="@string/browser_menu_new_tab"
-            android:layout_height="50dp"
-            android:layout_alignParentStart="true"
-            android:scaleType="centerInside" />
+        android:id="@+id/button_search_widget_new_tab_icon"
+        android:contentDescription="@string/browser_menu_new_tab"
+        android:layout_width="50dp"
+        android:layout_height="50dp"
+        android:layout_alignParentStart="true"
+        android:scaleType="centerInside" />
 
     <TextView
-            android:id="@+id/button_search_widget_new_tab"
-            android:layout_toEndOf="@id/button_search_widget_new_tab_icon"
-            android:layout_width="match_parent"
-            android:layout_height="32dp"
-            android:gravity="center_vertical"
-            android:textAlignment="viewStart"
-            android:textSize="15sp"
-            android:textColor="@color/search_widget_text"
-            android:letterSpacing="-0.025"
-            android:layout_marginStart="9dp"
-            android:layout_marginTop="9dp"
-            tools:ignore="RtlCompat" />
+        android:id="@+id/button_search_widget_new_tab"
+        android:layout_width="match_parent"
+        android:layout_height="32dp"
+        android:layout_marginStart="9dp"
+        android:layout_marginTop="9dp"
+        android:layout_toEndOf="@id/button_search_widget_new_tab_icon"
+        android:gravity="center_vertical"
+        android:letterSpacing="-0.025"
+        android:textAlignment="viewStart"
+        android:textColor="@color/search_widget_text"
+        android:textSize="15sp"
+        tools:ignore="RtlCompat" />
 
     <ImageButton
-            android:id="@+id/button_search_widget_voice"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:contentDescription="@string/search_widget_voice"
-            android:background="@drawable/ic_microphone_widget"
-            android:layout_alignParentEnd="true"
-            android:layout_alignTop="@id/button_search_widget_new_tab"
-            android:layout_marginEnd="9dp"/>
+        android:id="@+id/button_search_widget_voice"
+        android:contentDescription="@string/search_widget_voice"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
+        android:layout_alignTop="@id/button_search_widget_new_tab"
+        android:layout_alignParentEnd="true"
+        android:layout_marginEnd="9dp"
+        android:background="@drawable/ic_microphone_widget" />
 </RelativeLayout>

--- a/app/src/main/res/layout/search_widget_medium.xml
+++ b/app/src/main/res/layout/search_widget_medium.xml
@@ -1,45 +1,43 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- This Source Code Form is subject to the terms of the Mozilla Public
+<?xml version="1.0" encoding="utf-8"?><!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
-<RelativeLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="192dp"
-        android:layout_height="50dp"
-        android:background="@drawable/rounded_white_corners"
-        android:layout_gravity="center">
+    android:layout_height="50dp"
+    android:layout_gravity="center"
+    android:background="@drawable/rounded_white_corners">
 
     <ImageView
-            android:id="@+id/button_search_widget_new_tab_icon"
-            android:layout_width="50dp"
-            android:layout_height="50dp"
-            android:contentDescription="@string/browser_menu_new_tab"
-            android:layout_alignParentStart="true"
-            android:scaleType="centerInside" />
+        android:id="@+id/button_search_widget_new_tab_icon"
+        android:contentDescription="@string/browser_menu_new_tab"
+        android:layout_width="50dp"
+        android:layout_height="50dp"
+        android:layout_alignParentStart="true"
+        android:scaleType="centerInside" />
 
     <TextView
-            android:id="@+id/button_search_widget_new_tab"
-            android:layout_toEndOf="@id/button_search_widget_new_tab_icon"
-            android:layout_width="match_parent"
-            android:layout_height="32dp"
-            android:gravity="center_vertical"
-            android:textAlignment="viewStart"
-            android:textSize="15sp"
-            android:textColor="@color/search_widget_text"
-            android:letterSpacing="-0.025"
-            android:layout_marginStart="9dp"
-            android:layout_marginTop="9dp"
-            tools:ignore="RtlCompat" />
+        android:id="@+id/button_search_widget_new_tab"
+        android:layout_width="match_parent"
+        android:layout_height="32dp"
+        android:layout_marginStart="9dp"
+        android:layout_marginTop="9dp"
+        android:layout_toEndOf="@id/button_search_widget_new_tab_icon"
+        android:gravity="center_vertical"
+        android:letterSpacing="-0.025"
+        android:textAlignment="viewStart"
+        android:textColor="@color/search_widget_text"
+        android:textSize="15sp"
+        tools:ignore="RtlCompat" />
 
     <ImageButton
-            android:id="@+id/button_search_widget_voice"
-            android:layout_width="32dp"
-            android:layout_height="32dp"
-            android:background="@drawable/ic_microphone_widget"
-            android:contentDescription="@string/search_widget_voice"
-            android:layout_alignParentEnd="true"
-            android:layout_alignTop="@id/button_search_widget_new_tab"
-            android:layout_marginEnd="9dp"/>
+        android:id="@+id/button_search_widget_voice"
+        android:contentDescription="@string/search_widget_voice"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
+        android:layout_alignTop="@id/button_search_widget_new_tab"
+        android:layout_alignParentEnd="true"
+        android:layout_marginEnd="9dp"
+        android:background="@drawable/ic_microphone_widget" />
 </RelativeLayout>

--- a/app/src/main/res/layout/search_widget_medium.xml
+++ b/app/src/main/res/layout/search_widget_medium.xml
@@ -5,7 +5,8 @@
 
 <RelativeLayout
         xmlns:android="http://schemas.android.com/apk/res/android"
-        android:layout_width="192dp"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="192dp"
         android:layout_height="50dp"
         android:background="@drawable/rounded_white_corners"
         android:layout_gravity="center">
@@ -24,11 +25,13 @@
             android:layout_width="match_parent"
             android:layout_height="32dp"
             android:gravity="center_vertical"
+            android:textAlignment="viewStart"
             android:textSize="15sp"
             android:textColor="@color/search_widget_text"
             android:letterSpacing="-0.025"
             android:layout_marginStart="9dp"
-            android:layout_marginTop="9dp"/>
+            android:layout_marginTop="9dp"
+            tools:ignore="RtlCompat" />
 
     <ImageButton
             android:id="@+id/button_search_widget_voice"


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. 
![prtl](https://user-images.githubusercontent.com/48995920/77656552-b3b78c80-6f7c-11ea-91e3-fef0204e5c41.png)
### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

