### PR TITLE
For #11903: fix custom tab private gradient

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabsIntegration.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabsIntegration.kt
@@ -5,7 +5,7 @@
 package org.mozilla.fenix.customtabs
 
 import android.app.Activity
-import androidx.appcompat.content.res.AppCompatResources
+import androidx.appcompat.content.res.AppCompatResources.getDrawable
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.browser.toolbar.display.DisplayToolbar
@@ -30,16 +30,13 @@ class CustomTabsIntegration(
         // Remove toolbar shadow
         toolbar.elevation = 0f
 
-        val uncoloredEtpShield = AppCompatResources.getDrawable(
-            activity,
-            R.drawable.ic_tracking_protection_enabled
-        )!!
+        val uncoloredEtpShield = getDrawable(activity, R.drawable.ic_tracking_protection_enabled)!!
 
         toolbar.display.icons = toolbar.display.icons.copy(
             // Custom private tab backgrounds have bad contrast against the colored shield
             trackingProtectionTrackersBlocked = uncoloredEtpShield,
             trackingProtectionNothingBlocked = uncoloredEtpShield,
-            trackingProtectionException = AppCompatResources.getDrawable(
+            trackingProtectionException = getDrawable(
                 activity,
                 R.drawable.ic_tracking_protection_disabled
             )!!
@@ -70,10 +67,7 @@ class CustomTabsIntegration(
                 )
             }
 
-            toolbar.background = AppCompatResources.getDrawable(
-                activity,
-                R.drawable.toolbar_background
-            )
+            toolbar.background = getDrawable(activity, R.drawable.toolbar_background_private)
         }
     }
 

--- a/app/src/main/res/drawable/toolbar_background_private.xml
+++ b/app/src/main/res/drawable/toolbar_background_private.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape android:shape="rectangle">
+             <gradient
+                android:angle="45"
+                android:startColor="@color/toolbar_start_gradient_private_theme"
+                android:centerColor="@color/toolbar_center_gradient_private_theme"
+                android:endColor="@color/toolbar_end_gradient_private_theme"
+                android:type="linear" />
+        </shape>
+    </item>
+    <item android:gravity="top">
+        <shape android:shape="rectangle">
+            <size android:height="1dp" />
+            <solid android:color="@color/neutral_faded_private_theme" />
+        </shape>
+    </item>
+</layer-list>


### PR DESCRIPTION
Seems like the private theme isn't getting picked up.

![image](https://user-images.githubusercontent.com/1782266/85599548-76a57980-b601-11ea-8e42-7006c8a9a31c.png)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture