### PR TITLE
Scroll to the top of home when using the tab tray

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -568,6 +568,8 @@ class HomeFragment : Fragment() {
         requireContext().settings().useNewTabTray.also {
             view?.add_tab_button?.isVisible = !it
             view?.tab_button?.isVisible = it
+            // Scrolls to the top of the screen
+            view?.homeAppBar?.setExpanded(true, false)
         }
     }
 


### PR DESCRIPTION
To test:

1.  On the home screen, go to private mode
2.  Scroll to the bottom
3.  Open a new private tab
4.  Tab the tab tray icon again

The home screen is scrolled to the top; I avoid animation as it didn't look good.

Note: This doesn't remove unnecessary scrolling from the homepage -- that can be addressed separately.