### PR TITLE
Switch to groovy in buildSrc

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 plugins {
-    `kotlin-dsl`
+    id "org.gradle.kotlin.kotlin-dsl" version "1.3.6"
 }
 
 repositories {


### PR DESCRIPTION
In [AC](https://github.com/mozilla-mobile/android-components/pull/7630) this change saved us 13 seconds of build time.