### PR TITLE
BaseBrowserFragment cleanup

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -477,9 +477,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Session
 
             @Suppress("ConstantConditionIf")
             if (FeatureFlags.pullToRefreshEnabled) {
-                val primaryTextColor =
-                    ThemeManager.resolveAttribute(R.attr.primaryText, context)
-                view.swipeRefresh.setColorSchemeColors(primaryTextColor)
+                view.swipeRefresh.setColorSchemeColors(context.getColorFromAttr(R.attr.primaryText))
                 swipeRefreshFeature.set(
                     feature = SwipeRefreshFeature(
                         sessionManager,
@@ -633,13 +631,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Session
     @CallSuper
     override fun onResume() {
         super.onResume()
-        val components = requireComponents
-
-        val preferredColorScheme = components.core.getPreferredColorScheme()
-        if (components.core.engine.settings.preferredColorScheme != preferredColorScheme) {
-            components.core.engine.settings.preferredColorScheme = preferredColorScheme
-            components.useCases.sessionUseCases.reload()
-        }
+        requireComponents.customizeColorSchemeUseCase.customizeEngine()
         hideToolbar()
     }
 

--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -85,12 +85,17 @@ import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.enterToImmersiveMode
 import org.mozilla.fenix.ext.hideToolbar
 import org.mozilla.fenix.ext.metrics
+import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.sessionsOfType
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.home.SharedViewModel
 import org.mozilla.fenix.theme.ThemeManager
+<<<<<<< HEAD
 import org.mozilla.fenix.wifi.SitePermissionsWifiIntegration
+=======
+import org.mozilla.fenix.utils.allowUndo
+>>>>>>> cad92e3c... Update tests
 import java.lang.ref.WeakReference
 
 /**
@@ -110,9 +115,6 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Session
     private var _browserToolbarView: BrowserToolbarView? = null
     protected val browserToolbarView: BrowserToolbarView
         get() = _browserToolbarView!!
-
-    private val sessionManager: SessionManager
-        get() = requireComponents.core.sessionManager
 
     protected val readerViewFeature = ViewBoundFeatureWrapper<ReaderViewFeature>()
 

--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -207,7 +207,6 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Session
                     action = Intent.ACTION_VIEW
                     putExtra(HomeActivity.OPEN_TO_BROWSER, true)
                 },
-                bookmarkTapped = { viewLifecycleOwner.lifecycleScope.launch { bookmarkTapped(it) } },
                 scope = viewLifecycleOwner.lifecycleScope,
                 tabCollectionStorage = requireComponents.core.tabCollectionStorage,
                 topSiteStorage = requireComponents.core.topSiteStorage,
@@ -802,49 +801,6 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Session
             sessionManager.findSessionById(localCustomTabId)
         } else {
             sessionManager.selectedSession
-        }
-    }
-
-    private suspend fun bookmarkTapped(session: Session) = withContext(IO) {
-        val bookmarksStorage = requireComponents.core.bookmarksStorage
-        val existing =
-            bookmarksStorage.getBookmarksWithUrl(session.url).firstOrNull { it.url == session.url }
-        if (existing != null) {
-            // Bookmark exists, go to edit fragment
-            withContext(Main) {
-                nav(
-                    R.id.browserFragment,
-                    BrowserFragmentDirections.actionGlobalBookmarkEditFragment(existing.guid, true)
-                )
-            }
-        } else {
-            // Save bookmark, then go to edit fragment
-            val guid = bookmarksStorage.addItem(
-                BookmarkRoot.Mobile.id,
-                url = session.url,
-                title = session.title,
-                position = null
-            )
-
-            withContext(Main) {
-                requireComponents.analytics.metrics.track(Event.AddBookmark)
-
-                view?.let { view ->
-                    FenixSnackbar.make(
-                        view = view,
-                        duration = FenixSnackbar.LENGTH_LONG,
-                        isDisplayedWithBrowserToolbar = true
-                    )
-                        .setText(getString(R.string.bookmark_saved_snackbar))
-                        .setAction(getString(R.string.edit_bookmark_snackbar_action)) {
-                            nav(
-                                R.id.browserFragment,
-                                BrowserFragmentDirections.actionGlobalBookmarkEditFragment(guid, true)
-                            )
-                        }
-                        .show()
-                }
-            }
         }
     }
 

--- a/app/src/main/java/org/mozilla/fenix/components/ColorSchemeUseCases.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/ColorSchemeUseCases.kt
@@ -1,0 +1,48 @@
+package org.mozilla.fenix.components
+
+import android.content.res.Configuration
+import android.content.res.Resources
+import mozilla.components.concept.engine.mediaquery.PreferredColorScheme
+import mozilla.components.feature.session.SessionUseCases
+import org.mozilla.fenix.utils.Settings
+
+object ColorSchemeUseCases {
+    class RetrieveColorSchemeUseCase(
+        private val resources: Resources,
+        private val settings: Settings
+    ) {
+
+        /**
+         * Sets Preferred Color scheme based on Dark/Light Theme Settings or Current Configuration.
+         */
+        fun getPreferredColorScheme(): PreferredColorScheme {
+            val inDark =
+                (resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) ==
+                        Configuration.UI_MODE_NIGHT_YES
+            return when {
+                settings.shouldUseDarkTheme -> PreferredColorScheme.Dark
+                settings.shouldUseLightTheme -> PreferredColorScheme.Light
+                inDark -> PreferredColorScheme.Dark
+                else -> PreferredColorScheme.Light
+            }
+        }
+    }
+
+    class CustomizeColorSchemeUseCase(
+        private val engineSettings: mozilla.components.concept.engine.Settings,
+        private val reloadUrlUseCase: SessionUseCases.ReloadUrlUseCase,
+        private val retrieveColorScheme: RetrieveColorSchemeUseCase
+    ) {
+
+        /**
+         * Updates the browser engine with the preferred color scheme.
+         */
+        fun customizeEngine() {
+            val preferredColorScheme = retrieveColorScheme.getPreferredColorScheme()
+            if (engineSettings.preferredColorScheme != preferredColorScheme) {
+                engineSettings.preferredColorScheme = preferredColorScheme
+                reloadUrlUseCase()
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/components/Components.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Components.kt
@@ -100,6 +100,14 @@ class Components(private val context: Context) {
         AddonManager(core.store, core.engine, addonCollectionProvider, addonUpdater)
     }
 
+    val customizeColorSchemeUseCase by lazy {
+        ColorSchemeUseCases.CustomizeColorSchemeUseCase(
+            core.engine.settings,
+            useCases.sessionUseCases.reload,
+            core.retrieveColorScheme
+        )
+    }
+
     val analytics by lazy { Analytics(context) }
     val publicSuffixList by lazy { PublicSuffixList(context) }
     val clipboardHandler by lazy { ClipboardHandler(context) }

--- a/app/src/main/java/org/mozilla/fenix/components/Components.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Components.kt
@@ -4,7 +4,6 @@
 
 package org.mozilla.fenix.components
 
-import android.app.Application
 import android.content.Context
 import android.content.Intent
 import androidx.core.net.toUri
@@ -20,7 +19,6 @@ import org.mozilla.fenix.BuildConfig
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.utils.ClipboardHandler
 import org.mozilla.fenix.utils.Mockable
-import org.mozilla.fenix.wifi.WifiConnectionMonitor
 import java.util.concurrent.TimeUnit
 
 private const val DAY_IN_MINUTES = 24 * 60L

--- a/app/src/main/java/org/mozilla/fenix/components/Components.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Components.kt
@@ -106,5 +106,4 @@ class Components(private val context: Context) {
     val migrationStore by lazy { MigrationStore() }
     val performance by lazy { PerformanceComponent() }
     val push by lazy { Push(context, analytics.crashReporter) }
-    val wifiConnectionMonitor by lazy { WifiConnectionMonitor(context as Application) }
 }

--- a/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -69,7 +69,7 @@ class Core(private val context: Context) {
             testingModeEnabled = false,
             trackingProtectionPolicy = trackingProtectionPolicyFactory.createTrackingProtectionPolicy(),
             historyTrackingDelegate = HistoryDelegate(lazyHistoryStorage),
-            preferredColorScheme = getPreferredColorScheme(),
+            preferredColorScheme = retrieveColorScheme.getPreferredColorScheme(),
             automaticFontSizeAdjustment = context.settings().shouldUseAutoSize,
             fontInflationEnabled = context.settings().shouldUseAutoSize,
             suspendMediaWhenInactive = false,
@@ -254,20 +254,10 @@ class Core(private val context: Context) {
 
     val trackingProtectionPolicyFactory = TrackingProtectionPolicyFactory(context.settings())
 
-    /**
-     * Sets Preferred Color scheme based on Dark/Light Theme Settings or Current Configuration
-     */
-    fun getPreferredColorScheme(): PreferredColorScheme {
-        val inDark =
-            (context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) ==
-                    Configuration.UI_MODE_NIGHT_YES
-        return when {
-            context.settings().shouldUseDarkTheme -> PreferredColorScheme.Dark
-            context.settings().shouldUseLightTheme -> PreferredColorScheme.Light
-            inDark -> PreferredColorScheme.Dark
-            else -> PreferredColorScheme.Light
-        }
-    }
+    val retrieveColorScheme = ColorSchemeUseCases.RetrieveColorSchemeUseCase(
+        context.resources,
+        context.settings()
+    )
 
     companion object {
         private const val KEY_STRENGTH = 256

--- a/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -7,7 +7,6 @@ package org.mozilla.fenix.components
 import GeckoProvider
 import android.app.Application
 import android.content.Context
-import android.content.res.Configuration
 import io.sentry.Sentry
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
@@ -25,7 +24,6 @@ import mozilla.components.browser.storage.sync.PlacesHistoryStorage
 import mozilla.components.browser.thumbnails.storage.ThumbnailStorage
 import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.Engine
-import mozilla.components.concept.engine.mediaquery.PreferredColorScheme
 import mozilla.components.concept.fetch.Client
 import mozilla.components.feature.customtabs.store.CustomTabsServiceStore
 import mozilla.components.feature.downloads.DownloadMiddleware

--- a/app/src/main/java/org/mozilla/fenix/components/SitePermissionsIntegration.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/SitePermissionsIntegration.kt
@@ -1,0 +1,89 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.components
+
+import android.content.Context
+import androidx.core.content.getSystemService
+import androidx.fragment.app.FragmentManager
+import androidx.lifecycle.LifecycleOwner
+import mozilla.components.feature.sitepermissions.SitePermissionsFeature
+import mozilla.components.support.base.feature.LifecycleAwareFeature
+import mozilla.components.support.base.feature.OnNeedToRequestPermissions
+import mozilla.components.support.base.feature.PermissionsFeature
+import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.settings.PhoneFeature
+import org.mozilla.fenix.settings.registerOnSharedPreferenceChangeListener
+import org.mozilla.fenix.wifi.SitePermissionsWifiIntegration
+
+/**
+ * Integrates [SitePermissionsFeature] from Android Components with Fenix's [settings].
+ */
+class SitePermissionsIntegration(
+    context: Context,
+    private val lifecycleOwner: LifecycleOwner,
+    sessionId: String?,
+    fragmentManager: FragmentManager,
+    promptsStyling: SitePermissionsFeature.PromptsStyling,
+    onNeedToRequestPermissions: OnNeedToRequestPermissions,
+    onShouldShowRequestPermissionRationale: (permission: String) -> Boolean
+) : LifecycleAwareFeature, PermissionsFeature {
+
+    private val applicationContext = context.applicationContext
+    private val settings = context.settings()
+
+    val feature = SitePermissionsFeature(
+        context = context,
+        sessionManager = context.components.core.sessionManager,
+        sessionId = sessionId,
+        storage = context.components.core.permissionStorage.permissionsStorage,
+        fragmentManager = fragmentManager,
+        promptsStyling = promptsStyling,
+        onNeedToRequestPermissions = onNeedToRequestPermissions,
+        onShouldShowRequestPermissionRationale = onShouldShowRequestPermissionRationale
+    )
+
+    override val onNeedToRequestPermissions get() = feature.onNeedToRequestPermissions
+
+    override fun onPermissionsResult(permissions: Array<String>, grantResults: IntArray) =
+        feature.onPermissionsResult(permissions, grantResults)
+
+    /**
+     * Updates the site permissions rules based on user settings.
+     */
+    private fun assignSitePermissionsRules() {
+        feature.sitePermissionsRules = settings.getSitePermissionsCustomSettingsRules()
+    }
+
+    /**
+     * Adds a listener that gets called whenever a [PhoneFeature] setting is changed.
+     */
+    private fun setSitePermissionSettingChangeListener(owner: LifecycleOwner) {
+        val sitePermissionKeyToFeature = PhoneFeature.values()
+            .map { phoneFeature -> phoneFeature.getPreferenceKey(applicationContext) }
+            .toSet()
+
+        settings.preferences.registerOnSharedPreferenceChangeListener(owner) { _, key ->
+            if (key in sitePermissionKeyToFeature) assignSitePermissionsRules()
+        }
+    }
+
+    override fun start() {
+        feature.start()
+        lifecycleOwner.lifecycle.addObserver(
+            SitePermissionsWifiIntegration(
+                settings = settings,
+                connectivityManager = applicationContext.getSystemService()!!
+            )
+        )
+
+        setSitePermissionSettingChangeListener(lifecycleOwner)
+        assignSitePermissionsRules()
+    }
+
+    override fun stop() {
+        feature.stop()
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt
@@ -44,6 +44,7 @@ import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.home.SharedViewModel
 import org.mozilla.fenix.settings.deletebrowsingdata.deleteAndQuit
 import org.mozilla.fenix.utils.Do
+import org.mozilla.fenix.utils.Settings
 
 /**
  * An interface that handles the view manipulation of the BrowserToolbar, triggered by the Interactor
@@ -74,6 +75,7 @@ class DefaultBrowserToolbarController(
     private val tabCollectionStorage: TabCollectionStorage,
     private val topSiteStorage: TopSiteStorage,
     private val sharedViewModel: SharedViewModel,
+    private val settings: Settings = activity.settings(),
     private val onTabCounterClicked: () -> Unit
 ) : BrowserToolbarController {
 
@@ -124,9 +126,9 @@ class DefaultBrowserToolbarController(
     override fun handleBrowserMenuDismissed(lowPrioHighlightItems: List<ToolbarMenu.Item>) {
         lowPrioHighlightItems.forEach {
             when (it) {
-                ToolbarMenu.Item.AddToHomeScreen -> activity.settings().installPwaOpened = true
-                is ToolbarMenu.Item.ReaderMode -> activity.settings().readerModeOpened = true
-                ToolbarMenu.Item.OpenInApp -> activity.settings().openInAppOpened = true
+                ToolbarMenu.Item.AddToHomeScreen -> settings.installPwaOpened = true
+                is ToolbarMenu.Item.ReaderMode -> settings.readerModeOpened = true
+                ToolbarMenu.Item.OpenInApp -> settings.openInAppOpened = true
                 else -> { }
             }
         }
@@ -174,7 +176,7 @@ class DefaultBrowserToolbarController(
                 }
             }
             ToolbarMenu.Item.AddToHomeScreen, ToolbarMenu.Item.InstallToHomeScreen -> {
-                activity.settings().installPwaOpened = true
+                settings.installPwaOpened = true
                 scope.launch(Main) {
                     with(activity.components.useCases.webAppUseCases) {
                         if (isInstallable()) {
@@ -268,7 +270,7 @@ class DefaultBrowserToolbarController(
                 deleteAndQuit(activity, scope, snackbar)
             }
             is ToolbarMenu.Item.ReaderMode -> {
-                activity.settings().readerModeOpened = true
+                settings.readerModeOpened = true
 
                 val enabled = currentSession?.let {
                     activity.components.core.store.state.findTab(it.id)?.readerState?.active
@@ -284,7 +286,7 @@ class DefaultBrowserToolbarController(
                 readerModeController.showControls()
             }
             ToolbarMenu.Item.OpenInApp -> {
-                activity.settings().openInAppOpened = true
+                settings.openInAppOpened = true
 
                 val appLinksUseCases =
                     activity.components.useCases.appLinksUseCases
@@ -316,7 +318,7 @@ class DefaultBrowserToolbarController(
     }
 
     private fun animateTabAndNavigateHome() {
-        if (activity.settings().useNewTabTray) {
+        if (settings.useNewTabTray) {
             onTabCounterClicked.invoke()
             return
         }

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt
@@ -58,7 +58,7 @@ interface BrowserToolbarController {
     fun handleBrowserMenuDismissed(lowPrioHighlightItems: List<ToolbarMenu.Item>)
 }
 
-@Suppress("LargeClass")
+@Suppress("LargeClass", "TooManyFunctions")
 class DefaultBrowserToolbarController(
     private val activity: Activity,
     private val navController: NavController,
@@ -384,7 +384,7 @@ class DefaultBrowserToolbarController(
 
         activity.components.analytics.metrics.track(Event.BrowserMenuItemTapped(eventItem))
     }
-    
+
     private fun bookmarkTapped(session: Session) = scope.launch(IO) {
         val bookmarksStorage = activity.components.core.bookmarksStorage
         val existing =

--- a/app/src/main/java/org/mozilla/fenix/downloads/DownloadsIntegration.kt
+++ b/app/src/main/java/org/mozilla/fenix/downloads/DownloadsIntegration.kt
@@ -1,0 +1,160 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.downloads
+
+import android.view.Gravity
+import android.view.View
+import androidx.fragment.app.FragmentManager
+import com.google.android.material.snackbar.Snackbar
+import mozilla.components.browser.state.action.ContentAction
+import mozilla.components.browser.state.state.content.DownloadState
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.feature.downloads.AbstractFetchDownloadService.DownloadJobStatus
+import mozilla.components.feature.downloads.DownloadsFeature
+import mozilla.components.feature.downloads.DownloadsUseCases
+import mozilla.components.feature.downloads.manager.FetchDownloadManager
+import mozilla.components.support.base.feature.LifecycleAwareFeature
+import mozilla.components.support.base.feature.OnNeedToRequestPermissions
+import mozilla.components.support.base.feature.PermissionsFeature
+import org.mozilla.fenix.R
+import org.mozilla.fenix.components.FenixSnackbar
+import org.mozilla.fenix.home.SharedViewModel
+import org.mozilla.fenix.theme.ThemeManager
+
+class DownloadsIntegration(
+    private val rootView: View,
+    private val dynamicDownloadDialogView: View,
+    private val store: BrowserStore,
+    private val tabId: String,
+    useCases: DownloadsUseCases,
+    onNeedToRequestPermissions: OnNeedToRequestPermissions,
+    fragmentManager: FragmentManager,
+    private val viewModel: SharedViewModel,
+    private val expandToolbar: () -> Unit
+) : LifecycleAwareFeature, PermissionsFeature {
+
+    private val context = rootView.context
+    private val toolbarHeight = context.resources.getDimensionPixelSize(R.dimen.browser_toolbar_height)
+
+    private val feature = DownloadsFeature(
+        context.applicationContext,
+        store = store,
+        useCases = useCases,
+        fragmentManager = fragmentManager,
+        tabId = tabId,
+        downloadManager = FetchDownloadManager(
+            context.applicationContext,
+            store,
+            DownloadService::class
+        ),
+        promptsStyling = DownloadsFeature.PromptsStyling(
+            gravity = Gravity.BOTTOM,
+            shouldWidthMatchParent = true,
+            positiveButtonBackgroundColor = ThemeManager.resolveAttribute(
+                R.attr.accent,
+                context
+            ),
+            positiveButtonTextColor = ThemeManager.resolveAttribute(
+                R.attr.contrastText,
+                context
+            ),
+            positiveButtonRadius = context.resources.getDimension(R.dimen.tab_corner_radius)
+        ),
+        onNeedToRequestPermissions = onNeedToRequestPermissions
+    )
+
+    init {
+        feature.onDownloadStopped = { downloadState, _, downloadJobStatus ->
+            // If the download is just paused, don't show any in-app notification
+            if (downloadJobStatus == DownloadJobStatus.COMPLETED ||
+                downloadJobStatus == DownloadJobStatus.FAILED
+            ) {
+
+                saveDownloadDialogState(tabId, downloadState, downloadJobStatus)
+
+                buildDialog(
+                    downloadState,
+                    didFail = downloadJobStatus == DownloadJobStatus.FAILED,
+                    tryAgain = feature::tryAgain
+                )
+            }
+        }
+
+        resumeDownloadDialogState(tabId)
+    }
+
+    override val onNeedToRequestPermissions = feature.onNeedToRequestPermissions
+
+    override fun onPermissionsResult(permissions: Array<String>, grantResults: IntArray) {
+        feature.onPermissionsResult(permissions, grantResults)
+    }
+
+    override fun start() = feature.start()
+
+    override fun stop() = feature.stop()
+
+    /**
+     * Preserves current state of the [DynamicDownloadDialog] to persist through tab changes and
+     * other fragments navigation.
+     * */
+    private fun saveDownloadDialogState(
+        tabId: String,
+        downloadState: DownloadState,
+        downloadJobStatus: DownloadJobStatus
+    ) {
+        viewModel.downloadDialogState[tabId] = Pair(
+            downloadState,
+            downloadJobStatus == DownloadJobStatus.FAILED
+        )
+    }
+
+    /**
+     * Re-initializes [DynamicDownloadDialog] if the user hasn't dismissed the dialog
+     * before navigating away from it's original tab.
+     * onTryAgain it will use [ContentAction.UpdateDownloadAction] to re-enqueue the former failed
+     * download, because [DownloadsFeature] clears any queued downloads onStop.
+     * */
+    private fun resumeDownloadDialogState(tabId: String) {
+        val (savedDownloadState, didFail) = viewModel.downloadDialogState[tabId] ?: return
+
+        buildDialog(savedDownloadState, didFail) {
+            savedDownloadState?.let { dlState ->
+                store.dispatch(
+                    ContentAction.UpdateDownloadAction(
+                        tabId, dlState.copy(skipConfirmation = true)
+                    )
+                )
+            }
+        }
+    }
+
+    private fun buildDialog(
+        downloadState: DownloadState?,
+        didFail: Boolean,
+        tryAgain: (Long) -> Unit
+    ) {
+        DynamicDownloadDialog(
+            downloadState = downloadState,
+            didFail = didFail,
+            view = dynamicDownloadDialogView,
+            toolbarHeight = toolbarHeight,
+            tryAgain = tryAgain,
+            onCannotOpenFile = {
+                FenixSnackbar.make(
+                    view = rootView,
+                    duration = Snackbar.LENGTH_SHORT,
+                    isDisplayedWithBrowserToolbar = true
+                )
+                    .setText(context.getString(R.string.mozac_feature_downloads_could_not_open_file))
+                    .show()
+            },
+            onDismiss = {
+                viewModel.downloadDialogState.remove(tabId)
+            }
+        ).show()
+
+        expandToolbar()
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/downloads/DynamicDownloadDialog.kt
+++ b/app/src/main/java/org/mozilla/fenix/downloads/DynamicDownloadDialog.kt
@@ -7,8 +7,9 @@ package org.mozilla.fenix.downloads
 import android.view.View
 import android.view.ViewGroup
 import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.core.view.updateLayoutParams
 import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.download_dialog_layout.view.*
+import kotlinx.android.synthetic.main.download_dialog_layout.*
 import mozilla.components.browser.state.state.content.DownloadState
 import mozilla.components.feature.downloads.AbstractFetchDownloadService
 import mozilla.components.feature.downloads.toMegabyteString
@@ -25,7 +26,6 @@ import org.mozilla.fenix.ext.settings
  * */
 
 class DynamicDownloadDialog(
-    private val container: ViewGroup,
     private val downloadState: DownloadState?,
     private val didFail: Boolean,
     private val tryAgain: (Long) -> Unit,
@@ -35,46 +35,42 @@ class DynamicDownloadDialog(
     private val onDismiss: () -> Unit
 ) : LayoutContainer {
 
-    override val containerView: View?
-        get() = container
-
-    private val settings = container.context.settings()
+    override val containerView = view
+    private val settings = view.context.settings()
 
     init {
-        setupDownloadDialog(view)
+        setupDownloadDialog()
     }
 
-    private fun setupDownloadDialog(view: View) {
+    private fun setupDownloadDialog() {
         if (downloadState == null) return
-        view.apply {
-            if (FeatureFlags.dynamicBottomToolbar && layoutParams is CoordinatorLayout.LayoutParams) {
-                (layoutParams as CoordinatorLayout.LayoutParams).apply {
+        val context = view.context
 
-                    behavior =
-                        DynamicDownloadDialogBehavior<View>(
-                            context,
-                            null,
-                            toolbarHeight.toFloat()
-                        )
-                }
+        if (FeatureFlags.dynamicBottomToolbar) {
+            (view.layoutParams as? CoordinatorLayout.LayoutParams)?.apply {
+                behavior = DynamicDownloadDialogBehavior<View>(
+                    context,
+                    null,
+                    toolbarHeight.toFloat()
+                )
             }
         }
 
         if (settings.shouldUseBottomToolbar) {
-            val params: ViewGroup.MarginLayoutParams =
-                view.layoutParams as ViewGroup.MarginLayoutParams
-            params.bottomMargin = toolbarHeight
+            view.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                bottomMargin = toolbarHeight
+            }
         }
 
         if (didFail) {
-            view.download_dialog_title.text =
-                container.context.getString(R.string.mozac_feature_downloads_failed_notification_text2)
+            download_dialog_title.text =
+                context.getString(R.string.mozac_feature_downloads_failed_notification_text2)
 
-            view.download_dialog_icon.setImageResource(
+            download_dialog_icon.setImageResource(
                 mozilla.components.feature.downloads.R.drawable.mozac_feature_download_ic_download_failed
             )
 
-            view.download_dialog_action_button.apply {
+            download_dialog_action_button.apply {
                 text = context.getString(
                     mozilla.components.feature.downloads.R.string.mozac_feature_downloads_button_try_again
                 )
@@ -85,17 +81,17 @@ class DynamicDownloadDialog(
                 }
             }
         } else {
-            val titleText = container.context.getString(
+            val titleText = context.getString(
                 R.string.mozac_feature_downloads_completed_notification_text2
             ) + " (${downloadState.contentLength?.toMegabyteString()})"
 
-            view.download_dialog_title.text = titleText
+            download_dialog_title.text = titleText
 
-            view.download_dialog_icon.setImageResource(
+            download_dialog_icon.setImageResource(
                 mozilla.components.feature.downloads.R.drawable.mozac_feature_download_ic_download_complete
             )
 
-            view.download_dialog_action_button.apply {
+            download_dialog_action_button.apply {
                 text = context.getString(
                     mozilla.components.feature.downloads.R.string.mozac_feature_downloads_button_open
                 )
@@ -116,11 +112,11 @@ class DynamicDownloadDialog(
             }
         }
 
-        view.download_dialog_close_button.setOnClickListener {
+        download_dialog_close_button.setOnClickListener {
             dismiss(view)
         }
 
-        view.download_dialog_filename.text = downloadState.fileName
+        download_dialog_filename.text = downloadState.fileName
     }
 
     fun show() {

--- a/app/src/main/java/org/mozilla/fenix/home/SharedViewModel.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/SharedViewModel.kt
@@ -18,5 +18,5 @@ class SharedViewModel : ViewModel() {
      * Stores data needed for [DynamicDownloadDialog]. See #9044
      * Format: HashMap<sessionId, Pair<DownloadState, didFail>
      * */
-    var downloadDialogState: HashMap<String?, Pair<DownloadState?, Boolean>> = HashMap()
+    var downloadDialogState: MutableMap<String?, Pair<DownloadState?, Boolean>> = HashMap()
 }

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingThemePickerViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingThemePickerViewHolder.kt
@@ -102,8 +102,7 @@ class OnboardingThemePickerViewHolder(view: View) : RecyclerView.ViewHolder(view
         if (AppCompatDelegate.getDefaultNightMode() == mode) return
         AppCompatDelegate.setDefaultNightMode(mode)
         with(itemView.context.components) {
-            core.engine.settings.preferredColorScheme = core.getPreferredColorScheme()
-            useCases.sessionUseCases.reload.invoke()
+            customizeColorSchemeUseCase.customizeEngine()
         }
     }
 

--- a/app/src/main/java/org/mozilla/fenix/settings/CustomizationFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/CustomizationFragment.kt
@@ -113,10 +113,7 @@ class CustomizationFragment : PreferenceFragmentCompat() {
         if (AppCompatDelegate.getDefaultNightMode() == mode) return
         AppCompatDelegate.setDefaultNightMode(mode)
         activity?.recreate()
-        with(requireComponents.core) {
-            engine.settings.preferredColorScheme = getPreferredColorScheme()
-        }
-        requireComponents.useCases.sessionUseCases.reload.invoke()
+        requireComponents.customizeColorSchemeUseCase.customizeEngine()
     }
 
     private fun setupToolbarCategory() {

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -624,18 +624,19 @@ class Settings private constructor(
         )
     }
 
-    fun setSitePermissionSettingListener(lifecycleOwner: LifecycleOwner, listener: () -> Unit) {
-        val sitePermissionKeys = listOf(
-            PhoneFeature.NOTIFICATION,
-            PhoneFeature.MICROPHONE,
-            PhoneFeature.LOCATION,
-            PhoneFeature.CAMERA,
-            PhoneFeature.AUTOPLAY_AUDIBLE,
-            PhoneFeature.AUTOPLAY_INAUDIBLE
-        ).map { it.getPreferenceKey(appContext) }
+    /**
+     * Adds a listener that gets called whenever a [PhoneFeature] setting is changed.
+     */
+    fun setSitePermissionSettingChangeListener(
+        lifecycleOwner: LifecycleOwner,
+        listener: (PhoneFeature) -> Unit
+    ) {
+        val sitePermissionKeyToFeature = PhoneFeature.values()
+            .map { phoneFeature -> phoneFeature.getPreferenceKey(appContext) to phoneFeature }
+            .toMap()
 
         preferences.registerOnSharedPreferenceChangeListener(lifecycleOwner) { _, key ->
-            if (key in sitePermissionKeys) listener.invoke()
+            sitePermissionKeyToFeature[key]?.let(listener)
         }
     }
 

--- a/app/src/main/java/org/mozilla/fenix/wifi/NetworkOnlineLiveData.kt
+++ b/app/src/main/java/org/mozilla/fenix/wifi/NetworkOnlineLiveData.kt
@@ -4,7 +4,6 @@ import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkRequest
 import androidx.lifecycle.LiveData
-import org.mozilla.fenix.ext.isOnline
 
 /**
  * [LiveData] that emits network available/not available events.

--- a/app/src/main/java/org/mozilla/fenix/wifi/NetworkOnlineLiveData.kt
+++ b/app/src/main/java/org/mozilla/fenix/wifi/NetworkOnlineLiveData.kt
@@ -1,0 +1,40 @@
+package org.mozilla.fenix.wifi
+
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkRequest
+import androidx.lifecycle.LiveData
+import org.mozilla.fenix.ext.isOnline
+
+/**
+ * [LiveData] that emits network available/not available events.
+ * This allows calling code to set simpler listeners.
+ *
+ * @sample
+ * ```kotlin
+ *  NetworkOnlineLiveData().observer(owner) { isConnected ->
+ *    if (isConnected) {
+ *      downloadThing()
+ *    }
+ *  }
+ * ```
+ */
+class NetworkOnlineLiveData(
+    private val connectivityManager: ConnectivityManager,
+    private val request: NetworkRequest,
+    initialValue: Boolean = false
+) : LiveData<Boolean>(initialValue) {
+
+    private val networkCallback = object : ConnectivityManager.NetworkCallback() {
+        override fun onAvailable(network: Network) = postValue(true)
+        override fun onLost(network: Network) = postValue(false)
+    }
+
+    override fun onActive() {
+        connectivityManager.registerNetworkCallback(request, networkCallback)
+    }
+
+    override fun onInactive() {
+        connectivityManager.unregisterNetworkCallback(networkCallback)
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/wifi/SitePermissionsWifiIntegration.kt
+++ b/app/src/main/java/org/mozilla/fenix/wifi/SitePermissionsWifiIntegration.kt
@@ -12,7 +12,6 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.Transformations
 import androidx.lifecycle.observe
 import mozilla.components.feature.sitepermissions.SitePermissionsRules
-import mozilla.components.support.base.feature.LifecycleAwareFeature
 import org.mozilla.fenix.settings.PhoneFeature
 import org.mozilla.fenix.settings.sitepermissions.AUTOPLAY_ALLOW_ON_WIFI
 import org.mozilla.fenix.settings.sitepermissions.AUTOPLAY_BLOCK_ALL


### PR DESCRIPTION
I moved a lot of functionality out of the browser fragment and into helper classes. Each commit represents a different feature.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture