### PR TITLE
Add helper to find not-null preference

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/AccessibilityFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/AccessibilityFragment.kt
@@ -9,7 +9,6 @@ import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreference
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
-import org.mozilla.fenix.ext.getPreferenceKey
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.showToolbar
 
@@ -24,11 +23,11 @@ class AccessibilityFragment : PreferenceFragmentCompat() {
         super.onResume()
         showToolbar(getString(R.string.preferences_accessibility))
 
-        val forceZoomPreference = findPreference<SwitchPreference>(
-            getPreferenceKey(R.string.pref_key_accessibility_force_enable_zoom)
+        val forceZoomPreference = requirePreference<SwitchPreference>(
+            R.string.pref_key_accessibility_force_enable_zoom
         )
 
-        forceZoomPreference?.setOnPreferenceChangeListener<Boolean> { preference, shouldForce ->
+        forceZoomPreference.setOnPreferenceChangeListener<Boolean> { preference, shouldForce ->
             val settings = preference.context.settings()
             val components = preference.context.components
 
@@ -38,10 +37,10 @@ class AccessibilityFragment : PreferenceFragmentCompat() {
             true
         }
 
-        val textSizePreference = findPreference<TextPercentageSeekBarPreference>(
-            getPreferenceKey(R.string.pref_key_accessibility_font_scale)
+        val textSizePreference = requirePreference<TextPercentageSeekBarPreference>(
+            R.string.pref_key_accessibility_font_scale
         )
-        textSizePreference?.setOnPreferenceChangeListener<Int> { preference, newTextSize ->
+        textSizePreference.setOnPreferenceChangeListener<Int> { preference, newTextSize ->
             val settings = preference.context.settings()
             val components = preference.context.components
 
@@ -56,11 +55,11 @@ class AccessibilityFragment : PreferenceFragmentCompat() {
             components.useCases.sessionUseCases.reload()
             true
         }
-        textSizePreference?.isVisible = !requireContext().settings().shouldUseAutoSize
+        textSizePreference.isVisible = !requireContext().settings().shouldUseAutoSize
 
         val useAutoSizePreference =
-            findPreference<SwitchPreference>(getPreferenceKey(R.string.pref_key_accessibility_auto_size))
-        useAutoSizePreference?.setOnPreferenceChangeListener<Boolean> { preference, useAutoSize ->
+            requirePreference<SwitchPreference>(R.string.pref_key_accessibility_auto_size)
+        useAutoSizePreference.setOnPreferenceChangeListener<Boolean> { preference, useAutoSize ->
             val settings = preference.context.settings()
             val components = preference.context.components
 
@@ -74,7 +73,7 @@ class AccessibilityFragment : PreferenceFragmentCompat() {
                 components.core.engine.settings.fontSizeFactor = settings.fontSizeFactor
             }
             // Show the manual sizing controls if automatic sizing is turned off.
-            textSizePreference?.isVisible = !useAutoSize
+            textSizePreference.isVisible = !useAutoSize
 
             // Reload the current session to reflect the new text scale
             components.useCases.sessionUseCases.reload()

--- a/app/src/main/java/org/mozilla/fenix/settings/CustomizationFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/CustomizationFragment.kt
@@ -13,7 +13,6 @@ import androidx.preference.PreferenceFragmentCompat
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.components
-import org.mozilla.fenix.ext.getPreferenceKey
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.showToolbar
@@ -69,8 +68,7 @@ class CustomizationFragment : PreferenceFragmentCompat() {
     }
 
     private fun bindLightTheme() {
-        val keyLightTheme = getPreferenceKey(R.string.pref_key_light_theme)
-        radioLightTheme = requireNotNull(findPreference(keyLightTheme))
+        radioLightTheme = requirePreference(R.string.pref_key_light_theme)
         radioLightTheme.onClickListener {
             setNewTheme(AppCompatDelegate.MODE_NIGHT_NO)
         }
@@ -79,16 +77,14 @@ class CustomizationFragment : PreferenceFragmentCompat() {
     @SuppressLint("WrongConstant")
     // Suppressing erroneous lint warning about using MODE_NIGHT_AUTO_BATTERY, a likely library bug
     private fun bindAutoBatteryTheme() {
-        val keyBatteryTheme = getPreferenceKey(R.string.pref_key_auto_battery_theme)
-        radioAutoBatteryTheme = requireNotNull(findPreference(keyBatteryTheme))
+        radioAutoBatteryTheme = requirePreference(R.string.pref_key_auto_battery_theme)
         radioAutoBatteryTheme.onClickListener {
             setNewTheme(AppCompatDelegate.MODE_NIGHT_AUTO_BATTERY)
         }
     }
 
     private fun bindDarkTheme() {
-        val keyDarkTheme = getPreferenceKey(R.string.pref_key_dark_theme)
-        radioDarkTheme = requireNotNull(findPreference(keyDarkTheme))
+        radioDarkTheme = requirePreference(R.string.pref_key_dark_theme)
         radioDarkTheme.onClickListener {
             requireContext().components.analytics.metrics.track(
                 Event.DarkThemeSelected(
@@ -100,8 +96,7 @@ class CustomizationFragment : PreferenceFragmentCompat() {
     }
 
     private fun bindFollowDeviceTheme() {
-        val keyDeviceTheme = getPreferenceKey(R.string.pref_key_follow_device_theme)
-        radioFollowDeviceTheme = requireNotNull(findPreference(keyDeviceTheme))
+        radioFollowDeviceTheme = requirePreference(R.string.pref_key_follow_device_theme)
         if (SDK_INT >= Build.VERSION_CODES.P) {
             radioFollowDeviceTheme.onClickListener {
                 setNewTheme(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM)
@@ -120,16 +115,14 @@ class CustomizationFragment : PreferenceFragmentCompat() {
     }
 
     private fun setupToolbarCategory() {
-        val keyToolbarTop = getPreferenceKey(R.string.pref_key_toolbar_top)
-        val topPreference = requireNotNull(findPreference<RadioButtonPreference>(keyToolbarTop))
+        val topPreference = requirePreference<RadioButtonPreference>(R.string.pref_key_toolbar_top)
         topPreference.onClickListener {
             requireContext().components.analytics.metrics.track(Event.ToolbarPositionChanged(
                 Event.ToolbarPositionChanged.Position.TOP
             ))
         }
 
-        val keyToolbarBottom = getPreferenceKey(R.string.pref_key_toolbar_bottom)
-        val bottomPreference = requireNotNull(findPreference<RadioButtonPreference>(keyToolbarBottom))
+        val bottomPreference = requirePreference<RadioButtonPreference>(R.string.pref_key_toolbar_top)
         bottomPreference.onClickListener {
             requireContext().components.analytics.metrics.track(Event.ToolbarPositionChanged(
                 Event.ToolbarPositionChanged.Position.BOTTOM

--- a/app/src/main/java/org/mozilla/fenix/settings/DataChoicesFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/DataChoicesFragment.kt
@@ -50,7 +50,7 @@ class DataChoicesFragment : PreferenceFragmentCompat() {
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         setPreferencesFromResource(R.xml.data_choices_preferences, rootKey)
 
-        findPreference<SwitchPreference>(getPreferenceKey(R.string.pref_key_telemetry))?.apply {
+        requirePreference<SwitchPreference>(R.string.pref_key_telemetry).apply {
             isChecked = context.settings().isTelemetryEnabled
 
             val appName = context.getString(R.string.app_name)
@@ -59,7 +59,7 @@ class DataChoicesFragment : PreferenceFragmentCompat() {
             onPreferenceChangeListener = SharedPreferenceUpdater()
         }
 
-        findPreference<SwitchPreference>(getPreferenceKey(R.string.pref_key_marketing_telemetry))?.apply {
+        requirePreference<SwitchPreference>(R.string.pref_key_marketing_telemetry).apply {
             isChecked = context.settings().isMarketingTelemetryEnabled
 
             val appName = context.getString(R.string.app_name)
@@ -68,7 +68,7 @@ class DataChoicesFragment : PreferenceFragmentCompat() {
             onPreferenceChangeListener = SharedPreferenceUpdater()
         }
 
-        findPreference<SwitchPreference>(getPreferenceKey(R.string.pref_key_experimentation))?.apply {
+        requirePreference<SwitchPreference>(R.string.pref_key_experimentation).apply {
             isChecked = context.settings().isExperimentationEnabled
             isVisible = Config.channel.isReleaseOrBeta
             onPreferenceChangeListener = SharedPreferenceUpdater()

--- a/app/src/main/java/org/mozilla/fenix/settings/Extensions.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/Extensions.kt
@@ -5,10 +5,13 @@
 package org.mozilla.fenix.settings
 
 import android.widget.RadioButton
+import androidx.annotation.StringRes
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.preference.Preference
+import androidx.preference.PreferenceFragmentCompat
 import mozilla.components.feature.sitepermissions.SitePermissions
 import mozilla.components.support.ktx.android.view.putCompoundDrawablesRelative
+import org.mozilla.fenix.ext.getPreferenceKey
 import org.mozilla.fenix.theme.ThemeManager
 
 fun SitePermissions.toggle(featurePhone: PhoneFeature): SitePermissions {
@@ -60,3 +63,10 @@ inline fun <reified T> Preference.setOnPreferenceChangeListener(
         (newValue as? T)?.let { onPreferenceChangeListener(preference, it) } ?: false
     }
 }
+
+/**
+ * Find a preference with the corresponding key and throw if it does not exist.
+ * @param preferenceId Resource ID from preference_keys
+ */
+fun <T : Preference> PreferenceFragmentCompat.requirePreference(@StringRes preferenceId: Int) =
+    requireNotNull(findPreference<T>(getPreferenceKey(preferenceId)))

--- a/app/src/main/java/org/mozilla/fenix/settings/PhoneFeature.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/PhoneFeature.kt
@@ -85,16 +85,26 @@ enum class PhoneFeature(val androidPermissionsList: Array<String>) : Parcelable 
         }
     }
 
-    fun getPreferenceKey(context: Context): String {
+    /**
+     * Returns a resource ID from preference_keys representing the preference corresponding
+     * to this phone feature.
+     */
+    @StringRes
+    fun getPreferenceId(): Int {
         return when (this) {
-            CAMERA -> context.getPreferenceKey(R.string.pref_key_phone_feature_camera)
-            LOCATION -> context.getPreferenceKey(R.string.pref_key_phone_feature_location)
-            MICROPHONE -> context.getPreferenceKey(R.string.pref_key_phone_feature_microphone)
-            NOTIFICATION -> context.getPreferenceKey(R.string.pref_key_phone_feature_notification)
-            AUTOPLAY_AUDIBLE -> context.getPreferenceKey(R.string.pref_key_browser_feature_autoplay_audible)
-            AUTOPLAY_INAUDIBLE -> context.getPreferenceKey(R.string.pref_key_browser_feature_autoplay_inaudible)
+            CAMERA -> R.string.pref_key_phone_feature_camera
+            LOCATION -> R.string.pref_key_phone_feature_location
+            MICROPHONE -> R.string.pref_key_phone_feature_microphone
+            NOTIFICATION -> R.string.pref_key_phone_feature_notification
+            AUTOPLAY_AUDIBLE -> R.string.pref_key_browser_feature_autoplay_audible
+            AUTOPLAY_INAUDIBLE -> R.string.pref_key_browser_feature_autoplay_inaudible
         }
     }
+
+    /**
+     * Returns the key representing the preference corresponding to this phone feature.
+     */
+    fun getPreferenceKey(context: Context): String = context.getPreferenceKey(getPreferenceId())
 
     fun getAction(settings: Settings): SitePermissionsRules.Action =
         settings.getSitePermissionsPhoneFeatureAction(this, getDefault())

--- a/app/src/main/java/org/mozilla/fenix/settings/PrivateBrowsingFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/PrivateBrowsingFragment.kt
@@ -12,7 +12,6 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.components.PrivateShortcutCreateManager
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.checkAndUpdateScreenshotPermission
-import org.mozilla.fenix.ext.getPreferenceKey
 import org.mozilla.fenix.ext.metrics
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.showToolbar
@@ -32,7 +31,7 @@ class PrivateBrowsingFragment : PreferenceFragmentCompat() {
     }
 
     private fun updatePreferences() {
-        findPreference<Preference>(getPreferenceKey(R.string.pref_key_add_private_browsing_shortcut))?.apply {
+        requirePreference<Preference>(R.string.pref_key_add_private_browsing_shortcut).apply {
             setOnPreferenceClickListener {
                 requireContext().metrics.track(Event.PrivateBrowsingCreateShortcut)
                 PrivateShortcutCreateManager.createPrivateShortcut(requireContext())
@@ -40,13 +39,12 @@ class PrivateBrowsingFragment : PreferenceFragmentCompat() {
             }
         }
 
-        findPreference<SwitchPreference>(getPreferenceKey(R.string.pref_key_open_links_in_a_private_tab))?.apply {
+        requirePreference<SwitchPreference>(R.string.pref_key_open_links_in_a_private_tab).apply {
             onPreferenceChangeListener = SharedPreferenceUpdater()
             isChecked = context.settings().openLinksInAPrivateTab
         }
 
-        findPreference<SwitchPreference>(getPreferenceKey
-            (R.string.pref_key_allow_screenshots_in_private_mode))?.apply {
+        requirePreference<SwitchPreference>(R.string.pref_key_allow_screenshots_in_private_mode).apply {
             onPreferenceChangeListener = object : SharedPreferenceUpdater() {
                 override fun onPreferenceChange(preference: Preference, newValue: Any?): Boolean {
                     return super.onPreferenceChange(preference, newValue).also {

--- a/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
@@ -17,7 +17,6 @@ import androidx.appcompat.content.res.AppCompatResources
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavDirections
 import androidx.navigation.findNavController
-import androidx.navigation.fragment.findNavController
 import androidx.preference.Preference
 import androidx.preference.PreferenceCategory
 import androidx.preference.PreferenceFragmentCompat
@@ -137,8 +136,8 @@ class SettingsFragment : PreferenceFragmentCompat() {
 
     private fun update(shouldUpdateAccountUIState: Boolean) {
         val trackingProtectionPreference =
-            findPreference<Preference>(getPreferenceKey(R.string.pref_key_tracking_protection_settings))
-        trackingProtectionPreference?.summary = context?.let {
+            requirePreference<Preference>(R.string.pref_key_tracking_protection_settings)
+        trackingProtectionPreference.summary = context?.let {
             if (it.settings().shouldUseTrackingProtection) {
                 getString(R.string.tracking_protection_on)
             } else {
@@ -146,21 +145,13 @@ class SettingsFragment : PreferenceFragmentCompat() {
             }
         }
 
-        val toolbarPreference =
-            findPreference<Preference>(getPreferenceKey(R.string.pref_key_toolbar))
-        toolbarPreference?.summary = context?.settings()?.toolbarSettingString
-
-        val aboutPreference = findPreference<Preference>(getPreferenceKey(R.string.pref_key_about))
+        val aboutPreference = requirePreference<Preference>(R.string.pref_key_about)
         val appName = getString(R.string.app_name)
-        aboutPreference?.title = getString(R.string.preferences_about, appName)
+        aboutPreference.title = getString(R.string.preferences_about, appName)
 
         val deleteBrowsingDataPreference =
-            findPreference<Preference>(
-                getPreferenceKey(
-                    R.string.pref_key_delete_browsing_data_on_quit_preference
-                )
-            )
-        deleteBrowsingDataPreference?.summary = context?.let {
+            requirePreference<Preference>(R.string.pref_key_delete_browsing_data_on_quit_preference)
+        deleteBrowsingDataPreference.summary = context?.let {
             if (it.settings().shouldDeleteBrowsingDataOnQuit) {
                 getString(R.string.delete_browsing_data_quit_on)
             } else {
@@ -291,11 +282,10 @@ class SettingsFragment : PreferenceFragmentCompat() {
     private fun setupPreferences() {
         val leakKey = getPreferenceKey(R.string.pref_key_leakcanary)
         val debuggingKey = getPreferenceKey(R.string.pref_key_remote_debugging)
-        val makeDefaultBrowserKey = getPreferenceKey(R.string.pref_key_make_default_browser)
 
         val preferenceLeakCanary = findPreference<Preference>(leakKey)
         val preferenceRemoteDebugging = findPreference<Preference>(debuggingKey)
-        val preferenceMakeDefaultBrowser = findPreference<Preference>(makeDefaultBrowserKey)
+        val preferenceMakeDefaultBrowser = requirePreference<Preference>(R.string.pref_key_make_default_browser)
 
         if (!Config.channel.isReleased) {
             preferenceLeakCanary?.setOnPreferenceChangeListener { _, newValue ->
@@ -312,7 +302,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
             true
         }
 
-        preferenceMakeDefaultBrowser?.onPreferenceClickListener =
+        preferenceMakeDefaultBrowser.onPreferenceClickListener =
             getClickListenerForMakeDefaultBrowser()
 
         val preferenceFxAOverride =
@@ -365,8 +355,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
     }
 
     private fun updateMakeDefaultBrowserPreference() {
-        findPreference<DefaultBrowserPreference>(getPreferenceKey(R.string.pref_key_make_default_browser))
-            ?.updateSwitch()
+        requirePreference<DefaultBrowserPreference>(R.string.pref_key_make_default_browser).updateSwitch()
     }
 
     private fun navigateFromSettings(directions: NavDirections) {
@@ -395,17 +384,13 @@ class SettingsFragment : PreferenceFragmentCompat() {
      */
     private fun updateAccountUIState(context: Context, profile: Profile?) {
         val preferenceSignIn =
-            findPreference<Preference>(context.getPreferenceKey(R.string.pref_key_sign_in))
+            requirePreference<Preference>(R.string.pref_key_sign_in)
         val preferenceFirefoxAccount =
-            findPreference<AccountPreference>(context.getPreferenceKey(R.string.pref_key_account))
+            requirePreference<AccountPreference>(R.string.pref_key_account)
         val preferenceFirefoxAccountAuthError =
-            findPreference<AccountAuthErrorPreference>(
-                context.getPreferenceKey(
-                    R.string.pref_key_account_auth_error
-                )
-            )
+            requirePreference<AccountAuthErrorPreference>(R.string.pref_key_account_auth_error)
         val accountPreferenceCategory =
-            findPreference<PreferenceCategory>(context.getPreferenceKey(R.string.pref_key_account_category))
+            requirePreference<PreferenceCategory>(R.string.pref_key_account_category)
 
         val accountManager = requireComponents.backgroundServices.accountManager
         val account = accountManager.authenticatedAccount()
@@ -414,44 +399,44 @@ class SettingsFragment : PreferenceFragmentCompat() {
 
         // Signed-in, no problems.
         if (account != null && !accountManager.accountNeedsReauth()) {
-            preferenceSignIn?.isVisible = false
+            preferenceSignIn.isVisible = false
 
             profile?.avatar?.url?.let { avatarUrl ->
                 lifecycleScope.launch(Main) {
                     val roundedDrawable =
                         avatarUrl.toRoundedDrawable(context, requireComponents.core.client)
-                    preferenceFirefoxAccount?.icon =
+                    preferenceFirefoxAccount.icon =
                         roundedDrawable ?: AppCompatResources.getDrawable(
                             context,
                             R.drawable.ic_account
                         )
                 }
             }
-            preferenceSignIn?.onPreferenceClickListener = null
-            preferenceFirefoxAccountAuthError?.isVisible = false
-            preferenceFirefoxAccount?.isVisible = true
-            accountPreferenceCategory?.isVisible = true
+            preferenceSignIn.onPreferenceClickListener = null
+            preferenceFirefoxAccountAuthError.isVisible = false
+            preferenceFirefoxAccount.isVisible = true
+            accountPreferenceCategory.isVisible = true
 
-            preferenceFirefoxAccount?.displayName = profile?.displayName
-            preferenceFirefoxAccount?.email = profile?.email
+            preferenceFirefoxAccount.displayName = profile?.displayName
+            preferenceFirefoxAccount.email = profile?.email
 
             // Signed-in, need to re-authenticate.
         } else if (account != null && accountManager.accountNeedsReauth()) {
-            preferenceFirefoxAccount?.isVisible = false
-            preferenceFirefoxAccountAuthError?.isVisible = true
-            accountPreferenceCategory?.isVisible = true
+            preferenceFirefoxAccount.isVisible = false
+            preferenceFirefoxAccountAuthError.isVisible = true
+            accountPreferenceCategory.isVisible = true
 
-            preferenceSignIn?.isVisible = false
-            preferenceSignIn?.onPreferenceClickListener = null
+            preferenceSignIn.isVisible = false
+            preferenceSignIn.onPreferenceClickListener = null
 
-            preferenceFirefoxAccountAuthError?.email = profile?.email
+            preferenceFirefoxAccountAuthError.email = profile?.email
 
             // Signed-out.
         } else {
-            preferenceSignIn?.isVisible = true
-            preferenceFirefoxAccount?.isVisible = false
-            preferenceFirefoxAccountAuthError?.isVisible = false
-            accountPreferenceCategory?.isVisible = false
+            preferenceSignIn.isVisible = true
+            preferenceFirefoxAccount.isVisible = false
+            preferenceFirefoxAccountAuthError.isVisible = false
+            accountPreferenceCategory.isVisible = false
         }
     }
 

--- a/app/src/main/java/org/mozilla/fenix/settings/TrackingProtectionFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/TrackingProtectionFragment.kt
@@ -16,7 +16,6 @@ import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.components
-import org.mozilla.fenix.ext.getPreferenceKey
 import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.settings
@@ -56,11 +55,10 @@ class TrackingProtectionFragment : PreferenceFragmentCompat() {
         showToolbar(getString(R.string.preference_enhanced_tracking_protection))
 
         // Tracking Protection Switch
-        val trackingProtectionKey = getPreferenceKey(R.string.pref_key_tracking_protection)
-        val preferenceTP = findPreference<SwitchPreference>(trackingProtectionKey)
+        val preferenceTP = requirePreference<SwitchPreference>(R.string.pref_key_tracking_protection)
 
-        preferenceTP?.isChecked = requireContext().settings().shouldUseTrackingProtection
-        preferenceTP?.setOnPreferenceChangeListener<Boolean> { preference, trackingProtectionOn ->
+        preferenceTP.isChecked = requireContext().settings().shouldUseTrackingProtection
+        preferenceTP.setOnPreferenceChangeListener<Boolean> { preference, trackingProtectionOn ->
             preference.context.settings().shouldUseTrackingProtection =
                 trackingProtectionOn
             with(preference.context.components) {
@@ -72,10 +70,8 @@ class TrackingProtectionFragment : PreferenceFragmentCompat() {
             true
         }
 
-        val trackingProtectionLearnMore =
-            requireContext().getPreferenceKey(R.string.pref_key_etp_learn_more)
-        val learnMorePreference = findPreference<Preference>(trackingProtectionLearnMore)
-        learnMorePreference?.setOnPreferenceClickListener {
+        val learnMorePreference = requirePreference<Preference>(R.string.pref_key_etp_learn_more)
+        learnMorePreference.setOnPreferenceClickListener {
             (activity as HomeActivity).openToBrowserAndLoad(
                 searchTermOrURL = SupportUtils.getGenericSumoURLForTopic
                     (SupportUtils.SumoTopic.TRACKING_PROTECTION),
@@ -84,22 +80,19 @@ class TrackingProtectionFragment : PreferenceFragmentCompat() {
             )
             true
         }
-        learnMorePreference?.summary = getString(
+        learnMorePreference.summary = getString(
             R.string.preference_enhanced_tracking_protection_explanation,
             getString(R.string.app_name)
         )
 
-        val exceptions = getPreferenceKey(R.string.pref_key_tracking_protection_exceptions)
-        val preferenceExceptions = findPreference<Preference>(exceptions)
-        preferenceExceptions?.onPreferenceClickListener = exceptionsClickListener
+        val preferenceExceptions = requirePreference<Preference>(R.string.pref_key_tracking_protection_exceptions)
+        preferenceExceptions.onPreferenceClickListener = exceptionsClickListener
     }
 
     private fun bindTrackingProtectionRadio(
         mode: TrackingProtectionMode
     ): RadioButtonInfoPreference {
-        val radio = requireNotNull(findPreference<RadioButtonInfoPreference>(
-            getPreferenceKey(mode.preferenceKey)
-        ))
+        val radio = requirePreference<RadioButtonInfoPreference>(mode.preferenceKey)
         radio.contentDescription = getString(mode.contentDescriptionRes)
 
         val metrics = requireComponents.analytics.metrics
@@ -132,37 +125,23 @@ class TrackingProtectionFragment : PreferenceFragmentCompat() {
     private fun bindCustom(): RadioButtonInfoPreference {
         val radio = bindTrackingProtectionRadio(TrackingProtectionMode.CUSTOM)
 
-        customCookies = requireNotNull(
-            findPreference(
-                getString(R.string.pref_key_tracking_protection_custom_cookies)
-            )
-        )
+        customCookies =
+            requirePreference(R.string.pref_key_tracking_protection_custom_cookies)
 
-        customCookiesSelect = requireNotNull(
-            findPreference(
-                getString(R.string.pref_key_tracking_protection_custom_cookies_select)
-            )
-        )
-        customTracking = requireNotNull(
-            findPreference(
-                getString(R.string.pref_key_tracking_protection_custom_tracking_content)
-            )
-        )
-        customTrackingSelect = requireNotNull(
-            findPreference(
-                getString(R.string.pref_key_tracking_protection_custom_tracking_content_select)
-            )
-        )
-        customCryptominers = requireNotNull(
-            findPreference(
-                getString(R.string.pref_key_tracking_protection_custom_cryptominers)
-            )
-        )
-        customFingerprinters = requireNotNull(
-            findPreference(
-                getString(R.string.pref_key_tracking_protection_custom_fingerprinters)
-            )
-        )
+        customCookiesSelect =
+            requirePreference(R.string.pref_key_tracking_protection_custom_cookies_select)
+
+        customTracking =
+            requirePreference(R.string.pref_key_tracking_protection_custom_tracking_content)
+
+        customTrackingSelect =
+            requirePreference(R.string.pref_key_tracking_protection_custom_tracking_content_select)
+
+        customCryptominers =
+            requirePreference(R.string.pref_key_tracking_protection_custom_cryptominers)
+
+        customFingerprinters =
+            requirePreference(R.string.pref_key_tracking_protection_custom_fingerprinters)
 
         customCookies.onPreferenceChangeListener = object : SharedPreferenceUpdater() {
             override fun onPreferenceChange(preference: Preference, newValue: Any?): Boolean {

--- a/app/src/main/java/org/mozilla/fenix/settings/account/AccountSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/account/AccountSettingsFragment.kt
@@ -46,6 +46,7 @@ import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.secure
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.showToolbar
+import org.mozilla.fenix.settings.requirePreference
 
 @SuppressWarnings("TooManyFunctions", "LargeClass")
 class AccountSettingsFragment : PreferenceFragmentCompat() {
@@ -129,29 +130,26 @@ class AccountSettingsFragment : PreferenceFragmentCompat() {
         accountManager.register(accountStateObserver, this, true)
 
         // Sign out
-        val signOut = getPreferenceKey(R.string.pref_key_sign_out)
-        val preferenceSignOut = findPreference<Preference>(signOut)
-        preferenceSignOut?.onPreferenceClickListener = getClickListenerForSignOut()
+        val preferenceSignOut = requirePreference<Preference>(R.string.pref_key_sign_out)
+        preferenceSignOut.onPreferenceClickListener = getClickListenerForSignOut()
 
         // Sync now
-        val syncNow = getPreferenceKey(R.string.pref_key_sync_now)
-        val preferenceSyncNow = findPreference<Preference>(syncNow)
-        preferenceSyncNow?.let {
-            it.onPreferenceClickListener = getClickListenerForSyncNow()
+        val preferenceSyncNow = requirePreference<Preference>(R.string.pref_key_sync_now)
+        preferenceSyncNow.apply {
+            onPreferenceClickListener = getClickListenerForSyncNow()
 
             // Current sync state
             if (requireComponents.backgroundServices.accountManager.isSyncActive()) {
-                it.title = getString(R.string.sync_syncing_in_progress)
-                it.isEnabled = false
+                title = getString(R.string.sync_syncing_in_progress)
+                isEnabled = false
             } else {
-                it.isEnabled = true
+                isEnabled = true
             }
         }
 
         // Device Name
         val deviceConstellation = accountManager.authenticatedAccount()?.deviceConstellation()
-        val deviceNameKey = getPreferenceKey(R.string.pref_key_sync_device_name)
-        findPreference<EditTextPreference>(deviceNameKey)?.apply {
+        requirePreference<EditTextPreference>(R.string.pref_key_sync_device_name).apply {
             onPreferenceChangeListener = getChangeListenerForDeviceName()
             deviceConstellation?.state()?.currentDevice?.let { device ->
                 summary = device.displayName
@@ -168,8 +166,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat() {
         updateSyncEngineStates()
         setDisabledWhileSyncing(accountManager.isSyncActive())
 
-        val historyNameKey = getPreferenceKey(R.string.pref_key_sync_history)
-        findPreference<CheckBoxPreference>(historyNameKey)?.apply {
+        requirePreference<CheckBoxPreference>(R.string.pref_key_sync_history).apply {
             setOnPreferenceChangeListener { _, newValue ->
                 SyncEnginesStorage(context).setStatus(SyncEngine.History, newValue as Boolean)
                 @Suppress("DeferredResultUnused")
@@ -178,8 +175,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat() {
             }
         }
 
-        val bookmarksNameKey = getPreferenceKey(R.string.pref_key_sync_bookmarks)
-        findPreference<CheckBoxPreference>(bookmarksNameKey)?.apply {
+        requirePreference<CheckBoxPreference>(R.string.pref_key_sync_bookmarks).apply {
             setOnPreferenceChangeListener { _, newValue ->
                 SyncEnginesStorage(context).setStatus(SyncEngine.Bookmarks, newValue as Boolean)
                 @Suppress("DeferredResultUnused")
@@ -188,8 +184,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat() {
             }
         }
 
-        val loginsNameKey = getPreferenceKey(R.string.pref_key_sync_logins)
-        findPreference<CheckBoxPreference>(loginsNameKey)?.apply {
+        requirePreference<CheckBoxPreference>(R.string.pref_key_sync_logins).apply {
             setOnPreferenceChangeListener { _, newValue ->
                 val manager =
                     activity?.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
@@ -207,8 +202,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat() {
             }
         }
 
-        val tabsNameKey = getPreferenceKey(R.string.pref_key_sync_tabs)
-        findPreference<CheckBoxPreference>(tabsNameKey)?.apply {
+        requirePreference<CheckBoxPreference>(R.string.pref_key_sync_tabs).apply {
             setOnPreferenceChangeListener { _, newValue ->
                 SyncEnginesStorage(context).setStatus(SyncEngine.Tabs, newValue as Boolean)
                 @Suppress("DeferredResultUnused")
@@ -259,23 +253,19 @@ class AccountSettingsFragment : PreferenceFragmentCompat() {
 
     private fun updateSyncEngineStates() {
         val syncEnginesStatus = SyncEnginesStorage(requireContext()).getStatus()
-        val bookmarksNameKey = getPreferenceKey(R.string.pref_key_sync_bookmarks)
-        findPreference<CheckBoxPreference>(bookmarksNameKey)?.apply {
+        requirePreference<CheckBoxPreference>(R.string.pref_key_sync_bookmarks).apply {
             isEnabled = syncEnginesStatus.containsKey(SyncEngine.Bookmarks)
             isChecked = syncEnginesStatus.getOrElse(SyncEngine.Bookmarks) { true }
         }
-        val historyNameKey = getPreferenceKey(R.string.pref_key_sync_history)
-        findPreference<CheckBoxPreference>(historyNameKey)?.apply {
+        requirePreference<CheckBoxPreference>(R.string.pref_key_sync_history).apply {
             isEnabled = syncEnginesStatus.containsKey(SyncEngine.History)
             isChecked = syncEnginesStatus.getOrElse(SyncEngine.History) { true }
         }
-        val loginsNameKey = getPreferenceKey(R.string.pref_key_sync_logins)
-        findPreference<CheckBoxPreference>(loginsNameKey)?.apply {
+        requirePreference<CheckBoxPreference>(R.string.pref_key_sync_logins).apply {
             isEnabled = syncEnginesStatus.containsKey(SyncEngine.Passwords)
             isChecked = syncEnginesStatus.getOrElse(SyncEngine.Passwords) { true }
         }
-        val tabsNameKey = getPreferenceKey(R.string.pref_key_sync_tabs)
-        findPreference<CheckBoxPreference>(tabsNameKey)?.apply {
+        requirePreference<CheckBoxPreference>(R.string.pref_key_sync_tabs).apply {
             isVisible = FeatureFlags.syncedTabs
             isEnabled = syncEnginesStatus.containsKey(SyncEngine.Tabs)
             isChecked = syncEnginesStatus.getOrElse(SyncEngine.Tabs) { FeatureFlags.syncedTabs }
@@ -342,22 +332,18 @@ class AccountSettingsFragment : PreferenceFragmentCompat() {
     }
 
     private fun setDisabledWhileSyncing(isSyncing: Boolean) {
-        findPreference<PreferenceCategory>(
-            getPreferenceKey(R.string.preferences_sync_category)
-        )?.isEnabled = !isSyncing
-
-        findPreference<EditTextPreference>(
-            getPreferenceKey(R.string.pref_key_sync_device_name)
-        )?.isEnabled = !isSyncing
+        requirePreference<PreferenceCategory>(R.string.preferences_sync_category).isEnabled = !isSyncing
+        requirePreference<EditTextPreference>(R.string.pref_key_sync_device_name).isEnabled = !isSyncing
     }
 
     private val syncStatusObserver = object : SyncStatusObserver {
+        private val pref by lazy { requirePreference<Preference>(R.string.pref_key_sync_now) }
+
         override fun onStarted() {
             viewLifecycleOwner.lifecycleScope.launch {
-                val pref = findPreference<Preference>(getPreferenceKey(R.string.pref_key_sync_now))
                 view?.announceForAccessibility(getString(R.string.sync_syncing_in_progress))
-                pref?.title = getString(R.string.sync_syncing_in_progress)
-                pref?.isEnabled = false
+                pref.title = getString(R.string.sync_syncing_in_progress)
+                pref.isEnabled = false
                 setDisabledWhileSyncing(true)
             }
         }
@@ -365,14 +351,11 @@ class AccountSettingsFragment : PreferenceFragmentCompat() {
         // Sync stopped successfully.
         override fun onIdle() {
             viewLifecycleOwner.lifecycleScope.launch {
-                val pref = findPreference<Preference>(getPreferenceKey(R.string.pref_key_sync_now))
-                pref?.let {
-                    pref.title = getString(R.string.preferences_sync_now)
-                    pref.isEnabled = true
+                pref.title = getString(R.string.preferences_sync_now)
+                pref.isEnabled = true
 
-                    val time = getLastSynced(requireContext())
-                    accountSettingsStore.dispatch(AccountSettingsFragmentAction.SyncEnded(time))
-                }
+                val time = getLastSynced(requireContext())
+                accountSettingsStore.dispatch(AccountSettingsFragmentAction.SyncEnded(time))
                 // Make sure out sync engine checkboxes are up-to-date.
                 updateSyncEngineStates()
                 setDisabledWhileSyncing(false)
@@ -382,19 +365,16 @@ class AccountSettingsFragment : PreferenceFragmentCompat() {
         // Sync stopped after encountering a problem.
         override fun onError(error: Exception?) {
             viewLifecycleOwner.lifecycleScope.launch {
-                val pref = findPreference<Preference>(getPreferenceKey(R.string.pref_key_sync_now))
-                pref?.let {
-                    pref.title = getString(R.string.preferences_sync_now)
-                    // We want to only enable the sync button, and not the checkboxes here
-                    pref.isEnabled = true
+                pref.title = getString(R.string.preferences_sync_now)
+                // We want to only enable the sync button, and not the checkboxes here
+                pref.isEnabled = true
 
-                    val failedTime = getLastSynced(requireContext())
-                    accountSettingsStore.dispatch(
-                        AccountSettingsFragmentAction.SyncFailed(
-                            failedTime
-                        )
+                val failedTime = getLastSynced(requireContext())
+                accountSettingsStore.dispatch(
+                    AccountSettingsFragmentAction.SyncFailed(
+                        failedTime
                     )
-                }
+                )
             }
         }
     }
@@ -408,9 +388,8 @@ class AccountSettingsFragment : PreferenceFragmentCompat() {
     }
 
     private fun updateDeviceName(state: AccountSettingsFragmentState) {
-        val deviceNameKey = getPreferenceKey(R.string.pref_key_sync_device_name)
-        val preferenceDeviceName = findPreference<Preference>(deviceNameKey)
-        preferenceDeviceName?.summary = state.deviceName
+        val preferenceDeviceName = requirePreference<Preference>(R.string.pref_key_sync_device_name)
+        preferenceDeviceName.summary = state.deviceName
     }
 
     private fun updateLastSyncTimePref(state: AccountSettingsFragmentState) {
@@ -432,8 +411,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat() {
             )
         }
 
-        val syncNow = getPreferenceKey(R.string.pref_key_sync_now)
-        findPreference<Preference>(syncNow)?.summary = value
+        requirePreference<Preference>(R.string.pref_key_sync_now).summary = value
     }
 
     companion object {

--- a/app/src/main/java/org/mozilla/fenix/settings/deletebrowsingdata/DeleteBrowsingDataOnQuitFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/deletebrowsingdata/DeleteBrowsingDataOnQuitFragment.kt
@@ -10,10 +10,10 @@ import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreference
 import org.mozilla.fenix.R
-import org.mozilla.fenix.ext.getPreferenceKey
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.showToolbar
 import org.mozilla.fenix.settings.SharedPreferenceUpdater
+import org.mozilla.fenix.settings.requirePreference
 
 class DeleteBrowsingDataOnQuitFragment : PreferenceFragmentCompat() {
 
@@ -39,10 +39,10 @@ class DeleteBrowsingDataOnQuitFragment : PreferenceFragmentCompat() {
         showToolbar(getString(R.string.preferences_delete_browsing_data_on_quit))
 
         // Delete Browsing Data on Quit Switch
-        val deleteOnQuitPref = findPreference<SwitchPreference>(
-            getPreferenceKey(R.string.pref_key_delete_browsing_data_on_quit)
+        val deleteOnQuitPref = requirePreference<SwitchPreference>(
+            R.string.pref_key_delete_browsing_data_on_quit
         )
-        deleteOnQuitPref?.apply {
+        deleteOnQuitPref.apply {
             onPreferenceChangeListener = object : SharedPreferenceUpdater() {
                 override fun onPreferenceChange(preference: Preference, newValue: Any?): Boolean {
                     setAllCheckboxes(newValue as Boolean)
@@ -58,7 +58,7 @@ class DeleteBrowsingDataOnQuitFragment : PreferenceFragmentCompat() {
                 val settings = preference.context.settings()
 
                 if (!settings.shouldDeleteAnyDataOnQuit()) {
-                    deleteOnQuitPref?.isChecked = false
+                    deleteOnQuitPref.isChecked = false
                     settings.shouldDeleteBrowsingDataOnQuit = false
                 }
                 return true

--- a/app/src/main/java/org/mozilla/fenix/settings/logins/SavedLoginsAuthFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/SavedLoginsAuthFragment.kt
@@ -34,12 +34,12 @@ import org.mozilla.fenix.Config
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.components
-import org.mozilla.fenix.ext.getPreferenceKey
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.secure
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.showToolbar
 import org.mozilla.fenix.settings.SharedPreferenceUpdater
+import org.mozilla.fenix.settings.requirePreference
 import java.util.concurrent.Executors
 
 @Suppress("TooManyFunctions", "LargeClass")
@@ -98,8 +98,7 @@ class SavedLoginsAuthFragment : PreferenceFragmentCompat(), AccountObserver {
         super.onResume()
         showToolbar(getString(R.string.preferences_passwords_logins_and_passwords))
 
-        val saveLoginsSettingKey = getPreferenceKey(R.string.pref_key_save_logins_settings)
-        findPreference<Preference>(saveLoginsSettingKey)?.apply {
+        requirePreference<Preference>(R.string.pref_key_save_logins_settings).apply {
             summary = getString(
                 if (context.settings().shouldPromptToSaveLogins)
                     R.string.preferences_passwords_save_logins_ask_to_save else
@@ -111,8 +110,7 @@ class SavedLoginsAuthFragment : PreferenceFragmentCompat(), AccountObserver {
             }
         }
 
-        val autofillPreferenceKey = getPreferenceKey(R.string.pref_key_autofill_logins)
-        findPreference<SwitchPreference>(autofillPreferenceKey)?.apply {
+        requirePreference<SwitchPreference>(R.string.pref_key_autofill_logins).apply {
             // The ability to toggle autofill on the engine is only available in Nightly currently
             // See https://github.com/mozilla-mobile/fenix/issues/11320
             isVisible = Config.channel.isNightlyOrDebug
@@ -126,8 +124,7 @@ class SavedLoginsAuthFragment : PreferenceFragmentCompat(), AccountObserver {
             }
         }
 
-        val savedLoginsKey = getPreferenceKey(R.string.pref_key_saved_logins)
-        findPreference<Preference>(savedLoginsKey)?.setOnPreferenceClickListener {
+        requirePreference<Preference>(R.string.pref_key_saved_logins).setOnPreferenceClickListener {
             if (Build.VERSION.SDK_INT >= M && isHardwareAvailable && hasBiometricEnrolled) {
                 biometricPrompt.authenticate(promptInfo)
             } else {
@@ -181,8 +178,7 @@ class SavedLoginsAuthFragment : PreferenceFragmentCompat(), AccountObserver {
     }
 
     private fun updateSyncPreferenceStatus() {
-        val syncLogins = getPreferenceKey(R.string.pref_key_password_sync_logins)
-        findPreference<Preference>(syncLogins)?.apply {
+        requirePreference<Preference>(R.string.pref_key_password_sync_logins).apply {
             val syncEnginesStatus = SyncEnginesStorage(requireContext()).getStatus()
             val loginsSyncStatus = syncEnginesStatus.getOrElse(SyncEngine.Passwords) { false }
             summary = getString(
@@ -197,8 +193,7 @@ class SavedLoginsAuthFragment : PreferenceFragmentCompat(), AccountObserver {
     }
 
     private fun updateSyncPreferenceNeedsLogin() {
-        val syncLogins = getPreferenceKey(R.string.pref_key_password_sync_logins)
-        findPreference<Preference>(syncLogins)?.apply {
+        requirePreference<Preference>(R.string.pref_key_password_sync_logins).apply {
             summary = getString(R.string.preferences_passwords_sync_logins_sign_in)
             setOnPreferenceClickListener {
                 navigateToTurnOnSyncFragment()
@@ -208,8 +203,7 @@ class SavedLoginsAuthFragment : PreferenceFragmentCompat(), AccountObserver {
     }
 
     private fun updateSyncPreferenceNeedsReauth() {
-        val syncLogins = getPreferenceKey(R.string.pref_key_password_sync_logins)
-        findPreference<Preference>(syncLogins)?.apply {
+        requirePreference<Preference>(R.string.pref_key_password_sync_logins).apply {
             summary = getString(R.string.preferences_passwords_sync_logins_reconnect)
             setOnPreferenceClickListener {
                 navigateToAccountProblemFragment()

--- a/app/src/main/java/org/mozilla/fenix/settings/logins/SavedLoginsSettingFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/SavedLoginsSettingFragment.kt
@@ -14,6 +14,7 @@ import org.mozilla.fenix.ext.metrics
 import org.mozilla.fenix.ext.showToolbar
 import org.mozilla.fenix.settings.RadioButtonPreference
 import org.mozilla.fenix.settings.SharedPreferenceUpdater
+import org.mozilla.fenix.settings.requirePreference
 
 class SavedLoginsSettingFragment : PreferenceFragmentCompat() {
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
@@ -29,9 +30,8 @@ class SavedLoginsSettingFragment : PreferenceFragmentCompat() {
     }
 
     private fun bindSave(): RadioButtonPreference {
-        val keySave = getString(R.string.pref_key_save_logins)
-        val preferenceSave = findPreference<RadioButtonPreference>(keySave)
-        preferenceSave?.onPreferenceChangeListener = object : SharedPreferenceUpdater() {
+        val preferenceSave = requirePreference<RadioButtonPreference>(R.string.pref_key_save_logins)
+        preferenceSave.onPreferenceChangeListener = object : SharedPreferenceUpdater() {
             override fun onPreferenceChange(preference: Preference, newValue: Any?): Boolean {
                 if (newValue == true) {
                     context?.metrics?.track(
@@ -45,13 +45,12 @@ class SavedLoginsSettingFragment : PreferenceFragmentCompat() {
                 return super.onPreferenceChange(preference, newValue)
             }
         }
-        return requireNotNull(preferenceSave)
+        return preferenceSave
     }
 
     private fun bindNeverSave(): RadioButtonPreference {
-        val keyNeverSave = getString(R.string.pref_key_never_save_logins)
-        val preferenceNeverSave = findPreference<RadioButtonPreference>(keyNeverSave)
-        preferenceNeverSave?.onPreferenceChangeListener = object : SharedPreferenceUpdater() {
+        val preferenceNeverSave = requirePreference<RadioButtonPreference>(R.string.pref_key_never_save_logins)
+        preferenceNeverSave.onPreferenceChangeListener = object : SharedPreferenceUpdater() {
             override fun onPreferenceChange(preference: Preference, newValue: Any?): Boolean {
                 if (newValue == true) {
                     context?.metrics?.track(
@@ -65,7 +64,7 @@ class SavedLoginsSettingFragment : PreferenceFragmentCompat() {
                 return super.onPreferenceChange(preference, newValue)
             }
         }
-        return requireNotNull(preferenceNeverSave)
+        return preferenceNeverSave
     }
 
     private fun setupRadioGroups(

--- a/app/src/main/java/org/mozilla/fenix/settings/search/SearchEngineFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/search/SearchEngineFragment.kt
@@ -15,6 +15,7 @@ import org.mozilla.fenix.ext.getPreferenceKey
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.showToolbar
 import org.mozilla.fenix.settings.SharedPreferenceUpdater
+import org.mozilla.fenix.settings.requirePreference
 
 class SearchEngineFragment : PreferenceFragmentCompat() {
 
@@ -27,57 +28,56 @@ class SearchEngineFragment : PreferenceFragmentCompat() {
         showToolbar(getString(R.string.preferences_search))
 
         val searchSuggestionsPreference =
-            findPreference<SwitchPreference>(getPreferenceKey(R.string.pref_key_show_search_suggestions))?.apply {
+            requirePreference<SwitchPreference>(R.string.pref_key_show_search_suggestions).apply {
                 isChecked = context.settings().shouldShowSearchSuggestions
             }
 
         val searchSuggestionsInPrivatePreference =
-            findPreference<CheckBoxPreference>(getPreferenceKey(R.string.pref_key_show_search_suggestions_in_private))
-                ?.apply {
+            requirePreference<CheckBoxPreference>(R.string.pref_key_show_search_suggestions_in_private).apply {
                 isChecked = context.settings().shouldShowSearchSuggestionsInPrivate
             }
 
         val showSearchShortcuts =
-            findPreference<SwitchPreference>(getPreferenceKey(R.string.pref_key_show_search_shortcuts))?.apply {
+            requirePreference<SwitchPreference>(R.string.pref_key_show_search_shortcuts).apply {
                 isChecked = context.settings().shouldShowSearchShortcuts
             }
 
         val showHistorySuggestions =
-            findPreference<SwitchPreference>(getPreferenceKey(R.string.pref_key_search_browsing_history))?.apply {
+            requirePreference<SwitchPreference>(R.string.pref_key_search_browsing_history).apply {
                 isChecked = context.settings().shouldShowHistorySuggestions
             }
 
         val showBookmarkSuggestions =
-            findPreference<SwitchPreference>(getPreferenceKey(R.string.pref_key_search_bookmarks))?.apply {
+            requirePreference<SwitchPreference>(R.string.pref_key_search_bookmarks).apply {
                 isChecked = context.settings().shouldShowBookmarkSuggestions
             }
 
         val showClipboardSuggestions =
-            findPreference<SwitchPreference>(getPreferenceKey(R.string.pref_key_show_clipboard_suggestions))?.apply {
+            requirePreference<SwitchPreference>(R.string.pref_key_show_clipboard_suggestions).apply {
                 isChecked = context.settings().shouldShowClipboardSuggestions
             }
 
         val searchEngineListPreference =
-            findPreference<SearchEngineListPreference>(getPreferenceKey(R.string.pref_key_search_engine_list))
+            requirePreference<SearchEngineListPreference>(R.string.pref_key_search_engine_list)
 
         val showVoiceSearchPreference =
-            findPreference<SwitchPreference>(getPreferenceKey(R.string.pref_key_show_voice_search))?.apply {
+            requirePreference<SwitchPreference>(R.string.pref_key_show_voice_search).apply {
                 isChecked = context.settings().shouldShowVoiceSearch
             }
 
-        searchEngineListPreference?.reload(requireContext())
-        searchSuggestionsPreference?.onPreferenceChangeListener = SharedPreferenceUpdater()
-        showSearchShortcuts?.onPreferenceChangeListener = SharedPreferenceUpdater()
-        showHistorySuggestions?.onPreferenceChangeListener = SharedPreferenceUpdater()
-        showBookmarkSuggestions?.onPreferenceChangeListener = SharedPreferenceUpdater()
-        showClipboardSuggestions?.onPreferenceChangeListener = SharedPreferenceUpdater()
-        searchSuggestionsInPrivatePreference?.onPreferenceChangeListener = SharedPreferenceUpdater()
-        showVoiceSearchPreference?.onPreferenceChangeListener = SharedPreferenceUpdater()
+        searchEngineListPreference.reload(requireContext())
+        searchSuggestionsPreference.onPreferenceChangeListener = SharedPreferenceUpdater()
+        showSearchShortcuts.onPreferenceChangeListener = SharedPreferenceUpdater()
+        showHistorySuggestions.onPreferenceChangeListener = SharedPreferenceUpdater()
+        showBookmarkSuggestions.onPreferenceChangeListener = SharedPreferenceUpdater()
+        showClipboardSuggestions.onPreferenceChangeListener = SharedPreferenceUpdater()
+        searchSuggestionsInPrivatePreference.onPreferenceChangeListener = SharedPreferenceUpdater()
+        showVoiceSearchPreference.onPreferenceChangeListener = SharedPreferenceUpdater()
 
-        searchSuggestionsPreference?.setOnPreferenceClickListener {
+        searchSuggestionsPreference.setOnPreferenceClickListener {
             if (!searchSuggestionsPreference.isChecked) {
-                searchSuggestionsInPrivatePreference?.isChecked = false
-                searchSuggestionsInPrivatePreference?.callChangeListener(false)
+                searchSuggestionsInPrivatePreference.isChecked = false
+                searchSuggestionsInPrivatePreference.callChangeListener(false)
             }
             true
         }

--- a/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsDetailsExceptionsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsDetailsExceptionsFragment.kt
@@ -18,13 +18,13 @@ import kotlinx.coroutines.withContext
 import mozilla.components.feature.sitepermissions.SitePermissions
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
-import org.mozilla.fenix.ext.getPreferenceKey
 import org.mozilla.fenix.ext.showToolbar
 import org.mozilla.fenix.settings.PhoneFeature
 import org.mozilla.fenix.settings.PhoneFeature.CAMERA
 import org.mozilla.fenix.settings.PhoneFeature.LOCATION
 import org.mozilla.fenix.settings.PhoneFeature.MICROPHONE
 import org.mozilla.fenix.settings.PhoneFeature.NOTIFICATION
+import org.mozilla.fenix.settings.requirePreference
 
 class SitePermissionsDetailsExceptionsFragment : PreferenceFragmentCompat() {
     private lateinit var sitePermissions: SitePermissions
@@ -75,8 +75,7 @@ class SitePermissionsDetailsExceptionsFragment : PreferenceFragmentCompat() {
     }
 
     private fun bindClearPermissionsButton() {
-        val keyPreference = getPreferenceKey(R.string.pref_key_exceptions_clear_site_permissions)
-        val button: Preference = requireNotNull(findPreference(keyPreference))
+        val button: Preference = requirePreference(R.string.pref_key_exceptions_clear_site_permissions)
 
         button.onPreferenceClickListener = Preference.OnPreferenceClickListener {
             AlertDialog.Builder(requireContext()).apply {

--- a/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsDetailsExceptionsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsDetailsExceptionsFragment.kt
@@ -64,8 +64,7 @@ class SitePermissionsDetailsExceptionsFragment : PreferenceFragmentCompat() {
 
     private fun initPhoneFeature(phoneFeature: PhoneFeature) {
         val summary = phoneFeature.getActionLabel(requireContext(), sitePermissions)
-        val keyPreference = phoneFeature.getPreferenceKey(requireContext())
-        val cameraPhoneFeatures: Preference = requireNotNull(findPreference(keyPreference))
+        val cameraPhoneFeatures = requirePreference<Preference>(phoneFeature.getPreferenceId())
         cameraPhoneFeatures.summary = summary
 
         cameraPhoneFeatures.onPreferenceClickListener = Preference.OnPreferenceClickListener {

--- a/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsFragment.kt
@@ -14,6 +14,7 @@ import org.mozilla.fenix.ext.getPreferenceKey
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.showToolbar
 import org.mozilla.fenix.settings.PhoneFeature
+import org.mozilla.fenix.settings.requirePreference
 
 @SuppressWarnings("TooManyFunctions")
 class SitePermissionsFragment : PreferenceFragmentCompat() {
@@ -64,9 +65,8 @@ class SitePermissionsFragment : PreferenceFragmentCompat() {
             } else {
                 null
             }
-        val preferenceKey = phoneFeature.getPreferenceKey(context)
 
-        val cameraPhoneFeatures: Preference = requireNotNull(findPreference(preferenceKey))
+        val cameraPhoneFeatures = requirePreference<Preference>(phoneFeature.getPreferenceId())
         cameraPhoneFeatures.summary = autoplaySummary ?: summary
 
         cameraPhoneFeatures.onPreferenceClickListener = OnPreferenceClickListener {


### PR DESCRIPTION
All of our `findPreference` calls correspond to preferences defined in corresponding XML files. We should throw if these are null, rather than silently doing nothing. The current system occasionally leads to code being left behind for a removed preference.

This change adds a helper to streamline `requireNotNull(findPreference(getPreferenceKey()))`, and updates the settings fragments so they use it.