### PR TITLE
SearchFragmentStore: Remove Session reference from state and read values from BrowserStore.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/search/SearchController.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchController.kt
@@ -69,7 +69,7 @@ class DefaultSearchController(
     private fun openSearchOrUrl(url: String) {
         activity.openToBrowserAndLoad(
             searchTermOrURL = url,
-            newTab = store.state.session == null,
+            newTab = store.state.tabId == null,
             from = BrowserDirection.FromSearch,
             engine = store.state.searchEngineSource.searchEngine
         )
@@ -103,8 +103,8 @@ class DefaultSearchController(
     override fun handleTextChanged(text: String) {
         val settings = activity.settings()
         // Display the search shortcuts on each entry of the search fragment (see #5308)
-        val textMatchesCurrentUrl = store.state.session?.url ?: "" == text
-        val textMatchesCurrentSearch = store.state.session?.searchTerms ?: "" == text
+        val textMatchesCurrentUrl = store.state.url == text
+        val textMatchesCurrentSearch = store.state.searchTerms == text
 
         store.dispatch(SearchFragmentAction.UpdateQuery(text))
         store.dispatch(
@@ -126,7 +126,7 @@ class DefaultSearchController(
     override fun handleUrlTapped(url: String) {
         activity.openToBrowserAndLoad(
             searchTermOrURL = url,
-            newTab = store.state.session == null,
+            newTab = store.state.tabId == null,
             from = BrowserDirection.FromSearch
         )
 
@@ -138,7 +138,7 @@ class DefaultSearchController(
 
         activity.openToBrowserAndLoad(
             searchTermOrURL = searchTerms,
-            newTab = store.state.session == null,
+            newTab = store.state.tabId == null,
             from = BrowserDirection.FromSearch,
             engine = store.state.searchEngineSource.searchEngine,
             forceSearch = true

--- a/app/src/main/java/org/mozilla/fenix/search/SearchFragmentStore.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchFragmentStore.kt
@@ -5,7 +5,6 @@
 package org.mozilla.fenix.search
 
 import mozilla.components.browser.search.SearchEngine
-import mozilla.components.browser.session.Session
 import mozilla.components.lib.state.Action
 import mozilla.components.lib.state.State
 import mozilla.components.lib.state.Store
@@ -34,6 +33,9 @@ sealed class SearchEngineSource {
 /**
  * The state for the Search Screen
  * @property query The current search query string
+ * @property url The current URL of the tab (if this fragment is shown for an already existing tab)
+ * @property searchTerms The search terms used to search previously in this tab (if this fragment is shown
+ * for an already existing tab)
  * @property searchEngineSource The current selected search engine with the context of how it was selected
  * @property defaultEngineSource The current default search engine source
  * @property showSearchSuggestions Whether or not to show search suggestions from the search engine in the AwesomeBar
@@ -42,11 +44,12 @@ sealed class SearchEngineSource {
  * @property showClipboardSuggestions Whether or not to show clipboard suggestion in the AwesomeBar
  * @property showHistorySuggestions Whether or not to show history suggestions in the AwesomeBar
  * @property showBookmarkSuggestions Whether or not to show the bookmark suggestion in the AwesomeBar
- * @property session The current session if available
  * @property pastedText The text pasted from the long press toolbar menu
  */
 data class SearchFragmentState(
     val query: String,
+    val url: String,
+    val searchTerms: String,
     val searchEngineSource: SearchEngineSource,
     val defaultEngineSource: SearchEngineSource.Default,
     val showSearchSuggestions: Boolean,
@@ -55,7 +58,7 @@ data class SearchFragmentState(
     val showClipboardSuggestions: Boolean,
     val showHistorySuggestions: Boolean,
     val showBookmarkSuggestions: Boolean,
-    val session: Session?,
+    val tabId: String?,
     val pastedText: String? = null,
     val searchAccessPoint: Event.PerformedSearch.SearchAccessPoint?
 ) : State

--- a/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarView.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarView.kt
@@ -198,7 +198,7 @@ class AwesomeBarView(
         updateSuggestionProvidersVisibility(state)
 
         // Do not make suggestions based on user's current URL unless it's a search shortcut
-        if (state.query == state.session?.url && !state.showSearchShortcuts) {
+        if (state.query == state.url && !state.showSearchShortcuts) {
             return
         }
 

--- a/app/src/main/java/org/mozilla/fenix/search/toolbar/ToolbarView.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/toolbar/ToolbarView.kt
@@ -125,7 +125,7 @@ class ToolbarView(
             /* Only set the search terms if pasted text is null so that the search term doesn't
             overwrite pastedText when view enters `editMode` */
             if (searchState.pastedText.isNullOrEmpty()) {
-                view.setSearchTerms(searchState.session?.searchTerms.orEmpty())
+                view.setSearchTerms(searchState.searchTerms)
             }
 
             // We must trigger an onTextChanged so when search terms are set when transitioning to `editMode`

--- a/app/src/test/java/org/mozilla/fenix/search/DefaultSearchControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/search/DefaultSearchControllerTest.kt
@@ -15,7 +15,6 @@ import mozilla.components.browser.search.SearchEngine
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.support.test.robolectric.testContext
-import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Before
 import org.junit.Test
@@ -43,7 +42,6 @@ class DefaultSearchControllerTest {
     private val store: SearchFragmentStore = mockk(relaxed = true)
     private val navController: NavController = mockk(relaxed = true)
     private val defaultSearchEngine: SearchEngine? = mockk(relaxed = true)
-    private val session: Session? = mockk(relaxed = true)
     private val searchEngine: SearchEngine = mockk(relaxed = true)
     private val metrics: MetricController = mockk(relaxed = true)
     private val sessionManager: SessionManager = mockk(relaxed = true)
@@ -55,7 +53,7 @@ class DefaultSearchControllerTest {
     @Before
     fun setUp() {
         every { activity.searchEngineManager.defaultSearchEngine } returns defaultSearchEngine
-        every { store.state.session } returns session
+        every { store.state.tabId } returns "test-tab-id"
         every { store.state.searchEngineSource.searchEngine } returns searchEngine
         every { activity.metrics } returns metrics
         every { activity.components.core.sessionManager } returns sessionManager
@@ -79,7 +77,7 @@ class DefaultSearchControllerTest {
         verify {
             activity.openToBrowserAndLoad(
                 searchTermOrURL = url,
-                newTab = session == null,
+                newTab = false,
                 from = BrowserDirection.FromSearch,
                 engine = searchEngine
             )
@@ -105,7 +103,7 @@ class DefaultSearchControllerTest {
         verify {
             activity.openToBrowserAndLoad(
                 searchTermOrURL = SupportUtils.getMozillaPageUrl(SupportUtils.MozillaPage.MANIFESTO),
-                newTab = session == null,
+                newTab = false,
                 from = BrowserDirection.FromSearch,
                 engine = searchEngine
             )
@@ -163,13 +161,11 @@ class DefaultSearchControllerTest {
     @Test
     fun `show search shortcuts when setting enabled AND query equals url`() {
         val text = "mozilla.org"
-        every { session?.url } returns "mozilla.org"
+        every { store.state.url } returns "mozilla.org"
         testContext.settings().preferences
                 .edit()
                 .putBoolean(testContext.getString(R.string.pref_key_show_search_shortcuts), true)
                 .apply()
-
-        assertEquals(text, session?.url)
 
         controller.handleTextChanged(text)
 
@@ -226,7 +222,7 @@ class DefaultSearchControllerTest {
         verify {
             activity.openToBrowserAndLoad(
                 searchTermOrURL = url,
-                newTab = session == null,
+                newTab = false,
                 from = BrowserDirection.FromSearch
             )
         }
@@ -242,7 +238,7 @@ class DefaultSearchControllerTest {
         verify {
             activity.openToBrowserAndLoad(
                 searchTermOrURL = searchTerms,
-                newTab = session == null,
+                newTab = false,
                 from = BrowserDirection.FromSearch,
                 engine = searchEngine,
                 forceSearch = true

--- a/app/src/test/java/org/mozilla/fenix/search/SearchFragmentStoreTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/search/SearchFragmentStoreTest.kt
@@ -48,6 +48,9 @@ class SearchFragmentStoreTest {
     }
 
     private fun emptyDefaultState(): SearchFragmentState = SearchFragmentState(
+        tabId = null,
+        url = "",
+        searchTerms = "",
         query = "",
         searchEngineSource = mockk(),
         defaultEngineSource = mockk(),
@@ -57,7 +60,6 @@ class SearchFragmentStoreTest {
         showClipboardSuggestions = false,
         showHistorySuggestions = false,
         showBookmarkSuggestions = false,
-        session = null,
         searchAccessPoint = Event.PerformedSearch.SearchAccessPoint.NONE
     )
 }


### PR DESCRIPTION
In AC I am preparing to slowly remove properties from `Session` in favor of using `BrowserStore`. One of the things I want to start with is `searchTerms`. Before removing anything in AC I want to migrate code in Fenix over. This patch primarily addresses `SearchFragmentStore`. There are more things that access `searchTerms` that I want to look at in future patches.