### PR TITLE
A-C 44.0.20200528190114: Pass store to download manager and service

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -373,6 +373,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Session
                 tabId = customTabSessionId,
                 downloadManager = FetchDownloadManager(
                     context.applicationContext,
+                    store,
                     DownloadService::class
                 ),
                 promptsStyling = DownloadsFeature.PromptsStyling(

--- a/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -27,6 +27,7 @@ import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.mediaquery.PreferredColorScheme
 import mozilla.components.concept.fetch.Client
 import mozilla.components.feature.customtabs.store.CustomTabsServiceStore
+import mozilla.components.feature.downloads.DownloadMiddleware
 import mozilla.components.feature.media.RecordingDevicesNotificationFeature
 import mozilla.components.feature.media.middleware.MediaMiddleware
 import mozilla.components.feature.pwa.ManifestStorage
@@ -42,6 +43,7 @@ import org.mozilla.fenix.AppRequestInterceptor
 import org.mozilla.fenix.Config
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
+import org.mozilla.fenix.downloads.DownloadService
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.media.MediaService
@@ -103,6 +105,7 @@ class Core(private val context: Context) {
         BrowserStore(
             middleware = listOf(
                 MediaMiddleware(context, MediaService::class.java),
+                DownloadMiddleware(context, DownloadService::class.java),
                 ReaderViewMiddleware()
             )
         )

--- a/app/src/main/java/org/mozilla/fenix/downloads/DownloadService.kt
+++ b/app/src/main/java/org/mozilla/fenix/downloads/DownloadService.kt
@@ -4,9 +4,11 @@
 
 package org.mozilla.fenix.downloads
 
+import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.feature.downloads.AbstractFetchDownloadService
 import org.mozilla.fenix.ext.components
 
 class DownloadService : AbstractFetchDownloadService() {
     override val httpClient by lazy { components.core.client }
+    override val store: BrowserStore by lazy { components.core.store }
 }

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "44.0.20200528130107"
+    const val VERSION = "44.0.20200528190114"
 }


### PR DESCRIPTION
Preparing for breaking API change in A-C downloads. Needs to land after mozilla-mobile/android-components#7103.