### PR TITLE
Revert "Bug 1631839 - part 1: Expose new routes without `project.`"

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -168,18 +168,11 @@ tasks:
                                         # staging release promotion on forks.
                                         - $if: 'tasks_for == "github-push"'
                                           then:
-                                              - index.mobile.v2.${project}.branch.${short_head_branch}.latest.taskgraph.decision
-                                              - index.mobile.v2.${project}.branch.${short_head_branch}.revision.${head_sha}.taskgraph.decision
-                                              # TODO Bug 1631839: Remove the following routes once all consumers have migrated
                                               - index.project.mobile.${project}.v2.branch.${short_head_branch}.latest.taskgraph.decision
                                               - index.project.mobile.${project}.v2.branch.${short_head_branch}.revision.${head_sha}.taskgraph.decision
                                         - $if: 'tasks_for == "cron"'
                                           then:
                                               # cron context provides ${head_branch} as a short one
-                                              - index.mobile.v2.${project}.branch.${head_branch}.latest.taskgraph.decision-${cron.job_name}
-                                              - index.mobile.v2.${project}.branch.${head_branch}.revision.${head_sha}.taskgraph.decision-${cron.job_name}
-                                              - index.mobile.v2.${project}.branch.${head_branch}.revision.${head_sha}.taskgraph.cron.${ownTaskId}
-                                              # TODO Bug 1631839: Remove the following routes once all consumers have migrated
                                               - index.project.mobile.${project}.v2.branch.${head_branch}.latest.taskgraph.decision-${cron.job_name}
                                               - index.project.mobile.${project}.v2.branch.${head_branch}.revision.${head_sha}.taskgraph.decision-${cron.job_name}
                                               - index.project.mobile.${project}.v2.branch.${head_branch}.revision.${head_sha}.taskgraph.cron.${ownTaskId}

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -25,7 +25,7 @@ taskgraph:
     repositories:
         mobile:
             name: "Fenix"
-    cached-task-prefix: mobile.v2.fenix
+    cached-task-prefix: project.mobile.fenix
     decision-parameters: 'fenix_taskgraph.parameters:get_decision_parameters'
 
 workers:

--- a/taskcluster/fenix_taskgraph/routes.py
+++ b/taskcluster/fenix_taskgraph/routes.py
@@ -12,12 +12,6 @@ from taskgraph.transforms.task import index_builder
 # In the future, notifying consumers may be easier (https://bugzilla.mozilla.org/show_bug.cgi?id=1548810), but
 # we need to remember to tell users for the time being
 SIGNING_ROUTE_TEMPLATES = [
-    "index.{trust-domain}.v2.{project}.{variant}.latest.{abi}",
-    "index.{trust-domain}.v2.{project}.{variant}.{build_date}.revision.{head_rev}.{abi}",
-    "index.{trust-domain}.v2.{project}.{variant}.{build_date}.latest.{abi}",
-    "index.{trust-domain}.v2.{project}.{variant}.revision.{head_rev}.{abi}",
-
-    # TODO Bug 1631839: Remove the following scopes once all consumers have migrated
     "index.project.{trust-domain}.{project}.v2.{variant}.{build_date}.revision.{head_rev}",
     "index.project.{trust-domain}.{project}.v2.{variant}.{build_date}.latest",
     "index.project.{trust-domain}.{project}.v2.{variant}.latest",
@@ -26,6 +20,8 @@ SIGNING_ROUTE_TEMPLATES = [
 
 @index_builder("signing")
 def add_signing_indexes(config, task):
+    routes = task.setdefault("routes", [])
+
     if config.params["level"] != "3":
         return task
 
@@ -36,11 +32,6 @@ def add_signing_indexes(config, task):
     subs["trust-domain"] = config.graph_config["trust-domain"]
     subs["variant"] = task["attributes"]["build-type"]
 
-    unique_routes = set()
     for tpl in SIGNING_ROUTE_TEMPLATES:
-        for abi in task["attributes"]["apks"].keys():
-            subs["abi"] = abi
-            unique_routes.add(tpl.format(**subs))
-
-    task.setdefault("routes", sorted(list(unique_routes)))
+        routes.append(tpl.format(**subs))
     return task


### PR DESCRIPTION
Reverts mozilla-mobile/fenix#10092

#10092 broke the decision task with an error I've never seen before and I currently don't understand:

```
[task 2020-04-23T09:26:18.316Z] 2020-04-23 09:26:18,316 - INFO - Replaced 7 tasks by index-search during optimization.
[task 2020-04-23T09:26:18.318Z] Traceback (most recent call last):
[task 2020-04-23T09:26:18.319Z]   File "/builds/worker/.local/lib/python2.7/site-packages/taskgraph/main.py", line 480, in main
[task 2020-04-23T09:26:18.319Z]     args.command(vars(args))
[task 2020-04-23T09:26:18.320Z]   File "/builds/worker/.local/lib/python2.7/site-packages/taskgraph/main.py", line 320, in decision
[task 2020-04-23T09:26:18.320Z]     taskgraph_decision(options)
[task 2020-04-23T09:26:18.320Z]   File "/builds/worker/.local/lib/python2.7/site-packages/taskgraph/decision.py", line 109, in taskgraph_decision
[task 2020-04-23T09:26:18.321Z]     write_artifact('task-graph.json', tgg.morphed_task_graph.to_json())
[task 2020-04-23T09:26:18.321Z]   File "/builds/worker/.local/lib/python2.7/site-packages/taskgraph/generator.py", line 199, in morphed_task_graph
[task 2020-04-23T09:26:18.321Z]     return self._run_until('morphed_task_graph')
[task 2020-04-23T09:26:18.321Z]   File "/builds/worker/.local/lib/python2.7/site-packages/taskgraph/generator.py", line 338, in _run_until
[task 2020-04-23T09:26:18.322Z]     k, v = self._run.next()
[task 2020-04-23T09:26:18.322Z]   File "/builds/worker/.local/lib/python2.7/site-packages/taskgraph/generator.py", line 330, in _run
[task 2020-04-23T09:26:18.322Z]     optimized_task_graph, label_to_taskid, parameters, graph_config)
[task 2020-04-23T09:26:18.322Z]   File "/builds/worker/.local/lib/python2.7/site-packages/taskgraph/morph.py", line 246, in morph
[task 2020-04-23T09:26:18.323Z]     taskgraph, label_to_taskid = m(taskgraph, label_to_taskid, parameters, graph_config)
[task 2020-04-23T09:26:18.323Z]   File "/builds/worker/.local/lib/python2.7/site-packages/taskgraph/morph.py", line 159, in add_index_tasks
[task 2020-04-23T09:26:18.324Z]     added.append(make_index_task(task, taskgraph, label_to_taskid, parameters, graph_config))
[task 2020-04-23T09:26:18.324Z]   File "/builds/worker/.local/lib/python2.7/site-packages/taskgraph/morph.py", line 122, in make_index_task
[task 2020-04-23T09:26:18.324Z]     taskgraph, label_to_taskid, parameters, graph_config)
[task 2020-04-23T09:26:18.325Z]   File "/builds/worker/.local/lib/python2.7/site-packages/taskgraph/morph.py", line 59, in derive_misc_task
[task 2020-04-23T09:26:18.325Z]     image_taskid = label_to_taskid['build-docker-image-' + image]
[task 2020-04-23T09:26:18.325Z] KeyError: u'build-docker-image-index-task'
```