### PR TITLE
Decode Gzip payload in the Glean sample test

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/glean/BaselinePingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/glean/BaselinePingTest.kt
@@ -33,6 +33,35 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.HomeActivityTestRule
 import org.mozilla.fenix.helpers.MockWebServerHelper
 import java.util.concurrent.TimeUnit
+import java.io.BufferedReader
+import java.io.ByteArrayInputStream
+import java.util.zip.GZIPInputStream
+
+/**
+ * Decompress the GZIP returned by the glean-core layer.
+ *
+ * @param data the gzipped [ByteArray] to decompress
+ * @return a [String] containing the uncompressed data.
+ */
+fun decompressGZIP(data: ByteArray): String {
+    return GZIPInputStream(ByteArrayInputStream(data)).bufferedReader().use(BufferedReader::readText)
+}
+
+/**
+ * Convenience method to get the body of a request as a String.
+ * The UTF8 representation of the request body will be returned.
+ * If the request body is gzipped, it will be decompressed first.
+ *
+ * @return a [String] containing the body of the request.
+ */
+fun RecordedRequest.getPlainBody(): String {
+    return if (this.getHeader("Content-Encoding") == "gzip") {
+        val bodyInBytes = this.body.readByteArray()
+        decompressGZIP(bodyInBytes)
+    } else {
+        this.body.readUtf8()
+    }
+}
 
 @RunWith(AndroidJUnit4::class)
 class BaselinePingTest {
@@ -84,7 +113,7 @@ class BaselinePingTest {
             val request = server.takeRequest(20L, TimeUnit.SECONDS)
             val docType = request.path.split("/")[3]
             if (pingName == docType) {
-                val parsedPayload = JSONObject(request.body.readUtf8())
+                val parsedPayload = JSONObject(request.getPlainBody())
                 if (pingReason == null) {
                     return parsedPayload
                 }


### PR DESCRIPTION
Unfortunately this requires us to duplicate the code that's also used inside glean-core and android-components.
This can be cleaned up later.

---

We deployed the same fix in a-c: https://github.com/mozilla-mobile/android-components/pull/7228
This can go in now, it has a correct fall back to use the plaintext if not encoded.
Also the UI test for Glean is currently not run in testing, but there's work in progress to re-enable it.

I plan to find a cleaner solution that works across the projects.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture