### PR TITLE
Add profiler markers for HomeActivity.load and DefaultTabTrayController.onNewTabTapped methods

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -484,6 +484,7 @@ open class HomeActivity : LocaleAwareAppCompatActivity() {
         engine: SearchEngine?,
         forceSearch: Boolean
     ) {
+        val startTime = components.core.engine.profiler?.getProfilerTime()
         val mode = browsingModeManager.mode
 
         val loadUrlUseCase = if (newTab) {
@@ -510,6 +511,12 @@ open class HomeActivity : LocaleAwareAppCompatActivity() {
             loadUrlUseCase.invoke(searchTermOrURL.toNormalizedUrl())
         } else {
             searchUseCase.invoke(searchTermOrURL)
+        }
+
+        if (components.core.engine.profiler?.isProfilerActive() == true) {
+            // Wrapping the `addMarker` method with `isProfilerActive` even though it's no-op when
+            // profiler is not active. That way, `text` argument will not create a string builder all the time.
+            components.core.engine.profiler?.addMarker("HomeActivity.load", startTime, "newTab: $newTab")
         }
     }
 

--- a/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayController.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayController.kt
@@ -38,9 +38,11 @@ class DefaultTabTrayController(
     private val registerCollectionStorageObserver: () -> Unit
 ) : TabTrayController {
     override fun onNewTabTapped(private: Boolean) {
+        val startTime = activity.components.core.engine.profiler?.getProfilerTime()
         activity.browsingModeManager.mode = BrowsingMode.fromBoolean(private)
         navController.navigate(TabTrayDialogFragmentDirections.actionGlobalHome(focusOnAddressBar = true))
         dismissTabTray()
+        activity.components.core.engine.profiler?.addMarker("DefaultTabTrayController.onNewTabTapped", startTime)
     }
 
     override fun onTabTrayDismissed() {


### PR DESCRIPTION
Hi all, I'm on the profiler team and was working on the profiler marker API for Android for a while. [This is the GeckoView bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1624993) and [this is the android-components PR](https://github.com/mozilla-mobile/android-components/pull/7510). Since android-components side is merged now, it's possible to use the marker API inside the Fenix codebase. This PR adds the first markers of Fenix, to demonstrate two different usages.
I wanted to add these markers to somewhere relevant for Fenix devs, but keep in mind that I don't know the codebase that much, so correct me if they are not great places :)

For example you can see an example profile here with these markers: https://share.firefox.dev/2YWKpXS
Here's the documentation about this new API: https://github.com/mozilla-mobile/android-components/blob/master/components/concept/engine/src/main/java/mozilla/components/concept/engine/profiler/Profiler.kt

Lastly, I was using my local android-components repo while writing this patch, I hope the latest a-c is merged here as well :)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture