### PR TITLE
For issue #10727 - Hide saved logins details

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -196,8 +196,6 @@ open class HomeActivity : LocaleAwareAppCompatActivity() {
     final override fun onPause() {
         if (settings().lastKnownMode.isPrivate) {
             window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
-        } else {
-            window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
         }
         super.onPause()
 

--- a/app/src/main/java/org/mozilla/fenix/ext/Fragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/Fragment.kt
@@ -57,14 +57,12 @@ fun Fragment.hideToolbar() {
 /**
  * Pops the backstack to force users to re-auth if they put the app in the background and return to it
  * while being inside the saved logins flow
- * It also updates the FLAG_SECURE status for the activity's window
  *
  * Does nothing if the user is currently navigating to any of the [destinations] given as a parameter
  *
  */
 fun Fragment.redirectToReAuth(destinations: List<Int>, currentDestination: Int?) {
     if (currentDestination !in destinations) {
-        activity?.let { it.checkAndUpdateScreenshotPermission(it.settings()) }
         findNavController().popBackStack(R.id.savedLoginsAuthFragment, false)
     }
 }


### PR DESCRIPTION
Removed the clearFlags call from the HomeActivity that was causing this issue and removed the now redundant call to update the flag from the redirectToReAuth method



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture