### PR TITLE
Fixes #11764: delay single-click duration to avoid long-clicks in ThreeDotMenu UI tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/ThreeDotMenuMainTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/ThreeDotMenuMainTest.kt
@@ -9,6 +9,7 @@ import androidx.test.uiautomator.UiDevice
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
+import org.junit.BeforeClass
 import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
@@ -24,7 +25,6 @@ import org.mozilla.fenix.ui.robots.homeScreen
 class ThreeDotMenuMainTest {
     /* ktlint-disable no-blank-line-before-rbrace */ // This imposes unreadable grouping.
 
-    private val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
     private lateinit var mockWebServer: MockWebServer
 
     @get:Rule
@@ -35,6 +35,16 @@ class ThreeDotMenuMainTest {
         mockWebServer = MockWebServer().apply {
             setDispatcher(AndroidAssetDispatcher())
             start()
+        }
+    }
+
+    // changing the device preference for Touch and Hold delay, to avoid long-clicks instead of a single-click
+    companion object {
+        @BeforeClass
+        @JvmStatic
+        fun setDevicePreference() {
+            val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+            mDevice.executeShellCommand("settings put secure long_press_timeout 1500")
         }
     }
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
@@ -19,7 +19,6 @@ import androidx.test.espresso.intent.matcher.IntentMatchers.toPackage
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.Visibility
 import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
-import androidx.test.espresso.matcher.ViewMatchers.isCompletelyDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
@@ -369,19 +368,19 @@ private fun assertLeakCanaryButton() {
 private fun assertAboutHeading(): ViewInteraction {
     scrollToElementByText("About")
     return onView(withText("About"))
-        .check(matches(isCompletelyDisplayed()))
+        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 }
 
 private fun assertRateOnGooglePlay(): ViewInteraction {
     scrollToElementByText("About Firefox Preview")
     return onView(withText("Rate on Google Play"))
-        .check(matches(isCompletelyDisplayed()))
+        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 }
 
 private fun assertAboutFirefoxPreview(): ViewInteraction {
     scrollToElementByText("About Firefox Preview")
     return onView(withText("About Firefox Preview"))
-        .check(matches(isCompletelyDisplayed()))
+        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 }
 
 fun swipeToBottom() = onView(withId(R.id.recycler_view)).perform(ViewActions.swipeUp())


### PR DESCRIPTION
For #11764. The test remains disabled until the GV bug causing instrumentation crashes is fixed. 
Also fixed some flaky Settings items verifications.
Verified the tests 20x times using the flank-x86 config file before opening the PR.