### PR TITLE
For issue #9949 - Inconsistencies between deleting bookmark and history items

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/HistoryTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/HistoryTest.kt
@@ -158,6 +158,7 @@ class HistoryTest {
         }.openHistory {
         }.openThreeDotMenu {
         }.clickDelete {
+            verifyDeleteSnackbarText("Deleted")
             verifyEmptyHistoryView()
         }
     }
@@ -174,6 +175,7 @@ class HistoryTest {
             clickDeleteHistoryButton()
             verifyDeleteConfirmationMessage()
             confirmDeleteAllHistory()
+            verifyDeleteSnackbarText("Browsing data deleted")
             verifyEmptyHistoryView()
         }
     }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HistoryRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HistoryRobot.kt
@@ -83,6 +83,8 @@ class HistoryRobot {
             .click()
     }
 
+    fun verifyDeleteSnackbarText(text: String) = assertSnackBarText(text)
+
     class Transition {
         fun goBack(interact: HistoryRobot.() -> Unit): Transition {
             goBackButton().click()
@@ -152,3 +154,6 @@ private fun assertDeleteConfirmationMessage() =
         .check(matches(isDisplayed()))
 
 private fun assertCopySnackBarText() = snackBarText().check(matches(withText("URL copied")))
+
+private fun assertSnackBarText(text: String) =
+    snackBarText().check(matches(withText(Matchers.containsString(text))))

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkController.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkController.kt
@@ -35,7 +35,7 @@ interface BookmarkController {
     fun handleBookmarkSharing(item: BookmarkNode)
     fun handleOpeningBookmark(item: BookmarkNode, mode: BrowsingMode)
     fun handleBookmarkDeletion(nodes: Set<BookmarkNode>, eventType: Event)
-    fun handleBookmarkFolderDeletion(node: BookmarkNode)
+    fun handleBookmarkFolderDeletion(nodes: Set<BookmarkNode>)
     fun handleBackPressed()
 }
 
@@ -45,7 +45,7 @@ class DefaultBookmarkController(
     private val navController: NavController,
     private val showSnackbar: (String) -> Unit,
     private val deleteBookmarkNodes: (Set<BookmarkNode>, Event) -> Unit,
-    private val deleteBookmarkFolder: (BookmarkNode) -> Unit,
+    private val deleteBookmarkFolder: (Set<BookmarkNode>) -> Unit,
     private val invokePendingDeletion: () -> Unit
 ) : BookmarkController {
 
@@ -94,8 +94,8 @@ class DefaultBookmarkController(
         deleteBookmarkNodes(nodes, eventType)
     }
 
-    override fun handleBookmarkFolderDeletion(node: BookmarkNode) {
-        deleteBookmarkFolder(node)
+    override fun handleBookmarkFolderDeletion(nodes: Set<BookmarkNode>) {
+        deleteBookmarkFolder(nodes)
     }
 
     override fun handleBackPressed() {

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragment.kt
@@ -274,13 +274,17 @@ class BookmarkFragment : LibraryPageFragment<BookmarkNode>(), UserInteractionHan
     }
 
     private fun deleteMulti(selected: Set<BookmarkNode>, eventType: Event = Event.RemoveBookmarks) {
+        selected.forEach { if (it.type == BookmarkNodeType.FOLDER) {
+            showRemoveFolderDialog(selected)
+            return
+        } }
         updatePendingBookmarksToDelete(selected)
 
         pendingBookmarkDeletionJob = getDeleteOperation(eventType)
 
         val message = when (eventType) {
             is Event.RemoveBookmarks -> {
-                getRemoveBookmarksSnackBarMessage(selected)
+                getRemoveBookmarksSnackBarMessage(selected, containsFolders = false)
             }
             is Event.RemoveBookmarkFolder,
             is Event.RemoveBookmark -> {
@@ -301,9 +305,16 @@ class BookmarkFragment : LibraryPageFragment<BookmarkNode>(), UserInteractionHan
         )
     }
 
-    private fun getRemoveBookmarksSnackBarMessage(selected: Set<BookmarkNode>): String {
+    private fun getRemoveBookmarksSnackBarMessage(
+        selected: Set<BookmarkNode>,
+        containsFolders: Boolean
+    ): String {
         return if (selected.size > 1) {
-            getString(R.string.bookmark_deletion_multiple_snackbar_message_2)
+            return if (containsFolders) {
+                getString(R.string.bookmark_deletion_multiple_snackbar_message_3)
+            } else {
+                getString(R.string.bookmark_deletion_multiple_snackbar_message_2)
+            }
         } else {
             val bookmarkNode = selected.first()
             getString(
@@ -314,29 +325,38 @@ class BookmarkFragment : LibraryPageFragment<BookmarkNode>(), UserInteractionHan
         }
     }
 
+    private fun getDialogConfirmationMessage(selected: Set<BookmarkNode>): String {
+        return if (selected.size > 1) {
+            getString(R.string.bookmark_delete_multiple_folders_confirmation_dialog, getString(R.string.app_name))
+        } else {
+            getString(R.string.bookmark_delete_folder_confirmation_dialog)
+        }
+    }
+
     override fun onDestroyView() {
         super.onDestroyView()
         _bookmarkInteractor = null
     }
 
-    private fun showRemoveFolderDialog(selected: BookmarkNode) {
+    private fun showRemoveFolderDialog(selected: Set<BookmarkNode>) {
         activity?.let { activity ->
             AlertDialog.Builder(activity).apply {
-                setMessage(R.string.bookmark_delete_folder_confirmation_dialog)
+                val dialogConfirmationMessage = getDialogConfirmationMessage(selected)
+                setMessage(dialogConfirmationMessage)
                 setNegativeButton(R.string.delete_browsing_data_prompt_cancel) { dialog: DialogInterface, _ ->
                     dialog.cancel()
                 }
                 setPositiveButton(R.string.delete_browsing_data_prompt_allow) { dialog: DialogInterface, _ ->
-                    updatePendingBookmarksToDelete(setOf(selected))
+                    updatePendingBookmarksToDelete(selected)
                     pendingBookmarkDeletionJob = getDeleteOperation(Event.RemoveBookmarkFolder)
                     dialog.dismiss()
-                    val message = getDeleteDialogString(selected)
+                    val snackbarMessage = getRemoveBookmarksSnackBarMessage(selected, containsFolders = true)
                     viewLifecycleOwner.lifecycleScope.allowUndo(
                         requireView(),
-                        message,
+                        snackbarMessage,
                         getString(R.string.bookmark_undo_deletion),
                         {
-                            undoPendingDeletion(setOf(selected))
+                            undoPendingDeletion(selected)
                         },
                         operation = getDeleteOperation(Event.RemoveBookmarkFolder)
                     )
@@ -351,14 +371,6 @@ class BookmarkFragment : LibraryPageFragment<BookmarkNode>(), UserInteractionHan
         pendingBookmarksToDelete.addAll(selected)
         val bookmarkTree = sharedViewModel.selectedFolder!! - pendingBookmarksToDelete
         bookmarkInteractor.onBookmarksChanged(bookmarkTree)
-    }
-
-    private fun getDeleteDialogString(selected: BookmarkNode): String {
-        return getString(
-            R.string.bookmark_deletion_snackbar_message,
-            context?.components?.publicSuffixList?.let { selected.url?.toShortUrl(it) }
-                ?: selected.title
-        )
     }
 
     private suspend fun undoPendingDeletion(selected: Set<BookmarkNode>) {

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragmentInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragmentInteractor.kt
@@ -90,7 +90,7 @@ class BookmarkFragmentInteractor(
             null -> Event.RemoveBookmarks
         }
         if (eventType == Event.RemoveBookmarkFolder) {
-            bookmarksController.handleBookmarkFolderDeletion(nodes.first())
+            bookmarksController.handleBookmarkFolderDeletion(nodes)
         } else {
             bookmarksController.handleBookmarkDeletion(nodes, eventType)
         }

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryView.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryView.kt
@@ -90,7 +90,6 @@ class HistoryView(
     val view: View = LayoutInflater.from(container.context)
         .inflate(R.layout.component_history, container, true)
 
-    private var items: List<HistoryItem> = listOf()
     var mode: HistoryFragmentState.Mode = HistoryFragmentState.Mode.Normal
         private set
 
@@ -116,12 +115,15 @@ class HistoryView(
     fun update(state: HistoryFragmentState) {
         val oldMode = mode
 
-        view.progress_bar.isVisible = state.mode === HistoryFragmentState.Mode.Deleting
+        view.progress_bar.isVisible = state.isDeletingItems
         view.swipe_refresh.isRefreshing = state.mode === HistoryFragmentState.Mode.Syncing
         view.swipe_refresh.isEnabled =
             state.mode === HistoryFragmentState.Mode.Normal || state.mode === HistoryFragmentState.Mode.Syncing
-        items = state.items
         mode = state.mode
+
+        historyAdapter.updatePendingDeletionIds(state.pendingDeletionIds)
+
+        updateEmptyState(state.pendingDeletionIds.size != historyAdapter.currentList?.size)
 
         historyAdapter.updateMode(state.mode)
         val first = layoutManager.findFirstVisibleItemPosition()

--- a/app/src/main/java/org/mozilla/fenix/library/history/viewholders/HistoryListItemViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/viewholders/HistoryListItemViewHolder.kt
@@ -11,13 +11,13 @@ import kotlinx.android.synthetic.main.library_site_item.view.*
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.hideAndDisable
 import org.mozilla.fenix.ext.showAndEnable
-import org.mozilla.fenix.utils.Do
 import org.mozilla.fenix.library.SelectionHolder
 import org.mozilla.fenix.library.history.HistoryFragmentState
 import org.mozilla.fenix.library.history.HistoryInteractor
 import org.mozilla.fenix.library.history.HistoryItem
 import org.mozilla.fenix.library.history.HistoryItemMenu
 import org.mozilla.fenix.library.history.HistoryItemTimeGroup
+import org.mozilla.fenix.utils.Do
 
 class HistoryListItemViewHolder(
     view: View,
@@ -44,8 +44,15 @@ class HistoryListItemViewHolder(
         item: HistoryItem,
         timeGroup: HistoryItemTimeGroup?,
         showDeleteButton: Boolean,
-        mode: HistoryFragmentState.Mode
+        mode: HistoryFragmentState.Mode,
+        isPendingDeletion: Boolean = false
     ) {
+        if (isPendingDeletion) {
+            itemView.history_layout.visibility = View.GONE
+        } else {
+            itemView.history_layout.visibility = View.VISIBLE
+        }
+
         itemView.history_layout.titleView.text = item.title
         itemView.history_layout.urlView.text = item.url
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -566,6 +566,8 @@
     <string name="bookmark_select_folder">Select folder</string>
     <!-- Confirmation message for a dialog confirming if the user wants to delete the selected folder -->
     <string name="bookmark_delete_folder_confirmation_dialog">Are you sure you want to delete this folder?</string>
+    <!-- Confirmation message for a dialog confirming if the user wants to delete multiple items including folders. Parameter will be replaced by app name. -->
+    <string name="bookmark_delete_multiple_folders_confirmation_dialog">%s will delete the selected items.</string>
     <!-- Snackbar title shown after a folder has been deleted. This first parameter is the name of the deleted folder -->
     <string name="bookmark_delete_folder_snackbar">Deleted %1$s</string>
     <!-- Screen title for adding a bookmarks folder -->
@@ -620,8 +622,10 @@
     <!-- Bookmark snackbar message on deletion
      The first parameter is the host part of the URL of the bookmark deleted, if any -->
     <string name="bookmark_deletion_snackbar_message">Deleted %1$s</string>
-    <!-- Bookmark snackbar message on deleting multiple bookmarks -->
+    <!-- Bookmark snackbar message on deleting multiple bookmarks not including folders-->
     <string name="bookmark_deletion_multiple_snackbar_message_2">Bookmarks deleted</string>
+    <!-- Bookmark snackbar message on deleting multiple bookmarks including folders-->
+    <string name="bookmark_deletion_multiple_snackbar_message_3">Deleting selected folders</string>
     <!-- Bookmark undo button for deletion snackbar action -->
     <string name="bookmark_undo_deletion">UNDO</string>
 

--- a/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkControllerTest.kt
@@ -42,7 +42,7 @@ class BookmarkControllerTest {
     private val navController: NavController = mockk(relaxed = true)
     private val showSnackbar: (String) -> Unit = mockk(relaxed = true)
     private val deleteBookmarkNodes: (Set<BookmarkNode>, Event) -> Unit = mockk(relaxed = true)
-    private val deleteBookmarkFolder: (BookmarkNode) -> Unit = mockk(relaxed = true)
+    private val deleteBookmarkFolder: (Set<BookmarkNode>) -> Unit = mockk(relaxed = true)
     private val invokePendingDeletion: () -> Unit = mockk(relaxed = true)
 
     private val homeActivity: HomeActivity = mockk(relaxed = true)
@@ -240,10 +240,10 @@ class BookmarkControllerTest {
 
     @Test
     fun `handleBookmarkDeletion for a folder should properly call the delete folder delegate`() {
-        controller.handleBookmarkFolderDeletion(subfolder)
+        controller.handleBookmarkFolderDeletion(setOf(subfolder))
 
         verify {
-            deleteBookmarkFolder(subfolder)
+            deleteBookmarkFolder(setOf(subfolder))
         }
     }
 

--- a/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkFragmentInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkFragmentInteractorTest.kt
@@ -196,7 +196,7 @@ class BookmarkFragmentInteractorTest {
         interactor.onDelete(setOf(subfolder))
 
         verify {
-            bookmarkController.handleBookmarkFolderDeletion(subfolder)
+            bookmarkController.handleBookmarkFolderDeletion(setOf(subfolder))
         }
     }
 

--- a/app/src/test/java/org/mozilla/fenix/library/history/HistoryFragmentStoreTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/history/HistoryFragmentStoreTest.kt
@@ -60,7 +60,9 @@ class HistoryFragmentStoreTest {
     fun finishSync() = runBlocking {
         val initialState = HistoryFragmentState(
             items = listOf(),
-            mode = HistoryFragmentState.Mode.Syncing
+            mode = HistoryFragmentState.Mode.Syncing,
+            pendingDeletionIds = emptySet(),
+            isDeletingItems = false
         )
         val store = HistoryFragmentStore(initialState)
 
@@ -71,16 +73,22 @@ class HistoryFragmentStoreTest {
 
     private fun emptyDefaultState(): HistoryFragmentState = HistoryFragmentState(
         items = listOf(),
-        mode = HistoryFragmentState.Mode.Normal
+        mode = HistoryFragmentState.Mode.Normal,
+        pendingDeletionIds = emptySet(),
+        isDeletingItems = false
     )
 
     private fun oneItemEditState(): HistoryFragmentState = HistoryFragmentState(
         items = listOf(),
-        mode = HistoryFragmentState.Mode.Editing(setOf(historyItem))
+        mode = HistoryFragmentState.Mode.Editing(setOf(historyItem)),
+        pendingDeletionIds = emptySet(),
+        isDeletingItems = false
     )
 
     private fun twoItemEditState(): HistoryFragmentState = HistoryFragmentState(
         items = listOf(),
-        mode = HistoryFragmentState.Mode.Editing(setOf(historyItem, newHistoryItem))
+        mode = HistoryFragmentState.Mode.Editing(setOf(historyItem, newHistoryItem)),
+        pendingDeletionIds = emptySet(),
+        isDeletingItems = false
     )
 }


### PR DESCRIPTION
 - Added a new check inside the "deleteMulti" method from BookmarkFragment that calls the showRemoveFoldersDialog to prevent the user from being able to delete one or more bookmark folders without being asked for confirmation, as in #8648.

- Added the undo action for deleting individual history items by creating a new field to the history state containing the id's of the history items that are pending for deletion; This field is used inside the update function from the view to show/hide the items. 

- In order to show the correct headers while items are being hidden/deleted, a map was added in the adapter that keeps the position of the headers and updates it as items are pending for deletion/deleted.

- In addition, the state's modes have been reduced to "Normal" and "Editing", since the "Deleting" mode's UI updates (showing and hiding the deletion progress bar) is doesn't overlap the other states.

<img src = "https://user-images.githubusercontent.com/23737079/82219871-907adf00-9926-11ea-9f90-1a9888f04c13.png" width = "300">

<img src = "https://user-images.githubusercontent.com/23737079/83106731-a2e2de80-a0c5-11ea-81b5-1c141995b6c3.png" width = "300">


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ X ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ X ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ X ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture