### PR TITLE
Issue #9295 - Add back non-blocking bors to trigger CI on contributor PRs

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -17,15 +17,16 @@ tasks:
                   $if: 'tasks_for in ["cron", "action"]'
                   then: '${tasks_for}@noreply.mozilla.org'
                   else:
-                      $if: 'tasks_for == "github-push"'
-                      then: '${event.pusher.email}'
-                      # Assume Pull Request
+                      $if: 'event.sender.login == "bors[bot]"'
+                      then: 'skaspari+mozlando@mozilla.com'   # It must match what's in bors.toml
                       else:
-                          $if: 'tasks_for == "github-pull-request"'
-                          then: '${event.pull_request.user.login}@users.noreply.github.com'
-                          else:
-                              $if: 'tasks_for == "github-release"'
-                              then: '${event.sender.login}@users.noreply.github.com'
+                          $if: 'tasks_for == "github-push"'
+                          then: '${event.pusher.email}'
+                              $if: 'tasks_for == "github-pull-request"'
+                              then: '${event.pull_request.user.login}@users.noreply.github.com'
+                              else:
+                                  $if: 'tasks_for == "github-release"'
+                                  then: '${event.sender.login}@users.noreply.github.com'
               baseRepoUrl:
                   $if: 'tasks_for in ["github-push", "github-release"]'
                   then: '${event.repository.html_url}'
@@ -101,7 +102,7 @@ tasks:
               $if: >
                 tasks_for in ["action", "cron"]
                 || (tasks_for == "github-pull-request" && pullRequestAction in ["opened", "reopened", "edited", "synchronize"])
-                || (tasks_for == "github-push" && head_branch[:10] != "refs/tags/")
+                || (tasks_for == "github-push" && head_branch[:10] != "refs/tags/") && (head_branch != "staging.tmp") && (head_branch != "trying.tmp")
                 || (tasks_for == "github-release" && releaseAction == "published")
               then:
                   $let:

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -22,7 +22,7 @@ tasks:
                       else:
                           $if: 'tasks_for == "github-push"'
                           then: '${event.pusher.email}'
-                          else
+                          else:
                               $if: 'tasks_for == "github-pull-request"'
                               then: '${event.pull_request.user.login}@users.noreply.github.com'
                               else:

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -22,6 +22,7 @@ tasks:
                       else:
                           $if: 'tasks_for == "github-push"'
                           then: '${event.pusher.email}'
+                          else
                               $if: 'tasks_for == "github-pull-request"'
                               then: '${event.pull_request.user.login}@users.noreply.github.com'
                               else:

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,13 @@
+status = []
+block_labels = [
+  "needs:data-review",
+  "do not land",
+  "pr:work-in-progress",
+  "pr:needs-changes"
+]
+required_approvals = 0
+delete_merged_branches = true
+cut_body_after = "---"
+[committer]
+name = "MozLando"
+email = "skaspari+mozlando@mozilla.com"


### PR DESCRIPTION
Added bors back to taskcluster scripts, and updating some of the trigger/block parameters.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture