### PR TITLE
For #10401 - Hide Shortcuts if just one search engine is installed

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
@@ -99,6 +99,7 @@ class SearchFragment : Fragment(), UserInteractionHandler {
 
         requireComponents.analytics.metrics.track(Event.InteractWithSearchURLArea)
 
+        val areShortcutsAvailable = areShortcutsAvailable()
         searchStore = StoreProvider.get(this) {
             SearchFragmentStore(
                 SearchFragmentState(
@@ -107,7 +108,10 @@ class SearchFragment : Fragment(), UserInteractionHandler {
                     defaultEngineSource = currentSearchEngine,
                     showSearchSuggestions = shouldShowSearchSuggestions(isPrivate),
                     showSearchSuggestionsHint = false,
-                    showSearchShortcuts = requireContext().settings().shouldShowSearchShortcuts && url.isEmpty(),
+                    showSearchShortcuts = requireContext().settings().shouldShowSearchShortcuts &&
+                            url.isEmpty() &&
+                            areShortcutsAvailable,
+                    areShortcutsAvailable = areShortcutsAvailable,
                     showClipboardSuggestions = requireContext().settings().shouldShowClipboardSuggestions,
                     showHistorySuggestions = requireContext().settings().shouldShowHistorySuggestions,
                     showBookmarkSuggestions = requireContext().settings().shouldShowBookmarkSuggestions,
@@ -330,6 +334,12 @@ class SearchFragment : Fragment(), UserInteractionHandler {
             )
         }
 
+        // Users can from this fragment go to install/uninstall search engines and then return.
+        val areShortcutsAvailable = areShortcutsAvailable()
+        if (searchStore.state.areShortcutsAvailable != areShortcutsAvailable) {
+            searchStore.dispatch(SearchFragmentAction.UpdateShortcutsAvailability(areShortcutsAvailable))
+        }
+
         if (!permissionDidUpdate) {
             toolbarView.view.edit.focus()
         }
@@ -427,6 +437,8 @@ class SearchFragment : Fragment(), UserInteractionHandler {
 
     private fun updateSearchShortcutsIcon(searchState: SearchFragmentState) {
         view?.apply {
+            search_shortcuts_button.isVisible = searchState.areShortcutsAvailable
+
             val showShortcuts = searchState.showSearchShortcuts
             search_shortcuts_button.isChecked = showShortcuts
 
@@ -437,7 +449,16 @@ class SearchFragment : Fragment(), UserInteractionHandler {
         }
     }
 
+    /**
+     * Return if the user has *at least 2* installed search engines.
+     * Useful to decide whether to show / enable certain functionalities.
+     */
+    private fun areShortcutsAvailable() =
+            requireContext().components.search.provider.installedSearchEngines(requireContext())
+                    .list.size >= MINIMUM_SEARCH_ENGINES_NUMBER_TO_SHOW_SHORTCUTS
+
     companion object {
         private const val REQUEST_CODE_CAMERA_PERMISSIONS = 1
+        private const val MINIMUM_SEARCH_ENGINES_NUMBER_TO_SHOW_SHORTCUTS = 2
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/search/SearchFragmentStore.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchFragmentStore.kt
@@ -39,6 +39,8 @@ sealed class SearchEngineSource {
  * @property showSearchSuggestions Whether or not to show search suggestions from the search engine in the AwesomeBar
  * @property showSearchSuggestionsHint Whether or not to show search suggestions in private hint panel
  * @property showSearchShortcuts Whether or not to show search shortcuts in the AwesomeBar
+ * @property areShortcutsAvailable Whether or not there are >=2 search engines installed
+ *                                 so to know to present users with certain options or not.
  * @property showClipboardSuggestions Whether or not to show clipboard suggestion in the AwesomeBar
  * @property showHistorySuggestions Whether or not to show history suggestions in the AwesomeBar
  * @property showBookmarkSuggestions Whether or not to show the bookmark suggestion in the AwesomeBar
@@ -52,6 +54,7 @@ data class SearchFragmentState(
     val showSearchSuggestions: Boolean,
     val showSearchSuggestionsHint: Boolean,
     val showSearchShortcuts: Boolean,
+    val areShortcutsAvailable: Boolean,
     val showClipboardSuggestions: Boolean,
     val showHistorySuggestions: Boolean,
     val showBookmarkSuggestions: Boolean,
@@ -68,6 +71,7 @@ sealed class SearchFragmentAction : Action {
     data class SearchShortcutEngineSelected(val engine: SearchEngine) : SearchFragmentAction()
     data class SelectNewDefaultSearchEngine(val engine: SearchEngine) : SearchFragmentAction()
     data class ShowSearchShortcutEnginePicker(val show: Boolean) : SearchFragmentAction()
+    data class UpdateShortcutsAvailability(val areShortcutsAvailable: Boolean) : SearchFragmentAction()
     data class AllowSearchSuggestionsInPrivateModePrompt(val show: Boolean) : SearchFragmentAction()
     data class UpdateQuery(val query: String) : SearchFragmentAction()
 }
@@ -83,7 +87,9 @@ private fun searchStateReducer(state: SearchFragmentState, action: SearchFragmen
                 showSearchShortcuts = false
             )
         is SearchFragmentAction.ShowSearchShortcutEnginePicker ->
-            state.copy(showSearchShortcuts = action.show)
+            state.copy(showSearchShortcuts = action.show && state.areShortcutsAvailable)
+        is SearchFragmentAction.UpdateShortcutsAvailability ->
+            state.copy(areShortcutsAvailable = action.areShortcutsAvailable)
         is SearchFragmentAction.UpdateQuery ->
             state.copy(query = action.query)
         is SearchFragmentAction.SelectNewDefaultSearchEngine ->

--- a/app/src/test/java/org/mozilla/fenix/search/SearchFragmentStoreTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/search/SearchFragmentStoreTest.kt
@@ -47,6 +47,16 @@ class SearchFragmentStoreTest {
         assertEquals(true, store.state.showSearchShortcuts)
     }
 
+    @Test
+    fun hideSearchShortcutEnginePicker() = runBlocking {
+        val initialState = emptyDefaultState()
+        val store = SearchFragmentStore(initialState)
+
+        store.dispatch(SearchFragmentAction.UpdateShortcutsAvailability(false)).join()
+        assertNotSame(initialState, store.state)
+        assertEquals(false, store.state.showSearchShortcuts)
+    }
+
     private fun emptyDefaultState(): SearchFragmentState = SearchFragmentState(
         query = "",
         searchEngineSource = mockk(),
@@ -54,6 +64,7 @@ class SearchFragmentStoreTest {
         showSearchSuggestionsHint = false,
         showSearchSuggestions = false,
         showSearchShortcuts = false,
+        areShortcutsAvailable = true,
         showClipboardSuggestions = false,
         showHistorySuggestions = false,
         showBookmarkSuggestions = false,


### PR DESCRIPTION
Otherwise, the Shortcuts option which allows to choose with what search engines
to search would be redundant.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes a new test for the change.
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made.
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).

![NoShortcutsForJustOneSearchEngin](https://user-images.githubusercontent.com/11428869/86341232-af2b0000-bc5e-11ea-9d9e-1aec785b80c7.gif)


### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture