### PR TITLE
For #9626: improve Save To Collections Performance

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/collections/CollectionCreationView.kt
+++ b/app/src/main/java/org/mozilla/fenix/collections/CollectionCreationView.kt
@@ -73,10 +73,6 @@ class CollectionCreationView(
             view.context,
             R.layout.component_collection_creation_select_collection
         )
-        nameCollectionConstraints.clone(
-            view.context,
-            R.layout.component_collection_creation_name_collection
-        )
 
         view.bottom_bar_icon_button.apply {
             increaseTapArea(increaseButtonByDps)
@@ -243,6 +239,10 @@ class CollectionCreationView(
         }
 
         view.name_collection_edittext.showKeyboard()
+        nameCollectionConstraints.clone(
+            view.context,
+            R.layout.component_collection_creation_name_collection
+        )
         val constraint = nameCollectionConstraints
         constraint.applyTo(view.collection_constraint_layout)
         name_collection_edittext.setText(
@@ -272,6 +272,10 @@ class CollectionCreationView(
                 collectionCreationTabListAdapter.updateData(tabs, tabs.toSet(), true)
             }
         }
+        nameCollectionConstraints.clone(
+            view.context,
+            R.layout.component_collection_creation_name_collection
+        )
         val constraint = nameCollectionConstraints
         constraint.applyTo(view.collection_constraint_layout)
         name_collection_edittext.setText(state.selectedTabCollection?.title)


### PR DESCRIPTION
We should avoid cloning the naming collections layout unless we need it to improve performance.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture