### PR TITLE
For #6832 - Fix various fragment not attached to a context crashes

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/addons/AddonDetailsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/addons/AddonDetailsFragment.kt
@@ -94,7 +94,7 @@ class AddonDetailsFragment : Fragment(R.layout.fragment_add_on_details) {
     }
 
     private fun showUpdaterDialog(addon: Addon) {
-        lifecycleScope.launch(IO) {
+        viewLifecycleOwner.lifecycleScope.launch(IO) {
             val updateAttempt = updateAttemptStorage.findUpdateAttemptBy(addon.id)
             updateAttempt?.let {
                 withContext(Main) {

--- a/app/src/main/java/org/mozilla/fenix/addons/AddonsManagementFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/addons/AddonsManagementFragment.kt
@@ -98,10 +98,10 @@ class AddonsManagementFragment : Fragment(R.layout.fragment_add_ons_management),
     private fun bindRecyclerView(view: View) {
         val recyclerView = view.add_ons_list
         recyclerView.layoutManager = LinearLayoutManager(requireContext())
-        lifecycleScope.launch(IO) {
+        viewLifecycleOwner.lifecycleScope.launch(IO) {
             try {
                 val addons = requireContext().components.addonManager.getAddons()
-                lifecycleScope.launch(Dispatchers.Main) {
+                viewLifecycleOwner.lifecycleScope.launch(Dispatchers.Main) {
                     runIfFragmentIsAttached {
                         val adapter = AddonsManagerAdapter(
                             requireContext().components.addonCollectionProvider,
@@ -117,9 +117,12 @@ class AddonsManagementFragment : Fragment(R.layout.fragment_add_ons_management),
                     }
                 }
             } catch (e: AddonManagerException) {
-                lifecycleScope.launch(Dispatchers.Main) {
+                viewLifecycleOwner.lifecycleScope.launch(Dispatchers.Main) {
                     runIfFragmentIsAttached {
-                        showSnackBar(view, getString(R.string.mozac_feature_addons_failed_to_query_add_ons))
+                        showSnackBar(
+                            view,
+                            getString(R.string.mozac_feature_addons_failed_to_query_add_ons)
+                        )
                         isInstallationInProgress = false
                         view.add_ons_progress_bar.isVisible = false
                         view.add_ons_empty_message.isVisible = true
@@ -220,7 +223,10 @@ class AddonsManagementFragment : Fragment(R.layout.fragment_add_ons_management),
                     val rootView = activity?.getRootView() ?: view
                     showSnackBar(
                         rootView,
-                        getString(R.string.mozac_feature_addons_failed_to_install, addon.translatedName)
+                        getString(
+                            R.string.mozac_feature_addons_failed_to_install,
+                            addon.translatedName
+                        )
                     )
                     addonProgressOverlay?.visibility = View.GONE
                     isInstallationInProgress = false

--- a/app/src/main/java/org/mozilla/fenix/collections/CollectionCreationController.kt
+++ b/app/src/main/java/org/mozilla/fenix/collections/CollectionCreationController.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.feature.tab.collections.TabCollection
-import mozilla.components.feature.tabs.TabsUseCases
 import org.mozilla.fenix.components.Analytics
 import org.mozilla.fenix.components.TabCollectionStorage
 import org.mozilla.fenix.components.metrics.Event
@@ -64,9 +63,8 @@ class DefaultCollectionCreationController(
     private val dismiss: () -> Unit,
     private val analytics: Analytics,
     private val tabCollectionStorage: TabCollectionStorage,
-    private val tabsUseCases: TabsUseCases,
     private val sessionManager: SessionManager,
-    private val lifecycleScope: CoroutineScope
+    private val viewLifecycleScope: CoroutineScope
 ) : CollectionCreationController {
 
     companion object {
@@ -78,7 +76,7 @@ class DefaultCollectionCreationController(
         dismiss()
 
         val sessionBundle = tabs.toList().toSessionBundle(sessionManager)
-        lifecycleScope.launch(Dispatchers.IO) {
+        viewLifecycleScope.launch(Dispatchers.IO) {
             tabCollectionStorage.createCollection(name, sessionBundle)
         }
 
@@ -89,7 +87,7 @@ class DefaultCollectionCreationController(
 
     override fun renameCollection(collection: TabCollection, name: String) {
         dismiss()
-        lifecycleScope.launch(Dispatchers.IO) {
+        viewLifecycleScope.launch(Dispatchers.IO) {
             tabCollectionStorage.renameCollection(collection, name)
             analytics.metrics.track(Event.CollectionRenamed)
         }
@@ -114,7 +112,7 @@ class DefaultCollectionCreationController(
     override fun selectCollection(collection: TabCollection, tabs: List<Tab>) {
         dismiss()
         val sessionBundle = tabs.toList().toSessionBundle(sessionManager)
-        lifecycleScope.launch(Dispatchers.IO) {
+        viewLifecycleScope.launch(Dispatchers.IO) {
             tabCollectionStorage
                 .addTabsToCollection(collection, sessionBundle)
         }

--- a/app/src/main/java/org/mozilla/fenix/collections/CollectionCreationFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/collections/CollectionCreationFragment.kt
@@ -77,7 +77,6 @@ class CollectionCreationFragment : DialogFragment() {
                 ::dismiss,
                 requireComponents.analytics,
                 requireComponents.core.tabCollectionStorage,
-                requireComponents.useCases.tabsUseCases,
                 requireComponents.core.sessionManager,
                 viewLifecycleOwner.lifecycleScope
             )

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt
@@ -29,7 +29,6 @@ import org.mozilla.fenix.browser.BrowserAnimator
 import org.mozilla.fenix.browser.BrowserAnimator.Companion.getToolbarNavOptions
 import org.mozilla.fenix.browser.BrowserFragment
 import org.mozilla.fenix.browser.BrowserFragmentDirections
-import org.mozilla.fenix.browser.browsingmode.BrowsingModeManager
 import org.mozilla.fenix.browser.readermode.ReaderModeController
 import org.mozilla.fenix.collections.SaveCollectionStep
 import org.mozilla.fenix.components.FenixSnackbar
@@ -59,18 +58,15 @@ interface BrowserToolbarController {
 
 @Suppress("LargeClass")
 class DefaultBrowserToolbarController(
-    private val store: BrowserFragmentStore,
     private val activity: Activity,
     private val navController: NavController,
     private val readerModeController: ReaderModeController,
-    private val browsingModeManager: BrowsingModeManager,
     private val sessionManager: SessionManager,
     private val findInPageLauncher: () -> Unit,
     private val engineView: EngineView,
     private val browserAnimator: BrowserAnimator,
     private val swipeRefresh: SwipeRefreshLayout,
     private val customTabSession: Session?,
-    private val getSupportUrl: () -> String,
     private val openInFenixIntent: Intent,
     private val bookmarkTapped: (Session) -> Unit,
     private val scope: CoroutineScope,

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -211,7 +211,7 @@ class HomeFragment : Fragment() {
                 fragmentStore = homeFragmentStore,
                 navController = findNavController(),
                 browsingModeManager = browsingModeManager,
-                lifecycleScope = viewLifecycleOwner.lifecycleScope,
+                viewLifecycleScope = viewLifecycleOwner.lifecycleScope,
                 closeTab = ::closeTab,
                 closeAllTabs = ::closeAllTabs,
                 getListOfTabs = ::getListOfTabs,
@@ -684,7 +684,7 @@ class HomeFragment : Fragment() {
                 HomeMenu.Item.Quit -> activity?.let { activity ->
                     deleteAndQuit(
                         activity,
-                        lifecycleScope,
+                        viewLifecycleOwner.lifecycleScope,
                         view?.let { view -> FenixSnackbar.make(
                             view = view,
                             isDisplayedWithBrowserToolbar = false
@@ -823,7 +823,7 @@ class HomeFragment : Fragment() {
     }
 
     private fun scrollToTheTop() {
-        lifecycleScope.launch(Main) {
+        viewLifecycleOwner.lifecycleScope.launch(Main) {
             delay(ANIM_SCROLL_DELAY)
             sessionControlView!!.view.smoothScrollToPosition(0)
         }

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
@@ -172,7 +172,7 @@ class DefaultSessionControlController(
     private val fragmentStore: HomeFragmentStore,
     private val navController: NavController,
     private val browsingModeManager: BrowsingModeManager,
-    private val lifecycleScope: CoroutineScope,
+    private val viewLifecycleScope: CoroutineScope,
     private val closeTab: (sessionId: String) -> Unit,
     private val closeAllTabs: (isPrivateMode: Boolean) -> Unit,
     private val getListOfTabs: () -> List<Tab>,
@@ -252,7 +252,7 @@ class DefaultSessionControlController(
     override fun handleCollectionRemoveTab(collection: TabCollection, tab: ComponentTab) {
         metrics.track(Event.CollectionTabRemoved)
 
-        lifecycleScope.launch(Dispatchers.IO) {
+        viewLifecycleScope.launch(Dispatchers.IO) {
             tabCollectionStorage.removeTabFromCollection(collection, tab)
         }
     }
@@ -301,7 +301,7 @@ class DefaultSessionControlController(
             metrics.track(Event.PocketTopSiteRemoved)
         }
 
-        lifecycleScope.launch(Dispatchers.IO) {
+        viewLifecycleScope.launch(Dispatchers.IO) {
             topSiteStorage.removeTopSite(topSite)
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragment.kt
@@ -291,7 +291,7 @@ class BookmarkFragment : LibraryPageFragment<BookmarkNode>(), UserInteractionHan
             else -> throw IllegalStateException("Illegal event type in onDeleteSome")
         }
 
-        lifecycleScope.allowUndo(
+        viewLifecycleOwner.lifecycleScope.allowUndo(
             view!!, message,
             getString(R.string.bookmark_undo_deletion), {
                 pendingBookmarksToDelete.removeAll(selected)

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/addfolder/AddBookmarkFolderFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/addfolder/AddBookmarkFolderFragment.kt
@@ -57,7 +57,7 @@ class AddBookmarkFolderFragment : Fragment(R.layout.fragment_edit_bookmark) {
         super.onResume()
         showToolbar(getString(R.string.bookmark_add_folder_fragment_label))
 
-        lifecycleScope.launch(Main) {
+        viewLifecycleOwner.lifecycleScope.launch(Main) {
             sharedViewModel.selectedFolder = withContext(IO) {
                 sharedViewModel.selectedFolder
                     ?: requireComponents.core.bookmarksStorage.getTree(BookmarkRoot.Mobile.id)
@@ -95,7 +95,7 @@ class AddBookmarkFolderFragment : Fragment(R.layout.fragment_edit_bookmark) {
                     return true
                 }
                 this.view?.hideKeyboard()
-                lifecycleScope.launch(IO) {
+                viewLifecycleOwner.lifecycleScope.launch(IO) {
                     val newGuid = requireComponents.core.bookmarksStorage.addFolder(
                         sharedViewModel.selectedFolder!!.guid, bookmarkNameEdit.text.toString(), null
                     )

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/edit/EditBookmarkFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/edit/EditBookmarkFragment.kt
@@ -65,7 +65,7 @@ class EditBookmarkFragment : Fragment(R.layout.fragment_edit_bookmark) {
         super.onViewCreated(view, savedInstanceState)
         initToolbar()
 
-        lifecycleScope.launch(Main) {
+        viewLifecycleOwner.lifecycleScope.launch(Main) {
             val context = requireContext()
 
             withContext(IO) {
@@ -155,7 +155,7 @@ class EditBookmarkFragment : Fragment(R.layout.fragment_edit_bookmark) {
                     dialog.cancel()
                 }
                 setPositiveButton(R.string.tab_collection_dialog_positive) { dialog: DialogInterface, _ ->
-                    lifecycleScope.launch(IO) {
+                    viewLifecycleOwner.lifecycleScope.launch(IO) {
                         requireComponents.core.bookmarksStorage.deleteNode(args.guidToEdit)
                         requireComponents.analytics.metrics.track(Event.RemoveBookmark)
 
@@ -194,7 +194,7 @@ class EditBookmarkFragment : Fragment(R.layout.fragment_edit_bookmark) {
     }
 
     private fun updateBookmarkNode(title: String?, url: String?) {
-        lifecycleScope.launch(IO) {
+        viewLifecycleOwner.lifecycleScope.launch(IO) {
             try {
                 requireComponents.let { components ->
                     if (title != bookmarkNode?.title || url != bookmarkNode?.url) {

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/selectfolder/SelectBookmarkFolderFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/selectfolder/SelectBookmarkFolderFragment.kt
@@ -50,7 +50,7 @@ class SelectBookmarkFolderFragment : Fragment() {
         super.onResume()
         showToolbar(getString(R.string.bookmark_select_folder_fragment_label))
 
-        lifecycleScope.launch(Main) {
+        viewLifecycleOwner.lifecycleScope.launch(Main) {
             bookmarkNode = withContext(IO) {
                 val context = requireContext()
                 context.components.core.bookmarksStorage
@@ -74,7 +74,7 @@ class SelectBookmarkFolderFragment : Fragment() {
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.add_folder_button -> {
-                lifecycleScope.launch(Main) {
+                viewLifecycleOwner.lifecycleScope.launch(Main) {
                     nav(
                         R.id.bookmarkSelectFolderFragment,
                         SelectBookmarkFolderFragmentDirections

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragment.kt
@@ -106,7 +106,7 @@ class HistoryFragment : LibraryPageFragment<HistoryItem>(), UserInteractionHandl
     }
 
     private fun deleteHistoryItems(items: Set<HistoryItem>) {
-        lifecycleScope.launch {
+        viewLifecycleOwner.lifecycleScope.launch {
             context?.components?.run {
                 for (item in items) {
                     analytics.metrics.track(Event.HistoryItemRemoved)
@@ -155,7 +155,7 @@ class HistoryFragment : LibraryPageFragment<HistoryItem>(), UserInteractionHandl
             true
         }
         R.id.delete_history_multi_select -> {
-            lifecycleScope.launch(Main) {
+            viewLifecycleOwner.lifecycleScope.launch(Main) {
                 deleteSelectedHistory(historyStore.state.mode.selectedItems, requireComponents)
                 viewModel.invalidate()
                 historyStore.dispatch(HistoryFragmentAction.ExitDeletionMode)
@@ -216,7 +216,7 @@ class HistoryFragment : LibraryPageFragment<HistoryItem>(), UserInteractionHandl
                 }
                 setPositiveButton(R.string.delete_browsing_data_prompt_allow) { dialog: DialogInterface, _ ->
                     historyStore.dispatch(HistoryFragmentAction.EnterDeletionMode)
-                    lifecycleScope.launch {
+                    viewLifecycleOwner.lifecycleScope.launch {
                         requireComponents.analytics.metrics.track(Event.HistoryAllItemsRemoved)
                         requireComponents.core.historyStorage.deleteEverything()
                         launch(Main) {

--- a/app/src/main/java/org/mozilla/fenix/search/SearchController.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchController.kt
@@ -47,7 +47,7 @@ class DefaultSearchController(
     private val context: Context,
     private val store: SearchFragmentStore,
     private val navController: NavController,
-    private val lifecycleScope: CoroutineScope,
+    private val viewLifecycleScope: CoroutineScope,
     private val clearToolbarFocus: () -> Unit
 ) : SearchController {
 
@@ -82,7 +82,7 @@ class DefaultSearchController(
     }
 
     override fun handleEditingCancelled() {
-        lifecycleScope.launch {
+        viewLifecycleScope.launch {
             clearToolbarFocus()
             // Delay a short amount so the keyboard begins animating away. This makes exit animation
             // much smoother instead of having two separate parts (keyboard hides THEN animation)

--- a/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
@@ -109,7 +109,7 @@ class SearchFragment : Fragment(), UserInteractionHandler {
             context = activity as HomeActivity,
             store = searchStore,
             navController = findNavController(),
-            lifecycleScope = viewLifecycleOwner.lifecycleScope,
+            viewLifecycleScope = viewLifecycleOwner.lifecycleScope,
             clearToolbarFocus = ::clearToolbarFocus
         )
 

--- a/app/src/main/java/org/mozilla/fenix/settings/LoginsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/LoginsFragment.kt
@@ -69,7 +69,7 @@ class LoginsFragment : PreferenceFragmentCompat(), AccountObserver {
 
             override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
                 Log.d(LOG_TAG, "onAuthenticationSucceeded")
-                lifecycleScope.launch(Main) {
+                viewLifecycleOwner.lifecycleScope.launch(Main) {
                     // Workaround for likely biometric library bug
                     // https://github.com/mozilla-mobile/fenix/issues/8438
                     delay(SHORT_DELAY_MS)

--- a/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
@@ -51,7 +51,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
     private val accountObserver = object : AccountObserver {
         private fun updateAccountUi(profile: Profile? = null) {
             val context = context ?: return
-            lifecycleScope.launch {
+            viewLifecycleOwner.lifecycleScope.launch {
                 updateAccountUIState(
                     context = context,
                     profile = profile
@@ -125,7 +125,8 @@ class SettingsFragment : PreferenceFragmentCompat() {
         // update it here if we're not going through the `onCreate->onStart->onResume` lifecycle chain.
         update(shouldUpdateAccountUIState = !creatingFragment)
 
-        view!!.findViewById<RecyclerView>(R.id.recycler_view)?.hideInitialScrollBar(lifecycleScope)
+        view!!.findViewById<RecyclerView>(R.id.recycler_view)
+            ?.hideInitialScrollBar(viewLifecycleOwner.lifecycleScope)
 
         // Consider finish of `onResume` to be the point at which we consider this fragment as 'created'.
         creatingFragment = false
@@ -376,10 +377,14 @@ class SettingsFragment : PreferenceFragmentCompat() {
             preferenceSignIn?.isVisible = false
 
             profile?.avatar?.url?.let { avatarUrl ->
-                lifecycleScope.launch(Main) {
-                    val roundedDrawable = avatarUrl.toRoundedDrawable(context, requireComponents.core.client)
+                viewLifecycleOwner.lifecycleScope.launch(Main) {
+                    val roundedDrawable =
+                        avatarUrl.toRoundedDrawable(context, requireComponents.core.client)
                     preferenceFirefoxAccount?.icon =
-                        roundedDrawable ?: AppCompatResources.getDrawable(context, R.drawable.ic_account)
+                        roundedDrawable ?: AppCompatResources.getDrawable(
+                            context,
+                            R.drawable.ic_account
+                        )
                 }
             }
             preferenceSignIn?.onPreferenceClickListener = null
@@ -420,7 +425,8 @@ class SettingsFragment : PreferenceFragmentCompat() {
                 settings.overrideSyncTokenServer.isNotEmpty() ||
                 settings.showSecretDebugMenuThisSession
         // Only enable changes to these prefs when the user isn't connected to an account.
-        val enabled = requireComponents.backgroundServices.accountManager.authenticatedAccount() == null
+        val enabled =
+            requireComponents.backgroundServices.accountManager.authenticatedAccount() == null
         preferenceFxAOverride?.apply {
             isVisible = show
             isEnabled = enabled

--- a/app/src/main/java/org/mozilla/fenix/settings/account/AccountSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/account/AccountSettingsFragment.kt
@@ -55,13 +55,13 @@ class AccountSettingsFragment : PreferenceFragmentCompat() {
     // Navigate away from this fragment when we encounter auth problems or logout events.
     private val accountStateObserver = object : AccountObserver {
         override fun onAuthenticationProblems() {
-            lifecycleScope.launch {
+            viewLifecycleOwner.lifecycleScope.launch {
                 findNavController().popBackStack()
             }
         }
 
         override fun onLoggedOut() {
-            lifecycleScope.launch {
+            viewLifecycleOwner.lifecycleScope.launch {
                 findNavController().popBackStack()
 
                 // Remove the device name when we log out.
@@ -266,7 +266,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat() {
     }
 
     private fun syncNow() {
-        lifecycleScope.launch {
+        viewLifecycleOwner.lifecycleScope.launch {
             requireComponents.analytics.metrics.track(Event.SyncAccountSyncNow)
             // Trigger a sync.
             requireComponents.backgroundServices.accountManager.syncNowAsync(SyncReason.User)
@@ -285,7 +285,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat() {
             return false
         }
         // This may fail, and we'll have a disparity in the UI until `updateDeviceName` is called.
-        lifecycleScope.launch(Main) {
+        viewLifecycleOwner.lifecycleScope.launch(Main) {
             context?.let {
                 accountManager.authenticatedAccount()
                     ?.deviceConstellation()
@@ -336,7 +336,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat() {
 
     private val syncStatusObserver = object : SyncStatusObserver {
         override fun onStarted() {
-            lifecycleScope.launch {
+            viewLifecycleOwner.lifecycleScope.launch {
                 val pref = findPreference<Preference>(getPreferenceKey(R.string.pref_key_sync_now))
                 view?.announceForAccessibility(getString(R.string.sync_syncing_in_progress))
                 pref?.title = getString(R.string.sync_syncing_in_progress)
@@ -347,7 +347,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat() {
 
         // Sync stopped successfully.
         override fun onIdle() {
-            lifecycleScope.launch {
+            viewLifecycleOwner.lifecycleScope.launch {
                 val pref = findPreference<Preference>(getPreferenceKey(R.string.pref_key_sync_now))
                 pref?.let {
                     pref.title = getString(R.string.preferences_sync_now)
@@ -364,7 +364,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat() {
 
         // Sync stopped after encountering a problem.
         override fun onError(error: Exception?) {
-            lifecycleScope.launch {
+            viewLifecycleOwner.lifecycleScope.launch {
                 val pref = findPreference<Preference>(getPreferenceKey(R.string.pref_key_sync_now))
                 pref?.let {
                     pref.title = getString(R.string.preferences_sync_now)

--- a/app/src/main/java/org/mozilla/fenix/settings/account/SignOutFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/account/SignOutFragment.kt
@@ -61,7 +61,7 @@ class SignOutFragment : BottomSheetDialogFragment() {
         super.onViewCreated(view, savedInstanceState)
 
         view.signOutDisconnect.setOnClickListener {
-            lifecycleScope.launch {
+            viewLifecycleOwner.lifecycleScope.launch {
                 requireComponents
                     .backgroundServices.accountAbnormalities.userRequestedLogout()
                 accountManager.logoutAsync().await()

--- a/app/src/main/java/org/mozilla/fenix/settings/logins/SavedLoginSiteInfoFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/SavedLoginSiteInfoFragment.kt
@@ -96,7 +96,7 @@ class SavedLoginSiteInfoFragment : Fragment(R.layout.fragment_saved_login_site_i
 
     private fun deleteLogin() {
         var deleteLoginJob: Deferred<Boolean>? = null
-        val deleteJob = lifecycleScope.launch(IO) {
+        val deleteJob = viewLifecycleOwner.lifecycleScope.launch(IO) {
             deleteLoginJob = async {
                 requireContext().components.core.passwordsStorage.delete(args.savedLoginItem.id)
             }

--- a/app/src/main/java/org/mozilla/fenix/settings/logins/SavedLoginsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/SavedLoginsFragment.kt
@@ -136,7 +136,7 @@ class SavedLoginsFragment : Fragment() {
 
     private fun loadAndMapLogins() {
         var deferredLogins: Deferred<List<Login>>? = null
-        val fetchLoginsJob = lifecycleScope.launch(IO) {
+        val fetchLoginsJob = viewLifecycleOwner.lifecycleScope.launch(IO) {
             deferredLogins = async {
                 requireContext().components.core.passwordsStorage.list()
             }

--- a/app/src/main/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsSheetDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsSheetDialogFragment.kt
@@ -72,7 +72,7 @@ class QuickSettingsSheetDialogFragment : AppCompatDialogFragment() {
         quickSettingsController = DefaultQuickSettingsController(
             context = context,
             quickSettingsStore = quickSettingsStore,
-            coroutineScope = lifecycleScope,
+            coroutineScope = viewLifecycleOwner.lifecycleScope,
             navController = findNavController(),
             session = context.components.core.sessionManager.findSessionById(args.sessionId),
             sitePermissions = args.sitePermissions,

--- a/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsDetailsExceptionsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsDetailsExceptionsFragment.kt
@@ -44,7 +44,7 @@ class SitePermissionsDetailsExceptionsFragment : PreferenceFragmentCompat() {
     override fun onResume() {
         super.onResume()
         showToolbar(sitePermissions.origin)
-        lifecycleScope.launch(IO) {
+        viewLifecycleOwner.lifecycleScope.launch(IO) {
             val context = requireContext()
             sitePermissions =
                 requireNotNull(context.components.core.permissionStorage.findSitePermissionsBy(sitePermissions.origin))
@@ -96,7 +96,7 @@ class SitePermissionsDetailsExceptionsFragment : PreferenceFragmentCompat() {
     }
 
     private fun clearSitePermissions() {
-        lifecycleScope.launch(IO) {
+        viewLifecycleOwner.lifecycleScope.launch(IO) {
             requireContext().components.core.permissionStorage.deleteSitePermissions(sitePermissions)
             withContext(Main) {
                 requireView().findNavController().popBackStack()

--- a/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsExceptionsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsExceptionsFragment.kt
@@ -108,7 +108,7 @@ class SitePermissionsExceptionsFragment :
     }
 
     private fun deleteAllSitePermissions() {
-        lifecycleScope.launch(IO) {
+        viewLifecycleOwner.lifecycleScope.launch(IO) {
             requireContext().components.core.permissionStorage.deleteAllSitePermissions()
             launch(Main) {
                 showEmptyListMessage()

--- a/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsManageExceptionsPhoneFeatureFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsManageExceptionsPhoneFeatureFragment.kt
@@ -163,7 +163,7 @@ class SitePermissionsManageExceptionsPhoneFeatureFragment : Fragment() {
             PhoneFeature.AUTOPLAY_AUDIBLE -> sitePermissions.copy(autoplayAudible = status)
             PhoneFeature.AUTOPLAY_INAUDIBLE -> sitePermissions.copy(autoplayInaudible = status)
         }
-        lifecycleScope.launch(IO) {
+        viewLifecycleOwner.lifecycleScope.launch(IO) {
             requireComponents.core.permissionStorage.updateSitePermissions(updatedSitePermissions)
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/share/ShareController.kt
+++ b/app/src/main/java/org/mozilla/fenix/share/ShareController.kt
@@ -68,7 +68,7 @@ class DefaultShareController(
     private val snackbar: FenixSnackbar,
     private val navController: NavController,
     private val recentAppsStorage: RecentAppsStorage,
-    private val lifecycleScope: CoroutineScope,
+    private val viewLifecycleScope: CoroutineScope,
     private val dismiss: (ShareController.Result) -> Unit
 ) : ShareController {
 
@@ -83,7 +83,7 @@ class DefaultShareController(
     }
 
     override fun handleShareToApp(app: AppShareOption) {
-        lifecycleScope.launch(Dispatchers.IO) {
+        viewLifecycleScope.launch(Dispatchers.IO) {
             recentAppsStorage.updateRecentApp(app.activityName)
         }
 

--- a/app/src/main/java/org/mozilla/fenix/share/ShareFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/share/ShareFragment.kt
@@ -79,7 +79,7 @@ class ShareFragment : AppCompatDialogFragment() {
                 navController = findNavController(),
                 sendTabUseCases = SendTabUseCases(accountManager),
                 recentAppsStorage = RecentAppsStorage(requireContext()),
-                lifecycleScope = lifecycleScope
+                viewLifecycleScope = viewLifecycleOwner.lifecycleScope
             ) { result ->
                 consumePrompt {
                     when (result) {

--- a/app/src/test/java/org/mozilla/fenix/collections/DefaultCollectionCreationControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/collections/DefaultCollectionCreationControllerTest.kt
@@ -42,8 +42,10 @@ class DefaultCollectionCreationControllerTest {
         every { state.tabCollections } returns emptyList()
         every { state.tabs } returns emptyList()
 
-        controller = DefaultCollectionCreationController(store, dismiss, analytics,
-            tabCollectionStorage, tabsUseCases, sessionManager, testCoroutineScope)
+        controller = DefaultCollectionCreationController(
+            store, dismiss, analytics,
+            tabCollectionStorage, sessionManager, testCoroutineScope
+        )
     }
 
     @Test

--- a/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarControllerTest.kt
@@ -46,7 +46,6 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.browser.BrowserAnimator
 import org.mozilla.fenix.browser.BrowserFragment
 import org.mozilla.fenix.browser.BrowserFragmentDirections
-import org.mozilla.fenix.browser.browsingmode.BrowsingModeManager
 import org.mozilla.fenix.browser.readermode.ReaderModeController
 import org.mozilla.fenix.collections.SaveCollectionStep
 import org.mozilla.fenix.components.Analytics
@@ -71,12 +70,10 @@ class DefaultBrowserToolbarControllerTest {
     private var swipeRefreshLayout: SwipeRefreshLayout = mockk(relaxed = true)
     private var activity: HomeActivity = mockk(relaxed = true)
     private var analytics: Analytics = mockk(relaxed = true)
-    private val browsingModeManager: BrowsingModeManager = mockk(relaxed = true)
     private var navController: NavController = mockk(relaxed = true)
     private var findInPageLauncher: () -> Unit = mockk(relaxed = true)
     private val engineView: EngineView = mockk(relaxed = true)
     private val currentSession: Session = mockk(relaxed = true)
-    private val getSupportUrl: () -> String = { "https://supportUrl.org" }
     private val openInFenixIntent: Intent = mockk(relaxed = true)
     private val currentSessionAsTab: Tab = mockk(relaxed = true)
     private val metrics: MetricController = mockk(relaxed = true)
@@ -104,12 +101,10 @@ class DefaultBrowserToolbarControllerTest {
         controller = DefaultBrowserToolbarController(
             activity = activity,
             navController = navController,
-            browsingModeManager = browsingModeManager,
             findInPageLauncher = findInPageLauncher,
             engineView = engineView,
             browserAnimator = browserAnimator,
             customTabSession = null,
-            getSupportUrl = getSupportUrl,
             openInFenixIntent = openInFenixIntent,
             scope = scope,
             swipeRefresh = swipeRefreshLayout,
@@ -118,7 +113,6 @@ class DefaultBrowserToolbarControllerTest {
             bookmarkTapped = mockk(),
             readerModeController = readerModeController,
             sessionManager = mockk(),
-            store = mockk(),
             sharedViewModel = mockk()
         )
 
@@ -200,12 +194,10 @@ class DefaultBrowserToolbarControllerTest {
         controller = DefaultBrowserToolbarController(
             activity = activity,
             navController = navController,
-            browsingModeManager = browsingModeManager,
             findInPageLauncher = findInPageLauncher,
             engineView = engineView,
             browserAnimator = browserAnimator,
             customTabSession = null,
-            getSupportUrl = getSupportUrl,
             openInFenixIntent = openInFenixIntent,
             scope = this,
             swipeRefresh = swipeRefreshLayout,
@@ -214,7 +206,6 @@ class DefaultBrowserToolbarControllerTest {
             bookmarkTapped = mockk(),
             readerModeController = mockk(),
             sessionManager = mockk(),
-            store = mockk(),
             sharedViewModel = mockk()
         )
 
@@ -353,12 +344,10 @@ class DefaultBrowserToolbarControllerTest {
         controller = DefaultBrowserToolbarController(
             activity = activity,
             navController = navController,
-            browsingModeManager = browsingModeManager,
             findInPageLauncher = findInPageLauncher,
             engineView = engineView,
             browserAnimator = browserAnimator,
             customTabSession = null,
-            getSupportUrl = getSupportUrl,
             openInFenixIntent = openInFenixIntent,
             scope = this,
             swipeRefresh = swipeRefreshLayout,
@@ -367,7 +356,6 @@ class DefaultBrowserToolbarControllerTest {
             bookmarkTapped = mockk(),
             readerModeController = mockk(),
             sessionManager = mockk(),
-            store = mockk(),
             sharedViewModel = mockk()
         )
         controller.ioScope = this
@@ -560,12 +548,10 @@ class DefaultBrowserToolbarControllerTest {
         controller = DefaultBrowserToolbarController(
             activity = activity,
             navController = navController,
-            browsingModeManager = browsingModeManager,
             findInPageLauncher = findInPageLauncher,
             engineView = engineView,
             browserAnimator = browserAnimator,
             customTabSession = currentSession,
-            getSupportUrl = getSupportUrl,
             openInFenixIntent = openInFenixIntent,
             scope = scope,
             swipeRefresh = swipeRefreshLayout,
@@ -574,7 +560,6 @@ class DefaultBrowserToolbarControllerTest {
             bookmarkTapped = mockk(),
             readerModeController = mockk(),
             sessionManager = mockk(),
-            store = mockk(),
             sharedViewModel = mockk()
         )
 
@@ -602,12 +587,10 @@ class DefaultBrowserToolbarControllerTest {
         controller = DefaultBrowserToolbarController(
             activity = activity,
             navController = navController,
-            browsingModeManager = browsingModeManager,
             findInPageLauncher = findInPageLauncher,
             engineView = engineView,
             browserAnimator = browserAnimator,
             customTabSession = null,
-            getSupportUrl = getSupportUrl,
             openInFenixIntent = openInFenixIntent,
             scope = testScope,
             swipeRefresh = swipeRefreshLayout,
@@ -616,7 +599,6 @@ class DefaultBrowserToolbarControllerTest {
             bookmarkTapped = mockk(),
             readerModeController = mockk(),
             sessionManager = mockk(),
-            store = mockk(),
             sharedViewModel = mockk()
         )
 

--- a/app/src/test/java/org/mozilla/fenix/home/DefaultSessionControlControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/DefaultSessionControlControllerTest.kt
@@ -88,7 +88,7 @@ class DefaultSessionControlControllerTest {
             fragmentStore = fragmentStore,
             navController = navController,
             browsingModeManager = browsingModeManager,
-            lifecycleScope = MainScope(),
+            viewLifecycleScope = MainScope(),
             closeTab = closeTab,
             closeAllTabs = closeAllTabs,
             getListOfTabs = getListOfTabs,

--- a/app/src/test/java/org/mozilla/fenix/search/DefaultSearchControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/search/DefaultSearchControllerTest.kt
@@ -66,7 +66,7 @@ class DefaultSearchControllerTest {
             context = context,
             store = store,
             navController = navController,
-            lifecycleScope = lifecycleScope,
+            viewLifecycleScope = lifecycleScope,
             clearToolbarFocus = clearToolbarFocus
         )
 
@@ -96,7 +96,7 @@ class DefaultSearchControllerTest {
             context = context,
             store = store,
             navController = navController,
-            lifecycleScope = this,
+            viewLifecycleScope = this,
             clearToolbarFocus = clearToolbarFocus
         )
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -249,6 +249,14 @@ This ping is intended to provide an understanding of startup performance.
 The ping is intended to be captured by performance testing automation to report results there, in addition to user telemetry. We place these metrics into their own ping in order to isolate them and make this process easier.
 
 
+**Data reviews for this ping:**
+
+- <https://github.com/mozilla-mobile/fenix/pull/9788#pullrequestreview-394228626>
+
+**Bugs related to this ping:**
+
+- <https://github.com/mozilla-mobile/fenix/issues/8803>
+
 The following metrics are added to the ping:
 
 | Name | Type | Description | Data reviews | Extras | Expiration |


### PR DESCRIPTION
If you use `lifecycleScope` to launch, it will be canceled before the fragment's `onDestroy()`, which can be too late to touch views inside of the scope. We want to be using `viewLifecycleScope` for a tighter lifecycle.

See a list of the rare but numerous crashes I believe are tied to this issue:
https://sentry.prod.mozaws.net/operations/fenix-nightly/?query=is%3Aunresolved+attached+to+a+context&statsPeriod=14d

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture