### PR TITLE
Upgrade to A-C 39.0.20200422203205

### DIFF
--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "39.0.20200422145552"
+    const val VERSION = "39.0.20200422203205"
 }


### PR DESCRIPTION
Need another manual A-C upgrade to bring in Arturo's fix to `SupportedAddonsChecker` that makes sure we check for newly supported add-ons on startup.