### PR TITLE
Close #10571 - Add dark mode for error pages

### DIFF
--- a/app/src/main/assets/high_risk_error_pages.html
+++ b/app/src/main/assets/high_risk_error_pages.html
@@ -5,34 +5,33 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
 <html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-    <meta charset="UTF-8">
+  <head>
+    <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width; user-scalable=false;" />
-    <link rel="stylesheet" type="text/css" href="high_risk_error_style.css">
-</head>
+    <link rel="stylesheet" type="text/css" href="shared_error_style.css" />
+    <link rel="stylesheet" type="text/css" href="high_risk_error_style.css" />
+  </head>
 
-<body id="errorPage" dir="auto">
-<!-- PAGE CONTAINER (for styling purposes only) -->
-<div id="errorPageContainer">
+  <body id="errorPage" dir="auto">
+    <!-- PAGE CONTAINER (for styling purposes only) -->
+    <div id="errorPageContainer">
+      <!-- Error Image -->
+      <iframe id="errorImage" src="" frameborder="0"></iframe>
 
-    <!-- Error Image -->
-    <iframe id="errorImage" src="" frameborder="0"></iframe>
-
-    <!-- Error Title -->
-    <div id="errorTitle">
+      <!-- Error Title -->
+      <div id="errorTitle">
         <h1 id="errorTitleText"></h1>
-    </div>
+      </div>
 
-    <!-- LONG CONTENT (the section most likely to require scrolling) -->
-    <div id="errorLongContent">
+      <!-- LONG CONTENT (the section most likely to require scrolling) -->
+      <div id="errorLongContent">
         <div id="errorShortDesc"></div>
+      </div>
+
+      <!-- Back Button -->
+      <button id="backButton" onclick="window.history.back()">Go back</button>
     </div>
+  </body>
 
-    <!-- Back Button -->
-    <button id="backButton" onclick="window.history.back()">Go back</button>
-</div>
-
-</body>
-
-<script src="./errorPageScripts.js"></script>
+  <script src="./errorPageScripts.js"></script>
 </html>

--- a/app/src/main/assets/high_risk_error_style.css
+++ b/app/src/main/assets/high_risk_error_style.css
@@ -2,49 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-html,
-body {
-  margin: 0;
-  padding: 0;
-  height: 100%;
-  --moz-vertical-spacing: 10px;
-  --moz-background-height: 32px;
-}
-
-body {
-  background-size: 64px var(--moz-background-height);
-  background-repeat: repeat-x;
-  background-color: #c50042;
-  color: #ffffff;
-  padding: 0 40px;
-  font-size: 14px;
-  -moz-text-size-adjust: none;
-  font-family: sharp-sans;
-}
-
-ul {
-  /* Shove the list indicator so that its left aligned, but use outside so that text
-   * doesn't don't wrap the text around it */
-  padding: 0 1em;
-  margin: 0;
-  list-style-type: disc;
-}
-
-#errorShortDesc,
-li:not(:last-of-type) {
-  /* Margins between the li and buttons below it won't be collapsed. Remove the bottom margin here. */
-  margin: var(--moz-vertical-spacing) 0;
-}
-
-h1 {
-  margin: 0;
-  padding: 0;
-  margin: var(--moz-vertical-spacing) 0;
-  color: #ffffff;
-  font-family: sharp-sans;
-  font-weight: bold;
-  font-size: 20px;
-  line-height: 24px;
+:root {
+  --background-color: #c50042;
+  --text-color: #ffffff;
+  --primary-button-color: #e6e6eb;
+  --primary-button-text-color: #2f2c61;
+  --header-color: #ffffff;
 }
 
 p {
@@ -53,46 +16,14 @@ p {
   color: #ffffff;
 }
 
-button {
-  display: block;
-  height: 36px;
-  width: 100%;
-  border-radius: 5px;
-  border-color: #e3e3e7;
-  font-family: sans-serif;
-  background-color: #e6e6eb;
-  color: #2f2c61;
-  font-size: 14px;
-  font-weight: bold;
-  margin: var(--moz-vertical-spacing) auto;
-  text-aligned:center;
-  vertical-aligned:center;
-  background-image: none;
-}
-
-
-.hidden {
-  display: none;
-}
-
 /* On large width devices, apply specific styles here. Often triggered by landscape mode or tablets */
 @media (min-width: 550px) {
-  button {
-    margin: var(--moz-vertical-spacing) var(--moz-vertical-spacing);
-    min-width: 400px;
-    width: auto;
-  }
-
   /* If the device is tall as well, add some padding to make content feel a bit more centered */
   @media (min-height: 550px) {
     #errorPageContainer {
-      padding-top: 64px;
-      min-height: calc(100% - 64px);
       -webkit-box-sizing: border-box;
-         -moz-box-sizing: border-box;
-              box-sizing: border-box;
+      -moz-box-sizing: border-box;
+      box-sizing: border-box;
     }
   }
 }
-
-

--- a/app/src/main/assets/low_and_medium_risk_error_pages.html
+++ b/app/src/main/assets/low_and_medium_risk_error_pages.html
@@ -5,68 +5,96 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
 <html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-    <meta charset="UTF-8">
+  <head>
+    <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width; user-scalable=false;" />
-    <link rel="stylesheet" type="text/css" href="low_and_medium_risk_error_style.css">
-</head>
+    <link rel="stylesheet" type="text/css" href="shared_error_style.css" />
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="low_and_medium_risk_error_style.css"
+    />
+  </head>
 
-<body id="errorPage" dir="auto">
-<!-- PAGE CONTAINER (for styling purposes only) -->
-<div id="errorPageContainer">
+  <body id="errorPage" dir="auto">
+    <!-- PAGE CONTAINER (for styling purposes only) -->
+    <div id="errorPageContainer">
+      <!-- Error Image -->
+      <iframe id="errorImage" src="" frameborder="0"></iframe>
 
-    <!-- Error Image -->
-    <iframe id="errorImage" src="" frameborder="0"></iframe>
-
-    <!-- Error Title -->
-    <div id="errorTitle">
+      <!-- Error Title -->
+      <div id="errorTitle">
         <h1 id="errorTitleText"></h1>
-    </div>
+      </div>
 
-    <!-- LONG CONTENT (the section most likely to require scrolling) -->
-    <div id="errorLongContent">
+      <!-- LONG CONTENT (the section most likely to require scrolling) -->
+      <div id="errorLongContent">
         <div id="errorShortDesc"></div>
-    </div>
+      </div>
 
-    <!-- Retry Button -->
-    <button id="errorTryAgain" onclick="window.location.reload()"></button>
+      <!-- Retry Button -->
+      <button id="errorTryAgain" onclick="window.location.reload()"></button>
 
-    <!-- Advanced Button -->
-    <button id="advancedButton" class="buttonSecondary hidden" onclick="toggleAdvancedAndScroll()"></button>
+      <!-- Advanced Button -->
+      <button
+        id="advancedButton"
+        class="buttonSecondary hidden"
+        onclick="toggleAdvancedAndScroll()"
+      ></button>
 
-    <hr id="horizontalLine" class="hidden">
-    <div id="advancedPanelContainer">
-        <div id="badCertAdvancedPanel" class="advanced-panel hidden">
-            <p id="badCertTechnicalInfo"></p>
-            <div id="advancedPanelBackButtonContainer" class="advancedPanelButtonContainer">
-                <button id="advancedPanelBackButton" onClick="window.history.back()"></button>
-            </div>
-            <div id="advancedPanelAcceptButtonContainer" class="advancedPanelButtonContainer">
-                <button id="advancedPanelAcceptButton" class="buttonSecondary" onClick="acceptAndContinue(true)"></button>
-            </div>
+      <hr id="horizontalLine" hidden />
+      <div id="advancedPanelContainer">
+        <div id="badCertAdvancedPanel" hidden class="advanced-panel">
+          <p id="badCertTechnicalInfo"></p>
+          <div
+            id="advancedPanelBackButtonContainer"
+            class="advancedPanelButtonContainer"
+          >
+            <button
+              id="advancedPanelBackButton"
+              onClick="window.history.back()"
+            ></button>
+          </div>
+          <div
+            id="advancedPanelAcceptButtonContainer"
+            class="advancedPanelButtonContainer"
+          >
+            <button
+              id="advancedPanelAcceptButton"
+              class="buttonSecondary"
+              onClick="acceptAndContinue(true)"
+            ></button>
+          </div>
         </div>
+      </div>
     </div>
-</div>
+  </body>
 
-</body>
+  <script type="text/javascript">
+    function toggleAdvancedAndScroll() {
+      toggleAdvanced();
 
-<script type="text/javascript">
-function toggleAdvancedAndScroll() {
-    toggleAdvanced();
+      const horizontalLine = document.getElementById("horizontalLine");
+      const advancedPanelAcceptButton = document.getElementById(
+        "advancedPanelAcceptButton"
+      );
+      const badCertAdvancedPanel = document.getElementById(
+        "badCertAdvancedPanel"
+      );
 
-    const horizontalLine = document.getElementById("horizontalLine");
-    const advancedPanelAcceptButton = document.getElementById("advancedPanelAcceptButton");
-    const badCertAdvancedPanel = document.getElementById("badCertAdvancedPanel");
-
-    // We know that the button is being displayed
-    if (badCertAdvancedPanel.style.display === "block") {
-        horizontalLine.classList.remove("hidden");
-        advancedPanelAcceptButton.scrollIntoView({behavior: "smooth", block: "center", inline: "nearest"});
-    } else {
-        horizontalLine.classList.add("hidden");
+      // We know that the button is being displayed
+      if (badCertAdvancedPanel.style.display === "block") {
+        horizontalLine.hidden = false;
+        advancedPanelAcceptButton.scrollIntoView({
+          behavior: "smooth",
+          block: "center",
+          inline: "nearest",
+        });
+      } else {
+        horizontalLine.hidden = true;
+      }
     }
-}
-</script>
+  </script>
 
-<script src="./errorPageScripts.js"></script>
+  <script src="./errorPageScripts.js"></script>
 </html>

--- a/app/src/main/assets/low_and_medium_risk_error_style.css
+++ b/app/src/main/assets/low_and_medium_risk_error_style.css
@@ -2,132 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-html,
-body {
-  margin: 0;
-  padding: 0;
-  height: 100%;
-  --moz-vertical-spacing: 10px;
-  --moz-background-height: 32px;
-}
-
-body {
-  background-size: 64px var(--moz-background-height);
-  background-repeat: repeat-x;
-  background-color: #f9f9fb;
-  color: #15141A;
-  padding: 0 40px;
-  font-size: 14px;
-  -moz-text-size-adjust: none;
-  font-family: sans-serif;
-}
-
-ul {
-  /* Shove the list indicator so that its left aligned, but use outside so that text
-   * doesn't don't wrap the text around it */
-  padding: 0 1em;
-  margin: 0;
-  list-style-type: disc;
-}
-
-#errorShortDesc,
-li:not(:last-of-type) {
-  /* Margins between the li and buttons below it won't be collapsed. Remove the bottom margin here. */
-  margin: var(--moz-vertical-spacing) 0;
-}
-
-h1 {
-  margin: 0;
-  padding: 0;
-  margin: var(--moz-vertical-spacing) 0;
-  color: #312a65;
-  font-family: sans-serif;
-  font-weight: bold;
-  font-size: 20px;
-  line-height: 24px;
-}
-
-p {
-  line-height: 20px;
-  margin: var(--moz-vertical-spacing) 0;
-}
-
-
-button {
-  display: block;
-  height: 36px;
-  width: 100%;
-  border-radius: 5px;
-  border-color: #312A65;
-  font-family: sans-serif;
-  background-color: #312A65;
-  color: #FFFFFF;
-  font-size: 14px;
-  font-weight: bold;
-  margin: var(--moz-vertical-spacing) auto;
-  text-aligned:center;
-  vertical-aligned:center;
-}
-
-hr {
-  height: 0;
-  border: 0;
-  border-top: 1px solid #D7D7DB;
-}
-
-.horizontalLine {
-  margin-left: -40px;
-  margin-right: -40px;
-}
-
-.buttonSecondary {
-  display: block;
-  width: 100%;
-  height: 36px;
-  border-radius: 5px;
-  border-color: #E0E0E6;
-  font-family: sans-serif;
-  font-weight: bold;
-  background-color: #E0E0E6;
-  color: #20123A;
-  text-aligned:center;
-  vertical-aligned:center;
-  margin: var(--moz-vertical-spacing) auto;
-}
-
-#errorPageContainer {
-  /* If the page is greater than 550px center the content.
-   * This number should be kept in sync with the media query for tablets below */
-  max-width: 550px;
-  margin: 0 auto;
-  min-height: 100%;
-}
-
-.hidden {
-  display: none;
-}
-
-/* On large width devices, apply specific styles here. Often triggered by landscape mode or tablets */
-@media (min-width: 550px) {
-  button {
-    margin: var(--moz-vertical-spacing) auto;
-    min-width: 400px;
-    width: auto;
-  }
-
-  .buttonSecondary {
-    margin: var(--moz-vertical-spacing) auto;
-    min-width: 400px;
-    width: auto;
-  }
-
-  /* If the device is tall as well, add some padding to make content feel a bit more centered */
-  @media (min-height: 550px) {
-    #errorPageContainer {
-      padding-top: 64px;
-      min-height: calc(100% - 64px);
-    }
-  }
+:root {
+  --background-color: #f9f9fb;
+  --text-color: #15141a;
+  --primary-button-color: #312a65;
+  --primary-button-text-color: #ffffff;
+  --secondary-button-color: #e0e0e6;
+  --secondary-button-text-color: #20123a;
+  --header-color: #312a65;
 }
 
 #badCertTechnicalInfo {
@@ -140,3 +22,14 @@ hr {
   justify-content: center;
 }
 
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background-color: #15141a;
+    --text-color: #fbfbfe;
+    --primary-button-color: #9059ff;
+    --primary-button-text-color: #ffffff;
+    --secondary-button-color: #e0e0e6;
+    --secondary-button-text-color: #312a65;
+    --header-color: #fbfbfe;
+  }
+}

--- a/app/src/main/assets/shared_error_style.css
+++ b/app/src/main/assets/shared_error_style.css
@@ -1,0 +1,131 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+:root {
+  --moz-vertical-spacing: 10px;
+  --moz-background-height: 32px;
+  /* Default values just to indicate what color variables we use */
+  --background-color: #f9f9fb;
+  --text-color: #15141a;
+  --primary-button-color: #312a65;
+  --primary-button-text-color: #ffffff;
+  --secondary-button-color: #e0e0e6;
+  --secondary-button-text-color: #20123a;
+  --header-color: var(--text-color);
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+}
+
+body {
+  background-size: 64px var(--moz-background-height);
+  background-repeat: repeat-x;
+  background-color: var(--background-color);
+  color: var(--text-color);
+  padding: 0 40px;
+  font-size: 14px;
+  font-family: sharp-sans, sans-serif;
+  -moz-text-size-adjust: none;
+}
+
+ul {
+  /* Shove the list indicator so that its left aligned, but use outside so that text
+    * doesn't don't wrap the text around it */
+  padding: 0 1em;
+  margin: 0;
+  list-style-type: disc;
+}
+
+#errorShortDesc,
+li:not(:last-of-type) {
+  /* Margins between the li and buttons below it won't be collapsed. Remove the bottom margin here. */
+  margin: var(--moz-vertical-spacing) 0;
+}
+
+h1 {
+  margin: 0;
+  padding: 0;
+  margin: var(--moz-vertical-spacing) 0;
+  color: var(--header-color);
+  font-weight: bold;
+  font-size: 20px;
+  line-height: 24px;
+}
+
+p {
+  line-height: 20px;
+  margin: var(--moz-vertical-spacing) 0;
+}
+
+button {
+  display: block;
+  height: 36px;
+  width: 100%;
+  border-radius: 5px;
+  border: 0;
+  font-family: inherit;
+  background-color: var(--primary-button-color);
+  color: var(--primary-button-text-color);
+  font-size: 14px;
+  font-weight: bold;
+  margin: var(--moz-vertical-spacing) auto;
+  text-align: center;
+}
+
+hr {
+  height: 1px;
+  border: 0;
+  background: rgba(21, 20, 26, 0.12);
+  margin: 32px 0;
+}
+
+.horizontalLine {
+  margin-left: -40px;
+  margin-right: -40px;
+}
+
+.buttonSecondary {
+  background-color: var(--secondary-button-color);
+  color: var(--secondary-button-text-color);
+}
+
+#errorPageContainer {
+  /* If the page is greater than 550px center the content.
+    * This number should be kept in sync with the media query for tablets below */
+  max-width: 550px;
+  margin: 0 auto;
+  min-height: 100%;
+}
+
+/* On large width devices, apply specific styles here. Often triggered by landscape mode or tablets */
+@media (min-width: 550px) {
+  button,
+  .buttonSecondary {
+    margin: var(--moz-vertical-spacing) auto;
+    min-width: 400px;
+    width: auto;
+  }
+
+  /* If the device is tall as well, add some padding to make content feel a bit more centered */
+  @media (min-height: 550px) {
+    #errorPageContainer {
+      padding-top: 64px;
+      min-height: calc(100% - 64px);
+    }
+  }
+}
+
+#badCertTechnicalInfo {
+  overflow: auto;
+  white-space: pre-line;
+}
+
+#advancedPanelButtonContainer {
+  display: flex;
+  justify-content: center;
+}


### PR DESCRIPTION
- Moved shared CSS into a separate file
- Ran [prettier](prettier.io/) on the HTML & CSS

<img src="https://user-images.githubusercontent.com/1782266/83178657-b39b5080-a0d5-11ea-8023-2b21d6a8f5d5.png" height="400">


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture