### PR TITLE
Bug 1625971 - Add google-search-restaurants to pageload tests in browsertime.

### DIFF
--- a/taskcluster/ci/browsertime/kind.yml
+++ b/taskcluster/ci/browsertime/kind.yml
@@ -224,3 +224,9 @@ jobs:
         test-name: cnn
         treeherder:
             symbol: 'Btime(tp6m-27-c)'
+
+    tp6m-28-cold:
+        test-name: google-search-restaurants
+        run-on-tasks-for: [github-pull-request]
+        treeherder:
+            symbol: 'Btime(tp6m-28-c)'

--- a/taskcluster/ci/browsertime/kind.yml
+++ b/taskcluster/ci/browsertime/kind.yml
@@ -80,7 +80,7 @@ job-defaults:
             - '--browsertime'
             - '--cold'
             - '--binary=org.mozilla.fenix.performancetest'
-            - '--activity=org.mozilla.fenix.browser.BrowserPerformanceTestActivity'
+            - '--activity=org.mozilla.fenix.IntentReceiverActivity'
             - '--download-symbols=ondemand'
             - '--browsertime-node=$MOZ_FETCHES_DIR/node/bin/node'
             - '--browsertime-geckodriver=$MOZ_FETCHES_DIR/geckodriver'

--- a/taskcluster/ci/browsertime/kind.yml
+++ b/taskcluster/ci/browsertime/kind.yml
@@ -227,6 +227,5 @@ jobs:
 
     tp6m-28-cold:
         test-name: google-search-restaurants
-        run-on-tasks-for: [github-pull-request]
         treeherder:
             symbol: 'Btime(tp6m-28-c)'

--- a/taskcluster/ci/raptor/kind.yml
+++ b/taskcluster/ci/raptor/kind.yml
@@ -77,7 +77,7 @@ job-defaults:
             - '--cfg=mozharness/configs/raptor/android_hw_config.py'
             - '--app=fenix'
             - '--binary=org.mozilla.fenix.performancetest'
-            - '--activity=org.mozilla.fenix.browser.BrowserPerformanceTestActivity'
+            - '--activity=org.mozilla.fenix.IntentReceiverActivity'
             - '--download-symbols=ondemand'
     fetches:
         toolchain:


### PR DESCRIPTION
This patch adds the `google-search-restaurants` to the pageload tests being run on browsertime. A temporary workaround for the activity issue is also added. This will be removed before landing this change.