### PR TITLE
Integrate activity for showing past crashes.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -191,6 +191,10 @@
                 android:exported="false">
         </activity>
 
+        <activity
+            android:name=".crashes.CrashListActivity"
+            android:exported="false" />
+
         <activity android:name=".widget.VoiceSearchActivity" />
 
         <activity

--- a/app/src/main/java/org/mozilla/fenix/components/Analytics.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Analytics.kt
@@ -68,6 +68,7 @@ class Analytics(
         )
 
         CrashReporter(
+            context = context,
             services = services,
             telemetryServices = listOf(GleanCrashReporterService(context)),
             shouldPrompt = CrashReporter.Prompt.ALWAYS,

--- a/app/src/main/java/org/mozilla/fenix/crashes/CrashListActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/crashes/CrashListActivity.kt
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.crashes
+
+import android.content.Intent
+import android.net.Uri
+import mozilla.components.lib.crash.CrashReporter
+import mozilla.components.lib.crash.ui.AbstractCrashListActivity
+import org.mozilla.fenix.ext.components
+
+/**
+ * Activity showing the list of past crashes.
+ */
+class CrashListActivity : AbstractCrashListActivity() {
+    override val crashReporter: CrashReporter by lazy { components.analytics.crashReporter }
+
+    override fun onCrashServiceSelected(url: String) {
+        val intent = Intent(Intent.ACTION_VIEW)
+        intent.data = Uri.parse(url)
+        intent.`package` = packageName
+        startActivity(intent)
+        finish()
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/search/SearchController.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchController.kt
@@ -6,6 +6,7 @@
 package org.mozilla.fenix.search
 
 import android.content.Context
+import android.content.Intent
 import androidx.navigation.NavController
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
@@ -22,6 +23,7 @@ import org.mozilla.fenix.components.metrics.Event.PerformedSearch.SearchAccessPo
 import org.mozilla.fenix.components.metrics.Event.PerformedSearch.SearchAccessPoint.SUGGESTION
 import org.mozilla.fenix.components.metrics.MetricsUtils
 import org.mozilla.fenix.components.searchengine.CustomSearchEngineStore
+import org.mozilla.fenix.crashes.CrashListActivity
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.metrics
 import org.mozilla.fenix.ext.navigateSafe
@@ -52,6 +54,14 @@ class DefaultSearchController(
 ) : SearchController {
 
     override fun handleUrlCommitted(url: String) {
+        if (url == "about:crashes") {
+            // The list of past crashes can be accessed via "settings > about", but desktop and
+            // fennec users may be used to navigating to "about:crashes". So we intercept this here
+            // and open the crash list activity instead.
+            context.startActivity(Intent(context, CrashListActivity::class.java))
+            return
+        }
+
         if (url.isNotBlank()) {
             (context as HomeActivity).openToBrowserAndLoad(
                 searchTermOrURL = url,

--- a/app/src/main/java/org/mozilla/fenix/settings/about/AboutFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/about/AboutFragment.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.mozilla.fenix.BuildConfig
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.metrics.Event
+import org.mozilla.fenix.crashes.CrashListActivity
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.utils.Do
@@ -153,6 +154,10 @@ class AboutFragment : Fragment(), AboutPageListener {
                 ), getString(R.string.about_support)
             ),
             AboutPageItem.Item(
+                AboutItem.Crashes,
+                getString(R.string.about_crashes)
+            ),
+            AboutPageItem.Item(
                 AboutItem.ExternalLink(
                     PRIVACY_NOTICE,
                     SupportUtils.getPrivacyNoticeUrl()
@@ -214,6 +219,9 @@ class AboutFragment : Fragment(), AboutPageListener {
             is AboutItem.Libraries -> {
                 requireComponents.analytics.metrics.track(Event.LibrariesThatWeUseTapped)
                 openLibrariesPage()
+            }
+            is AboutItem.Crashes -> {
+                startActivity(Intent(requireContext(), CrashListActivity::class.java))
             }
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/settings/about/AboutItem.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/about/AboutItem.kt
@@ -7,6 +7,7 @@ package org.mozilla.fenix.settings.about
 sealed class AboutItem {
     data class ExternalLink(val type: AboutItemType, val url: String) : AboutItem()
     object Libraries : AboutItem()
+    object Crashes : AboutItem()
 }
 
 enum class AboutItemType {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1108,6 +1108,8 @@
 
     <!-- About page link text to open support link -->
     <string name="about_support">Support</string>
+    <!-- About page link text to list of past crashes (like about:crashes on desktop) -->
+    <string name="about_crashes">Crashes</string>
     <!-- About page link text to open privacy notice link -->
     <string name="about_privacy_notice">Privacy notice</string>
     <!-- About page link text to open know your rights link -->

--- a/app/src/test/java/org/mozilla/fenix/components/metrics/BreadcrumbRecorderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/metrics/BreadcrumbRecorderTest.kt
@@ -20,6 +20,9 @@ internal class BreadcrumbRecorderTest {
     @Test
     fun `ensure crash reporter recordCrashBreadcrumb is called`() {
         val service = object : CrashReporterService {
+            override val id: String = "test"
+            override val name: String = "Test"
+            override fun createCrashReportUrl(identifier: String): String? = null
             override fun report(throwable: Throwable, breadcrumbs: ArrayList<Breadcrumb>): String? = ""
             override fun report(crash: Crash.NativeCodeCrash): String? = ""
             override fun report(crash: Crash.UncaughtExceptionCrash): String? = ""
@@ -27,6 +30,7 @@ internal class BreadcrumbRecorderTest {
 
         val reporter = spy(
             CrashReporter(
+                context = mock(),
                 services = listOf(service),
                 shouldPrompt = CrashReporter.Prompt.NEVER
             )

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "41.0.20200510130109"
+    const val VERSION = "41.0.20200511120152"
 }


### PR DESCRIPTION
The `lib-crash` component now saves information about past crashes to disk and comes with a bit of UI to show this list of crashes. It can directly link to crash reports on Socorro and Sentry which hopefully will make it easier to figure out why the app has crashed and to report crashes.

There are two ways to access the crash list, via "settings > about" and by just typing "about:crashes" into the URL bar (like desktop/Fennec).

Closes #8769, #3552, #2295