### PR TITLE
Closes #9561: Fix initialization order in HomeMenu

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeMenu.kt
@@ -51,6 +51,32 @@ class HomeMenu(
     private val menuCategoryTextColor =
         ThemeManager.resolveAttribute(R.attr.menuCategoryText, context)
 
+    // 'Reconnect' and 'Quit' items aren't needed most of the time, so we'll only create the if necessary.
+    private val reconnectToSyncItem by lazy {
+        BrowserMenuHighlightableItem(
+            context.getString(R.string.sync_reconnect),
+            R.drawable.ic_sync_disconnected,
+            iconTintColorResource = syncDisconnectedColor,
+            textColorResource = primaryTextColor,
+            highlight = BrowserMenuHighlight.HighPriority(
+                backgroundTint = syncDisconnectedBackgroundColor
+            ),
+            isHighlighted = { true }
+        ) {
+            onItemTapped.invoke(Item.Sync)
+        }
+    }
+
+    private val quitItem by lazy {
+        BrowserMenuImageText(
+            context.getString(R.string.delete_browsing_data_on_quit_action),
+            R.drawable.ic_exit,
+            primaryTextColor
+        ) {
+            onItemTapped.invoke(Item.Quit)
+        }
+    }
+
     private val coreMenuItems by lazy {
         val whatsNewItem = BrowserMenuHighlightableItem(
             context.getString(R.string.browser_menu_whats_new),
@@ -142,32 +168,6 @@ class HomeMenu(
                     ))
                 }
             }, lifecycleOwner)
-        }
-    }
-
-    // 'Reconnect' and 'Quit' items aren't needed most of the time, so we'll only create the if necessary.
-    private val reconnectToSyncItem by lazy {
-        BrowserMenuHighlightableItem(
-            context.getString(R.string.sync_reconnect),
-            R.drawable.ic_sync_disconnected,
-            iconTintColorResource = syncDisconnectedColor,
-            textColorResource = primaryTextColor,
-            highlight = BrowserMenuHighlight.HighPriority(
-                backgroundTint = syncDisconnectedBackgroundColor
-            ),
-            isHighlighted = { true }
-        ) {
-            onItemTapped.invoke(Item.Sync)
-        }
-    }
-
-    private val quitItem by lazy {
-        BrowserMenuImageText(
-            context.getString(R.string.delete_browsing_data_on_quit_action),
-            R.drawable.ic_exit,
-            primaryTextColor
-        ) {
-            onItemTapped.invoke(Item.Quit)
         }
     }
 }


### PR DESCRIPTION
This is fall-out from https://github.com/mozilla-mobile/fenix/pull/9239

`init` blocks are executed before `val` initialization which is declared afterwards
in the class. In this case, we had `quitItem` and `reconnectToSyncItem` as lazy,
but declared after the `init` block which may need them. And so, while this compiles
just fine, in practice we run into an NPE as the `init` block tries to get the lazy's value.

Simply re-ordering initialization fixes the problem.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture