### PR TITLE
Bug 1628413 - part 2: Re-enable nightlies but don't ship them to Goog…

### DIFF
--- a/.cron.yml
+++ b/.cron.yml
@@ -9,7 +9,17 @@ jobs:
           type: decision-task
           treeherder-symbol: Nd
           target-tasks-method: nightly
-      when: [] # XXX Nightlies are temporarily disabled until Google Play catches up
+      when:
+          - {hour: 6, minute: 0}
+          - {hour: 18, minute: 0}
+    # This is a temporary hook in order to not overload Google Play.
+    # See bug 1628413 for more context.
+    - name: nightly-on-google-play
+      job:
+          type: decision-task
+          treeherder-symbol: Nd-gp
+          target-tasks-method: nightly-on-google-play
+      when: []  # Manual push only
     - name: fennec-beta
       job:
           type: decision-task

--- a/taskcluster/fenix_taskgraph/target_tasks.py
+++ b/taskcluster/fenix_taskgraph/target_tasks.py
@@ -31,6 +31,18 @@ def target_tasks_nightly(full_task_graph, parameters, graph_config):
     """Select the set of tasks required for a nightly build."""
 
     def filter(task, parameters):
+        # We don't want to ship nightly while Google Play is still behind manual review.
+        # See bug 1628413 for more context.
+        return task.attributes.get("nightly", False) and task.kind != "push-apk"
+
+    return [l for l, t in full_task_graph.tasks.iteritems() if filter(t, parameters)]
+
+
+@_target_task("nightly-on-google-play")
+def target_tasks_nightly_on_google_play(full_task_graph, parameters, graph_config):
+    """Select the set of tasks required for a nightly build that goes on Google Play."""
+
+    def filter(task, parameters):
         return task.attributes.get("nightly", False)
 
     return [l for l, t in full_task_graph.tasks.iteritems() if filter(t, parameters)]


### PR DESCRIPTION
…le Play automatically anymore.

Follows https://github.com/mozilla-mobile/fenix/pull/9810 up. Not having any nightly builds at all caused https://github.com/mozilla-mobile/perf-frontend-issues/issues/100. So I'm making a new hook that will allows us to ship nightlies manually, while the regular hook keeps generating builds (without shipping them).

Depends on https://phabricator.services.mozilla.com/D70826

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture