### PR TITLE
For #11044 - Sets the anchorView of the snackbar to be the new tab fab

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayDialogFragment.kt
@@ -10,11 +10,13 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatDialogFragment
+import androidx.core.view.isVisible
 import androidx.core.view.updatePadding
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import kotlinx.android.synthetic.main.component_tabstray.view.*
+import kotlinx.android.synthetic.main.component_tabstray_fab.view.*
 import kotlinx.android.synthetic.main.fragment_tab_tray_dialog.*
 import kotlinx.android.synthetic.main.fragment_tab_tray_dialog.view.*
 import mozilla.components.browser.session.Session
@@ -41,6 +43,10 @@ class TabTrayDialogFragment : AppCompatDialogFragment() {
     private var _tabTrayView: TabTrayView? = null
     private val tabTrayView: TabTrayView
         get() = _tabTrayView!!
+
+    private val snackbarAnchor: View?
+        get() = if (tabTrayView.fabView.new_tab_button.isVisible) tabTrayView.fabView.new_tab_button
+                else null
 
     private val collectionStorageObserver = object : TabCollectionStorage.Observer {
         override fun onCollectionCreated(title: String, sessions: List<Session>) {
@@ -182,7 +188,8 @@ class TabTrayDialogFragment : AppCompatDialogFragment() {
                     sessionManager.add(snapshot.session, isSelected, engineSessionState = state)
                 },
                 operation = { },
-                elevation = ELEVATION
+                elevation = ELEVATION,
+                anchorView = snackbarAnchor
             )
         }
     }
@@ -226,7 +233,8 @@ class TabTrayDialogFragment : AppCompatDialogFragment() {
                     context?.components?.core?.sessionManager?.restore(snapshot)
                 },
                 operation = { },
-                elevation = ELEVATION
+                elevation = ELEVATION,
+                anchorView = snackbarAnchor
             )
         }
     }
@@ -239,6 +247,7 @@ class TabTrayDialogFragment : AppCompatDialogFragment() {
                     isDisplayedWithBrowserToolbar = true,
                     view = (view as View)
                 )
+                .setAnchorView(snackbarAnchor)
                 .setText(requireContext().getString(R.string.create_collection_tabs_saved))
                 .setAction(requireContext().getString(R.string.create_collection_view)) {
                     dismissAllowingStateLoss()


### PR DESCRIPTION

<img width="700" alt="image" src="https://user-images.githubusercontent.com/1250545/85639694-5d6eee00-b63e-11ea-9d0b-93025d722950.png">

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture