### PR TITLE
Revert "For #6313 - On first load, hides engineView until firstContentfulPaint"

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -40,6 +40,12 @@ import org.mozilla.fenix.helpers.click
 import org.mozilla.fenix.helpers.ext.waitNotNull
 
 class BrowserRobot {
+
+    fun verifyBrowserScreen() {
+        onView(ViewMatchers.withResourceName("browserLayout"))
+            .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+    }
+
     fun verifyCurrentPrivateSession(context: Context) {
         val session = context.components.core.sessionManager.selectedSession
         assertTrue("Current session is private", session?.private!!)
@@ -73,7 +79,6 @@ class BrowserRobot {
     */
     fun verifyPageContent(expectedText: String) {
         val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-        mDevice.waitNotNull(Until.findObject(By.res("org.mozilla.fenix.debug:id/engineView")), waitingTime)
         mDevice.waitNotNull(Until.findObject(text(expectedText)), waitingTime)
     }
 

--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -179,8 +179,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Session
             engineView = WeakReference(engineView),
             swipeRefresh = WeakReference(swipeRefresh),
             viewLifecycleScope = viewLifecycleOwner.lifecycleScope,
-            arguments = requireArguments(),
-            firstContentfulHappened = ::didFirstContentfulHappen
+            arguments = requireArguments()
         ).apply {
             beginAnimateInIfNecessary()
         }
@@ -861,15 +860,6 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Session
         if (!FeatureFlags.dynamicBottomToolbar) {
             updateLayoutMargins(inFullScreen)
         }
-    }
-
-    private fun didFirstContentfulHappen(): Boolean {
-        val store = context?.components?.core?.store
-        val tabState = store?.state?.tabs?.find {
-            it.id == (customTabSessionId
-                ?: context?.components?.core?.sessionManager?.selectedSession?.id)
-        }
-        return tabState?.content?.firstContentfulPaint == true
     }
 
     /*

--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserAnimator.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserAnimator.kt
@@ -33,8 +33,7 @@ class BrowserAnimator(
     private val engineView: WeakReference<EngineView>,
     private val swipeRefresh: WeakReference<View>,
     private val viewLifecycleScope: LifecycleCoroutineScope,
-    private val arguments: Bundle,
-    private val firstContentfulHappened: () -> Boolean
+    private val arguments: Bundle
 ) {
 
     private val unwrappedEngineView: EngineView?
@@ -53,9 +52,22 @@ class BrowserAnimator(
         }
 
         doOnEnd {
-            if (firstContentfulHappened()) {
-                unwrappedEngineView?.asView()?.visibility = View.VISIBLE
-            }
+            unwrappedEngineView?.asView()?.visibility = View.VISIBLE
+            unwrappedSwipeRefresh?.background = null
+            arguments.putBoolean(SHOULD_ANIMATE_FLAG, false)
+        }
+
+        interpolator = DecelerateInterpolator()
+        duration = ANIMATION_DURATION
+    }
+
+    private val browserFadeInValueAnimator = ValueAnimator.ofFloat(0f, END_ANIMATOR_VALUE).apply {
+        addUpdateListener {
+            unwrappedSwipeRefresh?.alpha = it.animatedFraction
+        }
+
+        doOnEnd {
+            unwrappedEngineView?.asView()?.visibility = View.VISIBLE
             unwrappedSwipeRefresh?.background = null
             arguments.putBoolean(SHOULD_ANIMATE_FLAG, false)
         }
@@ -80,9 +92,7 @@ class BrowserAnimator(
             }
         } else {
             unwrappedSwipeRefresh?.alpha = 1f
-            if (firstContentfulHappened()) {
-                unwrappedEngineView?.asView()?.visibility = View.VISIBLE
-            }
+            unwrappedEngineView?.asView()?.visibility = View.VISIBLE
             unwrappedSwipeRefresh?.background = null
         }
     }


### PR DESCRIPTION
Reverts mozilla-mobile/fenix#10358

Seeing some issues here, let's revert until we can fix them
https://github.com/mozilla-mobile/fenix/issues/10708
 https://github.com/mozilla-mobile/fenix/issues/10695
 https://github.com/mozilla-mobile/fenix/issues/10689