### PR TITLE
Open in Firefox Preview" from Custom Tab should open tab, not home page.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -435,6 +435,7 @@ open class HomeActivity : LocaleAwareAppCompatActivity() {
         const val OPEN_TO_BROWSER_AND_LOAD = "open_to_browser_and_load"
         const val OPEN_TO_SEARCH = "open_to_search"
         const val PRIVATE_BROWSING_MODE = "private_browsing_mode"
+        const val BROWSER_TOOLBAR_MODE = "browser_toolbar_mode"
         const val EXTRA_DELETE_PRIVATE_TABS = "notification_delete_and_open"
         const val EXTRA_OPENED_FROM_NOTIFICATION = "notification_open"
         const val delay = 5000L

--- a/app/src/main/java/org/mozilla/fenix/IntentReceiverActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/IntentReceiverActivity.kt
@@ -69,7 +69,8 @@ class IntentReceiverActivity : Activity() {
             intent.putExtra(HomeActivity.PRIVATE_BROWSING_MODE, false)
             listOf(
                 components.intentProcessors.customTabIntentProcessor,
-                components.intentProcessors.intentProcessor
+                components.intentProcessors.intentProcessor,
+                components.intentProcessors.browserToolbarIntentProcessor
             )
         }
 

--- a/app/src/main/java/org/mozilla/fenix/components/IntentProcessorType.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/IntentProcessorType.kt
@@ -11,7 +11,7 @@ import org.mozilla.fenix.customtabs.ExternalAppBrowserActivity
 import org.mozilla.fenix.migration.MigrationProgressActivity
 
 enum class IntentProcessorType {
-    EXTERNAL_APP, NEW_TAB, MIGRATION, OTHER;
+    EXTERNAL_APP, NEW_TAB, MIGRATION, BROWSER_TOOLBAR, OTHER;
 
     /**
      * The destination activity based on this intent
@@ -19,7 +19,7 @@ enum class IntentProcessorType {
     val activityClassName: String
         get() = when (this) {
             EXTERNAL_APP -> ExternalAppBrowserActivity::class.java.name
-            NEW_TAB, OTHER -> HomeActivity::class.java.name
+            NEW_TAB, BROWSER_TOOLBAR, OTHER -> HomeActivity::class.java.name
             MIGRATION -> MigrationProgressActivity::class.java.name
         }
 
@@ -30,6 +30,7 @@ enum class IntentProcessorType {
         EXTERNAL_APP -> true
         NEW_TAB -> intent.flags and Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY == 0
         MIGRATION, OTHER -> false
+        BROWSER_TOOLBAR -> true
     }
 }
 
@@ -43,5 +44,6 @@ fun IntentProcessors.getType(processor: IntentProcessor?) = when {
             privateCustomTabIntentProcessor == processor -> IntentProcessorType.EXTERNAL_APP
     intentProcessor == processor ||
             privateIntentProcessor == processor -> IntentProcessorType.NEW_TAB
+    browserToolbarIntentProcessor == processor -> IntentProcessorType.BROWSER_TOOLBAR
     else -> IntentProcessorType.OTHER
 }

--- a/app/src/main/java/org/mozilla/fenix/components/IntentProcessors.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/IntentProcessors.kt
@@ -18,6 +18,7 @@ import mozilla.components.feature.session.SessionUseCases
 import mozilla.components.support.migration.MigrationIntentProcessor
 import mozilla.components.support.migration.state.MigrationStore
 import org.mozilla.fenix.BuildConfig
+import org.mozilla.fenix.components.toolbar.BrowserToolbarIntentProcessor
 import org.mozilla.fenix.customtabs.FennecWebAppIntentProcessor
 import org.mozilla.fenix.home.intent.FennecBookmarkShortcutsIntentProcessor
 import org.mozilla.fenix.utils.Mockable
@@ -52,6 +53,10 @@ class IntentProcessors(
 
     val customTabIntentProcessor by lazy {
         CustomTabIntentProcessor(sessionManager, sessionUseCases.loadUrl, context.resources, isPrivate = false)
+    }
+
+    val browserToolbarIntentProcessor by lazy {
+        BrowserToolbarIntentProcessor()
     }
 
     val privateCustomTabIntentProcessor by lazy {

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt
@@ -23,6 +23,7 @@ import mozilla.components.browser.state.selector.selectedTab
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.concept.engine.prompt.ShareData
 import mozilla.components.support.ktx.kotlin.isUrl
+import org.mozilla.fenix.HomeActivity.Companion.BROWSER_TOOLBAR_MODE
 import org.mozilla.fenix.NavGraphDirections
 import org.mozilla.fenix.R
 import org.mozilla.fenix.browser.BrowserAnimator
@@ -254,6 +255,9 @@ class DefaultBrowserToolbarController(
                 // Strip the CustomTabConfig to turn this Session into a regular tab and then select it
                 customTabSession!!.customTabConfig = null
                 activity.components.core.sessionManager.select(customTabSession)
+
+                // BrowserToolbarIntentProcessor need this to check if the intent is from BrowserToolbar
+                openInFenixIntent.putExtra(BROWSER_TOOLBAR_MODE, true)
 
                 // Switch to the actual browser which should now display our new selected session
                 activity.startActivity(openInFenixIntent)

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarIntentProcessor.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarIntentProcessor.kt
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.components.toolbar
+
+import android.content.Intent
+import mozilla.components.feature.intent.processing.IntentProcessor
+import org.mozilla.fenix.HomeActivity
+
+
+/**
+ * Handle the intent from BrowserToolBar in custom tab
+ */
+class BrowserToolbarIntentProcessor : IntentProcessor {
+
+    override suspend fun process(intent: Intent): Boolean {
+        return intent.extras?.getBoolean(HomeActivity.BROWSER_TOOLBAR_MODE) == true
+    }
+
+}


### PR DESCRIPTION
This PR is not ready to land. I'd like to seek some early advice before I refine it.

I can't find a good place to place the logic for Intents from `BrowserToolbarController` to 
 `HomeActivity` [here](https://github.com/mozilla-mobile/fenix/blob/master/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt#L259)

If I follow the contract in [TabIntentProcessor](https://github.com/mozilla-mobile/android-components/blob/945d1a4727c78efd0a9be2143e6bcc1c72b2226c/components/feature/intent/src/main/java/mozilla/components/feature/intent/processing/TabIntentProcessor.kt#L50) and  set data Uri in `openInFenixIntent` intent,  it will create an additional session.
```
    private fun processViewIntent(intent: SafeIntent): Boolean {
        val url = intent.dataString

        return if (url.isNullOrEmpty()) {
            false
        } else {
            val session = createSession(url, private = isPrivate, source = Source.ACTION_VIEW)
             // ----- a new session. will be created.-------
            loadUrlUseCase(url, session, LoadUrlFlags.external())
            true
        }
    }
```
If I want to follow the logic in [OpenBrowserIntentProcessor](https://github.com/mozilla-mobile/fenix/blob/9f154dc3a0584c8f5753c729a015374536c0c9fd/app/src/main/java/org/mozilla/fenix/home/intent/OpenBrowserIntentProcessor.kt#L24), and put `OPEN_TO_BROWSER` in `openInFenixIntent` intent,
```
override fun process(intent: Intent, navController: NavController, out: Intent): Boolean {
       // ----- I can't follow the contract here...continue reading for the reason.... -----
        return if (intent.extras?.getBoolean(HomeActivity.OPEN_TO_BROWSER) == true) {
            out.putExtra(HomeActivity.OPEN_TO_BROWSER, false)

            activity.openToBrowser(BrowserDirection.FromGlobal, getIntentSessionId(intent.toSafeIntent()))
            true
        } else {
            false
        }
    }
```
It's not possible because this flag will be clear by [IntentRecieverActivity](https://github.com/mozilla-mobile/fenix/blob/c38cfae69d01c7b2d757f9f752d4abbf359d0142/app/src/main/java/org/mozilla/fenix/IntentReceiverActivity.kt#L45)  due to there isn't a right `IntentProcessor` for it so it was treated as "OTHERS" `IntentProcessorType`
```
    suspend fun processIntent(intent: Intent) {
        val processor = getIntentProcessors().firstOrNull { it.process(intent) }
        // -----above will return null, thus below will be `OTHERS`-----
        val intentProcessorType = components.intentProcessors.getType(processor)

        launch(intent, intentProcessorType)
    }

    private fun launch(intent: Intent, intentProcessorType: IntentProcessorType) {
        intent.setClassName(applicationContext, intentProcessorType.activityClassName)

        // ----- and later `OPEN_TO_BROWSER` will be set to false again because shouldOpenToBrowser will return false for "OTHERS" IntentProcessorType -----
        intent.putExtra(HomeActivity.OPEN_TO_BROWSER, intentProcessorType.shouldOpenToBrowser(intent))

        startActivity(intent)
        finish() 
    }
```

So when the time `HomeActivity` [wants to process it](https://github.com/mozilla-mobile/fenix/blob/c38cfae69d01c7b2d757f9f752d4abbf359d0142/app/src/main/java/org/mozilla/fenix/HomeActivity.kt#L140) this flag will still be false
```
    override fun process(intent: Intent, navController: NavController, out: Intent): Boolean {
       // ----- `OPEN_TO_BROWSER` is false so this will return false.-----
        return if (intent.extras?.getBoolean(HomeActivity.OPEN_TO_BROWSER) == true) {
            out.putExtra(HomeActivity.OPEN_TO_BROWSER, false)

            activity.openToBrowser(BrowserDirection.FromGlobal, getIntentSessionId(intent.toSafeIntent()))
            true
        } else {
            false
        }
    }
```

In my two cents, it seems to make sense to have both `HomeIntentProcessor`(in Fenix only) and `IntentProcessor`(from feature-intent) for different purposes of communication.
But the interaction will make it hard. Avoid using the same Intent Action, or Intent Data as logic for `process` seems to be unavoidable.  Since there's already a contract for intent processing(`IntentProcessor`from feature-intent), we should extend it and have the centralized control there. That's why I create another `BrowserToolbarIntentProcessor` and implement `IntentProcessor` instead of `HomeIntentProcessor`


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture