### PR TITLE
No issue: Disable verifyBasicNavigationToolbarFunctionality

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -9,6 +9,7 @@ import androidx.test.uiautomator.UiDevice
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
@@ -21,6 +22,8 @@ import org.mozilla.fenix.ui.robots.navigationToolbar
  * Test Suite that contains tests defined as part of the Smoke and Sanity check defined in Test rail.
  * These tests will verify different functionalities of the app as a way to quickly detect regressions in main areas
  */
+
+@Ignore("Temp disable for triggering a native Gecko crash - https://github.com/mozilla-mobile/fenix/issues/11642")
 class SmokeTest {
     private val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
     private lateinit var mockWebServer: MockWebServer


### PR DESCRIPTION
Disabling this test as it's triggering a native crash in GeckoView https://github.com/mozilla-mobile/fenix/issues/11642