### PR TITLE
No issue: Refactor readerview to use browser-state

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -29,6 +29,7 @@ import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
 import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
+import org.mozilla.fenix.addons.runIfFragmentIsAttached
 import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.components.TabCollectionStorage
 import org.mozilla.fenix.components.metrics.Event
@@ -62,7 +63,6 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
 
     override fun initializeUI(view: View): Session? {
         val context = requireContext()
-        val sessionManager = context.components.core.sessionManager
         val components = context.components
 
         return super.initializeUI(view)?.also {
@@ -70,11 +70,14 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
                 feature = ReaderViewFeature(
                     context,
                     components.core.engine,
-                    sessionManager,
+                    components.core.store,
                     view.readerViewControlsBar
-                ) { available ->
+                ) { available, _ ->
                     if (available) {
                         components.analytics.metrics.track(Event.ReaderModeAvailable)
+                    }
+                    runIfFragmentIsAttached {
+                        browserToolbarView.toolbarIntegration.invalidateMenu()
                     }
                 },
                 owner = this,

--- a/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -31,6 +31,7 @@ import mozilla.components.feature.media.RecordingDevicesNotificationFeature
 import mozilla.components.feature.media.middleware.MediaMiddleware
 import mozilla.components.feature.pwa.ManifestStorage
 import mozilla.components.feature.pwa.WebAppShortcutManager
+import mozilla.components.feature.readerview.ReaderViewMiddleware
 import mozilla.components.feature.session.HistoryDelegate
 import mozilla.components.feature.webcompat.WebCompatFeature
 import mozilla.components.feature.webnotifications.WebNotificationFeature
@@ -99,7 +100,8 @@ class Core(private val context: Context) {
     val store by lazy {
         BrowserStore(
             middleware = listOf(
-                MediaMiddleware(context, MediaService::class.java)
+                MediaMiddleware(context, MediaService::class.java),
+                ReaderViewMiddleware()
             )
         )
     }

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
+import mozilla.components.browser.state.selector.findTab
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.concept.engine.prompt.ShareData
 import mozilla.components.support.ktx.kotlin.isUrl
@@ -275,9 +276,9 @@ class DefaultBrowserToolbarController(
             is ToolbarMenu.Item.ReaderMode -> {
                 activity.settings().readerModeOpened = true
 
-                val enabled = currentSession?.readerMode
-                    ?: activity.components.core.sessionManager.selectedSession?.readerMode
-                    ?: false
+                val enabled = currentSession?.let {
+                    activity.components.core.store.state.findTab(it.id)?.readerState?.active
+                } ?: false
 
                 if (enabled) {
                     readerModeController.hideReaderView()

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarView.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarView.kt
@@ -207,6 +207,7 @@ class BrowserToolbarView(
                     onItemTapped = { interactor.onBrowserToolbarMenuItemTapped(it) },
                     lifecycleOwner = lifecycleOwner,
                     sessionManager = sessionManager,
+                    store = components.core.store,
                     bookmarksStorage = bookmarkStorage
                 )
                 view.display.setMenuDismissAction {

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/MenuPresenter.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/MenuPresenter.kt
@@ -22,20 +22,20 @@ class MenuPresenter(
 
     /** Redraw the refresh/stop button */
     override fun onLoadingStateChanged(session: Session, loading: Boolean) {
-        menuToolbar.invalidateActions()
+        invalidateActions()
     }
 
     /** Redraw the back and forward buttons */
     override fun onNavigationStateChanged(session: Session, canGoBack: Boolean, canGoForward: Boolean) {
-        menuToolbar.invalidateActions()
+        invalidateActions()
     }
 
     /** Redraw the install web app button */
     override fun onWebAppManifestChanged(session: Session, manifest: WebAppManifest?) {
-        menuToolbar.invalidateActions()
+        invalidateActions()
     }
 
-    override fun onReaderableStateUpdated(session: Session, readerable: Boolean) {
+    fun invalidateActions() {
         menuToolbar.invalidateActions()
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarIntegration.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarIntegration.kt
@@ -45,7 +45,7 @@ abstract class ToolbarIntegration(
         )
     )
 
-    private var menuPresenter =
+    private val menuPresenter =
         MenuPresenter(toolbar, context.components.core.sessionManager, sessionId)
 
     init {
@@ -61,6 +61,10 @@ abstract class ToolbarIntegration(
     override fun stop() {
         menuPresenter.stop()
         toolbarPresenter.stop()
+    }
+
+    fun invalidateMenu() {
+        menuPresenter.invalidateActions()
     }
 }
 

--- a/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenuTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenuTest.kt
@@ -8,6 +8,10 @@ import io.mockk.mockkStatic
 import io.mockk.spyk
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.state.ReaderState
+import mozilla.components.browser.state.state.createTab
+import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.storage.BookmarksStorage
 import mozilla.components.feature.app.links.AppLinkRedirect
 import mozilla.components.feature.app.links.AppLinksUseCases
@@ -28,12 +32,19 @@ class DefaultToolbarMenuTest {
     private val lifecycleOwner: LifecycleOwner = mockk(relaxed = true)
     private val bookmarksStorage: BookmarksStorage = mockk(relaxed = true)
 
+    private val store: BrowserStore = BrowserStore(initialState = BrowserState(
+        listOf(
+            createTab("https://www.mozilla.org", id = "readerable-tab", readerState = ReaderState(readerable = true))
+        )
+    ))
+
     @Before
     fun setUp() {
         defaultToolbarMenu = spyk(
             DefaultToolbarMenu(
                 context,
                 sessionManager,
+                store,
                 hasAccountProblem = false,
                 shouldReverseItems = false,
                 onItemTapped = onItemTapped,
@@ -59,7 +70,7 @@ class DefaultToolbarMenuTest {
         every { getAppLinkRedirect(any()) } returns appLinkRedirect
 
         val session: Session = mockk(relaxed = true)
-        every { session.readerable } returns true
+        every { session.id } returns "readerable-tab"
         every { sessionManager.selectedSession } returns session
 
         val list = defaultToolbarMenu.getLowPrioHighlightItems()
@@ -84,7 +95,7 @@ class DefaultToolbarMenuTest {
         every { getAppLinkRedirect(any()) } returns appLinkRedirect
 
         val session: Session = mockk(relaxed = true)
-        every { session.readerable } returns true
+        every { session.id } returns "readerable-tab"
         every { sessionManager.selectedSession } returns session
 
         val list = defaultToolbarMenu.getLowPrioHighlightItems()
@@ -114,7 +125,7 @@ class DefaultToolbarMenuTest {
         every { context.components.useCases.webAppUseCases.isInstallable() } returns true
 
         val session: Session = mockk(relaxed = true)
-        every { session.readerable } returns true
+        every { session.id } returns "readerable-tab"
         every { sessionManager.selectedSession } returns session
 
         val getAppLinkRedirect: AppLinksUseCases.GetAppLinkRedirect = mockk(relaxed = true)

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "38.0.20200407130106"
+    const val VERSION = "38.0.20200407190120"
 }


### PR DESCRIPTION
Next step in moving away from `browser-session`/`SessionManager`. Added a unit test for the menu as well which was missing.

Blocked on: https://github.com/mozilla-mobile/android-components/pull/6547