### PR TITLE
No issue: re-enables tests ignoring the verifyPageContent step

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/HistoryTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/HistoryTest.kt
@@ -11,7 +11,6 @@ import mozilla.components.browser.storage.sync.PlacesHistoryStorage
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
@@ -223,7 +222,6 @@ class HistoryTest {
         }
     }
 
-    @Ignore("Intermittent failures: https://github.com/mozilla-mobile/fenix/issues/10642")
     @Test
     fun openHistoryInPrivateTabTest() {
         val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
@@ -244,7 +242,6 @@ class HistoryTest {
         }
     }
 
-    @Ignore("Intermittent failures: https://github.com/mozilla-mobile/fenix/issues/10642")
     @Test
     fun deleteMultipleSelectionTest() {
         val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/NavigationToolbarTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/NavigationToolbarTest.kt
@@ -95,7 +95,6 @@ class NavigationToolbarTest {
         }
     }
 
-    @Ignore("Intermittent failures: https://github.com/mozilla-mobile/fenix/issues/10642")
     @Test
     fun refreshPageTest() {
         val refreshWebPage = TestAssetHelper.getRefreshAsset(mockWebServer)

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
@@ -56,7 +56,6 @@ class TabbedBrowsingTest {
         mockWebServer.shutdown()
     }
 
-    @Ignore("Intermittent failures: https://github.com/mozilla-mobile/fenix/issues/10642")
     @Test
     fun openNewTabTest() {
         homeScreen { }.dismissOnboarding()
@@ -76,7 +75,6 @@ class TabbedBrowsingTest {
         }
     }
 
-    @Ignore("Intermittent failures: https://github.com/mozilla-mobile/fenix/issues/10642")
     @Test
     fun openNewPrivateTabTest() {
         homeScreen { }.dismissOnboarding()


### PR DESCRIPTION
Now that the method which was causing the tests to fail is no longer used, we can re-enable these tests which I disabled a day ago.
I've run the tests on Firebase 30 times and so far they seem stable.
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture