### PR TITLE
For #1824: Prevent extremely long URLs from locking up HomeFragment

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/TabViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/TabViewHolder.kt
@@ -11,6 +11,7 @@ import android.view.ViewOutlineProvider
 import androidx.appcompat.content.res.AppCompatResources
 import kotlinx.android.synthetic.main.tab_list_row.*
 import mozilla.components.browser.state.state.MediaState
+import mozilla.components.browser.toolbar.MAX_URI_LENGTH
 import mozilla.components.support.ktx.android.util.dpToFloat
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.metrics.Event
@@ -81,7 +82,12 @@ class TabViewHolder(
     internal fun bindSession(tab: Tab) {
         updateTab(tab)
         updateTitle(tab.title)
-        updateHostname(tab.hostname)
+        // Truncate to MAX_URI_LENGTH to prevent the UI from locking up for
+        // extremely large URLs such as data URIs or bookmarklets. The same
+        // is done in the toolbar and awesomebar:
+        // https://github.com/mozilla-mobile/fenix/issues/1824
+        // https://github.com/mozilla-mobile/android-components/issues/6985
+        updateHostname(tab.hostname.take(MAX_URI_LENGTH))
         updateFavIcon(tab.url, tab.icon)
         updateSelected(tab.selected ?: false)
         updatePlayPauseButton(tab.mediaState)

--- a/app/src/test/java/org/mozilla/fenix/home/TabViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/TabViewHolderTest.kt
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.home
+
+import android.view.LayoutInflater
+import io.mockk.mockk
+import kotlinx.android.synthetic.main.tab_list_row.view.*
+import mozilla.components.browser.state.state.MediaState
+import mozilla.components.browser.toolbar.MAX_URI_LENGTH
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.fenix.R
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+import org.mozilla.fenix.home.sessioncontrol.TabSessionInteractor
+import org.mozilla.fenix.home.sessioncontrol.viewholders.TabViewHolder
+
+@RunWith(FenixRobolectricTestRunner::class)
+class TabViewHolderTest {
+
+    @Test
+    fun `extremely long URLs are truncated to prevent slowing down the UI`() {
+        val view = LayoutInflater.from(testContext).inflate(
+            R.layout.tab_list_row, null, false)
+
+        val interactor: TabSessionInteractor = mockk()
+        val tabViewHolder = TabViewHolder(view, interactor)
+
+        val extremelyLongUrl = "m".repeat(MAX_URI_LENGTH + 1)
+        val tab = Tab(
+            sessionId = "123",
+            url = extremelyLongUrl,
+            hostname = extremelyLongUrl,
+            title = "test",
+            mediaState = MediaState.State.NONE)
+        tabViewHolder.bindSession(tab)
+
+        assertEquals("m".repeat(MAX_URI_LENGTH), view.hostname.text)
+    }
+}

--- a/app/src/test/java/org/mozilla/fenix/tabtray/TabTrayViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabtray/TabTrayViewHolderTest.kt
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabtray
+
+import android.view.LayoutInflater
+import androidx.test.core.app.ApplicationProvider
+import io.mockk.mockk
+import mozilla.components.browser.toolbar.MAX_URI_LENGTH
+import mozilla.components.concept.tabstray.Tab
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.doNothing
+import org.mockito.Mockito.spy
+import org.mozilla.fenix.R
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+
+@RunWith(FenixRobolectricTestRunner::class)
+class TabTrayViewHolderTest {
+
+    @Test
+    fun `extremely long URLs are truncated to prevent slowing down the UI`() {
+        val view = LayoutInflater.from(ApplicationProvider.getApplicationContext()).inflate(
+            R.layout.tab_tray_item, null, false)
+
+        val tabViewHolder = spy(TabTrayViewHolder(view))
+        doNothing().`when`(tabViewHolder).updateBackgroundColor(false)
+
+        val extremelyLongUrl = "m".repeat(MAX_URI_LENGTH + 1)
+        val tab = Tab(
+            id = "123",
+            url = extremelyLongUrl)
+        tabViewHolder.bind(tab, false, mockk())
+
+        assertEquals("m".repeat(MAX_URI_LENGTH), tabViewHolder.urlView?.text)
+    }
+}


### PR DESCRIPTION
One more fix in the series needed to prevent extremely long URLs from locking up our UIs.  :)

The first parts where handled in A-C (awesomebar and toolbar) and this is handling it in the HomeFragment. With this change we can now open data URIs properly.