### PR TITLE
Issue #12311: BrowserToolbarController: Stop SessionFeature and release session from EngineView.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -211,6 +211,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Session
                     isPrivate = (activity as HomeActivity).browsingModeManager.mode.isPrivate
                 ),
                 sessionManager = requireComponents.core.sessionManager,
+                sessionFeature = sessionFeature,
                 findInPageLauncher = { findInPageIntegration.withFeature { it.launch() } },
                 engineView = engineView,
                 swipeRefresh = swipeRefresh,

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt
@@ -19,6 +19,8 @@ import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.concept.engine.prompt.ShareData
+import mozilla.components.feature.session.SessionFeature
+import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
 import mozilla.components.support.ktx.kotlin.isUrl
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.NavGraphDirections
@@ -61,6 +63,7 @@ class DefaultBrowserToolbarController(
     private val activity: HomeActivity,
     private val navController: NavController,
     private val readerModeController: ReaderModeController,
+    private val sessionFeature: ViewBoundFeatureWrapper<SessionFeature>,
     private val sessionManager: SessionManager,
     private val findInPageLauncher: () -> Unit,
     private val engineView: EngineView,
@@ -260,8 +263,10 @@ class DefaultBrowserToolbarController(
                 }
             }
             ToolbarMenu.Item.OpenInFenix -> {
-                // Release the session from this view so that it can immediately be rendered by a different view
-                engineView.release()
+                // Stop the SessionFeature from updating the EngineView and let it release the session
+                // from the EngineView so that it can immediately be rendered by a different view once
+                // we switch to the actual browser.
+                sessionFeature.get()?.release()
 
                 // Strip the CustomTabConfig to turn this Session into a regular tab and then select it
                 customTabSession!!.customTabConfig = null


### PR DESCRIPTION
Now with BrowserStore we need to call `release()` on the feature, so that the feature stops observing the store. Otherwise it is possible that the feature will reattach the session and then we render it in the custom tab again before we switch to the browser.