### PR TITLE
DO NOT LAND: measure performance of edit bookmark menu

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/edit/EditBookmarkFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/edit/EditBookmarkFragment.kt
@@ -6,10 +6,14 @@ package org.mozilla.fenix.library.bookmarks.edit
 
 import android.content.DialogInterface
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.os.SystemClock
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
+import android.view.ViewTreeObserver
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
@@ -43,6 +47,8 @@ import org.mozilla.fenix.ext.setToolbarColors
 import org.mozilla.fenix.ext.toShortUrl
 import org.mozilla.fenix.library.bookmarks.BookmarksSharedViewModel
 import org.mozilla.fenix.library.bookmarks.DesktopFolders
+
+import mozilla.components.browser.menu.item.MenuButtonClick
 
 /**
  * Menu to edit the name, URL, and location of a bookmark item.
@@ -106,6 +112,27 @@ class EditBookmarkFragment : Fragment(R.layout.fragment_edit_bookmark) {
                 }
             }
         }
+    }
+
+    private class DrawOnce(private val view: View) : ViewTreeObserver.OnDrawListener {
+        private val uiHandler = Handler(Looper.getMainLooper())
+
+        override fun onDraw() {
+            // I verified that this frame is the one that draws the EditBookmark by adding thread.sleep
+            // into uiHandler.post.
+            uiHandler.post {
+                view.viewTreeObserver.removeOnDrawListener(this)
+            }
+
+            val now = SystemClock.elapsedRealtime()
+            android.util.Log.e("lol", "displayed ${now - MenuButtonClick.initialMillis}")
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+
+        requireView().viewTreeObserver.addOnDrawListener(DrawOnce(requireView()))
     }
 
     private fun initToolbar() {


### PR DESCRIPTION
This code is never intended to be landed. This PR is opened solely for code review of methodology for measuring:

> GIVEN Fenix on 2018 (low-end|high-end) Android reference
AND the Context Menu is open
AND the current website is bookmarked
WHEN the bookmark button is actioned
THEN the edit bookmark UI renders in less than 250ms

This PR also needs https://github.com/mozilla-mobile/android-components/pull/6845 to work.

N.B.: intermittently I find the `onDraw` method is called twice before the listener is removed. I believe it's because our UI thread code doesn't get scheduled before drawing two frames. It seems inconsequential (only a few ms in between) so I just take the later measurement.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture