### PR TITLE
For 11616: removed black flicker with placeholder animation

### DIFF
--- a/app/src/main/res/anim/placeholder_animation.xml
+++ b/app/src/main/res/anim/placeholder_animation.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<translate
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:fromXDelta="0"
+    android:toXDelta="0"
+    android:duration="900" />

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -20,6 +20,7 @@
         <item name="alertDialogStyle">@style/DialogStyleNormal</item>
         <item name="alertDialogTheme">@style/DialogStyleNormal</item>
         <item name="android:windowEnableSplitTouch">false</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:splitMotionEvents">false</item>
 
         <item name="mozacInputLayoutErrorTextColor"

--- a/app/src/migration/java/org/mozilla/fenix/MigrationDecisionActivity.kt
+++ b/app/src/migration/java/org/mozilla/fenix/MigrationDecisionActivity.kt
@@ -39,6 +39,6 @@ class MigrationDecisionActivity : Activity() {
         // and then we switch to the actual activity without an animation. This visually looks like
         // a faster start than launching this activity invisibly and switching to the actual
         // activity after that.
-        overridePendingTransition(0, 0)
+        overridePendingTransition(0, R.anim.placeholder_animation)
     }
 }


### PR DESCRIPTION
Video with the changes: https://streamable.com/zk47js (no flicker)
Video without the changes (with black screen flicker): https://streamable.com/1qqee7

I think this is a better option than changing the `MigrationDecisionActivity` to inherit `HomeActivity`, especially right before release.  I'm not sure how adding the animation would affect newer devices though. It seemed fine on my Pixel 4 though.

Thoughts? 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture