### PR TITLE
For #10466: Sort context menu text selection actions

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -86,7 +86,8 @@ class Core(private val context: Context) {
         GeckoEngine(
             context,
             defaultSettings,
-            GeckoProvider.getOrCreateRuntime(context, lazyPasswordsStorage)
+            GeckoProvider.getOrCreateRuntime(context, lazyPasswordsStorage),
+            actionSorter = ::actionSorter
         ).also {
             WebCompatFeature.install(it)
 
@@ -104,6 +105,20 @@ class Core(private val context: Context) {
                 WebCompatReporterFeature.install(it)
             }
         }
+    }
+
+    private fun actionSorter(actions: Array<String>) : Array<String> {
+        val order = hashMapOf<String, Int>()
+
+        order["org.mozilla.geckoview.COPY"] = 0
+        order["CUSTOM_CONTEXT_MENU_SEARCH"] = 1
+        order["org.mozilla.geckoview.SELECT_ALL"] = 2
+        order["CUSTOM_CONTEXT_MENU_SHARE"] = 3
+
+        return actions.sortedBy { actionName ->
+            // Sort the actions in our preferred order, putting "other" actions unsorted at the end
+            order[actionName] ?: actions.size
+        }.toTypedArray()
     }
 
     /**


### PR DESCRIPTION
I'm not sure what the best approach is for these hardcoded strings. Some of them live in AC, so those I could just make public and access them here, but a few of these are generated by GeckoView. Is there a good place in AC for all these action identifiers to live @pocmo?

## Demo

<img width="350" alt="image" src="https://user-images.githubusercontent.com/4400286/86063550-fa0b0480-ba1f-11ea-88c0-a8def95b5cde.png">

<img width="350" alt="image" src="https://user-images.githubusercontent.com/4400286/86063561-0000e580-ba20-11ea-9eb9-9aad0688431c.png">

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture