### PR TITLE
Fix: Set correct height for EditText

### DIFF
--- a/app/src/main/res/layout/fragment_edit_bookmark.xml
+++ b/app/src/main/res/layout/fragment_edit_bookmark.xml
@@ -36,7 +36,7 @@
     <org.mozilla.fenix.utils.ClearableEditText
         android:id="@+id/bookmarkNameEdit"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="@dimen/bookmark_edit_text_height"
         android:layout_marginBottom="8dp"
         android:drawablePadding="8dp"
         android:ellipsize="none"
@@ -62,7 +62,7 @@
     <org.mozilla.fenix.utils.ClearableEditText
         android:id="@+id/bookmarkUrlEdit"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="@dimen/bookmark_edit_text_height"
         android:layout_marginBottom="8dp"
         android:drawablePadding="8dp"
         android:ellipsize="none"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -67,6 +67,9 @@
     <!-- ETP Onboarding Popup -->
     <dimen name="etp_onboarding_popup_width">256dp</dimen>
 
+    <!-- Edit  Fragment  -->
+    <dimen name="bookmark_edit_text_height">48dp</dimen>
+
     <!-- Search Fragment -->
     <dimen name="search_fragment_clipboard_item_height">56dp</dimen>
     <dimen name="search_fragment_clipboard_item_horizontal_margin">12dp</dimen>


### PR DESCRIPTION
Created a dimension for the correct height that the EditText in the
fragment_edit_bookmark.xml has to have.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture