### PR TITLE
For #10656: Adjust etp checkbox dimensions for a11y.

### DIFF
--- a/app/src/main/res/layout/checkbox_left_preference_etp.xml
+++ b/app/src/main/res/layout/checkbox_left_preference_etp.xml
@@ -8,12 +8,13 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_marginStart="66dp"
+    android:minHeight="48dp"
     android:background="?android:selectableItemBackground"
     android:clickable="true"
     android:focusable="true"
     android:gravity="center_vertical"
-    android:paddingTop="@dimen/radio_button_preference_vertical"
-    android:paddingBottom="@dimen/radio_button_preference_vertical">
+    android:paddingTop="@dimen/checkbox_preference_padding_vertical"
+    android:paddingBottom="@dimen/checkbox_preference_padding_vertical">
 
     <LinearLayout
         android:id="@android:id/widget_frame"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -44,6 +44,9 @@
 
     <dimen name="tab_counter_box_width_height">24dp</dimen>
 
+    <!--Preferences-->
+    <dimen name="checkbox_preference_padding_vertical">12dp</dimen>
+
     <!--Quick Settings-->
     <dimen name="quicksettings_item_height">28dp</dimen>
     <dimen name="tracking_protection_item_height">48dp</dimen>


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture