### PR TITLE
For #9365: Partially reverse menu items order when using top toolbar.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeMenu.kt
@@ -99,7 +99,7 @@ class HomeMenu(
             onItemTapped.invoke(Item.Bookmarks)
         }
 
-        val libraryItem = BrowserMenuImageText(
+        val historyItem = BrowserMenuImageText(
             context.getString(R.string.library_history),
             R.drawable.ic_history,
             primaryTextColor) {
@@ -139,7 +139,7 @@ class HomeMenu(
                 textColorResource = menuCategoryTextColor
             ),
             bookmarksItem,
-            libraryItem,
+            historyItem,
             BrowserMenuDivider(),
             settingsItem,
             helpItem,

--- a/app/src/main/java/org/mozilla/fenix/home/HomeMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeMenu.kt
@@ -21,6 +21,7 @@ import mozilla.components.concept.sync.OAuthAccount
 import mozilla.components.support.ktx.android.content.getColorFromAttr
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.theme.ThemeManager
 import org.mozilla.fenix.utils.Settings
 import org.mozilla.fenix.whatsnew.WhatsNew
@@ -50,6 +51,7 @@ class HomeMenu(
 
     private val menuCategoryTextColor =
         ThemeManager.resolveAttribute(R.attr.menuCategoryText, context)
+    private val shouldUseBottomToolbar = context.settings().shouldUseBottomToolbar
 
     // 'Reconnect' and 'Quit' items aren't needed most of the time, so we'll only create the if necessary.
     private val reconnectToSyncItem by lazy {
@@ -102,7 +104,8 @@ class HomeMenu(
         val historyItem = BrowserMenuImageText(
             context.getString(R.string.library_history),
             R.drawable.ic_history,
-            primaryTextColor) {
+            primaryTextColor
+        ) {
             onItemTapped.invoke(Item.History)
         }
 
@@ -130,22 +133,42 @@ class HomeMenu(
             null
         }
 
-        listOfNotNull(
-            accountAuthItem,
-            whatsNewItem,
-            BrowserMenuDivider(),
-            BrowserMenuCategory(
-                context.getString(R.string.browser_menu_library),
-                textColorResource = menuCategoryTextColor
-            ),
-            bookmarksItem,
-            historyItem,
-            BrowserMenuDivider(),
-            settingsItem,
-            helpItem,
-            if (Settings.getInstance(context).shouldDeleteBrowsingDataOnQuit) quitItem else null
-        ).also { items ->
-            items.getHighlight()?.let { onHighlightPresent(it) }
+        if (shouldUseBottomToolbar) {
+            listOfNotNull(
+                accountAuthItem,
+                whatsNewItem,
+                BrowserMenuDivider(),
+                BrowserMenuCategory(
+                    context.getString(R.string.browser_menu_library),
+                    textColorResource = menuCategoryTextColor
+                ),
+                bookmarksItem,
+                historyItem,
+                BrowserMenuDivider(),
+                settingsItem,
+                helpItem,
+                if (Settings.getInstance(context).shouldDeleteBrowsingDataOnQuit) quitItem else null
+            ).also { items ->
+                items.getHighlight()?.let { onHighlightPresent(it) }
+            }
+        } else {
+            listOfNotNull(
+                if (Settings.getInstance(context).shouldDeleteBrowsingDataOnQuit) quitItem else null,
+                helpItem,
+                settingsItem,
+                accountAuthItem,
+                BrowserMenuDivider(),
+                BrowserMenuCategory(
+                    context.getString(R.string.browser_menu_library),
+                    textColorResource = menuCategoryTextColor
+                ),
+                bookmarksItem,
+                historyItem,
+                BrowserMenuDivider(),
+                whatsNewItem
+            ).also { items ->
+                items.getHighlight()?.let { onHighlightPresent(it) }
+            }
         }
     }
 


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.
![hmenu](https://user-images.githubusercontent.com/48995920/78128838-3fb73180-741f-11ea-9425-a480ef616166.png)

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture