### PR TITLE
Bug 1642657 - Add a per-commit fenix build that simulates the nightly.

### DIFF
--- a/taskcluster/ci/browsertime/kind.yml
+++ b/taskcluster/ci/browsertime/kind.yml
@@ -105,7 +105,6 @@ jobs:
 
     tp6m-2-cold:
         test-name: google
-        run-on-tasks-for: [github-pull-request]
         treeherder:
             symbol: 'Btime(tp6m-2-c)'
 

--- a/taskcluster/ci/browsertime/kind.yml
+++ b/taskcluster/ci/browsertime/kind.yml
@@ -13,7 +13,7 @@ kind-dependencies:
 primary-dependency: signing
 
 only-for-build-types:
-    - android-test
+    - nightly-simulation
 
 only-for-abis:
     - armeabi-v7a

--- a/taskcluster/ci/browsertime/kind.yml
+++ b/taskcluster/ci/browsertime/kind.yml
@@ -13,7 +13,7 @@ kind-dependencies:
 primary-dependency: signing
 
 only-for-build-types:
-    - nightly
+    - android-test
 
 only-for-abis:
     - armeabi-v7a
@@ -105,6 +105,7 @@ jobs:
 
     tp6m-2-cold:
         test-name: google
+        run-on-tasks-for: [github-pull-request]
         treeherder:
             symbol: 'Btime(tp6m-2-c)'
 

--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -104,7 +104,7 @@ jobs:
         treeherder:
             symbol: nightly(B)
 
-    android-test:
+    nightly-simulation:
         attributes:
             nightly: false
         run-on-tasks-for: [github-push]
@@ -112,9 +112,9 @@ jobs:
         include-shippable-secrets: true
         run:
             geckoview-engine: geckoNightly
-            gradle-build-type: fenixNightly
+            gradle-build-type: fennecNightly
         treeherder:
-            symbol: nightly(Bo)
+            symbol: nightlySim(B)
 
     beta:
         attributes:

--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -104,6 +104,18 @@ jobs:
         treeherder:
             symbol: nightly(B)
 
+    android-test:
+        attributes:
+            nightly: false
+        run-on-tasks-for: [github-push]
+        include-nightly-version: true
+        include-shippable-secrets: true
+        run:
+            geckoview-engine: geckoNightly
+            gradle-build-type: fenixNightly
+        treeherder:
+            symbol: nightly(Bo)
+
     beta:
         attributes:
             release-type: beta

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -11,6 +11,7 @@ treeherder:
         'forPerformanceTest': 'Builds made for Raptor and other performance tests'
         'I': 'Docker Image Builds'
         'nightly': 'Nightly-related tasks'
+        'nightlySim': 'Nightly-related tasks that run on each github push'
         'nightlyFennec': 'Nightly-related tasks with same APK configuration as Fennec'
         'production': 'Release-related tasks'
         'productionFennec': 'Production-related tasks with same APK configuration as Fennec'

--- a/taskcluster/ci/signing/kind.yml
+++ b/taskcluster/ci/signing/kind.yml
@@ -66,7 +66,7 @@ job-template:
           default: autograph_apk
     index:
         by-build-type:
-            (fennec-.+|nightly|performance-test|beta|production|debug):
+            (fennec-.+|nightly|performance-test|beta|production|debug|nightly-simulation):
                 type: signing
             default: {}
     run-on-tasks-for: []

--- a/taskcluster/ci/signing/kind.yml
+++ b/taskcluster/ci/signing/kind.yml
@@ -20,7 +20,7 @@ job-template:
     description: Sign Fenix
     worker-type:
         by-build-type:
-            (fennec-.+|nightly|beta|production|android-test-nightly|android-test):
+            (fennec-.+|nightly|beta|production|android-test-nightly|nightly-simulation):
                 by-level:
                     '3': signing
                     default: dep-signing
@@ -36,11 +36,11 @@ job-template:
                     by-level:
                         '3': fennec-nightly-signing
                         default: dep-signing
-                nightly:
+                nightly-simulation:
                     by-level:
-                        '3': nightly-signing
+                        '3': fennec-nightly-signing
                         default: dep-signing
-                android-test:
+                nightly:
                     by-level:
                         '3': nightly-signing
                         default: dep-signing
@@ -66,7 +66,7 @@ job-template:
           default: autograph_apk
     index:
         by-build-type:
-            (fennec-.+|nightly|performance-test|beta|production|debug|android-test):
+            (fennec-.+|nightly|performance-test|beta|production|debug|nightly-simulation):
                 type: signing
             default: {}
     run-on-tasks-for: []
@@ -74,7 +74,6 @@ job-template:
         job-symbol:
             by-build-type:
                 android-test.+: Bats
-                android-test: Bos
                 default: Bs
         kind: build
         platform: android-all/opt

--- a/taskcluster/ci/signing/kind.yml
+++ b/taskcluster/ci/signing/kind.yml
@@ -20,7 +20,7 @@ job-template:
     description: Sign Fenix
     worker-type:
         by-build-type:
-            (fennec-.+|nightly|beta|production|android-test-nightly):
+            (fennec-.+|nightly|beta|production|android-test-nightly|android-test):
                 by-level:
                     '3': signing
                     default: dep-signing
@@ -37,6 +37,10 @@ job-template:
                         '3': fennec-nightly-signing
                         default: dep-signing
                 nightly:
+                    by-level:
+                        '3': nightly-signing
+                        default: dep-signing
+                android-test:
                     by-level:
                         '3': nightly-signing
                         default: dep-signing
@@ -62,7 +66,7 @@ job-template:
           default: autograph_apk
     index:
         by-build-type:
-            (fennec-.+|nightly|performance-test|beta|production|debug):
+            (fennec-.+|nightly|performance-test|beta|production|debug|android-test):
                 type: signing
             default: {}
     run-on-tasks-for: []
@@ -70,6 +74,7 @@ job-template:
         job-symbol:
             by-build-type:
                 android-test.+: Bats
+                android-test: Bos
                 default: Bs
         kind: build
         platform: android-all/opt

--- a/taskcluster/ci/signing/kind.yml
+++ b/taskcluster/ci/signing/kind.yml
@@ -66,7 +66,7 @@ job-template:
           default: autograph_apk
     index:
         by-build-type:
-            (fennec-.+|nightly|performance-test|beta|production|debug|nightly-simulation):
+            (fennec-.+|nightly|performance-test|beta|production|debug):
                 type: signing
             default: {}
     run-on-tasks-for: []


### PR DESCRIPTION
This patch adds a new build that is a copy of the nightly build but it's built on each commit instead of once daily so that we can easily run performance tests on each commit (for app-link tests).