### PR TITLE
For #8546 - Use destructive_normal_theme colors for login panel errors

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -20,6 +20,7 @@
         <item name="alertDialogTheme">@style/DialogStyleNormal</item>
         <item name="android:windowEnableSplitTouch">false</item>
         <item name="android:splitMotionEvents">false</item>
+        
         <item name="mozacInputLayoutErrorTextColor"
             tools:ignore="UnusedResources">@color/destructive_normal_theme</item>
         <item name="mozacInputLayoutErrorIconColor"
@@ -125,6 +126,11 @@
         <item name="alertDialogTheme">@style/DialogStyleDark</item>
         <item name="android:windowEnableSplitTouch">false</item>
         <item name="android:splitMotionEvents">false</item>
+
+        <item name="mozacInputLayoutErrorTextColor"
+            tools:ignore="UnusedResources">@color/destructive_private_theme</item>
+        <item name="mozacInputLayoutErrorIconColor"
+            tools:ignore="UnusedResources">@color/destructive_private_theme</item>
 
         <!-- Inactive thumb color -->
         <item name="colorSwitchThumbNormal">@color/toggle_off_knob_dark_theme</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -20,6 +20,10 @@
         <item name="alertDialogTheme">@style/DialogStyleNormal</item>
         <item name="android:windowEnableSplitTouch">false</item>
         <item name="android:splitMotionEvents">false</item>
+        <item name="mozacInputLayoutErrorTextColor"
+            tools:ignore="UnusedResources">@color/destructive_normal_theme</item>
+        <item name="mozacInputLayoutErrorIconColor"
+            tools:ignore="UnusedResources">@color/destructive_normal_theme</item>
 
         <!-- Active thumb color & Active track color (30% transparency) -->
         <item name="colorControlActivated">@color/accent_high_contrast_normal_theme</item>


### PR DESCRIPTION
For #8546 

These values will override the default error colors for the password login TextInputLayout used in the feature-prompts component.

**Note**: Should only be mereged **AFTER** [a-c/pull/6504](https://github.com/mozilla-mobile/android-components/pull/6504) and [a-c/pull/6507](https://github.com/mozilla-mobile/android-components/pull/6507) otherwise it won't compile.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR does not include any tests because it is only a minor change.
- [x] **Screenshots**: This PR includes screenshots.
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

<img src="https://user-images.githubusercontent.com/60002907/78344574-42dc2a00-75a5-11ea-8a69-d68c52bf6489.png" width="240"/>
<img src="https://user-images.githubusercontent.com/60002907/78344587-45d71a80-75a5-11ea-866d-d2a615eaa31e.png" width="240"/>