### PR TITLE
Bugfix #10501 - Onboarding radio buttons red on older APIs

### DIFF
--- a/app/src/main/res/color/onboarding_radio_button_color.xml
+++ b/app/src/main/res/color/onboarding_radio_button_color.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- This Source Code Form is subject to the terms of the Mozilla Public
-   - License, v. 2.0. If a copy of the MPL was not distributed with this
-   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:color="?attr/onboardingSelected" android:state_checked="true" />
-    <item android:color="?attr/onboardingDeselected" />
-</selector>

--- a/app/src/main/res/layout/onboarding_theme_picker.xml
+++ b/app/src/main/res/layout/onboarding_theme_picker.xml
@@ -51,11 +51,11 @@
         android:layout_height="wrap_content"
         android:contentDescription="@string/onboarding_theme_light_title"
         android:elevation="1dp"
+        android:theme="@style/Checkable.Colored"
         android:translationX="@dimen/onboarding_dual_pane_radio_button_translation_x"
         android:translationY="@dimen/onboarding_dual_pane_radio_button_translation_y"
         app:layout_constraintStart_toStartOf="@+id/theme_light_image"
         app:layout_constraintTop_toTopOf="@+id/theme_light_image"
-        android:buttonTint="@color/onboarding_radio_button_color"
         app:onboardingKey="@string/pref_key_light_theme" />
 
     <ImageView
@@ -64,13 +64,13 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
         android:layout_marginTop="16dp"
-        app:srcCompat="@drawable/onboarding_light_theme"
         android:contentDescription="@string/onboarding_theme_light_title"
         android:foreground="@drawable/rounded_ripple"
         app:layout_constraintEnd_toStartOf="@+id/theme_dark_image"
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/description_text" />
+        app:layout_constraintTop_toBottomOf="@+id/description_text"
+        app:srcCompat="@drawable/onboarding_light_theme" />
 
     <org.mozilla.fenix.onboarding.OnboardingRadioButton
         android:id="@+id/theme_dark_radio_button"
@@ -78,11 +78,11 @@
         android:layout_height="wrap_content"
         android:contentDescription="@string/onboarding_theme_dark_title"
         android:elevation="1dp"
+        android:theme="@style/Checkable.Colored"
         android:translationX="@dimen/onboarding_dual_pane_radio_button_translation_x"
         android:translationY="@dimen/onboarding_dual_pane_radio_button_translation_y"
         app:layout_constraintStart_toStartOf="@+id/theme_dark_image"
         app:layout_constraintTop_toTopOf="@+id/theme_dark_image"
-        android:buttonTint="@color/onboarding_radio_button_color"
         app:onboardingKey="@string/pref_key_dark_theme" />
 
     <ImageView
@@ -92,13 +92,13 @@
         android:layout_marginStart="16dp"
         android:layout_marginTop="16dp"
         android:layout_marginEnd="16dp"
-        app:srcCompat="@drawable/onboarding_dark_theme"
         android:contentDescription="@string/onboarding_theme_dark_title"
         android:foreground="@drawable/rounded_ripple"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toEndOf="@+id/theme_light_image"
-        app:layout_constraintTop_toBottomOf="@+id/description_text" />
+        app:layout_constraintTop_toBottomOf="@+id/description_text"
+        app:srcCompat="@drawable/onboarding_dark_theme" />
 
     <TextView
         android:id="@+id/dark_theme_title"
@@ -143,10 +143,10 @@
         android:contentDescription="@string/onboarding_theme_automatic_title"
         android:paddingStart="0dp"
         android:paddingEnd="8dp"
+        android:theme="@style/Checkable.Colored"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/divider"
-        android:buttonTint="@color/onboarding_radio_button_color"
         app:onboardingKey="@string/pref_key_follow_device_theme" />
 
     <TextView

--- a/app/src/main/res/layout/onboarding_toolbar_position_picker.xml
+++ b/app/src/main/res/layout/onboarding_toolbar_position_picker.xml
@@ -53,12 +53,12 @@
         android:layout_height="wrap_content"
         android:contentDescription="@string/preference_top_toolbar"
         android:elevation="1dp"
+        android:theme="@style/Checkable.Colored"
         android:translationX="@dimen/onboarding_dual_pane_radio_button_translation_x"
         android:translationY="@dimen/onboarding_dual_pane_radio_button_translation_y"
         app:layout_constraintStart_toStartOf="@+id/toolbar_top_image"
         app:layout_constraintTop_toBottomOf="@+id/description_text"
         app:layout_constraintTop_toTopOf="@+id/toolbar_top_image"
-        android:buttonTint="@color/onboarding_radio_button_color"
         app:onboardingKey="@string/pref_key_toolbar_top" />
 
     <ImageView
@@ -67,13 +67,13 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
         android:layout_marginTop="16dp"
-        app:srcCompat="@drawable/onboarding_toolbar_top"
         android:contentDescription="@string/preference_top_toolbar"
         android:foreground="@drawable/rounded_ripple"
         app:layout_constraintEnd_toStartOf="@+id/toolbar_bottom_image"
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/description_text" />
+        app:layout_constraintTop_toBottomOf="@+id/description_text"
+        app:srcCompat="@drawable/onboarding_toolbar_top" />
 
     <org.mozilla.fenix.onboarding.OnboardingRadioButton
         android:id="@+id/toolbar_bottom_radio_button"
@@ -81,12 +81,12 @@
         android:layout_height="wrap_content"
         android:contentDescription="@string/preference_bottom_toolbar"
         android:elevation="1dp"
+        android:theme="@style/Checkable.Colored"
         android:translationX="@dimen/onboarding_dual_pane_radio_button_translation_x"
         android:translationY="@dimen/onboarding_dual_pane_radio_button_translation_y"
         app:layout_constraintStart_toStartOf="@+id/toolbar_bottom_image"
-        app:layout_constraintTop_toTopOf="@+id/toolbar_bottom_image"
         app:layout_constraintTop_toBottomOf="@+id/description_text"
-        android:buttonTint="@color/onboarding_radio_button_color"
+        app:layout_constraintTop_toTopOf="@+id/toolbar_bottom_image"
         app:onboardingKey="@string/pref_key_toolbar_bottom" />
 
     <ImageView
@@ -96,13 +96,13 @@
         android:layout_marginStart="16dp"
         android:layout_marginTop="16dp"
         android:layout_marginEnd="16dp"
-        app:srcCompat="@drawable/onboarding_toolbar_bottom"
         android:contentDescription="@string/preference_bottom_toolbar"
         android:foreground="@drawable/rounded_ripple"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toEndOf="@+id/toolbar_top_image"
-        app:layout_constraintTop_toBottomOf="@+id/description_text" />
+        app:layout_constraintTop_toBottomOf="@+id/description_text"
+        app:srcCompat="@drawable/onboarding_toolbar_bottom" />
 
     <TextView
         android:id="@+id/toolbar_bottom_title"

--- a/app/src/main/res/layout/onboarding_tracking_protection.xml
+++ b/app/src/main/res/layout/onboarding_tracking_protection.xml
@@ -29,7 +29,7 @@
         android:layout_height="wrap_content"
         app:layout_constraintBottom_toBottomOf="@id/header_text"
         app:layout_constraintEnd_toEndOf="parent"
-        android:theme="@style/Switch.Colored"
+        android:theme="@style/Checkable.Colored"
         app:layout_constraintTop_toTopOf="@id/header_text" />
 
     <TextView
@@ -62,9 +62,9 @@
         android:layout_marginBottom="16dp"
         android:paddingStart="0dp"
         android:paddingEnd="8dp"
+        android:theme="@style/Checkable.Colored"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/description_text"
-        android:buttonTint="@color/onboarding_radio_button_color"
         app:onboardingKey="@string/pref_key_tracking_protection_standard_option" />
 
     <TextView
@@ -108,10 +108,10 @@
         android:checked="true"
         android:paddingStart="0dp"
         android:paddingEnd="8dp"
+        android:theme="@style/Checkable.Colored"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/tracking_protection_standard_option"
-        android:buttonTint="@color/onboarding_radio_button_color"
         app:onboardingKey="@string/pref_key_tracking_protection_strict_default" />
 
     <TextView

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -104,8 +104,9 @@
         <item name="buttonBarPositiveButtonStyle">@style/DialogButtonStyleLight</item>
     </style>
 
-    <style name="Switch.Colored" parent="Theme.AppCompat">
+    <style name="Checkable.Colored" parent="Theme.AppCompat">
         <item name="colorControlActivated">?attr/onboardingSelected</item>
+        <item name="colorControlNormal">?attr/onboardingDeselected</item>
     </style>
 
     <style name="DialogStyleDark" parent="BaseDialogStyle">


### PR DESCRIPTION
**Screenshot on Pixel 2 API 21:**
<img width="309" alt="Screenshot 2020-05-08 at 09 30 27" src="https://user-images.githubusercontent.com/1709373/81377672-aca0a400-910e-11ea-8b7d-341b8ad0a33c.png">

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture