### PR TITLE
No issue: Update Flank to v20.06.2

### DIFF
--- a/taskcluster/docker/ui-tests/Dockerfile
+++ b/taskcluster/docker/ui-tests/Dockerfile
@@ -12,7 +12,7 @@ USER worker:worker
 
 ENV GOOGLE_SDK_DOWNLOAD ./gcloud.tar.gz
 ENV GOOGLE_SDK_VERSION 233
-ENV FLANK_VERSION v20.06.0
+ENV FLANK_VERSION v20.06.2
 
 ENV TEST_TOOLS /builds/worker/test-tools
 ENV PATH ${PATH}:${TEST_TOOLS}:${TEST_TOOLS}/google-cloud-sdk/bin


### PR DESCRIPTION
Update Flank to [v20.06.2](https://github.com/Flank/flank/releases/tag/v20.06.2)

This release has a fix which stores `@Ignore` tests in the Unit XML without sending ignored tests to FTL.

On performance:

> It’s definitely faster, the run is still only as fast as the slowest shard. I see this as more of a correctness win than performance, although both are improved.