### PR TITLE
Bug 1644331 - Disable conditioned profiles on Raptor YTP tests.

### DIFF
--- a/taskcluster/ci/raptor/kind.yml
+++ b/taskcluster/ci/raptor/kind.yml
@@ -80,6 +80,7 @@ job-defaults:
             - '--binary=org.mozilla.fenix.nightly'
             - '--activity=org.mozilla.fenix.IntentReceiverActivity'
             - '--download-symbols=ondemand'
+            - '--no-conditioned-profile'
     fetches:
         toolchain:
             - linux64-minidump-stackwalk


### PR DESCRIPTION
This patch disables conditioned profiles for the Raptor YTP tests. Pending try test run: https://treeherder.mozilla.org/#/jobs?repo=try&revision=176c47c93f6c582fbabc65261b90cb48bdc16cdd