### PR TITLE
#10281: Allow top sites items to use full screen width

### DIFF
--- a/app/src/main/res/layout/component_top_sites.xml
+++ b/app/src/main/res/layout/component_top_sites.xml
@@ -7,6 +7,7 @@
     android:id="@+id/top_sites_list"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:paddingStart="12dp"
-    android:paddingEnd="12dp"
+    android:paddingStart="4dp"
+    android:paddingEnd="4dp"
+    android:layout_marginBottom="8dp"
     tools:listitem="@layout/top_site_item" />

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -48,7 +48,7 @@
                 android:layout_height="40dp"
                 android:layout_marginStart="28dp"
                 android:layout_marginTop="56dp"
-                android:layout_marginBottom="40dp"
+                android:layout_marginBottom="32dp"
                 android:adjustViewBounds="true"
                 android:clickable="false"
                 android:contentDescription="@string/app_name"

--- a/app/src/main/res/layout/top_site_item.xml
+++ b/app/src/main/res/layout/top_site_item.xml
@@ -8,8 +8,7 @@
     android:id="@+id/top_site_item"
     android:layout_width="64dp"
     android:layout_height="wrap_content"
-    android:layout_marginEnd="16dp"
-    android:layout_marginBottom="16dp">
+    android:padding="8dp">
 
     <FrameLayout
         android:id="@+id/favicon_wrapper"


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.
![after1](https://user-images.githubusercontent.com/48995920/84495198-6f9e7300-acb3-11ea-920d-3957690eafc1.png)

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture