### PR TITLE
For #9856 - AddonsManagementFragment: Use FenixSnackbar for install msg

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/addons/AddonsManagementFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/addons/AddonsManagementFragment.kt
@@ -31,6 +31,7 @@ import mozilla.components.feature.addons.ui.translatedName
 import mozilla.components.lib.state.ext.flowScoped
 import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
 import org.mozilla.fenix.R
+import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.getRootView
 import org.mozilla.fenix.ext.showToolbar
@@ -203,13 +204,16 @@ class AddonsManagementFragment : Fragment(R.layout.fragment_add_ons_management),
             onSuccess = {
                 this@AddonsManagementFragment.view?.let { view ->
                     val rootView = activity?.getRootView() ?: view
-                    showSnackBar(
-                        rootView,
-                        getString(
-                            R.string.mozac_feature_addons_successfully_installed,
-                            it.translatedName
-                        )
+                    FenixSnackbar.make(
+                        view = rootView,
+                        duration = FenixSnackbar.LENGTH_SHORT,
+                        isDisplayedWithBrowserToolbar = false
                     )
+                    .setText(
+                        view.context.getString(R.string.mozac_feature_addons_successfully_installed,
+                        addon.translatedName)
+                    )
+                    .show()
                     bindRecyclerView(view)
                     addonProgressOverlay?.visibility = View.GONE
                     isInstallationInProgress = false
@@ -218,10 +222,16 @@ class AddonsManagementFragment : Fragment(R.layout.fragment_add_ons_management),
             onError = { _, _ ->
                 this@AddonsManagementFragment.view?.let { view ->
                     val rootView = activity?.getRootView() ?: view
-                    showSnackBar(
-                        rootView,
-                        getString(R.string.mozac_feature_addons_failed_to_install, addon.translatedName)
+                    FenixSnackbar.make(
+                        view = rootView,
+                        duration = FenixSnackbar.LENGTH_SHORT,
+                        isDisplayedWithBrowserToolbar = false
                     )
+                    .setText(
+                        view.context.getString(R.string.mozac_feature_addons_failed_to_install,
+                        addon.translatedName)
+                    )
+                    .show()
                     addonProgressOverlay?.visibility = View.GONE
                     isInstallationInProgress = false
                 }


### PR DESCRIPTION
Commit 0def456 uses activity rootview if available to show snackbars,
if using this view we need to be able to set to not use toolbar padding.

Before:
![Screenshot_20200420-103725](https://user-images.githubusercontent.com/59484634/79769275-e6de0900-82f9-11ea-9cf1-6ef145856da7.jpg)

After change:
![Screenshot_20200420-112615](https://user-images.githubusercontent.com/59484634/79769305-f1000780-82f9-11ea-915f-dada2726bfe4.jpg)



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture