### PR TITLE
For #7854 - Update the views only if the bookmark node has changed

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/edit/EditBookmarkFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/edit/EditBookmarkFragment.kt
@@ -67,6 +67,7 @@ class EditBookmarkFragment : Fragment(R.layout.fragment_edit_bookmark) {
 
         lifecycleScope.launch(Main) {
             val context = requireContext()
+            val bookmarkNodeBeforeReload = bookmarkNode
 
             withContext(IO) {
                 val bookmarksStorage = context.components.core.bookmarksStorage
@@ -89,9 +90,10 @@ class EditBookmarkFragment : Fragment(R.layout.fragment_edit_bookmark) {
                 else -> throw IllegalArgumentException()
             }
 
-            bookmarkNode?.let { bookmarkNode ->
-                bookmarkNameEdit.setText(bookmarkNode.title)
-                bookmarkUrlEdit.setText(bookmarkNode.url)
+            val currentBookmarkNode = bookmarkNode
+            if (currentBookmarkNode != null && currentBookmarkNode != bookmarkNodeBeforeReload) {
+                bookmarkNameEdit.setText(currentBookmarkNode.title)
+                bookmarkUrlEdit.setText(currentBookmarkNode.url)
             }
 
             bookmarkParent?.let { node ->


### PR DESCRIPTION
Copy of #9965 to run CI

As the bookmark node data is loaded from storage every time the fragment's view is created, when the user navigates to the SelectFolderFragment and returns, the bookmark is loaded once again from storage, replacing the EditText's content (title and URL) which causes the loss of user input.

Validating that the loaded bookmark is different from the one that is already referenced in the fragment avoids unnecessarily replacing the `EditText`s values.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture