### PR TITLE
For #8589 - Fix for accessibility navigation in ETP panel

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionPanelDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionPanelDialogFragment.kt
@@ -73,7 +73,8 @@ class TrackingProtectionPanelDialogFragment : AppCompatDialogFragment(), UserInt
                     args.url,
                     args.trackingProtectionEnabled,
                     listTrackers = listOf(),
-                    mode = TrackingProtectionState.Mode.Normal
+                    mode = TrackingProtectionState.Mode.Normal,
+                    lastAccessedCategory = ""
                 )
             )
         }

--- a/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionStore.kt
+++ b/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionStore.kt
@@ -50,13 +50,16 @@ sealed class TrackingProtectionAction : Action {
  * @property isTrackingProtectionEnabled Current status of tracking protection for this session (ie is an exception)
  * @property listTrackers Current Tracker Log list of blocked and loaded tracker categories
  * @property mode Current Mode of TrackingProtection
+ * @property lastAccessedCategory Remembers the last accessed details category, used to move
+ *           accessibly focus after returning from details_moode
  */
 data class TrackingProtectionState(
     val session: Session?,
     val url: String,
     val isTrackingProtectionEnabled: Boolean,
     val listTrackers: List<TrackerLog>,
-    val mode: Mode
+    val mode: Mode,
+    val lastAccessedCategory: String
 ) : State {
     sealed class Mode {
         object Normal : Mode()
@@ -112,7 +115,8 @@ fun trackingProtectionStateReducer(
             mode = TrackingProtectionState.Mode.Details(
                 action.category,
                 action.categoryBlocked
-            )
+            ),
+            lastAccessedCategory = action.category.name
         )
         is TrackingProtectionAction.TrackerBlockingChanged ->
             state.copy(isTrackingProtectionEnabled = action.isTrackingProtectionEnabled)

--- a/app/src/main/res/layout/component_tracking_protection_panel.xml
+++ b/app/src/main/res/layout/component_tracking_protection_panel.xml
@@ -43,6 +43,7 @@
         <TextView
             android:id="@+id/blocking_header"
             style="@style/QuickSettingsText"
+            android:accessibilityHeading="true"
             android:layout_width="wrap_content"
             android:layout_height="@dimen/tracking_protection_item_height"
             android:text="@string/enhanced_tracking_protection_blocked"
@@ -50,7 +51,8 @@
             android:textStyle="bold"
             android:visibility="gone"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/trackingProtectionSwitch" />
+            app:layout_constraintTop_toBottomOf="@id/trackingProtectionSwitch"
+            tools:targetApi="p" />
 
         <TextView
             android:id="@+id/cross_site_tracking"
@@ -106,12 +108,14 @@
             android:id="@+id/not_blocking_header"
             style="@style/QuickSettingsText"
             android:layout_width="wrap_content"
+            android:accessibilityHeading="true"
             android:layout_height="@dimen/tracking_protection_item_height"
             android:text="@string/enhanced_tracking_protection_allowed"
             android:textStyle="bold"
             android:visibility="gone"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tracking_content" />
+            app:layout_constraintTop_toBottomOf="@id/tracking_content"
+            tools:targetApi="p" />
 
         <TextView
             android:id="@+id/fingerprinters_loaded"
@@ -227,6 +231,7 @@
 
         <TextView
             android:id="@+id/details_blocking_header"
+            android:accessibilityHeading="true"
             style="@style/QuickSettingsText"
             android:layout_width="wrap_content"
             android:layout_height="@dimen/tracking_protection_item_height"
@@ -237,7 +242,8 @@
             android:text="@string/enhanced_tracking_protection_blocked"
             android:textStyle="bold"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/line_divider_details" />
+            app:layout_constraintTop_toBottomOf="@id/line_divider_details"
+            tools:targetApi="p" />
 
         <androidx.core.widget.NestedScrollView
             android:id="@+id/blocking_scrollview"

--- a/app/src/test/java/org/mozilla/fenix/trackingprotection/TrackingProtectionStoreTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/trackingprotection/TrackingProtectionStoreTest.kt
@@ -33,6 +33,7 @@ class TrackingProtectionStoreTest {
             store.state.mode,
             TrackingProtectionState.Mode.Details(TrackingProtectionCategory.FINGERPRINTERS, true)
         )
+        assertEquals(store.state.lastAccessedCategory, TrackingProtectionCategory.FINGERPRINTERS.name)
     }
 
     @Test
@@ -46,6 +47,7 @@ class TrackingProtectionStoreTest {
             store.state.mode,
             TrackingProtectionState.Mode.Normal
         )
+        assertEquals(store.state.lastAccessedCategory, initialState.lastAccessedCategory)
     }
 
     @Test
@@ -133,7 +135,8 @@ class TrackingProtectionStoreTest {
         url = "www.mozilla.org",
         isTrackingProtectionEnabled = true,
         listTrackers = listOf(),
-        mode = TrackingProtectionState.Mode.Normal
+        mode = TrackingProtectionState.Mode.Normal,
+        lastAccessedCategory = ""
     )
 
     private fun detailsState(): TrackingProtectionState = TrackingProtectionState(
@@ -141,6 +144,7 @@ class TrackingProtectionStoreTest {
         url = "www.mozilla.org",
         isTrackingProtectionEnabled = true,
         listTrackers = listOf(),
-        mode = TrackingProtectionState.Mode.Details(TrackingProtectionCategory.CRYPTOMINERS, true)
+        mode = TrackingProtectionState.Mode.Details(TrackingProtectionCategory.CRYPTOMINERS, true),
+        lastAccessedCategory = TrackingProtectionCategory.CRYPTOMINERS.name
     )
 }


### PR DESCRIPTION
For #8589 
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests.
- [x] **Screenshots**: This PR includes a GIF.
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

![accessibility navigation](https://user-images.githubusercontent.com/60002907/78647021-a5456b00-78c2-11ea-985e-7c8292880fc2.gif)