### PR TITLE
Fixes #4840 - Adds dark search widget based on system theme

### DIFF
--- a/app/src/main/res/drawable/rounded_dark_corners.xml
+++ b/app/src/main/res/drawable/rounded_dark_corners.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/inset_dark_theme" />
+    <corners android:radius="@dimen/tab_corner_radius"/>
+</shape>

--- a/app/src/main/res/layout/search_widget_extra_small_v1_dark.xml
+++ b/app/src/main/res/layout/search_widget_extra_small_v1_dark.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@id/button_search_widget_new_tab"
+    android:layout_width="match_parent"
+    android:layout_height="50dp"
+    android:background="@drawable/rounded_dark_corners"
+    android:layout_gravity="center">
+
+    <ImageView
+        android:id="@+id/button_search_widget_new_tab_icon"
+        android:layout_width="50dp"
+        android:layout_height="50dp"
+        android:scaleType="centerInside"
+        tools:src="@drawable/ic_launcher_foreground"
+        android:layout_gravity="center"/>
+
+</FrameLayout>

--- a/app/src/main/res/layout/search_widget_extra_small_v2_dark.xml
+++ b/app/src/main/res/layout/search_widget_extra_small_v2_dark.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:id="@id/button_search_widget_new_tab"
+        android:layout_width="64dp"
+        android:layout_height="50dp"
+        android:background="@drawable/rounded_dark_corners"
+        android:layout_gravity="center">
+
+    <ImageView
+            android:id="@+id/button_search_widget_new_tab_icon"
+            android:layout_width="50dp"
+            android:layout_height="50dp"
+            android:scaleType="centerInside"
+            tools:src="@drawable/ic_launcher_foreground"
+            android:layout_gravity="center"/>
+</FrameLayout>

--- a/app/src/main/res/layout/search_widget_large_dark.xml
+++ b/app/src/main/res/layout/search_widget_large_dark.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?><!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="50dp"
+    android:layout_gravity="center"
+    android:background="@drawable/rounded_dark_corners">
+
+    <ImageView
+        android:id="@+id/button_search_widget_new_tab_icon"
+        android:contentDescription="@string/browser_menu_new_tab"
+        android:layout_width="50dp"
+        android:layout_height="50dp"
+        android:layout_alignParentStart="true"
+        android:scaleType="centerInside" />
+
+    <TextView
+        android:id="@+id/button_search_widget_new_tab"
+        android:layout_width="match_parent"
+        android:layout_height="32dp"
+        android:layout_marginStart="9dp"
+        android:layout_marginTop="9dp"
+        android:layout_toEndOf="@id/button_search_widget_new_tab_icon"
+        android:gravity="center_vertical"
+        android:letterSpacing="-0.025"
+        android:textAlignment="viewStart"
+        android:textColor="@color/primary_text_dark_theme"
+        android:textSize="15sp"
+        tools:text="Test"
+        tools:ignore="RtlCompat" />
+
+    <ImageButton
+        android:id="@+id/button_search_widget_voice"
+        android:contentDescription="@string/search_widget_voice"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
+        android:layout_alignTop="@id/button_search_widget_new_tab"
+        android:layout_alignParentEnd="true"
+        android:layout_marginEnd="9dp"
+        android:backgroundTint="@color/primary_text_dark_theme"
+        android:background="@drawable/ic_microphone_widget" />
+</RelativeLayout>

--- a/app/src/main/res/layout/search_widget_medium_dark.xml
+++ b/app/src/main/res/layout/search_widget_medium_dark.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?><!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="192dp"
+    android:layout_height="50dp"
+    android:layout_gravity="center"
+    android:background="@drawable/rounded_dark_corners">
+
+    <ImageView
+        android:id="@+id/button_search_widget_new_tab_icon"
+        android:contentDescription="@string/browser_menu_new_tab"
+        android:layout_width="50dp"
+        android:layout_height="50dp"
+        android:layout_alignParentStart="true"
+        android:scaleType="centerInside" />
+
+    <TextView
+        android:id="@+id/button_search_widget_new_tab"
+        android:layout_width="match_parent"
+        android:layout_height="32dp"
+        android:layout_marginStart="9dp"
+        android:layout_marginTop="9dp"
+        android:layout_toEndOf="@id/button_search_widget_new_tab_icon"
+        android:gravity="center_vertical"
+        android:letterSpacing="-0.025"
+        android:textAlignment="viewStart"
+        android:textColor="@color/primary_text_dark_theme"
+        android:textSize="15sp"
+        tools:ignore="RtlCompat" />
+
+    <ImageButton
+        android:id="@+id/button_search_widget_voice"
+        android:contentDescription="@string/search_widget_voice"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
+        android:layout_alignTop="@id/button_search_widget_new_tab"
+        android:layout_alignParentEnd="true"
+        android:layout_marginEnd="9dp"
+        android:backgroundTint="@color/primary_text_dark_theme"
+        android:background="@drawable/ic_microphone_widget" />
+</RelativeLayout>

--- a/app/src/main/res/layout/search_widget_small_dark.xml
+++ b/app/src/main/res/layout/search_widget_small_dark.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="100dp"
+    android:layout_height="50dp"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:background="@drawable/rounded_dark_corners"
+    android:orientation="horizontal">
+
+    <ImageView
+        android:id="@+id/button_search_widget_new_tab_icon"
+        android:layout_width="50dp"
+        android:layout_height="50dp"
+        android:scaleType="centerInside" />
+
+    <ImageView
+        android:id="@+id/button_search_widget_voice"
+        android:layout_width="50dp"
+        android:layout_height="50dp"
+        android:padding="10dp"
+        android:tint="@color/primary_text_dark_theme"
+        app:srcCompat="@drawable/ic_microphone_widget"
+        android:scaleType="centerInside" />
+</LinearLayout>

--- a/app/src/main/res/layout/search_widget_small_no_mic_dark.xml
+++ b/app/src/main/res/layout/search_widget_small_no_mic_dark.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@id/button_search_widget_new_tab"
+        android:layout_width="100dp"
+        android:layout_height="50dp"
+        android:background="@drawable/rounded_dark_corners"
+        android:layout_gravity="center"
+        android:orientation="vertical">
+
+    <ImageView
+            android:id="@+id/button_search_widget_new_tab_icon"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:layout_gravity="center"/>
+</FrameLayout>


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

## Screenshots: 
* System theme dark, fenix theme light
![image](https://user-images.githubusercontent.com/12149313/80278315-db804880-8712-11ea-8827-56a033ce4f5d.png)

* System theme light, fenix theme light
![image](https://user-images.githubusercontent.com/12149313/80278335-05396f80-8713-11ea-9ace-4b7cb00d1e4d.png)
