### PR TITLE
Add links in Checks panel for test/lint tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -181,9 +181,45 @@ tasks.withType(io.gitlab.arturbosch.detekt.Detekt.class) {
     exclude("**/tmp/**")
 }
 
-task listRepositories {
+tasks.register("listRepositories") {
     doLast {
         println "Repositories:"
         project.repositories.each { println "Name: " + it.name + "; url: " + it.url }
    }
+}
+
+tasks.register("writeGithubTestDetails") {
+    ext.details_file = new File('/builds/worker/github/customCheckRunText.md')
+
+    doLast {
+        mkdir "/builds/worker/github"
+
+        def url = "https://firefoxci.taskcluster-artifacts.net/$System.env.TASK_ID/0/public/reports"
+        details_file.text = """#### [Unit Test Results]($url/test/testGeckoNightlyDebugUnitTest/index.html)
+_(404 if compilation failed)_"""
+    }
+}
+
+tasks.register("writeGithubLintDetektDetails") {
+    ext.details_file = new File('/builds/worker/github/customCheckRunText.md')
+
+    doLast {
+        mkdir "/builds/worker/github"
+
+        def url = "https://firefoxci.taskcluster-artifacts.net/$System.env.TASK_ID/0/public/reports"
+        details_file.text = """#### [Detekt Results]($url/detekt.html)
+_(404 if compilation failed)_"""
+    }
+}
+
+tasks.register("writeGithubLintAndroidDetails") {
+    ext.details_file = new File('/builds/worker/github/customCheckRunText.md')
+
+    doLast {
+        mkdir "/builds/worker/github"
+
+        def url = "https://firefoxci.taskcluster-artifacts.net/$System.env.TASK_ID/0/public/reports"
+        details_file.text = """#### [Android Lint Results]($url/lint-results-geckoNightlyDebug.html)
+_(404 if compilation failed)_"""
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
+import org.mozilla.fenix.gradle.tasks.GithubDetailsTask
+
 buildscript {
     // This logic is duplicated in the allprojects block: I don't know how to fix that.
     repositories {
@@ -188,38 +190,14 @@ tasks.register("listRepositories") {
    }
 }
 
-tasks.register("writeGithubTestDetails") {
-    ext.details_file = new File('/builds/worker/github/customCheckRunText.md')
-
-    doLast {
-        mkdir "/builds/worker/github"
-
-        def url = "https://firefoxci.taskcluster-artifacts.net/$System.env.TASK_ID/0/public/reports"
-        details_file.text = """#### [Unit Test Results]($url/test/testGeckoNightlyDebugUnitTest/index.html)
-_(404 if compilation failed)_"""
-    }
+tasks.register("writeGithubTestDetails", GithubDetailsTask) {
+    text = "### [Unit Test Results](/reports/test/testGeckoNightlyDebugUnitTest/index.html)"
 }
 
-tasks.register("writeGithubLintDetektDetails") {
-    ext.details_file = new File('/builds/worker/github/customCheckRunText.md')
-
-    doLast {
-        mkdir "/builds/worker/github"
-
-        def url = "https://firefoxci.taskcluster-artifacts.net/$System.env.TASK_ID/0/public/reports"
-        details_file.text = """#### [Detekt Results]($url/detekt.html)
-_(404 if compilation failed)_"""
-    }
+tasks.register("writeGithubLintDetektDetails", GithubDetailsTask) {
+    text = "### [Detekt Results](/reports/detekt.html)"
 }
 
-tasks.register("writeGithubLintAndroidDetails") {
-    ext.details_file = new File('/builds/worker/github/customCheckRunText.md')
-
-    doLast {
-        mkdir "/builds/worker/github"
-
-        def url = "https://firefoxci.taskcluster-artifacts.net/$System.env.TASK_ID/0/public/reports"
-        details_file.text = """#### [Android Lint Results]($url/lint-results-geckoNightlyDebug.html)
-_(404 if compilation failed)_"""
-    }
+tasks.register("writeGithubLintAndroidDetails", GithubDetailsTask) {
+    text = "### [Android Lint Results](/reports/lint-results-geckoNightlyDebug.html)"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -190,14 +190,14 @@ tasks.register("listRepositories") {
    }
 }
 
-tasks.register("writeGithubTestDetails", GithubDetailsTask) {
+tasks.register("githubTestDetails", GithubDetailsTask) {
     text = "### [Unit Test Results](/reports/test/testGeckoNightlyDebugUnitTest/index.html)"
 }
 
-tasks.register("writeGithubLintDetektDetails", GithubDetailsTask) {
+tasks.register("githubLintDetektDetails", GithubDetailsTask) {
     text = "### [Detekt Results](/reports/detekt.html)"
 }
 
-tasks.register("writeGithubLintAndroidDetails", GithubDetailsTask) {
+tasks.register("githubLintAndroidDetails", GithubDetailsTask) {
     text = "### [Android Lint Results](/reports/lint-results-geckoNightlyDebug.html)"
 }

--- a/buildSrc/src/main/java/org/mozilla/fenix/gradle/tasks/GithubDetailsTask.kt
+++ b/buildSrc/src/main/java/org/mozilla/fenix/gradle/tasks/GithubDetailsTask.kt
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.gradle.tasks
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+/**
+ * Helper to write to the "customCheckRunText.md" file for Taskcluster.
+ * Taskcluster uses this file to populate the "Details" section in the GitHub Checks panel UI.
+ */
+open class GithubDetailsTask : DefaultTask() {
+
+    /**
+     * Text to write to the file.
+     * Links are automatically rewritten to point to the correct Taskcluster URL.
+     */
+    @Input
+    var text: String = ""
+
+    private val detailsFile = File("/builds/worker/github/customCheckRunText.md")
+    private val suffix = "\n\n_(404 if compilation failed)_"
+
+    /**
+     * Captures the link name and URL in a markdown link.
+     * i.e. "### [Hello](/world.html)" -> "/world.html"
+     */
+    private val markdownLinkRegex = """\[(.*)]\((.*)\)""".toRegex()
+
+    @TaskAction
+    fun writeFile() {
+        val taskId = System.getenv("TASK_ID")
+        val url = "https://firefoxci.taskcluster-artifacts.net/$taskId/0/public"
+        val replaced = text.replace(markdownLinkRegex) { match ->
+            val (_, linkName, linkUrl) = match.groupValues
+            "[$linkName](${url + linkUrl})"
+        }
+
+        project.mkdir("/builds/worker/github")
+        detailsFile.writeText(replaced + suffix)
+    }
+
+}

--- a/buildSrc/src/main/java/org/mozilla/fenix/gradle/tasks/GithubDetailsTask.kt
+++ b/buildSrc/src/main/java/org/mozilla/fenix/gradle/tasks/GithubDetailsTask.kt
@@ -16,7 +16,8 @@ import java.io.File
 open class GithubDetailsTask : DefaultTask() {
 
     /**
-     * Text to write to the file.
+     * Text to display in the Github Checks panel under "Details". Any markdown works here.
+     * The text is written to a markdown file which is used by Taskcluster.
      * Links are automatically rewritten to point to the correct Taskcluster URL.
      */
     @Input

--- a/taskcluster/ci/lint/kind.yml
+++ b/taskcluster/ci/lint/kind.yml
@@ -47,13 +47,16 @@ jobs:
         description: 'Running detekt over all modules'
         run:
             using: gradlew
-            gradlew: [detekt]
+            gradlew: [detekt, writeGithubLintDetektDetails]
         treeherder:
             symbol: detekt
         worker:
             artifacts:
                 - name: public/reports
                   path: /builds/worker/checkouts/src/build/reports
+                  type: directory
+                - name: public/github
+                  path: /builds/worker/github
                   type: directory
     ktlint:
         description: 'Running ktlint over all modules'
@@ -66,11 +69,14 @@ jobs:
         description: 'Running lint over all modules'
         run:
             using: gradlew
-            gradlew: ['lintGeckoNightlyDebug']
+            gradlew: ['lintGeckoNightlyDebug', 'writeGithubLintAndroidDetails']
         treeherder:
             symbol: lint
         worker:
             artifacts:
                 - name: public/reports
                   path: /builds/worker/checkouts/src/app/build/reports
+                  type: directory
+                - name: public/github
+                  path: /builds/worker/github
                   type: directory

--- a/taskcluster/ci/lint/kind.yml
+++ b/taskcluster/ci/lint/kind.yml
@@ -47,7 +47,7 @@ jobs:
         description: 'Running detekt over all modules'
         run:
             using: gradlew
-            gradlew: [detekt, writeGithubLintDetektDetails]
+            gradlew: [detekt, githubLintDetektDetails]
         treeherder:
             symbol: detekt
         worker:
@@ -69,7 +69,7 @@ jobs:
         description: 'Running lint over all modules'
         run:
             using: gradlew
-            gradlew: ['lintGeckoNightlyDebug', 'writeGithubLintAndroidDetails']
+            gradlew: ['lintGeckoNightlyDebug', 'githubLintAndroidDetails']
         treeherder:
             symbol: lint
         worker:

--- a/taskcluster/ci/test/kind.yml
+++ b/taskcluster/ci/test/kind.yml
@@ -44,7 +44,7 @@ jobs:
                 - 'clean'
                 - '-Pcoverage'
                 - 'jacocoGeckoNightlyDebugTestReport'
-                - 'writeGithubTestDetails'
+                - 'githubTestDetails'
 #            post-gradlew:
 #                - ['automation/taskcluster/upload_coverage_report.sh']
             secrets:

--- a/taskcluster/ci/test/kind.yml
+++ b/taskcluster/ci/test/kind.yml
@@ -40,7 +40,11 @@ jobs:
             geckoview-engine: geckoNightly
             code-review: true
         run:
-            gradlew: ['clean', '-Pcoverage', 'jacocoGeckoNightlyDebugTestReport']
+            gradlew:
+                - 'clean'
+                - '-Pcoverage'
+                - 'jacocoGeckoNightlyDebugTestReport'
+                - 'writeGithubTestDetails'
 #            post-gradlew:
 #                - ['automation/taskcluster/upload_coverage_report.sh']
             secrets:
@@ -58,4 +62,7 @@ jobs:
                   type: file
                 - name: public/reports/test
                   path: /builds/worker/checkouts/src/app/build/reports/tests
+                  type: directory
+                - name: public/github
+                  path: /builds/worker/github
                   type: directory


### PR DESCRIPTION
Makes it easier to see the HTML artifact files :)

If you click on the "Checks" tab above, you'll see links to HTML files in test-debug, lint-lint, and lint-detekt. With this change we'll rarely have to open Taskcluster.