### PR TITLE
Fix breaking APIs in TabsAdapter and ViewHolder

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -509,6 +509,7 @@ dependencies {
     implementation Deps.mozilla_service_location
 
     implementation Deps.mozilla_support_base
+    implementation Deps.mozilla_support_images
     implementation Deps.mozilla_support_ktx
     implementation Deps.mozilla_support_rustlog
     implementation Deps.mozilla_support_utils

--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -34,6 +34,7 @@ import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.state.state.WebExtensionState
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.browser.tabstray.BrowserTabsTray
+import mozilla.components.browser.thumbnails.loader.ThumbnailLoader
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.concept.tabstray.TabsTray
 import mozilla.components.feature.contextmenu.DefaultSelectionActionDelegate
@@ -242,13 +243,10 @@ open class HomeActivity : LocaleAwareAppCompatActivity() {
                 stackFromEnd = true
             }
 
-            val adapter = FenixTabsAdapter(context)
-            BrowserTabsTray(
-                context,
-                attrs,
-                tabsAdapter = adapter,
-                layout = layout
-            )
+            val thumbnailLoader = ThumbnailLoader(components.core.thumbnailStorage)
+            val adapter = FenixTabsAdapter(context, thumbnailLoader)
+
+            BrowserTabsTray(context, attrs, 0, adapter, layout)
         }
         else -> super.onCreateView(parent, name, context, attrs)
     }

--- a/app/src/main/java/org/mozilla/fenix/tabtray/FenixTabsAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/FenixTabsAdapter.kt
@@ -8,17 +8,20 @@ import android.content.Context
 import android.view.LayoutInflater
 import mozilla.components.browser.tabstray.TabsAdapter
 import mozilla.components.concept.tabstray.Tabs
+import mozilla.components.support.images.loader.ImageLoader
 import org.mozilla.fenix.R
 
 class FenixTabsAdapter(
-    context: Context
+    context: Context,
+    imageLoader: ImageLoader
 ) : TabsAdapter(
     viewHolderProvider = { parentView, _ ->
         TabTrayViewHolder(
             LayoutInflater.from(context).inflate(
                 R.layout.tab_tray_item,
                 parentView,
-                false)
+                false),
+            imageLoader
         )
     }
 ) {

--- a/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayViewHolder.kt
@@ -6,7 +6,6 @@ package org.mozilla.fenix.tabtray
 
 import android.view.View
 import android.widget.ImageButton
-import android.widget.ImageView
 import android.widget.TextView
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.widget.AppCompatImageButton
@@ -20,6 +19,7 @@ import mozilla.components.concept.tabstray.TabsTray
 import mozilla.components.feature.media.ext.pauseIfPlaying
 import mozilla.components.feature.media.ext.playIfPaused
 import mozilla.components.support.base.observer.Observable
+import mozilla.components.support.images.loader.ImageLoader
 import mozilla.components.support.ktx.kotlin.tryGetHostFromUrl
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.metrics.Event
@@ -35,9 +35,9 @@ import org.mozilla.fenix.ext.toTab
  */
 class TabTrayViewHolder(
     itemView: View,
+    private val imageLoader: ImageLoader,
     val getSelectedTabId: () -> String? = { itemView.context.components.core.store.state.selectedTabId }
 ) : TabViewHolder(itemView) {
-    private val iconView: ImageView? = itemView.findViewById(R.id.mozac_browser_tabstray_icon)
     private val titleView: TextView = itemView.findViewById(R.id.mozac_browser_tabstray_title)
     private val closeView: AppCompatImageButton =
         itemView.findViewById(R.id.mozac_browser_tabstray_close)
@@ -69,13 +69,8 @@ class TabTrayViewHolder(
 
         if (tab.thumbnail != null) {
             thumbnailView.setImageBitmap(tab.thumbnail)
-            thumbnailView.visibility = View.VISIBLE
-            iconView?.visibility = View.INVISIBLE
         } else {
-            thumbnailView.setImageBitmap(null)
-            iconView?.setImageBitmap(tab.icon)
-            thumbnailView.visibility = View.INVISIBLE
-            iconView?.visibility = View.VISIBLE
+            imageLoader.loadIntoView(thumbnailView, tab.id)
         }
 
         // Media state

--- a/app/src/main/res/layout/tab_tray_item.xml
+++ b/app/src/main/res/layout/tab_tray_item.xml
@@ -35,15 +35,6 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
-        <ImageView
-            android:id="@+id/mozac_browser_tabstray_icon"
-            android:layout_width="50dp"
-            android:layout_height="28dp"
-            android:layout_marginStart="21dp"
-            android:layout_marginTop="20dp"
-            android:importantForAccessibility="no"
-            android:visibility="invisible" />
-
         <mozilla.components.browser.tabstray.thumbnail.TabThumbnailView
             android:id="@+id/mozac_browser_tabstray_thumbnail"
             android:layout_width="match_parent"

--- a/app/src/test/java/org/mozilla/fenix/tabtray/TabTrayViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabtray/TabTrayViewHolderTest.kt
@@ -13,6 +13,7 @@ import io.mockk.mockk
 import io.mockk.spyk
 import mozilla.components.browser.toolbar.MAX_URI_LENGTH
 import mozilla.components.concept.tabstray.Tab
+import mozilla.components.support.images.loader.ImageLoader
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -25,15 +26,18 @@ class TabTrayViewHolderTest {
     @Test
     fun `extremely long URLs are truncated to prevent slowing down the UI`() {
         val view = LayoutInflater.from(ApplicationProvider.getApplicationContext()).inflate(
-            R.layout.tab_tray_item, null, false)
-
-        val tabViewHolder = spyk(TabTrayViewHolder(view) { null })
+            R.layout.tab_tray_item, null, false
+        )
+        val imageLoader: ImageLoader = mockk()
+        every { imageLoader.loadIntoView(any(), any(), any(), any()) } just Runs
+        val tabViewHolder = spyk(TabTrayViewHolder(view, imageLoader) { null })
         every { tabViewHolder.updateBackgroundColor(false) } just Runs
 
         val extremelyLongUrl = "m".repeat(MAX_URI_LENGTH + 1)
         val tab = Tab(
             id = "123",
-            url = extremelyLongUrl)
+            url = extremelyLongUrl
+        )
         tabViewHolder.bind(tab, false, mockk())
 
         assertEquals("m".repeat(MAX_URI_LENGTH), tabViewHolder.urlView?.text)

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "45.0.20200612130101"
+    const val VERSION = "45.0.20200613130120"
 }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -133,6 +133,7 @@ object Deps {
     const val mozilla_ui_publicsuffixlist = "org.mozilla.components:lib-publicsuffixlist:${Versions.mozilla_android_components}"
 
     const val mozilla_support_base = "org.mozilla.components:support-base:${Versions.mozilla_android_components}"
+    const val mozilla_support_images = "org.mozilla.components:support-images:${Versions.mozilla_android_components}"
     const val mozilla_support_ktx = "org.mozilla.components:support-ktx:${Versions.mozilla_android_components}"
     const val mozilla_support_rusthttp = "org.mozilla.components:support-rusthttp:${Versions.mozilla_android_components}"
     const val mozilla_support_rustlog = "org.mozilla.components:support-rustlog:${Versions.mozilla_android_components}"


### PR DESCRIPTION
Requires breaking API changes from https://github.com/mozilla-mobile/android-components/pull/7356 in the next AC upgrade to land.