### PR TITLE
For #11430 - Gives enough padding to the tab tray give adequate space…

### DIFF
--- a/app/src/main/res/layout/component_tabstray.xml
+++ b/app/src/main/res/layout/component_tabstray.xml
@@ -108,7 +108,7 @@
         android:id="@+id/tabsTray"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:paddingBottom="80dp"
+        android:paddingBottom="140dp"
         android:clipToPadding="false"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION

<img width="600" alt="image" src="https://user-images.githubusercontent.com/1250545/85640044-82b02c00-b63f-11ea-8cb6-1bebc4bdd79a.png">

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture