### PR TITLE
DO NOT LAND: measure tabs tray close timing.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayDialogFragment.kt
@@ -4,11 +4,16 @@
 
 package org.mozilla.fenix.tabtray
 
+import android.app.Dialog
+import android.content.DialogInterface
 import android.content.res.Configuration
 import android.os.Bundle
+import android.os.SystemClock
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.app.AppCompatDialog
 import androidx.appcompat.app.AppCompatDialogFragment
 import androidx.core.view.updatePadding
 import androidx.fragment.app.FragmentManager
@@ -23,9 +28,9 @@ import mozilla.components.browser.state.selector.normalTabs
 import mozilla.components.browser.state.selector.privateTabs
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.concept.engine.prompt.ShareData
-import mozilla.components.feature.tabs.tabstray.TabsFeature
 import mozilla.components.feature.tab.collections.TabCollection
 import mozilla.components.feature.tabs.TabsUseCases
+import mozilla.components.feature.tabs.tabstray.TabsFeature
 import mozilla.components.lib.state.ext.consumeFrom
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
 import org.mozilla.fenix.HomeActivity
@@ -33,11 +38,17 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.collections.SaveCollectionStep
 import org.mozilla.fenix.components.FenixSnackbar
+import org.mozilla.fenix.components.TabCollectionStorage
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.sessionsOfType
 import org.mozilla.fenix.utils.allowUndo
-import org.mozilla.fenix.components.TabCollectionStorage
+
+object Timings {
+    var dismissStart = -1L
+    var dismissEnd = -1L
+    val dismissDuration get() = dismissEnd - dismissStart
+}
 
 @SuppressWarnings("TooManyFunctions", "LargeClass")
 class TabTrayDialogFragment : AppCompatDialogFragment(), TabTrayInteractor {
@@ -83,6 +94,24 @@ class TabTrayDialogFragment : AppCompatDialogFragment(), TabTrayInteractor {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setStyle(STYLE_NO_TITLE, R.style.TabTrayDialogStyle)
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        return object : AppCompatDialog(context, theme) {
+            override fun onBackPressed() {
+//                Thread.sleep(5000)
+                Timings.dismissStart = SystemClock.elapsedRealtime()
+                Log.e("lol", "onBackPressed")
+                super.onBackPressed()
+            }
+        }
+    }
+
+    override fun onDismiss(dialog: DialogInterface) {
+        super.onDismiss(dialog)
+        Timings.dismissEnd = SystemClock.elapsedRealtime()
+        Log.e("lol onDismiss", "average ${Timings.dismissDuration}")
+//        Thread.sleep(5000)
     }
 
     override fun onCreateView(


### PR DESCRIPTION
@MarcLeclair This will not land: please review for correctness of measurement.

It's easy to add a probe here – unlike other measurements – but I don't think it's a very valuable measurement because the result doesn't seem related to the content in the tabs tray.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture