### PR TITLE
For #9536: Open report issue tab depending on current browsing mode.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.launch
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.state.selector.findTab
+import mozilla.components.browser.state.selector.selectedTab
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.concept.engine.prompt.ShareData
 import mozilla.components.support.ktx.kotlin.isUrl
@@ -211,10 +212,12 @@ class DefaultBrowserToolbarController(
                 activity.components.analytics.metrics.track(Event.FindInPageOpened)
             }
             ToolbarMenu.Item.ReportIssue -> {
-                val currentUrl = currentSession?.url
-                currentUrl?.apply {
-                    val reportUrl = String.format(BrowserFragment.REPORT_SITE_ISSUE_URL, this)
-                    activity.components.useCases.tabsUseCases.addTab.invoke(reportUrl)
+                val selectedTab = activity.components.core.store.state.selectedTab
+                selectedTab?.let {
+                    val currentUrl = it.content.url
+                    val reportUrl = String.format(BrowserFragment.REPORT_SITE_ISSUE_URL, currentUrl)
+                    val private = it.content.private
+                    reportSiteIssue(reportUrl, private)
                 }
             }
 
@@ -323,6 +326,14 @@ class DefaultBrowserToolbarController(
                     null
                 )
             }
+        }
+    }
+
+    private fun reportSiteIssue(reportUrl: String, private: Boolean) {
+        if (private) {
+            activity.components.useCases.tabsUseCases.addPrivateTab.invoke(reportUrl)
+        } else {
+            activity.components.useCases.tabsUseCases.addTab.invoke(reportUrl)
         }
     }
 


### PR DESCRIPTION
Checking if session is private uses the new browser state API.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture