### PR TITLE
For issue#10727 - Logins auth redirect

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/ext/Fragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/Fragment.kt
@@ -12,7 +12,9 @@ import androidx.navigation.NavDirections
 import androidx.navigation.NavOptions
 import androidx.navigation.Navigator
 import androidx.navigation.fragment.NavHostFragment.findNavController
+import androidx.navigation.fragment.findNavController
 import org.mozilla.fenix.HomeActivity
+import org.mozilla.fenix.R
 import org.mozilla.fenix.components.Components
 
 /**
@@ -50,4 +52,19 @@ fun Fragment.showToolbar(title: String) {
  */
 fun Fragment.hideToolbar() {
     (requireActivity() as AppCompatActivity).supportActionBar?.hide()
+}
+
+/**
+ * Pops the backstack to force users to re-auth if they put the app in the background and return to it
+ * while being inside the saved logins flow
+ * It also updates the FLAG_SECURE status for the activity's window
+ *
+ * Does nothing if the user is currently navigating to any of the [destinations] given as a parameter
+ *
+ */
+fun Fragment.redirectToReAuth(destinations: List<Int>, currentDestination: Int?) {
+    if (currentDestination !in destinations) {
+        activity?.let { it.checkAndUpdateScreenshotPermission(it.settings()) }
+        findNavController().popBackStack(R.id.savedLoginsAuthFragment, false)
+    }
 }

--- a/app/src/main/java/org/mozilla/fenix/settings/logins/EditLoginFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/EditLoginFragment.kt
@@ -42,6 +42,7 @@ import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.components.StoreProvider
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.redirectToReAuth
 import org.mozilla.fenix.ext.settings
 
 /**
@@ -112,6 +113,14 @@ class EditLoginFragment : Fragment(R.layout.fragment_edit_login) {
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         inflater.inflate(R.menu.login_save, menu)
+    }
+
+    override fun onPause() {
+        redirectToReAuth(
+            listOf(R.id.loginDetailFragment),
+            findNavController().currentDestination?.id
+        )
+        super.onPause()
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean = when (item.itemId) {

--- a/app/src/main/java/org/mozilla/fenix/settings/logins/SavedLoginsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/SavedLoginsFragment.kt
@@ -38,8 +38,8 @@ import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.StoreProvider
 import org.mozilla.fenix.components.metrics.Event
-import org.mozilla.fenix.ext.checkAndUpdateScreenshotPermission
 import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.redirectToReAuth
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.showToolbar
 import org.mozilla.fenix.settings.SupportUtils
@@ -134,10 +134,7 @@ class SavedLoginsFragment : Fragment() {
         (activity as HomeActivity).getSupportActionBarAndInflateIfNecessary().setDisplayShowTitleEnabled(true)
         sortingStrategyPopupMenu.dismiss()
 
-        if (findNavController().currentDestination?.id != R.id.loginDetailFragment) {
-            activity?.let { it.checkAndUpdateScreenshotPermission(it.settings()) }
-            findNavController().popBackStack(R.id.savedLoginsAuthFragment, false)
-        }
+        redirectToReAuth(listOf(R.id.loginDetailFragment), findNavController().currentDestination?.id)
         super.onPause()
     }
 


### PR DESCRIPTION
Added an extension function that pops the backstack of the fragment so the user is redirected to the Logins and passwords screen.

This is done to force the user to re-authenticate if he wants to re-enter the saved logins flow.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture