### PR TITLE
Provided unique no tabs message per mode

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayView.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayView.kt
@@ -145,13 +145,24 @@ class TabTrayView(
     }
 
     fun updateState(state: BrowserState) {
-        val hasNoTabs = if (isPrivateModeSelected) {
-            state.privateTabs.isEmpty()
-        } else {
-            state.normalTabs.isEmpty()
+        view.let {
+            val hasNoTabs = if (isPrivateModeSelected) {
+                state.privateTabs.isEmpty()
+            } else {
+                state.normalTabs.isEmpty()
+            }
+
+            view.tab_tray_empty_view.isVisible = hasNoTabs
+            if (hasNoTabs) {
+                view.tab_tray_empty_view.text = if (isPrivateModeSelected) {
+                    view.context.getString(R.string.no_private_tabs_description)
+                } else {
+                    view.context?.getString(R.string.no_open_tabs_description)
+                }
+            }
+
+            view.tab_tray_overflow.isVisible = !hasNoTabs
         }
-        view?.tab_tray_empty_view?.isVisible = hasNoTabs
-        view?.tab_tray_overflow?.isVisible = !hasNoTabs
     }
 
     override fun onTabClosed(tab: Tab) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,6 +19,8 @@
     <string name="no_open_tabs_header_2">No open tabs</string>
     <!-- No Open Tabs Message Description -->
     <string name="no_open_tabs_description">Your open tabs will be shown here.</string>
+    <!-- No Private Tabs Message Description -->
+    <string name="no_private_tabs_description">Your private tabs will be shown here.</string>
 
     <!-- About content. The first parameter is the name of the application. (For example: Fenix) -->
     <string name="about_content">%1$s is produced by Mozilla.</string>


### PR DESCRIPTION
Tiny detail but I like the "no tabs" message changing between switching tab modes.  Without it, when there are no tabs of either type, the message stays the same and something feels slightly off.