### PR TITLE
For #11534 - Don't check lastUsed mode for screenshots

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -484,6 +484,7 @@ dependencies {
     implementation Deps.mozilla_feature_media
     implementation Deps.mozilla_feature_prompts
     implementation Deps.mozilla_feature_push
+    implementation Deps.mozilla_feature_privatemode
     implementation Deps.mozilla_feature_pwa
     implementation Deps.mozilla_feature_qr
     implementation Deps.mozilla_feature_search

--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -58,7 +58,6 @@ import org.mozilla.fenix.components.metrics.BreadcrumbsRecorder
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.exceptions.ExceptionsFragmentDirections
 import org.mozilla.fenix.ext.alreadyOnDestination
-import org.mozilla.fenix.ext.checkAndUpdateScreenshotPermission
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.settings
@@ -140,7 +139,6 @@ open class HomeActivity : LocaleAwareAppCompatActivity() {
         components.publicSuffixList.prefetch()
 
         setupThemeAndBrowsingMode(getModeFromIntentOrLastKnown(intent))
-        checkAndUpdateScreenshotPermission(settings())
         setContentView(R.layout.activity_home)
 
         // Must be after we set the content view
@@ -182,7 +180,6 @@ open class HomeActivity : LocaleAwareAppCompatActivity() {
 
     @CallSuper
     override fun onResume() {
-        checkAndUpdateScreenshotPermission(settings())
         super.onResume()
 
         components.backgroundServices.accountManagerAvailableQueue.runIfReadyOrQueue {

--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -23,6 +23,7 @@ import androidx.navigation.fragment.findNavController
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.android.synthetic.main.fragment_browser.*
 import kotlinx.android.synthetic.main.fragment_browser.view.*
+import kotlinx.android.synthetic.main.fragment_installed_add_on_details.*
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.Dispatchers.Main
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -52,6 +53,7 @@ import mozilla.components.feature.downloads.DownloadsFeature
 import mozilla.components.feature.downloads.manager.FetchDownloadManager
 import mozilla.components.feature.intent.ext.EXTRA_SESSION_ID
 import mozilla.components.feature.media.fullscreen.MediaFullscreenOrientationFeature
+import mozilla.components.feature.privatemode.feature.SecureWindowFeature
 import mozilla.components.feature.prompts.PromptFeature
 import mozilla.components.feature.prompts.share.ShareDelegate
 import mozilla.components.feature.readerview.ReaderViewFeature
@@ -144,6 +146,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Session
     private val swipeRefreshFeature = ViewBoundFeatureWrapper<SwipeRefreshFeature>()
     private val webchannelIntegration = ViewBoundFeatureWrapper<FxaWebChannelFeature>()
     private val sitePermissionWifiIntegration = ViewBoundFeatureWrapper<SitePermissionsWifiIntegration>()
+    private val secureWindowFeature = ViewBoundFeatureWrapper<SecureWindowFeature>()
     private var fullScreenMediaFeature = ViewBoundFeatureWrapper<MediaFullscreenOrientationFeature>()
     private var pipFeature: PictureInPictureFeature? = null
 
@@ -308,6 +311,18 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Session
                     engineView = view.engineView,
                     useCases = context.components.useCases.contextMenuUseCases,
                     tabId = customTabSessionId
+                ),
+                owner = this,
+                view = view
+            )
+
+            val allowScreenshotsInPrivateMode = context.settings().allowScreenshotsInPrivateMode
+            secureWindowFeature.set(
+                feature = SecureWindowFeature(
+                    window = requireActivity().window,
+                    store = store,
+                    customTabId = customTabSessionId,
+                    isSecure = { !allowScreenshotsInPrivateMode && it.content.private }
                 ),
                 owner = this,
                 view = view

--- a/app/src/main/java/org/mozilla/fenix/ext/Activity.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/Activity.kt
@@ -7,7 +7,6 @@ package org.mozilla.fenix.ext
 import android.app.Activity
 import android.view.View
 import android.view.WindowManager
-import org.mozilla.fenix.utils.Settings
 
 /**
  * Attempts to call immersive mode using the View to hide the status bar and navigation buttons.
@@ -22,20 +21,4 @@ fun Activity.enterToImmersiveMode() {
             or View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
             or View.SYSTEM_UI_FLAG_FULLSCREEN
             or View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY)
-}
-
-/**
- * Prevents or allows screenshots from being taken in private mode based on the user preferences.
- *
- * The default setting is set to true (screenshots are allowed to be taken in private mode), as
- * described in #2768
- */
-fun Activity.checkAndUpdateScreenshotPermission(settings: Settings) {
-    if (!settings.allowScreenshotsInPrivateMode &&
-        settings.lastKnownMode.isPrivate
-    ) {
-        window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
-    } else {
-        window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
-    }
 }

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -11,6 +11,7 @@ import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
 import android.os.StrictMode
+import android.view.Display.FLAG_SECURE
 import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
@@ -47,6 +48,7 @@ import kotlinx.android.synthetic.main.fragment_home.*
 import kotlinx.android.synthetic.main.fragment_home.view.*
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.Dispatchers.Main
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -84,10 +86,10 @@ import org.mozilla.fenix.ext.hideToolbar
 import org.mozilla.fenix.ext.metrics
 import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.requireComponents
+import org.mozilla.fenix.ext.resetPoliciesAfter
 import org.mozilla.fenix.ext.sessionsOfType
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.toTab
-import org.mozilla.fenix.ext.resetPoliciesAfter
 import org.mozilla.fenix.home.sessioncontrol.DefaultSessionControlController
 import org.mozilla.fenix.home.sessioncontrol.SessionControlInteractor
 import org.mozilla.fenix.home.sessioncontrol.SessionControlView
@@ -106,7 +108,8 @@ import java.lang.ref.WeakReference
 import kotlin.math.abs
 import kotlin.math.min
 
-@SuppressWarnings("TooManyFunctions", "LargeClass")
+@ExperimentalCoroutinesApi
+@Suppress("TooManyFunctions", "LargeClass")
 class HomeFragment : Fragment() {
     private val args by navArgs<HomeFragmentArgs>()
 
@@ -382,6 +385,12 @@ class HomeFragment : Fragment() {
                 view.toolbar_wrapper?.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_FOCUSED)
             }
         }
+
+        if (browsingModeManager.mode.isPrivate) {
+            requireActivity().window.addFlags(FLAG_SECURE)
+        } else {
+            requireActivity().window.clearFlags(FLAG_SECURE)
+        }
     }
 
     override fun onDestroyView() {
@@ -389,6 +398,7 @@ class HomeFragment : Fragment() {
         _sessionControlInteractor = null
         sessionControlView = null
         requireView().homeAppBar.removeOnOffsetChangedListener(homeAppBarOffSetListener)
+        requireActivity().window.clearFlags(FLAG_SECURE)
     }
 
     override fun onStart() {

--- a/app/src/main/java/org/mozilla/fenix/settings/PrivateBrowsingFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/PrivateBrowsingFragment.kt
@@ -11,7 +11,6 @@ import androidx.preference.SwitchPreference
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.PrivateShortcutCreateManager
 import org.mozilla.fenix.components.metrics.Event
-import org.mozilla.fenix.ext.checkAndUpdateScreenshotPermission
 import org.mozilla.fenix.ext.metrics
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.showToolbar
@@ -45,12 +44,7 @@ class PrivateBrowsingFragment : PreferenceFragmentCompat() {
         }
 
         requirePreference<SwitchPreference>(R.string.pref_key_allow_screenshots_in_private_mode).apply {
-            onPreferenceChangeListener = object : SharedPreferenceUpdater() {
-                override fun onPreferenceChange(preference: Preference, newValue: Any?): Boolean {
-                    return super.onPreferenceChange(preference, newValue).also {
-                        requireActivity().checkAndUpdateScreenshotPermission(requireActivity().settings()) }
-                }
-            }
+            onPreferenceChangeListener = SharedPreferenceUpdater()
         }
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/ext/ActivityTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/ext/ActivityTest.kt
@@ -7,13 +7,10 @@ package org.mozilla.fenix.ext
 import android.app.Activity
 import android.view.View
 import android.view.WindowManager
-import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.robolectric.Robolectric
 import org.robolectric.Shadows.shadowOf
@@ -41,68 +38,5 @@ class ActivityTest {
         // Test
         for (f in flags) assertEquals(f, window.decorView.systemUiVisibility and f)
         assertTrue(shadowOf(window).getFlag(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON))
-    }
-
-    @Test
-    fun `testCheckAndUpdateScreenshotPermission adds flag in private mode when screenshots are not allowed `() {
-        // given
-        val activity = Robolectric.buildActivity(Activity::class.java).create().get()
-        val window = activity.window
-        testContext.settings().lastKnownMode = BrowsingMode.Private
-        testContext.settings().allowScreenshotsInPrivateMode = false
-
-        // when
-        activity.checkAndUpdateScreenshotPermission(activity.settings())
-
-        // then
-        assertTrue(shadowOf(window).getFlag(WindowManager.LayoutParams.FLAG_SECURE))
-    }
-
-    @Test
-    fun `testCheckAndUpdateScreenshotPermission removes flag in private mode when screenshots are allowed `() {
-        // given
-        val activity = Robolectric.buildActivity(Activity::class.java).create().get()
-        val window = activity.window
-        window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
-        testContext.settings().lastKnownMode = BrowsingMode.Private
-        testContext.settings().allowScreenshotsInPrivateMode = true
-
-        // when
-        activity.checkAndUpdateScreenshotPermission(activity.settings())
-
-        // then
-        assertFalse(shadowOf(window).getFlag(WindowManager.LayoutParams.FLAG_SECURE))
-    }
-
-    @Test
-    fun `testCheckAndUpdateScreenshotPermission removes flag in normal mode when screenshots are allowed `() {
-        // given
-        val activity = Robolectric.buildActivity(Activity::class.java).create().get()
-        val window = activity.window
-        window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
-        testContext.settings().lastKnownMode = BrowsingMode.Normal
-        testContext.settings().allowScreenshotsInPrivateMode = true
-
-        // when
-        activity.checkAndUpdateScreenshotPermission(activity.settings())
-
-        // then
-        assertFalse(shadowOf(window).getFlag(WindowManager.LayoutParams.FLAG_SECURE))
-    }
-
-    @Test
-    fun `testCheckAndUpdateScreenshotPermission removes flag when in normal mode screenshots are not allowed `() {
-        // given
-        val activity = Robolectric.buildActivity(Activity::class.java).create().get()
-        val window = activity.window
-        window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
-        testContext.settings().lastKnownMode = BrowsingMode.Normal
-        testContext.settings().allowScreenshotsInPrivateMode = false
-
-        // when
-        activity.checkAndUpdateScreenshotPermission(activity.settings())
-
-        // then
-        assertFalse(shadowOf(window).getFlag(WindowManager.LayoutParams.FLAG_SECURE))
     }
 }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -102,6 +102,7 @@ object Deps {
     const val mozilla_feature_storage = "org.mozilla.components:feature-storage:${Versions.mozilla_android_components}"
     const val mozilla_feature_prompts = "org.mozilla.components:feature-prompts:${Versions.mozilla_android_components}"
     const val mozilla_feature_push = "org.mozilla.components:feature-push:${Versions.mozilla_android_components}"
+    const val mozilla_feature_privatemode = "org.mozilla.components:feature-privatemode:${Versions.mozilla_android_components}"
     const val mozilla_feature_pwa = "org.mozilla.components:feature-pwa:${Versions.mozilla_android_components}"
     const val mozilla_feature_toolbar = "org.mozilla.components:feature-toolbar:${Versions.mozilla_android_components}"
     const val mozilla_feature_findinpage = "org.mozilla.components:feature-findinpage:${Versions.mozilla_android_components}"


### PR DESCRIPTION
Previously SECURE_FLAG was set on the activity level, checking `lastUsed` mode in settings. This messes with views outside the main browsing fragment.

The new version uses a pre-existing Android Component to set SECURE_FLAG on the base browsing fragment. I also added some code for the home fragment. All other fragments won't have the flag set.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture