### PR TITLE
Fix errors in top_sites_count metric.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
@@ -553,8 +553,11 @@ class GleanMetricsService(private val context: Context) : MetricsService {
             adjustAdGroup.set(context.settings().adjustAdGroup)
             adjustCreative.set(context.settings().adjustCreative)
             adjustNetwork.set(context.settings().adjustNetwork)
-            hasTopSites.set(context.settings().topSitesSize > 0)
-            topSitesCount.add(context.settings().topSitesSize)
+            val topSitesSize = context.settings().topSitesSize
+            hasTopSites.set(topSitesSize > 0)
+            if (topSitesSize > 0) {
+                topSitesCount.add(topSitesSize)
+            }
 
             toolbarPosition.set(
                 if (context.settings().shouldUseBottomToolbar) {


### PR DESCRIPTION
We discovered in the Fenix metrics errors query [1] that
top_sites_count had a spike in the number of errors. It
seems to be recording a count of 0, which is an invalid value.

[1] https://sql.telemetry.mozilla.org/queries/67107/source#169983



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture