### PR TITLE
Extract accounts from SettingsFragment & add tests

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/metrics/Metrics.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/Metrics.kt
@@ -4,7 +4,7 @@
 
 package org.mozilla.fenix.components.metrics
 
-import android.content.Context
+import android.content.res.Resources
 import mozilla.components.browser.awesomebar.facts.BrowserAwesomeBarFacts
 import mozilla.components.browser.errorpages.ErrorType
 import mozilla.components.browser.menu.facts.BrowserMenuFacts
@@ -178,23 +178,23 @@ sealed class Event {
     data class PreferenceToggled(
         val preferenceKey: String,
         val enabled: Boolean,
-        val context: Context
+        val resources: Resources
     ) : Event() {
         private val booleanPreferenceTelemetryAllowList = listOf(
-            context.getString(R.string.pref_key_show_search_suggestions),
-            context.getString(R.string.pref_key_remote_debugging),
-            context.getString(R.string.pref_key_telemetry),
-            context.getString(R.string.pref_key_tracking_protection),
-            context.getString(R.string.pref_key_search_bookmarks),
-            context.getString(R.string.pref_key_search_browsing_history),
-            context.getString(R.string.pref_key_show_clipboard_suggestions),
-            context.getString(R.string.pref_key_show_search_shortcuts),
-            context.getString(R.string.pref_key_open_links_in_a_private_tab),
-            context.getString(R.string.pref_key_sync_logins),
-            context.getString(R.string.pref_key_sync_bookmarks),
-            context.getString(R.string.pref_key_sync_history),
-            context.getString(R.string.pref_key_show_voice_search),
-            context.getString(R.string.pref_key_show_search_suggestions_in_private)
+            resources.getString(R.string.pref_key_show_search_suggestions),
+            resources.getString(R.string.pref_key_remote_debugging),
+            resources.getString(R.string.pref_key_telemetry),
+            resources.getString(R.string.pref_key_tracking_protection),
+            resources.getString(R.string.pref_key_search_bookmarks),
+            resources.getString(R.string.pref_key_search_browsing_history),
+            resources.getString(R.string.pref_key_show_clipboard_suggestions),
+            resources.getString(R.string.pref_key_show_search_shortcuts),
+            resources.getString(R.string.pref_key_open_links_in_a_private_tab),
+            resources.getString(R.string.pref_key_sync_logins),
+            resources.getString(R.string.pref_key_sync_bookmarks),
+            resources.getString(R.string.pref_key_sync_history),
+            resources.getString(R.string.pref_key_show_voice_search),
+            resources.getString(R.string.pref_key_show_search_suggestions_in_private)
         )
 
         override val extras: Map<Events.preferenceToggledKeys, String>?

--- a/app/src/main/java/org/mozilla/fenix/settings/BooleanSharedPreferenceUpdater.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/BooleanSharedPreferenceUpdater.kt
@@ -8,13 +8,16 @@ import org.mozilla.fenix.ext.settings
  * Updates the corresponding [android.content.SharedPreferences] when the boolean [Preference] is changed.
  * The preference key is used as the shared preference key.
  */
-open class SharedPreferenceUpdater : Preference.OnPreferenceChangeListener {
+class BooleanSharedPreferenceUpdater(
+    private val callback: ((Boolean) -> Unit)? = null
+) : Preference.OnPreferenceChangeListener {
 
     override fun onPreferenceChange(preference: Preference, newValue: Any?): Boolean {
         val newBooleanValue = newValue as? Boolean ?: return false
         preference.context.settings().preferences.edit {
             putBoolean(preference.key, newBooleanValue)
         }
+        callback?.invoke(newBooleanValue)
         return true
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/settings/DataChoicesFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/DataChoicesFragment.kt
@@ -56,7 +56,7 @@ class DataChoicesFragment : PreferenceFragmentCompat() {
             val appName = context.getString(R.string.app_name)
             summary = context.getString(R.string.preferences_usage_data_description, appName)
 
-            onPreferenceChangeListener = SharedPreferenceUpdater()
+            onPreferenceChangeListener = BooleanSharedPreferenceUpdater()
         }
 
         findPreference<SwitchPreference>(getPreferenceKey(R.string.pref_key_marketing_telemetry))?.apply {
@@ -65,13 +65,13 @@ class DataChoicesFragment : PreferenceFragmentCompat() {
             val appName = context.getString(R.string.app_name)
             summary = context.getString(R.string.preferences_marketing_data_description, appName)
 
-            onPreferenceChangeListener = SharedPreferenceUpdater()
+            onPreferenceChangeListener = BooleanSharedPreferenceUpdater()
         }
 
         findPreference<SwitchPreference>(getPreferenceKey(R.string.pref_key_experimentation))?.apply {
             isChecked = context.settings().isExperimentationEnabled
             isVisible = Config.channel.isReleaseOrBeta
-            onPreferenceChangeListener = SharedPreferenceUpdater()
+            onPreferenceChangeListener = BooleanSharedPreferenceUpdater()
         }
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/settings/OnSharedPreferenceChangeListener.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/OnSharedPreferenceChangeListener.kt
@@ -5,24 +5,19 @@
 package org.mozilla.fenix.settings
 
 import android.content.SharedPreferences
-import androidx.lifecycle.Lifecycle.Event.ON_CREATE
-import androidx.lifecycle.Lifecycle.Event.ON_DESTROY
-import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.OnLifecycleEvent
 
 class OnSharedPreferenceChangeListener(
     private val sharedPreferences: SharedPreferences,
     private val listener: (SharedPreferences, String) -> Unit
-) : SharedPreferences.OnSharedPreferenceChangeListener, LifecycleObserver {
+) : SharedPreferences.OnSharedPreferenceChangeListener, DefaultLifecycleObserver {
 
-    @OnLifecycleEvent(ON_CREATE)
-    fun onCreate() {
+    override fun onCreate(owner: LifecycleOwner) {
         sharedPreferences.registerOnSharedPreferenceChangeListener(this)
     }
 
-    @OnLifecycleEvent(ON_DESTROY)
-    fun onDestroy() {
+    override fun onDestroy(owner: LifecycleOwner) {
         sharedPreferences.unregisterOnSharedPreferenceChangeListener(this)
     }
 

--- a/app/src/main/java/org/mozilla/fenix/settings/PrivateBrowsingFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/PrivateBrowsingFragment.kt
@@ -41,17 +41,14 @@ class PrivateBrowsingFragment : PreferenceFragmentCompat() {
         }
 
         findPreference<SwitchPreference>(getPreferenceKey(R.string.pref_key_open_links_in_a_private_tab))?.apply {
-            onPreferenceChangeListener = SharedPreferenceUpdater()
+            onPreferenceChangeListener = BooleanSharedPreferenceUpdater()
             isChecked = context.settings().openLinksInAPrivateTab
         }
 
         findPreference<SwitchPreference>(getPreferenceKey
             (R.string.pref_key_allow_screenshots_in_private_mode))?.apply {
-            onPreferenceChangeListener = object : SharedPreferenceUpdater() {
-                override fun onPreferenceChange(preference: Preference, newValue: Any?): Boolean {
-                    return super.onPreferenceChange(preference, newValue).also {
-                        requireActivity().checkAndUpdateScreenshotPermission(requireActivity().settings()) }
-                }
+            onPreferenceChangeListener = BooleanSharedPreferenceUpdater {
+                requireActivity().checkAndUpdateScreenshotPermission(requireActivity().settings())
             }
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/settings/SecretSettingsPreference.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SecretSettingsPreference.kt
@@ -28,7 +28,7 @@ class SecretSettingsPreference : PreferenceFragmentCompat() {
 
     private fun updatePreferences() {
         findPreference<SwitchPreference>(getPreferenceKey(R.string.pref_key_enable_new_tab_tray))?.apply {
-            onPreferenceChangeListener = SharedPreferenceUpdater()
+            onPreferenceChangeListener = BooleanSharedPreferenceUpdater()
             isChecked = context.settings().useNewTabTray
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/settings/SettingsAccountView.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SettingsAccountView.kt
@@ -1,0 +1,177 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.settings
+
+import android.os.Handler
+import android.widget.Toast
+import androidx.appcompat.content.res.AppCompatResources.getDrawable
+import androidx.lifecycle.lifecycleScope
+import androidx.preference.Preference
+import androidx.preference.PreferenceCategory
+import androidx.preference.PreferenceFragmentCompat
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import mozilla.components.concept.sync.AccountObserver
+import mozilla.components.concept.sync.AuthType
+import mozilla.components.concept.sync.OAuthAccount
+import mozilla.components.concept.sync.Profile
+import org.mozilla.fenix.R
+import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.getPreferenceKey
+import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.ext.toRoundedDrawable
+import org.mozilla.fenix.settings.account.AccountAuthErrorPreference
+import org.mozilla.fenix.settings.account.AccountPreference
+import kotlin.system.exitProcess
+
+/**
+ * Updates the view for the account controls located at the top of the [SettingsFragment].
+ */
+class SettingsAccountView(fragment: PreferenceFragmentCompat) {
+
+    private val context = fragment.requireContext()
+    private val settings = context.settings()
+    private val accountManager = context.components.backgroundServices.accountManager
+    private val lifecycleOwner = fragment.viewLifecycleOwner
+
+    private val preferenceSignIn = fragment.findPreference<Preference>(
+        context.getPreferenceKey(R.string.pref_key_sign_in)
+    )!!
+    private val preferenceFirefoxAccount = fragment.findPreference<AccountPreference>(
+        context.getPreferenceKey(R.string.pref_key_account)
+    )!!
+    private val preferenceFirefoxAccountAuthError = fragment.findPreference<AccountAuthErrorPreference>(
+        context.getPreferenceKey(R.string.pref_key_account_auth_error)
+    )!!
+    private val accountPreferenceCategory = fragment.findPreference<PreferenceCategory>(
+        context.getPreferenceKey(R.string.pref_key_account_category)
+    )!!
+
+    private val preferenceFxAOverride = fragment.findPreference<Preference>(
+        context.getPreferenceKey(R.string.pref_key_override_fxa_server)
+    )!!
+    private val preferenceSyncOverride = fragment.findPreference<Preference>(
+        context.getPreferenceKey(R.string.pref_key_override_sync_tokenserver)
+    )!!
+
+    private val accountObserver = object : AccountObserver {
+        private fun updateAccountUi(profile: Profile? = null) {
+            lifecycleOwner.lifecycleScope.launch {
+                updateAccountUIState(profile)
+            }
+        }
+
+        override fun onAuthenticated(account: OAuthAccount, authType: AuthType) = updateAccountUi()
+        override fun onLoggedOut() = updateAccountUi()
+        override fun onProfileUpdated(profile: Profile) = updateAccountUi(profile)
+        override fun onAuthenticationProblems() = updateAccountUi()
+    }
+
+    private val syncFxAOverrideUpdater = StringSharedPreferenceUpdater {
+        updateFxASyncOverrideMenu(accountManager.authenticatedAccount() != null)
+        Toast.makeText(
+            context,
+            context.getString(R.string.toast_override_fxa_sync_server_done),
+            Toast.LENGTH_LONG
+        ).show()
+        Handler().postDelayed({ exitProcess(0) }, FXA_SYNC_OVERRIDE_EXIT_DELAY)
+    }
+
+    init {
+        // Observe account changes to keep the UI up-to-date.
+        accountManager.register(
+            accountObserver,
+            owner = lifecycleOwner,
+            autoPause = true
+        )
+
+        // It's important to update the account UI state in onCreate since that ensures we'll never
+        // display an incorrect state in the UI. We take care to not also call it as part of onResume
+        // if it was just called here (via the 'creatingFragment' flag).
+        // For example, if user is signed-in, and we don't perform this call in onCreate, we'll briefly
+        // display a "Sign In" preference, which will then get replaced by the correct account information
+        // once this call is ran in onResume shortly after.
+        updateAccountUIState()
+    }
+
+    /**
+     * Updates the UI to reflect current account state.
+     * Possible conditions are logged-in without problems, logged-out, and logged-in but needs to re-authenticate.
+     */
+    fun updateAccountUIState(givenProfile: Profile? = null) {
+        val profile = givenProfile ?: accountManager.accountProfile()
+        val hasAuthenticatedAccount = accountManager.authenticatedAccount() != null
+        updateFxASyncOverrideMenu(hasAuthenticatedAccount)
+
+        if (hasAuthenticatedAccount) {
+            preferenceSignIn.isVisible = false
+            accountPreferenceCategory.isVisible = true
+
+            if (accountManager.accountNeedsReauth()) {
+                // Signed-in, need to re-authenticate.
+
+                preferenceFirefoxAccount.isVisible = false
+                preferenceFirefoxAccountAuthError.isVisible = true
+
+                preferenceSignIn.onPreferenceClickListener = null
+
+                preferenceFirefoxAccountAuthError.email = profile?.email
+            } else {
+                // Signed-in, no problems.
+
+                profile?.avatar?.url?.let { avatarUrl ->
+                    lifecycleOwner.lifecycleScope.launch(Dispatchers.Main) {
+                        val roundedDrawable =
+                            avatarUrl.toRoundedDrawable(context, context.components.core.client)
+                        preferenceFirefoxAccount.icon =
+                            roundedDrawable ?: getDrawable(context, R.drawable.ic_account)
+                    }
+                }
+                preferenceSignIn.onPreferenceClickListener = null
+                preferenceFirefoxAccountAuthError.isVisible = false
+                preferenceFirefoxAccount.isVisible = true
+
+                preferenceFirefoxAccount.displayName = profile?.displayName
+                preferenceFirefoxAccount.email = profile?.email
+            }
+        } else {
+            // Signed-out.
+            preferenceSignIn.isVisible = true
+            preferenceFirefoxAccount.isVisible = false
+            preferenceFirefoxAccountAuthError.isVisible = false
+            accountPreferenceCategory.isVisible = false
+        }
+    }
+
+    fun setupOverridePreferences() {
+        preferenceFxAOverride.onPreferenceChangeListener = syncFxAOverrideUpdater
+        preferenceSyncOverride.onPreferenceChangeListener = syncFxAOverrideUpdater
+    }
+
+    /**
+     * @param hasAuthenticatedAccount Only enable changes to these prefs
+     * when the user isn't connected to an account.
+     */
+    private fun updateFxASyncOverrideMenu(hasAuthenticatedAccount: Boolean) {
+        val show = settings.overrideFxAServer.isNotEmpty() ||
+            settings.overrideSyncTokenServer.isNotEmpty() ||
+            settings.showSecretDebugMenuThisSession
+
+        preferenceFxAOverride.apply {
+            isVisible = show
+            isEnabled = hasAuthenticatedAccount
+            summary = settings.overrideFxAServer.ifEmpty { null }
+        }
+        preferenceSyncOverride.apply {
+            isVisible = show
+            isEnabled = hasAuthenticatedAccount
+            summary = settings.overrideSyncTokenServer.ifEmpty { null }
+        }
+    }
+
+    companion object {
+        private const val FXA_SYNC_OVERRIDE_EXIT_DELAY = 2000L
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
@@ -5,66 +5,33 @@
 package org.mozilla.fenix.settings
 
 import android.content.ActivityNotFoundException
-import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
-import android.os.Handler
-import android.widget.Toast
-import androidx.appcompat.content.res.AppCompatResources
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavDirections
 import androidx.navigation.findNavController
-import androidx.navigation.fragment.findNavController
 import androidx.preference.Preference
-import androidx.preference.PreferenceCategory
 import androidx.preference.PreferenceFragmentCompat
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers.Main
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import mozilla.components.concept.sync.AccountObserver
-import mozilla.components.concept.sync.AuthType
-import mozilla.components.concept.sync.OAuthAccount
-import mozilla.components.concept.sync.Profile
 import org.mozilla.fenix.BrowserDirection
 import org.mozilla.fenix.Config
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.application
-import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.getPreferenceKey
 import org.mozilla.fenix.ext.metrics
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.showToolbar
-import org.mozilla.fenix.ext.toRoundedDrawable
-import org.mozilla.fenix.settings.account.AccountAuthErrorPreference
-import org.mozilla.fenix.settings.account.AccountPreference
-import kotlin.system.exitProcess
 
-@Suppress("LargeClass", "TooManyFunctions")
 class SettingsFragment : PreferenceFragmentCompat() {
 
-    private val accountObserver = object : AccountObserver {
-        private fun updateAccountUi(profile: Profile? = null) {
-            val context = context ?: return
-            lifecycleScope.launch {
-                updateAccountUIState(
-                    context = context,
-                    profile = profile
-                        ?: context.components.backgroundServices.accountManager.accountProfile()
-                )
-            }
-        }
-
-        override fun onAuthenticated(account: OAuthAccount, authType: AuthType) = updateAccountUi()
-        override fun onLoggedOut() = updateAccountUi()
-        override fun onProfileUpdated(profile: Profile) = updateAccountUi(profile)
-        override fun onAuthenticationProblems() = updateAccountUi()
-    }
+    private var accountView: SettingsAccountView? = null
 
     // A flag used to track if we're going through the onCreate->onStart->onResume lifecycle chain.
     // If it's set to `true`, code in `onResume` can assume that `onCreate` executed a moment prior.
@@ -74,42 +41,8 @@ class SettingsFragment : PreferenceFragmentCompat() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // Observe account changes to keep the UI up-to-date.
-        requireComponents.backgroundServices.accountManager.register(
-            accountObserver,
-            owner = this,
-            autoPause = true
-        )
-
-        // It's important to update the account UI state in onCreate since that ensures we'll never
-        // display an incorrect state in the UI. We take care to not also call it as part of onResume
-        // if it was just called here (via the 'creatingFragment' flag).
-        // For example, if user is signed-in, and we don't perform this call in onCreate, we'll briefly
-        // display a "Sign In" preference, which will then get replaced by the correct account information
-        // once this call is ran in onResume shortly after.
-        updateAccountUIState(
-            requireContext(),
-            requireComponents.backgroundServices.accountManager.accountProfile()
-        )
-
-        preferenceManager.sharedPreferences
-            .registerOnSharedPreferenceChangeListener(this) { sharedPreferences, key ->
-                try {
-                    context?.let { context ->
-                        context.components.analytics.metrics.track(
-                            Event.PreferenceToggled(
-                                key,
-                                sharedPreferences.getBoolean(key, false),
-                                context
-                            )
-                        )
-                    }
-                } catch (e: IllegalArgumentException) {
-                    // The event is not tracked
-                } catch (e: ClassCastException) {
-                    // The setting is not a boolean, not tracked
-                }
-            }
+        accountView = SettingsAccountView(this)
+        addMetricsPreferenceListener()
     }
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
@@ -132,46 +65,44 @@ class SettingsFragment : PreferenceFragmentCompat() {
         creatingFragment = false
     }
 
+    override fun onDestroyView() {
+        accountView = null
+        super.onDestroyView()
+    }
+
     private fun update(shouldUpdateAccountUIState: Boolean) {
+        val context = context ?: return
+        val settings = context.settings()
+
         val trackingProtectionPreference =
-            findPreference<Preference>(getPreferenceKey(R.string.pref_key_tracking_protection_settings))
-        trackingProtectionPreference?.summary = context?.let {
-            if (it.settings().shouldUseTrackingProtection) {
-                getString(R.string.tracking_protection_on)
-            } else {
-                getString(R.string.tracking_protection_off)
-            }
-        }
+            findPreference<Preference>(getPreferenceKey(R.string.pref_key_tracking_protection_settings))!!
+        trackingProtectionPreference.setSummary(if (settings.shouldUseTrackingProtection) {
+            R.string.tracking_protection_on
+        } else {
+            R.string.tracking_protection_off
+        })
 
         val toolbarPreference =
-            findPreference<Preference>(getPreferenceKey(R.string.pref_key_toolbar))
-        toolbarPreference?.summary = context?.settings()?.toolbarSettingString
+            findPreference<Preference>(getPreferenceKey(R.string.pref_key_toolbar))!!
+        toolbarPreference.summary = settings.toolbarSettingString
 
-        val aboutPreference = findPreference<Preference>(getPreferenceKey(R.string.pref_key_about))
+        val aboutPreference = findPreference<Preference>(getPreferenceKey(R.string.pref_key_about))!!
         val appName = getString(R.string.app_name)
-        aboutPreference?.title = getString(R.string.preferences_about, appName)
+        aboutPreference.title = getString(R.string.preferences_about, appName)
 
-        val deleteBrowsingDataPreference =
-            findPreference<Preference>(
-                getPreferenceKey(
-                    R.string.pref_key_delete_browsing_data_on_quit_preference
-                )
-            )
-        deleteBrowsingDataPreference?.summary = context?.let {
-            if (it.settings().shouldDeleteBrowsingDataOnQuit) {
-                getString(R.string.delete_browsing_data_quit_on)
-            } else {
-                getString(R.string.delete_browsing_data_quit_off)
-            }
-        }
+        val deleteBrowsingDataPreference = findPreference<Preference>(
+            getPreferenceKey(R.string.pref_key_delete_browsing_data_on_quit_preference)
+        )!!
+        deleteBrowsingDataPreference.setSummary(if (settings.shouldDeleteBrowsingDataOnQuit) {
+            R.string.delete_browsing_data_quit_on
+        } else {
+            R.string.delete_browsing_data_quit_off
+        })
 
         setupPreferences()
 
         if (shouldUpdateAccountUIState) {
-            updateAccountUIState(
-                requireContext(),
-                requireComponents.backgroundServices.accountManager.accountProfile()
-            )
+            accountView?.updateAccountUIState()
         }
     }
 
@@ -287,52 +218,28 @@ class SettingsFragment : PreferenceFragmentCompat() {
     }
 
     private fun setupPreferences() {
-        val leakKey = getPreferenceKey(R.string.pref_key_leakcanary)
-        val debuggingKey = getPreferenceKey(R.string.pref_key_remote_debugging)
-
-        val preferenceLeakCanary = findPreference<Preference>(leakKey)
-        val preferenceRemoteDebugging = findPreference<Preference>(debuggingKey)
+        val preferenceLeakCanary = findPreference<Preference>(
+            getPreferenceKey(R.string.pref_key_leakcanary)
+        )!!
+        val preferenceRemoteDebugging = findPreference<Preference>(
+            getPreferenceKey(R.string.pref_key_remote_debugging)
+        )!!
 
         if (!Config.channel.isReleased) {
-            preferenceLeakCanary?.setOnPreferenceChangeListener { _, newValue ->
-                val isEnabled = newValue == true
-                context?.application?.updateLeakCanaryState(isEnabled)
+            preferenceLeakCanary.setOnPreferenceChangeListener<Boolean> { preference, isEnabled ->
+                preference.context.application.updateLeakCanaryState(isEnabled)
                 true
             }
         }
 
-        preferenceRemoteDebugging?.setOnPreferenceChangeListener { preference, newValue ->
-            preference.context.settings().preferences.edit()
-                .putBoolean(preference.key, newValue as Boolean).apply()
-            requireComponents.core.engine.settings.remoteDebuggingEnabled = newValue
-            true
+        preferenceRemoteDebugging.onPreferenceChangeListener = BooleanSharedPreferenceUpdater {
+            requireComponents.core.engine.settings.remoteDebuggingEnabled = it
         }
 
-        val preferenceFxAOverride =
-            findPreference<Preference>(getPreferenceKey(R.string.pref_key_override_fxa_server))
-        val preferenceSyncOverride =
-            findPreference<Preference>(getPreferenceKey(R.string.pref_key_override_sync_tokenserver))
-
-        val syncFxAOverrideUpdater = object : StringSharedPreferenceUpdater() {
-            override fun onPreferenceChange(preference: Preference, newValue: Any?): Boolean {
-                return super.onPreferenceChange(preference, newValue).also {
-                    updateFxASyncOverrideMenu()
-                    Toast.makeText(
-                        context,
-                        getString(R.string.toast_override_fxa_sync_server_done),
-                        Toast.LENGTH_LONG
-                    ).show()
-                    Handler().postDelayed({
-                        exitProcess(0)
-                    }, FXA_SYNC_OVERRIDE_EXIT_DELAY)
-                }
-            }
-        }
-        preferenceFxAOverride?.onPreferenceChangeListener = syncFxAOverrideUpdater
-        preferenceSyncOverride?.onPreferenceChangeListener = syncFxAOverrideUpdater
+        accountView?.setupOverridePreferences()
         findPreference<Preference>(
             getPreferenceKey(R.string.pref_key_debug_settings)
-        )?.isVisible = requireContext().settings().showSecretDebugMenuThisSession
+        )!!.isVisible = requireContext().settings().showSecretDebugMenuThisSession
     }
 
     private fun navigateFromSettings(directions: NavDirections) {
@@ -355,98 +262,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
         }
     }
 
-    /**
-     * Updates the UI to reflect current account state.
-     * Possible conditions are logged-in without problems, logged-out, and logged-in but needs to re-authenticate.
-     */
-    private fun updateAccountUIState(context: Context, profile: Profile?) {
-        val preferenceSignIn =
-            findPreference<Preference>(context.getPreferenceKey(R.string.pref_key_sign_in))
-        val preferenceFirefoxAccount =
-            findPreference<AccountPreference>(context.getPreferenceKey(R.string.pref_key_account))
-        val preferenceFirefoxAccountAuthError =
-            findPreference<AccountAuthErrorPreference>(
-                context.getPreferenceKey(
-                    R.string.pref_key_account_auth_error
-                )
-            )
-        val accountPreferenceCategory =
-            findPreference<PreferenceCategory>(context.getPreferenceKey(R.string.pref_key_account_category))
-
-        val accountManager = requireComponents.backgroundServices.accountManager
-        val account = accountManager.authenticatedAccount()
-
-        updateFxASyncOverrideMenu()
-
-        // Signed-in, no problems.
-        if (account != null && !accountManager.accountNeedsReauth()) {
-            preferenceSignIn?.isVisible = false
-
-            profile?.avatar?.url?.let { avatarUrl ->
-                lifecycleScope.launch(Main) {
-                    val roundedDrawable =
-                        avatarUrl.toRoundedDrawable(context, requireComponents.core.client)
-                    preferenceFirefoxAccount?.icon =
-                        roundedDrawable ?: AppCompatResources.getDrawable(
-                            context,
-                            R.drawable.ic_account
-                        )
-                }
-            }
-            preferenceSignIn?.onPreferenceClickListener = null
-            preferenceFirefoxAccountAuthError?.isVisible = false
-            preferenceFirefoxAccount?.isVisible = true
-            accountPreferenceCategory?.isVisible = true
-
-            preferenceFirefoxAccount?.displayName = profile?.displayName
-            preferenceFirefoxAccount?.email = profile?.email
-
-            // Signed-in, need to re-authenticate.
-        } else if (account != null && accountManager.accountNeedsReauth()) {
-            preferenceFirefoxAccount?.isVisible = false
-            preferenceFirefoxAccountAuthError?.isVisible = true
-            accountPreferenceCategory?.isVisible = true
-
-            preferenceSignIn?.isVisible = false
-            preferenceSignIn?.onPreferenceClickListener = null
-
-            preferenceFirefoxAccountAuthError?.email = profile?.email
-
-            // Signed-out.
-        } else {
-            preferenceSignIn?.isVisible = true
-            preferenceFirefoxAccount?.isVisible = false
-            preferenceFirefoxAccountAuthError?.isVisible = false
-            accountPreferenceCategory?.isVisible = false
-        }
-    }
-
-    private fun updateFxASyncOverrideMenu() {
-        val preferenceFxAOverride =
-            findPreference<Preference>(getPreferenceKey(R.string.pref_key_override_fxa_server))
-        val preferenceSyncOverride =
-            findPreference<Preference>(getPreferenceKey(R.string.pref_key_override_sync_tokenserver))
-        val settings = requireContext().settings()
-        val show = settings.overrideFxAServer.isNotEmpty() ||
-                settings.overrideSyncTokenServer.isNotEmpty() ||
-                settings.showSecretDebugMenuThisSession
-        // Only enable changes to these prefs when the user isn't connected to an account.
-        val enabled =
-            requireComponents.backgroundServices.accountManager.authenticatedAccount() == null
-        preferenceFxAOverride?.apply {
-            isVisible = show
-            isEnabled = enabled
-            summary = settings.overrideFxAServer.ifEmpty { null }
-        }
-        preferenceSyncOverride?.apply {
-            isVisible = show
-            isEnabled = enabled
-            summary = settings.overrideSyncTokenServer.ifEmpty { null }
-        }
-    }
-
     companion object {
         private const val SCROLL_INDICATOR_DELAY = 10L
-        private const val FXA_SYNC_OVERRIDE_EXIT_DELAY = 2000L
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/settings/StringSharedPreferenceUpdater.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/StringSharedPreferenceUpdater.kt
@@ -12,13 +12,16 @@ import org.mozilla.fenix.ext.settings
  * Updates the corresponding [android.content.SharedPreferences] when the String [Preference] is changed.
  * The preference key is used as the shared preference key.
  */
-open class StringSharedPreferenceUpdater : Preference.OnPreferenceChangeListener {
+class StringSharedPreferenceUpdater(
+    private val callback: (() -> Unit)? = null
+) : Preference.OnPreferenceChangeListener {
 
     override fun onPreferenceChange(preference: Preference, newValue: Any?): Boolean {
         val newStringValue = newValue as? String ?: return false
         preference.context.settings().preferences.edit {
             putString(preference.key, newStringValue)
         }
+        callback?.invoke()
         return true
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/settings/TrackingProtectionFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/TrackingProtectionFragment.kt
@@ -171,20 +171,14 @@ class TrackingProtectionFragment : PreferenceFragmentCompat() {
         }
 
         customCookies = requireNotNull(
-            findPreference(
-                getString(R.string.pref_key_tracking_protection_custom_cookies)
-            )
+            findPreference(getString(R.string.pref_key_tracking_protection_custom_cookies))
         )
 
         customCookiesSelect = requireNotNull(
-            findPreference(
-                getString(R.string.pref_key_tracking_protection_custom_cookies_select)
-            )
+            findPreference(getString(R.string.pref_key_tracking_protection_custom_cookies_select))
         )
         customTracking = requireNotNull(
-            findPreference(
-                getString(R.string.pref_key_tracking_protection_custom_tracking_content)
-            )
+            findPreference(getString(R.string.pref_key_tracking_protection_custom_tracking_content))
         )
         customTrackingSelect = requireNotNull(
             findPreference(
@@ -192,66 +186,34 @@ class TrackingProtectionFragment : PreferenceFragmentCompat() {
             )
         )
         customCryptominers = requireNotNull(
-            findPreference(
-                getString(R.string.pref_key_tracking_protection_custom_cryptominers)
-            )
+            findPreference(getString(R.string.pref_key_tracking_protection_custom_cryptominers))
         )
         customFingerprinters = requireNotNull(
-            findPreference(
-                getString(R.string.pref_key_tracking_protection_custom_fingerprinters)
-            )
+            findPreference(getString(R.string.pref_key_tracking_protection_custom_fingerprinters))
         )
 
-        customCookies.onPreferenceChangeListener = object : SharedPreferenceUpdater() {
-            override fun onPreferenceChange(preference: Preference, newValue: Any?): Boolean {
-                customCookiesSelect.isVisible = !customCookies.isChecked
-                return super.onPreferenceChange(preference, newValue).also {
-                    updateTrackingProtectionPolicy()
-                }
-            }
+        customCookies.onPreferenceChangeListener = BooleanSharedPreferenceUpdater {
+            customCookiesSelect.isVisible = !customCookies.isChecked
+            updateTrackingProtectionPolicy()
         }
 
-        customTracking.onPreferenceChangeListener = object : SharedPreferenceUpdater() {
-            override fun onPreferenceChange(preference: Preference, newValue: Any?): Boolean {
-                customTrackingSelect.isVisible = !customTracking.isChecked
-                return super.onPreferenceChange(preference, newValue).also {
-                    updateTrackingProtectionPolicy()
-                }
-            }
+        customTracking.onPreferenceChangeListener = BooleanSharedPreferenceUpdater {
+            customTrackingSelect.isVisible = !customTracking.isChecked
+            updateTrackingProtectionPolicy()
         }
 
-        customCookiesSelect.onPreferenceChangeListener = object : StringSharedPreferenceUpdater() {
-            override fun onPreferenceChange(preference: Preference, newValue: Any?): Boolean {
-                return super.onPreferenceChange(preference, newValue).also {
-                    updateTrackingProtectionPolicy()
-                }
-            }
+        val updateStringPreferenceAndPolicy = StringSharedPreferenceUpdater {
+            updateTrackingProtectionPolicy()
+        }
+        val updateBooleanPreferenceAndPolicy = BooleanSharedPreferenceUpdater {
+            updateTrackingProtectionPolicy()
         }
 
-        customTrackingSelect.onPreferenceChangeListener = object : StringSharedPreferenceUpdater() {
-            override fun onPreferenceChange(preference: Preference, newValue: Any?): Boolean {
+        customCookiesSelect.onPreferenceChangeListener = updateStringPreferenceAndPolicy
+        customTrackingSelect.onPreferenceChangeListener = updateStringPreferenceAndPolicy
 
-                return super.onPreferenceChange(preference, newValue).also {
-                    updateTrackingProtectionPolicy()
-                }
-            }
-        }
-
-        customCryptominers.onPreferenceChangeListener = object : SharedPreferenceUpdater() {
-            override fun onPreferenceChange(preference: Preference, newValue: Any?): Boolean {
-                return super.onPreferenceChange(preference, newValue).also {
-                    updateTrackingProtectionPolicy()
-                }
-            }
-        }
-
-        customFingerprinters.onPreferenceChangeListener = object : SharedPreferenceUpdater() {
-            override fun onPreferenceChange(preference: Preference, newValue: Any?): Boolean {
-                return super.onPreferenceChange(preference, newValue).also {
-                    updateTrackingProtectionPolicy()
-                }
-            }
-        }
+        customCryptominers.onPreferenceChangeListener = updateBooleanPreferenceAndPolicy
+        customFingerprinters.onPreferenceChangeListener = updateBooleanPreferenceAndPolicy
 
         updateCustomOptionsVisibility()
     }

--- a/app/src/main/java/org/mozilla/fenix/settings/deletebrowsingdata/DeleteBrowsingDataOnQuitFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/deletebrowsingdata/DeleteBrowsingDataOnQuitFragment.kt
@@ -6,14 +6,13 @@ package org.mozilla.fenix.settings.deletebrowsingdata
 
 import android.os.Bundle
 import androidx.preference.CheckBoxPreference
-import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreference
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.getPreferenceKey
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.showToolbar
-import org.mozilla.fenix.settings.SharedPreferenceUpdater
+import org.mozilla.fenix.settings.BooleanSharedPreferenceUpdater
 
 class DeleteBrowsingDataOnQuitFragment : PreferenceFragmentCompat() {
 
@@ -33,7 +32,6 @@ class DeleteBrowsingDataOnQuitFragment : PreferenceFragmentCompat() {
         setPreferencesFromResource(R.xml.delete_browsing_data_quit_preferences, rootKey)
     }
 
-    @Suppress("ComplexMethod")
     override fun onResume() {
         super.onResume()
         showToolbar(getString(R.string.preferences_delete_browsing_data_on_quit))
@@ -42,26 +40,19 @@ class DeleteBrowsingDataOnQuitFragment : PreferenceFragmentCompat() {
         val deleteOnQuitPref = findPreference<SwitchPreference>(
             getPreferenceKey(R.string.pref_key_delete_browsing_data_on_quit)
         )
+
+        val settings = requireContext().settings()
         deleteOnQuitPref?.apply {
-            onPreferenceChangeListener = object : SharedPreferenceUpdater() {
-                override fun onPreferenceChange(preference: Preference, newValue: Any?): Boolean {
-                    setAllCheckboxes(newValue as Boolean)
-                    return super.onPreferenceChange(preference, newValue)
-                }
+            onPreferenceChangeListener = BooleanSharedPreferenceUpdater {
+                setAllCheckboxes(it)
             }
-            isChecked = context.settings().shouldDeleteBrowsingDataOnQuit
+            isChecked = settings.shouldDeleteBrowsingDataOnQuit
         }
 
-        val checkboxUpdater = object : SharedPreferenceUpdater() {
-            override fun onPreferenceChange(preference: Preference, newValue: Any?): Boolean {
-                super.onPreferenceChange(preference, newValue)
-                val settings = preference.context.settings()
-
-                if (!settings.shouldDeleteAnyDataOnQuit()) {
-                    deleteOnQuitPref?.isChecked = false
-                    settings.shouldDeleteBrowsingDataOnQuit = false
-                }
-                return true
+        val checkboxUpdater = BooleanSharedPreferenceUpdater {
+            if (!settings.shouldDeleteAnyDataOnQuit()) {
+                deleteOnQuitPref?.isChecked = false
+                settings.shouldDeleteBrowsingDataOnQuit = false
             }
         }
 

--- a/app/src/main/java/org/mozilla/fenix/settings/logins/SavedLoginsAuthFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/SavedLoginsAuthFragment.kt
@@ -38,7 +38,7 @@ import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.secure
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.showToolbar
-import org.mozilla.fenix.settings.SharedPreferenceUpdater
+import org.mozilla.fenix.settings.BooleanSharedPreferenceUpdater
 import java.util.concurrent.Executors
 
 @Suppress("TooManyFunctions", "LargeClass")
@@ -116,7 +116,7 @@ class SavedLoginsAuthFragment : PreferenceFragmentCompat(), AccountObserver {
             isChecked =
                 context.settings().shouldAutofillLogins && context.settings().shouldPromptToSaveLogins
             onPreferenceChangeListener =
-                SharedPreferenceUpdater()
+                BooleanSharedPreferenceUpdater()
         }
 
         val savedLoginsKey = getPreferenceKey(R.string.pref_key_saved_logins)

--- a/app/src/main/java/org/mozilla/fenix/settings/logins/SavedLoginsSettingFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/SavedLoginsSettingFragment.kt
@@ -5,15 +5,13 @@
 package org.mozilla.fenix.settings.logins
 
 import android.os.Bundle
-import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.metrics.Event
-import org.mozilla.fenix.ext.components
-import org.mozilla.fenix.ext.metrics
+import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.showToolbar
+import org.mozilla.fenix.settings.BooleanSharedPreferenceUpdater
 import org.mozilla.fenix.settings.RadioButtonPreference
-import org.mozilla.fenix.settings.SharedPreferenceUpdater
 
 class SavedLoginsSettingFragment : PreferenceFragmentCompat() {
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
@@ -31,19 +29,17 @@ class SavedLoginsSettingFragment : PreferenceFragmentCompat() {
     private fun bindSave(): RadioButtonPreference {
         val keySave = getString(R.string.pref_key_save_logins)
         val preferenceSave = findPreference<RadioButtonPreference>(keySave)
-        preferenceSave?.onPreferenceChangeListener = object : SharedPreferenceUpdater() {
-            override fun onPreferenceChange(preference: Preference, newValue: Any?): Boolean {
-                if (newValue == true) {
-                    context?.metrics?.track(
-                        Event.SaveLoginsSettingChanged(
-                            Event.SaveLoginsSettingChanged.Setting.ASK_TO_SAVE
-                        )
+        val components = requireComponents
+        preferenceSave?.onPreferenceChangeListener = BooleanSharedPreferenceUpdater {
+            if (it) {
+                components.analytics.metrics.track(
+                    Event.SaveLoginsSettingChanged(
+                        Event.SaveLoginsSettingChanged.Setting.ASK_TO_SAVE
                     )
-                }
-                // We want to reload the current session here so we can try to fill the current page
-                context?.components?.useCases?.sessionUseCases?.reload?.invoke()
-                return super.onPreferenceChange(preference, newValue)
+                )
             }
+            // We want to reload the current session here so we can try to fill the current page
+            components.useCases.sessionUseCases.reload.invoke()
         }
         return requireNotNull(preferenceSave)
     }
@@ -51,19 +47,17 @@ class SavedLoginsSettingFragment : PreferenceFragmentCompat() {
     private fun bindNeverSave(): RadioButtonPreference {
         val keyNeverSave = getString(R.string.pref_key_never_save_logins)
         val preferenceNeverSave = findPreference<RadioButtonPreference>(keyNeverSave)
-        preferenceNeverSave?.onPreferenceChangeListener = object : SharedPreferenceUpdater() {
-            override fun onPreferenceChange(preference: Preference, newValue: Any?): Boolean {
-                if (newValue == true) {
-                    context?.metrics?.track(
-                        Event.SaveLoginsSettingChanged(
-                            Event.SaveLoginsSettingChanged.Setting.NEVER_SAVE
-                        )
+        val components = requireComponents
+        preferenceNeverSave?.onPreferenceChangeListener = BooleanSharedPreferenceUpdater {
+            if (it) {
+                components.analytics.metrics.track(
+                    Event.SaveLoginsSettingChanged(
+                        Event.SaveLoginsSettingChanged.Setting.NEVER_SAVE
                     )
-                }
-                // We want to reload the current session here so we don't save any currently inserted login
-                context?.components?.useCases?.sessionUseCases?.reload?.invoke()
-                return super.onPreferenceChange(preference, newValue)
+                )
             }
+            // We want to reload the current session here so we don't save any currently inserted login
+            components.useCases.sessionUseCases.reload.invoke()
         }
         return requireNotNull(preferenceNeverSave)
     }

--- a/app/src/main/java/org/mozilla/fenix/settings/search/SearchEngineFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/search/SearchEngineFragment.kt
@@ -15,7 +15,7 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.getPreferenceKey
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.showToolbar
-import org.mozilla.fenix.settings.SharedPreferenceUpdater
+import org.mozilla.fenix.settings.BooleanSharedPreferenceUpdater
 
 class SearchEngineFragment : PreferenceFragmentCompat() {
 
@@ -68,13 +68,13 @@ class SearchEngineFragment : PreferenceFragmentCompat() {
             }
 
         searchEngineListPreference?.reload(requireContext())
-        searchSuggestionsPreference?.onPreferenceChangeListener = SharedPreferenceUpdater()
-        showSearchShortcuts?.onPreferenceChangeListener = SharedPreferenceUpdater()
-        showHistorySuggestions?.onPreferenceChangeListener = SharedPreferenceUpdater()
-        showBookmarkSuggestions?.onPreferenceChangeListener = SharedPreferenceUpdater()
-        showClipboardSuggestions?.onPreferenceChangeListener = SharedPreferenceUpdater()
-        searchSuggestionsInPrivatePreference?.onPreferenceChangeListener = SharedPreferenceUpdater()
-        showVoiceSearchPreference?.onPreferenceChangeListener = SharedPreferenceUpdater()
+        searchSuggestionsPreference?.onPreferenceChangeListener = BooleanSharedPreferenceUpdater()
+        showSearchShortcuts?.onPreferenceChangeListener = BooleanSharedPreferenceUpdater()
+        showHistorySuggestions?.onPreferenceChangeListener = BooleanSharedPreferenceUpdater()
+        showBookmarkSuggestions?.onPreferenceChangeListener = BooleanSharedPreferenceUpdater()
+        showClipboardSuggestions?.onPreferenceChangeListener = BooleanSharedPreferenceUpdater()
+        searchSuggestionsInPrivatePreference?.onPreferenceChangeListener = BooleanSharedPreferenceUpdater()
+        showVoiceSearchPreference?.onPreferenceChangeListener = BooleanSharedPreferenceUpdater()
 
         searchSuggestionsPreference?.setOnPreferenceClickListener {
             if (!searchSuggestionsPreference.isChecked) {

--- a/app/src/test/java/org/mozilla/fenix/settings/ExtensionsTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/ExtensionsTest.kt
@@ -1,0 +1,82 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.settings
+
+import android.content.SharedPreferences
+import androidx.preference.Preference
+import androidx.preference.PreferenceFragmentCompat
+import io.mockk.Called
+import io.mockk.Runs
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.fenix.components.metrics.Event
+import org.mozilla.fenix.components.metrics.MetricController
+import org.mozilla.fenix.ext.requireComponents
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+
+@RunWith(FenixRobolectricTestRunner::class)
+class ExtensionsTest {
+
+    @Test
+    fun testSetOnPreferenceChangeListener() {
+        val preference = Preference(testContext)
+        var called = false
+        preference.setOnPreferenceChangeListener<Boolean> { _, _ ->
+            called = true
+            true
+        }
+
+        preference.callChangeListener("hello")
+        assertFalse(called)
+
+        preference.callChangeListener(false)
+        assertTrue(called)
+    }
+
+    @Test
+    fun testAddMetricsPreferenceListener() {
+        val fragment = mockk<PreferenceFragmentCompat>()
+        val sharedPreferences = mockk<SharedPreferences>(relaxed = true)
+        val metrics = mockk<MetricController>()
+
+        every { fragment.requireContext() } returns testContext
+        every { fragment.requireContext().resources } returns testContext.resources
+        every { fragment.requireComponents.analytics.metrics } returns metrics
+        every { fragment.preferenceManager.sharedPreferences } returns sharedPreferences
+        every { metrics.track(any()) } just Runs
+
+        val slot = slot<OnSharedPreferenceChangeListener>()
+        every { fragment.lifecycle.addObserver(capture(slot)) } just Runs
+
+        fragment.addMetricsPreferenceListener()
+        val key = "pref_key_search_bookmarks"
+
+        every { sharedPreferences.getBoolean(key, false) } returns false
+        slot.captured.onSharedPreferenceChanged(sharedPreferences, key)
+        verify {
+            metrics.track(
+                Event.PreferenceToggled(key, false, testContext.resources)
+            )
+        }
+        clearMocks(metrics)
+
+        every { sharedPreferences.getBoolean(key, false) } throws IllegalArgumentException()
+        slot.captured.onSharedPreferenceChanged(sharedPreferences, key)
+        verify { metrics wasNot Called }
+
+        every { sharedPreferences.getBoolean(key, false) } throws ClassCastException()
+        slot.captured.onSharedPreferenceChanged(sharedPreferences, key)
+        verify { metrics wasNot Called }
+    }
+}

--- a/app/src/test/java/org/mozilla/fenix/settings/SettingsAccountViewTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/SettingsAccountViewTest.kt
@@ -1,0 +1,130 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.settings
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import androidx.preference.Preference
+import androidx.preference.PreferenceCategory
+import androidx.preference.PreferenceFragmentCompat
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.spyk
+import io.mockk.verify
+import mozilla.components.service.fxa.manager.FxaAccountManager
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+import org.mozilla.fenix.settings.account.AccountAuthErrorPreference
+import org.mozilla.fenix.settings.account.AccountPreference
+import org.mozilla.fenix.utils.Settings
+
+@RunWith(FenixRobolectricTestRunner::class)
+class SettingsAccountViewTest {
+
+    private lateinit var accountView: SettingsAccountView
+    private lateinit var fragment: PreferenceFragmentCompat
+    private lateinit var accountManager: FxaAccountManager
+    private lateinit var settings: Settings
+    private lateinit var lifecycle: Lifecycle
+
+    private lateinit var preferenceSignIn: Preference
+    private lateinit var preferenceFirefoxAccount: AccountPreference
+    private lateinit var preferenceFirefoxAccountAuthError: AccountAuthErrorPreference
+    private lateinit var accountPreferenceCategory: PreferenceCategory
+    private lateinit var preferenceFxAOverride: Preference
+    private lateinit var preferenceSyncOverride: Preference
+
+    @Before
+    fun setup() {
+        fragment = mockk()
+        settings = mockk(relaxed = true)
+        accountManager = mockk(relaxed = true)
+        val owner = LifecycleOwner { lifecycle }
+        lifecycle = LifecycleRegistry(owner)
+
+        preferenceSignIn = mockk(relaxed = true)
+        preferenceFirefoxAccount = mockk(relaxed = true)
+        preferenceFirefoxAccountAuthError = mockk(relaxed = true)
+        accountPreferenceCategory = mockk(relaxed = true)
+        preferenceFxAOverride = mockk(relaxed = true)
+        preferenceSyncOverride = mockk(relaxed = true)
+
+        mockkStatic("org.mozilla.fenix.ext.ContextKt")
+
+        val context = spyk(testContext)
+        every { fragment.requireContext() } returns context
+        every { fragment.viewLifecycleOwner } returns owner
+        every { fragment.findPreference<Preference>("pref_key_sign_in") } returns preferenceSignIn
+        every { fragment.findPreference<AccountPreference>("pref_key_account") } returns preferenceFirefoxAccount
+        every { fragment.findPreference<AccountAuthErrorPreference>("pref_key_account_auth_error") } returns preferenceFirefoxAccountAuthError
+        every { fragment.findPreference<PreferenceCategory>("pref_key_account_category") } returns accountPreferenceCategory
+        every { fragment.findPreference<Preference>("pref_key_override_fxa_server") } returns preferenceFxAOverride
+        every { fragment.findPreference<Preference>("pref_key_override_sync_tokenserver") } returns preferenceSyncOverride
+        every { context.components.core.client } returns mockk()
+        every { context.components.backgroundServices.accountManager } returns accountManager
+        every { context.settings() } returns settings
+        every { accountManager.accountProfile() } returns null
+
+        accountView = SettingsAccountView(fragment)
+    }
+
+    @Test
+    fun testRegistersObserver() {
+        verify { accountManager.register(any(), any(), autoPause = true) }
+    }
+
+    @Test
+    fun testSignedOutUi() {
+        every { accountManager.authenticatedAccount() } returns null
+        accountView.updateAccountUIState()
+
+        verify { preferenceSignIn.isVisible = true }
+        verify { preferenceFirefoxAccount.isVisible = false }
+        verify { preferenceFirefoxAccountAuthError.isVisible = false }
+        verify { accountPreferenceCategory.isVisible = false }
+
+        verify { preferenceSyncOverride.isEnabled = false }
+        verify { preferenceSyncOverride.isEnabled = false }
+    }
+
+    @Test
+    fun testAuthenticatedUi() {
+        every { accountManager.authenticatedAccount() } returns mockk()
+        every { accountManager.accountNeedsReauth() } returns false
+        accountView.updateAccountUIState()
+
+        verify { preferenceSignIn.isVisible = false }
+        verify { accountPreferenceCategory.isVisible = true }
+        verify { preferenceSignIn.onPreferenceClickListener = null }
+        verify { preferenceFirefoxAccountAuthError.isVisible = false }
+        verify { preferenceFirefoxAccount.isVisible = true }
+        verify { preferenceFirefoxAccount.displayName = null }
+        verify { preferenceFirefoxAccount.email = null }
+
+        verify { preferenceSyncOverride.isEnabled = true }
+        verify { preferenceSyncOverride.isEnabled = true }
+    }
+
+    @Test
+    fun testReauthUi() {
+        every { accountManager.authenticatedAccount() } returns mockk()
+        every { accountManager.accountNeedsReauth() } returns true
+        accountView.updateAccountUIState()
+
+        verify { preferenceSignIn.isVisible = false }
+        verify { accountPreferenceCategory.isVisible = true }
+        verify { preferenceFirefoxAccount.isVisible = false }
+        verify { preferenceFirefoxAccountAuthError.isVisible = true }
+        verify { preferenceSignIn.onPreferenceClickListener = null }
+        verify { preferenceFirefoxAccountAuthError.email = null }
+    }
+}


### PR DESCRIPTION
Shrinks down the `SettingsFragment` below the lint limit by moving all the account related logic into a helper class. That logic is now tested as well.

`BooleanSharedPreferenceUpdater` and `StringSharedPreferenceUpdater` now take callbacks rather than being open classes.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture