### PR TITLE
No issue: remove num-flaky-test-attempts from all Flank templates

### DIFF
--- a/automation/taskcluster/androidTest/flank-arm64-v8a.yml
+++ b/automation/taskcluster/androidTest/flank-arm64-v8a.yml
@@ -19,11 +19,7 @@ gcloud:
   # by default, set to app name
   # declare results-history-name to create a separate dropdown menu in Firebase 
   # see: https://github.com/TestArmada/flank/issues/341
-  #results-history-name: tmp_parallel 
-
-  # The number of times a TestExecution should be re-attempted if one or more\nof its test cases fail for any reason.
-  # The maximum number of reruns allowed is 10.  Default is 0, which implies noi reruns.
-  num-flaky-test-attempts: 2
+  #results-history-name: tmp_parallel
 
   # test and app are the only required args
   app: /APP/PATH

--- a/automation/taskcluster/androidTest/flank-armeabi-v7a-start-test.yml
+++ b/automation/taskcluster/androidTest/flank-armeabi-v7a-start-test.yml
@@ -21,10 +21,6 @@ gcloud:
   # see: https://github.com/TestArmada/flank/issues/341
   #results-history-name: tmp_parallel 
 
-  # The number of times a TestExecution should be re-attempted if one or more\nof its test cases fail for any reason.
-  # The maximum number of reruns allowed is 10. Default is 0, which implies no reruns.
-  num-flaky-test-attempts: 2
-
   # test and app are the only required args
   app: /app/path 
   test: /test/path

--- a/automation/taskcluster/androidTest/flank-armeabi-v7a.yml
+++ b/automation/taskcluster/androidTest/flank-armeabi-v7a.yml
@@ -45,7 +45,3 @@ flank:
   # repeat tests - the amount of times to run the tests.
   # 1 runs the tests once. 10 runs all the tests 10x
   repeat-tests: 1
-
-  # The number of times a TestExecution should be re-attempted if one or more\nof its test cases fail for any reason.
-  # The maximum number of reruns allowed is 10. Default is 0, which implies no reruns.
-  num-flaky-test-attempts: 3

--- a/automation/taskcluster/androidTest/flank-x86-start-test.yml
+++ b/automation/taskcluster/androidTest/flank-x86-start-test.yml
@@ -21,10 +21,6 @@ gcloud:
   # see: https://github.com/TestArmada/flank/issues/341
   #results-history-name: tmp_parallel 
 
-  # The number of times a TestExecution should be re-attempted if one or more\nof its test cases fail for any reason.
-  # The maximum number of reruns allowed is 10. Default is 0, which implies no reruns.
-  num-flaky-test-attempts: 2
-
   # test and app are the only required args
   app: /app/path 
   test: /test/path

--- a/automation/taskcluster/androidTest/flank-x86.yml
+++ b/automation/taskcluster/androidTest/flank-x86.yml
@@ -21,10 +21,6 @@ gcloud:
   # see: https://github.com/TestArmada/flank/issues/341
   #results-history-name: tmp_parallel 
 
-  # The number of times a TestExecution should be re-attempted if one or more\nof its test cases fail for any reason.
-  # The maximum number of reruns allowed is 10. Default is 0, which implies no reruns.
-  num-flaky-test-attempts: 2
-
   # test and app are the only required args
   app: /app/path 
   test: /test/path


### PR DESCRIPTION
With re-runs enabled Flank is adding test executions. This experimental flag might be also masking intermittent tests. Let's see what happens with the flag removed.