### PR TITLE
Closes #9529: changed styling for permissions dialog to set proper padding.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsFragmentStore.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsFragmentStore.kt
@@ -145,8 +145,7 @@ class QuickSettingsFragmentStore(
             val autoplayInaudiblePermission =
                 PhoneFeature.AUTOPLAY_INAUDIBLE.toWebsitePermission(context, permissions, settings)
             val shouldBeVisible = cameraPermission.isVisible || microphonePermission.isVisible ||
-                    notificationPermission.isVisible || locationPermission.isVisible ||
-                    autoplayAudiblePermission.isVisible || autoplayInaudiblePermission.isVisible
+                    notificationPermission.isVisible || locationPermission.isVisible
 
             return WebsitePermissionsState(
                 shouldBeVisible, cameraPermission, microphonePermission,

--- a/app/src/main/java/org/mozilla/fenix/settings/quicksettings/WebsitePermissionsView.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/quicksettings/WebsitePermissionsView.kt
@@ -55,7 +55,12 @@ class WebsitePermissionsView(
      * @param state [WebsitePermissionsState] to be rendered.
      */
     fun update(state: WebsitePermissionsState) {
-        if (state.isVisible) {
+        val isAnyPermissionVisible = state.camera.isVisible || state.location.isVisible ||
+                state.microphone.isVisible || state.notification.isVisible
+
+        // Can not use state.isVisible because we are not handling the audio permissions here right
+        // now. If we add more permissions below we should update isAnyPermissionVisible too
+        if (isAnyPermissionVisible) {
             interactor.onPermissionsShown()
         }
 

--- a/app/src/main/java/org/mozilla/fenix/settings/quicksettings/WebsitePermissionsView.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/quicksettings/WebsitePermissionsView.kt
@@ -55,12 +55,7 @@ class WebsitePermissionsView(
      * @param state [WebsitePermissionsState] to be rendered.
      */
     fun update(state: WebsitePermissionsState) {
-        val isAnyPermissionVisible = state.camera.isVisible || state.location.isVisible ||
-                state.microphone.isVisible || state.notification.isVisible
-
-        // Can not use state.isVisible because we are not handling the audio permissions here right
-        // now. If we add more permissions below we should update isAnyPermissionVisible too
-        if (isAnyPermissionVisible) {
+        if (state.isVisible) {
             interactor.onPermissionsShown()
         }
 

--- a/app/src/main/res/layout/quicksettings_permissions.xml
+++ b/app/src/main/res/layout/quicksettings_permissions.xml
@@ -9,7 +9,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/permissions_view"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="8dp">
 
     <TextView
         android:id="@+id/cameraStatus"


### PR DESCRIPTION
From #10227 by @apoorv9990, this already has an r+ from @Amejia481 

- Changed the visibility check to check just for the permissions shown instead of all the permissions in WebsitePermissionsState
- Added bottom padding to the permissions root view so there is balanced padding on top and bottom

### Screnshots
![no permissions](https://user-images.githubusercontent.com/16693039/80314372-167f8c00-87a6-11ea-9711-ecdd8f70ac15.png)
![Permissions with notifications blocked](https://user-images.githubusercontent.com/16693039/80314374-1aaba980-87a6-11ea-815f-6453e07893fb.png)

### Accessibility scan screenshot
![Screenshot_1587920912](https://user-images.githubusercontent.com/16693039/80314384-344cf100-87a6-11ea-9249-3ae26f34a5de.png)
![Screenshot_1587920918](https://user-images.githubusercontent.com/16693039/80314387-3747e180-87a6-11ea-814d-318de56e01c7.png)

There seems to be one suggestion based on the accessibility scan which exists in the master branch before this issue.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.
