### PR TITLE
For #10482 - made SVG gradient compatible with API < 22

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/onboarding/OnboardingRadioButton.kt
+++ b/app/src/main/java/org/mozilla/fenix/onboarding/OnboardingRadioButton.kt
@@ -6,7 +6,7 @@ package org.mozilla.fenix.onboarding
 
 import android.content.Context
 import android.util.AttributeSet
-import android.widget.ImageButton
+import android.widget.ImageView
 import androidx.appcompat.widget.AppCompatRadioButton
 import androidx.core.content.edit
 import androidx.core.content.withStyledAttributes
@@ -15,7 +15,7 @@ import org.mozilla.fenix.ext.settings
 
 class OnboardingRadioButton(context: Context, attrs: AttributeSet) : AppCompatRadioButton(context, attrs) {
     private val radioGroups = mutableListOf<OnboardingRadioButton>()
-    private var illustration: ImageButton? = null
+    private var illustration: ImageView? = null
     private var clickListener: (() -> Unit)? = null
     var key: Int = 0
 
@@ -33,7 +33,7 @@ class OnboardingRadioButton(context: Context, attrs: AttributeSet) : AppCompatRa
         radioGroups.add(radioButton)
     }
 
-    fun addIllustration(illustration: ImageButton) {
+    fun addIllustration(illustration: ImageView) {
         this.illustration = illustration
     }
 

--- a/app/src/main/res/layout/onboarding_theme_picker.xml
+++ b/app/src/main/res/layout/onboarding_theme_picker.xml
@@ -58,13 +58,13 @@
         android:buttonTint="@color/onboarding_radio_button_color"
         app:onboardingKey="@string/pref_key_light_theme" />
 
-    <ImageButton
+    <ImageView
         android:id="@+id/theme_light_image"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
         android:layout_marginTop="16dp"
-        android:background="@drawable/onboarding_light_theme"
+        app:srcCompat="@drawable/onboarding_light_theme"
         android:contentDescription="@string/onboarding_theme_light_title"
         android:foreground="@drawable/rounded_ripple"
         app:layout_constraintEnd_toStartOf="@+id/theme_dark_image"
@@ -85,14 +85,14 @@
         android:buttonTint="@color/onboarding_radio_button_color"
         app:onboardingKey="@string/pref_key_dark_theme" />
 
-    <ImageButton
+    <ImageView
         android:id="@+id/theme_dark_image"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
         android:layout_marginTop="16dp"
         android:layout_marginEnd="16dp"
-        android:background="@drawable/onboarding_dark_theme"
+        app:srcCompat="@drawable/onboarding_dark_theme"
         android:contentDescription="@string/onboarding_theme_dark_title"
         android:foreground="@drawable/rounded_ripple"
         app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/onboarding_toolbar_position_picker.xml
+++ b/app/src/main/res/layout/onboarding_toolbar_position_picker.xml
@@ -61,13 +61,13 @@
         android:buttonTint="@color/onboarding_radio_button_color"
         app:onboardingKey="@string/pref_key_toolbar_top" />
 
-    <ImageButton
+    <ImageView
         android:id="@+id/toolbar_top_image"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
         android:layout_marginTop="16dp"
-        android:background="@drawable/onboarding_toolbar_top"
+        app:srcCompat="@drawable/onboarding_toolbar_top"
         android:contentDescription="@string/preference_top_toolbar"
         android:foreground="@drawable/rounded_ripple"
         app:layout_constraintEnd_toStartOf="@+id/toolbar_bottom_image"
@@ -89,14 +89,14 @@
         android:buttonTint="@color/onboarding_radio_button_color"
         app:onboardingKey="@string/pref_key_toolbar_bottom" />
 
-    <ImageButton
+    <ImageView
         android:id="@+id/toolbar_bottom_image"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
         android:layout_marginTop="16dp"
         android:layout_marginEnd="16dp"
-        android:background="@drawable/onboarding_toolbar_bottom"
+        app:srcCompat="@drawable/onboarding_toolbar_bottom"
         android:contentDescription="@string/preference_bottom_toolbar"
         android:foreground="@drawable/rounded_ripple"
         app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
The SVGs look the same as before, just that now they work on API < 22

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture