### PR TITLE
Closes #10927: Improve wait on session loaded for UI tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/SessionLoadedIdlingResource.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/SessionLoadedIdlingResource.kt
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package org.mozilla.fenix.helpers
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.IdlingResource
+import org.mozilla.fenix.FenixApplication
+
+/**
+ * An IdlingResource implementation that waits until the current session is not loading anymore.
+ * Only after loading has completed further actions will be performed.
+ */
+
+class SessionLoadedIdlingResource : IdlingResource {
+    private var resourceCallback: IdlingResource.ResourceCallback? = null
+
+    override fun getName(): String {
+        return SessionLoadedIdlingResource::class.java.simpleName
+    }
+
+    override fun isIdleNow(): Boolean {
+        val context = ApplicationProvider.getApplicationContext<FenixApplication>()
+        val sessionManager = context.components.core.sessionManager
+        val session = sessionManager.selectedSession
+
+        return if (session?.loading == true) {
+            false
+        } else {
+            if (session?.progress == 100) {
+                invokeCallback()
+                true
+            } else {
+                false
+            }
+        }
+    }
+
+    private fun invokeCallback() {
+        if (resourceCallback != null) {
+            resourceCallback!!.onTransitionToIdle()
+        }
+    }
+
+    override fun registerIdleTransitionCallback(callback: IdlingResource.ResourceCallback) {
+        this.resourceCallback = callback
+    }
+}

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -79,7 +79,7 @@ class BrowserRobot {
     */
     fun verifyPageContent(expectedText: String) {
         val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-        mDevice.waitNotNull(Until.findObject(text(expectedText)), waitingTime)
+        mDevice.waitNotNull(Until.findObject(By.textContains(expectedText)), waitingTime)
     }
 
     fun verifyTabCounter(expectedText: String) {


### PR DESCRIPTION
Closes #10927

> A number of our tests are flaky because Espresso continues during page load which causes them to break on assertions afterwards. We should use a an IdlingResource implementation that waits until the current session is not loading anymore.

Opening as draft to run a few times.

