### PR TITLE
For #7157 - Set BrowserMenu width to be max 314 dp

### DIFF
--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -2,11 +2,13 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <dimen name="crash_reporter_close_tab_button_horizontal_margin">26dp</dimen>
     <dimen name="crash_reporter_close_tab_button_bottom_margin">24dp</dimen>
     <dimen name="glyph_button_height">48dp</dimen>
     <dimen name="glyph_button_width">48dp</dimen>
+    <dimen name="mozac_browser_menu_width_min" tools:ignore="UnusedResources">250dp</dimen>
+    <dimen name="mozac_browser_menu_width_max" tools:ignore="UnusedResources">314dp</dimen>
     <dimen name="mozac_browser_menu_corner_radius">8dp</dimen>
     <dimen name="toolbar_elevation">7dp</dimen>
     <dimen name="library_item_height">56dp</dimen>


### PR DESCRIPTION
Instead of having a fixed width of 250dp the BrowserMenu will now have a
dynamic width between 250dp and 314dp allowing for a better fit for the menu
items it could display.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: No tests. Small layout change.
- [x] **Screenshots**: This PR includes before/after screenshots below.
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) .

![BeforeAfterDynamicWidthMenu](https://user-images.githubusercontent.com/11428869/78532531-16681e00-77f0-11ea-8d30-133507581e4a.png)


### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture