### PR TITLE
No issue - Make fill link from clipboard divider stretch full screen

### DIFF
--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -109,7 +109,6 @@
         android:id="@+id/divider_line"
         android:layout_width="match_parent"
         android:layout_height="1.5dp"
-        android:layout_marginStart="8dp"
         android:background="?neutralFaded"
         app:layout_constraintEnd_toEndOf="@id/fill_link_from_clipboard"
         app:layout_constraintStart_toStartOf="@id/fill_link_from_clipboard"


### PR DESCRIPTION
Looks weird to be flush up to the end but not the start

<img width="424" alt="Clippy" src="https://user-images.githubusercontent.com/46655/77781813-33e4fd00-7024-11ea-9b6d-00fdbdca1d3e.png">

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture