### PR TITLE
Speed-up and improve autoPublication workflows for a-c and a-s [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,17 +156,17 @@ git push <remote> --no-verify
 There are multiple helper flags available via `local.properties` that will help speed up local development workflow
 when working across multiple layers of the dependency stack - specifically, with android-components, geckoview or application-services.
 
-### android-components auto-publication workflow
-Specify a relative path to your local `android-components` checkout via `autoPublish.android-components.dir`.
+### Auto-publication workflow for android-components and application-services
+If you're making changes to these projects and want to test them in Fenix, auto-publication workflow is the fastest, most reliable
+way to do that.
 
-If enabled, during a Fenix build android-components will be compiled and locally published if it has been modified,
-and published versions of android-components modules will be automatically used instead of whatever is declared in Dependencies.kt.
+In `local.properties`, specify a relative path to your local `android-components` and/or `application-services` checkouts. E.g.:
+- `autoPublish.android-components.dir=../android-components`
+- `autoPublish.application-services.dir=../application-services`
 
-### application-services auto-publication workflow
-Specify a relative path to your local `application-services` checkout via `autoPublish.application-services.dir`.
+Once these flags are set, your Fenix builds will include any local modifications present in these projects.
 
-If enabled, during a Fenix build application-services will be compiled and locally published,
-and published versions of application-services modules will be automatically used instead of whatever is declared in Dependencies.kt.
+See a [demo of auto-publication workflow in action](https://www.youtube.com/watch?v=qZKlBzVvQGc).
 
 ### GeckoView
 Specify a relative path to your local `mozilla-central` checkout via `dependencySubstitutions.geckoviewTopsrcdir`,

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -249,6 +249,14 @@ This ping is intended to provide an understanding of startup performance.
 The ping is intended to be captured by performance testing automation to report results there, in addition to user telemetry. We place these metrics into their own ping in order to isolate them and make this process easier.
 
 
+**Data reviews for this ping:**
+
+- <https://github.com/mozilla-mobile/fenix/pull/9788#pullrequestreview-394228626>
+
+**Bugs related to this ping:**
+
+- <https://github.com/mozilla-mobile/fenix/issues/8803>
+
 The following metrics are added to the ping:
 
 | Name | Type | Description | Data reviews | Extras | Expiration |

--- a/settings.gradle
+++ b/settings.gradle
@@ -20,10 +20,6 @@ def runCmd(cmd, workingDir, successMessage, captureStdout=true) {
     return captureStdout ? standardOutput : null
 }
 
-def gradlew = './gradlew'
-if (System.properties['os.name'].toLowerCase().contains('windows')) {
-    gradlew += ".bat"
-}
 //////////////////////////////////////////////////////////////////////////
 // Local Development overrides
 //////////////////////////////////////////////////////////////////////////
@@ -49,7 +45,7 @@ if (localProperties != null) {
 
     if (appServicesLocalPath != null) {
         log("Enabling automatic publication of application-services from: $appServicesLocalPath")
-        def publishAppServicesCmd = ["./gradlew", "autoPublishForLocalDevelopment"]
+        def publishAppServicesCmd = ["./automation/publish_to_maven_local_if_modified.py"]
         runCmd(publishAppServicesCmd, appServicesLocalPath, "Published application-services for local development.", false)
     } else {
         log("Disabled auto-publication of application-services. Enable it by settings '$settingAppServicesPath' in local.properties")
@@ -59,19 +55,8 @@ if (localProperties != null) {
 
     if (androidComponentsLocalPath != null) {
         log("Enabling automatic publication of android-components from: $androidComponentsLocalPath")
-        log("Determining if android-components are up-to-date...")
-        def compileAcCmd = [gradlew, "compileReleaseKotlin"]
-        def compileOutput = runCmd(compileAcCmd, androidComponentsLocalPath, "Compiled android-components.")
-        // This is somewhat brittle: parse last line of gradle output, to fish out how many tasks were executed.
-        // One executed task means gradle didn't do any work other than executing the top-level 'compile' task.
-        def compileTasksExecuted = compileOutput.toString().split('\n').last().split(':')[1].split(' ')[1]
-        if (compileTasksExecuted.equals("1")) {
-            log("android-components are up-to-date, skipping publication.")
-        } else {
-            log("android-components changed, publishing locally...")
-            def publishAcCmd = ["${androidComponentsLocalPath}/${gradlew}", "publishToMavenLocal", "-Plocal=true"]
-            runCmd(publishAcCmd, androidComponentsLocalPath, "Published android-components.", false)
-        }
+        def publishAcCmd = ["./automation/publish_to_maven_local_if_modified.py"]
+        runCmd(publishAcCmd, androidComponentsLocalPath, "Published android-components for local development.", false)
     } else {
         log("Disabled auto-publication of android-components. Enable it by settings '$settingAndroidComponentsPath' in local.properties")
     }


### PR DESCRIPTION
This change switches to using python scripts directly in a-c and a-s repositories, which achieves two things:
- we avoid overhead of running through a-c and a-s gradle's build phases, which is quite significant
- all of the logic for checking if projects are up-to-date or need to be republished now lives in those projects

End result is that local fenix builds now incur zero costs if there are no changes in a-c or a-s,
and if there are _any_ changes at all, the corresponding project is reliably recompiled and republished.

Depends on https://github.com/mozilla-mobile/android-components/pull/6732

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture