### PR TITLE
For #11651 - Fix top site favicon size and dark theme border color.

### DIFF
--- a/app/src/main/res/layout/top_site_item.xml
+++ b/app/src/main/res/layout/top_site_item.xml
@@ -12,8 +12,8 @@
 
     <FrameLayout
         android:id="@+id/favicon_wrapper"
-        android:layout_width="48dp"
-        android:layout_height="48dp"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
         android:padding="4dp"
         android:background="@drawable/top_sites_background"
         app:layout_constraintBottom_toTopOf="@id/top_site_title"
@@ -23,11 +23,12 @@
         app:layout_constraintTop_toTopOf="parent">
         <ImageView
             android:id="@+id/favicon_image"
-            android:layout_width="40dp"
-            android:layout_height="40dp"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_gravity="center"
             android:adjustViewBounds="true"
             android:importantForAccessibility="no"
-            android:scaleType="centerInside" />
+            android:scaleType="fitCenter" />
     </FrameLayout>
 
     <TextView

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -103,7 +103,7 @@
     <color name="scrimStart_dark_theme">#F520123A</color>
     <color name="scrimEnd_dark_theme">#F515141A</color>
     <color name="top_site_background_dark_theme">@color/dark_grey_50</color>
-    <color name="top_site_border_dark_theme">@color/dark_grey_50</color>
+    <color name="top_site_border_dark_theme">@color/dark_grey_10</color>
     <color name="top_site_title_text_dark_theme">@color/light_grey_90</color>
     <color name="collection_icon_color_violet_dark_theme">#AB71FF</color>
     <color name="collection_icon_color_blue_dark_theme">#00B3F4</color>


### PR DESCRIPTION

![Screenshot_1592333591](https://user-images.githubusercontent.com/6396431/84816086-d29c4c80-afc8-11ea-9399-61a7e9457b7d.png)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture