### PR TITLE
For #9951 - Authors not aligned correctly in Addon Details

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/addons/AddonDetailsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/addons/AddonDetailsFragment.kt
@@ -106,8 +106,8 @@ class AddonDetailsFragment : Fragment(R.layout.fragment_add_on_details) {
 
     private fun bindAuthors(addon: Addon, view: View) {
         view.author_text.text = addon.authors.joinToString { author ->
-            author.name + " \n"
-        }
+            author.name
+        }.trim()
     }
 
     private fun bindDetails(addon: Addon, view: View) {


### PR DESCRIPTION
Removed the extra empty line that was causing the spacing issue.

<img src = "https://user-images.githubusercontent.com/23737079/79348131-41afe300-7f3d-11ea-80c5-bf7a5ef4b011.png" width = "300">

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture