### PR TITLE
For #10757: remove no-op Experiments code and dependency.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -498,9 +498,7 @@ dependencies {
     implementation Deps.mozilla_service_sync_logins
     implementation Deps.mozilla_service_firefox_accounts
     implementation Deps.mozilla_service_glean
-    implementation Deps.mozilla_service_experiments
     implementation Deps.mozilla_service_location
-
 
     implementation Deps.mozilla_support_base
     implementation Deps.mozilla_support_ktx

--- a/app/src/geckoBeta/java/org/mozilla/fenix/engine/GeckoProvider.kt
+++ b/app/src/geckoBeta/java/org/mozilla/fenix/engine/GeckoProvider.kt
@@ -8,7 +8,6 @@ import mozilla.components.browser.engine.gecko.autofill.GeckoLoginDelegateWrappe
 import mozilla.components.browser.engine.gecko.glean.GeckoAdapter
 import mozilla.components.concept.storage.LoginsStorage
 import mozilla.components.lib.crash.handler.CrashHandlerService
-import mozilla.components.service.experiments.Experiments
 import mozilla.components.service.sync.logins.GeckoLoginStorageDelegate
 import org.mozilla.fenix.Config
 import org.mozilla.fenix.ext.settings
@@ -49,12 +48,6 @@ object GeckoProvider {
             .aboutConfigEnabled(Config.channel.isBeta)
             .debugLogging(Config.channel.isDebug)
             .build()
-
-        Experiments.withExperiment("webrender-performance-comparison-experiment") { branchName ->
-            if (branchName == "disable_webrender") {
-                runtimeSettings.extras.putInt("forcedisablewebrender", 1)
-            }
-        }
 
         if (!Settings.getInstance(context).shouldUseAutoSize) {
             runtimeSettings.automaticFontSizeAdjustment = false

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -117,7 +117,6 @@ object Deps {
         "org.mozilla.components:service-sync-logins:${Versions.mozilla_android_components}"
     const val mozilla_service_firefox_accounts = "org.mozilla.components:service-firefox-accounts:${Versions.mozilla_android_components}"
     const val mozilla_service_glean = "org.mozilla.components:service-glean:${Versions.mozilla_android_components}"
-    const val mozilla_service_experiments = "org.mozilla.components:service-experiments:${Versions.mozilla_android_components}"
     const val mozilla_service_location = "org.mozilla.components:service-location:${Versions.mozilla_android_components}"
 
     const val mozilla_ui_colors = "org.mozilla.components:ui-colors:${Versions.mozilla_android_components}"


### PR DESCRIPTION
We were supposed to have removed Experiments for performance purposes.
However, I find some code dangling in the tree.

Experiments.initialize is no longer called so I suspect
Experiments.withExperiment is a no-op. I verified that the lambda
function provided to it never ran in my local geckoBetaDebug on startup.
Assuming experiments behavior doesn't change in other build types, this
change appears safe.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture