### PR TITLE
For #10201 - Provide proper button padding and no tabs message visibility in tabs tray

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayFragment.kt
@@ -217,7 +217,8 @@ class TabTrayFragment : Fragment(R.layout.fragment_tab_tray), TabsTray.Observer,
     private fun onTabsChanged() {
         val hasNoTabs = getListOfSessions().toList().isEmpty()
 
-        view?.tab_tray_empty_view?.isVisible = !hasNoTabs
+        view?.tab_tray_empty_view?.isVisible = hasNoTabs
+        view?.tabsTray?.asView()?.isVisible = !hasNoTabs
         view?.save_to_collection_button?.isVisible = !hasNoTabs
 
         if (hasNoTabs) {

--- a/app/src/main/res/layout/fragment_tab_tray.xml
+++ b/app/src/main/res/layout/fragment_tab_tray.xml
@@ -5,7 +5,6 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:mozac="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -36,15 +35,15 @@
         mozac:tabsTraySelectedItemBackgroundColor="?tabTrayItemSelectedBackground"
         mozac:tabsTraySelectedItemTextColor="?tabTrayItemSelectedText" />
 
-        <include
-            layout="@layout/save_to_collection_button"
-            android:id="@+id/save_to_collection_button"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingStart="16dp"
-            android:paddingEnd="16dp"
-            app:layout_constraintBottom_toTopOf="@id/bottomBarShadow"
-            app:layout_constraintTop_toBottomOf="@+id/tabsTray" />
+    <include
+        layout="@layout/save_to_collection_button"
+        android:id="@+id/save_to_collection_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        app:layout_constraintBottom_toTopOf="@id/bottomBarShadow"
+        app:layout_constraintTop_toBottomOf="@+id/tabsTray" />
 
     <View
         android:id="@+id/bottomBarShadow"


### PR DESCRIPTION
 - Adds left and right margin to "Save to Collections" button
-  Properly shows and hides the tab tray empty message based on number of open tabs



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture