### PR TITLE
No issue: Update Flank in UI-Tests Dockerfile [dummy edit]

### DIFF
--- a/taskcluster/docker/ui-tests/Dockerfile
+++ b/taskcluster/docker/ui-tests/Dockerfile
@@ -1,6 +1,8 @@
 # %ARG DOCKER_IMAGE_PARENT
 FROM $DOCKER_IMAGE_PARENT
-MAINTAINER Richard Pappalardo <rpappalax@gmail.com>
+
+LABEL authors="Richard Pappalardo <rpappalax@gmail.com>, Aaron Train <atrain@mozilla.com>"
+LABEL maintainer="Richard Pappalardo <rpappalax@gmail.com>
 
 #----------------------------------------------------------------------------------------------------------------------
 #-- Test tools --------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Dummy edit required to force update Flank in UI-Tests Dockerfile.

$ java -jar flank.jar --version
flank_snapshot
7b518f26d5d06f510901b1ec8b61421239e2edb3

This should use that flank_snapshot version (April 22, 2020).