### PR TITLE
Wire up UI to make add-on installation cancelable

### DIFF
--- a/app/src/main/res/layout/overlay_add_on_progress.xml
+++ b/app/src/main/res/layout/overlay_add_on_progress.xml
@@ -9,16 +9,34 @@
     android:layout_height="wrap_content"
     android:elevation="1dp">
 
-    <TextView
-        android:id="@+id/add_ons_overlay_text"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginEnd="8dp"
-        android:drawablePadding="8dp"
-        android:gravity="start|center_vertical"
-        android:padding="16dp"
-        android:text="@string/mozac_add_on_install_progress_caption"
-        app:drawableStartCompat="@drawable/mozac_ic_extensions_black" />
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <TextView
+            android:id="@+id/add_ons_overlay_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginEnd="8dp"
+            android:drawablePadding="8dp"
+            android:gravity="start|center_vertical"
+            android:padding="16dp"
+            android:text="@string/mozac_add_on_install_progress_caption"
+            app:drawableStartCompat="@drawable/mozac_ic_extensions_black" />
+
+        <Button
+            android:id="@+id/cancel_button"
+            style="?android:attr/borderlessButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/add_ons_overlay_text"
+            android:layout_alignParentEnd="true"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="16dp"
+            android:text="@string/mozac_feature_addons_install_addon_dialog_cancel"
+            android:textAllCaps="false" />
+
+    </RelativeLayout>
 
 </androidx.cardview.widget.CardView>


### PR DESCRIPTION
This brings in the missing piece of our add-on installation UI: https://miro.com/app/board/o9J_kw8Lt8g=/?moveToWidget=3074457347043892302&cot=3