### PR TITLE
Closes #9414: Make AMO collection configurable

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,6 +47,7 @@ android {
         testInstrumentationRunnerArguments clearPackageData: 'true'
         resValue "bool", "IS_DEBUG", "false"
         buildConfigField "boolean", "USE_RELEASE_VERSIONING", "false"
+        buildConfigField "String", "AMO_COLLECTION", "\"7e8d6dc651b54ab385fb8791bf9dac\""
         manifestPlaceholders = [
                 "isRaptorEnabled": "false",
                 "deepLinkScheme": "fenix-dev"

--- a/app/src/main/java/org/mozilla/fenix/components/Components.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Components.kt
@@ -17,6 +17,7 @@ import mozilla.components.feature.addons.migration.DefaultSupportedAddonsChecker
 import mozilla.components.feature.tabs.TabsUseCases
 import mozilla.components.lib.publicsuffixlist.PublicSuffixList
 import mozilla.components.support.migration.state.MigrationStore
+import org.mozilla.fenix.BuildConfig
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.test.Mockable
@@ -69,7 +70,16 @@ class Components(private val context: Context) {
     }
 
     val addonCollectionProvider by lazy {
-        AddonCollectionProvider(context, core.client, maxCacheAgeInMinutes = DAY_IN_MINUTES)
+        if (!BuildConfig.AMO_COLLECTION.isNullOrEmpty()) {
+            AddonCollectionProvider(
+                context,
+                core.client,
+                collectionName = BuildConfig.AMO_COLLECTION,
+                maxCacheAgeInMinutes = DAY_IN_MINUTES
+            )
+        } else {
+            AddonCollectionProvider(context, core.client, maxCacheAgeInMinutes = DAY_IN_MINUTES)
+        }
     }
 
     @Suppress("MagicNumber")


### PR DESCRIPTION
With this we can configure the AMO collection per build type/variant. By default, we use the Fenix "prod" collection.