### PR TITLE
For #10885: Don't add migration activity to history stack

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -187,6 +187,7 @@
 
         <activity
                 android:name=".migration.MigrationProgressActivity"
+                android:noHistory="true"
                 android:launchMode="singleInstance"
                 android:exported="false">
         </activity>


### PR DESCRIPTION
If we're on the migration UI, we do not add it to the history stack. So if we click the notification to complete the migration, we don't have the migration UI there when we press the back button.

This should be a safe change since we don't allow any direct means of entering the migration UI from user-gestures.