### PR TITLE
Use relative package name for 'App' activity alias

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,7 +37,7 @@
           inside their source set.
         -->
         <activity-alias
-            android:name="${applicationId}.App"
+            android:name=".App"
             android:targetActivity=".HomeActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
The `${applicationID}` does ~n't~ include the suffix of variants which causes launching from Android Studio to fail. Using the relative package name solves this and is also in alignment with Fennec (see [here](https://searchfox.org/mozilla-esr68/rev/0ef234279fd0608a8fd6bb1f792d080087d638d8/mobile/android/base/AndroidManifest.xml.in#72-74)).