### PR TITLE
No issue: Re-use existing usecases for addons

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -348,16 +348,16 @@ open class FenixApplication : LocaleAwareApplication() {
                         session.id
                 },
                 onCloseTabOverride = {
-                    _, sessionId -> components.tabsUseCases.removeTab(sessionId)
+                    _, sessionId -> components.useCases.tabsUseCases.removeTab(sessionId)
                 },
                 onSelectTabOverride = {
                     _, sessionId ->
                         val selected = components.core.sessionManager.findSessionById(sessionId)
-                        selected?.let { components.tabsUseCases.selectTab(it) }
+                        selected?.let { components.useCases.tabsUseCases.selectTab(it) }
                 },
                 onExtensionsLoaded = { extensions ->
                     components.addonUpdater.registerForFutureUpdates(extensions)
-                    components.supportedAddChecker.registerForChecks()
+                    components.supportedAddonsChecker.registerForChecks()
                 },
                 onUpdatePermissionRequest = components.addonUpdater::onUpdatePermissionRequest
             )

--- a/app/src/main/java/org/mozilla/fenix/addons/InstalledAddonDetailsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/addons/InstalledAddonDetailsFragment.kt
@@ -177,9 +177,9 @@ class InstalledAddonDetailsFragment : Fragment() {
                             ?: false
 
                     if (shouldCreatePrivateSession) {
-                        components.tabsUseCases.addPrivateTab(settingUrl)
+                        components.useCases.tabsUseCases.addPrivateTab(settingUrl)
                     } else {
-                        components.tabsUseCases.addTab(settingUrl)
+                        components.useCases.tabsUseCases.addTab(settingUrl)
                     }
 
                     InstalledAddonDetailsFragmentDirections

--- a/app/src/main/java/org/mozilla/fenix/components/Components.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Components.kt
@@ -14,7 +14,6 @@ import mozilla.components.feature.addons.update.AddonUpdater
 import mozilla.components.feature.addons.update.DefaultAddonUpdater
 import mozilla.components.feature.addons.migration.SupportedAddonsChecker
 import mozilla.components.feature.addons.migration.DefaultSupportedAddonsChecker
-import mozilla.components.feature.tabs.TabsUseCases
 import mozilla.components.lib.publicsuffixlist.PublicSuffixList
 import mozilla.components.support.migration.state.MigrationStore
 import org.mozilla.fenix.BuildConfig
@@ -86,7 +85,7 @@ class Components(private val context: Context) {
     }
 
     @Suppress("MagicNumber")
-    val supportedAddChecker by lazy {
+    val supportedAddonsChecker by lazy {
         DefaultSupportedAddonsChecker(context, SupportedAddonsChecker.Frequency(16, TimeUnit.MINUTES),
             onNotificationClickIntent = Intent(context, HomeActivity::class.java).apply {
                 action = Intent.ACTION_VIEW
@@ -99,8 +98,6 @@ class Components(private val context: Context) {
     val addonManager by lazy {
         AddonManager(core.store, core.engine, addonCollectionProvider, addonUpdater)
     }
-
-    val tabsUseCases: TabsUseCases by lazy { TabsUseCases(core.sessionManager) }
 
     val analytics by lazy { Analytics(context) }
     val publicSuffixList by lazy { PublicSuffixList(context) }


### PR DESCRIPTION
Minor refactoring. We introduced a second `TabsUseCase` instance with addons which is not needed.