### PR TITLE
For #9550 - Don't overlap search with shortcuts text

### DIFF
--- a/app/src/main/res/layout/component_awesomebar.xml
+++ b/app/src/main/res/layout/component_awesomebar.xml
@@ -12,7 +12,7 @@
     android:fadingEdgeLength="40dp"
     android:nestedScrollingEnabled="false"
     android:requiresFadingEdge="vertical"
-    app:layout_constraintTop_toTopOf="@id/awesomeBar_barrier"
+    app:layout_constraintTop_toBottomOf="@id/search_with_shortcuts"
     app:layout_constraintEnd_toEndOf="parent"
     app:layout_constraintStart_toStartOf="parent"
     mozac:awesomeBarDescriptionTextColor="?secondaryText"

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -137,7 +137,7 @@
                 android:visibility="gone"
                 android:text="@string/search_shortcuts_search_with_2"
                 app:layout_constraintStart_toStartOf="@id/scrollable_area"
-                app:layout_constraintTop_toBottomOf="@id/divider_line"
+                app:layout_constraintTop_toBottomOf="@id/awesomeBar_barrier"
                 tools:text="This time, search with:" />
 
             <androidx.constraintlayout.widget.Barrier


### PR DESCRIPTION
Private mode search with suggestion onboarding was overlapping "This time, search with: " text. Adjust constraints to allow it to show under onboarding when present.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture