### PR TITLE
No issue: Set all Flank templates to one AVD

### DIFF
--- a/automation/taskcluster/androidTest/flank-arm64-v8a.yml
+++ b/automation/taskcluster/androidTest/flank-arm64-v8a.yml
@@ -34,9 +34,7 @@ gcloud:
   performance-metrics: true
 
   device:
-   - model: walleye 
-     version: 26
-   - model: walleye 
+   - model: Pixel2
      version: 28
 
 flank:

--- a/automation/taskcluster/androidTest/flank-armeabi-v7a-start-test.yml
+++ b/automation/taskcluster/androidTest/flank-armeabi-v7a-start-test.yml
@@ -37,9 +37,7 @@ gcloud:
    - class org.mozilla.fenix.ui.NavigationToolbarTest#visitURLTest
 
   device:
-   - model: sailfish
-     version: 25
-   - model: sailfish
+   - model: Pixel2
      version: 28
 
 flank:

--- a/automation/taskcluster/androidTest/flank-armeabi-v7a.yml
+++ b/automation/taskcluster/androidTest/flank-armeabi-v7a.yml
@@ -34,8 +34,8 @@ gcloud:
   performance-metrics: true
 
   device:
-   - model: shamu
-     version: 21
+   - model: Pixel2
+     version: 28
 
 flank:
   project: GOOGLE_PROJECT

--- a/automation/taskcluster/androidTest/flank-x86-start-test.yml
+++ b/automation/taskcluster/androidTest/flank-x86-start-test.yml
@@ -37,9 +37,7 @@ gcloud:
    - class org.mozilla.fenix.ui.NavigationToolbarTest#visitURLTest
 
   device:
-   - model: Nexus6 
-     version: 25
-   - model: Pixel2 
+   - model: Pixel2
      version: 28
 
 flank:

--- a/automation/taskcluster/androidTest/flank-x86.yml
+++ b/automation/taskcluster/androidTest/flank-x86.yml
@@ -41,9 +41,7 @@ gcloud:
    - package org.mozilla.fenix.ui
 
   device:
-   - model: Nexus6P
-     version: 27
-   - model: Pixel2 
+   - model: Pixel2
      version: 28
 
 flank:


### PR DESCRIPTION
To reduce automation costs, one immediate action is to limit all Firebase Test Lab runs to one Android Virtual Device. This PR sets all Flank configuration templates to use the Pixel 2 on API 28.