### PR TITLE
Closes #9688: Disable ReaderViewTest for intermittent investigation

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/ReaderViewTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/ReaderViewTest.kt
@@ -8,6 +8,7 @@ import android.view.View
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.ui.robots.navigationToolbar
@@ -28,6 +29,7 @@ import org.mozilla.fenix.helpers.TestAssetHelper
  *
  */
 
+@Ignore("Temp disable - reader view page detection issues: https://github.com/mozilla-mobile/fenix/issues/9688 ")
 class ReaderViewTest {
     private lateinit var mockWebServer: MockWebServer
     private var readerViewNotificationDot: ViewVisibilityIdlingResource? = null


### PR DESCRIPTION
#9688 

> A lot of the ReaderViewTest Class tests rely on notification detection but that is failing recently. Let's disable for now and figure out what's going on.
