### PR TITLE
For #8399: Hide keyboard to prevent content resizes

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/search/toolbar/ToolbarView.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/toolbar/ToolbarView.kt
@@ -21,6 +21,7 @@ import mozilla.components.concept.storage.HistoryStorage
 import mozilla.components.feature.toolbar.ToolbarAutocompleteFeature
 import mozilla.components.support.ktx.android.content.getColorFromAttr
 import mozilla.components.support.ktx.android.util.dpToPx
+import mozilla.components.support.ktx.android.view.hideKeyboard
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.search.SearchFragmentState
@@ -86,6 +87,10 @@ class ToolbarView(
             elevation = TOOLBAR_ELEVATION_IN_DP.dpToPx(resources.displayMetrics).toFloat()
 
             setOnUrlCommitListener {
+                // We're hiding the keyboard as early as possible to prevent the engine view
+                // from resizing in case the BrowserFragment is being displayed before the
+                // keyboard is gone: https://github.com/mozilla-mobile/fenix/issues/8399
+                hideKeyboard()
                 interactor.onUrlCommitted(it)
                 false
             }


### PR DESCRIPTION
This hides the keyboard after committing a URL in the Toolbar right before we navigate from the SearchFragment to the BrowserFragment. If the BrowserFragment is being displayed before the keyboard is gone an expensive resize of the engine view (content) is triggered when the
keyboard finally goes away. This is to prevent that.
