### PR TITLE
For #9100 - Private browsing notification fixes

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -43,7 +43,6 @@ import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.perf.StartupTimeline
 import org.mozilla.fenix.push.PushFxaIntegration
 import org.mozilla.fenix.push.WebPushEngineIntegration
-import org.mozilla.fenix.session.NotificationSessionObserver
 import org.mozilla.fenix.session.PerformanceActivityLifecycleCallbacks
 import org.mozilla.fenix.session.VisibilityLifecycleCallback
 import org.mozilla.fenix.utils.BrowsersCache
@@ -156,9 +155,6 @@ open class FenixApplication : LocaleAwareApplication() {
 
         visibilityLifecycleCallback = VisibilityLifecycleCallback(getSystemService())
         registerActivityLifecycleCallbacks(visibilityLifecycleCallback)
-
-        val privateNotificationObserver = NotificationSessionObserver(this)
-        privateNotificationObserver.start()
 
         // Storage maintenance disabled, for now, as it was interfering with background migrations.
         // See https://github.com/mozilla-mobile/fenix/issues/7227 for context.

--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -320,14 +320,12 @@ open class HomeActivity : LocaleAwareAppCompatActivity() {
     /**
      * Determines whether the activity should be pushed to be backstack (i.e., 'minimized' to the recents
      * screen) upon starting.
-     * @param intent    The intent that started this activity. Is checked for having the 'START_IN_RECENTS_SCREEN'-extra.
-     * @return          True if the activity should be started and pushed to the recents screen, false .
+     * @param intent - The intent that started this activity. Is checked for having the 'START_IN_RECENTS_SCREEN'-extra.
+     * @return true if the activity should be started and pushed to the recents screen, false .
      */
     private fun shouldStartInRecentsScreen(intent: Intent?): Boolean {
         intent?.toSafeIntent()?.let {
-            if (it.hasExtra(START_IN_RECENTS_SCREEN)) {
-                return it.getBooleanExtra(START_IN_RECENTS_SCREEN, false)
-            }
+            return it.getBooleanExtra(START_IN_RECENTS_SCREEN, false)
         }
         return false
     }
@@ -514,6 +512,7 @@ open class HomeActivity : LocaleAwareAppCompatActivity() {
         const val OPEN_TO_BROWSER = "open_to_browser"
         const val OPEN_TO_BROWSER_AND_LOAD = "open_to_browser_and_load"
         const val OPEN_TO_SEARCH = "open_to_search"
+        const val OPEN_FROM_SHORTCUT = "open_from_shortcut"
         const val PRIVATE_BROWSING_MODE = "private_browsing_mode"
         const val EXTRA_DELETE_PRIVATE_TABS = "notification_delete_and_open"
         const val EXTRA_OPENED_FROM_NOTIFICATION = "notification_open"

--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -177,7 +177,6 @@ open class HomeActivity : LocaleAwareAppCompatActivity() {
         )
         StartupTimeline.onActivityCreateEndHome(this)
 
-
         if(shouldStartInRecentsScreen(intent)) {
             moveTaskToBack(true)
         }
@@ -197,8 +196,6 @@ open class HomeActivity : LocaleAwareAppCompatActivity() {
                 }
             }
         }
-
-
     }
 
     final override fun onPause() {

--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -176,6 +176,11 @@ open class HomeActivity : LocaleAwareAppCompatActivity() {
             StartupTimeline.homeActivityLifecycleObserver
         )
         StartupTimeline.onActivityCreateEndHome(this)
+
+
+        if(shouldStartInRecentsScreen(intent)) {
+            moveTaskToBack(true)
+        }
     }
 
     @CallSuper
@@ -192,6 +197,8 @@ open class HomeActivity : LocaleAwareAppCompatActivity() {
                 }
             }
         }
+
+
     }
 
     final override fun onPause() {
@@ -311,6 +318,21 @@ open class HomeActivity : LocaleAwareAppCompatActivity() {
             }
         }
         return settings().lastKnownMode
+    }
+
+    /**
+     * Determines whether the activity should be pushed to be backstack (i.e., 'minimized' to the recents
+     * screen) upon starting.
+     * @param intent    The intent that started this activity. Is checked for having the 'START_IN_RECENTS_SCREEN'-extra.
+     * @return          True if the activity should be started and pushed to the recents screen, false .
+     */
+    private fun shouldStartInRecentsScreen(intent: Intent?): Boolean {
+        intent?.toSafeIntent()?.let {
+            if (it.hasExtra(START_IN_RECENTS_SCREEN)) {
+                return it.getBooleanExtra(START_IN_RECENTS_SCREEN, false)
+            }
+        }
+        return false
     }
 
     private fun setupThemeAndBrowsingMode(mode: BrowsingMode) {
@@ -499,5 +521,6 @@ open class HomeActivity : LocaleAwareAppCompatActivity() {
         const val EXTRA_DELETE_PRIVATE_TABS = "notification_delete_and_open"
         const val EXTRA_OPENED_FROM_NOTIFICATION = "notification_open"
         const val delay = 5000L
+        const val START_IN_RECENTS_SCREEN = "start_in_recents_screen"
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/session/NotificationSessionObserver.kt
+++ b/app/src/main/java/org/mozilla/fenix/session/NotificationSessionObserver.kt
@@ -34,7 +34,7 @@ class NotificationSessionObserver(
                 .ifChanged()
                 .collect { hasPrivateTabs ->
                     if (hasPrivateTabs) {
-                        notificationService.start(context)
+                        notificationService.start(context, isStartedFromPrivateShortcut)
                         started = true
                     } else if (started) {
                         notificationService.stop(context)
@@ -46,5 +46,9 @@ class NotificationSessionObserver(
 
     fun stop() {
         scope?.cancel()
+    }
+
+    companion object {
+        var isStartedFromPrivateShortcut = false
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/session/SessionNotificationService.kt
+++ b/app/src/main/java/org/mozilla/fenix/session/SessionNotificationService.kt
@@ -49,6 +49,24 @@ class SessionNotificationService : Service() {
             ACTION_ERASE -> {
                 metrics.track(Event.PrivateBrowsingNotificationTapped)
                 components.core.sessionManager.removeAndCloseAllPrivateSessions()
+
+                val homeScreenIntent = Intent(this, HomeActivity::class.java);
+                val intentFlags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                if (VisibilityLifecycleCallback.finishAndRemoveTaskIfInBackground(this)) {
+                    // Set browsing mode to 'regular' and it's startmode to be in background (recents screen)
+                    homeScreenIntent.apply {
+                        setFlags(intentFlags)
+                        putExtra(HomeActivity.PRIVATE_BROWSING_MODE, false)
+                        putExtra(HomeActivity.START_IN_RECENTS_SCREEN, true)
+                    }
+                } else {
+                    // Bring back the PB Home to foreground
+                    homeScreenIntent.apply {
+                        setFlags(intentFlags)
+                        putExtra(HomeActivity.PRIVATE_BROWSING_MODE, true)
+                    }
+                }
+                startActivity(homeScreenIntent)
             }
 
             else -> throw IllegalStateException("Unknown intent: $intent")

--- a/app/src/main/java/org/mozilla/fenix/session/SessionNotificationService.kt
+++ b/app/src/main/java/org/mozilla/fenix/session/SessionNotificationService.kt
@@ -38,7 +38,7 @@ import org.mozilla.fenix.ext.sessionsOfType
 class SessionNotificationService : Service() {
 
     override fun onStartCommand(intent: Intent, flags: Int, startId: Int): Int {
-        val action = intent.action ?: return Service.START_NOT_STICKY
+        val action = intent.action ?: return START_NOT_STICKY
 
         when (action) {
             ACTION_START -> {
@@ -50,20 +50,16 @@ class SessionNotificationService : Service() {
                 metrics.track(Event.PrivateBrowsingNotificationTapped)
                 components.core.sessionManager.removeAndCloseAllPrivateSessions()
 
-                val homeScreenIntent = Intent(this, HomeActivity::class.java);
+                val homeScreenIntent = Intent(this, HomeActivity::class.java)
                 val intentFlags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                homeScreenIntent.apply {
+                    setFlags(intentFlags)
+                    putExtra(HomeActivity.PRIVATE_BROWSING_MODE, true)
+                }
                 if (VisibilityLifecycleCallback.finishAndRemoveTaskIfInBackground(this)) {
-                    // Set browsing mode to 'regular' and it's startmode to be in background (recents screen)
+                    // Set start mode to be in background (recents screen)
                     homeScreenIntent.apply {
-                        setFlags(intentFlags)
-                        putExtra(HomeActivity.PRIVATE_BROWSING_MODE, false)
                         putExtra(HomeActivity.START_IN_RECENTS_SCREEN, true)
-                    }
-                } else {
-                    // Bring back the PB Home to foreground
-                    homeScreenIntent.apply {
-                        setFlags(intentFlags)
-                        putExtra(HomeActivity.PRIVATE_BROWSING_MODE, true)
                     }
                 }
                 startActivity(homeScreenIntent)
@@ -72,7 +68,7 @@ class SessionNotificationService : Service() {
             else -> throw IllegalStateException("Unknown intent: $intent")
         }
 
-        return Service.START_NOT_STICKY
+        return START_NOT_STICKY
     }
 
     override fun onTaskRemoved(rootIntent: Intent) {

--- a/app/src/main/java/org/mozilla/fenix/session/SessionNotificationService.kt
+++ b/app/src/main/java/org/mozilla/fenix/session/SessionNotificationService.kt
@@ -49,14 +49,6 @@ class SessionNotificationService : Service() {
             ACTION_ERASE -> {
                 metrics.track(Event.PrivateBrowsingNotificationTapped)
                 components.core.sessionManager.removeAndCloseAllPrivateSessions()
-
-                if (!VisibilityLifecycleCallback.finishAndRemoveTaskIfInBackground(this)) {
-                    startActivity(
-                        Intent(this, HomeActivity::class.java).apply {
-                            this.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-                        }
-                    )
-                }
             }
 
             else -> throw IllegalStateException("Unknown intent: $intent")

--- a/app/src/main/java/org/mozilla/fenix/session/VisibilityLifecycleCallback.kt
+++ b/app/src/main/java/org/mozilla/fenix/session/VisibilityLifecycleCallback.kt
@@ -29,7 +29,7 @@ class VisibilityLifecycleCallback(private val activityManager: ActivityManager?)
      * Finishes and removes the list of AppTasks only if the application is in the background.
      * The application is considered to be in the background if it has at least 1 Activity in the
      * started state
-     * @return  True if application is in background (also finishes and removes all AppTasks),
+     * @return True if application is in background (also finishes and removes all AppTasks),
      *          false otherwise
      */
     private fun finishAndRemoveTaskIfInBackground(): Boolean {
@@ -67,7 +67,7 @@ class VisibilityLifecycleCallback(private val activityManager: ActivityManager?)
          * If all activities of this app are in the background then finish and remove all tasks. After
          * that the app won't show up in "recent apps" anymore.
          *
-         * @return  True if application is in background (and consequently, finishes and removes all tasks),
+         * @return True if application is in background (and consequently, finishes and removes all tasks),
          *          false otherwise.
          */
         internal fun finishAndRemoveTaskIfInBackground(context: Context): Boolean {

--- a/app/src/main/java/org/mozilla/fenix/session/VisibilityLifecycleCallback.kt
+++ b/app/src/main/java/org/mozilla/fenix/session/VisibilityLifecycleCallback.kt
@@ -8,14 +8,8 @@ import android.app.Activity
 import android.app.ActivityManager
 import android.app.Application
 import android.content.Context
-import android.content.Intent
-import android.graphics.BitmapFactory
 import android.os.Bundle
 import org.mozilla.fenix.FenixApplication
-import org.mozilla.fenix.HomeActivity
-import org.mozilla.fenix.R
-import org.mozilla.fenix.ext.application
-import org.mozilla.fenix.ext.asActivity
 
 /**
  * This ActivityLifecycleCallbacks implementations tracks if there is at least one activity in the
@@ -48,14 +42,6 @@ class VisibilityLifecycleCallback(private val activityManager: ActivityManager?)
             }
         }
         return false
-    }
-
-    private fun finishAndRemoveTasks() {
-        activityManager?.let {
-            for (task in it.appTasks) {
-                task.finishAndRemoveTask()
-            }
-        }
     }
 
     override fun onActivityStarted(activity: Activity?) {

--- a/app/src/test/java/org/mozilla/fenix/session/NotificationSessionObserverTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/session/NotificationSessionObserverTest.kt
@@ -35,6 +35,7 @@ class NotificationSessionObserverTest {
         store = BrowserStore()
         every { context.components.core.store } returns store
         observer = NotificationSessionObserver(context, notificationService)
+        NotificationSessionObserver.isStartedFromPrivateShortcut = false
     }
 
     @Test
@@ -44,7 +45,7 @@ class NotificationSessionObserverTest {
         store.dispatch(TabListAction.AddTabAction(privateSession)).join()
 
         observer.start()
-        verify(exactly = 1) { notificationService.start(context) }
+        verify(exactly = 1) { notificationService.start(context, false) }
         confirmVerified(notificationService)
     }
 
@@ -57,10 +58,10 @@ class NotificationSessionObserverTest {
         verify { notificationService wasNot Called }
 
         store.dispatch(TabListAction.AddTabAction(normalSession)).join()
-        verify(exactly = 0) { notificationService.start(context) }
+        verify(exactly = 0) { notificationService.start(context, false) }
 
         store.dispatch(CustomTabListAction.AddCustomTabAction(customSession)).join()
-        verify(exactly = 0) { notificationService.start(context) }
+        verify(exactly = 0) { notificationService.start(context, false) }
     }
 
     @Test
@@ -74,9 +75,9 @@ class NotificationSessionObserverTest {
         verify { notificationService wasNot Called }
 
         store.dispatch(CustomTabListAction.AddCustomTabAction(privateCustomSession)).join()
-        verify(exactly = 0) { notificationService.start(context) }
+        verify(exactly = 0) { notificationService.start(context, false) }
 
         store.dispatch(CustomTabListAction.AddCustomTabAction(customSession)).join()
-        verify(exactly = 0) { notificationService.start(context) }
+        verify(exactly = 0) { notificationService.start(context, false) }
     }
 }


### PR DESCRIPTION
[Video with fix](https://drive.google.com/file/d/17g9P1103grkpQ9PnU3i5Ov7orGxCv_VD/view?usp=sharing), states covered:
- press notification when private tab visible
- press notification when private home visible
- press notification when private tab focused and app in background
- press notification when private home focused and app in background

From the static private shortcut or the pinned private shortcut, all 4 cases above redirect to private mode. If you enter the app normally, it will redirect to normal mode.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture