### PR TITLE
For #11889: Changes collection creation confirmation snackbar strings

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -20,7 +20,6 @@ import android.view.accessibility.AccessibilityEvent
 import android.widget.Button
 import android.widget.LinearLayout
 import android.widget.PopupWindow
-import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.constraintlayout.widget.ConstraintSet
@@ -132,11 +131,11 @@ class HomeFragment : Fragment() {
 
     private val collectionStorageObserver = object : TabCollectionStorage.Observer {
         override fun onCollectionCreated(title: String, sessions: List<Session>) {
-            scrollAndAnimateCollection(sessions.size)
+            scrollAndAnimateCollection()
         }
 
         override fun onTabsAdded(tabCollection: TabCollection, sessions: List<Session>) {
-            scrollAndAnimateCollection(sessions.size, tabCollection)
+            scrollAndAnimateCollection(tabCollection)
         }
 
         override fun onCollectionRenamed(tabCollection: TabCollection, title: String) {
@@ -791,7 +790,6 @@ class HomeFragment : Fragment() {
     }
 
     private fun scrollAndAnimateCollection(
-        tabsAddedToCollectionSize: Int,
         changedCollection: TabCollection? = null
     ) {
         if (view != null) {
@@ -822,7 +820,7 @@ class HomeFragment : Fragment() {
                         ) {
                             super.onScrollStateChanged(recyclerView, newState)
                             if (newState == SCROLL_STATE_IDLE) {
-                                animateCollection(tabsAddedToCollectionSize, indexOfCollection)
+                                animateCollection(indexOfCollection)
                                 recyclerView.removeOnScrollListener(this)
                             }
                         }
@@ -830,13 +828,13 @@ class HomeFragment : Fragment() {
                     recyclerView.addOnScrollListener(onScrollListener)
                     recyclerView.smoothScrollToPosition(indexOfCollection)
                 } else {
-                    animateCollection(tabsAddedToCollectionSize, indexOfCollection)
+                    animateCollection(indexOfCollection)
                 }
             }
         }
     }
 
-    private fun animateCollection(addedTabsSize: Int, indexOfCollection: Int) {
+    private fun animateCollection(indexOfCollection: Int) {
         viewLifecycleOwner.lifecycleScope.launch {
             val viewHolder =
                 sessionControlView!!.view.findViewHolderForAdapterPosition(indexOfCollection)
@@ -863,26 +861,20 @@ class HomeFragment : Fragment() {
                 ?.setDuration(FADE_ANIM_DURATION)
                 ?.setListener(listener)?.start()
         }.invokeOnCompletion {
-            showSavedSnackbar(addedTabsSize)
+            showSavedSnackbar()
         }
     }
 
-    private fun showSavedSnackbar(tabSize: Int) {
+    private fun showSavedSnackbar() {
         viewLifecycleOwner.lifecycleScope.launch {
             delay(ANIM_SNACKBAR_DELAY)
             view?.let { view ->
-                @StringRes
-                val stringRes = if (tabSize > 1) {
-                    R.string.create_collection_tabs_saved
-                } else {
-                    R.string.create_collection_tab_saved
-                }
                 FenixSnackbar.make(
                     view = view,
                     duration = Snackbar.LENGTH_LONG,
                     isDisplayedWithBrowserToolbar = false
                 )
-                    .setText(view.context.getString(stringRes))
+                    .setText(view.context.getString(R.string.create_collection_tabs_saved_new_collection))
                     .setAnchorView(snackbarAnchorView)
                     .show()
             }

--- a/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayDialogFragment.kt
@@ -51,11 +51,11 @@ class TabTrayDialogFragment : AppCompatDialogFragment() {
 
     private val collectionStorageObserver = object : TabCollectionStorage.Observer {
         override fun onCollectionCreated(title: String, sessions: List<Session>) {
-            showCollectionSnackbar()
+            showCollectionSnackbar(sessions.size, true)
         }
 
         override fun onTabsAdded(tabCollection: TabCollection, sessions: List<Session>) {
-            showCollectionSnackbar()
+            showCollectionSnackbar(sessions.size)
         }
     }
 
@@ -245,8 +245,19 @@ class TabTrayDialogFragment : AppCompatDialogFragment() {
         }
     }
 
-    private fun showCollectionSnackbar() {
+    private fun showCollectionSnackbar(tabSize: Int, isNewCollection: Boolean = false) {
         view.let {
+            val messageStringRes = when {
+                isNewCollection -> {
+                    R.string.create_collection_tabs_saved_new_collection
+                }
+                tabSize > 1 -> {
+                    R.string.create_collection_tabs_saved
+                }
+                else -> {
+                    R.string.create_collection_tab_saved
+                }
+            }
             val snackbar = FenixSnackbar
                 .make(
                     duration = FenixSnackbar.LENGTH_LONG,
@@ -254,7 +265,7 @@ class TabTrayDialogFragment : AppCompatDialogFragment() {
                     view = (view as View)
                 )
                 .setAnchorView(snackbarAnchor)
-                .setText(requireContext().getString(R.string.create_collection_tabs_saved))
+                .setText(requireContext().getString(messageStringRes))
                 .setAction(requireContext().getString(R.string.create_collection_view)) {
                     dismissAllowingStateLoss()
                     findNavController().navigate(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -714,6 +714,8 @@
     <string name="create_collection_save_to_collection_tab_selected">%d tab selected</string>
     <!-- Text shown in snackbar when multiple tabs have been saved in a collection -->
     <string name="create_collection_tabs_saved">Tabs saved!</string>
+    <!-- Text shown in snackbar when one or multiple tabs have been saved in a new collection -->
+    <string name="create_collection_tabs_saved_new_collection">Collection saved!</string>
     <!-- Text shown in snackbar when one tab has been saved in a collection -->
     <string name="create_collection_tab_saved">Tab saved!</string>
     <!-- Content description (not visible, for screen readers etc.): button to close the collection creator -->


### PR DESCRIPTION
Also I changed the adding tabs to collection confirmation string from
tabtray to take into account the number of tabs.
Example: 1 tab-"Tab saved!"; multiple tabs-"Tabs saved!"



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR does not include thorough tests.
- [x] **Screenshots**: This PR includes a [video](https://drive.google.com/file/d/1sz9FXqcXWIDH9Z4qtUXFfNwO0etXLbKm/view?usp=sharing) of the changes made.
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture