### PR TITLE
For #10494: Process HomeMenu builder changes on the main thread

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeMenu.kt
@@ -8,6 +8,9 @@ import android.content.Context
 import androidx.core.content.ContextCompat.getColor
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import mozilla.components.browser.menu.BrowserMenuBuilder
 import mozilla.components.browser.menu.BrowserMenuHighlight
 import mozilla.components.browser.menu.ext.getHighlight
@@ -174,21 +177,31 @@ class HomeMenu(
             }
             context.components.backgroundServices.accountManager.register(object : AccountObserver {
                 override fun onAuthenticationProblems() {
-                    onMenuBuilderChanged(BrowserMenuBuilder(
-                        listOf(reconnectToSyncItem) + coreMenuItems
-                    ))
+                    lifecycleOwner.lifecycleScope.launch(Dispatchers.Main) {
+                        onMenuBuilderChanged(BrowserMenuBuilder(
+                            listOf(reconnectToSyncItem) + coreMenuItems
+                        ))
+                    }
                 }
 
                 override fun onAuthenticated(account: OAuthAccount, authType: AuthType) {
-                    onMenuBuilderChanged(BrowserMenuBuilder(
-                        coreMenuItems
-                    ))
+                    lifecycleOwner.lifecycleScope.launch(Dispatchers.Main) {
+                        onMenuBuilderChanged(
+                            BrowserMenuBuilder(
+                                coreMenuItems
+                            )
+                        )
+                    }
                 }
 
                 override fun onLoggedOut() {
-                    onMenuBuilderChanged(BrowserMenuBuilder(
-                        coreMenuItems
-                    ))
+                    lifecycleOwner.lifecycleScope.launch(Dispatchers.Main) {
+                        onMenuBuilderChanged(
+                            BrowserMenuBuilder(
+                                coreMenuItems
+                            )
+                        )
+                    }
                 }
             }, lifecycleOwner)
         }


### PR DESCRIPTION
Problem was that we were trying to process menu changes (in response to account manager events) on some background thread as that's what account manager emits them on, so some code internally in PopupWindow's dismiss handling (i think, didn't dig very deeply here) was silently giving up and we'd get into a bad state.

The reason this seemingly only happened if you quickly opened a menu on startup is because account manager isn't initialized until sometime after the startup finished. So the trick was to open the menu (and register account manager state callbacks) before it got initialized, so that the callbacks are invoked.

This should also reproduce in other, much more obscure ways, e.g. if you open the menu right before sync is scheduled to run in the background, change FxA password on another connected client, and then eventually receive a onAuthenticationProblem callback.

One "problem" this introduces is that if you open the menu right after the startup, it will be dismissed in a few seconds (as account manager is initialized). Fixing that will require changes to a-c, so I'll leave that to a follow-up.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture