### PR TITLE
Automatically switch to PWA when web app is installed

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/AppRequestInterceptor.kt
+++ b/app/src/main/java/org/mozilla/fenix/AppRequestInterceptor.kt
@@ -36,6 +36,12 @@ class AppRequestInterceptor(private val context: Context) : RequestInterceptor {
                 engineSession, uri, hasUserGesture, isSameDomain)
         }
 
+        if (result == null) {
+            result = context.components.services.webAppInterceptor.onLoadRequest(
+                engineSession, uri, hasUserGesture, isSameDomain
+            )
+        }
+
         return result
     }
 

--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -19,6 +19,7 @@ import androidx.appcompat.app.ActionBar
 import androidx.appcompat.widget.Toolbar
 import androidx.core.view.doOnPreDraw
 import androidx.lifecycle.lifecycleScope
+import androidx.navigation.NavController
 import androidx.navigation.NavDestination
 import androidx.navigation.NavDirections
 import androidx.navigation.fragment.NavHostFragment
@@ -114,6 +115,9 @@ open class HomeActivity : LocaleAwareAppCompatActivity() {
         supportFragmentManager.findFragmentById(R.id.container) as NavHostFragment
     }
 
+    protected val navController: NavController
+        get() = navHost.navController
+
     private val externalSourceIntentProcessors by lazy {
         listOf(
             SpeechProcessingIntentProcessor(this, components.analytics.metrics),
@@ -186,7 +190,7 @@ open class HomeActivity : LocaleAwareAppCompatActivity() {
         }
     }
 
-    final override fun onPause() {
+    override fun onPause() {
         if (settings().lastKnownMode.isPrivate) {
             window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
         } else {

--- a/app/src/main/java/org/mozilla/fenix/components/Services.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Services.kt
@@ -11,8 +11,10 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import mozilla.components.feature.accounts.FirefoxAccountsAuthFeature
 import mozilla.components.feature.app.links.AppLinksInterceptor
+import mozilla.components.feature.pwa.WebAppInterceptor
 import mozilla.components.service.fxa.manager.FxaAccountManager
 import org.mozilla.fenix.R
+import org.mozilla.fenix.ext.application
 import org.mozilla.fenix.ext.getPreferenceKey
 import org.mozilla.fenix.settings.SupportUtils
 import org.mozilla.fenix.utils.Mockable
@@ -42,6 +44,12 @@ class Services(
                 PreferenceManager.getDefaultSharedPreferences(context).getBoolean(
                     context.getPreferenceKey(R.string.pref_key_open_links_in_external_app), false)
             }
+        )
+    }
+
+    val webAppInterceptor by lazy {
+        WebAppInterceptor(
+            context.application.components.core.webAppManifestStorage
         )
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/customtabs/ExternalAppBrowserActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/ExternalAppBrowserActivity.kt
@@ -14,7 +14,9 @@ import mozilla.components.support.utils.SafeIntent
 import org.mozilla.fenix.BrowserDirection
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.NavGraphDirections
+import org.mozilla.fenix.R
 import org.mozilla.fenix.components.metrics.Event
+import org.mozilla.fenix.ext.alreadyOnDestination
 import org.mozilla.fenix.ext.components
 import java.security.InvalidParameterException
 
@@ -41,6 +43,12 @@ open class ExternalAppBrowserActivity : HomeActivity() {
             finish()
             return null
         }
+
+        if (navController.alreadyOnDestination(R.id.externalAppBrowserFragment)) {
+            return null
+        }
+
+        ensureSessionIsReleased()
 
         val manifest = intent
             .getWebAppManifest()
@@ -73,5 +81,13 @@ open class ExternalAppBrowserActivity : HomeActivity() {
                 true
             }
         }
+    }
+
+    private fun ensureSessionIsReleased() {
+        val sessionManager = components.core.sessionManager
+        val sessionId = intent.getSessionId() ?: return
+        val session = sessionManager.findSessionById(sessionId) ?: return
+
+        sessionManager.getOrCreateEngineSession(session).releaseFromView()
     }
 }


### PR DESCRIPTION
For #5772 and requires mozilla-mobile/android-components#7367 and mozilla-mobile/android-components#7381

- android components has a new web app interceptor which needs to be integrated by Fenix.
- `ExternalAppBrowserActivity` should not navigate to `externalAppBrowserFragment` if it's already there.
- `ExternalAppBrowserActivity` has to release its session`onPause`, because it's possible that it will be replaced by a new activity. This happens when the activity is launched both from the android launcher and from inside Fenix.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture