### PR TITLE
For issue #12126 - Tab counter consumeFrom update

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -63,6 +63,7 @@ import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.state.selector.normalTabs
 import mozilla.components.browser.state.selector.privateTabs
+import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.concept.sync.AccountObserver
 import mozilla.components.concept.sync.AuthType
 import mozilla.components.concept.sync.OAuthAccount
@@ -390,15 +391,9 @@ class HomeFragment : Fragment() {
         }
 
         consumeFrom(requireComponents.core.store) {
-            val tabCount = if (browsingModeManager.mode.isPrivate) {
-                it.privateTabs.size
-            } else {
-                it.normalTabs.size
-            }
-
-            view.tab_button?.setCountWithAnimation(tabCount)
-            view.add_tabs_to_collections_button?.isVisible = tabCount > 0
+            updateTabCounter(it)
         }
+        updateTabCounter(requireComponents.core.store.state)
     }
 
     override fun onDestroyView() {
@@ -933,6 +928,17 @@ class HomeFragment : Fragment() {
 
     private fun openTabTray() {
         TabTrayDialogFragment.show(parentFragmentManager)
+    }
+
+    private fun updateTabCounter(browserState: BrowserState) {
+        val tabCount = if (browsingModeManager.mode.isPrivate) {
+            browserState.privateTabs.size
+        } else {
+            browserState.normalTabs.size
+        }
+
+        view?.tab_button?.setCountWithAnimation(tabCount)
+        view?.add_tabs_to_collections_button?.isVisible = tabCount > 0
     }
 
     companion object {


### PR DESCRIPTION
Modified the consumeFrom method inside HomeFragment for the tab counter

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture