### PR TITLE
For #10453: Add item decoration after setAdapter() is called.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -223,16 +223,6 @@ open class HomeActivity : LocaleAwareAppCompatActivity() {
         TabsTray::class.java.name -> {
             val layout = LinearLayoutManager(context)
             val adapter = TabsAdapter { parentView, tabsTray ->
-                val decoration = DividerItemDecoration(
-                    context,
-                    DividerItemDecoration.VERTICAL
-                )
-                val drawable = AppCompatResources.getDrawable(context, R.drawable.tab_tray_divider)
-                drawable?.let {
-                    decoration.setDrawable(it)
-                    tabsTray.addItemDecoration(decoration)
-                }
-
                 DefaultTabViewHolder(
                     LayoutInflater.from(parentView.context).inflate(
                         R.layout.tab_tray_item,
@@ -241,7 +231,17 @@ open class HomeActivity : LocaleAwareAppCompatActivity() {
                     tabsTray
                 )
             }
-            BrowserTabsTray(context, attrs, tabsAdapter = adapter, layout = layout)
+            val browserTabsTray = BrowserTabsTray(context, attrs, tabsAdapter = adapter, layout = layout)
+            val decoration = DividerItemDecoration(
+                context,
+                DividerItemDecoration.VERTICAL
+            )
+            val drawable = AppCompatResources.getDrawable(context, R.drawable.tab_tray_divider)
+            drawable?.let {
+                decoration.setDrawable(it)
+            }
+            browserTabsTray.addItemDecoration(decoration)
+            browserTabsTray
         }
         else -> super.onCreateView(parent, name, context, attrs)
     }


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture