### PR TITLE
Closes #9495: Dismiss the ShareFragment in onPause()

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/share/ShareFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/share/ShareFragment.kt
@@ -53,6 +53,11 @@ class ShareFragment : AppCompatDialogFragment() {
         setStyle(STYLE_NO_TITLE, R.style.ShareDialogStyle)
     }
 
+    override fun onPause() {
+        super.onPause()
+        dismiss()
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,


### PR DESCRIPTION
Doing this will ensure no corruption of the initial share to apps list while the user went away.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: No tests. Small change.
- [x] **Screenshots**: No screenshots. Simple flow.
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture