### PR TITLE
For #9798: Disable buttons on hiding and enable on showing.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/CollectionViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/CollectionViewHolder.kt
@@ -17,7 +17,9 @@ import mozilla.components.browser.menu.item.SimpleBrowserMenuItem
 import mozilla.components.feature.tab.collections.TabCollection
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.getIconColor
+import org.mozilla.fenix.ext.hideAndDisable
 import org.mozilla.fenix.ext.increaseTapArea
+import org.mozilla.fenix.ext.showAndEnable
 import org.mozilla.fenix.home.sessioncontrol.CollectionInteractor
 import org.mozilla.fenix.theme.ThemeManager
 
@@ -78,11 +80,11 @@ class CollectionViewHolder(
 
         view.isActivated = expanded
         if (expanded) {
-            view.collection_share_button.visibility = View.VISIBLE
-            view.collection_overflow_button.visibility = View.VISIBLE
+            view.collection_share_button.showAndEnable()
+            view.collection_overflow_button.showAndEnable()
         } else {
-            view.collection_share_button.visibility = View.GONE
-            view.collection_overflow_button.visibility = View.GONE
+            view.collection_share_button.hideAndDisable()
+            view.collection_overflow_button.hideAndDisable()
         }
 
         view.collection_icon.colorFilter = createBlendModeColorFilterCompat(


### PR DESCRIPTION
This is triggered on collection expanding or shrinking that is animated.
The animation has android:fillEnabled="true" android:fillAfter="true".
This interferes with set visibility to gone and the click still triggers.
Disabling button avoids changing animation or force clearing it.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture