### PR TITLE
for #10759: close notification shade if still open

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/MediaNotificationTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/MediaNotificationTest.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.fenix.ui
 
+import androidx.test.uiautomator.UiSelector
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
@@ -43,6 +44,12 @@ class MediaNotificationTest {
     @After
     fun tearDown() {
         mockWebServer.shutdown()
+        // verify if the notification tray is expanded and should be closed before the next test
+        val notificationShade =
+            mDevice.findObject(UiSelector().resourceId("com.android.systemui:id/notification_stack_scroller"))
+
+        if (notificationShade.exists())
+            mDevice.pressBack()
     }
 
     @Test


### PR DESCRIPTION
In case Media Notification tests fail, the notification shade might remain open on top of the app. This verifies and closes the tray if it's still open at the end of each test.
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture