### PR TITLE
For #11291 - Provide New Tab button when accessibility enabled

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayView.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayView.kt
@@ -25,6 +25,7 @@ import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.tabstray.BrowserTabsTray
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.settings
 
 interface TabTrayInteractor {
     fun onNewTabTapped(private: Boolean)
@@ -61,14 +62,18 @@ class TabTrayView(
         get() = container
 
     init {
+        val hasAccessibilityEnabled = view.context.settings().accessibilityServicesEnabled
+
         toggleFabText(isPrivate)
 
         behavior.addBottomSheetCallback(object : BottomSheetBehavior.BottomSheetCallback() {
             override fun onSlide(bottomSheet: View, slideOffset: Float) {
-                if (slideOffset >= SLIDE_OFFSET) {
-                    fabView.new_tab_button.show()
-                } else {
-                    fabView.new_tab_button.hide()
+                if (!hasAccessibilityEnabled) {
+                    if (slideOffset >= SLIDE_OFFSET) {
+                        fabView.new_tab_button.show()
+                    } else {
+                        fabView.new_tab_button.hide()
+                    }
                 }
             }
 
@@ -142,8 +147,18 @@ class TabTrayView(
                 }
         }
 
-        fabView.new_tab_button.setOnClickListener {
-            interactor.onNewTabTapped(isPrivateModeSelected)
+        view.tab_tray_new_tab.apply {
+            isVisible = hasAccessibilityEnabled
+            setOnClickListener {
+                interactor.onNewTabTapped(isPrivateModeSelected)
+            }
+        }
+
+        fabView.new_tab_button.apply {
+            isVisible = !hasAccessibilityEnabled
+            setOnClickListener {
+                interactor.onNewTabTapped(isPrivateModeSelected)
+            }
         }
     }
 

--- a/app/src/main/res/layout/component_tabstray.xml
+++ b/app/src/main/res/layout/component_tabstray.xml
@@ -71,6 +71,18 @@
     </com.google.android.material.tabs.TabLayout>
 
     <ImageButton
+        android:id="@+id/tab_tray_new_tab"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:visibility="gone"
+        android:background="?android:attr/selectableItemBackgroundBorderless"
+        android:contentDescription="@string/add_tab"
+        app:srcCompat="@drawable/ic_new"
+        app:layout_constraintTop_toTopOf="@id/tab_layout"
+        app:layout_constraintEnd_toStartOf="@id/tab_tray_overflow"
+        app:layout_constraintBottom_toBottomOf="@id/tab_layout" />
+
+    <ImageButton
         android:id="@+id/tab_tray_overflow"
         android:layout_width="48dp"
         android:layout_height="48dp"


### PR DESCRIPTION
Fixes #11291. 

This provides an "Add tab" button at the header of the tab tray so that users with accessibility features enabled can more easily add a tab instead of the FAB.  Even better is that the user wouldn't need to scroll through all tabs to get to the "New tab" FAB -- it would be the third control available!

![Screenshot_20200610-124510](https://user-images.githubusercontent.com/46655/84303793-2c120080-ab1d-11ea-8002-633c27c9c61a.png)

To test:
1.  Open the tab tray with talkback off
2. View FAB, don't view "add tab" button in header
3.  Turn on Talkback
4.  Open the tab tray
5.  View "add tab" button, don't view FAB