### PR TITLE
 For #9987: Set FLAG_SECURE to dialog when flag set in activity.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/ext/Dialog.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/Dialog.kt
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.ext
+
+import android.app.Activity
+import android.app.Dialog
+import android.view.WindowManager
+
+/**
+ * Checks if activity's window has a FLAG_SECURE set and sets it to dialog
+ */
+fun Dialog.secure(activity: Activity?) {
+    this.window.apply {
+        val flags = activity?.window?.attributes?.flags
+        if (flags != null && flags and WindowManager.LayoutParams.FLAG_SECURE != 0) {
+            this?.setFlags(
+                WindowManager.LayoutParams.FLAG_SECURE,
+                WindowManager.LayoutParams.FLAG_SECURE
+            )
+        }
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/settings/account/AccountSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/account/AccountSettingsFragment.kt
@@ -42,6 +42,7 @@ import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.getPreferenceKey
 import org.mozilla.fenix.ext.requireComponents
+import org.mozilla.fenix.ext.secure
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.showToolbar
 
@@ -240,7 +241,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat() {
                     startActivity(intent)
                 }
                 create()
-            }.show()
+            }.show().secure(activity)
             it.settings().incrementShowLoginsSecureWarningSyncCount()
         }
     }


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture