### PR TITLE
For #10162: Set switch back to prev state when failed to enable/disable addon

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/addons/InstalledAddonDetailsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/addons/InstalledAddonDetailsFragment.kt
@@ -116,6 +116,7 @@ class InstalledAddonDetailsFragment : Fragment() {
                         runIfFragmentIsAttached {
                             switch.isClickable = true
                             view.remove_add_on.isEnabled = true
+                            switch.setState(addon.isEnabled())
                             showSnackBar(
                                 view,
                                 getString(
@@ -149,6 +150,7 @@ class InstalledAddonDetailsFragment : Fragment() {
                         runIfFragmentIsAttached {
                             switch.isClickable = true
                             view.remove_add_on.isEnabled = true
+                            switch.setState(addon.isEnabled())
                             showSnackBar(
                                 view,
                                 getString(
@@ -230,6 +232,7 @@ class InstalledAddonDetailsFragment : Fragment() {
                     }
                 },
                 onError = {
+                    switch.isChecked = addon.isAllowedInPrivateBrowsing()
                     runIfFragmentIsAttached {
                         switch.isClickable = true
                         view.remove_add_on.isEnabled = true


### PR DESCRIPTION
Debugged and verified that setting `switch.isChecked`  inside `switch.setOnCheckedChangeListener` doesn't fire up the callback again.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture