### PR TITLE
For #11892: Remove dynamic calls to setupNavigationToolbar

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -367,11 +367,11 @@ open class HomeActivity : LocaleAwareAppCompatActivity() {
      * Everyone should call this instead of supportActionBar.
      */
     fun getSupportActionBarAndInflateIfNecessary(): ActionBar {
-        // Add ids to this that we don't want to have a toolbar back button
         if (!isToolbarInflated) {
             navigationToolbar = navigationToolbarStub.inflate() as Toolbar
 
             setSupportActionBar(navigationToolbar)
+            // Add ids to this that we don't want to have a toolbar back button
             setupNavigationToolbar()
 
             isToolbarInflated = true

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkView.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkView.kt
@@ -13,7 +13,6 @@ import kotlinx.android.synthetic.main.component_bookmark.view.*
 import mozilla.appservices.places.BookmarkRoot
 import mozilla.components.concept.storage.BookmarkNode
 import mozilla.components.support.base.feature.UserInteractionHandler
-import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.NavGraphDirections
 import org.mozilla.fenix.library.LibraryPageView
@@ -140,17 +139,9 @@ class BookmarkView(
         bookmarkAdapter.updateData(state.tree, mode)
         when (mode) {
             is BookmarkFragmentState.Mode.Normal -> {
-                if (tree != null) {
-                    if (BookmarkRoot.Mobile.id == tree?.guid) {
-                        (activity as HomeActivity).setupNavigationToolbar(R.id.bookmarkFragment)
-                    } else {
-                        (activity as HomeActivity).setupNavigationToolbar()
-                    }
-                }
                 setUiForNormalMode(state.tree)
             }
             is BookmarkFragmentState.Mode.Selecting -> {
-                (activity as HomeActivity).setupNavigationToolbar()
                 setUiForSelectingMode(
                     context.getString(
                         R.string.bookmarks_multi_select_title,

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryView.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryView.kt
@@ -13,7 +13,6 @@ import androidx.recyclerview.widget.SimpleItemAnimator
 import kotlinx.android.synthetic.main.component_history.*
 import kotlinx.android.synthetic.main.component_history.view.*
 import mozilla.components.support.base.feature.UserInteractionHandler
-import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.library.LibraryPageView
 import org.mozilla.fenix.library.SelectionInteractor
@@ -143,13 +142,11 @@ class HistoryView(
 
         when (val mode = state.mode) {
             is HistoryFragmentState.Mode.Normal -> {
-                (activity as HomeActivity).setupNavigationToolbar(R.id.historyFragment)
                 setUiForNormalMode(
                     context.getString(R.string.library_history)
                 )
             }
             is HistoryFragmentState.Mode.Editing -> {
-                (activity as HomeActivity).setupNavigationToolbar()
                 setUiForSelectingMode(
                     context.getString(R.string.history_multi_select_title, mode.selectedItems.size)
                 )


### PR DESCRIPTION
This is a speculative fix for 11892 crash.
The side effect is that the back button will be visible in bookmarks root.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR does not include thorough tests.
- [x] **Screenshots**: This PR does not include screenshots or GIFs of the changes made.
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture