### PR TITLE
For 10665 - Show the most recent tabs at the top of the tab tray

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -221,6 +221,9 @@ open class HomeActivity : LocaleAwareAppCompatActivity() {
         }.asView()
         TabsTray::class.java.name -> {
             val layout = LinearLayoutManager(context)
+            layout.reverseLayout = true
+            layout.stackFromEnd = true
+
             val adapter = TabsAdapter { parentView, _ ->
                 TabTrayViewHolder(
                     LayoutInflater.from(this).inflate(


### PR DESCRIPTION
`layout.stackFromEnd` is required to make the tabs start at the top of the screen instead of the bottom.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture