### PR TITLE
no issue - removed unused feature flag

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -26,11 +26,6 @@ object FeatureFlags {
     val dynamicBottomToolbar = Config.channel.isNightlyOrDebug
 
     /**
-     * Enables deleting individual tracking protection exceptions.
-     */
-    val deleteIndividualTrackingProtectionExceptions = Config.channel.isNightlyOrDebug
-
-    /**
      * Integration of push support provided by `feature-push` component into the Gecko engine.
      *
      * Behind nightly flag until all fatal bugs are resolved.


### PR DESCRIPTION
The feature flag was removed in https://github.com/mozilla-mobile/fenix/commit/b484ad38cc9f95a74f37ca7c74f9cc53391d75a7 and accidentally re-added in #9191. It is unused.