### PR TITLE
🎲 For 11031 - Fix landscape mode for tab tray

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayDialogFragment.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.fenix.tabtray
 
+import android.content.res.Configuration
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -44,12 +45,21 @@ class TabTrayDialogFragment : AppCompatDialogFragment(), TabTrayInteractor {
         savedInstanceState: Bundle?
     ): View? = inflater.inflate(R.layout.fragment_tab_tray_dialog, container, false)
 
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+
+        if (newConfig.orientation == Configuration.ORIENTATION_LANDSCAPE) {
+            tabTrayView.expand()
+        }
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         tabTrayView = TabTrayView(
             view.tabLayout,
             this,
-            (activity as HomeActivity).browsingModeManager.mode.isPrivate
+            (activity as HomeActivity).browsingModeManager.mode.isPrivate,
+            requireContext().resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
         )
 
         tabLayout.setOnClickListener {

--- a/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayView.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayView.kt
@@ -45,7 +45,8 @@ interface TabTrayInteractor {
 class TabTrayView(
     private val container: ViewGroup,
     private val interactor: TabTrayInteractor,
-    private val isPrivate: Boolean
+    private val isPrivate: Boolean,
+    private val startingInLandscape: Boolean
 ) : LayoutContainer, TabsTray.Observer, TabLayout.OnTabSelectedListener {
     val fabView = LayoutInflater.from(container.context)
         .inflate(R.layout.component_tabstray_fab, container, true)
@@ -113,8 +114,8 @@ class TabTrayView(
         val selectedBrowserTabIndex = tabs
             .indexOfFirst { it.id == view.context.components.core.store.state.selectedTabId }
 
-        if (tabs.size > EXPAND_AT_SIZE) {
-            behavior.state = BottomSheetBehavior.STATE_EXPANDED
+        if (tabs.size > EXPAND_AT_SIZE || startingInLandscape) {
+            expand()
         }
 
         (view.tabsTray as? BrowserTabsTray)?.also { tray ->
@@ -159,6 +160,10 @@ class TabTrayView(
 
         tabsTray.register(this)
         tabsFeature.start()
+    }
+
+    fun expand() {
+        behavior.state = BottomSheetBehavior.STATE_EXPANDED
     }
 
     override fun onTabSelected(tab: Tab) {


### PR DESCRIPTION
Fixes #11031 

To test:

- Open tab tray in portrait mode, rotate to landscape -- tab tray should take up expanded screen
- Open tab tray in landscape mode -- tab tray should take up expanded screen