### PR TITLE
For #10642: Comment out verifyPageContent calls

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
@@ -233,7 +233,7 @@ class BookmarksTest {
             IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
         }.openThreeDotMenu(defaultWebPage.url) {
         }.clickOpenInNewTab {
-            verifyPageContent(defaultWebPage.content)
+            // verifyPageContent(defaultWebPage.content)
         }.openTabDrawer {
             verifyNormalModeSelected()
         }
@@ -252,7 +252,7 @@ class BookmarksTest {
             IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
         }.openThreeDotMenu(defaultWebPage.url) {
         }.clickOpenInPrivateTab {
-            verifyPageContent(defaultWebPage.content)
+            // verifyPageContent(defaultWebPage.content)
         }.openTabDrawer {
             verifyPrivateModeSelected()
         }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/ContextMenusTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/ContextMenusTest.kt
@@ -62,7 +62,7 @@ class ContextMenusTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(pageLinks.url) {
-            verifyPageContent(pageLinks.content)
+            // verifyPageContent(pageLinks.content)
             longClickMatchingText("Link 1")
             verifyLinkContextMenuItems(genericURL.url)
             clickContextOpenLinkInNewTab()
@@ -85,7 +85,7 @@ class ContextMenusTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(pageLinks.url) {
-            verifyPageContent(pageLinks.content)
+            // verifyPageContent(pageLinks.content)
             longClickMatchingText("Link 2")
             verifyLinkContextMenuItems(genericURL.url)
             clickContextOpenLinkInPrivateTab()
@@ -108,7 +108,7 @@ class ContextMenusTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(pageLinks.url) {
-            verifyPageContent(pageLinks.content)
+            // verifyPageContent(pageLinks.content)
             longClickMatchingText("Link 3")
             verifyLinkContextMenuItems(genericURL.url)
             clickContextCopyLink()
@@ -129,7 +129,7 @@ class ContextMenusTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(pageLinks.url) {
-            verifyPageContent(pageLinks.content)
+            // verifyPageContent(pageLinks.content)
             longClickMatchingText("Link 1")
             verifyLinkContextMenuItems(genericURL.url)
             clickContextShareLink(genericURL.url) // verify share intent is matched with associated URL
@@ -146,7 +146,7 @@ class ContextMenusTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(pageLinks.url) {
-            verifyPageContent(pageLinks.content)
+            // verifyPageContent(pageLinks.content)
             longClickMatchingText("test_link_image")
             verifyLinkImageContextMenuItems(imageResource.url)
             clickContextOpenImageNewTab()
@@ -166,7 +166,7 @@ class ContextMenusTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(pageLinks.url) {
-            verifyPageContent(pageLinks.content)
+            // verifyPageContent(pageLinks.content)
             longClickMatchingText("test_link_image")
             verifyLinkImageContextMenuItems(imageResource.url)
             clickContextCopyImageLocation()
@@ -187,7 +187,7 @@ class ContextMenusTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(pageLinks.url) {
-            verifyPageContent(pageLinks.content)
+            // verifyPageContent(pageLinks.content)
             longClickMatchingText("test_link_image")
             verifyLinkImageContextMenuItems(imageResource.url)
             clickContextSaveImage()
@@ -214,7 +214,7 @@ class ContextMenusTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(pageLinks.url) {
-            verifyPageContent(pageLinks.content)
+            // verifyPageContent(pageLinks.content)
             longClickMatchingText("Link 1")
             verifyLinkContextMenuItems(genericURL.url)
             mDevice.pressBack()

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/DownloadTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/DownloadTest.kt
@@ -81,7 +81,7 @@ class DownloadTest {
 
         navigationToolbar {
         }.openNewTabAndEnterToBrowser(defaultWebPage.url) {
-            verifyPageContent(defaultWebPage.content)
+            // verifyPageContent(defaultWebPage.content)
             clickLinkMatchingText(defaultWebPage.content)
         }
 
@@ -99,7 +99,7 @@ class DownloadTest {
 
         navigationToolbar {
         }.openNewTabAndEnterToBrowser(defaultWebPage.url) {
-            verifyPageContent(defaultWebPage.content)
+            // verifyPageContent(defaultWebPage.content)
             clickLinkMatchingText(defaultWebPage.content)
         }
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/HistoryTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/HistoryTest.kt
@@ -71,7 +71,7 @@ class HistoryTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(firstWebPage.url) {
-            verifyPageContent("Page content: 1")
+            // verifyPageContent("Page content: 1")
         }.openThreeDotMenu {
         }.openHistory {
             verifyHistoryMenuView()
@@ -87,7 +87,7 @@ class HistoryTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(firstWebPage.url) {
-            verifyPageContent("Page content: 1")
+            // verifyPageContent("Page content: 1")
         }.openThreeDotMenu {
         }.openHistory {
         }.openThreeDotMenu {
@@ -102,7 +102,7 @@ class HistoryTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(firstWebPage.url) {
-            verifyPageContent("Page content: 1")
+            // verifyPageContent("Page content: 1")
         }.openThreeDotMenu {
         }.openHistory {
         }.openThreeDotMenu {
@@ -120,12 +120,12 @@ class HistoryTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(firstWebPage.url) {
-            verifyPageContent("Page content: 1")
+            // verifyPageContent("Page content: 1")
         }.openThreeDotMenu {
         }.openHistory {
         }.openThreeDotMenu {
         }.clickOpenInNormalTab {
-            verifyPageContent(firstWebPage.content)
+            // verifyPageContent(firstWebPage.content)
         }.openTabDrawer {
             verifyNormalModeSelected()
         }
@@ -137,12 +137,12 @@ class HistoryTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(firstWebPage.url) {
-            verifyPageContent("Page content: 1")
+            // verifyPageContent("Page content: 1")
         }.openThreeDotMenu {
         }.openHistory {
         }.openThreeDotMenu {
         }.clickOpenInPrivateTab {
-            verifyPageContent(firstWebPage.content)
+            // verifyPageContent(firstWebPage.content)
         }.openTabDrawer {
             verifyPrivateModeSelected()
         }
@@ -154,7 +154,7 @@ class HistoryTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(firstWebPage.url) {
-            verifyPageContent("Page content: 1")
+            // verifyPageContent("Page content: 1")
         }.openThreeDotMenu {
         }.openHistory {
         }.openThreeDotMenu {
@@ -170,7 +170,7 @@ class HistoryTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(firstWebPage.url) {
-            verifyPageContent("Page content: 1")
+            // verifyPageContent("Page content: 1")
         }.openThreeDotMenu {
         }.openHistory {
             clickDeleteHistoryButton()
@@ -187,7 +187,7 @@ class HistoryTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(firstWebPage.url) {
-            verifyPageContent("Page content: 1")
+            // verifyPageContent("Page content: 1")
         }.openThreeDotMenu {
         }.openHistory {
             longTapSelectItem(firstWebPage.url)
@@ -209,7 +209,7 @@ class HistoryTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(firstWebPage.url) {
-            verifyPageContent("Page content: 1")
+            // verifyPageContent("Page content: 1")
         }.openTabDrawer {
             closeTab()
         }.openHomeScreen { }.openThreeDotMenu {
@@ -232,7 +232,7 @@ class HistoryTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(firstWebPage.url) {
-            verifyPageContent("Page content: 1")
+            // verifyPageContent("Page content: 1")
         }.openThreeDotMenu {
         }.openHistory {
             longTapSelectItem(firstWebPage.url)
@@ -254,12 +254,12 @@ class HistoryTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(firstWebPage.url) {
-            verifyPageContent("Page content: 1")
+            // verifyPageContent("Page content: 1")
         }.openTabDrawer { }.openHomeScreen { }
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(secondWebPage.url) {
-            verifyPageContent("Page content: 2")
+            // verifyPageContent("Page content: 2")
         }.openThreeDotMenu {
         }.openHistory {
             longTapSelectItem(firstWebPage.url)
@@ -282,7 +282,7 @@ class HistoryTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(firstWebPage.url) {
-            verifyPageContent("Page content: 1")
+            // verifyPageContent("Page content: 1")
         }.openThreeDotMenu {
         }.openHistory {
             longTapSelectItem(firstWebPage.url)

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/MediaNotificationTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/MediaNotificationTest.kt
@@ -58,10 +58,10 @@ class MediaNotificationTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(videoTestPage.url) {
-            verifyPageContent(videoTestPage.content)
+            // verifyPageContent(videoTestPage.content)
             clickMediaPlayerPlayButton()
             waitForPlaybackToStart()
-            verifyPageContent("Media file is playing")
+            // verifyPageContent("Media file is playing")
         }.openNotificationShade {
             verifySystemNotificationExists(videoTestPage.title)
             clickMediaSystemNotificationControlButton("Pause")
@@ -92,7 +92,7 @@ class MediaNotificationTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(audioTestPage.url) {
-            verifyPageContent(audioTestPage.content)
+            // verifyPageContent(audioTestPage.content)
             clickMediaPlayerPlayButton()
             waitForPlaybackToStart()
         }.openNotificationShade {
@@ -125,10 +125,10 @@ class MediaNotificationTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(audioTestPage.url) {
-            verifyPageContent(audioTestPage.content)
+            // verifyPageContent(audioTestPage.content)
             clickMediaPlayerPlayButton()
             waitForPlaybackToStart()
-            verifyPageContent("Media file is playing")
+            // verifyPageContent("Media file is playing")
         }.openTabDrawer {
             verifyTabMediaControlButtonState("Pause")
             clickTabMediaControlButton()
@@ -146,10 +146,10 @@ class MediaNotificationTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(audioTestPage.url) {
-            verifyPageContent(audioTestPage.content)
+            // verifyPageContent(audioTestPage.content)
             clickMediaPlayerPlayButton()
             waitForPlaybackToStart()
-            verifyPageContent("Media file is playing")
+            // verifyPageContent("Media file is playing")
         }.openNotificationShade {
             verifySystemNotificationExists("A site is playing media")
             clickMediaSystemNotificationControlButton("Pause")

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/NavigationToolbarTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/NavigationToolbarTest.kt
@@ -55,10 +55,10 @@ class NavigationToolbarTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(defaultWebPage.url) {
-            verifyPageContent(defaultWebPage.content)
+            // verifyPageContent(defaultWebPage.content)
         }.openNavigationToolbar {
         }.enterURLAndEnterToBrowser(nextWebPage.url) {
-            verifyPageContent(nextWebPage.content)
+            // verifyPageContent(nextWebPage.content)
         }
 
         // Re-open the three-dot menu for verification
@@ -66,7 +66,7 @@ class NavigationToolbarTest {
         }.openThreeDotMenu {
             verifyThreeDotMenuExists()
         }.goBack {
-            verifyPageContent(defaultWebPage.content)
+            // verifyPageContent(defaultWebPage.content)
         }
     }
 
@@ -77,12 +77,12 @@ class NavigationToolbarTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(defaultWebPage.url) {
-            verifyPageContent(defaultWebPage.content)
+            // verifyPageContent(defaultWebPage.content)
         }.openNavigationToolbar {
         }.enterURLAndEnterToBrowser(nextWebPage.url) {
-            verifyPageContent(nextWebPage.content)
+            // verifyPageContent(nextWebPage.content)
             mDevice.pressBack()
-            verifyPageContent(defaultWebPage.content)
+            // verifyPageContent(defaultWebPage.content)
         }
 
         // Re-open the three-dot menu for verification
@@ -91,7 +91,7 @@ class NavigationToolbarTest {
             verifyThreeDotMenuExists()
             verifyForwardButton()
         }.goForward {
-            verifyPageContent(nextWebPage.content)
+            // verifyPageContent(nextWebPage.content)
         }
     }
 
@@ -102,7 +102,7 @@ class NavigationToolbarTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(refreshWebPage.url) {
-            verifyPageContent("DEFAULT")
+            // verifyPageContent("DEFAULT")
         }
 
         // Use refresh from the three-dot menu
@@ -111,7 +111,7 @@ class NavigationToolbarTest {
             verifyThreeDotMenuExists()
             verifyRefreshButton()
         }.refreshPage {
-            verifyPageContent("REFRESHED")
+            // verifyPageContent("REFRESHED")
         }
     }
 
@@ -121,7 +121,7 @@ class NavigationToolbarTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(defaultWebPage.url) {
-            verifyPageContent(defaultWebPage.content)
+            // verifyPageContent(defaultWebPage.content)
         }
     }
 
@@ -132,7 +132,7 @@ class NavigationToolbarTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(loremIpsumWebPage.url) {
-            verifyPageContent(loremIpsumWebPage.content)
+            // verifyPageContent(loremIpsumWebPage.content)
         }
 
         navigationToolbar {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/ReaderViewTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/ReaderViewTest.kt
@@ -70,7 +70,7 @@ class ReaderViewTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(readerViewPage.url) {
-            verifyPageContent(readerViewPage.content)
+            // verifyPageContent(readerViewPage.content)
         }
 
         IdlingRegistry.getInstance().register(readerViewNotificationDot)
@@ -99,7 +99,7 @@ class ReaderViewTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(genericPage.url) {
-            verifyPageContent(genericPage.content)
+            // verifyPageContent(genericPage.content)
         }
 
         readerViewRobot {
@@ -120,7 +120,7 @@ class ReaderViewTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(readerViewPage.url) {
-            verifyPageContent(readerViewPage.content)
+            // verifyPageContent(readerViewPage.content)
         }
 
         IdlingRegistry.getInstance().register(readerViewNotificationDot)
@@ -152,7 +152,7 @@ class ReaderViewTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(readerViewPage.url) {
-            verifyPageContent(readerViewPage.content)
+            // verifyPageContent(readerViewPage.content)
         }
 
         IdlingRegistry.getInstance().register(readerViewNotificationDot)
@@ -187,7 +187,7 @@ class ReaderViewTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(readerViewPage.url) {
-            verifyPageContent(readerViewPage.content)
+            // verifyPageContent(readerViewPage.content)
         }
 
         IdlingRegistry.getInstance().register(readerViewNotificationDot)
@@ -222,7 +222,7 @@ class ReaderViewTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(readerViewPage.url) {
-            verifyPageContent(readerViewPage.content)
+            // verifyPageContent(readerViewPage.content)
         }
 
         IdlingRegistry.getInstance().register(readerViewNotificationDot)
@@ -263,7 +263,7 @@ class ReaderViewTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(readerViewPage.url) {
-            verifyPageContent(readerViewPage.content)
+            // verifyPageContent(readerViewPage.content)
         }
 
         IdlingRegistry.getInstance().register(readerViewNotificationDot)

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsBasicsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsBasicsTest.kt
@@ -134,21 +134,21 @@ class SettingsBasicsTest {
         homeScreen {
         }.openNavigationToolbar {
         }.enterURLAndEnterToBrowser(page1.url) {
-            verifyPageContent(page1.content)
+            // verifyPageContent(page1.content)
         }.openThreeDotMenu {
             clickAddBookmarkButton()
         }
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(page2.url) {
-            verifyPageContent(page2.content)
+            // verifyPageContent(page2.content)
         }.openThreeDotMenu {
             clickAddBookmarkButton()
         }
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(page3.url) {
-            verifyPageContent(page3.content)
+            // verifyPageContent(page3.content)
         }
 
         navigationToolbar {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/ShareButtonTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/ShareButtonTest.kt
@@ -50,7 +50,7 @@ class ShareButtonTest {
         //  - Visit a URL, wait until it's loaded
         navigationToolbar {
         }.enterURLAndEnterToBrowser(defaultWebPage.url) {
-            verifyPageContent(defaultWebPage.content)
+            // verifyPageContent(defaultWebPage.content)
         }
 
         // From the 3-dot menu next to the Select share menu

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -51,7 +51,7 @@ class SmokeTest {
         homeScreen {
             navigationToolbar {
             }.enterURLAndEnterToBrowser(defaultWebPage.url) {
-                verifyPageContent(defaultWebPage.content)
+                // verifyPageContent(defaultWebPage.content)
                 verifyNavURLBarItems()
             }.openNavigationToolbar {
             }.goBackToWebsite {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
@@ -65,7 +65,7 @@ class TabbedBrowsingTest {
 
         navigationToolbar {
         }.openNewTabAndEnterToBrowser(defaultWebPage.url) {
-            verifyPageContent(defaultWebPage.content)
+            // verifyPageContent(defaultWebPage.content)
             verifyTabCounter("1")
         }.openTabDrawer {
             verifyExistingTabList()
@@ -92,7 +92,7 @@ class TabbedBrowsingTest {
 
         navigationToolbar {
         }.openNewTabAndEnterToBrowser(defaultWebPage.url) {
-            verifyPageContent(defaultWebPage.content)
+            // verifyPageContent(defaultWebPage.content)
             verifyTabCounter("1")
         }.openTabDrawer {
             verifyExistingTabList()
@@ -110,7 +110,7 @@ class TabbedBrowsingTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(defaultWebPage.url) {
-            verifyPageContent(defaultWebPage.content)
+            // verifyPageContent(defaultWebPage.content)
         }.openTabDrawer {
             verifyExistingTabList()
         }.openTabsListThreeDotMenu {
@@ -128,7 +128,7 @@ class TabbedBrowsingTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(defaultWebPage.url) {
-            verifyPageContent(defaultWebPage.content)
+            // verifyPageContent(defaultWebPage.content)
         }.openTabDrawer {
             verifyPrivateModeSelected()
             verifyExistingTabList()
@@ -149,7 +149,7 @@ class TabbedBrowsingTest {
         genericURLS.forEachIndexed { index, element ->
             navigationToolbar {
             }.openNewTabAndEnterToBrowser(element.url) {
-                verifyPageContent(element.content)
+                // verifyPageContent(element.content)
             }.openTabDrawer {
                 verifyExistingOpenTabs("Test_Page_${index + 1}")
                 verifyCloseTabsButton("Test_Page_${index + 1}")
@@ -182,7 +182,7 @@ class TabbedBrowsingTest {
         genericURLS.forEachIndexed { index, element ->
             navigationToolbar {
             }.openNewTabAndEnterToBrowser(element.url) {
-                verifyPageContent(element.content)
+                // verifyPageContent(element.content)
             }.openTabDrawer {
                 verifyExistingOpenTabs("Test_Page_${index + 1}")
                 verifyCloseTabsButton("Test_Page_${index + 1}")

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/TopSitesTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/TopSitesTest.kt
@@ -53,7 +53,7 @@ class TopSitesTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(defaultWebPage.url) {
-            verifyPageContent(defaultWebPage.content)
+            // verifyPageContent(defaultWebPage.content)
         }.openThreeDotMenu {
             verifyAddFirefoxHome()
         }.addToFirefoxHome {
@@ -72,7 +72,7 @@ class TopSitesTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(defaultWebPage.url) {
-            verifyPageContent(defaultWebPage.content)
+            // verifyPageContent(defaultWebPage.content)
         }.openThreeDotMenu {
             verifyAddFirefoxHome()
         }.addToFirefoxHome {
@@ -82,7 +82,7 @@ class TopSitesTest {
             verifyExistingTopSitesList()
             verifyExistingTopSitesTabs(defaultWebPageTitle)
         }.openTopSiteTabWithTitle(title = defaultWebPageTitle) {
-            verifyPageContent(defaultWebPage.content)
+            // verifyPageContent(defaultWebPage.content)
             verifyUrl(defaultWebPage.url.toString().replace("http://", ""))
         }.openTabDrawer {
         }.openHomeScreen {
@@ -103,7 +103,7 @@ class TopSitesTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(defaultWebPage.url) {
-            verifyPageContent(defaultWebPage.content)
+            // verifyPageContent(defaultWebPage.content)
         }.openThreeDotMenu {
             verifyAddFirefoxHome()
         }.addToFirefoxHome {
@@ -126,7 +126,7 @@ class TopSitesTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(defaultWebPage.url) {
-            verifyPageContent(defaultWebPage.content)
+            // verifyPageContent(defaultWebPage.content)
         }.openThreeDotMenu {
             verifyAddFirefoxHome()
         }.addToFirefoxHome {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -78,11 +78,14 @@ class BrowserRobot {
 
     /* Asserts that the text within DOM element with ID="testContent" has the given text, i.e.
     *  document.querySelector('#testContent').innerText == expectedText
+    *
+    *  This function is not working at intended and needs a replacement.
     */
-    fun verifyPageContent(expectedText: String) {
-        val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-        mDevice.waitNotNull(Until.findObject(By.textContains(expectedText)), waitingTime)
-    }
+
+    /* fun verifyPageContent(expectedText: String) {
+        // val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+        // mDevice.waitNotNull(Until.findObject(By.textContains(expectedText)), waitingTime)
+    }*/
 
     fun verifyTabCounter(expectedText: String) {
         onView(withId(R.id.counter_text))


### PR DESCRIPTION
Issue #10642 (verifyPageContent) is very flaky and causing test timeouts in test-failures. I wouldn't be surprised if the MockWebServer version we're using from 2018 is part of the problem, for now comment out each ``verifyPageContent`` call and the function. Retaining its definition so we can still investigate on the side.