### PR TITLE
For #9692 - Fix "Install" PWA menu item labeling.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt
@@ -40,8 +40,8 @@ import org.mozilla.fenix.ext.getRootView
 import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.home.SharedViewModel
-import org.mozilla.fenix.utils.Do
 import org.mozilla.fenix.settings.deletebrowsingdata.deleteAndQuit
+import org.mozilla.fenix.utils.Do
 
 /**
  * An interface that handles the view manipulation of the BrowserToolbar, triggered by the Interactor
@@ -179,7 +179,7 @@ class DefaultBrowserToolbarController(
                     }
                 }
             }
-            ToolbarMenu.Item.AddToHomeScreen -> {
+            ToolbarMenu.Item.AddToHomeScreen, ToolbarMenu.Item.InstallToHomeScreen -> {
                 activity.settings().installPwaOpened = true
                 MainScope().launch {
                     with(activity.components.useCases.webAppUseCases) {
@@ -349,6 +349,7 @@ class DefaultBrowserToolbarController(
             ToolbarMenu.Item.SaveToCollection -> Event.BrowserMenuItemTapped.Item.SAVE_TO_COLLECTION
             ToolbarMenu.Item.AddToTopSites -> Event.BrowserMenuItemTapped.Item.ADD_TO_TOP_SITES
             ToolbarMenu.Item.AddToHomeScreen -> Event.BrowserMenuItemTapped.Item.ADD_TO_HOMESCREEN
+            ToolbarMenu.Item.InstallToHomeScreen -> Event.BrowserMenuItemTapped.Item.ADD_TO_HOMESCREEN
             ToolbarMenu.Item.Quit -> Event.BrowserMenuItemTapped.Item.QUIT
             is ToolbarMenu.Item.ReaderMode ->
                 if (item.isChecked) {

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarMenu.kt
@@ -22,6 +22,7 @@ interface ToolbarMenu {
         object OpenInFenix : Item()
         object SaveToCollection : Item()
         object AddToTopSites : Item()
+        object InstallToHomeScreen : Item()
         object AddToHomeScreen : Item()
         object AddonsManager : Item()
         object Quit : Item()

--- a/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenuTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenuTest.kt
@@ -75,7 +75,7 @@ class DefaultToolbarMenuTest {
 
         val list = defaultToolbarMenu.getLowPrioHighlightItems()
 
-        assertEquals(ToolbarMenu.Item.AddToHomeScreen, list[0])
+        assertEquals(ToolbarMenu.Item.InstallToHomeScreen, list[0])
         assertEquals(ToolbarMenu.Item.ReaderMode(false), list[1])
         assertEquals(ToolbarMenu.Item.OpenInApp, list[2])
     }
@@ -115,7 +115,7 @@ class DefaultToolbarMenuTest {
 
         val list = defaultToolbarMenu.getLowPrioHighlightItems()
 
-        assertEquals(ToolbarMenu.Item.AddToHomeScreen, list[0])
+        assertEquals(ToolbarMenu.Item.InstallToHomeScreen, list[0])
         assertEquals(ToolbarMenu.Item.OpenInApp, list[1])
     }
 
@@ -134,7 +134,7 @@ class DefaultToolbarMenuTest {
 
         val list = defaultToolbarMenu.getLowPrioHighlightItems()
 
-        assertEquals(ToolbarMenu.Item.AddToHomeScreen, list[0])
+        assertEquals(ToolbarMenu.Item.InstallToHomeScreen, list[0])
         assertEquals(ToolbarMenu.Item.ReaderMode(false), list[1])
     }
 }


### PR DESCRIPTION
Because we can't dynamically change the label on a button but can change the visibility dynamically (ie when a session, url changes), I had to do a small hack which was separating out the two menu items and only showing 1 at a time.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture