### PR TITLE
For #10969: Fix and clarify logic for checking showing PWA dialog.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/perf/Performance.kt
+++ b/app/src/main/java/org/mozilla/fenix/perf/Performance.kt
@@ -74,6 +74,6 @@ object Performance {
      * Disables the first time PWA popup.
      */
     private fun disableFirstTimePWAPopup(context: Context) {
-        Settings.getInstance(context).shouldShowFirstTimePwaFragment = false
+        Settings.getInstance(context).userKnowsAboutPWAs = true
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/shortcut/FirstTimePwaObserver.kt
+++ b/app/src/main/java/org/mozilla/fenix/shortcut/FirstTimePwaObserver.kt
@@ -27,7 +27,7 @@ class FirstTimePwaObserver(
             val directions = BrowserFragmentDirections.actionBrowserFragmentToFirstTimePwaFragment()
             navController.nav(R.id.browserFragment, directions)
 
-            settings.shouldShowFirstTimePwaFragment = false
+            settings.userKnowsAboutPWAs = true
         }
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -456,34 +456,25 @@ class Settings private constructor(
         default = false
     )
 
-    var shouldShowFirstTimePwaFragment: Boolean
+    val shouldShowFirstTimePwaFragment: Boolean
         get() {
-            val alreadyShownPwaOnboarding = preferences.getBoolean(
-                appContext.getPreferenceKey(R.string.pref_key_show_first_time_pwa), false)
-
             // ShortcutManager::pinnedShortcuts is only available on Oreo+
-            if (!alreadyShownPwaOnboarding && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            if (!userKnowsAboutPWAs && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 val alreadyHavePWaInstalled =
                     appContext.getSystemService(ShortcutManager::class.java)
                         .pinnedShortcuts.size > 0
 
-                // Users don't need to be shown the PWA onboarding if they already have PWAs installed.
-                preferences.edit()
-                    .putBoolean(
-                        appContext.getPreferenceKey(R.string.pref_key_show_first_time_pwa),
-                        alreadyHavePWaInstalled)
-                    .apply()
-
-                return !alreadyHavePWaInstalled
+                // Users know about PWAs onboarding if they already have PWAs installed.
+                userKnowsAboutPWAs = alreadyHavePWaInstalled
             }
+            // Show dialog only if user does not know abut PWAs
+            return !userKnowsAboutPWAs
+        }
 
-            return !alreadyShownPwaOnboarding
-        }
-        set(value) {
-            preferences.edit()
-                .putBoolean(appContext.getPreferenceKey(R.string.pref_key_show_first_time_pwa), value)
-                .apply()
-        }
+    var userKnowsAboutPWAs by booleanPreference(
+        appContext.getPreferenceKey(R.string.pref_key_user_knows_about_pwa),
+        default = false
+    )
 
     @VisibleForTesting(otherwise = PRIVATE)
     internal val trackingProtectionOnboardingCount by intPreference(

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -161,7 +161,8 @@
     <string name="default_top_sites_added" translatable="false">pref_key_pocket_top_site_added</string>
     <string name="pref_key_top_sites_size" translatable="false">pref_key_top_sites_size</string>
 
-    <string name="pref_key_show_first_time_pwa" translatable="false">pref_key_show_first_time_pwa</string>
+    <!-- A value  of `true` means the PWA dialog has been showed or user already has PWAs installed-->
+    <string name="pref_key_user_knows_about_pwa" translatable="false">pref_key_user_knows_about_pwa</string>
 
     <string name="pref_key_migrating_from_fenix_nightly_tip" translatable="false">pref_key_migrating_from_fenix_nightly_tip</string>
     <string name="pref_key_migrating_from_firefox_nightly_tip" translatable="false">pref_key_migrating_from_firefox_nightly_tip</string>


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture