### PR TITLE
For #9712 - show "AC: " before AC version on "About" screen

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/about/AboutFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/about/AboutFragment.kt
@@ -111,6 +111,7 @@ class AboutFragment : Fragment(), AboutPageListener {
         val aboutText = try {
             val packageInfo = requireContext().packageManager.getPackageInfo(requireContext().packageName, 0)
             val versionCode = PackageInfoCompat.getLongVersionCode(packageInfo).toString()
+            val componentsAbbreviation = getString(R.string.components_abbreviation)
             val componentsVersion = mozilla.components.Build.version + ", " + mozilla.components.Build.gitHash
             val maybeGecko = getString(R.string.gecko_view_abbreviation)
             val geckoVersion = GeckoViewBuildConfig.MOZ_APP_VERSION + "-" + GeckoViewBuildConfig.MOZ_APP_BUILDID
@@ -118,9 +119,10 @@ class AboutFragment : Fragment(), AboutPageListener {
             val appServicesVersion = mozilla.components.Build.applicationServicesVersion
 
             String.format(
-                "%s (Build #%s)\n%s\n%s: %s\n%s: %s",
+                "%s (Build #%s)\n%s: %s\n%s: %s\n%s: %s",
                 packageInfo.versionName,
                 versionCode,
+                componentsAbbreviation,
                 componentsVersion,
                 maybeGecko,
                 geckoVersion,

--- a/app/src/main/res/layout/fragment_about.xml
+++ b/app/src/main/res/layout/fragment_about.xml
@@ -59,7 +59,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/about_content"
             app:layout_constraintWidth_percent="0.8"
-            tools:text="1.0.x (Build #x)\nGV: 69.x-x\nAC: 1.0.0" />
+            tools:text="1.0.x (Build #x)\nAC: 1.0.0\nGV: 69.x-x\nAS: 1.0.0" />
 
         <TextView
             android:id="@+id/build_date"

--- a/app/src/main/res/values/static_strings.xml
+++ b/app/src/main/res/values/static_strings.xml
@@ -25,6 +25,8 @@
     <string name="default_top_site_wikipedia" translatable="false">Wikipedia</string>
     <!-- Default title for pinned YouTube top site that links to Youtube home page  -->
     <string name="default_top_site_youtube" translatable="false">YouTube</string>
+    <!-- Android Components abbreviation used in AboutFragment -->
+    <string name="components_abbreviation" translatable="false">AC</string>
     <!-- Application Services abbreviation used in AboutFragment -->
     <string name="app_services_abbreviation" translatable="false">AS</string>
 


### PR DESCRIPTION
Opening in place for https://github.com/mozilla-mobile/fenix/pull/11605.