### PR TITLE
Fixes mozilla-mobile#10989: Link tabs feature to view lifecycle

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayDialogFragment.kt
@@ -63,7 +63,8 @@ class TabTrayDialogFragment : AppCompatDialogFragment(), TabTrayInteractor {
             view.tabLayout,
             this,
             (activity as HomeActivity).browsingModeManager.mode.isPrivate,
-            requireContext().resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+            requireContext().resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE,
+            viewLifecycleOwner
         )
 
         tabLayout.setOnClickListener {

--- a/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayView.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayView.kt
@@ -11,6 +11,7 @@ import android.view.ViewGroup
 import androidx.cardview.widget.CardView
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
+import androidx.lifecycle.LifecycleOwner
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.tabs.TabLayout
 import kotlinx.android.extensions.LayoutContainer
@@ -46,7 +47,8 @@ class TabTrayView(
     private val container: ViewGroup,
     private val interactor: TabTrayInteractor,
     private val isPrivate: Boolean,
-    private val startingInLandscape: Boolean
+    private val startingInLandscape: Boolean,
+    lifecycleOwner: LifecycleOwner
 ) : LayoutContainer, TabsTray.Observer, TabLayout.OnTabSelectedListener {
     val fabView = LayoutInflater.from(container.context)
         .inflate(R.layout.component_tabstray_fab, container, true)
@@ -105,6 +107,8 @@ class TabTrayView(
             { }
         )
 
+        lifecycleOwner.lifecycle.addObserver(tabsFeature)
+
         val tabs = if (isPrivate) {
             view.context.components.core.store.state.privateTabs
         } else {
@@ -160,8 +164,7 @@ class TabTrayView(
             interactor.onNewTabTapped(isPrivateModeSelected)
         }
 
-        tabsTray.register(this)
-        tabsFeature.start()
+        tabsTray.register(this, lifecycleOwner)
     }
 
     fun expand() {


### PR DESCRIPTION
The `TabsTrayFeature` was not previously connected to the view lifecycle owner, which resulted in the memory leaks affecting both the `TabsTrayPresenter` and `TabsTrayInteractor`.
 
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture