### PR TITLE
For #11655: add leanplum event for installing an addon

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/addons/AddonsManagementFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/addons/AddonsManagementFragment.kt
@@ -29,8 +29,10 @@ import mozilla.components.feature.addons.ui.AddonsManagerAdapterDelegate
 import mozilla.components.feature.addons.ui.PermissionsDialogFragment
 import mozilla.components.feature.addons.ui.translatedName
 import org.mozilla.fenix.R
+import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.getRootView
+import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.showToolbar
 import org.mozilla.fenix.theme.ThemeManager
@@ -192,11 +194,13 @@ class AddonsManagementFragment : Fragment(R.layout.fragment_add_ons_management),
                 onPositiveButtonClicked = onPositiveButtonClicked
             )
             dialog.show(parentFragmentManager, PERMISSIONS_DIALOG_FRAGMENT_TAG)
+            requireContext().components.analytics.metrics.track(Event.AddonInstalled(addon.id))
         }
     }
 
     private fun showInstallationDialog(addon: Addon) {
         if (!isInstallationInProgress && !hasExistingAddonInstallationDialogFragment()) {
+            requireComponents.analytics.metrics.track(Event.AddonInstalled(addon.id))
             val addonCollectionProvider = requireContext().components.addonCollectionProvider
 
             val dialog = AddonInstallationDialogFragment.newInstance(

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
@@ -650,6 +650,7 @@ private val Event.wrapper: EventWrapper<*>?
         is Event.ClearedPrivateData -> null
         is Event.DismissedOnboarding -> null
         is Event.FennecToFenixMigrated -> null
+        is Event.AddonInstalled -> null
     }
 
 class GleanMetricsService(private val context: Context) : MetricsService {

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/LeanplumMetricsService.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/LeanplumMetricsService.kt
@@ -38,9 +38,10 @@ private val Event.name: String?
         is Event.ClearedPrivateData -> "E_Cleared_Private_Data"
         is Event.DismissedOnboarding -> "E_Dismissed_Onboarding"
         is Event.FennecToFenixMigrated -> "E_Fennec_To_Fenix_Migrated"
+        is Event.AddonInstalled -> "E_Addon_Installed"
 
         // Do not track other events in Leanplum
-        else -> ""
+        else -> null
     }
 
 class LeanplumMetricsService(private val application: Application) : MetricsService {

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/Metrics.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/Metrics.kt
@@ -465,6 +465,8 @@ sealed class Event {
     }
 
     object CrashReporterOpened : Event()
+    data class AddonInstalled(val addonId: String) : Event()
+
     data class CrashReporterClosed(val crashSubmitted: Boolean) : Event() {
         override val extras: Map<CrashReporter.closedKeys, String>?
             get() = mapOf(CrashReporter.closedKeys.crashSubmitted to crashSubmitted.toString())

--- a/docs/mma.md
+++ b/docs/mma.md
@@ -234,7 +234,7 @@ Here is the list of current Events sent, which can be found here in the code bas
   <tr>
     <td>`E_Addon_Installed`</td>
     <td>The user has installed an addon from the addon management page.</td>
-    <td><a href="">#</a></td>
+    <td><a href="https://github.com/mozilla-mobile/fenix/pull/12136#issuecomment-651922547">#12136</a></td>
   </tr>
 </table>
 

--- a/docs/mma.md
+++ b/docs/mma.md
@@ -231,6 +231,11 @@ Here is the list of current Events sent, which can be found here in the code bas
     <td>The user has just migrated from Fennec to Fenix.</td>
     <td><a href="https://github.com/mozilla-mobile/fenix/pull/8208#issuecomment-584040440">#8208</a></td>
   </tr>
+  <tr>
+    <td>`E_Addon_Installed`</td>
+    <td>The user has installed an addon from the addon management page.</td>
+    <td><a href="">#</a></td>
+  </tr>
 </table>
 
 Deep links


### PR DESCRIPTION
Fixes #11655.

This PR adds a metrics `Event` fired when the user has successfully installed an addon from the addon manager.

It further enables the event to be logged as a LeanPlum event. It is not enabled as a Glean event.

The data-review will occur in this PR.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- ~[ ] **Tests**: This PR includes thorough tests or an explanation of why it does not~
- ~[ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not~
- ~[ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.~

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture