### PR TITLE
No issue: Restore num-flaky-test-attempts in flank-x86.yml

### DIFF
--- a/automation/taskcluster/androidTest/flank-x86.yml
+++ b/automation/taskcluster/androidTest/flank-x86.yml
@@ -21,6 +21,10 @@ gcloud:
   # see: https://github.com/TestArmada/flank/issues/341
   #results-history-name: tmp_parallel 
 
+  # The number of times a test execution should be re-attempted if one or more failures occur.
+  # The maximum number of reruns allowed is 10. Default is 0, which implies no reruns.
+  num-flaky-test-attempts: 1
+
   # test and app are the only required args
   app: /app/path 
   test: /test/path


### PR DESCRIPTION
Removing the Flank template option is revealing lots of intermittent failures. I think we should revert our decision to remove this in #9635 and limit the re-runs to 2. 