### PR TITLE
For #9644: restrict deps to specific repositories

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,19 +1,3 @@
-// Allow installing Gradle plugins from the Mozilla Maven repositories
-buildscript {
-    repositories {
-        maven {
-            url "https://nightly.maven.mozilla.org/maven2"
-        }
-        maven {
-            url "https://maven.mozilla.org/maven2"
-        }
-
-        dependencies {
-            classpath "org.mozilla.components:tooling-glean-gradle:${Versions.mozilla_android_components}"
-        }
-    }
-}
-
 plugins {
     id "com.jetbrains.python.envs" version "0.0.26"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ buildscript {
                 // Improve performance: only check google maven for mozilla deps.
                 includeGroupByRegex RepoMatching.androidx
                 includeGroupByRegex RepoMatching.comGoogleAndroid
+                includeGroupByRegex RepoMatching.comGoogleFirebase
                 includeGroupByRegex RepoMatching.comAndroid
             }
         }
@@ -31,6 +32,7 @@ buildscript {
                 excludeGroupByRegex RepoMatching.mozilla
                 excludeGroupByRegex RepoMatching.androidx
                 excludeGroupByRegex RepoMatching.comGoogleAndroid
+                excludeGroupByRegex RepoMatching.comGoogleFirebase
                 excludeGroupByRegex RepoMatching.comAndroid
             }
         }
@@ -76,6 +78,7 @@ allprojects {
                 // Improve performance: only check google maven for google deps.
                 includeGroupByRegex RepoMatching.androidx
                 includeGroupByRegex RepoMatching.comGoogleAndroid
+                includeGroupByRegex RepoMatching.comGoogleFirebase
                 includeGroupByRegex RepoMatching.comAndroid
             }
         }
@@ -85,6 +88,7 @@ allprojects {
                 excludeGroupByRegex RepoMatching.mozilla
                 excludeGroupByRegex RepoMatching.androidx
                 excludeGroupByRegex RepoMatching.comGoogleAndroid
+                excludeGroupByRegex RepoMatching.comGoogleFirebase
                 excludeGroupByRegex RepoMatching.comAndroid
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -30,9 +30,6 @@ allprojects {
         maven {
             url "https://maven.mozilla.org/maven2"
         }
-        maven {
-            url "https://repo.leanplum.com/"
-        }
         jcenter()
     }
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,12 @@
 
 buildscript {
     repositories {
+        maven {
+            url "https://nightly.maven.mozilla.org/maven2"
+        }
+        maven {
+            url "https://maven.mozilla.org/maven2"
+        }
         google()
         jcenter()
     }
@@ -11,6 +17,8 @@ buildscript {
         classpath Deps.androidx_safeargs
         classpath Deps.allopen
         classpath Deps.osslicenses_plugin
+
+        classpath "org.mozilla.components:tooling-glean-gradle:${Versions.mozilla_android_components}"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,41 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
+    // This logic is duplicated in the allprojects block: I don't know how to fix that.
     repositories {
         maven {
             url "https://nightly.maven.mozilla.org/maven2"
+            content {
+                // Improve performance: only check moz maven for mozilla deps.
+                includeGroupByRegex RepoMatching.mozilla
+            }
         }
         maven {
             url "https://maven.mozilla.org/maven2"
+            content {
+                // Improve performance: only check moz maven for mozilla deps.
+                includeGroupByRegex RepoMatching.mozilla
+            }
         }
-        google()
-        jcenter()
+        google() {
+            content {
+                // Improve performance: only check google maven for mozilla deps.
+                includeGroupByRegex RepoMatching.androidx
+                includeGroupByRegex RepoMatching.comGoogleAndroid
+                includeGroupByRegex RepoMatching.comAndroid
+            }
+        }
+        jcenter() {
+            content {
+                // Improve security: don't search deps with known repos.
+                excludeGroupByRegex RepoMatching.mozilla
+                excludeGroupByRegex RepoMatching.androidx
+                excludeGroupByRegex RepoMatching.comGoogleAndroid
+                excludeGroupByRegex RepoMatching.comAndroid
+            }
+        }
     }
+
     dependencies {
         classpath Deps.tools_androidgradle
         classpath Deps.tools_kotlingradle
@@ -30,16 +55,41 @@ plugins {
 }
 
 allprojects {
+    // This logic is duplicated in the buildscript block: I don't know how to fix that.
     repositories {
-        google()
         maven {
             url "https://nightly.maven.mozilla.org/maven2"
+            content {
+                // Improve performance: only check moz maven for mozilla deps.
+                includeGroupByRegex RepoMatching.mozilla
+            }
         }
         maven {
             url "https://maven.mozilla.org/maven2"
+            content {
+                // Improve performance: only check moz maven for mozilla deps.
+                includeGroupByRegex RepoMatching.mozilla
+            }
         }
-        jcenter()
+        google() {
+            content {
+                // Improve performance: only check google maven for google deps.
+                includeGroupByRegex RepoMatching.androidx
+                includeGroupByRegex RepoMatching.comGoogleAndroid
+                includeGroupByRegex RepoMatching.comAndroid
+            }
+        }
+        jcenter() {
+            content {
+                // Improve security: don't search deps with known repos.
+                excludeGroupByRegex RepoMatching.mozilla
+                excludeGroupByRegex RepoMatching.androidx
+                excludeGroupByRegex RepoMatching.comGoogleAndroid
+                excludeGroupByRegex RepoMatching.comAndroid
+            }
+        }
     }
+
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
         kotlinOptions.jvmTarget = "1.8"
         kotlinOptions.allWarningsAsErrors = true

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -220,6 +220,7 @@ object RepoMatching {
     const val mozilla = "org\\.mozilla\\..*"
     const val androidx = "androidx\\..*"
     const val comAndroid = "com\\.android\\..*"
+    const val comGoogleFirebase = "com\\.google\\.firebase"
 
     /**
      * A matcher for com.google.android.* with one exception: the espresso-contrib dependency includes the

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -208,3 +208,24 @@ object Deps {
     const val junitParams = "org.junit.jupiter:junit-jupiter-params:${Versions.junit}"
     const val junitEngine = "org.junit.jupiter:junit-jupiter-engine:${Versions.junit}"
 }
+
+/**
+ * Functionality to limit specific dependencies to specific repositories. These are typically expected to be used by
+ * dependency group name (i.e. with `include/excludeGroup`). For additional info, see:
+ * https://docs.gradle.org/current/userguide/declaring_repositories.html#sec::matching_repositories_to_dependencies
+ *
+ * Note: I wanted to nest this in Deps but for some reason gradle can't find it so it's top-level now. :|
+ */
+object RepoMatching {
+    const val mozilla = "org\\.mozilla\\..*"
+    const val androidx = "androidx\\..*"
+    const val comAndroid = "com\\.android\\..*"
+
+    /**
+     * A matcher for com.google.android.* with one exception: the espresso-contrib dependency includes the
+     * accessibility-test-framework dependency, which is not available in the google repo. As such, we must
+     * explicitly exclude it from this regex so it can be found on jcenter. Note that the transitive dependency
+     * com.google.guava is also not available on google's repo.
+     */
+    const val comGoogleAndroid = "com\\.google\\.android\\.(?!apps\\.common\\.testing\\.accessibility\\.framework).*"
+}


### PR DESCRIPTION
See the issue for motivations and let me know if you have questions. After landing this, I intend to send an email to the team mentioning possible side effects (i.e. if you add a dependency but the ruleset didn't take it into account, it could fail until you update the rules but we haven't really had this problem on FFTV).

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture