### PR TITLE
For #6126 - Moved sessionObserver init

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -100,12 +100,11 @@ open class HomeActivity : LocaleAwareAppCompatActivity() {
     private var webExtScope: CoroutineScope? = null
     lateinit var themeManager: ThemeManager
     lateinit var browsingModeManager: BrowsingModeManager
+    private lateinit var sessionObserver: SessionManager.Observer
 
     private var isVisuallyComplete = false
 
     private var visualCompletenessQueue: RunWhenReadyQueue? = null
-
-    private var sessionObserver: SessionManager.Observer? = null
 
     private var isToolbarInflated = false
 
@@ -150,6 +149,8 @@ open class HomeActivity : LocaleAwareAppCompatActivity() {
                 }, delay)
             }
         }
+
+        sessionObserver = UriOpenedObserver(this)
 
         externalSourceIntentProcessors.any { it.process(intent, navHost.navController, this.intent) }
 
@@ -353,10 +354,6 @@ open class HomeActivity : LocaleAwareAppCompatActivity() {
     }
 
     fun openToBrowser(from: BrowserDirection, customTabSessionId: String? = null) {
-        if (sessionObserver == null) {
-            sessionObserver = UriOpenedObserver(this)
-        }
-
         if (navHost.navController.alreadyOnDestination(R.id.browserFragment)) return
         @IdRes val fragmentId = if (from.fragmentId != 0) from.fragmentId else null
         val directions = getNavDirections(from, customTabSessionId)


### PR DESCRIPTION
This was necessary because tab tray calls a different method than `openToBrowser` for opening the browser, which didn't have this init included. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: Modified only the activity
- [x] **Screenshots**: No visual changes
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture