### PR TITLE
Issue #9815: Allow Intents to set HomeActivity.OPEN_TO_BROWSER.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/IntentReceiverActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/IntentReceiverActivity.kt
@@ -50,7 +50,13 @@ class IntentReceiverActivity : Activity() {
 
     private fun launch(intent: Intent, intentProcessorType: IntentProcessorType) {
         intent.setClassName(applicationContext, intentProcessorType.activityClassName)
-        intent.putExtra(HomeActivity.OPEN_TO_BROWSER, intentProcessorType.shouldOpenToBrowser(intent))
+
+        if (!intent.hasExtra(HomeActivity.OPEN_TO_BROWSER)) {
+            intent.putExtra(
+                HomeActivity.OPEN_TO_BROWSER,
+                intentProcessorType.shouldOpenToBrowser(intent)
+            )
+        }
 
         startActivity(intent)
         finish() // must finish() after starting the other activity

--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -205,6 +205,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Session
                 customTabSession = customTabSessionId?.let { sessionManager.findSessionById(it) },
                 openInFenixIntent = Intent(context, IntentReceiverActivity::class.java).apply {
                     action = Intent.ACTION_VIEW
+                    putExtra(HomeActivity.OPEN_TO_BROWSER, true)
                 },
                 bookmarkTapped = { viewLifecycleOwner.lifecycleScope.launch { bookmarkTapped(it) } },
                 scope = viewLifecycleOwner.lifecycleScope,


### PR DESCRIPTION
This is a fix for issue #9815. We are allowing `Intent`s to set the `HomeActivity.OPEN_TO_BROWSER` flag and only override it with `intentProcessorType.shouldOpenToBrowser(intent)` if no value was provided. We then use this to always set it to `true` in `DefaultBrowserToolbarController.openInFenixIntent` when switching from a custom tab to the browser.