### PR TITLE
Issue #11112 - Update empty collections string.

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
@@ -514,13 +514,13 @@ private fun assertCollectionsHeader() =
         .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
 private fun assertNoCollectionsHeader() =
-    onView(allOf(withText("No collections")))
+    onView(allOf(withText("Collect the things that matter to you")))
         .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
 private fun assertNoCollectionsText() =
     onView(
         allOf(
-            withText("Collect the things that matter to you. To start, save open tabs to a new collection.")
+            withText("Group together similar searches, sites, and tabs for quick access later.")
         )
     )
         .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlView.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlView.kt
@@ -21,8 +21,8 @@ import org.mozilla.fenix.home.OnboardingState
 import org.mozilla.fenix.components.tips.Tip
 
 val noCollectionMessage = AdapterItem.NoContentMessage(
-    R.string.no_collections_header,
-    R.string.collections_description
+    R.string.no_collections_header1,
+    R.string.no_collections_description1
 )
 
 // This method got a little complex with the addition of the tab tray feature flag

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,8 +15,6 @@
     <string name="content_description_disable_private_browsing_button">Disable private browsing</string>
     <!-- Placeholder text shown in the search bar before a user enters text -->
     <string name="search_hint">Search or enter address</string>
-    <!-- No Open Tabs Message Header -->
-    <string name="no_open_tabs_header_2">No open tabs</string>
     <!-- No Open Tabs Message Description -->
     <string name="no_open_tabs_description">Your open tabs will be shown here.</string>
     <!-- No Private Tabs Message Description -->
@@ -477,7 +475,7 @@
     <!-- Open tabs menu item to share all tabs -->
     <string name="tabs_menu_share_tabs">Share tabs</string>
     <!-- Open tabs menu item to save tabs to collection -->
-    <string name="tabs_menu_save_to_collection">Save to collection</string>
+    <string name="tabs_menu_save_to_collection1">Save tabs to collection</string>
     <!-- Content description (not visible, for screen readers etc.): Opens the tab menu when pressed -->
     <string name="tab_menu">Tab menu</string>
     <!-- Tab menu item to share the tab -->
@@ -686,16 +684,14 @@
     <string name="delete_browsing_data_quit_off">Off</string>
 
     <!-- Collections -->
-    <!-- Label to describe what collections are to a new user without any collections -->
-    <string name="collections_description">Collect the things that matter to you. To start, save open tabs to a new collection.</string>
     <!-- Collections header on home fragment -->
     <string name="collections_header">Collections</string>
     <!-- Content description (not visible, for screen readers etc.): Opens the collection menu when pressed -->
     <string name="collection_menu_button_content_description">Collection menu</string>
     <!-- No Open Tabs Message Header -->
-    <string name="no_collections_header">No collections</string>
-    <!-- No Open Tabs Message Description -->
-    <string name="no_collections_description">Your collections will be shown here.</string>
+    <string name="no_collections_header1">Collect the things that matter to you</string>
+    <!-- Label to describe what collections are to a new user without any collections -->
+    <string name="no_collections_description1">Group together similar searches, sites, and tabs for quick access later.</string>
     <!-- Title for the "select tabs" step of the collection creator -->
     <string name="create_collection_select_tabs">Select Tabs</string>
     <!-- Title for the "select collection" step of the collection creator -->


### PR DESCRIPTION
String updated in app, and button string added.

Also removed 2 unused "no open tabs" / "your collections go here" strings.
![Screenshot_1591997365](https://user-images.githubusercontent.com/1082253/84547825-27824f00-acb9-11ea-94ce-1956f96c5598.png)



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture