### PR TITLE
DO NOT LAND: add measurements of tabs tray.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/TabCounterToolbarButton.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/TabCounterToolbarButton.kt
@@ -5,6 +5,7 @@
 package org.mozilla.fenix.components.toolbar
 
 import android.content.Context
+import android.os.SystemClock
 import android.util.TypedValue
 import android.view.View
 import android.view.ViewGroup
@@ -12,6 +13,7 @@ import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.toolbar.Toolbar
 import org.mozilla.fenix.R
+import mozilla.components.browser.tabstray.Timings
 import org.mozilla.fenix.ext.sessionsOfType
 import java.lang.ref.WeakReference
 
@@ -31,6 +33,7 @@ class TabCounterToolbarButton(
         val view = TabCounter(parent.context).apply {
             reference = WeakReference(this)
             setOnClickListener {
+                Timings.tabsStart = SystemClock.elapsedRealtime()
                 showTabs.invoke()
             }
 

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -11,6 +11,7 @@ import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
 import android.os.StrictMode
+import android.os.SystemClock
 import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
@@ -22,9 +23,7 @@ import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.constraintlayout.widget.ConstraintSet
-import androidx.constraintlayout.widget.ConstraintSet.BOTTOM
-import androidx.constraintlayout.widget.ConstraintSet.PARENT_ID
-import androidx.constraintlayout.widget.ConstraintSet.TOP
+import androidx.constraintlayout.widget.ConstraintSet.*
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.content.ContextCompat
 import androidx.core.view.doOnLayout
@@ -65,6 +64,7 @@ import mozilla.components.support.ktx.android.util.dpToPx
 import org.mozilla.fenix.BrowserDirection
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
+import mozilla.components.browser.tabstray.Timings
 import org.mozilla.fenix.browser.BrowserAnimator.Companion.getToolbarNavOptions
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.cfr.SearchWidgetCFR
@@ -75,14 +75,7 @@ import org.mozilla.fenix.components.TabCollectionStorage
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.components.tips.FenixTipManager
 import org.mozilla.fenix.components.tips.providers.MigrationTipProvider
-import org.mozilla.fenix.ext.components
-import org.mozilla.fenix.ext.hideToolbar
-import org.mozilla.fenix.ext.metrics
-import org.mozilla.fenix.ext.nav
-import org.mozilla.fenix.ext.requireComponents
-import org.mozilla.fenix.ext.sessionsOfType
-import org.mozilla.fenix.ext.settings
-import org.mozilla.fenix.ext.toTab
+import org.mozilla.fenix.ext.*
 import org.mozilla.fenix.home.sessioncontrol.DefaultSessionControlController
 import org.mozilla.fenix.home.sessioncontrol.SessionControlInteractor
 import org.mozilla.fenix.home.sessioncontrol.SessionControlView
@@ -323,6 +316,7 @@ class HomeFragment : Fragment() {
         }
 
         view.tab_button.setOnClickListener {
+            Timings.tabsStart = SystemClock.elapsedRealtime()
             openTabTray()
         }
 

--- a/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayDialogFragment.kt
@@ -6,10 +6,15 @@ package org.mozilla.fenix.tabtray
 
 import android.content.res.Configuration
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.os.SystemClock
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatDialogFragment
+import androidx.core.view.doOnPreDraw
 import androidx.core.view.updatePadding
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.lifecycleScope
@@ -30,6 +35,7 @@ import mozilla.components.feature.tab.collections.TabCollection
 import mozilla.components.lib.state.ext.consumeFrom
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
+import mozilla.components.browser.tabstray.Timings
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.collections.SaveCollectionStep
 import org.mozilla.fenix.components.FenixSnackbar
@@ -66,6 +72,25 @@ class TabTrayDialogFragment : AppCompatDialogFragment(), TabTrayInteractor {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? = inflater.inflate(R.layout.fragment_tab_tray_dialog, container, false)
+
+    private val uiHandler = Handler(Looper.getMainLooper())
+
+    override fun onResume() {
+        super.onResume()
+        view?.doOnPreDraw {
+            uiHandler.postAtFrontOfQueue {
+                // # Duration from tabs tray button click to tabs tray shown
+                // # Excludes animation timing, which can be found in default
+                // # BottomSheetBehavior config, somewhere.
+                // When sleeping and animations are disabled, the full tabs tray
+                // is shown here. With animations enabled, the animation will continue
+                // but the app will be unresponsive if we sleep here.
+//                Thread.sleep(5000)
+                Timings.tabsTrayEnd = SystemClock.elapsedRealtime()
+                Log.e("lol trayEnd", "average ${Timings.trayDuration}")
+            }
+        }
+    }
 
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)


### PR DESCRIPTION
@MarcLeclair This will not land. Please ensure the correctness of these measurements for the tabs tray opening. They work with the associated android-components PR: https://github.com/mozilla-mobile/android-components/pull/7314

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture