### PR TITLE
Clear speculative session on engine settings change

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/Components.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Components.kt
@@ -47,9 +47,9 @@ class Components(private val context: Context) {
     val useCases by lazy {
         UseCases(
             context,
+            core.engine,
             core.sessionManager,
             core.store,
-            core.engine.settings,
             search.searchEngineManager,
             core.webAppShortcutManager,
             core.thumbnailStorage

--- a/app/src/main/java/org/mozilla/fenix/components/UseCases.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/UseCases.kt
@@ -10,7 +10,7 @@ import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.browser.thumbnails.ThumbnailsUseCases
 import mozilla.components.browser.thumbnails.storage.ThumbnailStorage
-import mozilla.components.concept.engine.Settings
+import mozilla.components.concept.engine.Engine
 import mozilla.components.feature.app.links.AppLinksUseCases
 import mozilla.components.feature.contextmenu.ContextMenuUseCases
 import mozilla.components.feature.downloads.DownloadsUseCases
@@ -29,9 +29,9 @@ import org.mozilla.fenix.utils.Mockable
 @Mockable
 class UseCases(
     private val context: Context,
+    private val engine: Engine,
     private val sessionManager: SessionManager,
     private val store: BrowserStore,
-    private val engineSettings: Settings,
     private val searchEngineManager: SearchEngineManager,
     private val shortcutManager: WebAppShortcutManager,
     private val thumbnailStorage: ThumbnailStorage
@@ -64,7 +64,7 @@ class UseCases(
     /**
      * Use cases that provide settings management.
      */
-    val settingsUseCases by lazy { SettingsUseCases(engineSettings, sessionManager) }
+    val settingsUseCases by lazy { SettingsUseCases(engine, sessionManager) }
 
     val appLinksUseCases by lazy { AppLinksUseCases(context.applicationContext) }
 

--- a/app/src/test/java/org/mozilla/fenix/components/TestComponents.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/TestComponents.kt
@@ -20,9 +20,9 @@ class TestComponents(private val context: Context) : Components(context) {
     override val useCases by lazy {
         UseCases(
             context,
+            core.engine,
             core.sessionManager,
             core.store,
-            core.engine.settings,
             search.searchEngineManager,
             core.webAppShortcutManager,
             core.thumbnailStorage

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "45.0.20200609130052"
+    const val VERSION = "45.0.20200609161836"
 }


### PR DESCRIPTION
Preparing for a breaking change in A-C: https://github.com/mozilla-mobile/android-components/pull/7296

We're passing the engine, instead of just `engine.settings` so we can also clear the speculative session when engine settings change.