### PR TITLE
For #9771, #9768: Adjust touch target for buttons in error pages.

### DIFF
--- a/app/src/main/assets/shared_error_style.css
+++ b/app/src/main/assets/shared_error_style.css
@@ -65,16 +65,31 @@ p {
 button {
   display: block;
   height: 36px;
+  box-sizing: content-box;
   width: 100%;
-  border-radius: 5px;
   border: 0;
+  padding: 6px 0px;
   font-family: inherit;
-  background-color: var(--primary-button-color);
+  background-color: transparent;
   color: var(--primary-button-text-color);
   font-size: 14px;
   font-weight: bold;
-  margin: var(--moz-vertical-spacing) auto;
+  margin: 0 auto;
   text-align: center;
+  position: relative;
+}
+
+button::after {
+  background-color: var(--primary-button-color);
+  content: '';
+  border-radius: 5px;
+  display: block;
+  position: absolute;
+  top: 6px;
+  left: 0px;
+  right: 0px;
+  bottom: 6px;
+  z-index: -1;
 }
 
 hr {
@@ -90,8 +105,12 @@ hr {
 }
 
 .buttonSecondary {
-  background-color: var(--secondary-button-color);
+  background-color: transparent;
   color: var(--secondary-button-text-color);
+}
+
+.buttonSecondary::after {
+  background-color: var(--secondary-button-color);
 }
 
 #errorPageContainer {


### PR DESCRIPTION
This not modify button visible size or color.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture