### PR TITLE
For #9670: fix intermittent tests and verify system media notification is gone  

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/MediaNotificationTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/MediaNotificationTest.kt
@@ -7,7 +7,6 @@ package org.mozilla.fenix.ui
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
@@ -17,6 +16,7 @@ import org.mozilla.fenix.ui.robots.browserScreen
 import org.mozilla.fenix.ui.robots.homeScreen
 import org.mozilla.fenix.ui.robots.mDevice
 import org.mozilla.fenix.ui.robots.navigationToolbar
+import org.mozilla.fenix.ui.robots.notificationShade
 
 /**
  *  Tests for verifying basic functionality of media notifications:
@@ -63,6 +63,14 @@ class MediaNotificationTest {
 
         browserScreen {
             verifyMediaIsPaused()
+        }.openHomeScreen {
+            closeTab()
+        }
+
+        mDevice.openNotification()
+
+        notificationShade {
+            verifySystemNotificationGone(videoTestPage.title)
         }
     }
 
@@ -85,11 +93,18 @@ class MediaNotificationTest {
 
         browserScreen {
             verifyMediaIsPaused()
+        }.openHomeScreen {
+            closeTab()
+        }
+
+        mDevice.openNotification()
+
+        notificationShade {
+            verifySystemNotificationGone(audioTestPage.title)
         }
     }
 
     @Test
-    @Ignore("Temp disable test - see: https://github.com/mozilla-mobile/fenix/issues/9670")
     fun tabMediaControlButtonTest() {
         val audioTestPage = TestAssetHelper.getAudioPageAsset(mockWebServer)
 
@@ -128,6 +143,14 @@ class MediaNotificationTest {
 
         browserScreen {
             verifyMediaIsPaused()
+        }.openHomeScreen {
+            closeTab()
+        }
+
+        mDevice.openNotification()
+
+        notificationShade {
+            verifySystemNotificationGone(audioTestPage.title)
         }
     }
 }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
@@ -11,6 +11,7 @@ import androidx.test.uiautomator.Until
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
@@ -250,6 +251,7 @@ class TabbedBrowsingTest {
         }
     }
 
+    @Ignore("Temp disabled, intermittent test: https://github.com/mozilla-mobile/fenix/issues/9783")
     @Test
     fun closePrivateTabsNotificationTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
@@ -194,7 +194,11 @@ class HomeScreenRobot {
 
     fun verifyTabMediaControlButtonState(action: String) {
         mDevice.waitNotNull(
-            Until.findObject(By.res("org.mozilla.fenix.debug:id/play_pause_button")),
+            findObject(
+                By
+                    .res("org.mozilla.fenix.debug:id/play_pause_button")
+                    .desc(action)
+            ),
             waitingTime
         )
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NotificationRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NotificationRobot.kt
@@ -5,6 +5,7 @@ import androidx.test.uiautomator.By.text
 import androidx.test.uiautomator.UiScrollable
 import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
+import org.junit.Assert.assertFalse
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.ext.waitNotNull
 
@@ -34,6 +35,19 @@ class NotificationRobot {
                 e.printStackTrace()
             }
         }
+    }
+
+    fun verifySystemNotificationGone(notificationMessage: String) {
+        mDevice.waitNotNull(
+            Until.gone(text(notificationMessage)),
+            waitingTime
+        )
+
+        assertFalse(
+            mDevice.findObject(
+                UiSelector().text(notificationMessage)
+            ).exists()
+        )
     }
 
     fun verifyPrivateTabsNotification() {


### PR DESCRIPTION
Extends the Media Notification Tests with an extra verification step.
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture