### PR TITLE
For #10652: Fix validateBaselinePing test

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/glean/BaselinePingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/glean/BaselinePingTest.kt
@@ -33,7 +33,6 @@ import org.mozilla.fenix.helpers.HomeActivityTestRule
 import org.mozilla.fenix.helpers.MockWebServerHelper
 import java.util.concurrent.TimeUnit
 
-
 @RunWith(AndroidJUnit4::class)
 class BaselinePingTest {
     private val server = MockWebServerHelper.createAlwaysOkMockWebServer()

--- a/app/src/androidTest/java/org/mozilla/fenix/glean/BaselinePingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/glean/BaselinePingTest.kt
@@ -24,7 +24,6 @@ import org.json.JSONObject
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertFalse
 import org.junit.BeforeClass
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -33,6 +32,7 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.HomeActivityTestRule
 import org.mozilla.fenix.helpers.MockWebServerHelper
 import java.util.concurrent.TimeUnit
+
 
 @RunWith(AndroidJUnit4::class)
 class BaselinePingTest {
@@ -81,7 +81,7 @@ class BaselinePingTest {
         var attempts = 0
         do {
             attempts += 1
-            val request = server.takeRequest(20L, TimeUnit.SECONDS)
+            val request = server.takeRequest(20L, TimeUnit.SECONDS) ?: break
             val docType = request.path.split("/")[3]
             if (pingName == docType) {
                 val parsedPayload = JSONObject(request.body.readUtf8())
@@ -100,7 +100,6 @@ class BaselinePingTest {
         return null
     }
 
-    @Ignore("Currently failing on firebase: https://github.com/mozilla-mobile/fenix/issues/10652")
     @Test
     fun validateBaselinePing() {
         // Wait for the app to be idle/ready.

--- a/app/src/androidTest/java/org/mozilla/fenix/glean/BaselinePingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/glean/BaselinePingTest.kt
@@ -20,6 +20,7 @@ import mozilla.components.service.glean.Glean
 import mozilla.components.service.glean.config.Configuration
 import mozilla.components.service.glean.net.ConceptFetchHttpUploader
 import mozilla.components.service.glean.testing.GleanTestLocalServer
+import okhttp3.mockwebserver.RecordedRequest
 import org.json.JSONObject
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertFalse
@@ -32,6 +33,35 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.HomeActivityTestRule
 import org.mozilla.fenix.helpers.MockWebServerHelper
 import java.util.concurrent.TimeUnit
+import java.io.BufferedReader
+import java.io.ByteArrayInputStream
+import java.util.zip.GZIPInputStream
+
+/**
+ * Decompress the GZIP returned by the glean-core layer.
+ *
+ * @param data the gzipped [ByteArray] to decompress
+ * @return a [String] containing the uncompressed data.
+ */
+fun decompressGZIP(data: ByteArray): String {
+    return GZIPInputStream(ByteArrayInputStream(data)).bufferedReader().use(BufferedReader::readText)
+}
+
+/**
+ * Convenience method to get the body of a request as a String.
+ * The UTF8 representation of the request body will be returned.
+ * If the request body is gzipped, it will be decompressed first.
+ *
+ * @return a [String] containing the body of the request.
+ */
+fun RecordedRequest.getPlainBody(): String {
+    return if (this.getHeader("Content-Encoding") == "gzip") {
+        val bodyInBytes = this.body.readByteArray()
+        decompressGZIP(bodyInBytes)
+    } else {
+        this.body.readUtf8()
+    }
+}
 
 @RunWith(AndroidJUnit4::class)
 class BaselinePingTest {
@@ -83,7 +113,7 @@ class BaselinePingTest {
             val request = server.takeRequest(20L, TimeUnit.SECONDS) ?: break
             val docType = request.path.split("/")[3]
             if (pingName == docType) {
-                val parsedPayload = JSONObject(request.body.readUtf8())
+                val parsedPayload = JSONObject(request.getPlainBody())
                 if (pingReason == null) {
                     return parsedPayload
                 }


### PR DESCRIPTION
I am opening this PR because I can't reproduce the test failure for the `validateBaselinePing` test locally. I also tried running it in Firebase through Android Studio with no success.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture