### PR TITLE
For #2768 - Prevent screenshots in private mode

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -48,6 +48,7 @@ import org.mozilla.fenix.components.metrics.BreadcrumbsRecorder
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.exceptions.ExceptionsFragmentDirections
 import org.mozilla.fenix.ext.alreadyOnDestination
+import org.mozilla.fenix.ext.checkAndUpdateScreenshotPermission
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.settings
@@ -116,6 +117,7 @@ open class HomeActivity : LocaleAwareAppCompatActivity() {
         components.publicSuffixList.prefetch()
 
         setupThemeAndBrowsingMode(getModeFromIntentOrLastKnown(intent))
+        checkAndUpdateScreenshotPermission(settings())
         setContentView(R.layout.activity_home)
 
         // Must be after we set the content view

--- a/app/src/main/java/org/mozilla/fenix/ext/Activity.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/Activity.kt
@@ -7,6 +7,7 @@ package org.mozilla.fenix.ext
 import android.app.Activity
 import android.view.View
 import android.view.WindowManager
+import org.mozilla.fenix.utils.Settings
 
 /**
  * Attempts to call immersive mode using the View to hide the status bar and navigation buttons.
@@ -21,4 +22,20 @@ fun Activity.enterToImmersiveMode() {
             or View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
             or View.SYSTEM_UI_FLAG_FULLSCREEN
             or View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY)
+}
+
+/**
+ * Prevents or allows screenshots from being taken in private mode based on the user preferences.
+ *
+ * The default setting is set to true (screenshots are allowed to be taken in private mode), as
+ * described in #2768
+ */
+fun Activity.checkAndUpdateScreenshotPermission(settings: Settings) {
+    if (!settings.allowScreenshotsInPrivateMode &&
+        settings.lastKnownMode.isPrivate
+    ) {
+        window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+    } else {
+        window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+    }
 }

--- a/app/src/main/java/org/mozilla/fenix/settings/PrivateBrowsingFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/PrivateBrowsingFragment.kt
@@ -11,8 +11,10 @@ import androidx.preference.SwitchPreference
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.PrivateShortcutCreateManager
 import org.mozilla.fenix.components.metrics.Event
+import org.mozilla.fenix.ext.checkAndUpdateScreenshotPermission
 import org.mozilla.fenix.ext.getPreferenceKey
 import org.mozilla.fenix.ext.metrics
+import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.showToolbar
 
 /**
@@ -40,6 +42,16 @@ class PrivateBrowsingFragment : PreferenceFragmentCompat() {
 
         findPreference<SwitchPreference>(getPreferenceKey(R.string.pref_key_open_links_in_a_private_tab))?.apply {
             onPreferenceChangeListener = SharedPreferenceUpdater()
+        }
+
+        findPreference<SwitchPreference>(getPreferenceKey
+            (R.string.pref_key_allow_screenshots_in_private_mode))?.apply {
+            onPreferenceChangeListener = object : SharedPreferenceUpdater() {
+                override fun onPreferenceChange(preference: Preference, newValue: Any?): Boolean {
+                    return super.onPreferenceChange(preference, newValue).also {
+                        requireActivity().checkAndUpdateScreenshotPermission(requireActivity().settings()) }
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -132,6 +132,11 @@ class Settings private constructor(
         default = false
     )
 
+    var allowScreenshotsInPrivateMode by booleanPreference(
+        appContext.getPreferenceKey(R.string.pref_key_allow_screenshots_in_private_mode),
+        default = true
+    )
+
     var defaultSearchEngineName by stringPreference(
         appContext.getPreferenceKey(R.string.pref_key_search_engine),
         default = ""

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -142,6 +142,7 @@
     <!-- Privacy Settings -->
     <string name="pref_key_open_links_in_a_private_tab" translatable="false">pref_key_open_links_in_a_private_tab</string>
     <string name="pref_key_open_links_in_external_app" translatable="false">pref_key_open_links_in_external_app</string>
+    <string name="pref_key_allow_screenshots_in_private_mode" translatable="false">pref_key_allow_screenshots_in_private_mode</string>
 
     <!-- Quick Action Sheet -->
     <string name="pref_key_bounce_quick_action" translatable="false">pref_key_bounce_quick_action</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -203,6 +203,8 @@
     <string name="preferences_private_browsing_options">Private browsing</string>
     <!-- Preference for opening links in a private tab-->
     <string name="preferences_open_links_in_a_private_tab">Open links in a private tab</string>
+    <!-- Preference for allowing screenshots to be taken while in a private tab-->
+    <string name="preferences_allow_screenshots_in_private_mode">Allow screenshots in private browsing</string>
     <!-- Preference for adding private browsing shortcut -->
     <string name="preferences_add_private_browsing_shortcut">Add private browsing shortcut</string>
     <!-- Preference for accessibility -->

--- a/app/src/main/res/xml/private_browsing_preferences.xml
+++ b/app/src/main/res/xml/private_browsing_preferences.xml
@@ -13,4 +13,9 @@
         android:key="@string/pref_key_open_links_in_a_private_tab"
         android:title="@string/preferences_open_links_in_a_private_tab"
         app:iconSpaceReserved="false" />
+    <SwitchPreference
+        android:defaultValue="true"
+        android:key="@string/pref_key_allow_screenshots_in_private_mode"
+        android:title="@string/preferences_allow_screenshots_in_private_mode"
+        app:iconSpaceReserved="false" />
 </PreferenceScreen>

--- a/app/src/test/java/org/mozilla/fenix/ext/ActivityTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/ext/ActivityTest.kt
@@ -7,12 +7,15 @@ package org.mozilla.fenix.ext
 import android.app.Activity
 import android.view.View
 import android.view.WindowManager
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.Robolectric
+import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+import org.robolectric.Robolectric
 import org.robolectric.Shadows.shadowOf
 
 @RunWith(FenixRobolectricTestRunner::class)
@@ -38,5 +41,68 @@ class ActivityTest {
         // Test
         for (f in flags) assertEquals(f, window.decorView.systemUiVisibility and f)
         assertTrue(shadowOf(window).getFlag(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON))
+    }
+
+    @Test
+    fun `testCheckAndUpdateScreenshotPermission adds flag in private mode when screenshots are not allowed `() {
+        // given
+        val activity = Robolectric.buildActivity(Activity::class.java).create().get()
+        val window = activity.window
+        testContext.settings().lastKnownMode = BrowsingMode.Private
+        testContext.settings().allowScreenshotsInPrivateMode = false
+
+        // when
+        activity.checkAndUpdateScreenshotPermission(activity.settings())
+
+        // then
+        assertTrue(shadowOf(window).getFlag(WindowManager.LayoutParams.FLAG_SECURE))
+    }
+
+    @Test
+    fun `testCheckAndUpdateScreenshotPermission removes flag in private mode when screenshots are allowed `() {
+        // given
+        val activity = Robolectric.buildActivity(Activity::class.java).create().get()
+        val window = activity.window
+        window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        testContext.settings().lastKnownMode = BrowsingMode.Private
+        testContext.settings().allowScreenshotsInPrivateMode = true
+
+        // when
+        activity.checkAndUpdateScreenshotPermission(activity.settings())
+
+        // then
+        assertFalse(shadowOf(window).getFlag(WindowManager.LayoutParams.FLAG_SECURE))
+    }
+
+    @Test
+    fun `testCheckAndUpdateScreenshotPermission removes flag in normal mode when screenshots are allowed `() {
+        // given
+        val activity = Robolectric.buildActivity(Activity::class.java).create().get()
+        val window = activity.window
+        window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        testContext.settings().lastKnownMode = BrowsingMode.Normal
+        testContext.settings().allowScreenshotsInPrivateMode = true
+
+        // when
+        activity.checkAndUpdateScreenshotPermission(activity.settings())
+
+        // then
+        assertFalse(shadowOf(window).getFlag(WindowManager.LayoutParams.FLAG_SECURE))
+    }
+
+    @Test
+    fun `testCheckAndUpdateScreenshotPermission removes flag when in normal mode screenshots are not allowed `() {
+        // given
+        val activity = Robolectric.buildActivity(Activity::class.java).create().get()
+        val window = activity.window
+        window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        testContext.settings().lastKnownMode = BrowsingMode.Normal
+        testContext.settings().allowScreenshotsInPrivateMode = false
+
+        // when
+        activity.checkAndUpdateScreenshotPermission(activity.settings())
+
+        // then
+        assertFalse(shadowOf(window).getFlag(WindowManager.LayoutParams.FLAG_SECURE))
     }
 }


### PR DESCRIPTION
 Added a new option in Private browsing menu to allow or prevent screenshots from being taken while in private mode by adding or removing the FLAG_SECURE flag from the home activity's window.

 This method is called whenever the activity is initialized to account for the browsing mode being changed and whenever the setting from the Private browsing menu is changed.

 The setting is by default set to true (screenshots are allowed to be taken). The system notification 
 that is displayed while screenshots are blocked is : "Can't take screenshot due to security policy"

<img src = "https://user-images.githubusercontent.com/23737079/78346587-e595a800-75a7-11ea-89ee-29fedf2a94ed.png" width = "300">



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture