### PR TITLE
For #11177 - Load all share targets in the horizontal share menu

### DIFF
--- a/app/src/main/res/layout/share_to_apps.xml
+++ b/app/src/main/res/layout/share_to_apps.xml
@@ -71,21 +71,34 @@
             app:layout_constraintStart_toEndOf="@+id/recentAppsContainer"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/appsList"
+        <!-- Having the RecyclerView inside a RelativeLayout means
+             the RecyclerView will load all items at once and never recycle.
+             This is a conscious choice since we use HorizontalScrollView to scroll all
+             children horizontally and so prevent scrolling in the RecyclerViews. -->
+        <RelativeLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/share_all_apps_list_margin"
-            android:clipToPadding="false"
-            android:minHeight="@dimen/share_list_min_height"
-            android:orientation="horizontal"
-            android:visibility="gone"
-            app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@+id/recentAppsContainer"
-            app:layout_constraintTop_toBottomOf="@id/apps_link_header"
-            app:spanCount="2" />
+            app:layout_constraintTop_toBottomOf="@id/apps_link_header">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/appsList"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/share_all_apps_list_margin"
+                android:clipToPadding="false"
+                android:minHeight="@dimen/share_list_min_height"
+                android:orientation="horizontal"
+                android:visibility="gone"
+                app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:spanCount="2" />
+        </RelativeLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </HorizontalScrollView>
 


### PR DESCRIPTION
This was previously regressed by having the RecyclerViews for "recent" and
"all" items put inside a HorizontalScrollView which would then prevent the
RecyclerViews from actually scrolling, recycling, showing new items.

As a quick solution that would keep the desired behavior the "all" items list
is now a child of a RelativeLayout which will allow it to load all items at
once and so all the share targets will be available to the user but which also
means no recycling.

The RecyclerView for the "recent" items uses a `RECENT_APPS_LIMIT = 6` so this
does not need the same "fix" as all the items would fit the screen without
any issue.

Before / after
![ShareTargetsBeforeAfter](https://user-images.githubusercontent.com/11428869/84356872-7b176e80-abcd-11ea-99ff-579acd510902.gif)


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: No tests. Small change in a not yet tested component.
- [x] **Screenshots**: This PR includes a before / after gif.
- [x] **Accessibility**: The code in this PR does not include any user facing features.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture