### PR TITLE
For #11660: added prefetch for topsites and update in onCreateView()

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -142,6 +142,7 @@ open class FenixApplication : LocaleAwareApplication() {
             }
         }
 
+        prefetchForHomeFragment()
         setupLeakCanary()
         if (settings().isTelemetryEnabled) {
             components.analytics.metrics.start(MetricServiceType.Data)
@@ -228,6 +229,13 @@ open class FenixApplication : LocaleAwareApplication() {
         // no-op, LeakCanary is disabled by default
     }
 
+    // This is for issue https://github.com/mozilla-mobile/fenix/issues/11660. We prefetch our info for startup
+    // so that we're sure that we have all the data available as our fragment is launched.
+    private fun prefetchForHomeFragment() {
+        StrictMode.allowThreadDiskReads().resetPoliciesAfter {
+            components.core.topSiteStorage.prefetch()
+        }
+    }
     private fun setupPush() {
         // Sets the PushFeature as the singleton instance for push messages to go to.
         // We need the push feature setup here to deliver messages in the case where the service

--- a/app/src/main/java/org/mozilla/fenix/components/TopSiteStorage.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/TopSiteStorage.kt
@@ -14,6 +14,7 @@ import mozilla.components.feature.top.sites.TopSite
 import mozilla.components.feature.top.sites.TopSiteStorage
 import mozilla.components.support.locale.LocaleManager
 import org.mozilla.fenix.R
+import org.mozilla.fenix.ext.observeOnce
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.settings.SupportUtils
 import org.mozilla.fenix.settings.advanced.getSelectedLocale
@@ -84,6 +85,12 @@ class TopSiteStorage(private val context: Context) {
                 }
             }
             context.settings().defaultTopSitesAdded = true
+        }
+    }
+
+    fun prefetch() {
+        getTopSites().observeOnce {
+            cachedTopSites = it
         }
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/ext/LiveData.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/LiveData.kt
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.ext
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.Observer
+
+/**
+ * Observe a LiveData once and unregister from it as soon as the live data returns a value
+ */
+fun <T> LiveData<T>.observeOnce(observer: (T) -> Unit) {
+    observeForever(object : Observer<T> {
+        override fun onChanged(value: T) {
+            removeObserver(this)
+            observer(value)
+        }
+    })
+}

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -215,6 +215,12 @@ class HomeFragment : Fragment() {
             sessionControlInteractor,
             homeViewModel
         )
+
+        // This has to be called separately from the consumeFrom block since the coroutine doesn't
+        // allow our UI to be updated right away and delays our start up. The init block allows us to
+        // force our UI to render with the data available in our store at fragment creation time.
+        sessionControlView?.update(homeFragmentStore.state)
+
         activity.themeManager.applyStatusBarTheme(activity)
 
         view.consumeFrom(homeFragmentStore, viewLifecycleOwner) {

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -216,16 +216,9 @@ class HomeFragment : Fragment() {
             homeViewModel
         )
 
-        // This has to be called separately from the consumeFrom block since the coroutine doesn't
-        // allow our UI to be updated right away and delays our start up. The init block allows us to
-        // force our UI to render with the data available in our store at fragment creation time.
-        sessionControlView?.update(homeFragmentStore.state)
+        updateSessionControlView(view)
 
         activity.themeManager.applyStatusBarTheme(activity)
-
-        view.consumeFrom(homeFragmentStore, viewLifecycleOwner) {
-            sessionControlView?.update(it)
-        }
 
         view.consumeFrom(requireComponents.core.store, viewLifecycleOwner) {
             val tabCount = if (currentMode.getCurrentMode() == Mode.Normal) {
@@ -238,6 +231,20 @@ class HomeFragment : Fragment() {
         }
 
         return view
+    }
+
+    /**
+     * The [SessionControlView] is forced to update with our current state when we call
+     * [HomeFragment.onCreateView] in order to be able to draw everything at once with the current
+     * data in our store. The [View.consumeFrom] coroutine dispatch
+     * doesn't get run right away which means that we won't draw on the first layout pass.
+     */
+    fun updateSessionControlView(view: View) {
+        sessionControlView?.update(homeFragmentStore.state)
+
+        view.consumeFrom(homeFragmentStore, viewLifecycleOwner) {
+            sessionControlView?.update(it)
+        }
     }
 
     private fun updateLayout(view: View) {

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlView.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlView.kt
@@ -4,7 +4,6 @@
 
 package org.mozilla.fenix.home.sessioncontrol
 
-import android.os.Build
 import android.view.View
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -142,13 +141,8 @@ class SessionControlView(
     }
 
     fun update(state: HomeFragmentState) {
-        // Workaround for list not updating until scroll on Android 5 + 6
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
-            sessionControlAdapter.submitList(null)
-        }
 
         val stateAdapterList = state.toAdapterList()
-
         if (homeScreenViewModel.shouldScrollToTopSites) {
             sessionControlAdapter.submitList(stateAdapterList) {
 


### PR DESCRIPTION
Took the timing for this fix on a g5+ 

With changes:
```
Fully drawn org.mozilla.fennec_aurora/org.mozilla.fenix.HomeActivity: +614ms (total +1s293ms)
Fully drawn org.mozilla.fennec_aurora/org.mozilla.fenix.HomeActivity: +622ms (total +1s304ms)
Fully drawn org.mozilla.fennec_aurora/org.mozilla.fenix.HomeActivity: +610ms (total +1s294ms)
Fully drawn org.mozilla.fennec_aurora/org.mozilla.fenix.HomeActivity: +597ms (total +1s257ms)
Fully drawn org.mozilla.fennec_aurora/org.mozilla.fenix.HomeActivity: +609ms (total +1s270ms)
```
and without the changes:
```
Fully drawn org.mozilla.fennec_aurora/org.mozilla.fenix.HomeActivity: +911ms (total +1s572ms)
Fully drawn org.mozilla.fennec_aurora/org.mozilla.fenix.HomeActivity: +930ms (total +1s558ms)
Fully drawn org.mozilla.fennec_aurora/org.mozilla.fenix.HomeActivity: +946ms (total +1s558ms)
Fully drawn org.mozilla.fennec_aurora/org.mozilla.fenix.HomeActivity: +793ms (total +1s428ms)
Fully drawn org.mozilla.fennec_aurora/org.mozilla.fenix.HomeActivity: +828ms (total +1s461ms)
```
I do see a net gain with these changes. It might be worthwhile to implement the same `prefetch` for collections since it uses the same `livedata` mechanism 😄 

FYI I also did a VIEW (the new app-link name) test with FNPRMS and my results are the same as they are currently (so ~2.9 seconds). This change shouldn't affect it.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture