### PR TITLE
Update built-in extensions for new AC/GV API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,7 @@ test_artifacts/
 /build/test-tools/google-cloud-sdk/
 /build/test-tools/*.jar
 /build/test-tools/*.gz
+
+
+# Web extensions: manifest.json files are generated
+manifest.json

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -186,6 +186,10 @@ android {
         // GeckoView must uncompress it before it can do anything else which
         // causes a significant delay on startup.
         noCompress 'ja'
+
+        // manifest.template.json is converted to manifest.json at build time.
+        // No need to package the template in the APK.
+        ignoreAssetsPattern "manifest.template.json"
     }
 
     testOptions {
@@ -755,3 +759,34 @@ if (gradle.hasProperty('localProperties.autoPublish.application-services.dir')) 
     ext.appServicesSrcDir = gradle."localProperties.autoPublish.application-services.dir"
     apply from: "../${appServicesSrcDir}/build-scripts/substitute-local-appservices.gradle"
 }
+
+// Define a reusable task for updating the versions of our built-in web extensions. We automate this
+// to make sure we never forget to update the version, either in local development or for releases.
+// In both cases, we want to make sure the latest version of all extensions (including their latest
+// changes) are installed on first start-up.
+// We're using the A-C version here as we want to uplift all built-in extensions to A-C (Once that's
+// done we can also remove the task below):
+// https://github.com/mozilla-mobile/android-components/issues/7249
+ext.updateExtensionVersion = { task, extDir ->
+    configure(task) {
+        from extDir
+        include 'manifest.template.json'
+        rename { 'manifest.json' }
+        into extDir
+
+        def values = ['version': AndroidComponents.VERSION + "." + new Date().format('MMddHHmmss')]
+        inputs.properties(values)
+        expand(values)
+    }
+}
+
+tasks.register("updateAdsExtensionVersion", Copy) { task ->
+    updateExtensionVersion(task, 'src/main/assets/extensions/ads')
+}
+
+tasks.register("updateCookiesExtensionVersion", Copy) { task ->
+    updateExtensionVersion(task, 'src/main/assets/extensions/cookies')
+}
+
+preBuild.dependsOn updateAdsExtensionVersion
+preBuild.dependsOn updateCookiesExtensionVersion

--- a/app/src/main/assets/extensions/ads/manifest.template.json
+++ b/app/src/main/assets/extensions/ads/manifest.template.json
@@ -1,7 +1,12 @@
 {
   "manifest_version": 2,
+  "applications": {
+    "gecko": {
+      "id": "ads@mozac.org"
+    }
+  },
   "name": "Mozilla Android Components - Ads",
-  "version": "1.0",
+  "version": "${version}",
   "content_scripts": [
     {
       "matches": ["https://*/*"],
@@ -16,6 +21,7 @@
   ],
   "permissions": [
     "geckoViewAddons",
-    "nativeMessaging"
+    "nativeMessaging",
+    "nativeMessagingFromContent"
   ]
 }

--- a/app/src/main/assets/extensions/cookies/manifest.template.json
+++ b/app/src/main/assets/extensions/cookies/manifest.template.json
@@ -1,7 +1,12 @@
 {
   "manifest_version": 2,
+  "applications": {
+    "gecko": {
+      "id": "cookies@mozac.org"
+    }
+  },
   "name": "Mozilla Android Components - Cookies",
-  "version": "1.0",
+  "version": "${version}",
   "content_scripts": [
     {
       "matches": ["https://*/*"],
@@ -23,6 +28,7 @@
   "permissions": [
     "geckoViewAddons",
     "nativeMessaging",
+    "nativeMessagingFromContent",
     "webNavigation",
     "webRequest",
     "webRequestBlocking",

--- a/app/src/main/java/org/mozilla/fenix/search/telemetry/BaseSearchTelemetry.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/telemetry/BaseSearchTelemetry.kt
@@ -93,7 +93,6 @@ abstract class BaseSearchTelemetry {
         engine.installWebExtension(
             id = extensionInfo.id,
             url = extensionInfo.resourceUrl,
-            allowContentMessaging = true,
             onSuccess = { extension ->
                 store.flowScoped { flow -> subscribeToUpdates(flow, extension, extensionInfo) }
             },

--- a/app/src/main/java/org/mozilla/fenix/search/telemetry/ads/AdsTelemetry.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/telemetry/ads/AdsTelemetry.kt
@@ -51,7 +51,7 @@ class AdsTelemetry(private val metrics: MetricController) : BaseSearchTelemetry(
 
     companion object {
         @VisibleForTesting
-        internal const val ADS_EXTENSION_ID = "mozacBrowserAds"
+        internal const val ADS_EXTENSION_ID = "ads@mozac.org"
         @VisibleForTesting
         internal const val ADS_EXTENSION_RESOURCE_URL = "resource://android/assets/extensions/ads/"
         @VisibleForTesting

--- a/app/src/main/java/org/mozilla/fenix/search/telemetry/incontent/InContentTelemetry.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/telemetry/incontent/InContentTelemetry.kt
@@ -131,7 +131,7 @@ class InContentTelemetry(private val metrics: MetricController) : BaseSearchTele
 
     companion object {
         @VisibleForTesting
-        internal const val COOKIES_EXTENSION_ID = "BrowserCookiesExtension"
+        internal const val COOKIES_EXTENSION_ID = "cookies@mozac.org"
         @VisibleForTesting
         internal const val COOKIES_EXTENSION_RESOURCE_URL =
             "resource://android/assets/extensions/cookies/"

--- a/app/src/test/java/org/mozilla/fenix/search/telemetry/BaseSearchTelemetryTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/search/telemetry/BaseSearchTelemetryTest.kt
@@ -44,7 +44,6 @@ class BaseSearchTelemetryTest {
             engine.installWebExtension(
                 id = id,
                 url = resourceUrl,
-                allowContentMessaging = true,
                 onSuccess = any(),
                 onError = any()
             )

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "49.0.20200707131055"
+    const val VERSION = "50.0.20200707200739"
 }


### PR DESCRIPTION
This will be needed once https://github.com/mozilla-mobile/android-components/pull/7245/files lands in Nightly. We need these new IDs (in this format), and the new permission for the new GV API to install built-in extensions.

I've also noticed that the extensions use the mozac (Mozilla Android Components) namespace, but no need to change that now. We should consider uplifting these extensions some time in the future: https://github.com/mozilla-mobile/android-components/issues/7249