### PR TITLE
For #8795: remove redundant ConstraintLayout around BrowserToolbar.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
@@ -294,8 +294,6 @@ class SearchFragment : Fragment(), UserInteractionHandler {
 
         view.search_suggestions_onboarding.setOnInflateListener((stubListener))
 
-        view.toolbar_wrapper.clipToOutline = false
-
         fill_link_from_clipboard.setOnClickListener {
             (activity as HomeActivity)
                 .openToBrowserAndLoad(

--- a/app/src/main/java/org/mozilla/fenix/search/toolbar/ToolbarView.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/toolbar/ToolbarView.kt
@@ -8,7 +8,6 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.drawable.BitmapDrawable
 import androidx.appcompat.content.res.AppCompatResources
-import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.content.ContextCompat
 import mozilla.components.browser.domains.autocomplete.ShippedDomainsProvider
 import mozilla.components.browser.toolbar.BrowserToolbar
@@ -16,7 +15,6 @@ import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.storage.HistoryStorage
 import mozilla.components.feature.toolbar.ToolbarAutocompleteFeature
 import mozilla.components.support.ktx.android.content.getColorFromAttr
-import mozilla.components.support.ktx.android.util.dpToPx
 import mozilla.components.support.ktx.android.view.hideKeyboard
 import org.mozilla.fenix.R
 import org.mozilla.fenix.search.SearchFragmentState
@@ -64,8 +62,6 @@ class ToolbarView(
         view.apply {
             editMode()
 
-            elevation = TOOLBAR_ELEVATION_IN_DP.dpToPx(resources.displayMetrics).toFloat()
-
             setOnUrlCommitListener {
                 // We're hiding the keyboard as early as possible to prevent the engine view
                 // from resizing in case the BrowserFragment is being displayed before the
@@ -79,8 +75,6 @@ class ToolbarView(
                 AppCompatResources.getDrawable(
                     context, ThemeManager.resolveAttribute(R.attr.foundation, context)
                 )
-
-            layoutParams.height = CoordinatorLayout.LayoutParams.MATCH_PARENT
 
             edit.hint = context.getString(R.string.search_hint)
 
@@ -155,9 +149,5 @@ class ToolbarView(
         val icon = BitmapDrawable(context.resources, scaledIcon)
 
         view.edit.setIcon(icon, searchState.searchEngineSource.searchEngine.name)
-    }
-
-    companion object {
-        private const val TOOLBAR_ELEVATION_IN_DP = 16
     }
 }

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -11,38 +11,24 @@
     android:background="?foundation"
     tools:context=".search.SearchFragment">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/toolbar_wrapper"
+    <mozilla.components.browser.toolbar.BrowserToolbar
+        android:id="@+id/toolbar"
         android:layout_width="0dp"
         android:layout_height="@dimen/browser_toolbar_height"
-        android:layout_margin="0dp"
-        android:outlineProvider="paddedBounds"
+        android:background="@drawable/toolbar_background_top"
+        android:clickable="true"
+        android:focusable="true"
+        android:focusableInTouchMode="true"
+        app:layout_scrollFlags="scroll|enterAlways|snap|exitUntilCollapsed"
+        app:browserToolbarClearColor="?primaryText"
+        app:browserToolbarInsecureColor="?primaryText"
+        app:browserToolbarMenuColor="?primaryText"
+        app:browserToolbarProgressBarGravity="bottom"
+        app:browserToolbarSecureColor="?primaryText"
+        app:browserToolbarTrackingProtectionAndSecurityIndicatorSeparatorColor="?toolbarDivider"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
-
-        <mozilla.components.browser.toolbar.BrowserToolbar
-            android:id="@+id/toolbar"
-            android:layout_width="match_parent"
-            android:layout_height="@dimen/browser_toolbar_height"
-            android:layout_gravity="top"
-            android:background="@drawable/toolbar_background_top"
-            android:clickable="true"
-            android:focusable="true"
-            android:focusableInTouchMode="true"
-            app:layout_scrollFlags="scroll|enterAlways|snap|exitUntilCollapsed"
-            app:browserToolbarClearColor="?primaryText"
-            app:browserToolbarInsecureColor="?primaryText"
-            app:browserToolbarMenuColor="?primaryText"
-            app:browserToolbarProgressBarGravity="bottom"
-            app:browserToolbarSecureColor="?primaryText"
-            app:browserToolbarTrackingProtectionAndSecurityIndicatorSeparatorColor="?toolbarDivider"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"/>
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
+        app:layout_constraintTop_toTopOf="parent"/>
 
     <androidx.core.widget.NestedScrollView
         android:layout_width="0dp"
@@ -51,7 +37,7 @@
         app:layout_constraintBottom_toBottomOf="@id/search_divider"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/toolbar_wrapper">
+        app:layout_constraintTop_toBottomOf="@id/toolbar">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/scrollable_area"


### PR DESCRIPTION
This is functionally equivalent to the code before this patch but should
be slightly more performant in theory because ConstraintLayout is
expensive to inflate.

The elevation and layoutParams set dynamically appeared to have no effect
with the wrapping view but broke the view when used by itself so I had
to remove them. I also updated a few other unnecessary params.

Theoretically this may have some perf benefits but I didn't see anything
outside noise levels after I took the numbers (but I didn't try very hard).

These were the perf results:

---
### NO CHANGES
first click
5 runs, average: 470.4
[432, 493, 504, 484, 439]

subsequent
10 runs, average: 346.7
[352, 390, 362, 337, 334, 344, 305, 315, 398, 330]

---

### REMOVE TOOLBAR_WRAPPER
first click
5 runs, average: 496.6
[490, 461, 443, 573, 516]

subsequent
10 runs, average: 344
[312, 352, 375, 342, 322, 380, 337, 333, 346, 341]

I suspect the first click is higher before because of the 573 outlier rather than a true regression.

---

Before:
![device-2020-06-26-093810](https://user-images.githubusercontent.com/759372/85881184-1134c280-b792-11ea-9ee1-825e81506f40.png)

After:
![device-2020-06-26-093706](https://user-images.githubusercontent.com/759372/85881174-0ed26880-b792-11ea-823a-5961aca338bb.png)

Scroll before:
![rm-toolbar-wrapper-master-scroll](https://user-images.githubusercontent.com/759372/85881216-1e51b180-b792-11ea-8b3a-b452250d45f5.png)

Scroll after:
![rm-toolbar-wrapper-patch-scroll](https://user-images.githubusercontent.com/759372/85881268-30335480-b792-11ea-957a-fcabe1561a00.png)


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
  - UI change
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.
  - 😬 I'll try to test if I have time today

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture