### PR TITLE
Bug 1632427 - Define artifact_prefix in browsertime task

### DIFF
--- a/taskcluster/ci/browsertime/kind.yml
+++ b/taskcluster/ci/browsertime/kind.yml
@@ -20,6 +20,8 @@ only-for-abis:
     - arm64-v8a
 
 job-defaults:
+    attributes:
+        artifact_prefix: public/test_info
     dependencies:
         geckoview-nightly: geckoview-nightly
     notify:

--- a/taskcluster/fenix_taskgraph/transforms/visual_metrics.py
+++ b/taskcluster/fenix_taskgraph/transforms/visual_metrics.py
@@ -64,10 +64,6 @@ def run_visual_metrics(config, jobs):
                 'extract': True
             }]
 
-            # Set the artifact prefix for the browsertime results
-            job.setdefault('attributes', {})
-            job['attributes']['artifact_prefix'] = 'public/test_info'
-
             # vismet runs on Linux but we want to have it displayed
             # alongside the job it was triggered by to make it easier for
             # people to find it back.

--- a/try_task_config.json
+++ b/try_task_config.json
@@ -1,7 +1,0 @@
-{
-    "parameters": {
-        "optimize_target_tasks": true,
-        "target_tasks_method": "browsertime"
-    },
-    "version": 2
-}

--- a/try_task_config.json
+++ b/try_task_config.json
@@ -1,0 +1,7 @@
+{
+    "parameters": {
+        "optimize_target_tasks": true,
+        "target_tasks_method": "browsertime"
+    },
+    "version": 2
+}


### PR DESCRIPTION
Graph is green at: https://firefox-ci-tc.services.mozilla.com/tasks/groups/HSGAHr4PQiOxpIh37C51jg

We're now getting the artifact prefix from the dependent task (here, browsertime): https://hg.mozilla.org/ci/taskgraph/rev/1777b15a4fb990f2862ddcd9bdc8188c566abefb#l2.95

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture