### PR TITLE
For #9932: Fix navigation icon theme missing from migration UI

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/migration/MigrationProgressActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/migration/MigrationProgressActivity.kt
@@ -17,6 +17,7 @@ import androidx.recyclerview.widget.RecyclerView
 import kotlinx.android.synthetic.main.activity_migration.*
 import kotlinx.android.synthetic.main.migration_list_item.view.*
 import mozilla.components.support.base.log.logger.Logger
+import mozilla.components.support.ktx.android.content.getColorFromAttr
 import mozilla.components.support.migration.AbstractMigrationProgressActivity
 import mozilla.components.support.migration.AbstractMigrationService
 import mozilla.components.support.migration.Migration
@@ -45,6 +46,8 @@ class MigrationProgressActivity : AbstractMigrationProgressActivity() {
     }
 
     fun init() {
+        window.navigationBarColor = getColorFromAttr(R.attr.foundation)
+
         val appName = migration_description.context.getString(R.string.app_name)
 
         migration_description.apply {


### PR DESCRIPTION
Setting the `navigationBarColor` is done in the ThemeManager for the
attached activity. Since the migration UI is separate from that, we did
not get this for free.

Fixes #9932

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

![Screenshot_1586898652](https://user-images.githubusercontent.com/1370580/79274679-ed403100-7e72-11ea-8c89-c892d4f47bb1.png)
