### PR TITLE
Bug 1642657 - Remove nightly-simulation signing-type specification.

### DIFF
--- a/taskcluster/ci/signing/kind.yml
+++ b/taskcluster/ci/signing/kind.yml
@@ -36,10 +36,6 @@ job-template:
                     by-level:
                         '3': fennec-nightly-signing
                         default: dep-signing
-                nightly-simulation:
-                    by-level:
-                        '3': fennec-nightly-signing
-                        default: dep-signing
                 nightly:
                     by-level:
                         '3': nightly-signing


### PR DESCRIPTION
This patch removes the nightly signing-type specification for nightly-simulation.