### PR TITLE
Followup for #11442 - Add tab counter menu metrics to home fragment.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -84,10 +84,10 @@ import org.mozilla.fenix.ext.hideToolbar
 import org.mozilla.fenix.ext.metrics
 import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.requireComponents
+import org.mozilla.fenix.ext.resetPoliciesAfter
 import org.mozilla.fenix.ext.sessionsOfType
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.toTab
-import org.mozilla.fenix.ext.resetPoliciesAfter
 import org.mozilla.fenix.home.sessioncontrol.DefaultSessionControlController
 import org.mozilla.fenix.home.sessioncontrol.SessionControlInteractor
 import org.mozilla.fenix.home.sessioncontrol.SessionControlView
@@ -617,11 +617,13 @@ class HomeFragment : Fragment() {
         val isPrivate = (activity as HomeActivity).browsingModeManager.mode == BrowsingMode.Private
         val menuItems = listOf(
             BrowserMenuImageText(
-                label = context.getString(if (isPrivate) {
-                    R.string.browser_menu_new_tab
-                } else {
-                    R.string.home_screen_shortcut_open_new_private_tab_2
-                }),
+                label = context.getString(
+                    if (isPrivate) {
+                        R.string.browser_menu_new_tab
+                    } else {
+                        R.string.home_screen_shortcut_open_new_private_tab_2
+                    }
+                ),
                 imageResource = if (isPrivate) {
                     R.drawable.ic_new
                 } else {
@@ -630,6 +632,15 @@ class HomeFragment : Fragment() {
                 iconTintColorResource = primaryTextColor,
                 textColorResource = primaryTextColor
             ) {
+                requireComponents.analytics.metrics.track(
+                    Event.TabCounterMenuItemTapped(
+                        if (isPrivate) {
+                            Event.TabCounterMenuItemTapped.Item.NEW_TAB
+                        } else {
+                            Event.TabCounterMenuItemTapped.Item.NEW_PRIVATE_TAB
+                        }
+                    )
+                )
                 (activity as HomeActivity).browsingModeManager.mode =
                     BrowsingMode.fromBoolean(!isPrivate)
             }


### PR DESCRIPTION
Fixes #11442 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture