### PR TITLE
For #10473: Fetch the addon from addon manager instead of the store

### DIFF
--- a/app/src/main/res/layout/fragment_installed_add_on_details.xml
+++ b/app/src/main/res/layout/fragment_installed_add_on_details.xml
@@ -99,4 +99,11 @@
                 android:text="@string/mozac_feature_addons_remove" />
         </RelativeLayout>
     </ScrollView>
+
+    <ProgressBar
+        android:id="@+id/add_on_progress_bar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center" />
+
 </FrameLayout>


### PR DESCRIPTION
This makes the add-on instance reference synchronized between different screen transitions a lot simpler and consistent by utilizing `AddonManager`'s `pendingAddonActions` logic.