### PR TITLE
Bug 1631834 - part 2: Express who triggered the action task

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -140,7 +140,10 @@ tasks:
                                         $if: 'tasks_for == "action"'
                                         then:
                                             name: "Action: ${action.title}"
-                                            description: '${action.description}'
+                                            description: |
+                                                ${action.description}
+
+                                                Action triggered by clientID `${clientId}`
                                         else:
                                             name: "Decision Task for cron job ${cron.job_name}"
                                             description: 'Created by a [cron task](https://firefox-ci-tc.services.mozilla.com/tasks/${cron.task_id})'
@@ -324,6 +327,7 @@ tasks:
                                                 taskGroupId: '${action.taskGroupId}'
                                                 taskId: {$eval: 'taskId'}
                                                 input: {$eval: 'input'}
+                                                clientId: {$eval: 'clientId'}
                                   - $if: 'tasks_for == "cron"'
                                     then:
                                         cron: {$json: {$eval: 'cron'}}


### PR DESCRIPTION
Excellent news! https://github.com/mozilla-mobile/fenix/pull/10644 worked like a charm! I was able to rerun/retrigger/cancel tasks on the Fenix repo! @Archaeopteryx tried it out too, and it worked. He noticed one nit: the action tasks don't tell who triggered them (they do in Gecko). It turns out the fix is simple. I just backported the bits from https://searchfox.org/mozilla-central/rev/9f074fab9bf905fad62e7cc32faf121195f4ba46/.taskcluster.yml#94


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture