### PR TITLE
For #6313 - On first load, hides engineView until firstContentfulPaint

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -40,12 +40,6 @@ import org.mozilla.fenix.helpers.click
 import org.mozilla.fenix.helpers.ext.waitNotNull
 
 class BrowserRobot {
-
-    fun verifyBrowserScreen() {
-        onView(ViewMatchers.withResourceName("browserLayout"))
-            .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
-    }
-
     fun verifyCurrentPrivateSession(context: Context) {
         val session = context.components.core.sessionManager.selectedSession
         assertTrue("Current session is private", session?.private!!)
@@ -79,6 +73,7 @@ class BrowserRobot {
     */
     fun verifyPageContent(expectedText: String) {
         val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+        mDevice.waitNotNull(Until.findObject(By.res("org.mozilla.fenix.debug:id/engineView")), waitingTime)
         mDevice.waitNotNull(Until.findObject(text(expectedText)), waitingTime)
     }
 

--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -179,7 +179,8 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Session
             engineView = WeakReference(engineView),
             swipeRefresh = WeakReference(swipeRefresh),
             viewLifecycleScope = viewLifecycleOwner.lifecycleScope,
-            arguments = requireArguments()
+            arguments = requireArguments(),
+            firstContentfulHappened = ::didFirstContentfulHappen
         ).apply {
             beginAnimateInIfNecessary()
         }
@@ -860,6 +861,15 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Session
         if (!FeatureFlags.dynamicBottomToolbar) {
             updateLayoutMargins(inFullScreen)
         }
+    }
+
+    private fun didFirstContentfulHappen(): Boolean {
+        val store = context?.components?.core?.store
+        val tabState = store?.state?.tabs?.find {
+            it.id == (customTabSessionId
+                ?: context?.components?.core?.sessionManager?.selectedSession?.id)
+        }
+        return tabState?.content?.firstContentfulPaint == true
     }
 
     /*

--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserAnimator.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserAnimator.kt
@@ -33,7 +33,8 @@ class BrowserAnimator(
     private val engineView: WeakReference<EngineView>,
     private val swipeRefresh: WeakReference<View>,
     private val viewLifecycleScope: LifecycleCoroutineScope,
-    private val arguments: Bundle
+    private val arguments: Bundle,
+    private val firstContentfulHappened: () -> Boolean
 ) {
 
     private val unwrappedEngineView: EngineView?
@@ -52,22 +53,9 @@ class BrowserAnimator(
         }
 
         doOnEnd {
-            unwrappedEngineView?.asView()?.visibility = View.VISIBLE
-            unwrappedSwipeRefresh?.background = null
-            arguments.putBoolean(SHOULD_ANIMATE_FLAG, false)
-        }
-
-        interpolator = DecelerateInterpolator()
-        duration = ANIMATION_DURATION
-    }
-
-    private val browserFadeInValueAnimator = ValueAnimator.ofFloat(0f, END_ANIMATOR_VALUE).apply {
-        addUpdateListener {
-            unwrappedSwipeRefresh?.alpha = it.animatedFraction
-        }
-
-        doOnEnd {
-            unwrappedEngineView?.asView()?.visibility = View.VISIBLE
+            if (firstContentfulHappened()) {
+                unwrappedEngineView?.asView()?.visibility = View.VISIBLE
+            }
             unwrappedSwipeRefresh?.background = null
             arguments.putBoolean(SHOULD_ANIMATE_FLAG, false)
         }
@@ -92,7 +80,9 @@ class BrowserAnimator(
             }
         } else {
             unwrappedSwipeRefresh?.alpha = 1f
-            unwrappedEngineView?.asView()?.visibility = View.VISIBLE
+            if (firstContentfulHappened()) {
+                unwrappedEngineView?.asView()?.visibility = View.VISIBLE
+            }
             unwrappedSwipeRefresh?.background = null
         }
     }


### PR DESCRIPTION
Based off https://github.com/mozilla-mobile/android-components/pull/6844 which has now landed

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture