### PR TITLE
For 11922:Removed MainScope from IntentReceiverActivity

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,6 +42,7 @@ android {
     }
 
     def releaseTemplate = {
+        signingConfig signingConfigs.debug
         shrinkResources true
         minifyEnabled true
         proguardFiles 'proguard-android-optimize-3.5.0-modified.txt', 'proguard-rules.pro'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,7 +42,6 @@ android {
     }
 
     def releaseTemplate = {
-        signingConfig signingConfigs.debug
         shrinkResources true
         minifyEnabled true
         proguardFiles 'proguard-android-optimize-3.5.0-modified.txt', 'proguard-rules.pro'

--- a/app/src/main/java/org/mozilla/fenix/IntentReceiverActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/IntentReceiverActivity.kt
@@ -9,8 +9,6 @@ import android.content.Intent
 import android.os.Bundle
 import android.os.StrictMode
 import androidx.annotation.VisibleForTesting
-import kotlinx.coroutines.MainScope
-import kotlinx.coroutines.launch
 import mozilla.components.feature.intent.processing.IntentProcessor
 import org.mozilla.fenix.components.IntentProcessorType
 import org.mozilla.fenix.components.getType
@@ -33,19 +31,17 @@ class IntentReceiverActivity : Activity() {
             super.onCreate(savedInstanceState)
         }
 
-        MainScope().launch {
-            // The intent property is nullable, but the rest of the code below
-            // assumes it is not. If it's null, then we make a new one and open
-            // the HomeActivity.
-            val intent = intent?.let { Intent(it) } ?: Intent()
-            intent.stripUnwantedFlags()
-            processIntent(intent)
-        }
+        // The intent property is nullable, but the rest of the code below
+        // assumes it is not. If it's null, then we make a new one and open
+        // the HomeActivity.
+        val intent = intent?.let { Intent(it) } ?: Intent()
+        intent.stripUnwantedFlags()
+        processIntent(intent)
 
         StartupTimeline.onActivityCreateEndIntentReceiver()
     }
 
-    suspend fun processIntent(intent: Intent) {
+    fun processIntent(intent: Intent) {
         // Call process for side effects, short on the first that returns true
         val processor = getIntentProcessors().firstOrNull { it.process(intent) }
         val intentProcessorType = components.intentProcessors.getType(processor)

--- a/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -188,7 +188,7 @@ class Core(private val context: Context) {
 
             WebNotificationFeature(
                 context, engine, icons, R.drawable.ic_status_logo,
-                HomeActivity::class.java
+                permissionStorage.permissionsStorage, HomeActivity::class.java
             )
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/home/intent/FennecBookmarkShortcutsIntentProcessor.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/intent/FennecBookmarkShortcutsIntentProcessor.kt
@@ -35,7 +35,7 @@ class FennecBookmarkShortcutsIntentProcessor(
      * If this is an Intent for a Fennec pinned website shortcut
      * prepare it for opening website's URL in a new tab.
      */
-    override suspend fun process(intent: Intent): Boolean {
+    override fun process(intent: Intent): Boolean {
         val safeIntent = intent.toSafeIntent()
         val url = safeIntent.dataString
 

--- a/app/src/main/java/org/mozilla/fenix/shortcut/NewTabShortcutIntentProcessor.kt
+++ b/app/src/main/java/org/mozilla/fenix/shortcut/NewTabShortcutIntentProcessor.kt
@@ -28,7 +28,7 @@ class NewTabShortcutIntentProcessor : IntentProcessor {
      * @param intent The intent to process.
      * @return True if the intent was processed, otherwise false.
      */
-    override suspend fun process(intent: Intent): Boolean {
+    override fun process(intent: Intent): Boolean {
         val safeIntent = SafeIntent(intent)
         val (searchExtra, startPrivateMode) = when (safeIntent.action) {
             ACTION_OPEN_TAB -> StartSearchIntentProcessor.STATIC_SHORTCUT_NEW_TAB to false

--- a/app/src/test/java/org/mozilla/fenix/components/IntentProcessorTypeTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/IntentProcessorTypeTest.kt
@@ -100,7 +100,7 @@ class IntentProcessorTypeTest {
     @Test
     fun `get type for generic intent processor`() {
         val processor = object : IntentProcessor {
-            override suspend fun process(intent: Intent) = true
+            override fun process(intent: Intent) = true
         }
         val type = testContext.components.intentProcessors.getType(processor)
 

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "48.0.20200626130049"
+    const val VERSION = "48.0.20200626213814"
 }


### PR DESCRIPTION
PR to remove the `suspend` from the intentReceiverActivity. 
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture