### PR TITLE
For 10844 - Fennec page shortcuts will open in normal tabs

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/IntentReceiverActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/IntentReceiverActivity.kt
@@ -75,6 +75,7 @@ class IntentReceiverActivity : Activity() {
 
         return listOf(components.intentProcessors.migrationIntentProcessor) +
             components.intentProcessors.externalAppIntentProcessors +
+            components.intentProcessors.fennecPageShortcutIntentProcessor +
             modeDependentProcessors +
             NewTabShortcutIntentProcessor()
     }

--- a/app/src/main/java/org/mozilla/fenix/components/IntentProcessorType.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/IntentProcessorType.kt
@@ -42,6 +42,7 @@ fun IntentProcessors.getType(processor: IntentProcessor?) = when {
             customTabIntentProcessor == processor ||
             privateCustomTabIntentProcessor == processor -> IntentProcessorType.EXTERNAL_APP
     intentProcessor == processor ||
-            privateIntentProcessor == processor -> IntentProcessorType.NEW_TAB
+            privateIntentProcessor == processor ||
+            fennecPageShortcutIntentProcessor == processor -> IntentProcessorType.NEW_TAB
     else -> IntentProcessorType.OTHER
 }

--- a/app/src/main/java/org/mozilla/fenix/components/IntentProcessors.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/IntentProcessors.kt
@@ -69,9 +69,12 @@ class IntentProcessors(
                 store = customTabsStore
             ),
             WebAppIntentProcessor(sessionManager, sessionUseCases.loadUrl, manifestStorage),
-            FennecBookmarkShortcutsIntentProcessor(sessionManager, sessionUseCases.loadUrl),
             FennecWebAppIntentProcessor(context, sessionManager, sessionUseCases.loadUrl, manifestStorage)
         )
+    }
+
+    val fennecPageShortcutIntentProcessor by lazy {
+        FennecBookmarkShortcutsIntentProcessor(sessionManager, sessionUseCases.loadUrl)
     }
 
     val migrationIntentProcessor by lazy {


### PR DESCRIPTION
This comes to resolve a small regression in which they were opened in new
custom tab.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: No tests. Small modifications in a not yet tested component.
- [x] **Screenshots**: No screenshots.
- [x] **Accessibility**: The code in this PR does not include any user facing features.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture