### PR TITLE
For #7725: Increase info button touch target while keeping size.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/RadioButtonInfoPreference.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/RadioButtonInfoPreference.kt
@@ -11,7 +11,6 @@ import androidx.core.content.res.TypedArrayUtils
 import androidx.core.content.withStyledAttributes
 import androidx.preference.PreferenceViewHolder
 import org.mozilla.fenix.R
-import org.mozilla.fenix.ext.increaseTapArea
 
 class RadioButtonInfoPreference @JvmOverloads constructor(
     context: Context,
@@ -61,15 +60,10 @@ class RadioButtonInfoPreference @JvmOverloads constructor(
     override fun onBindViewHolder(holder: PreferenceViewHolder) {
         super.onBindViewHolder(holder)
         infoView = holder.findViewById(R.id.info_button) as ImageView
-        infoView?.increaseTapArea(EXTRA_TAP_AREA)
         infoView?.setOnClickListener {
             infoClickListener?.invoke()
         }
         infoView?.alpha = if (isEnabled) FULL_ALPHA else HALF_ALPHA
         contentDescription?.let { infoView?.contentDescription = it }
-    }
-
-    companion object {
-        const val EXTRA_TAP_AREA = 22
     }
 }

--- a/app/src/main/res/layout/preference_widget_radiobutton_with_info.xml
+++ b/app/src/main/res/layout/preference_widget_radiobutton_with_info.xml
@@ -65,10 +65,11 @@
 
     <ImageView
         android:id="@+id/info_button"
-        android:layout_width="24dp"
-        android:layout_height="24dp"
-        android:layout_marginStart="18dp"
-        android:layout_marginEnd="18dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_marginStart="6dp"
+        android:layout_marginEnd="6dp"
+        android:padding="12dp"
         app:srcCompat="@drawable/ic_info"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
Also removed unnecessary touch delegate.
No visual changes = no screenshot

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture