### PR TITLE
Use HomeFragment's viewLifecycleOwner as the lifecycle for observer registry

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -159,17 +159,6 @@ class HomeFragment : Fragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         postponeEnterTransition()
-
-        val sessionObserver = BrowserSessionsObserver(
-            sessionManager,
-            requireComponents.core.store,
-            singleSessionObserver
-        ) {
-            emitSessionChanges()
-        }
-
-        lifecycle.addObserver(sessionObserver)
-
         if (!onboarding.userHasBeenOnboarded()) {
             requireComponents.analytics.metrics.track(Event.OpenedAppFirstRun)
         }
@@ -182,6 +171,16 @@ class HomeFragment : Fragment() {
     ): View? {
         val view = inflater.inflate(R.layout.fragment_home, container, false)
         val activity = activity as HomeActivity
+
+        val sessionObserver = BrowserSessionsObserver(
+            sessionManager,
+            requireComponents.core.store,
+            singleSessionObserver
+        ) {
+            emitSessionChanges()
+        }
+
+        viewLifecycleOwner.lifecycle.addObserver(sessionObserver)
 
         currentMode = CurrentMode(
             view.context,

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -379,11 +379,15 @@ class HomeFragment : Fragment() {
         )
 
         requireComponents.backgroundServices.accountManagerAvailableQueue.runIfReadyOrQueue {
-            // By the time this code runs, we may not be attached to a context.
-            if ((this@HomeFragment).context == null) {
+            // By the time this code runs, we may not be attached to a context or have a view lifecycle owner.
+            if ((this@HomeFragment).view?.context == null) {
                 return@runIfReadyOrQueue
             }
-            requireComponents.backgroundServices.accountManager.register(currentMode, owner = this@HomeFragment)
+
+            requireComponents.backgroundServices.accountManager.register(
+                currentMode,
+                owner = this@HomeFragment.viewLifecycleOwner
+            )
             requireComponents.backgroundServices.accountManager.register(object : AccountObserver {
                 override fun onAuthenticated(account: OAuthAccount, authType: AuthType) {
                     if (authType != AuthType.Existing) {
@@ -398,7 +402,7 @@ class HomeFragment : Fragment() {
                         }
                     }
                 }
-            }, owner = this@HomeFragment)
+            }, owner = this@HomeFragment.viewLifecycleOwner)
         }
 
         if (context.settings().showPrivateModeContextualFeatureRecommender &&
@@ -618,7 +622,7 @@ class HomeFragment : Fragment() {
 
     @SuppressWarnings("ComplexMethod", "LongMethod")
     private fun createHomeMenu(context: Context, menuButtonView: WeakReference<MenuButton>) = HomeMenu(
-        this,
+        this.viewLifecycleOwner,
         context,
         onItemTapped = {
             when (it) {


### PR DESCRIPTION
If we just use the HomeFragment itself, we end up with a memory leak since the lifecycle events
that would clean up the registry (e.g. destroy) won't run (if the fragment is retained in the backstack, for example).



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture