### PR TITLE
Bug 1642657 - Undo browsertime changes for nightly-simulation.

### DIFF
--- a/taskcluster/ci/browsertime/kind.yml
+++ b/taskcluster/ci/browsertime/kind.yml
@@ -13,7 +13,7 @@ kind-dependencies:
 primary-dependency: signing
 
 only-for-build-types:
-    - nightly-simulation
+    - nightly
 
 only-for-abis:
     - armeabi-v7a

--- a/taskcluster/ci/signing/kind.yml
+++ b/taskcluster/ci/signing/kind.yml
@@ -69,7 +69,12 @@ job-template:
             (fennec-.+|nightly|performance-test|beta|production|debug|nightly-simulation):
                 type: signing
             default: {}
-    run-on-tasks-for: []
+    run-on-tasks-for:
+        by-build-type:
+            # No test job runs on push against this build type. Although we do want nightly-simulation
+            # signed to use it in the gecko trees.
+            nightly-simulation: [github-push]
+            default: []
     treeherder:
         job-symbol:
             by-build-type:

--- a/taskcluster/fenix_taskgraph/transforms/signing.py
+++ b/taskcluster/fenix_taskgraph/transforms/signing.py
@@ -18,7 +18,7 @@ transforms = TransformSequence()
 @transforms.add
 def resolve_keys(config, tasks):
     for task in tasks:
-        for key in ("index", "worker-type", "worker.signing-type", "signing-format"):
+        for key in ("index", "run-on-tasks-for", "worker-type", "worker.signing-type", "signing-format"):
             resolve_keyed_by(
                 task,
                 key,


### PR DESCRIPTION
There was an error in a patch that changed the nightly to nightly-simulation - this patch reverts that change.