### PR TITLE
Issue #11798: Allow sharing of reader view pages

### DIFF
--- a/app/src/test/java/org/mozilla/fenix/share/ShareControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/share/ShareControllerTest.kt
@@ -273,6 +273,22 @@ class ShareControllerTest {
     }
 
     @Test
+    fun `getShareText attempts to use original URL for reader pages`() {
+        val shareData = listOf(
+            ShareData(url = "moz-extension://eb8df45a-895b-4f3a-896a-c0c71ae4/page.html"),
+            ShareData(url = "moz-extension://eb8df45a-895b-4f3a-896a-c0c71ae5/page.html?url=url0"),
+            ShareData(url = "url1")
+        )
+        val controller = DefaultShareController(
+            context, shareData, sendTabUseCases, snackbar, navController,
+            recentAppStorage, testCoroutineScope, dismiss
+        )
+
+        val expectedShareText = "${shareData[0].url}\n\nurl0\n\n${shareData[2].url}"
+        assertEquals(expectedShareText, controller.getShareText())
+    }
+
+    @Test
     fun `ShareTab#toTabData maps a list of ShareTab to a TabData list`() {
         var tabData: List<TabData>
 


### PR DESCRIPTION
Adds a workaround and test to make reader pages shareable again. This can be implemented in a cleaner way once https://github.com/mozilla-mobile/android-components/issues/2879 is available.