### PR TITLE
Closes #9189: Fixes "static asset not found" error in AndroidAssetDispatcher dispatcher

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/MockWebServer.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/MockWebServer.kt
@@ -62,12 +62,12 @@ const val HTTP_NOT_FOUND = 404
 class AndroidAssetDispatcher : Dispatcher() {
     private val mainThreadHandler = Handler(Looper.getMainLooper())
 
-    override fun dispatch(request: RecordedRequest): MockResponse {
+    override fun dispatch(request: RecordedRequest?): MockResponse {
         val assetManager = InstrumentationRegistry.getInstrumentation().context.assets
         try {
-            val pathNoLeadingSlash = request.path.drop(1)
-            assetManager.open(pathNoLeadingSlash).use { inputStream ->
-                return fileToResponse(pathNoLeadingSlash, inputStream)
+            val pathWithoutQueryParams = Uri.parse(request?.path?.drop(1)).path
+            assetManager.open(pathWithoutQueryParams!!).use { inputStream ->
+                return fileToResponse(pathWithoutQueryParams, inputStream)
             }
         } catch (e: IOException) { // e.g. file not found.
             // We're on a background thread so we need to forward the exception to the main thread.

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsPrivacyTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsPrivacyTest.kt
@@ -141,7 +141,6 @@ class SettingsPrivacyTest {
     }
 
     @Test
-    @Ignore("Passes locally, fails on CI. Fix in https://github.com/mozilla-mobile/fenix/issues/9189")
     fun saveLoginFromPromptTest() {
         val saveLoginTest =
             TestAssetHelper.getSaveLoginAsset(mockWebServer)
@@ -167,7 +166,6 @@ class SettingsPrivacyTest {
     }
 
     @Test
-    @Ignore("Passes locally, fails on CI. Fix in https://github.com/mozilla-mobile/fenix/issues/9189")
     fun doNotSaveLoginFromPromptTest() {
         val saveLoginTest = TestAssetHelper.getSaveLoginAsset(mockWebServer)
 


### PR DESCRIPTION
AndroidAssetDispatcher class dispatcher was attempting to open a local asset with a query suffix from the request. If query suffix is found, remove it. Re-enable saveLoginFromPromptTest() and doNotSaveLoginFromPromptTest()