### PR TITLE
bugfix/#10599 - Remove baseline pings form metrics.yaml

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -111,7 +111,6 @@ events:
       interaction by website scripts that programmatically redirect to a new
       location.
     send_in_pings:
-      - baseline
       - metrics
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/1301
@@ -122,8 +121,6 @@ events:
     notification_emails:
       - fenix-core@mozilla.com
     expires: "2020-09-01"
-    no_lint:
-      - BASELINE_PING
   preference_toggled:
     type: event
     description: |
@@ -366,7 +363,6 @@ metrics:
       `other` option for the source but it should never enter on this case.
     send_in_pings:
       - metrics
-      - baseline
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/1158
       - https://github.com/mozilla-mobile/fenix/issues/6556
@@ -377,8 +373,6 @@ metrics:
     notification_emails:
       - fenix-core@mozilla.com
     expires: "2020-09-01"
-    no_lint:
-      - BASELINE_PING
   mozilla_products:
     type: string_list
     lifetime: application
@@ -2043,7 +2037,6 @@ browser.search:
       Records counts of SERP pages with adverts displayed.
       The key format is ‘<provider-name>’.
     send_in_pings:
-      - baseline
       - metrics
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/6558
@@ -2052,15 +2045,12 @@ browser.search:
     notification_emails:
       - fenix-core@mozilla.com
     expires: "2020-09-01"
-    # TODO: https://github.com/mozilla-mobile/fenix/issues/10599
-    no_lint: [BASELINE_PING]
   ad_clicks:
     type: labeled_counter
     description: |
       Records clicks of adverts on SERP pages.
       The key format is ‘<provider-name>’.
     send_in_pings:
-      - baseline
       - metrics
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/6558
@@ -2069,14 +2059,11 @@ browser.search:
     notification_emails:
       - fenix-core@mozilla.com
     expires: "2020-09-01"
-    # TODO: https://github.com/mozilla-mobile/fenix/issues/10599
-    no_lint: [BASELINE_PING]
   in_content:
     type: labeled_counter
     description: |
       Records the type of interaction a user has on SERP pages.
     send_in_pings:
-      - baseline
       - metrics
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/6557
@@ -2085,8 +2072,6 @@ browser.search:
     notification_emails:
       - fenix-core@mozilla.com
     expires: "2020-09-01"
-    # TODO: https://github.com/mozilla-mobile/fenix/issues/10599
-    no_lint: [BASELINE_PING]
 
 addons:
   open_addons_in_settings:

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -8,7 +8,6 @@ This means you might have to go searching through the dependency tree to get a f
 # Pings
 
  - [activation](#activation)
- - [baseline](#baseline)
  - [events](#events)
  - [installation](#installation)
  - [metrics](#metrics)
@@ -38,22 +37,6 @@ The following metrics are added to the ping:
 | --- | --- | --- | --- | --- | --- |
 | activation.activation_id |[uuid](https://mozilla.github.io/glean/book/user/metrics/uuid.html) |An alternate identifier, not correlated with the client_id, generated once and only sent with the activation ping.  |[1](https://github.com/mozilla-mobile/fenix/pull/1707#issuecomment-486972209)||2020-09-01 |
 | activation.identifier |[string](https://mozilla.github.io/glean/book/user/metrics/string.html) |A hashed and salted version of the Google Advertising ID from the device. This will never be sent in a ping that also contains the client_id.  |[1](https://github.com/mozilla-mobile/fenix/pull/1707#issuecomment-486972209)||2020-09-01 |
-
-## baseline
-
-This is a built-in ping that is assembled out of the box by the Glean SDK.
-
-See the Glean SDK documentation for the [`baseline` ping](https://mozilla.github.io/glean/book/user/pings/baseline.html).
-
-The following metrics are added to the ping:
-
-| Name | Type | Description | Data reviews | Extras | Expiration |
-| --- | --- | --- | --- | --- | --- |
-| browser.search.ad_clicks |[labeled_counter](https://mozilla.github.io/glean/book/user/metrics/labeled_counters.html) |Records clicks of adverts on SERP pages. The key format is ‘<provider-name>’.  |[1](https://github.com/mozilla-mobile/fenix/pull/10112)||2020-09-01 |
-| browser.search.in_content |[labeled_counter](https://mozilla.github.io/glean/book/user/metrics/labeled_counters.html) |Records the type of interaction a user has on SERP pages.  |[1](https://github.com/mozilla-mobile/fenix/pull/10167)||2020-09-01 |
-| browser.search.with_ads |[labeled_counter](https://mozilla.github.io/glean/book/user/metrics/labeled_counters.html) |Records counts of SERP pages with adverts displayed. The key format is ‘<provider-name>’.  |[1](https://github.com/mozilla-mobile/fenix/pull/10112)||2020-09-01 |
-| events.total_uri_count |[counter](https://mozilla.github.io/glean/book/user/metrics/counter.html) |A counter of URIs visited by the user in the current session, including page reloads. This does not include background page requests and URIs from embedded pages or private browsing but may be incremented without user interaction by website scripts that programmatically redirect to a new location.  |[1](https://github.com/mozilla-mobile/fenix/pull/1785), [2](https://github.com/mozilla-mobile/fenix/pull/8314)||2020-09-01 |
-| metrics.search_count |[labeled_counter](https://mozilla.github.io/glean/book/user/metrics/labeled_counters.html) |The labels for this counter are `<search-engine-name>.<source>`.  If the search engine is bundled with Fenix `search-engine-name` will be the name of the search engine. If it's a custom search engine (defined: https://github.com/mozilla-mobile/fenix/issues/1607) the value will be `custom`.  `source` will be: `action`, `suggestion`, `widget` or `shortcut` (depending on the source from which the search started). Also added the `other` option for the source but it should never enter on this case.  |[1](https://github.com/mozilla-mobile/fenix/pull/1677), [2](https://github.com/mozilla-mobile/fenix/pull/5216), [3](https://github.com/mozilla-mobile/fenix/pull/7310)||2020-09-01 |
 
 ## events
 


### PR DESCRIPTION
As per [documentation](https://mozilla.github.io/glean/book/user/pings/baseline.html
), this ping is intended to provide metrics that are managed by the library itself, and not explicitly set by the application or included in the application's metrics.yaml file.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture