### PR TITLE
Bug 1627027 - Use fennec-nightly Fenix build on Raptor/Browsertime tests.

### DIFF
--- a/taskcluster/ci/browsertime/kind.yml
+++ b/taskcluster/ci/browsertime/kind.yml
@@ -13,7 +13,7 @@ kind-dependencies:
 primary-dependency: signing
 
 only-for-build-types:
-    - performance-test
+    - fennec-nightly
 
 only-for-abis:
     - armeabi-v7a
@@ -34,7 +34,7 @@ job-defaults:
                     subject: '[{product_name}] Raptor-Browsertime job "{task_name}" failed'
                     to-addresses: [perftest-alerts@mozilla.com]
             default: {}
-    run-on-tasks-for: []
+    run-on-tasks-for: [github-pull-request]
     treeherder:
         kind: test
         tier: 2
@@ -79,7 +79,7 @@ job-defaults:
             - '--app=fenix'
             - '--browsertime'
             - '--cold'
-            - '--binary=org.mozilla.fenix.performancetest'
+            - '--binary=org.mozilla.fennec_aurora'
             - '--activity=org.mozilla.fenix.IntentReceiverActivity'
             - '--download-symbols=ondemand'
             - '--browsertime-node=$MOZ_FETCHES_DIR/node/bin/node'

--- a/taskcluster/ci/browsertime/kind.yml
+++ b/taskcluster/ci/browsertime/kind.yml
@@ -34,7 +34,7 @@ job-defaults:
                     subject: '[{product_name}] Raptor-Browsertime job "{task_name}" failed'
                     to-addresses: [perftest-alerts@mozilla.com]
             default: {}
-    run-on-tasks-for: [github-pull-request]
+    run-on-tasks-for: []
     treeherder:
         kind: test
         tier: 2
@@ -97,6 +97,7 @@ job-defaults:
 jobs:
     tp6m-1-cold:
         test-name: amazon
+        run-on-tasks-for: [github-pull-request]
         treeherder:
             symbol: 'Btime(tp6m-1-c)'
 

--- a/taskcluster/ci/raptor/kind.yml
+++ b/taskcluster/ci/raptor/kind.yml
@@ -34,7 +34,7 @@ job-defaults:
                     subject: '[{product_name}] Raptor job "{task_name}" failed'
                     to-addresses: [perftest-alerts@mozilla.com]
             default: {}
-    run-on-tasks-for: [github-pull-request]
+    run-on-tasks-for: []
     treeherder:
         kind: test
         tier: 1

--- a/taskcluster/ci/raptor/kind.yml
+++ b/taskcluster/ci/raptor/kind.yml
@@ -11,7 +11,7 @@ kind-dependencies:
     - toolchain
 
 only-for-build-types:
-    - performance-test
+    - fennec-nightly
 
 only-for-abis:
     - armeabi-v7a
@@ -34,7 +34,7 @@ job-defaults:
                     subject: '[{product_name}] Raptor job "{task_name}" failed'
                     to-addresses: [perftest-alerts@mozilla.com]
             default: {}
-    run-on-tasks-for: []
+    run-on-tasks-for: [github-pull-request]
     treeherder:
         kind: test
         tier: 1
@@ -76,7 +76,7 @@ job-defaults:
             - './test-linux.sh'
             - '--cfg=mozharness/configs/raptor/android_hw_config.py'
             - '--app=fenix'
-            - '--binary=org.mozilla.fenix.performancetest'
+            - '--binary=org.mozilla.fennec_aurora'
             - '--activity=org.mozilla.fenix.IntentReceiverActivity'
             - '--download-symbols=ondemand'
     fetches:


### PR DESCRIPTION
This patch changes the build that we run performance tests on from the `performance-test` variant to the `fennec-nightly` variant.