### PR TITLE
Fixes #11641: Update synced tabs view

### DIFF
--- a/app/src/main/res/layout/component_sync_tabs.xml
+++ b/app/src/main/res/layout/component_sync_tabs.xml
@@ -6,7 +6,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/history_wrapper"
+    android:id="@+id/synced_tabs_wrapper"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
     <ProgressBar
@@ -43,7 +43,7 @@
             android:id="@+id/synced_tabs_list"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            tools:listitem="@layout/history_list_item"/>
+            tools:listitem="@layout/sync_tabs_list_item"/>
 
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/sync_tabs_list_item.xml
+++ b/app/src/main/res/layout/sync_tabs_list_item.xml
@@ -8,34 +8,31 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:paddingStart="60dp"
-    android:paddingEnd="20dp"
-    android:minHeight="@dimen/library_item_height"
     android:background="?android:attr/selectableItemBackground">
 
     <TextView
         android:id="@+id/synced_tab_item_title"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="12dp"
-        android:ellipsize="end"
+        android:layout_marginStart="72dp"
+        android:layout_marginEnd="48dp"
+        android:layout_marginTop="6dp"
         android:singleLine="true"
         android:textAlignment="viewStart"
         android:textColor="?primaryText"
-        android:textSize="18sp"
-        app:layout_constraintBottom_toTopOf="@+id/synced_tab_item_url"
+        android:textSize="16sp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_chainStyle="packed"
         tools:text="Tab Title" />
 
     <TextView
         android:id="@+id/synced_tab_item_url"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="12dp"
-        android:ellipsize="end"
+        android:layout_marginStart="72dp"
+        android:layout_marginEnd="48dp"
+        android:layout_marginTop="2dp"
         android:singleLine="true"
         android:textAlignment="viewStart"
         android:textColor="?secondaryText"
@@ -43,21 +40,18 @@
         tools:text="https://example.com/"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/synced_tab_item_title"
-        app:layout_constraintBottom_toBottomOf="parent" />
+        app:layout_constraintTop_toBottomOf="@+id/synced_tab_item_title" />
 
     <View
         android:id="@+id/synced_tab_item_separator"
-        android:layout_width="0dp"
-        android:layout_height="2dp"
-        android:layout_marginStart="16dp"
-        android:layout_marginEnd="16dp"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_marginTop="7dp"
+        android:background="?syncedTabsSeparator"
         android:importantForAccessibility="no"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
+        android:visibility="invisible"
         app:layout_constraintEnd_toEndOf="parent"
-        android:background="?neutralFaded"
-        android:visibility="gone"/>
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/synced_tab_item_url" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/sync_tabs_list_item.xml
+++ b/app/src/main/res/layout/sync_tabs_list_item.xml
@@ -12,10 +12,8 @@
 
     <TextView
         android:id="@+id/synced_tab_item_title"
-        android:layout_width="0dp"
+        style="@style/SyncedTabsStyle"
         android:layout_height="wrap_content"
-        android:layout_marginStart="72dp"
-        android:layout_marginEnd="48dp"
         android:layout_marginTop="6dp"
         android:singleLine="true"
         android:textAlignment="viewStart"
@@ -28,10 +26,8 @@
 
     <TextView
         android:id="@+id/synced_tab_item_url"
-        android:layout_width="0dp"
+        style="@style/SyncedTabsStyle"
         android:layout_height="wrap_content"
-        android:layout_marginStart="72dp"
-        android:layout_marginEnd="48dp"
         android:layout_marginTop="2dp"
         android:singleLine="true"
         android:textAlignment="viewStart"

--- a/app/src/main/res/layout/view_synced_tabs_group.xml
+++ b/app/src/main/res/layout/view_synced_tabs_group.xml
@@ -2,30 +2,39 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/synced_tabs_group"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:paddingTop="16dp"
-    android:paddingBottom="8dp"
-    android:paddingStart="16dp"
-    android:paddingEnd="16dp">
+    android:layout_marginTop="8dp">
 
     <TextView
         android:id="@+id/synced_tabs_group_name"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:drawablePadding="15dp"
-        app:drawableStartCompat="@drawable/mozac_ic_device_desktop"
-        app:drawableTint="?primaryText"
-        android:textSize="17sp"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="8dp"
+        android:drawablePadding="32dp"
         android:textAppearance="@style/Header14TextStyle"
         android:textColor="?primaryText"
-        android:paddingStart="20dp"
-        android:paddingEnd="0dp"
-        android:layout_marginBottom="8dp"
+        android:textSize="12sp"
+        android:gravity="center"
+        app:drawableStartCompat="@drawable/mozac_ic_device_desktop"
+        app:drawableTint="?primaryText"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
         tools:text="Header" />
 
-</RelativeLayout>
+    <View
+        android:id="@+id/synced_tabs_group_separator"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_marginTop="6dp"
+        android:background="?syncedTabsSeparator"
+        android:importantForAccessibility="no"
+        android:visibility="visible"
+        app:layout_constraintTop_toBottomOf="@+id/synced_tabs_group_name" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -65,7 +65,8 @@
     <color name="top_site_title_text">@color/top_site_title_text_dark_theme</color>
 
     <!-- Synced tabs colors-->
-    <color name="synced_tabs_separator">@color/synced_tabs_separator_dark_theme</color>
+    <color name="synced_tabs_separator_normal_theme">@color/synced_tabs_separator_dark_theme</color>
+
     <!-- Collection icons-->
     <color name="collection_icon_color_violet">@color/collection_icon_color_violet_dark_theme</color>
     <color name="collection_icon_color_blue">@color/collection_icon_color_blue_dark_theme</color>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -64,6 +64,8 @@
     <color name="top_site_border">@color/top_site_border_dark_theme</color>
     <color name="top_site_title_text">@color/top_site_title_text_dark_theme</color>
 
+    <!-- Synced tabs colors-->
+    <color name="synced_tabs_separator">@color/synced_tabs_separator_dark_theme</color>
     <!-- Collection icons-->
     <color name="collection_icon_color_violet">@color/collection_icon_color_violet_dark_theme</color>
     <color name="collection_icon_color_blue">@color/collection_icon_color_blue_dark_theme</color>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -51,6 +51,7 @@
     <attr name="addOnPrivateBrowsingInteriorIconBackground" format="reference"/>
     <attr name="readerModeStartGradient" format="reference"/>
     <attr name="readerModeEndGradient" format="reference"/>
+    <attr name="syncedTabsSeparator" format="reference"/>
 
     <!-- Tab tray -->
     <attr name="tabTrayItemBackground" format="reference" />

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -253,7 +253,8 @@
     <color name="top_site_title_text">@color/top_site_title_text_light_theme</color>
 
     <!-- Synced tabs colors-->
-    <color name="synced_tabs_separator">@color/synced_tabs_separator_light_theme</color>
+    <color name="synced_tabs_separator_normal_theme">@color/synced_tabs_separator_light_theme</color>
+    <color name="synced_tabs_separator_private_theme">@color/synced_tabs_separator_dark_theme</color>
 
     <!-- Collection icons-->
     <color name="collection_icon_color_violet">@color/collection_icon_color_violet_light_theme</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -47,6 +47,7 @@
     <color name="dark_grey_90_gradient_end">#0015141A</color>
     <color name="top_site_background_light_theme">@android:color/white</color>
     <color name="top_site_border_light_theme">@color/light_grey_30</color>
+    <color name="synced_tabs_separator_light_theme">@color/light_grey_30</color>
     <color name="top_site_title_text_light_theme">@color/light_grey_80</color>
     <color name="collection_icon_color_violet_light_theme">#7542E5</color>
     <color name="collection_icon_color_blue_light_theme">#0250BB</color>
@@ -104,6 +105,7 @@
     <color name="scrimEnd_dark_theme">#F515141A</color>
     <color name="top_site_background_dark_theme">@color/dark_grey_50</color>
     <color name="top_site_border_dark_theme">@color/dark_grey_10</color>
+    <color name="synced_tabs_separator_dark_theme">@color/dark_grey_50</color>
     <color name="top_site_title_text_dark_theme">@color/light_grey_90</color>
     <color name="collection_icon_color_violet_dark_theme">#AB71FF</color>
     <color name="collection_icon_color_blue_dark_theme">#00B3F4</color>
@@ -249,6 +251,9 @@
     <color name="top_site_background">@color/top_site_background_light_theme</color>
     <color name="top_site_border">@color/top_site_border_light_theme</color>
     <color name="top_site_title_text">@color/top_site_title_text_light_theme</color>
+
+    <!-- Synced tabs colors-->
+    <color name="synced_tabs_separator">@color/synced_tabs_separator_light_theme</color>
 
     <!-- Collection icons-->
     <color name="collection_icon_color_violet">@color/collection_icon_color_violet_light_theme</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -75,7 +75,7 @@
         <item name="mozacPromptLoginEditTextCursorColor">@color/prompt_login_edit_text_cursor_color_normal_theme</item>
         <item name="readerModeStartGradient">@color/readermode_start_gradient_normal_theme</item>
         <item name="readerModeEndGradient">@color/readermode_end_gradient_normal_theme</item>
-
+        <item name="syncedTabsSeparator">@color/synced_tabs_separator</item>
 
         <item name="tabTrayItemBackground">@color/tab_tray_item_background_normal_theme</item>
         <item name="tabTrayItemSelectedBackground">@color/tab_tray_item_selected_background_normal_theme</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -75,7 +75,7 @@
         <item name="mozacPromptLoginEditTextCursorColor">@color/prompt_login_edit_text_cursor_color_normal_theme</item>
         <item name="readerModeStartGradient">@color/readermode_start_gradient_normal_theme</item>
         <item name="readerModeEndGradient">@color/readermode_end_gradient_normal_theme</item>
-        <item name="syncedTabsSeparator">@color/synced_tabs_separator</item>
+        <item name="syncedTabsSeparator">@color/synced_tabs_separator_normal_theme</item>
 
         <item name="tabTrayItemBackground">@color/tab_tray_item_background_normal_theme</item>
         <item name="tabTrayItemSelectedBackground">@color/tab_tray_item_selected_background_normal_theme</item>
@@ -200,6 +200,7 @@
         <item name="addOnPrivateBrowsingExteriorCircleBackground">@color/add_on_private_browsing_exterior_circle_background_private_theme</item>
         <item name="addOnPrivateBrowsingInteriorIconBackground">@color/add_on_private_browsing_interior_icon_background_private_theme</item>
         <item name="mozacPromptLoginEditTextCursorColor">@color/prompt_login_edit_text_cursor_color_private_theme</item>
+        <item name="syncedTabsSeparator">@color/synced_tabs_separator_private_theme</item>
 
         <!-- Tab Tray -->
         <item name="tabTrayItemBackground">@color/tab_tray_item_background_normal_theme</item>
@@ -568,5 +569,10 @@
     <style name="TabTrayFab" parent="Widget.MaterialComponents.ExtendedFloatingActionButton">
         <item name="elevation">90dp</item>
         <item name="android:stateListAnimator">@null</item>
+    </style>
+    <style name="SyncedTabsStyle">
+        <item name="android:layout_marginStart">72dp</item>
+        <item name="android:layout_marginEnd">48dp</item>
+        <item name="android:layout_width">0dp</item>
     </style>
 </resources>


### PR DESCRIPTION
Fixes #11641

~~[mozac_ic_device_mobile.xml](https://github.com/mozilla-mobile/android-components/blob/master/components/ui/icons/src/main/res/drawable/mozac_ic_device_mobile.xml) is 16x16 thus it looks like misaligned. Please provide 24x24 icon.~~
~~Maybe we can use [photon icon](https://github.com/FirefoxUX/photon-icons/blob/master/icons/android/device-mobile-24.xml).~~
I've converted photon icon svg to xml and opened [pr in ac](https://github.com/mozilla-mobile/android-components/pull/7419).

**Warning**: I'm amateur. Sooo double-check :)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture