### PR TITLE
No issue: pin androidx test dependencies; add note.

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -186,19 +186,20 @@ object Deps {
     //   https://developer.android.com/jetpack/androidx/releases/test
     // For the full IDs of these test dependencies, see:
     //   https://developer.android.com/training/testing/set-up-project#android-test-dependencies
-    private const val androidx_test_shared_version = "1.2.0" // this appears to be shared with many deps.
+    private const val androidx_test_shared_version = "1.3.0-alpha05" // this appears to be shared with many deps.
     const val androidx_test_core = "androidx.test:core:$androidx_test_shared_version"
-    private const val androidx_espresso_version = "3.2.0"
+    private const val androidx_espresso_version = "3.3.0-alpha05"
     const val espresso_core = "androidx.test.espresso:espresso-core:$androidx_espresso_version"
     const val espresso_contrib = "androidx.test.espresso:espresso-contrib:$androidx_espresso_version"
     const val espresso_idling_resources = "androidx.test.espresso:espresso-idling-resource:$androidx_espresso_version"
     const val espresso_intents = "androidx.test.espresso:espresso-intents:$androidx_espresso_version"
-    const val androidx_junit = "androidx.test.ext:junit:1.1.1"
+    const val androidx_junit = "androidx.test.ext:junit:1.1.2-alpha05"
     // Monitor is unused
     const val orchestrator = "androidx.test:orchestrator:$androidx_test_shared_version"
     const val tools_test_runner = "androidx.test:runner:$androidx_test_shared_version"
     const val tools_test_rules = "androidx.test:rules:$androidx_test_shared_version"
     // Truth is unused
+    // Test services is unused
     // --- END AndroidX test dependencies --- //
 
     const val mockwebserver = "com.squareup.okhttp3:mockwebserver:${Versions.mockwebserver}"

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -24,8 +24,6 @@ object Versions {
     const val androidx_fragment = "1.2.1"
     const val androidx_navigation = "2.2.1"
     const val androidx_recyclerview = "1.1.0"
-    const val androidx_testing = "1.3.0-alpha04"
-    const val androidx_test_ext = "1.0.0"
     const val androidx_core = "1.2.0"
     const val androidx_paging = "2.1.0"
     const val androidx_transition = "1.3.0"
@@ -44,11 +42,7 @@ object Versions {
     const val mockk = "1.9.kotlin12"
     const val assertk = "0.19"
 
-    const val espresso_version = "3.2.0"
     const val mockwebserver = "3.11.0"
-    const val orchestrator = "1.3.0-alpha02"
-    const val tools_test_rules = "1.3.0-alpha02"
-    const val tools_test_runner = "1.3.0-alpha02"
     const val uiautomator = "2.2.0"
     const val robolectric = "4.2.1"
 
@@ -186,18 +180,30 @@ object Deps {
     const val mockk = "io.mockk:mockk:${Versions.mockk}"
     const val assertk = "com.willowtreeapps.assertk:assertk-jvm:${Versions.assertk}"
 
-    const val espresso_contrib = "androidx.test.espresso:espresso-contrib:${Versions.espresso_version}"
-    const val espresso_core = "androidx.test.espresso:espresso-core:${Versions.espresso_version}"
-    const val espresso_idling_resources = "androidx.test.espresso:espresso-idling-resource:${Versions.espresso_version}"
-    const val espresso_intents = "androidx.test.espresso:espresso-intents:${Versions.espresso_version}"
+    // --- START AndroidX test dependencies --- //
+    // N.B.: the versions of these dependencies appear to be pinned together. To avoid bugs, they
+    // should always be updated together based on the latest version from the Android test releases page:
+    //   https://developer.android.com/jetpack/androidx/releases/test
+    // For the full IDs of these test dependencies, see:
+    //   https://developer.android.com/training/testing/set-up-project#android-test-dependencies
+    private const val androidx_test_shared_version = "1.2.0" // this appears to be shared with many deps.
+    const val androidx_test_core = "androidx.test:core:$androidx_test_shared_version"
+    private const val androidx_espresso_version = "3.2.0"
+    const val espresso_core = "androidx.test.espresso:espresso-core:$androidx_espresso_version"
+    const val espresso_contrib = "androidx.test.espresso:espresso-contrib:$androidx_espresso_version"
+    const val espresso_idling_resources = "androidx.test.espresso:espresso-idling-resource:$androidx_espresso_version"
+    const val espresso_intents = "androidx.test.espresso:espresso-intents:$androidx_espresso_version"
+    const val androidx_junit = "androidx.test.ext:junit:1.1.1"
+    // Monitor is unused
+    const val orchestrator = "androidx.test:orchestrator:$androidx_test_shared_version"
+    const val tools_test_runner = "androidx.test:runner:$androidx_test_shared_version"
+    const val tools_test_rules = "androidx.test:rules:$androidx_test_shared_version"
+    // Truth is unused
+    // --- END AndroidX test dependencies --- //
+
     const val mockwebserver = "com.squareup.okhttp3:mockwebserver:${Versions.mockwebserver}"
-    const val orchestrator = "androidx.test:orchestrator:${Versions.orchestrator}"
-    const val tools_test_rules = "androidx.test:rules:${Versions.tools_test_rules}"
-    const val tools_test_runner = "androidx.test:runner:${Versions.tools_test_runner}"
     const val uiautomator = "androidx.test.uiautomator:uiautomator:${Versions.uiautomator}"
     const val robolectric = "org.robolectric:robolectric:${Versions.robolectric}"
-    const val androidx_junit = "androidx.test.ext:junit:${Versions.androidx_test_ext}"
-    const val androidx_test_core = "androidx.test:core:${Versions.androidx_testing}"
 
     const val google_ads_id = "com.google.android.gms:play-services-ads-identifier:${Versions.google_ads_id_version}"
 


### PR DESCRIPTION
I removed the version constant indirection for these items because I found it
challenging:
- it makes it harder to quickly identify which versions are in use
because it requires jumping to a new screen for each dependency
- it increases the length of the file, obscuring what's available

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture