### PR TITLE
For #9488: Init widgetExperiment after Experimenter init

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -179,14 +179,13 @@ open class FenixApplication : LocaleAwareApplication() {
                         kintoEndpoint = KINTO_ENDPOINT_PROD
                     )
                 )
+                ExperimentsManager.initSearchWidgetExperiment(this)
             }
         } else {
             // We should make a better way to opt out for when we have more experiments
             // See https://github.com/mozilla-mobile/fenix/issues/6278
             ExperimentsManager.optOutSearchWidgetExperiment(this)
         }
-
-        ExperimentsManager.initSearchWidgetExperiment(this)
 
         components.performance.visualCompletenessQueue.runIfReadyOrQueue {
             GlobalScope.launch(Dispatchers.IO) {


### PR DESCRIPTION
Created due to: https://github.com/mozilla-mobile/fenix/pull/10990/files#r435562825

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture