### PR TITLE
Gradle build improvements

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -346,9 +346,13 @@ android.applicationVariants.all { variant ->
     }
 
     def buildDate = Config.generateBuildDate()
-    buildConfigField 'String', 'BUILD_DATE', '"' + buildDate + '"'
-
-    def variantName = variant.getName()
+    // Setting buildDate with every build changes the generated BuildConfig, which slows down the
+    // build. Only do this for non-debug builds, to speed-up builds produced during local development.
+    if (isDebug) {
+        buildConfigField 'String', 'BUILD_DATE', '"debug build"'
+    } else {
+        buildConfigField 'String', 'BUILD_DATE', '"' + buildDate + '"'
+    }
 
 // -------------------------------------------------------------------------------------------------
 // Adjust: Read token from local file if it exists (Only release builds)

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAboutRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAboutRobot.kt
@@ -92,7 +92,11 @@ private fun assertProductCompany() {
 
 private fun assertCurrentTimestamp() {
     onView(withId(R.id.build_date))
-        .check(BuildDateAssertion.isDisplayedDateAccurate())
+        // Currently UI tests run against debug builds, which display a hard-coded string 'debug build'
+        // instead of the date. See https://github.com/mozilla-mobile/fenix/pull/10812#issuecomment-633746833
+        .check(matches(withText(containsString("debug build"))))
+        // This assertion should be valid for non-debug build types.
+        // .check(BuildDateAssertion.isDisplayedDateAccurate())
 }
 
 private fun assertWhatIsNewInFirefoxPreview() {


### PR DESCRIPTION
This is pretty minor, but the `BUILD_DATE` is a noticeable improvement (see comments below).

~~gradle plugin version is the same one we're using in a-c right now.~~

Small steps forward.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture