### PR TITLE
Closes issue #9781: Fix EditText height fragment_edit_bookmark

### DIFF
--- a/app/src/main/res/layout/fragment_edit_bookmark.xml
+++ b/app/src/main/res/layout/fragment_edit_bookmark.xml
@@ -36,7 +36,7 @@
     <org.mozilla.fenix.utils.ClearableEditText
         android:id="@+id/bookmarkNameEdit"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="@dimen/bookmark_edit_text_height"
         android:layout_marginBottom="8dp"
         android:drawablePadding="8dp"
         android:ellipsize="none"
@@ -62,7 +62,7 @@
     <org.mozilla.fenix.utils.ClearableEditText
         android:id="@+id/bookmarkUrlEdit"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="@dimen/bookmark_edit_text_height"
         android:layout_marginBottom="8dp"
         android:drawablePadding="8dp"
         android:ellipsize="none"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -65,6 +65,9 @@
     <!-- ETP Onboarding Popup -->
     <dimen name="etp_onboarding_popup_width">256dp</dimen>
 
+    <!-- Edit  Fragment  -->
+    <dimen name="bookmark_edit_text_height">48dp</dimen>
+
     <!-- Search Fragment -->
     <dimen name="search_fragment_clipboard_item_height">56dp</dimen>
     <dimen name="search_fragment_clipboard_item_horizontal_margin">12dp</dimen>


### PR DESCRIPTION

Created a dimension for the correct size suggested by the Google Accessibility Scanner, and applied to the layout.