### PR TITLE
No issue: Re-enable Context Menu UI tests

### DIFF
--- a/app/src/androidTest/assets/pages/generic4.html
+++ b/app/src/androidTest/assets/pages/generic4.html
@@ -9,11 +9,11 @@
     <a href="generic3.html">Link 3</a>
     <p>
     <a href="../resources/rabbit.jpg">
-        <img src="../resources/rabbit.jpg" title="test_link_image">
+        <img src="../resources/rabbit.jpg" alt="test_link_image">
     </a>
     </p>
     <p>
-        <img src="../resources/rabbit.jpg" title="test_no_link_image">
+        <img src="../resources/rabbit.jpg" alt="test_no_link_image">
     </p>
 </body>
 </html>

--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/Constants.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/Constants.kt
@@ -7,7 +7,5 @@ object Constants {
         const val GOOGLE_APPS_PHOTOS = "com.google.android.apps.photos"
     }
 
-    object LongClickDuration {
-        const val LONG_CLICK_DURATION: Long = 5000
-    }
+    const val LONG_CLICK_DURATION: Long = 5000
 }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/ContextMenusTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/ContextMenusTest.kt
@@ -53,7 +53,6 @@ class ContextMenusTest {
     }
 
     @Test
-    @Ignore("Disabling because of intermittent failures https://github.com/mozilla-mobile/fenix/issues/8663")
     fun verifyContextOpenLinkNewTab() {
         val pageLinks =
             TestAssetHelper.getGenericAsset(mockWebServer, 4)
@@ -75,7 +74,6 @@ class ContextMenusTest {
         }
     }
 
-    @Ignore("Intermittent failure - https://github.com/mozilla-mobile/fenix/issues/10586")
     @Test
     fun verifyContextOpenLinkPrivateTab() {
         val pageLinks =
@@ -98,7 +96,6 @@ class ContextMenusTest {
         }
     }
 
-    @Ignore("Intermittent failure - https://github.com/mozilla-mobile/fenix/issues/8832")
     @Test
     fun verifyContextCopyLink() {
         val pageLinks =
@@ -119,7 +116,6 @@ class ContextMenusTest {
         }
     }
 
-    @Ignore("Intermittent failure - https://github.com/mozilla-mobile/fenix/issues/10586")
     @Test
     fun verifyContextShareLink() {
         val pageLinks =
@@ -136,7 +132,6 @@ class ContextMenusTest {
         }
     }
 
-    @Ignore("Temp disable intermittent failure - https://github.com/mozilla-mobile/fenix/issues/7687")
     @Test
     fun verifyContextOpenImageNewTab() {
         val pageLinks =
@@ -156,8 +151,8 @@ class ContextMenusTest {
         }
     }
 
-    @Ignore("Temp disable intermittent failure - https://github.com/mozilla-mobile/fenix/issues/7687")
     @Test
+    @Ignore("Disabled – Google Keyboard Clipboard overlay blocks the address bar: https://github.com/mozilla-mobile/fenix/issues/10586")
     fun verifyContextCopyImageLocation() {
         val pageLinks =
             TestAssetHelper.getGenericAsset(mockWebServer, 4)
@@ -177,7 +172,6 @@ class ContextMenusTest {
         }
     }
 
-    @Ignore("Temp disable intermittent failure - https://github.com/mozilla-mobile/fenix/issues/7666")
     @Test
     fun verifyContextSaveImage() {
         val pageLinks =
@@ -202,7 +196,6 @@ class ContextMenusTest {
         }
     }
 
-    @Ignore("Temp disable intermittent failure - https://github.com/mozilla-mobile/fenix/issues/7693")
     @Test
     fun verifyContextMixedVariations() {
         val pageLinks =
@@ -217,12 +210,12 @@ class ContextMenusTest {
             // verifyPageContent(pageLinks.content)
             longClickMatchingText("Link 1")
             verifyLinkContextMenuItems(genericURL.url)
-            mDevice.pressBack()
+            dismissContentContextMenu(genericURL.url)
             longClickMatchingText("test_link_image")
             verifyLinkImageContextMenuItems(imageResource.url)
-            mDevice.pressBack()
+            dismissContentContextMenu(imageResource.url)
             longClickMatchingText("test_no_link_image")
-            verifyNoLinkImageContextMenuItems("test_no_link_image")
+            verifyNoLinkImageContextMenuItems(imageResource.url)
         }
     }
 }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -16,9 +16,11 @@ import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.matcher.BundleMatchers
 import androidx.test.espresso.intent.matcher.IntentMatchers
+import androidx.test.espresso.matcher.RootMatchers.isDialog
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.isCompletelyDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.Visibility
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
@@ -34,7 +36,7 @@ import org.hamcrest.CoreMatchers.containsString
 import org.junit.Assert.assertTrue
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
-import org.mozilla.fenix.helpers.Constants.LongClickDuration
+import org.mozilla.fenix.helpers.Constants.LONG_CLICK_DURATION
 import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeShort
@@ -165,9 +167,9 @@ class BrowserRobot {
         verifyMenuButton()
     }
 
-    fun verifyNoLinkImageContextMenuItems(containsTitle: String) {
+    fun verifyNoLinkImageContextMenuItems(containsURL: Uri) {
         val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-        mDevice.waitNotNull(Until.findObject(By.textContains(containsTitle)))
+        mDevice.waitNotNull(Until.findObject(By.textContains(containsURL.toString())))
         mDevice.waitNotNull(
             Until.findObject(text("Open image in new tab")),
             waitingTime
@@ -176,6 +178,13 @@ class BrowserRobot {
         mDevice.waitNotNull(
             Until.findObject(text("Copy image location")), waitingTime
         )
+    }
+
+    fun dismissContentContextMenu(containsURL: Uri) {
+        onView(withText(containsURL.toString()))
+            .inRoot(isDialog())
+            .check(matches(isDisplayed()))
+            .perform(ViewActions.pressBack())
     }
 
     fun clickEnhancedTrackingProtectionPanel() = enhancedTrackingProtectionPanel().click()
@@ -291,7 +300,7 @@ class BrowserRobot {
         mDevice.waitNotNull(Until.findObject(text(expectedText)), waitingTime)
 
         val element = mDevice.findObject(text(expectedText))
-        element.click(LongClickDuration.LONG_CLICK_DURATION)
+        element.click(LONG_CLICK_DURATION)
     }
 
     fun snackBarButtonClick(expectedText: String) {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/DownloadRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/DownloadRobot.kt
@@ -123,7 +123,7 @@ private fun clickDownloadButton() =
     onView(withText("Download")).inRoot(isDialog()).check(matches(isDisplayed()))
 
 private fun clickOpenButton() =
-    onView(withId(R.id.download_dialog_action_button)).inRoot(isDialog()).check(
+    onView(withId(R.id.download_dialog_action_button)).check(
         matches(isDisplayed())
     )
 


### PR DESCRIPTION
Re-enable all context menu tests except `verifyContextCopyImageLocation` see https://github.com/mozilla-mobile/fenix/issues/10586#issuecomment-649037049