### PR TITLE
8081 l10n screenshots test update latest

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/screenshots/DefaultHomeScreenTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/screenshots/DefaultHomeScreenTest.kt
@@ -47,6 +47,7 @@ class DefaultHomeScreenTest : ScreenshotTest() {
         homeScreen {
             togglePrivateBrowsingModeOnOff()
             Screengrab.screenshot("HomeScreenRobot_private-browsing-menu")
+            togglePrivateBrowsingModeOnOff()
         }
     }
 }

--- a/app/src/androidTest/java/org/mozilla/fenix/screenshots/MenuScreenShotTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/screenshots/MenuScreenShotTest.kt
@@ -80,35 +80,31 @@ class MenuScreenShotTest : ScreenshotTest() {
             Screengrab.screenshot("SettingsSubMenuAccessibilityRobot_settings-accessibility")
             mDevice.pressBack()
 
+            settingsLanguage()
+            Screengrab.screenshot("SettingsSubMenuAccessibilityRobot_settings-language")
+            mDevice.pressBack()
+
             settingDefaultBrowser()
             Screengrab.screenshot("SettingsSubMenuDefaultBrowserRobot_settings-default-browser")
             mDevice.pressBack()
 
-            settingsToolbar()
-            Screengrab.screenshot("SettingsSubMenuDefaultBrowserRobot_settings-toolbar")
+            settingsTP()
+            Screengrab.screenshot("settings-enhanced-tp")
             mDevice.pressBack()
 
-            // Need to find a way to swipe only a little to get all the options in all screensizes
-            // settingsTP()
-            // Screengrab.screenshot("settings-enhanced-tp")
-            // mDevice.pressBack()
-
-            // Need to find a way to swipe only a little to get all the options in all screensizes
-            // settingsAddToHomeScreen()
-            // Screengrab.screenshot("settings-add-to-homescreen")
-            // mDevice.pressBack()
-
-            // Wee need this but this way not going to work in other languages. Need a workaround to not use Sleep
-            // mDevice.waitNotNull(Until.findObjects(By.text("Delete browsing data on quit")), TestAssetHelper.waitingTime)
-            // settingsRemoveData()
-            // Screengrab.screenshot("settings-delete-browsing-data")
-            // device.pressBack()
+            loginsAndPassword()
+            Screengrab.screenshot("SettingsSubMenuLoginsAndPasswords-settings-logins-passwords")
+            mDevice.pressBack()
 
             swipeToBottom()
             Screengrab.screenshot("SettingsRobot_settings-scroll-to-bottom")
 
             settingsTelemetry()
             Screengrab.screenshot("settings-telemetry")
+            mDevice.pressBack()
+
+            addOns()
+            Screengrab.screenshot("settings-addons")
         }
     }
 
@@ -188,6 +184,19 @@ class MenuScreenShotTest : ScreenshotTest() {
             Screengrab.screenshot("remove-tab")
         }
     }
+
+    @Test
+    fun saveLoginPromptTest() {
+        val saveLoginTest =
+                TestAssetHelper.getSaveLoginAsset(mockWebServer)
+        TestAssetHelper.waitingTimeShort
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(saveLoginTest.url) {
+            Screengrab.screenshot("save-login-prompt")
+            TestAssetHelper.waitingTime
+            // verifySaveLoginPromptIsShown()
+        }
+    }
 }
 
 fun openHistoryThreeDotMenu() = onView(withText(R.string.library_history)).click()
@@ -221,3 +230,9 @@ fun settingsAddToHomeScreen() = onView(withText(R.string.preferences_add_private
 fun settingsRemoveData() = onView(withText(R.string.preferences_delete_browsing_data)).click()
 
 fun settingsTelemetry() = onView(withText(R.string.preferences_data_collection)).click()
+
+fun loginsAndPassword() = onView(withText(R.string.preferences_passwords_logins_and_passwords)).click()
+
+fun addOns() = onView(withText(R.string.preferences_addons)).click()
+
+fun settingsLanguage() = onView(withText(R.string.preferences_language)).click()

--- a/fastlane/Screengrabfile
+++ b/fastlane/Screengrabfile
@@ -3,10 +3,10 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 app_package_name('org.mozilla.fenix.debug')
-use_tests_in_packages(['org.mozilla.fenix.ui.screenshots'])
+use_tests_in_packages(['org.mozilla.fenix.screenshots'])
 
-app_apk_path('app/build/outputs/apk/x86/debug/app-x86-debug.apk')
-tests_apk_path('app/build/outputs/apk/androidTest/x86/debug/app-x86-debug-androidTest.apk')
+app_apk_path('app/build/outputs/apk/geckoBeta/debug/app-geckoBeta-x86-debug.apk')
+tests_apk_path('app/build/outputs/apk/androidTest/geckoBeta/debug/app-geckoBeta-debug-androidTest.apk')
 test_instrumentation_runner 'androidx.test.runner.AndroidJUnitRunner'
 
 locales(['en-US', 'fr-FR', 'it-IT', 'de-DE', 'ja', 'ru', 'zh-CN', 'zh-TW', 'ko'])


### PR DESCRIPTION
These tests are not running as part as the regular UI tests but we need to keep them up to date for when a set of screenshots is required.

Some modifications were needed so that they work again as well as a new test added for showing one more screen.