### PR TITLE
Update to new feature-media API.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -213,6 +213,9 @@
             android:exported="false"
             android:theme="@style/Theme.AppCompat.DayNight.DarkActionBar"/>
 
+        <service android:name=".media.MediaService"
+            android:exported="false" />
+
         <service
             android:name=".customtabs.CustomTabsService"
             android:exported="true"

--- a/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -11,20 +11,6 @@ object FeatureFlags {
     const val pullToRefreshEnabled = false
 
     /**
-     * Integration of media features provided by `feature-media` component:
-     * - Background playback without the app getting killed
-     * - Media notification with play/pause controls
-     * - Audio Focus handling (pausing/resuming in agreement with other media apps)
-     * - Support for hardware controls to toggle play/pause (e.g. buttons on a headset)
-     *
-     * Behind nightly flag until all related Android Components issues are fixed and QA has signed
-     * off.
-     *
-     * https://github.com/mozilla-mobile/fenix/issues/4431
-     */
-    const val mediaIntegration = true
-
-    /**
      * Allows Progressive Web Apps to be installed to the device home screen.
      */
     val progressiveWebApps = Config.channel.isNightlyOrDebug

--- a/app/src/main/java/org/mozilla/fenix/collections/CollectionCreationView.kt
+++ b/app/src/main/java/org/mozilla/fenix/collections/CollectionCreationView.kt
@@ -20,8 +20,20 @@ import androidx.transition.AutoTransition
 import androidx.transition.Transition
 import androidx.transition.TransitionManager
 import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.component_collection_creation.*
-import kotlinx.android.synthetic.main.component_collection_creation.view.*
+import kotlinx.android.synthetic.main.component_collection_creation.back_button
+import kotlinx.android.synthetic.main.component_collection_creation.collection_constraint_layout
+import kotlinx.android.synthetic.main.component_collection_creation.name_collection_edittext
+import kotlinx.android.synthetic.main.component_collection_creation.save_button
+import kotlinx.android.synthetic.main.component_collection_creation.select_all_button
+import kotlinx.android.synthetic.main.component_collection_creation.view.bottom_bar_icon_button
+import kotlinx.android.synthetic.main.component_collection_creation.view.bottom_bar_text
+import kotlinx.android.synthetic.main.component_collection_creation.view.bottom_button_bar_layout
+import kotlinx.android.synthetic.main.component_collection_creation.view.collection_constraint_layout
+import kotlinx.android.synthetic.main.component_collection_creation.view.collections_list
+import kotlinx.android.synthetic.main.component_collection_creation.view.name_collection_edittext
+import kotlinx.android.synthetic.main.component_collection_creation.view.select_all_button
+import kotlinx.android.synthetic.main.component_collection_creation.view.tab_list
+import mozilla.components.browser.state.state.MediaState
 import mozilla.components.feature.tab.collections.TabCollection
 import mozilla.components.support.ktx.android.view.hideKeyboard
 import mozilla.components.support.ktx.android.view.showKeyboard
@@ -266,7 +278,8 @@ class CollectionCreationView(
                     tab.id.toString(),
                     tab.url,
                     tab.url.toShortUrl(view.context.components.publicSuffixList),
-                    tab.title
+                    tab.title,
+                    mediaState = MediaState.State.NONE
                 )
             }.let { tabs ->
                 collectionCreationTabListAdapter.updateData(tabs, tabs.toSet(), true)

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -55,25 +55,27 @@ import kotlinx.android.synthetic.main.fragment_home.view.sessionControlRecyclerV
 import kotlinx.android.synthetic.main.fragment_home.view.toolbar
 import kotlinx.android.synthetic.main.fragment_home.view.toolbarLayout
 import kotlinx.android.synthetic.main.fragment_home.view.toolbar_wrapper
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.Dispatchers.Main
-import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import mozilla.appservices.places.BookmarkRoot
 import mozilla.components.browser.menu.ext.getHighlight
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
+import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.sync.AccountObserver
 import mozilla.components.concept.sync.AuthType
 import mozilla.components.concept.sync.OAuthAccount
-import mozilla.components.feature.media.ext.getSession
-import mozilla.components.feature.media.state.MediaState
-import mozilla.components.feature.media.state.MediaStateMachine
 import mozilla.components.feature.tab.collections.TabCollection
 import mozilla.components.feature.top.sites.TopSite
+import mozilla.components.lib.state.ext.flowScoped
 import mozilla.components.support.ktx.android.util.dpToPx
+import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
 import org.mozilla.fenix.BrowserDirection
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
@@ -105,7 +107,6 @@ import org.mozilla.fenix.whatsnew.WhatsNew
 import kotlin.math.abs
 import kotlin.math.min
 
-@ExperimentalCoroutinesApi
 @SuppressWarnings("TooManyFunctions", "LargeClass")
 class HomeFragment : Fragment() {
     private val homeViewModel: HomeScreenViewModel by viewModels {
@@ -162,7 +163,11 @@ class HomeFragment : Fragment() {
         super.onCreate(savedInstanceState)
         postponeEnterTransition()
 
-        val sessionObserver = BrowserSessionsObserver(sessionManager, singleSessionObserver) {
+        val sessionObserver = BrowserSessionsObserver(
+            sessionManager,
+            requireComponents.core.store,
+            singleSessionObserver
+        ) {
             emitSessionChanges()
         }
 
@@ -202,8 +207,9 @@ class HomeFragment : Fragment() {
 
         sessionControlInteractor = SessionControlInteractor(
             DefaultSessionControlController(
+                store = requireComponents.core.store,
                 activity = activity,
-                store = homeFragmentStore,
+                fragmentStore = homeFragmentStore,
                 navController = findNavController(),
                 browsingModeManager = browsingModeManager,
                 lifecycleScope = viewLifecycleOwner.lifecycleScope,
@@ -274,7 +280,6 @@ class HomeFragment : Fragment() {
         }
     }
 
-    @ExperimentalCoroutinesApi
     @SuppressWarnings("LongMethod")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -887,16 +892,9 @@ class HomeFragment : Fragment() {
 
     private fun List<Session>.toTabs(): List<Tab> {
         val selected = sessionManager.selectedSession
-        val mediaStateSession = MediaStateMachine.state.getSession()
 
-        return this.map {
-            val mediaState = if (mediaStateSession?.id == it.id) {
-                MediaStateMachine.state
-            } else {
-                null
-            }
-
-            it.toTab(requireContext(), it == selected, mediaState)
+        return map {
+            it.toTab(requireContext(), it == selected)
         }
     }
 
@@ -953,18 +951,24 @@ class HomeFragment : Fragment() {
  */
 private class BrowserSessionsObserver(
     private val manager: SessionManager,
+    private val store: BrowserStore,
     private val observer: Session.Observer,
     private val onChanged: () -> Unit
 ) : LifecycleObserver {
+    private var scope: CoroutineScope? = null
 
     /**
      * Start observing
      */
     @OnLifecycleEvent(Lifecycle.Event.ON_START)
     fun onStart() {
-        MediaStateMachine.register(managerObserver)
         manager.register(managerObserver)
         subscribeToAll()
+
+        scope = store.flowScoped { flow ->
+            flow.ifChanged { it.media.aggregate }
+                .collect { onChanged() }
+        }
     }
 
     /**
@@ -972,7 +976,7 @@ private class BrowserSessionsObserver(
      */
     @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
     fun onStop() {
-        MediaStateMachine.unregister(managerObserver)
+        scope?.cancel()
         manager.unregister(managerObserver)
         unsubscribeFromAll()
     }
@@ -993,11 +997,7 @@ private class BrowserSessionsObserver(
         session.unregister(observer)
     }
 
-    private val managerObserver = object : SessionManager.Observer, MediaStateMachine.Observer {
-        override fun onStateChanged(state: MediaState) {
-            onChanged()
-        }
-
+    private val managerObserver = object : SessionManager.Observer {
         override fun onSessionAdded(session: Session) {
             subscribeTo(session)
             onChanged()

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragmentStore.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragmentStore.kt
@@ -7,7 +7,7 @@ package org.mozilla.fenix.home
 import android.graphics.Bitmap
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
-import mozilla.components.feature.media.state.MediaState
+import mozilla.components.browser.state.state.MediaState
 import mozilla.components.feature.tab.collections.TabCollection
 import mozilla.components.feature.top.sites.TopSite
 import mozilla.components.lib.state.Action
@@ -29,8 +29,8 @@ data class Tab(
     val hostname: String,
     val title: String,
     val selected: Boolean? = null,
-    var mediaState: MediaState? = null,
-    val icon: Bitmap? = null
+    val icon: Bitmap? = null,
+    val mediaState: MediaState.State
 )
 
 data class TopSiteItem(

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlAdapter.kt
@@ -15,7 +15,6 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.android.synthetic.main.tab_list_row.*
-import mozilla.components.feature.media.state.MediaState
 import mozilla.components.feature.tab.collections.TabCollection
 import mozilla.components.feature.top.sites.TopSite
 import org.mozilla.fenix.home.OnboardingState
@@ -256,7 +255,7 @@ class SessionControlAdapter(
             }
             if (it.shouldUpdateSelected) { holder.updateSelected(it.tab.selected ?: false) }
             if (it.shouldUpdateMediaState) {
-                holder.updatePlayPauseButton(it.tab.mediaState ?: MediaState.None)
+                holder.updatePlayPauseButton(it.tab.mediaState)
             }
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
@@ -10,10 +10,10 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import mozilla.components.browser.session.SessionManager
+import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.prompt.ShareData
 import mozilla.components.feature.media.ext.pauseIfPlaying
 import mozilla.components.feature.media.ext.playIfPaused
-import mozilla.components.feature.media.state.MediaStateMachine
 import mozilla.components.feature.tab.collections.TabCollection
 import mozilla.components.feature.tab.collections.ext.restore
 import mozilla.components.feature.top.sites.TopSite
@@ -157,8 +157,9 @@ interface SessionControlController {
 
 @SuppressWarnings("TooManyFunctions", "LargeClass")
 class DefaultSessionControlController(
+    private val store: BrowserStore,
     private val activity: HomeActivity,
-    private val store: HomeFragmentStore,
+    private val fragmentStore: HomeFragmentStore,
     private val navController: NavController,
     private val browsingModeManager: BrowsingModeManager,
     private val lifecycleScope: CoroutineScope,
@@ -266,11 +267,11 @@ class DefaultSessionControlController(
     }
 
     override fun handlePauseMediaClicked() {
-        MediaStateMachine.state.pauseIfPlaying()
+        store.state.media.pauseIfPlaying()
     }
 
     override fun handlePlayMediaClicked() {
-        MediaStateMachine.state.playIfPaused()
+        store.state.media.playIfPaused()
     }
 
     override fun handlePrivateBrowsingLearnMoreClicked() {
@@ -358,7 +359,7 @@ class DefaultSessionControlController(
     }
 
     override fun handleToggleCollectionExpanded(collection: TabCollection, expand: Boolean) {
-        store.dispatch(HomeFragmentAction.CollectionExpanded(collection, expand))
+        fragmentStore.dispatch(HomeFragmentAction.CollectionExpanded(collection, expand))
     }
 
     override fun handleonOpenNewTabClicked() {

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/TabViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/TabViewHolder.kt
@@ -12,7 +12,7 @@ import androidx.appcompat.content.res.AppCompatResources
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.android.extensions.LayoutContainer
 import kotlinx.android.synthetic.main.tab_list_row.*
-import mozilla.components.feature.media.state.MediaState
+import mozilla.components.browser.state.state.MediaState
 import mozilla.components.support.ktx.android.util.dpToFloat
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.metrics.Event
@@ -50,15 +50,19 @@ class TabViewHolder(
 
         play_pause_button.setOnClickListener {
             when (tab?.mediaState) {
-                is MediaState.Playing -> {
+                MediaState.State.PLAYING -> {
                     it.context.components.analytics.metrics.track(Event.TabMediaPause)
                     interactor.onPauseMediaClicked()
                 }
 
-                is MediaState.Paused -> {
+                MediaState.State.PAUSED -> {
                     it.context.components.analytics.metrics.track(Event.TabMediaPlay)
                     interactor.onPlayMediaClicked()
                 }
+
+                MediaState.State.NONE -> throw AssertionError(
+                    "Play/Pause button clicked without play/pause state."
+                )
             }
         }
 
@@ -82,20 +86,20 @@ class TabViewHolder(
         updateHostname(tab.hostname)
         updateFavIcon(tab.url, tab.icon)
         updateSelected(tab.selected ?: false)
-        updatePlayPauseButton(tab.mediaState ?: MediaState.None)
+        updatePlayPauseButton(tab.mediaState)
         item_tab.transitionName = "$TAB_ITEM_TRANSITION_NAME${tab.sessionId}"
         updateCloseButtonDescription(tab.title)
     }
 
-    internal fun updatePlayPauseButton(mediaState: MediaState) {
+    internal fun updatePlayPauseButton(mediaState: MediaState.State) {
         with(play_pause_button) {
-            visibility = if (mediaState is MediaState.Playing || mediaState is MediaState.Paused) {
+            visibility = if (mediaState == MediaState.State.PLAYING || mediaState == MediaState.State.PAUSED) {
                 View.VISIBLE
             } else {
                 View.GONE
             }
 
-            if (mediaState is MediaState.Playing) {
+            if (mediaState == MediaState.State.PLAYING) {
                 play_pause_button.contentDescription =
                     context.getString(R.string.mozac_feature_media_notification_action_pause)
                 setImageDrawable(AppCompatResources.getDrawable(context, R.drawable.pause_with_background))

--- a/app/src/main/java/org/mozilla/fenix/media/MediaService.kt
+++ b/app/src/main/java/org/mozilla/fenix/media/MediaService.kt
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.media
+
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.feature.media.service.AbstractMediaService
+import org.mozilla.fenix.ext.components
+
+/**
+ * [AbstractMediaService] implementation for injecting [BrowserStore] singleton.
+ */
+class MediaService : AbstractMediaService() {
+    override val store: BrowserStore by lazy { components.core.store }
+}

--- a/app/src/test/java/org/mozilla/fenix/home/DefaultSessionControlControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/DefaultSessionControlControllerTest.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.newSingleThreadContext
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import mozilla.components.browser.session.SessionManager
+import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.Engine
 import mozilla.components.feature.tab.collections.TabCollection
 import mozilla.components.feature.tabs.TabsUseCases
@@ -38,8 +39,9 @@ import mozilla.components.feature.tab.collections.Tab as ComponentTab
 class DefaultSessionControlControllerTest {
 
     private val mainThreadSurrogate = newSingleThreadContext("UI thread")
+    private val store: BrowserStore = mockk(relaxed = true)
     private val activity: HomeActivity = mockk(relaxed = true)
-    private val store: HomeFragmentStore = mockk(relaxed = true)
+    private val fragmentStore: HomeFragmentStore = mockk(relaxed = true)
     private val navController: NavController = mockk(relaxed = true)
     private val browsingModeManager: BrowsingModeManager = mockk(relaxed = true)
     private val closeTab: (sessionId: String) -> Unit = mockk(relaxed = true)
@@ -71,7 +73,7 @@ class DefaultSessionControlControllerTest {
         every { activity.components.core.tabCollectionStorage } returns tabCollectionStorage
         every { activity.components.useCases.tabsUseCases } returns tabsUseCases
 
-        every { store.state } returns state
+        every { fragmentStore.state } returns state
         every { state.collections } returns emptyList()
         every { state.expandedCollections } returns emptySet()
         every { state.mode } returns Mode.Normal
@@ -79,8 +81,9 @@ class DefaultSessionControlControllerTest {
         every { activity.components.analytics.metrics } returns metrics
 
         controller = DefaultSessionControlController(
-            activity = activity,
             store = store,
+            activity = activity,
+            fragmentStore = fragmentStore,
             navController = navController,
             browsingModeManager = browsingModeManager,
             lifecycleScope = MainScope(),
@@ -235,6 +238,6 @@ class DefaultSessionControlControllerTest {
     fun handleToggleCollectionExpanded() {
         val collection: TabCollection = mockk(relaxed = true)
         controller.handleToggleCollectionExpanded(collection, true)
-        verify { store.dispatch(HomeFragmentAction.CollectionExpanded(collection, true)) }
+        verify { fragmentStore.dispatch(HomeFragmentAction.CollectionExpanded(collection, true)) }
     }
 }

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "38.0.20200326160141"
+    const val VERSION = "38.0.20200327101347"
 }


### PR DESCRIPTION
We are about to land a refactoring of `feature-media` that will make it use `browser-state` instead of `browser-session` (https://github.com/mozilla-mobile/android-components/pull/6362). This is the Fenix counterpart. I'll update this PR with the matching AC Nightly version once the AC PR landed.