### PR TITLE
For #11183: Redirect user to homescreen after widget added

### DIFF
--- a/app/src/main/java/org/mozilla/gecko/search/SearchWidgetProvider.kt
+++ b/app/src/main/java/org/mozilla/gecko/search/SearchWidgetProvider.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.gecko.search
 
+import android.app.ActivityManager
 import android.app.PendingIntent
 import android.appwidget.AppWidgetManager
 import android.appwidget.AppWidgetManager.OPTION_APPWIDGET_MIN_WIDTH
@@ -36,10 +37,21 @@ class SearchWidgetProvider : AppWidgetProvider() {
 
     override fun onEnabled(context: Context) {
         context.settings().addSearchWidgetInstalled(1)
-        val goHomeOnWidgetAdded = Intent(Intent.ACTION_MAIN)
-        goHomeOnWidgetAdded.addCategory(Intent.CATEGORY_HOME)
-        goHomeOnWidgetAdded.flags = Intent.FLAG_ACTIVITY_NEW_TASK
-        context.startActivity(goHomeOnWidgetAdded)
+        if (isAppInForeground(context)) {
+            val goHomeOnWidgetAdded = Intent(Intent.ACTION_MAIN)
+            goHomeOnWidgetAdded.addCategory(Intent.CATEGORY_HOME)
+            goHomeOnWidgetAdded.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            context.startActivity(goHomeOnWidgetAdded)
+        }
+    }
+
+    // We need this because user can not add widget via launcher app without this
+    private fun isAppInForeground(context: Context): Boolean {
+        val activityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+        val runningAppProcesses =
+            activityManager.runningAppProcesses ?: return false
+        return runningAppProcesses.any { it.processName == context.packageName &&
+                it.importance == ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND }
     }
 
     override fun onDeleted(context: Context, appWidgetIds: IntArray) {

--- a/app/src/main/java/org/mozilla/gecko/search/SearchWidgetProvider.kt
+++ b/app/src/main/java/org/mozilla/gecko/search/SearchWidgetProvider.kt
@@ -36,6 +36,10 @@ class SearchWidgetProvider : AppWidgetProvider() {
 
     override fun onEnabled(context: Context) {
         context.settings().addSearchWidgetInstalled(1)
+        val goHomeOnWidgetAdded = Intent(Intent.ACTION_MAIN)
+        goHomeOnWidgetAdded.addCategory(Intent.CATEGORY_HOME)
+        goHomeOnWidgetAdded.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        context.startActivity(goHomeOnWidgetAdded)
     }
 
     override fun onDeleted(context: Context, appWidgetIds: IntArray) {


### PR DESCRIPTION
Checks if app is in foreground (for cfr) and if true goes homescreen (app backgrounded, not closed). If we don't check "is app in foreground/background" user can't add widget via launcher.

![ezgif com-video-to-gif(1)](https://user-images.githubusercontent.com/17825767/84773940-cb376c00-afe5-11ea-9d32-c7eb4becb099.gif)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture