### PR TITLE
For #8114: Restore normal UI when a library fragment is detached.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/LibraryPageFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/LibraryPageFragment.kt
@@ -4,11 +4,15 @@
 
 package org.mozilla.fenix.library
 
+import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.Fragment
+import mozilla.components.support.ktx.android.content.getColorFromAttr
 import org.mozilla.fenix.HomeActivity
+import org.mozilla.fenix.R
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.hideToolbar
+import org.mozilla.fenix.ext.setToolbarColors
 
 abstract class LibraryPageFragment<T> : Fragment() {
 
@@ -26,5 +30,15 @@ abstract class LibraryPageFragment<T> : Fragment() {
 
         (activity as HomeActivity).browsingModeManager.mode = BrowsingMode.fromBoolean(private)
         hideToolbar()
+    }
+
+    override fun onDetach() {
+        super.onDetach()
+        context?.let {
+            activity?.findViewById<Toolbar>(R.id.navigationToolbar)?.setToolbarColors(
+                it.getColorFromAttr(R.attr.primaryText),
+                it.getColorFromAttr(R.attr.foundation)
+            )
+        }
     }
 }


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture