### PR TITLE
For #9605: remove duplication in @RunWith annotation; add lint check

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,6 +31,7 @@ apply plugin: 'com.google.android.gms.oss-licenses-plugin'
 import com.android.build.OutputFile
 import org.gradle.internal.logging.text.StyledTextOutput.Style
 import org.gradle.internal.logging.text.StyledTextOutputFactory
+import org.mozilla.fenix.gradle.tasks.LintUnitTestRunner
 
 import static org.gradle.api.tasks.testing.TestResult.ResultType
 
@@ -683,6 +684,8 @@ task buildTranslationArray {
     def foundLocalesString = foundLocales.toString().replaceAll(',}','}')
     android.defaultConfig.buildConfigField "String[]", "SUPPORTED_LOCALE_ARRAY", foundLocalesString
 }
+
+task lintUnitTestRunner(type: LintUnitTestRunner)
 
 afterEvaluate {
 

--- a/app/src/test/java/org/mozilla/fenix/AppRequestInterceptorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/AppRequestInterceptorTest.kt
@@ -21,11 +21,9 @@ import org.junit.runner.RunWith
 import org.mozilla.fenix.AppRequestInterceptor.Companion.HIGH_RISK_ERROR_PAGES
 import org.mozilla.fenix.AppRequestInterceptor.Companion.LOW_AND_MEDIUM_RISK_ERROR_PAGES
 import org.mozilla.fenix.ext.isOnline
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class AppRequestInterceptorTest {
 
     private lateinit var interceptor: RequestInterceptor

--- a/app/src/test/java/org/mozilla/fenix/HomeActivityTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/HomeActivityTest.kt
@@ -16,11 +16,9 @@ import org.mozilla.fenix.HomeActivity.Companion.PRIVATE_BROWSING_MODE
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.settings
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class HomeActivityTest {
 
     @Test

--- a/app/src/test/java/org/mozilla/fenix/IntentReceiverActivityTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/IntentReceiverActivityTest.kt
@@ -22,13 +22,11 @@ import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.shortcut.NewTabShortcutIntentProcessor
 import org.robolectric.Robolectric
-import org.robolectric.RobolectricTestRunner
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
-import org.robolectric.annotation.Config
 
 @ExperimentalCoroutinesApi
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class IntentReceiverActivityTest {
 
     @Test

--- a/app/src/test/java/org/mozilla/fenix/collections/CollectionCreationFragmentTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/collections/CollectionCreationFragmentTest.kt
@@ -4,7 +4,7 @@
 
 package org.mozilla.fenix.collections
 
-import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import assertk.assertThat
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
@@ -27,8 +27,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mozilla.fenix.TestApplication
-import org.robolectric.annotation.Config
 
 private const val URL_MOZILLA = "www.mozilla.org"
 private const val SESSION_ID_MOZILLA = "0"
@@ -40,8 +38,7 @@ private const val SESSION_ID_BAD_2 = "definitely not a real session id"
 
 @ExperimentalCoroutinesApi
 @ObsoleteCoroutinesApi
-@RunWith(AndroidJUnit4::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class CollectionCreationFragmentTest {
 
     @MockK private lateinit var sessionManager: SessionManager

--- a/app/src/test/java/org/mozilla/fenix/components/AccountAbnormalitiesTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/AccountAbnormalitiesTest.kt
@@ -4,7 +4,7 @@
 
 package org.mozilla.fenix.components
 
-import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.runBlocking
 import mozilla.components.lib.crash.CrashReporter
@@ -18,12 +18,9 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.verifyZeroInteractions
 import org.mockito.Mockito.verify
-import org.mozilla.fenix.TestApplication
-import org.robolectric.annotation.Config
 import kotlin.reflect.KClass
 
-@RunWith(AndroidJUnit4::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class AccountAbnormalitiesTest {
     @Test
     fun `account manager must be configured`() {

--- a/app/src/test/java/org/mozilla/fenix/components/IntentProcessorTypeTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/IntentProcessorTypeTest.kt
@@ -16,14 +16,11 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.HomeActivity
-import org.mozilla.fenix.TestApplication
 import org.mozilla.fenix.customtabs.ExternalAppBrowserActivity
 import org.mozilla.fenix.ext.components
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class IntentProcessorTypeTest {
 
     @Test

--- a/app/src/test/java/org/mozilla/fenix/components/StoreProviderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/StoreProviderTest.kt
@@ -14,12 +14,9 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mozilla.fenix.TestApplication
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class StoreProviderTest {
 
     private class BasicState : State

--- a/app/src/test/java/org/mozilla/fenix/components/TrackingProtectionPolicyFactoryTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/TrackingProtectionPolicyFactoryTest.kt
@@ -11,13 +11,10 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.R
-import org.mozilla.fenix.TestApplication
 import org.mozilla.fenix.utils.Settings
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class TrackingProtectionPolicyFactoryTest {
 
     @Test

--- a/app/src/test/java/org/mozilla/fenix/components/metrics/BreadcrumbRecorderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/metrics/BreadcrumbRecorderTest.kt
@@ -6,21 +6,15 @@ package org.mozilla.fenix.components.metrics
 
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import mozilla.components.lib.crash.Crash
 import mozilla.components.lib.crash.CrashReporter
 import mozilla.components.lib.crash.service.CrashReporterService
 import mozilla.components.support.test.any
 import mozilla.components.support.test.mock
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
-import org.mozilla.fenix.TestApplication
-import org.robolectric.annotation.Config
 
-@RunWith(AndroidJUnit4::class)
-@Config(application = TestApplication::class)
 internal class BreadcrumbRecorderTest {
     @Test
     fun `ensure crash reporter recordCrashBreadcrumb is called`() {

--- a/app/src/test/java/org/mozilla/fenix/components/metrics/GleanMetricsServiceTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/metrics/GleanMetricsServiceTest.kt
@@ -16,12 +16,9 @@ import org.junit.runner.RunWith
 import org.mozilla.fenix.GleanMetrics.Events
 import org.mozilla.fenix.GleanMetrics.Metrics
 import org.mozilla.fenix.GleanMetrics.SearchDefaultEngine
-import org.mozilla.fenix.TestApplication
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class GleanMetricsServiceTest {
     @get:Rule
     val gleanRule = GleanTestRule(testContext)

--- a/app/src/test/java/org/mozilla/fenix/components/metrics/MetricsUtilsTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/metrics/MetricsUtilsTest.kt
@@ -7,12 +7,9 @@ import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mozilla.fenix.TestApplication
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class MetricsUtilsTest {
 
     @Test

--- a/app/src/test/java/org/mozilla/fenix/components/metrics/PerformedSearchTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/metrics/PerformedSearchTest.kt
@@ -13,15 +13,12 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mozilla.fenix.TestApplication
 import org.mozilla.fenix.components.metrics.Event.PerformedSearch
 import org.mozilla.fenix.components.metrics.Event.PerformedSearch.EngineSource
 import org.mozilla.fenix.components.metrics.Event.PerformedSearch.EventSource
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class PerformedSearchTest {
     private lateinit var searchEngines: List<SearchEngine>
 

--- a/app/src/test/java/org/mozilla/fenix/components/searchengine/FenixSearchEngineProviderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/searchengine/FenixSearchEngineProviderTest.kt
@@ -17,13 +17,10 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
 import org.mockito.Mockito.mock
-import org.mozilla.fenix.TestApplication
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
 @ExperimentalCoroutinesApi
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class FenixSearchEngineProviderTest {
 
     private lateinit var fenixSearchEngineProvider: FenixSearchEngineProvider

--- a/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarControllerTest.kt
@@ -39,7 +39,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
-import org.mozilla.fenix.TestApplication
 import org.mozilla.fenix.browser.BrowserAnimator
 import org.mozilla.fenix.browser.BrowserFragment
 import org.mozilla.fenix.browser.BrowserFragmentDirections
@@ -57,12 +56,10 @@ import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.toTab
 import org.mozilla.fenix.home.Tab
 import org.mozilla.fenix.settings.deletebrowsingdata.deleteAndQuit
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
 @ExperimentalCoroutinesApi
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class DefaultBrowserToolbarControllerTest {
 
     private val mainThreadSurrogate = newSingleThreadContext("UI thread")

--- a/app/src/test/java/org/mozilla/fenix/customtabs/ExternalAppBrowserActivityTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/customtabs/ExternalAppBrowserActivityTest.kt
@@ -14,18 +14,12 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mockito.Mockito.never
 import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import org.mozilla.fenix.BrowserDirection
-import org.mozilla.fenix.TestApplication
 import org.mozilla.fenix.components.metrics.Event
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
 class ExternalAppBrowserActivityTest {
 
     @Test

--- a/app/src/test/java/org/mozilla/fenix/customtabs/PoweredByNotificationTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/customtabs/PoweredByNotificationTest.kt
@@ -13,12 +13,9 @@ import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mozilla.fenix.TestApplication
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class PoweredByNotificationTest {
 
     @Test

--- a/app/src/test/java/org/mozilla/fenix/ext/ActivityTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/ext/ActivityTest.kt
@@ -11,14 +11,11 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mozilla.fenix.TestApplication
 import org.robolectric.Robolectric
-import org.robolectric.RobolectricTestRunner
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
-import org.robolectric.annotation.Config
 
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class ActivityTest {
 
     @Test

--- a/app/src/test/java/org/mozilla/fenix/ext/BrowserIconsTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/ext/BrowserIconsTest.kt
@@ -13,12 +13,9 @@ import mozilla.components.browser.icons.IconRequest
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mozilla.fenix.TestApplication
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class BrowserIconsTest {
     @Test
     fun loadIntoViewTest() {

--- a/app/src/test/java/org/mozilla/fenix/ext/ConnectivityManagerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/ext/ConnectivityManagerTest.kt
@@ -15,12 +15,9 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mozilla.fenix.TestApplication
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class ConnectivityManagerTest {
 
     private lateinit var connectivityManager: ConnectivityManager

--- a/app/src/test/java/org/mozilla/fenix/ext/DrawableTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/ext/DrawableTest.kt
@@ -12,12 +12,9 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mozilla.fenix.TestApplication
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class DrawableTest {
     @Test
     fun testSetBounds() {

--- a/app/src/test/java/org/mozilla/fenix/ext/FragmentTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/ext/FragmentTest.kt
@@ -23,12 +23,9 @@ import mozilla.components.support.test.robolectric.testContext
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mozilla.fenix.TestApplication
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class FragmentTest {
 
     private val navDirections: NavDirections = mockk(relaxed = true)

--- a/app/src/test/java/org/mozilla/fenix/ext/ImageButtonTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/ext/ImageButtonTest.kt
@@ -6,18 +6,15 @@ package org.mozilla.fenix.ext
 
 import android.view.View
 import mozilla.components.support.test.robolectric.testContext
-import org.mozilla.fenix.TestApplication
 import org.junit.Test
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertEquals
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import android.widget.ImageButton
 
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class ImageButtonTest {
     private val imageButton = ImageButton(testContext)
 

--- a/app/src/test/java/org/mozilla/fenix/ext/LogTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/ext/LogTest.kt
@@ -10,13 +10,6 @@ import io.mockk.mockkStatic
 import io.mockk.verify
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mozilla.fenix.TestApplication
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
-
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
 
 class LogTest {
 

--- a/app/src/test/java/org/mozilla/fenix/ext/NavControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/ext/NavControllerTest.kt
@@ -15,13 +15,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mozilla.fenix.TestApplication
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
 class NavControllerTest {
 
     private val navController: NavController = mockk(relaxed = true)

--- a/app/src/test/java/org/mozilla/fenix/ext/StringTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/ext/StringTest.kt
@@ -15,15 +15,12 @@ import org.junit.Assert.assertEquals
 import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mozilla.fenix.TestApplication
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
 const val PUNYCODE = "xn--kpry57d"
 const val IDN = "台灣"
 
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class StringTest {
 
     private val publicSuffixList = testContext.components.publicSuffixList

--- a/app/src/test/java/org/mozilla/fenix/ext/TabCollectionTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/ext/TabCollectionTest.kt
@@ -14,12 +14,9 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.`when`
 import org.mozilla.fenix.R
-import org.mozilla.fenix.TestApplication
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class TabCollectionTest {
 
     @Test

--- a/app/src/test/java/org/mozilla/fenix/helpers/FenixRobolectricTestApplication.kt
+++ b/app/src/test/java/org/mozilla/fenix/helpers/FenixRobolectricTestApplication.kt
@@ -7,7 +7,10 @@ package org.mozilla.fenix.helpers
 import org.mozilla.fenix.FenixApplication
 import org.mozilla.fenix.components.TestComponents
 
-class TestApplication : FenixApplication() {
+/**
+ * An override of our application for use in Robolectric-based unit tests.
+ */
+class FenixRobolectricTestApplication : FenixApplication() {
 
     override val components = TestComponents(this)
 

--- a/app/src/test/java/org/mozilla/fenix/helpers/FenixRobolectricTestApplication.kt
+++ b/app/src/test/java/org/mozilla/fenix/helpers/FenixRobolectricTestApplication.kt
@@ -8,7 +8,9 @@ import org.mozilla.fenix.FenixApplication
 import org.mozilla.fenix.components.TestComponents
 
 /**
- * An override of our application for use in Robolectric-based unit tests.
+ * An override of our application for use in Robolectric-based unit tests. We're forced to override
+ * because our standard application fails to initialize in Robolectric with exceptions like:
+ * "Crash handler service must run in a separate process".
  */
 class FenixRobolectricTestApplication : FenixApplication() {
 

--- a/app/src/test/java/org/mozilla/fenix/helpers/FenixRobolectricTestRunner.kt
+++ b/app/src/test/java/org/mozilla/fenix/helpers/FenixRobolectricTestRunner.kt
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.helpers
+
+import org.mozilla.fenix.TestApplication
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * A test runner that starts Robolectric with our custom configuration for use in unit tests.
+ *
+ * usage:
+ * ```
+ * @RunWith(FenixRobolectricTestRunner::class)
+ * class ExampleUnitTest {
+ * ```
+ *
+ * IMPORTANT NOTES:
+ * - This should ALWAYS be used instead of RobolectricTestRunner and AndroidJUnit4 (note: the latter
+ * just delegates to the former)
+ * - You should only use Robolectric when necessary because it non-trivially increases test duration.
+ */
+class FenixRobolectricTestRunner(testClass: Class<*>) : RobolectricTestRunner(testClass) {
+
+    override fun buildGlobalConfig(): Config {
+        return Config.Builder()
+            .setApplication(TestApplication::class.java)
+            .build()
+    }
+}

--- a/app/src/test/java/org/mozilla/fenix/helpers/FenixRobolectricTestRunner.kt
+++ b/app/src/test/java/org/mozilla/fenix/helpers/FenixRobolectricTestRunner.kt
@@ -4,7 +4,6 @@
 
 package org.mozilla.fenix.helpers
 
-import org.mozilla.fenix.TestApplication
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 

--- a/app/src/test/java/org/mozilla/fenix/helpers/FenixRobolectricTestRunner.kt
+++ b/app/src/test/java/org/mozilla/fenix/helpers/FenixRobolectricTestRunner.kt
@@ -25,7 +25,7 @@ class FenixRobolectricTestRunner(testClass: Class<*>) : RobolectricTestRunner(te
 
     override fun buildGlobalConfig(): Config {
         return Config.Builder()
-            .setApplication(TestApplication::class.java)
+            .setApplication(FenixRobolectricTestApplication::class.java)
             .build()
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/helpers/FenixRobolectricTestRunner.kt
+++ b/app/src/test/java/org/mozilla/fenix/helpers/FenixRobolectricTestRunner.kt
@@ -8,7 +8,9 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 /**
- * A test runner that starts Robolectric with our custom configuration for use in unit tests.
+ * A test runner that starts Robolectric with our custom configuration for use in unit tests. This
+ * should ALWAYS be used instead of RobolectricTestRunner and AndroidJUnit4. You should only use
+ * Robolectric when necessary because it non-trivially increases test duration.
  *
  * usage:
  * ```
@@ -16,10 +18,17 @@ import org.robolectric.annotation.Config
  * class ExampleUnitTest {
  * ```
  *
- * IMPORTANT NOTES:
- * - This should ALWAYS be used instead of RobolectricTestRunner and AndroidJUnit4 (note: the latter
- * just delegates to the former)
- * - You should only use Robolectric when necessary because it non-trivially increases test duration.
+ * There were three common test runners before this patch:
+ * 1. The default (@RunWith not specified) = JUnit4
+ * 2. @RunWith(RobolectricTestRunner::class) = JUnit4 with support for the Android framework via Robolectric
+ * 3. @RunWith(AndroidJUnit4::class) = JUnit4 with support for the Android framework. This currently
+ * delegates to Robolectric but is presumably generically named so that it can support different
+ * implementations in the future. The name creates confusion on over the difference between this and
+ * JUnit without any Android support (1).
+ *
+ * We chose the name RobolectricTestRunner because we want folks to know they're starting Robolectric
+ * because it increases test runtime. Furthermore, the naming of 3) is unclear so we didn't want to
+ * use that name.
  */
 class FenixRobolectricTestRunner(testClass: Class<*>) : RobolectricTestRunner(testClass) {
 

--- a/app/src/test/java/org/mozilla/fenix/helpers/TestApplication.kt
+++ b/app/src/test/java/org/mozilla/fenix/helpers/TestApplication.kt
@@ -2,8 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.fenix
+package org.mozilla.fenix.helpers
 
+import org.mozilla.fenix.FenixApplication
 import org.mozilla.fenix.components.TestComponents
 
 class TestApplication : FenixApplication() {

--- a/app/src/test/java/org/mozilla/fenix/home/intent/CrashReporterIntentProcessorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/intent/CrashReporterIntentProcessorTest.kt
@@ -13,12 +13,9 @@ import io.mockk.verify
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.NavGraphDirections
-import org.mozilla.fenix.TestApplication
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class CrashReporterIntentProcessorTest {
 
     @Test

--- a/app/src/test/java/org/mozilla/fenix/home/intent/DeepLinkIntentProcessorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/intent/DeepLinkIntentProcessorTest.kt
@@ -18,13 +18,10 @@ import org.junit.runner.RunWith
 import org.mozilla.fenix.BrowserDirection
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.NavGraphDirections
-import org.mozilla.fenix.TestApplication
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class DeepLinkIntentProcessorTest {
 
     private lateinit var activity: HomeActivity

--- a/app/src/test/java/org/mozilla/fenix/home/intent/FennecBookmarkShortcutsIntentProcessorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/intent/FennecBookmarkShortcutsIntentProcessorTest.kt
@@ -25,14 +25,11 @@ import mozilla.components.feature.intent.ext.getSessionId
 import mozilla.components.feature.session.SessionUseCases
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mozilla.fenix.TestApplication
 import org.mozilla.fenix.home.intent.FennecBookmarkShortcutsIntentProcessor.Companion.ACTION_FENNEC_HOMESCREEN_SHORTCUT
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import java.util.UUID
 
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class FennecBookmarkShortcutsIntentProcessorTest {
     private val sessionManager = mockk<SessionManager>(relaxed = true)
     private val loadUrlUseCase = mockk<SessionUseCases.DefaultLoadUrlUseCase>(relaxed = true)

--- a/app/src/test/java/org/mozilla/fenix/home/intent/OpenBrowserIntentProcessorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/intent/OpenBrowserIntentProcessorTest.kt
@@ -13,12 +13,9 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.BrowserDirection
 import org.mozilla.fenix.HomeActivity
-import org.mozilla.fenix.TestApplication
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class OpenBrowserIntentProcessorTest {
 
     private val activity: HomeActivity = mockk(relaxed = true)

--- a/app/src/test/java/org/mozilla/fenix/home/intent/SpeechProcessingIntentProcessorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/intent/SpeechProcessingIntentProcessorTest.kt
@@ -14,15 +14,12 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.BrowserDirection
 import org.mozilla.fenix.HomeActivity
-import org.mozilla.fenix.TestApplication
 import org.mozilla.fenix.components.metrics.MetricController
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.widget.VoiceSearchActivity.Companion.SPEECH_PROCESSING
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class SpeechProcessingIntentProcessorTest {
 
     private val activity: HomeActivity = mockk(relaxed = true)

--- a/app/src/test/java/org/mozilla/fenix/home/intent/StartSearchIntentProcessorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/intent/StartSearchIntentProcessorTest.kt
@@ -13,14 +13,11 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.NavGraphDirections
-import org.mozilla.fenix.TestApplication
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.components.metrics.MetricController
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class StartSearchIntentProcessorTest {
 
     private val metrics: MetricController = mockk(relaxed = true)

--- a/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkAdapterTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkAdapterTest.kt
@@ -12,12 +12,9 @@ import mozilla.components.concept.storage.BookmarkNodeType
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mozilla.fenix.TestApplication
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 internal class BookmarkAdapterTest {
 
     private lateinit var bookmarkAdapter: BookmarkAdapter

--- a/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkDeselectNavigationListenerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkDeselectNavigationListenerTest.kt
@@ -15,12 +15,9 @@ import mozilla.components.concept.storage.BookmarkNodeType
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.R
-import org.mozilla.fenix.TestApplication
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class BookmarkDeselectNavigationListenerTest {
 
     private val basicNode = BookmarkNode(

--- a/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarksSharedViewModelTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarksSharedViewModelTest.kt
@@ -16,12 +16,9 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mozilla.fenix.TestApplication
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 internal class BookmarksSharedViewModelTest {
 
     private lateinit var viewModel: BookmarksSharedViewModel

--- a/app/src/test/java/org/mozilla/fenix/library/bookmarks/DesktopFoldersTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/bookmarks/DesktopFoldersTest.kt
@@ -21,13 +21,10 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.R
-import org.mozilla.fenix.TestApplication
 import org.mozilla.fenix.ext.components
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class DesktopFoldersTest {
 
     private lateinit var context: Context

--- a/app/src/test/java/org/mozilla/fenix/library/history/HistoryControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/history/HistoryControllerTest.kt
@@ -24,15 +24,12 @@ import org.junit.Assert.assertFalse
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mozilla.fenix.TestApplication
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.components.FenixSnackbar
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
 // Robolectric needed for `onShareItem()`
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class HistoryControllerTest {
     private val historyItem = HistoryItem(0, "title", "url", 0.toLong())
     private val store: HistoryFragmentStore = mockk(relaxed = true)

--- a/app/src/test/java/org/mozilla/fenix/search/DefaultSearchControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/search/DefaultSearchControllerTest.kt
@@ -7,7 +7,7 @@ package org.mozilla.fenix.search
 import androidx.lifecycle.LifecycleCoroutineScope
 import androidx.navigation.NavController
 import androidx.navigation.NavDirections
-import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -25,7 +25,6 @@ import org.junit.runner.RunWith
 import org.mozilla.fenix.BrowserDirection
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
-import org.mozilla.fenix.TestApplication
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.components.metrics.MetricController
 import org.mozilla.fenix.ext.components
@@ -36,11 +35,9 @@ import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.search.DefaultSearchController.Companion.KEYBOARD_ANIMATION_DELAY
 import org.mozilla.fenix.utils.Settings
 import org.mozilla.fenix.whatsnew.clear
-import org.robolectric.annotation.Config
 
 @ExperimentalCoroutinesApi
-@RunWith(AndroidJUnit4::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class DefaultSearchControllerTest {
 
     private val context: HomeActivity = mockk(relaxed = true)

--- a/app/src/test/java/org/mozilla/fenix/search/SearchInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/search/SearchInteractorTest.kt
@@ -8,39 +8,28 @@ import android.content.Context
 import androidx.lifecycle.LifecycleCoroutineScope
 import androidx.navigation.NavController
 import androidx.navigation.NavDirections
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
-import io.mockk.mockkObject
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
 import mozilla.components.browser.search.SearchEngine
 import mozilla.components.browser.search.SearchEngineManager
 import mozilla.components.browser.session.Session
-import mozilla.components.support.test.robolectric.testContext
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mozilla.fenix.BrowserDirection
 import org.mozilla.fenix.FenixApplication
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
-import org.mozilla.fenix.TestApplication
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.components.searchengine.CustomSearchEngineStore.PREF_FILE_SEARCH_ENGINES
 import org.mozilla.fenix.ext.metrics
 import org.mozilla.fenix.ext.navigateSafe
 import org.mozilla.fenix.ext.searchEngineManager
-import org.mozilla.fenix.ext.settings
-import org.mozilla.fenix.utils.Settings
-import org.mozilla.fenix.whatsnew.clear
-import org.robolectric.annotation.Config
 
 @ExperimentalCoroutinesApi
-@RunWith(AndroidJUnit4::class)
-@Config(application = TestApplication::class)
 class SearchInteractorTest {
 
     private val lifecycleScope: LifecycleCoroutineScope = mockk(relaxed = true)
@@ -121,10 +110,6 @@ class SearchInteractorTest {
     fun onTextChanged() {
         val store: SearchFragmentStore = mockk(relaxed = true)
         val context: HomeActivity = mockk(relaxed = true)
-        val settings = testContext.settings().apply { testContext.settings().clear() }
-
-        mockkObject(Settings)
-        every { Settings.getInstance(context = context) } returns settings
 
         every { store.state } returns mockk(relaxed = true)
 

--- a/app/src/test/java/org/mozilla/fenix/session/NotificationSessionObserverTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/session/NotificationSessionObserverTest.kt
@@ -9,13 +9,10 @@ import mozilla.components.support.test.robolectric.testContext
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mozilla.fenix.TestApplication
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import mozilla.components.browser.session.Session
 
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class NotificationSessionObserverTest {
 
     private lateinit var observer: NotificationSessionObserver

--- a/app/src/test/java/org/mozilla/fenix/settings/SupportUtilsTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/SupportUtilsTest.kt
@@ -11,14 +11,8 @@ import io.mockk.every
 import io.mockk.mockk
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mozilla.fenix.TestApplication
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 import java.util.Locale
 
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
 class SupportUtilsTest {
 
     @Test

--- a/app/src/test/java/org/mozilla/fenix/settings/about/AboutPageAdapterTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/about/AboutPageAdapterTest.kt
@@ -18,13 +18,10 @@ import kotlinx.android.synthetic.main.about_list_item.view.*
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mozilla.fenix.TestApplication
 import org.mozilla.fenix.settings.about.viewholders.AboutItemViewHolder
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class AboutPageAdapterTest {
     private var aboutList: List<AboutPageItem> =
         mutableListOf(

--- a/app/src/test/java/org/mozilla/fenix/settings/advanced/LocaleManagerExtensionTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/advanced/LocaleManagerExtensionTest.kt
@@ -17,13 +17,11 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.BuildConfig
-import org.mozilla.fenix.TestApplication
-import org.robolectric.RobolectricTestRunner
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.robolectric.annotation.Config
 import java.util.Locale
 
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class LocaleManagerExtensionTest {
 
     @Before

--- a/app/src/test/java/org/mozilla/fenix/settings/deletebrowsingdata/DefaultDeleteBrowsingDataControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/deletebrowsingdata/DefaultDeleteBrowsingDataControllerTest.kt
@@ -5,7 +5,6 @@
 package org.mozilla.fenix.settings.deletebrowsingdata
 
 import android.content.Context
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -21,14 +20,9 @@ import mozilla.components.concept.engine.Engine
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mozilla.fenix.TestApplication
 import org.mozilla.fenix.ext.components
-import org.robolectric.annotation.Config
 
 @ExperimentalCoroutinesApi
-@RunWith(AndroidJUnit4::class)
-@Config(application = TestApplication::class)
 class DefaultDeleteBrowsingDataControllerTest {
 
     private val mainThreadSurrogate = newSingleThreadContext("UI thread")

--- a/app/src/test/java/org/mozilla/fenix/settings/deletebrowsingdata/DeleteAndQuitTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/deletebrowsingdata/DeleteAndQuitTest.kt
@@ -6,7 +6,7 @@
 
 package org.mozilla.fenix.settings.deletebrowsingdata
 
-import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -27,17 +27,14 @@ import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.HomeActivity
-import org.mozilla.fenix.TestApplication
 import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.components.PermissionStorage
 import org.mozilla.fenix.ext.clearAndCommit
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.utils.Settings
-import org.robolectric.annotation.Config
 
 @ExperimentalCoroutinesApi
-@RunWith(AndroidJUnit4::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class DeleteAndQuitTest {
 
     private val mainThreadSurrogate = newSingleThreadContext("UI thread")

--- a/app/src/test/java/org/mozilla/fenix/settings/quicksettings/DefaultQuickSettingsControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/quicksettings/DefaultQuickSettingsControllerTest.kt
@@ -32,18 +32,15 @@ import mozilla.components.support.test.robolectric.testContext
 import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mozilla.fenix.TestApplication
 import org.mozilla.fenix.components.PermissionStorage
 import org.mozilla.fenix.settings.PhoneFeature
 import org.mozilla.fenix.settings.quicksettings.ext.shouldBeEnabled
 import org.mozilla.fenix.settings.toggle
 import org.mozilla.fenix.utils.Settings
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
 @ExperimentalCoroutinesApi
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class DefaultQuickSettingsControllerTest {
     private val context = testContext
     private val store = mockk<QuickSettingsFragmentStore>()

--- a/app/src/test/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsFragmentStoreTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsFragmentStoreTest.kt
@@ -25,7 +25,6 @@ import mozilla.components.support.test.robolectric.testContext
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.R
-import org.mozilla.fenix.TestApplication
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.settings.PhoneFeature
 import org.mozilla.fenix.settings.quicksettings.QuickSettingsFragmentStore.Companion.getInsecureWebsiteUiValues
@@ -36,11 +35,9 @@ import org.mozilla.fenix.settings.quicksettings.ext.shouldBeEnabled
 import org.mozilla.fenix.settings.quicksettings.ext.shouldBeVisible
 import org.mozilla.fenix.settings.sitepermissions.AUTOPLAY_BLOCK_ALL
 import org.mozilla.fenix.utils.Settings
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class QuickSettingsFragmentStoreTest {
     private val context = spyk(testContext)
     private val permissions = mockk<SitePermissions>()

--- a/app/src/test/java/org/mozilla/fenix/share/ShareControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/share/ShareControllerTest.kt
@@ -36,18 +36,15 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.R
-import org.mozilla.fenix.TestApplication
 import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.components.metrics.MetricController
 import org.mozilla.fenix.ext.metrics
 import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.share.listadapters.AppShareOption
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 @ExperimentalCoroutinesApi
 class ShareControllerTest {
     // Need a valid context to retrieve Strings for example, but we also need it to return our "metrics"

--- a/app/src/test/java/org/mozilla/fenix/share/ShareViewModelTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/share/ShareViewModelTest.kt
@@ -30,18 +30,15 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mozilla.fenix.TestApplication
 import org.mozilla.fenix.ext.application
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.isOnline
 import org.mozilla.fenix.share.ShareViewModel.Companion.RECENT_APPS_LIMIT
 import org.mozilla.fenix.share.listadapters.AppShareOption
 import org.mozilla.fenix.share.listadapters.SyncShareOption
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 @ExperimentalCoroutinesApi
 class ShareViewModelTest {
 

--- a/app/src/test/java/org/mozilla/fenix/share/listadapters/AccountDevicesShareAdapterTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/share/listadapters/AccountDevicesShareAdapterTest.kt
@@ -16,14 +16,11 @@ import io.mockk.verify
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mozilla.fenix.TestApplication
 import org.mozilla.fenix.share.ShareInteractor
 import org.mozilla.fenix.share.viewholders.AccountDeviceViewHolder
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class AccountDevicesShareAdapterTest {
     private val interactor: ShareInteractor = mockk(relaxed = true)
 

--- a/app/src/test/java/org/mozilla/fenix/share/listadapters/AppShareAdapterTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/share/listadapters/AppShareAdapterTest.kt
@@ -17,14 +17,11 @@ import io.mockk.verifyOrder
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mozilla.fenix.TestApplication
 import org.mozilla.fenix.share.ShareInteractor
 import org.mozilla.fenix.share.viewholders.AppViewHolder
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class AppShareAdapterTest {
 
     private val appOptions = mutableListOf(

--- a/app/src/test/java/org/mozilla/fenix/trackingprotection/TrackingProtectionOverlayTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/trackingprotection/TrackingProtectionOverlayTest.kt
@@ -16,13 +16,10 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.R
-import org.mozilla.fenix.TestApplication
 import org.mozilla.fenix.utils.Settings
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class TrackingProtectionOverlayTest {
 
     private lateinit var context: Context

--- a/app/src/test/java/org/mozilla/fenix/utils/BrowsersCacheTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/utils/BrowsersCacheTest.kt
@@ -10,7 +10,7 @@ import android.content.pm.ActivityInfo
 import android.content.pm.PackageInfo
 import android.content.pm.ResolveInfo
 import android.net.Uri
-import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.utils.Browsers
 import org.junit.Assert.assertEquals
@@ -18,12 +18,9 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mozilla.fenix.TestApplication
 import org.robolectric.Shadows.shadowOf
-import org.robolectric.annotation.Config
 
-@RunWith(AndroidJUnit4::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class BrowsersCacheTest {
 
     // NB: There is always one more browser than pretendBrowsersAreInstalled installs because

--- a/app/src/test/java/org/mozilla/fenix/utils/ClipboardHandlerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/utils/ClipboardHandlerTest.kt
@@ -7,17 +7,14 @@ package org.mozilla.fenix.utils
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
-import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mozilla.fenix.TestApplication
-import org.robolectric.annotation.Config
 
-@RunWith(AndroidJUnit4::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class ClipboardHandlerTest {
 
     private val clipboardUrl = "https://www.mozilla.org"

--- a/app/src/test/java/org/mozilla/fenix/utils/FragmentPreDrawManagerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/utils/FragmentPreDrawManagerTest.kt
@@ -6,21 +6,15 @@ package org.mozilla.fenix.utils
 
 import androidx.core.view.OneShotPreDrawListener
 import androidx.fragment.app.Fragment
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mozilla.fenix.TestApplication
-import org.robolectric.annotation.Config
 
 @ObsoleteCoroutinesApi
 @ExperimentalCoroutinesApi
-@RunWith(AndroidJUnit4::class)
-@Config(application = TestApplication::class)
 class FragmentPreDrawManagerTest {
     private fun doNothing() { /*noop*/ }
 

--- a/app/src/test/java/org/mozilla/fenix/utils/SettingsTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/utils/SettingsTest.kt
@@ -4,7 +4,7 @@
 
 package org.mozilla.fenix.utils
 
-import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import mozilla.components.feature.sitepermissions.SitePermissionsRules
 import mozilla.components.feature.sitepermissions.SitePermissionsRules.Action.ALLOWED
 import mozilla.components.feature.sitepermissions.SitePermissionsRules.Action.ASK_TO_ALLOW
@@ -17,15 +17,12 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mozilla.fenix.TestApplication
 import org.mozilla.fenix.ext.clearAndCommit
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.settings.PhoneFeature
 import org.mozilla.fenix.settings.deletebrowsingdata.DeleteBrowsingDataOnQuitType
-import org.robolectric.annotation.Config
 
-@RunWith(AndroidJUnit4::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class SettingsTest {
 
     lateinit var settings: Settings

--- a/app/src/test/java/org/mozilla/fenix/whatsnew/WhatsNewStorageTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/whatsnew/WhatsNewStorageTest.kt
@@ -4,19 +4,16 @@
 
 package org.mozilla.fenix.whatsnew
 
-import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mozilla.fenix.TestApplication
 import org.mozilla.fenix.ext.clearAndCommit
 import org.mozilla.fenix.utils.Settings
-import org.robolectric.annotation.Config
 
-@RunWith(AndroidJUnit4::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class WhatsNewStorageTest {
     private lateinit var storage: SharedPreferenceWhatsNewStorage
     private lateinit var settings: Settings

--- a/app/src/test/java/org/mozilla/fenix/whatsnew/WhatsNewTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/whatsnew/WhatsNewTest.kt
@@ -4,19 +4,16 @@ package org.mozilla.fenix.whatsnew
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mozilla.fenix.TestApplication
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.utils.Settings
-import org.robolectric.annotation.Config
 
-@RunWith(AndroidJUnit4::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class WhatsNewTest {
     private lateinit var storage: SharedPreferenceWhatsNewStorage
     private lateinit var settings: Settings

--- a/app/src/test/java/org/mozilla/fenix/whatsnew/WhatsNewVersionTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/whatsnew/WhatsNewVersionTest.kt
@@ -4,15 +4,9 @@ package org.mozilla.fenix.whatsnew
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.mozilla.fenix.TestApplication
-import org.robolectric.annotation.Config
 
-@RunWith(AndroidJUnit4::class)
-@Config(application = TestApplication::class)
 class WhatsNewVersionTest {
     @Test
     fun testMajorVersionNumber() {

--- a/app/src/test/java/org/mozilla/fenix/widget/VoiceSearchActivityTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/widget/VoiceSearchActivityTest.kt
@@ -23,20 +23,17 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.HomeActivity.Companion.OPEN_TO_BROWSER_AND_LOAD
 import org.mozilla.fenix.IntentReceiverActivity
-import org.mozilla.fenix.TestApplication
 import org.mozilla.fenix.widget.VoiceSearchActivity.Companion.PREVIOUS_INTENT
 import org.mozilla.fenix.widget.VoiceSearchActivity.Companion.SPEECH_PROCESSING
 import org.mozilla.fenix.widget.VoiceSearchActivity.Companion.SPEECH_REQUEST_CODE
 import org.robolectric.Robolectric
-import org.robolectric.RobolectricTestRunner
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.robolectric.Shadows
 import org.robolectric.android.controller.ActivityController
-import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowActivity
 
 @ExperimentalCoroutinesApi
-@RunWith(RobolectricTestRunner::class)
-@Config(application = TestApplication::class)
+@RunWith(FenixRobolectricTestRunner::class)
 class VoiceSearchActivityTest {
 
     private lateinit var controller: ActivityController<VoiceSearchActivity>

--- a/buildSrc/src/main/java/org/mozilla/fenix/gradle/tasks/LintUnitTestRunner.kt
+++ b/buildSrc/src/main/java/org/mozilla/fenix/gradle/tasks/LintUnitTestRunner.kt
@@ -1,0 +1,103 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.gradle.tasks
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.TaskExecutionException
+import java.io.File
+
+private val INVALID_TEST_RUNNERS = setOf(
+    // When updating this list, also update the violation message.
+    "AndroidJUnit4",
+    "RobolectricTestRunner"
+)
+
+/**
+ * A lint check that ensures unit tests do not specify an invalid test runner. See the error message
+ * for details.
+ *
+ * Related notes:
+ * - The AndroidJUnit4 runner seems to just delegate to robolectric. Since robolectric non-trivially
+ * increases test runtime, using AndroidJUnit4 in place of RobolectricTestRunner is very misleading
+ * about how the test will change.
+ */
+open class LintUnitTestRunner : DefaultTask() {
+    init {
+        group = "Verification"
+        description = "Ensures unit tests do not specify an invalid test runner"
+        attachToAssembleUnitTestTasks()
+    }
+
+    private fun attachToAssembleUnitTestTasks() {
+        project.gradle.projectsEvaluated { project.tasks.let { tasks ->
+            val assembleUnitTestTasks = tasks.filter {
+                it.name.startsWith("assemble") && it.name.endsWith("UnitTest")
+            }
+
+            assembleUnitTestTasks.forEach {
+                it.dependsOn(this@LintUnitTestRunner)
+            }
+        } }
+    }
+
+    @TaskAction
+    fun lint() {
+        val unitTestDir = File(project.projectDir, "/src/test")
+        check(unitTestDir.exists()) {
+            "Error in task impl: expected test directory - ${unitTestDir.absolutePath} - to exist"
+        }
+
+        val unitTestDirFileWalk = unitTestDir.walk().onEnter { true /* enter all dirs */ }.asSequence()
+        val kotlinFileWalk = unitTestDirFileWalk.filter { it.name.endsWith(".kt") && it.isFile }
+        check(kotlinFileWalk.count() > 0) { "Error in task impl: expected to walk > 0 test files" }
+
+        val violatingFiles = kotlinFileWalk.filter { file ->
+            file.useLines { lines -> lines.any(::isLineInViolation) }
+        }.sorted().toList()
+
+        if (violatingFiles.isNotEmpty()) {
+            throwViolation(violatingFiles)
+        }
+    }
+
+    private fun isLineInViolation(line: String): Boolean {
+        val trimmed = line.trimStart()
+        return INVALID_TEST_RUNNERS.any { invalid ->
+            trimmed.startsWith("@RunWith($invalid::class)")
+        }
+    }
+
+    private fun throwViolation(files: List<File>) {
+        val failureHeader = """Lint failure: saw unexpected unit test runners. The following code blocks:
+            |
+            |    @RunWith(AndroidJUnit4::class)
+            |    @Config(application = TestApplication::class)
+            |OR
+            |    @RunWith(RobolectricTestRunner::class)
+            |    @Config(application = TestApplication::class)
+            |
+            |should be replaced with:
+            |
+            |    @RunWith(FenixRobolectricTestRunner::class)
+            |
+            |To reduce redundancy of setting @Config. No @Config specification is necessary because
+            |the FenixRobolectricTestRunner sets it automatically.
+            |
+            |Relatedly, adding robolectric to a test increases its runtime non-trivially so please
+            |ensure Robolectric is necessary before adding it.
+            |
+            |The following files were found to be in violation:
+        """.trimMargin()
+
+        val filesInViolation = files.map {
+            "    ${it.relativeTo(project.rootDir)}"
+        }
+
+        val errorMsg = (listOf(failureHeader) + filesInViolation).joinToString("\n")
+        throw TaskExecutionException(this, GradleException(errorMsg))
+    }
+}


### PR DESCRIPTION
The primary focus of this PR is to remove redundancy in how we specify `@RunWith` and `@Config` in our unit tests by replacing them with a single invocation. It adds a gradle task lint check to prevent it from regressing again.

Secondarily, the PR removes any trivially unnecessary `@RunWith` annotations, removing Robolectric from those tests. In aggregate, this increases the unit test suite runtime by ~10s (note: I didn't do any thorough measurement so this value is subject to be inaccurate but lines up with theoretical Robolectric start times of ~1s).

Example failure output of the task:
```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:lintUnitTestRunner'.
> Lint failure: saw unexpected unit test runners. The following code blocks:

      @RunWith(AndroidJUnit4::class)
      @Config(application = TestApplication::class)
  OR
      @RunWith(RobolectricTestRunner::class)
      @Config(application = TestApplication::class)

  should be replaced with:

      @RunWith(FenixRobolectricTestRunner::class)

  To reduce redundancy of setting @Config. No @Config specification is necessary because
  the FenixRobolectricTestRunner sets it automatically.

  Relatedly, adding robolectric to a test increases its runtime non-trivially so please
  ensure Robolectric is necessary before adding it.

  The following files were found to be in violation:
      app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkAdapterTest.kt
```

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture