### PR TITLE
Bug 1627027 - part 2: Do not run perf tasks on Nd-gp graphs

### DIFF
--- a/taskcluster/ci/browsertime/kind.yml
+++ b/taskcluster/ci/browsertime/kind.yml
@@ -22,6 +22,7 @@ only-for-abis:
 job-defaults:
     attributes:
         artifact_prefix: public/test_info
+        nightly: true
     dependencies:
         geckoview-nightly: geckoview-nightly
     notify:

--- a/taskcluster/ci/raptor/kind.yml
+++ b/taskcluster/ci/raptor/kind.yml
@@ -19,6 +19,7 @@ only-for-abis:
 
 job-defaults:
     attributes:
+        nightly: true
         retrigger: true
     dependencies:
         geckoview-nightly: geckoview-nightly

--- a/taskcluster/ci/visual-metrics/kind.yml
+++ b/taskcluster/ci/visual-metrics/kind.yml
@@ -22,6 +22,8 @@ transforms:
     - taskgraph.transforms.task:transforms
 
 job-template:
+    attributes:
+        nightly: true
     description: "Run visual metrics calculations on Raptor"
     run-on-projects: []
     run-on-tasks-for: []

--- a/taskcluster/fenix_taskgraph/target_tasks.py
+++ b/taskcluster/fenix_taskgraph/target_tasks.py
@@ -33,8 +33,7 @@ def target_tasks_nightly(full_task_graph, parameters, graph_config):
     def filter(task, parameters):
         # We don't want to ship nightly while Google Play is still behind manual review.
         # See bug 1628413 for more context.
-        return task.attributes.get("nightly", False) and task.kind != "push-apk" or \
-            task.kind in ('browsertime', 'visual-metrics', 'raptor')
+        return task.attributes.get("nightly", False) and task.kind != "push-apk"
 
     return [l for l, t in full_task_graph.tasks.iteritems() if filter(t, parameters)]
 
@@ -44,7 +43,13 @@ def target_tasks_nightly_on_google_play(full_task_graph, parameters, graph_confi
     """Select the set of tasks required for a nightly build that goes on Google Play."""
 
     def filter(task, parameters):
-        return task.attributes.get("nightly", False)
+        return (
+            task.attributes.get("nightly", False) and
+            # This target_task is temporary while Google Play processes APKs slower than usually
+            # (bug 1628413). So we want this target task to be only about shipping APKs to GP and
+            # not doing any other miscellaneous tasks like performance testing
+            task.kind not in ("browsertime", "visual-metrics", "raptor")
+        )
 
     return [l for l, t in full_task_graph.tasks.iteritems() if filter(t, parameters)]
 


### PR DESCRIPTION
Follows https://github.com/mozilla-mobile/fenix/pull/10648 up. Fixes https://firefox-ci-tc.services.mozilla.com/tasks/EQK7qHxDTkaZxegLvqK-LQ/runs/0/logs/https%3A%2F%2Ffirefox-ci-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FEQK7qHxDTkaZxegLvqK-LQ%2Fruns%2F0%2Fartifacts%2Fpublic%2Flogs%2Flive.log#L3049 => the perf tests were part of the nightly-on-google-play graph which I don't think we want at the moment. The regular nightly graph runs once a day which was the schedule for the perf tests. 


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture