### PR TITLE
Bug 1639955 - Fix geckodriver path for performance tests.

### DIFF
--- a/taskcluster/ci/browsertime/kind.yml
+++ b/taskcluster/ci/browsertime/kind.yml
@@ -105,7 +105,6 @@ jobs:
 
     tp6m-2-cold:
         test-name: google
-        run-on-tasks-for: [github-pull-request]
         treeherder:
             symbol: 'Btime(tp6m-2-c)'
 

--- a/taskcluster/ci/browsertime/kind.yml
+++ b/taskcluster/ci/browsertime/kind.yml
@@ -105,6 +105,7 @@ jobs:
 
     tp6m-2-cold:
         test-name: google
+        run-on-tasks-for: [github-pull-request]
         treeherder:
             symbol: 'Btime(tp6m-2-c)'
 

--- a/taskcluster/ci/toolchain/gecko-derived.yml
+++ b/taskcluster/ci/toolchain/gecko-derived.yml
@@ -27,7 +27,7 @@ linux64-ffmpeg-4.1.4:
 
 linux64-geckodriver:
     attributes:
-        toolchain-artifact: public/build/geckodriver.tar.gz
+        toolchain-artifact: public/geckodriver.tar.gz
     description: "Geckodriver toolchain"
     run:
         index-search:


### PR DESCRIPTION
This patch fixes an issue with geckodriver toolchain paths (from public/build/ to public/).