### PR TITLE
For #11600 - Fix PIP toolbar

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -707,11 +707,6 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Session
     @CallSuper
     final override fun onPause() {
         super.onPause()
-        val session = requireComponents.core.store.state.findTabOrCustomTabOrSelectedTab(customTabSessionId)
-        // If we didn't enter PiP, exit full screen on pause
-        if (session?.content?.pictureInPictureEnabled == false && fullScreenFeature.onBackPressed()) {
-            fullScreenChanged(false)
-        }
         if (findNavController().currentDestination?.id != R.id.searchFragment) {
             view?.hideKeyboard()
         }
@@ -721,6 +716,13 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Session
     override fun onStop() {
         super.onStop()
         initUIJob?.cancel()
+
+        requireComponents.core.store.state.findTabOrCustomTabOrSelectedTab(customTabSessionId)?.let { session ->
+            // If we didn't enter PiP, exit full screen on stop
+            if (!session.content.pictureInPictureEnabled && fullScreenFeature.onBackPressed()) {
+                fullScreenChanged(false)
+            }
+        }
     }
 
     @CallSuper


### PR DESCRIPTION
Picture in Picture calls `onPause`, but not `onStop`. Moving the fullscreen exit code into `onStop` fixes the toolbar appearing in PIP. I don't think there are any scenarios where we want to exit if the activity is paused but not stopped.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture