### PR TITLE
Closes #9464 [Bug] Tapping on "Deny" from the camera permission doesn't redirect the user to the previous screen (Turn on Sync)

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/PairFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/PairFragment.kt
@@ -4,11 +4,13 @@
 
 package org.mozilla.fenix.settings
 
+import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import android.os.VibrationEffect
 import android.os.Vibrator
 import android.view.View
+import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
 import androidx.core.text.HtmlCompat
 import androidx.fragment.app.Fragment
@@ -94,8 +96,18 @@ class PairFragment : Fragment(R.layout.fragment_pair), UserInteractionHandler {
         grantResults: IntArray
     ) {
         when (requestCode) {
-            REQUEST_CODE_CAMERA_PERMISSIONS -> qrFeature.withFeature {
-                it.onPermissionsResult(permissions, grantResults)
+            REQUEST_CODE_CAMERA_PERMISSIONS -> {
+                if (ContextCompat.checkSelfPermission(
+                        context!!,
+                        android.Manifest.permission.CAMERA
+                    ) == PackageManager.PERMISSION_GRANTED
+                ) {
+                    qrFeature.withFeature {
+                        it.onPermissionsResult(permissions, grantResults)
+                    }
+                } else {
+                    findNavController().popBackStack(R.id.turnOnSyncFragment, false)
+                }
             }
         }
     }


### PR DESCRIPTION
Closes #9464: Tapping on "Deny" from the camera permission doesn't redirect the user to the previous screen (Turn on Sync)
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
![WuEP8lPcTG8J](https://user-images.githubusercontent.com/31808521/79850358-b6f73a00-83bb-11ea-9214-6d1af959950c.gif)


### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
@ekager  @abodea 