### PR TITLE
For #10408: Check current destination before navigating.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -35,6 +35,7 @@ import org.mozilla.fenix.components.TabCollectionStorage
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.nav
+import org.mozilla.fenix.ext.navigateSafe
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.shortcut.FirstTimePwaObserver
@@ -181,6 +182,8 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
     }
 
     override fun navToTrackingProtectionPanel(session: Session) {
+        val navController = findNavController()
+
         val useCase = TrackingProtectionUseCases(
             sessionManager = requireComponents.core.sessionManager,
             engine = requireComponents.core.engine
@@ -194,7 +197,7 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
                     trackingProtectionEnabled = isEnabled,
                     gravity = getAppropriateLayoutGravity()
                 )
-            nav(R.id.browserFragment, directions)
+            navController.navigateSafe(R.id.browserFragment, directions)
         }
     }
 

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt
@@ -38,6 +38,7 @@ import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.getRootView
 import org.mozilla.fenix.ext.nav
+import org.mozilla.fenix.ext.navigateSafe
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.home.SharedViewModel
 import org.mozilla.fenix.settings.deletebrowsingdata.deleteAndQuit
@@ -190,7 +191,7 @@ class DefaultBrowserToolbarController(
                         } else {
                             val directions =
                                 BrowserFragmentDirections.actionBrowserFragmentToCreateShortcutFragment()
-                            navController.navigate(directions)
+                            navController.navigateSafe(R.id.browserFragment, directions)
                         }
                     }
                 }


### PR DESCRIPTION
This fixes the crashes in #10408, but the issue of wrong menu showing up should still be handled.

LE: menu dismissal handled in https://github.com/mozilla-mobile/fenix/pull/10415.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture