### PR TITLE
Expose reports as artifacts

### DIFF
--- a/taskcluster/ci/lint/kind.yml
+++ b/taskcluster/ci/lint/kind.yml
@@ -50,6 +50,11 @@ jobs:
             gradlew: [detekt]
         treeherder:
             symbol: detekt
+        worker:
+            artifacts:
+                - name: public/reports
+                  path: /builds/worker/checkouts/src/build/reports
+                  type: directory
     ktlint:
         description: 'Running ktlint over all modules'
         run:
@@ -64,3 +69,8 @@ jobs:
             gradlew: ['lintGeckoNightlyDebug']
         treeherder:
             symbol: lint
+        worker:
+            artifacts:
+                - name: public/reports
+                  path: /builds/worker/checkouts/src/app/build/reports
+                  type: directory

--- a/taskcluster/ci/test/kind.yml
+++ b/taskcluster/ci/test/kind.yml
@@ -56,3 +56,6 @@ jobs:
                 - name: public/reports/index.html
                   path: /builds/worker/checkouts/src/app/build/reports/tests/testGeckoNightlyDebugUnitTest/index.html
                   type: file
+                - name: public/reports/test
+                  path: /builds/worker/checkouts/src/app/build/reports/tests
+                  type: directory


### PR DESCRIPTION
This exposes the HTML reports from tests & lint as Taskcluster build artifacts. After this change they can be accessed from the "Artifacts" menu in Taskcluster, and linked to!