### PR TITLE
For issue #9930 Do not assume all add-ons have a settings page

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/addons/InstalledAddonDetailsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/addons/InstalledAddonDetailsFragment.kt
@@ -99,7 +99,7 @@ class InstalledAddonDetailsFragment : Fragment() {
                         runIfFragmentIsAttached {
                             switch.isClickable = true
                             switch.setText(R.string.mozac_feature_addons_enabled)
-                            view.settings.isVisible = true
+                            view.settings.isVisible = shouldSettingsBeVisible()
                             view.remove_add_on.isEnabled = true
                             this.addon = it
                             showSnackBar(
@@ -164,8 +164,7 @@ class InstalledAddonDetailsFragment : Fragment() {
 
     private fun bindSettings(view: View) {
         view.settings.apply {
-            val optionsPageUrl = addon.installedState?.optionsPageUrl
-            isVisible = !optionsPageUrl.isNullOrEmpty()
+            isVisible = shouldSettingsBeVisible()
             setOnClickListener {
                 val settingUrl = addon.installedState?.optionsPageUrl ?: return@setOnClickListener
                 val directions = if (addon.installedState?.openOptionsPageInTab == true) {
@@ -263,4 +262,6 @@ class InstalledAddonDetailsFragment : Fragment() {
         setText(text)
         isChecked = checked
     }
+
+    private fun shouldSettingsBeVisible() = !addon.installedState?.optionsPageUrl.isNullOrEmpty()
 }


### PR DESCRIPTION
We were wrongly assuming that all add-ons must have a setting page.
 
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture