### PR TITLE
"Open in Firefox Preview" from Custom Tab should open tab, not home page.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/IntentReceiverActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/IntentReceiverActivity.kt
@@ -42,7 +42,8 @@ class IntentReceiverActivity : Activity() {
 
     suspend fun processIntent(intent: Intent) {
         // Call process for side effects, short on the first that returns true
-        val processor = getIntentProcessors().firstOrNull { it.process(intent) }
+        val processor =
+            getIntentProcessors().firstOrNull { it.process(intent) || it.process(intent) }
         val intentProcessorType = components.intentProcessors.getType(processor)
 
         launch(intent, intentProcessorType)


### PR DESCRIPTION
Since last commit (a477f14) didn't call `match()`, TabIntentProcessor won't have the chance to intercept the intent from Custom Tab "Open in Firefox Preview" menu item.

Before we fix the combination of `match()` and `process()` in A-C, we need to call it this way here: if matched, then process it.

It's a simple fix so screenshot and unit tests are not needed


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture