### PR TITLE
No issue: remove listing directory contents on UI test results

### DIFF
--- a/automation/taskcluster/androidTest/ui-test.sh
+++ b/automation/taskcluster/androidTest/ui-test.sh
@@ -99,14 +99,8 @@ function failure_check() {
     if [[ $exitcode -ne 0 ]]; then
         echo "FAILURE: UI test run failed, please check above URL"
     else
-	echo "All UI test(s) have passed!"
+	      echo "All UI test(s) have passed!"
     fi
-
-    echo
-    echo "RESULTS"
-    echo
-    ls -la "${RESULTS_DIR}" 
-
 
     echo
     echo "RESULTS"


### PR DESCRIPTION
This might have been added for debugging purposes but it just clutters the output and it dumps a RESULTS header twice e.g, [log](https://firefox-ci-tc.services.mozilla.com/tasks/JFkI0WNeQ3KR9MCahyB1JA/runs/0/logs/https%3A%2F%2Ffirefox-ci-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FJFkI0WNeQ3KR9MCahyB1JA%2Fruns%2F0%2Fartifacts%2Fpublic%2Flogs%2Flive.log ).

