### PR TITLE
For #11260 - Fixes ConcurrentModificationException on tabs tray

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayDialogFragment.kt
@@ -146,7 +146,9 @@ class TabTrayDialogFragment : AppCompatDialogFragment(), TabTrayInteractor {
     }
 
     override fun onTabSelected(tab: Tab) {
-        dismissAllowingStateLoss()
+        // dismiss the dialog on the next pass as it may cause a ConcurrentModificationException
+        // when TabsTrayInteractor.stop() unregisters with ObserverRegistry
+        view?.post { dismissAllowingStateLoss() }
         if (findNavController().currentDestination?.id == R.id.browserFragment) return
         if (!findNavController().popBackStack(R.id.browserFragment, false)) {
             findNavController().navigate(R.id.browserFragment)


### PR DESCRIPTION
I ran into this issue a few times last night. Thanks @AndiAJ for the bug report as I didn't pay enough attention to see how to reproduce it.

The bug is caused due to the `TabsTrayView` un-registering the `TabsTrayInteractor` from the `ObserverRegistry` while the registry observers are still being processed. This happens a bit indirectly as it's kicked off by the lifecycle observer receiving the `STOP` event when the dialog is dismissed. This usually is not an issue because the `TabsTrayView` is processed last in the registry but the order changes when the tab trays is open and the app is sent to the foreground (the lifecycle observer unregisters in `onStop` and re-registers in `onStart`).

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture