### PR TITLE
disable lottie and upgrade OkHTTP to 4.5.0 [do not merge]

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -538,7 +538,7 @@ dependencies {
 
     implementation Deps.google_flexbox
 
-    implementation Deps.lottie
+//    implementation Deps.lottie
 
     implementation Deps.adjust
     implementation Deps.installreferrer // Required by Adjust

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarIntegration.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarIntegration.kt
@@ -6,8 +6,8 @@ package org.mozilla.fenix.components.toolbar
 
 import android.content.Context
 import androidx.appcompat.content.res.AppCompatResources
-import com.airbnb.lottie.LottieCompositionFactory
-import com.airbnb.lottie.LottieDrawable
+// import com.airbnb.lottie.LottieCompositionFactory
+// import com.airbnb.lottie.LottieDrawable
 import mozilla.components.browser.domains.autocomplete.DomainAutocompleteProvider
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.toolbar.BrowserToolbar
@@ -92,45 +92,45 @@ class DefaultToolbarIntegration(
         toolbar.display.menuBuilder = toolbarMenu.menuBuilder
         toolbar.private = isPrivate
 
-        val task = LottieCompositionFactory
-            .fromRawRes(
-                context,
-                ThemeManager.resolveAttribute(R.attr.shieldLottieFile, context)
-            )
-        task.addListener { result ->
-            val lottieDrawable = LottieDrawable()
-            lottieDrawable.composition = result
-
-            toolbar.display.indicators =
-                if (context.settings().shouldUseTrackingProtection) {
-                    listOf(
-                        DisplayToolbar.Indicators.TRACKING_PROTECTION,
-                        DisplayToolbar.Indicators.SECURITY,
-                        DisplayToolbar.Indicators.EMPTY
-                    )
-                } else {
-                    listOf(
-                        DisplayToolbar.Indicators.SECURITY,
-                        DisplayToolbar.Indicators.EMPTY
-                    )
-                }
-
-            toolbar.display.displayIndicatorSeparator =
-                context.settings().shouldUseTrackingProtection
-
-            toolbar.display.icons = toolbar.display.icons.copy(
-                emptyIcon = null,
-                trackingProtectionTrackersBlocked = lottieDrawable,
-                trackingProtectionNothingBlocked = AppCompatResources.getDrawable(
-                    context,
-                    R.drawable.ic_tracking_protection_enabled
-                )!!,
-                trackingProtectionException = AppCompatResources.getDrawable(
-                    context,
-                    R.drawable.ic_tracking_protection_disabled
-                )!!
-            )
-        }
+//        val task = LottieCompositionFactory
+//            .fromRawRes(
+//                context,
+//                ThemeManager.resolveAttribute(R.attr.shieldLottieFile, context)
+//            )
+//        task.addListener { result ->
+//            val lottieDrawable = LottieDrawable()
+//            lottieDrawable.composition = result
+//
+//            toolbar.display.indicators =
+//                if (context.settings().shouldUseTrackingProtection) {
+//                    listOf(
+//                        DisplayToolbar.Indicators.TRACKING_PROTECTION,
+//                        DisplayToolbar.Indicators.SECURITY,
+//                        DisplayToolbar.Indicators.EMPTY
+//                    )
+//                } else {
+//                    listOf(
+//                        DisplayToolbar.Indicators.SECURITY,
+//                        DisplayToolbar.Indicators.EMPTY
+//                    )
+//                }
+//
+//            toolbar.display.displayIndicatorSeparator =
+//                context.settings().shouldUseTrackingProtection
+//
+//            toolbar.display.icons = toolbar.display.icons.copy(
+//                emptyIcon = null,
+//                trackingProtectionTrackersBlocked = lottieDrawable,
+//                trackingProtectionNothingBlocked = AppCompatResources.getDrawable(
+//                    context,
+//                    R.drawable.ic_tracking_protection_enabled
+//                )!!,
+//                trackingProtectionException = AppCompatResources.getDrawable(
+//                    context,
+//                    R.drawable.ic_tracking_protection_disabled
+//                )!!
+//            )
+//        }
 
         val tabsAction = TabCounterToolbarButton(sessionManager, isPrivate) {
             toolbar.hideKeyboard()

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -40,12 +40,12 @@ object Versions {
     const val mockito = "2.24.5"
     const val mockk = "1.9.kotlin12"
 
-    const val mockwebserver = "3.11.0"
+    const val mockwebserver = "4.5.0"
     const val uiautomator = "2.2.0"
 
     const val google_ads_id_version = "16.0.0"
 
-    const val airbnb_lottie = "3.3.0"
+//    const val airbnb_lottie = "3.3.0"
 }
 
 @Suppress("unused")
@@ -204,7 +204,7 @@ object Deps {
 
     const val google_ads_id = "com.google.android.gms:play-services-ads-identifier:${Versions.google_ads_id_version}"
 
-    const val lottie = "com.airbnb.android:lottie:${Versions.airbnb_lottie}"
+//    const val lottie = "com.airbnb.android:lottie:${Versions.airbnb_lottie}"
 
     const val detektApi = "io.gitlab.arturbosch.detekt:detekt-api:${Versions.detekt}"
     const val detektTest = "io.gitlab.arturbosch.detekt:detekt-test:${Versions.detekt}"


### PR DESCRIPTION
Hacky disabling of the tracking protection shield to allow removal of Lottie so we can try OkHTTP 4.5.0

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture