### PR TITLE
For #12007: Use 48dp height for search engine radio buttons

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/search/AddSearchEngineFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/search/AddSearchEngineFragment.kt
@@ -93,7 +93,7 @@ class AddSearchEngineFragment : Fragment(), CompoundButton.OnCheckedChangeListen
 
         availableEngines.forEachIndexed(setupSearchEngineItem)
 
-        val engineItem = makeCustomButton(layoutInflater)
+        val engineItem = makeCustomButton(layoutInflater, res = requireContext().resources)
         engineItem.id = CUSTOM_INDEX
         engineItem.radio_button.isChecked = selectedIndex == CUSTOM_INDEX
         engineViews.add(engineItem)
@@ -250,11 +250,12 @@ class AddSearchEngineFragment : Fragment(), CompoundButton.OnCheckedChangeListen
         toggleCustomForm(selectedIndex == -1)
     }
 
-    private fun makeCustomButton(layoutInflater: LayoutInflater): View {
+    private fun makeCustomButton(layoutInflater: LayoutInflater, res: Resources): View {
         val wrapper = layoutInflater
             .inflate(R.layout.custom_search_engine_radio_button, null) as ConstraintLayout
         wrapper.setOnClickListener { wrapper.radio_button.isChecked = true }
         wrapper.radio_button.setOnCheckedChangeListener(this)
+        wrapper.minHeight = res.getDimension(R.dimen.radio_button_preference_height).toInt()
         return wrapper
     }
 
@@ -280,6 +281,7 @@ class AddSearchEngineFragment : Fragment(), CompoundButton.OnCheckedChangeListen
         engineIcon.setBounds(0, 0, iconSize, iconSize)
         wrapper.engine_icon.setImageDrawable(engineIcon)
         wrapper.overflow_menu.visibility = View.GONE
+        wrapper.minHeight = res.getDimension(R.dimen.radio_button_preference_height).toInt()
         return wrapper
     }
 

--- a/app/src/main/java/org/mozilla/fenix/settings/search/AddSearchEngineFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/search/AddSearchEngineFragment.kt
@@ -255,7 +255,7 @@ class AddSearchEngineFragment : Fragment(), CompoundButton.OnCheckedChangeListen
             .inflate(R.layout.custom_search_engine_radio_button, null) as ConstraintLayout
         wrapper.setOnClickListener { wrapper.radio_button.isChecked = true }
         wrapper.radio_button.setOnCheckedChangeListener(this)
-        wrapper.minHeight = res.getDimension(R.dimen.radio_button_preference_height).toInt()
+        wrapper.minHeight = res.getDimensionPixelSize(R.dimen.radio_button_preference_height)
         return wrapper
     }
 

--- a/app/src/main/java/org/mozilla/fenix/settings/search/AddSearchEngineFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/search/AddSearchEngineFragment.kt
@@ -281,7 +281,7 @@ class AddSearchEngineFragment : Fragment(), CompoundButton.OnCheckedChangeListen
         engineIcon.setBounds(0, 0, iconSize, iconSize)
         wrapper.engine_icon.setImageDrawable(engineIcon)
         wrapper.overflow_menu.visibility = View.GONE
-        wrapper.minHeight = res.getDimension(R.dimen.radio_button_preference_height).toInt()
+        wrapper.minHeight = res.getDimensionPixelSize(R.dimen.radio_button_preference_height)
         return wrapper
     }
 

--- a/app/src/main/java/org/mozilla/fenix/settings/search/AddSearchEngineFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/search/AddSearchEngineFragment.kt
@@ -93,7 +93,7 @@ class AddSearchEngineFragment : Fragment(), CompoundButton.OnCheckedChangeListen
 
         availableEngines.forEachIndexed(setupSearchEngineItem)
 
-        val engineItem = makeCustomButton(layoutInflater, res = requireContext().resources)
+        val engineItem = makeCustomButton(layoutInflater, res = resources)
         engineItem.id = CUSTOM_INDEX
         engineItem.radio_button.isChecked = selectedIndex == CUSTOM_INDEX
         engineViews.add(engineItem)

--- a/app/src/main/res/layout/custom_search_engine_radio_button.xml
+++ b/app/src/main/res/layout/custom_search_engine_radio_button.xml
@@ -20,7 +20,8 @@
         android:textAppearance="?android:attr/textAppearanceListItem"
         android:layout_marginStart="@dimen/search_bar_search_engine_icon_padding"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"/>
     <TextView
         android:id="@+id/engine_text"
         android:textColor="?primaryText"
@@ -29,8 +30,9 @@
         android:layout_marginStart="@dimen/search_bar_search_icon_margin"
         android:layout_marginEnd="@dimen/radio_button_padding_horizontal"
         android:text="@string/search_add_custom_engine_label_other"
+        android:textSize="16sp"
         app:layout_constraintStart_toEndOf="@id/radio_button"
-        app:layout_constraintTop_toTopOf="@id/radio_button"
-        app:layout_constraintBottom_toBottomOf="@id/radio_button"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
https://github.com/mozilla-mobile/fenix/issues/12007#issuecomment-653448867

![resim](https://user-images.githubusercontent.com/17825767/86455067-c33b3400-bd28-11ea-9302-175e74fd779c.png)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [x] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture