### PR TITLE
For android-l10n #241: Mark a11y link type as not translatable.

### DIFF
--- a/app/src/main/res/values/static_strings.xml
+++ b/app/src/main/res/values/static_strings.xml
@@ -33,4 +33,7 @@
     <!-- Label for the secret settings preference -->
     <string name="preferences_debug_settings">Secret Settings</string>
     <string name="preferences_debug_settings_enable_tab_tray">Use New Tab Tray</string>
+
+    <!-- Content description (not visible, for screen readers etc.) used to announce [LinkTextView]. -->
+    <string name="link_text_view_type_announcement" translatable="false">link</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1418,6 +1418,4 @@
     <string name="top_sites_max_limit_content">To add a new top site, remove one. Long press the site and select remove.</string>
     <!-- Confirmation dialog button text when top sites limit is reached. -->
     <string name="top_sites_max_limit_confirmation_button">OK, Got It</string>
-    <!-- Content description (not visible, for screen readers etc.) used to announce [LinkTextView]. -->
-    <string name="link_text_view_type_announcement">link</string>
 </resources>


### PR DESCRIPTION
see: https://github.com/mozilla-l10n/android-l10n/pull/241#issuecomment-651957587

This will also keep consistency with link description in webpages, where the type description of links (from gecko) is not translated and announced as "link" in all device languages.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture