### PR TITLE
For 11114 - Correct landscape tab tray buttons

### DIFF
--- a/app/src/main/res/layout/component_tabstray.xml
+++ b/app/src/main/res/layout/component_tabstray.xml
@@ -49,6 +49,7 @@
         app:tabIndicatorColor="@color/accent_normal_theme"
         app:tabIconTint="@color/tab_icon"
         app:tabRippleColor="@android:color/transparent"
+        app:tabGravity="fill"
         app:layout_constraintWidth_percent="0.5"
         app:layout_constraintTop_toBottomOf="@+id/handle"
         app:layout_constraintStart_toStartOf="parent">


### PR DESCRIPTION
To reproduce the issue, and to see my fix, you need to open the tab tray in landscape mode.

My only concern is that, on a very large screen, the tabs will be somewhat far apart.  I attempted to use `app:tabMaxWidth` and `app:tabMinWidth` together but unfortunately the tabs still don't start flush to the left.

Let me know what you think, or if you have alternate ideas.