### PR TITLE
For #10877 - Show 'no tabs' message when no tabs are open

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayView.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayView.kt
@@ -145,12 +145,13 @@ class TabTrayView(
     }
 
     fun updateState(state: BrowserState) {
-        val shouldHide = if (isPrivateModeSelected) {
+        val hasNoTabs = if (isPrivateModeSelected) {
             state.privateTabs.isEmpty()
         } else {
             state.normalTabs.isEmpty()
         }
-        view?.tab_tray_overflow?.isVisible = !shouldHide
+        view?.tab_tray_empty_view?.isVisible = hasNoTabs
+        view?.tab_tray_overflow?.isVisible = !hasNoTabs
     }
 
     override fun onTabClosed(tab: Tab) {

--- a/app/src/main/res/layout/component_tabstray.xml
+++ b/app/src/main/res/layout/component_tabstray.xml
@@ -14,6 +14,7 @@
     style="@style/BottomSheetModal"
     android:backgroundTint="@color/foundation_normal_theme"
     app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
+
     <View
         android:id="@+id/handle"
         android:layout_width="0dp"
@@ -24,6 +25,22 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintWidth_percent="0.1"
         app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/tab_tray_empty_view"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:gravity="center_horizontal"
+        android:paddingTop="80dp"
+        android:text="@string/no_open_tabs_description"
+        android:textColor="?secondaryText"
+        android:textSize="16sp"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@id/tabsTray" />
+
     <com.google.android.material.tabs.TabLayout
         android:id="@+id/tab_layout"
         android:layout_width="0dp"
@@ -52,6 +69,7 @@
             android:contentDescription="@string/tabs_header_private_tabs_title" />
 
     </com.google.android.material.tabs.TabLayout>
+
     <ImageButton
         android:id="@+id/tab_tray_overflow"
         android:layout_width="48dp"
@@ -64,6 +82,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="@id/tab_layout"
         app:layout_constraintBottom_toBottomOf="@id/tab_layout" />
+
     <mozilla.components.concept.tabstray.TabsTray
         android:id="@+id/tabsTray"
         android:layout_width="0dp"
@@ -80,4 +99,5 @@
         mozac:tabsTraySelectedItemTextColor="@color/tab_tray_item_selected_background_normal_theme"
         mozac:tabsTrayItemUrlTextColor="@color/tab_tray_item_selected_background_normal_theme"
         mozac:tabsTraySelectedItemUrlTextColor="@color/tab_tray_item_url_normal_theme" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
![Screenshot_20200527-134638](https://user-images.githubusercontent.com/46655/83060133-9c4e5b80-a020-11ea-9b78-0cc9643ff848.png)

I went with `padding-top` and `center_horizontally` because `center` would only actually show the text at center if the tab tray was completely open, otherwise the text would display near the bottom when tab tray was half open.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture