### PR TITLE
Bug 1627027 - Use nightly Fenix variant instead of performancetest.

### DIFF
--- a/.cron.yml
+++ b/.cron.yml
@@ -26,18 +26,6 @@ jobs:
           treeherder-symbol: fennec-beta
           target-tasks-method: fennec-beta
       when: []  # Force hook only
-    - name: raptor
-      job:
-          type: decision-task
-          treeherder-symbol: raptor-D
-          target-tasks-method: raptor
-      when: [{hour: 1, minute: 0}]
-    - name: browsertime
-      job:
-          type: decision-task
-          treeherder-symbol: btime-D
-          target-tasks-method: browsertime
-      when: [{hour: 1, minute: 0}]
     - name: bump-android-components
       job:
           type: decision-task

--- a/taskcluster/ci/browsertime/kind.yml
+++ b/taskcluster/ci/browsertime/kind.yml
@@ -13,7 +13,7 @@ kind-dependencies:
 primary-dependency: signing
 
 only-for-build-types:
-    - performance-test
+    - nightly
 
 only-for-abis:
     - armeabi-v7a
@@ -81,7 +81,7 @@ job-defaults:
             - '--app=fenix'
             - '--browsertime'
             - '--cold'
-            - '--binary=org.mozilla.fenix.performancetest'
+            - '--binary=org.mozilla.fenix.nightly'
             - '--activity=org.mozilla.fenix.IntentReceiverActivity'
             - '--download-symbols=ondemand'
             - '--browsertime-node=$MOZ_FETCHES_DIR/node/bin/node'

--- a/taskcluster/ci/browsertime/kind.yml
+++ b/taskcluster/ci/browsertime/kind.yml
@@ -104,6 +104,7 @@ jobs:
 
     tp6m-2-cold:
         test-name: google
+        run-on-tasks-for: [github-pull-request]
         treeherder:
             symbol: 'Btime(tp6m-2-c)'
 

--- a/taskcluster/ci/browsertime/kind.yml
+++ b/taskcluster/ci/browsertime/kind.yml
@@ -104,7 +104,6 @@ jobs:
 
     tp6m-2-cold:
         test-name: google
-        run-on-tasks-for: [github-pull-request]
         treeherder:
             symbol: 'Btime(tp6m-2-c)'
 

--- a/taskcluster/ci/raptor/kind.yml
+++ b/taskcluster/ci/raptor/kind.yml
@@ -11,7 +11,7 @@ kind-dependencies:
     - toolchain
 
 only-for-build-types:
-    - performance-test
+    - nightly
 
 only-for-abis:
     - armeabi-v7a
@@ -76,7 +76,7 @@ job-defaults:
             - './test-linux.sh'
             - '--cfg=mozharness/configs/raptor/android_hw_config.py'
             - '--app=fenix'
-            - '--binary=org.mozilla.fenix.performancetest'
+            - '--binary=org.mozilla.fenix.nightly'
             - '--activity=org.mozilla.fenix.IntentReceiverActivity'
             - '--download-symbols=ondemand'
     fetches:

--- a/taskcluster/fenix_taskgraph/target_tasks.py
+++ b/taskcluster/fenix_taskgraph/target_tasks.py
@@ -33,7 +33,8 @@ def target_tasks_nightly(full_task_graph, parameters, graph_config):
     def filter(task, parameters):
         # We don't want to ship nightly while Google Play is still behind manual review.
         # See bug 1628413 for more context.
-        return task.attributes.get("nightly", False) and task.kind != "push-apk"
+        return task.attributes.get("nightly", False) and task.kind != "push-apk" or \
+            task.kind in ('browsertime', 'visual-metrics', 'raptor')
 
     return [l for l, t in full_task_graph.tasks.iteritems() if filter(t, parameters)]
 
@@ -57,22 +58,6 @@ def target_tasks_fennec_nightly(full_task_graph, parameters, graph_config):
     """Select the set of tasks required for a beta build signed with the fennec key."""
 
     return [l for l, t in full_task_graph.tasks.iteritems() if _filter_fennec("beta", t, parameters)]
-
-
-@_target_task('raptor')
-def target_tasks_raptor(full_task_graph, parameters, graph_config):
-    def filter(task, parameters):
-        return task.kind == 'raptor'
-
-    return [l for l, t in full_task_graph.tasks.iteritems() if filter(t, parameters)]
-
-
-@_target_task('browsertime')
-def target_tasks_raptor(full_task_graph, parameters, graph_config):
-    def filter(task, parameters):
-        return task.kind in ('browsertime', 'visual-metrics')
-
-    return [l for l, t in full_task_graph.tasks.iteritems() if filter(t, parameters)]
 
 
 @_target_task("bump_android_components")

--- a/try_task_config.json
+++ b/try_task_config.json
@@ -1,0 +1,7 @@
+{
+    "parameters": {
+        "optimize_target_tasks": true,
+        "target_tasks_method": "nightly"
+    },
+    "version": 2
+}

--- a/try_task_config.json
+++ b/try_task_config.json
@@ -1,7 +1,0 @@
-{
-    "parameters": {
-        "optimize_target_tasks": true,
-        "target_tasks_method": "nightly"
-    },
-    "version": 2
-}


### PR DESCRIPTION
This patch switches the build variant that is used in performance-tests (browsertime, raptor) from the performancetest variant to the nightly variant. It also removes the existing cron jobs for those two frameworks and runs these tests in the nightly cron.