### PR TITLE
For #9880 - fixed sync settings style

### DIFF
--- a/app/src/main/res/layout/checkbox_left_preference.xml
+++ b/app/src/main/res/layout/checkbox_left_preference.xml
@@ -13,7 +13,7 @@
     android:gravity="center_vertical"
     android:paddingStart="16dp"
     android:layout_marginBottom="8dp"
-    android:paddingEnd="?android:attr/scrollbarSize">
+    android:paddingEnd="16dp">
 
     <LinearLayout
         android:id="@android:id/widget_frame"

--- a/app/src/main/res/xml/account_settings_preferences.xml
+++ b/app/src/main/res/xml/account_settings_preferences.xml
@@ -2,17 +2,21 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <androidx.preference.Preference
+        app:iconSpaceReserved="false"
         android:key="@string/pref_key_sync_now"
         android:title="@string/preferences_sync_now" />
 
     <androidx.preference.EditTextPreference
+        app:iconSpaceReserved="false"
         android:key="@string/pref_key_sync_device_name"
         android:title="@string/preferences_sync_device_name" />
 
     <androidx.preference.Preference
+        app:iconSpaceReserved="false"
         android:key="@string/pref_key_sign_out"
         android:title="@string/preferences_sign_out" />
 
@@ -24,16 +28,19 @@
         <androidx.preference.CheckBoxPreference
             android:defaultValue="true"
             android:key="@string/pref_key_sync_bookmarks"
+            android:layout="@layout/checkbox_left_preference"
             android:title="@string/preferences_sync_bookmarks" />
 
         <androidx.preference.CheckBoxPreference
             android:defaultValue="true"
             android:key="@string/pref_key_sync_history"
+            android:layout="@layout/checkbox_left_preference"
             android:title="@string/preferences_sync_history" />
 
         <androidx.preference.CheckBoxPreference
             android:defaultValue="true"
             android:key="@string/pref_key_sync_logins"
+            android:layout="@layout/checkbox_left_preference"
             android:title="@string/preferences_sync_logins" />
     </androidx.preference.PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
I also had to change checkbox_left_preference.xml, otherwise the checkboxes were truncated in RTL.

Before:

![before](https://user-images.githubusercontent.com/1100614/80415279-9dca1e00-88d2-11ea-9f4d-46a1793eb295.png)

After:

![after](https://user-images.githubusercontent.com/1100614/80415290-a3276880-88d2-11ea-9039-7196f55e1eba.png)