### PR TITLE
Bug 1638073 - Update geckoview for new shippable index, and fix firefoxci index reference for tps

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/syncintegration/conftest.py
+++ b/app/src/androidTest/java/org/mozilla/fenix/syncintegration/conftest.py
@@ -45,11 +45,11 @@ def tps_addon(pytestconfig, tmpdir_factory):
     path = pytestconfig.getoption('tps')
     if path is not None:
         return path
-    task_url = 'https://index.taskcluster.net/v1/task/' \
+    task_url = 'https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/' \
                'gecko.v2.mozilla-central.latest.firefox.addons.tps'
     task_id = requests.get(task_url).json().get('taskId')
     cache_dir = str(pytestconfig.cache.makedir('tps-{}'.format(task_id)))
-    addon_url = 'https://queue.taskcluster.net/v1/task/' \
+    addon_url = 'https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/' \
                 '{}/artifacts/public/tps.xpi'.format(task_id)
     scraper = DirectScraper(addon_url, destination=cache_dir)
     return scraper.download()

--- a/taskcluster/ci/geckoview/kind.yml
+++ b/taskcluster/ci/geckoview/kind.yml
@@ -14,4 +14,4 @@ jobs:
         description: "upstream nightly job"
         run:
             index-search:
-                - gecko.v2.mozilla-central.nightly.latest.mobile.android-x86_64-opt
+                - gecko.v2.mozilla-central.shippable.latest.mobile.android-x86_64-opt


### PR DESCRIPTION
This can't merge in until after the stack on https://bugzilla.mozilla.org/show_bug.cgi?id=1614970 lands, I'll comment here when that happens.

Impacts of the delay is that you'll use a slightly out of date geckoview for 24-48 hours until this lands.
