### PR TITLE
Bug 1642657 -  Use default signing for nightly-simulation builds.

### DIFF
--- a/taskcluster/ci/signing/kind.yml
+++ b/taskcluster/ci/signing/kind.yml
@@ -20,7 +20,7 @@ job-template:
     description: Sign Fenix
     worker-type:
         by-build-type:
-            (fennec-.+|nightly|beta|production|android-test-nightly|nightly-simulation):
+            (fennec-.+|nightly|beta|production|android-test-nightly):
                 by-level:
                     '3': signing
                     default: dep-signing


### PR DESCRIPTION
Gecko decision task is currently failing becuase we are signing the nightly-simulation builds in the wrong way - this patch makes it use the default signing method (since it doesn't matter for us atm).