### PR TITLE
For #12240: Enable btime youtube-playback Fenix tests

### DIFF
--- a/taskcluster/ci/browsertime/kind.yml
+++ b/taskcluster/ci/browsertime/kind.yml
@@ -232,3 +232,15 @@ jobs:
         test-name: google-search-restaurants
         treeherder:
             symbol: 'Btime(tp6m-28-c)'
+
+    youtube-playback:
+        test-name: youtube-playback
+        run-visual-metrics: False
+        treeherder:
+            symbol: 'Btime(ytp)'
+        args:
+            by-abi:
+                # Bug 1558456 - Stop tracking youtube-playback-test on motoG5 for >1080p cases
+                armeabi-v7a:
+                    - '--test-url-params=exclude=1,2,9,10,17,18,21,22,26,28,30,32,39,40,47,48,55,56,63,64,71,72,79,80,83,84,89,90,95,96'
+                default: []

--- a/taskcluster/fenix_taskgraph/transforms/browsertime.py
+++ b/taskcluster/fenix_taskgraph/transforms/browsertime.py
@@ -94,7 +94,13 @@ def build_browsertime_task(config, tasks):
         run_visual_metrics = task.pop("run-visual-metrics", False)
         if run_visual_metrics:
             task["run"]["command"].append("--browsertime-video")
+            task["run"]["command"].append("--browsertime-no-ffwindowrecorder")
             task["attributes"]["run-visual-metrics"] = True
+
+        # taskcluster is merging task attributes with the default ones
+        # resulting the --cold extra option in the ytp warm tasks
+        if 'youtube-playback' in task["name"]:
+            task["run"]["command"].remove("--cold")
 
         yield task
 


### PR DESCRIPTION
Added the youtube-playback tests [from mozilla-central](https://searchfox.org/mozilla-central/search?q=raptor-youtube&path=testing%2Fraptor%2Fraptor%2Ftests%2Fbenchmark&case=false&regexp=false)