### PR TITLE
For #8847: Add preference for dynamic toolbar to Customization menu

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -21,11 +21,6 @@ object FeatureFlags {
     const val asFeatureSyncDisabled = false
 
     /**
-     * Enables dynamic bottom toolbar
-     */
-    val dynamicBottomToolbar = Config.channel.isNightlyOrDebug
-
-    /**
      * Enables deleting individual tracking protection exceptions.
      */
     val deleteIndividualTrackingProtectionExceptions = Config.channel.isNightlyOrDebug

--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -505,7 +505,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Session
     }
 
     private fun initializeEngineView(toolbarHeight: Int) {
-        if (FeatureFlags.dynamicBottomToolbar) {
+        if (requireContext().settings().shouldUseDynamicToolbar) {
             engineView.setDynamicToolbarMaxHeight(toolbarHeight)
 
             val behavior = if (requireContext().settings().shouldUseBottomToolbar) {
@@ -515,10 +515,6 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Session
             }
 
             (swipeRefresh.layoutParams as CoordinatorLayout.LayoutParams).behavior = behavior
-        } else {
-            if (!requireContext().settings().shouldUseBottomToolbar) {
-                engineView.setDynamicToolbarMaxHeight(toolbarHeight)
-            }
         }
     }
 
@@ -838,7 +834,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Session
             activity?.enterToImmersiveMode()
             browserToolbarView.view.visibility = View.GONE
 
-            if (FeatureFlags.dynamicBottomToolbar) {
+            if (requireContext().settings().shouldUseDynamicToolbar) {
                 engineView.setDynamicToolbarMaxHeight(0)
                 browserToolbarView.expand()
                 // Without this, fullscreen has a margin at the top.
@@ -850,12 +846,12 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Session
                 activity.themeManager.applyStatusBarTheme(activity)
             }
             browserToolbarView.view.visibility = View.VISIBLE
-            if (FeatureFlags.dynamicBottomToolbar) {
+            if (requireContext().settings().shouldUseDynamicToolbar) {
                 val toolbarHeight = resources.getDimensionPixelSize(R.dimen.browser_toolbar_height)
                 engineView.setDynamicToolbarMaxHeight(toolbarHeight)
             }
         }
-        if (!FeatureFlags.dynamicBottomToolbar) {
+        if (!requireContext().settings().shouldUseDynamicToolbar) {
             updateLayoutMargins(inFullScreen)
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -135,7 +135,7 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
     }
 
     private fun updateEngineBottomMargin() {
-        if (!FeatureFlags.dynamicBottomToolbar) {
+        if (!requireContext().settings().shouldUseDynamicToolbar) {
             val browserEngine = swipeRefresh.layoutParams as CoordinatorLayout.LayoutParams
 
             browserEngine.bottomMargin = if (requireContext().settings().shouldUseBottomToolbar) {

--- a/app/src/main/java/org/mozilla/fenix/components/FenixSnackbar.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/FenixSnackbar.kt
@@ -119,6 +119,7 @@ class FenixSnackbar private constructor(
 
             val callback = FenixSnackbarCallback(content)
             val shouldUseBottomToolbar = view.context.settings().shouldUseBottomToolbar
+            val shouldUseDynamicToolbar = view.context.settings().shouldUseDynamicToolbar
             val toolbarHeight = view.context.resources
                 .getDimensionPixelSize(R.dimen.browser_toolbar_height)
 
@@ -137,7 +138,7 @@ class FenixSnackbar private constructor(
                         // can't intelligently position the snackbar on the upper most view.
                         // Ideally we should not pass ContentFrameLayout in, but it's the only
                         // way to display snackbars through a fragment transition.
-                        (!FeatureFlags.dynamicBottomToolbar || view is ContentFrameLayout)
+                        (!shouldUseDynamicToolbar || view is ContentFrameLayout)
                     ) {
                         toolbarHeight
                     } else {

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarView.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarView.kt
@@ -259,7 +259,7 @@ class BrowserToolbarView(
     }
 
     fun expand() {
-        if (settings.shouldUseBottomToolbar && FeatureFlags.dynamicBottomToolbar) {
+        if (settings.shouldUseBottomToolbar && settings.shouldUseDynamicToolbar) {
             (view.layoutParams as CoordinatorLayout.LayoutParams).apply {
                 (behavior as BrowserToolbarBottomBehavior).forceExpand(view)
             }
@@ -270,11 +270,13 @@ class BrowserToolbarView(
 
     /**
      * Dynamically sets scroll flags for the toolbar when the user does not have a screen reader enabled
-     * Note that the bottom toolbar has a feature flag for being dynamic, so it may not get flags set.
+     * and dynamic toolbar preference is set to true
+     * Note that the bottom toolbar may not get flags set.
      */
     fun setScrollFlags(shouldDisableScroll: Boolean = false) {
         if (view.context.settings().shouldUseBottomToolbar) {
-            if (FeatureFlags.dynamicBottomToolbar && view.layoutParams is CoordinatorLayout.LayoutParams) {
+            if (view.context.settings().shouldUseDynamicToolbar &&
+                view.layoutParams is CoordinatorLayout.LayoutParams) {
                 (view.layoutParams as CoordinatorLayout.LayoutParams).apply {
                     behavior = BrowserToolbarBottomBehavior(view.context, null)
                 }
@@ -285,7 +287,8 @@ class BrowserToolbarView(
 
         val params = view.layoutParams as AppBarLayout.LayoutParams
 
-        params.scrollFlags = when (view.context.settings().shouldUseFixedTopToolbar || shouldDisableScroll) {
+        params.scrollFlags = when (!view.context.settings().shouldUseDynamicToolbar ||
+                view.context.settings().shouldUseFixedTopToolbar || shouldDisableScroll) {
             true -> {
                 // Force expand the toolbar so the user is not stuck with a hidden toolbar
                 expand()

--- a/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabsIntegration.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabsIntegration.kt
@@ -34,7 +34,7 @@ class CustomTabsIntegration(
         // Remove toolbar shadow
         toolbar.elevation = 0f
 
-        if (!FeatureFlags.dynamicBottomToolbar) {
+        if (!activity.settings().shouldUseDynamicToolbar) {
             // Reduce margin height of EngineView from the top for the toolbar
             engineLayout.run {
                 (layoutParams as ViewGroup.MarginLayoutParams).apply {

--- a/app/src/main/java/org/mozilla/fenix/customtabs/ExternalAppBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/ExternalAppBrowserFragment.kt
@@ -106,7 +106,9 @@ class ExternalAppBrowserFragment : BaseBrowserFragment(), UserInteractionHandler
                         trustedScopes
                     ) { toolbarVisible ->
                         if (!toolbarVisible) { engineView.setDynamicToolbarMaxHeight(0) }
-                        if (!FeatureFlags.dynamicBottomToolbar) { updateLayoutMargins(inFullScreen = !toolbarVisible) }
+                        if (!activity.settings().shouldUseDynamicToolbar) {
+                            updateLayoutMargins(inFullScreen = !toolbarVisible)
+                        }
                     },
                     owner = this,
                     view = toolbar

--- a/app/src/main/java/org/mozilla/fenix/settings/CustomizationFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/CustomizationFragment.kt
@@ -9,6 +9,7 @@ import android.os.Build
 import android.os.Build.VERSION.SDK_INT
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatDelegate
+import androidx.preference.CheckBoxPreference
 import androidx.preference.PreferenceFragmentCompat
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.metrics.Event
@@ -136,8 +137,14 @@ class CustomizationFragment : PreferenceFragmentCompat() {
             ))
         }
 
+        val keyToolbarDynamic = getPreferenceKey(R.string.pref_key_toolbar_dynamic)
+        val dynamicPreference = requireNotNull(findPreference<CheckBoxPreference>(keyToolbarDynamic))
+        dynamicPreference.onPreferenceChangeListener = SharedPreferenceUpdater()
+
+
         topPreference.setCheckedWithoutClickListener(!requireContext().settings().shouldUseBottomToolbar)
         bottomPreference.setCheckedWithoutClickListener(requireContext().settings().shouldUseBottomToolbar)
+        dynamicPreference.isChecked = requireContext().settings().shouldUseDynamicToolbar
 
         topPreference.addToRadioGroup(bottomPreference)
         bottomPreference.addToRadioGroup(topPreference)

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -348,6 +348,11 @@ class Settings private constructor(
         default = !touchExplorationIsEnabled && !switchServiceIsEnabled
     )
 
+    var shouldUseDynamicToolbar by booleanPreference(
+        appContext.getPreferenceKey(R.string.pref_key_toolbar_dynamic),
+        default = true
+    )
+
     /**
      * Check each active accessibility service to see if it can perform gestures, if any can,
      * then it is *likely* a switch service is enabled. We are assuming this to be the case based on #7486

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -105,6 +105,7 @@
     <!-- Toolbar Settings -->
     <string name="pref_key_toolbar_top" translatable="false">pref_key_toolbar_top</string>
     <string name="pref_key_toolbar_bottom" translatable="false">pref_key_toolbar_bottom</string>
+    <string name="pref_key_toolbar_dynamic" translatable="false">pref_key_toolbar_dynamic</string>
 
     <!-- Theme Settings -->
     <string name="pref_key_light_theme" translatable="false">pref_key_light_theme</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -374,6 +374,8 @@
     <string name="preference_top_toolbar">Top</string>
     <!-- Preference for using bottom toolbar -->
     <string name="preference_bottom_toolbar">Bottom</string>
+    <!-- Preference for using dynamic toolbar -->
+    <string name="preference_dynamic_toolbar">Dynamic</string>
 
     <!-- Theme Preferences -->
     <!-- Preference for using light theme -->

--- a/app/src/main/res/xml/customization_preferences.xml
+++ b/app/src/main/res/xml/customization_preferences.xml
@@ -43,5 +43,11 @@
         <org.mozilla.fenix.settings.RadioButtonPreference
             android:key="@string/pref_key_toolbar_bottom"
             android:title="@string/preference_bottom_toolbar" />
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:key="@string/pref_key_toolbar_dynamic"
+            android:title="@string/preference_dynamic_toolbar"
+            android:layout="@layout/checkbox_left_preference"
+            app:iconSpaceReserved="false" />
     </androidx.preference.PreferenceCategory>
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
Added new preference key and string value for dynamic toolbar. The new preference is now used instead of feature flag for dynamic bottom toolbar. This preference can be changed in settings, customization menu with CheckBox, which I've also added. 

When toolbar was on top, it checked if user has screen reader enabled to determine if it should not be dynamic. I left it as it was, because I'm not sure, how it should be. So if user has a dynamic top toolbar enabled, it still won't be dynamic if the screen reader is also enabled. If dynamic toolbar is enabled at the bottom, it will be dynamic regardless of screen reader.

Here's the GIF of how toolbar is behaving with different settings:
![Screen-Recording-20200615-231412](https://user-images.githubusercontent.com/34208167/84885851-ce9e2680-b0bd-11ea-9ecf-1a9703e39fc4.gif)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not


- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
