### PR TITLE
Revert "for #7032 scroll to dismiss keyboard in search fragment" 🎲

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
@@ -12,7 +12,6 @@ import android.graphics.Typeface.ITALIC
 import android.os.Bundle
 import android.text.style.StyleSpan
 import android.view.LayoutInflater
-import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewStub
@@ -34,7 +33,6 @@ import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
 import mozilla.components.support.ktx.android.content.getColorFromAttr
 import mozilla.components.support.ktx.android.content.hasCamera
 import mozilla.components.support.ktx.android.content.isPermissionGranted
-import mozilla.components.support.ktx.android.view.hideKeyboard
 import mozilla.components.ui.autocomplete.InlineAutocompleteEditText
 import org.mozilla.fenix.BrowserDirection
 import org.mozilla.fenix.HomeActivity
@@ -59,7 +57,6 @@ class SearchFragment : Fragment(), UserInteractionHandler {
     private lateinit var searchStore: SearchFragmentStore
     private lateinit var searchInteractor: SearchInteractor
 
-    @Suppress("LongMethod")
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -122,14 +119,6 @@ class SearchFragment : Fragment(), UserInteractionHandler {
 
         awesomeBarView = AwesomeBarView(view.scrollable_area, searchInteractor)
 
-        view.scrollView.setOnTouchListener { _, event ->
-            when (event?.action) {
-                MotionEvent.ACTION_SCROLL, MotionEvent.ACTION_MOVE -> {
-                    view.hideKeyboard()
-                }
-            }
-            false
-        }
         toolbarView = ToolbarView(
             view.toolbar_component_wrapper,
             searchInteractor,

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -35,7 +35,6 @@
     <androidx.core.widget.NestedScrollView
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:id="@+id/scrollView"
         app:layout_constraintBottom_toBottomOf="@id/search_divider"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
Reverts mozilla-mobile/fenix#10634

I'm seeing the homescreen on current master completely unresponsive with the following STR
1. Type something in Search Fragment
2. Scroll to dismiss keyboard
3. Press back 
4. Try to press toolbar again to do another search

(sometimes it just pops you entirely out of Fenix when you press back too)