### PR TITLE
Issue #11333: Set ContentBlocking settings directly on GeckoRuntime

### DIFF
--- a/app/src/geckoBeta/java/org/mozilla/fenix/engine/GeckoProvider.kt
+++ b/app/src/geckoBeta/java/org/mozilla/fenix/engine/GeckoProvider.kt
@@ -5,7 +5,9 @@
 import android.content.Context
 import android.os.Bundle
 import mozilla.components.browser.engine.gecko.autofill.GeckoLoginDelegateWrapper
+import mozilla.components.browser.engine.gecko.ext.toContentBlockingSetting
 import mozilla.components.browser.engine.gecko.glean.GeckoAdapter
+import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
 import mozilla.components.concept.storage.LoginsStorage
 import mozilla.components.lib.crash.handler.CrashHandlerService
 import mozilla.components.service.sync.logins.GeckoLoginStorageDelegate
@@ -21,10 +23,11 @@ object GeckoProvider {
     @Synchronized
     fun getOrCreateRuntime(
         context: Context,
-        storage: Lazy<LoginsStorage>
+        storage: Lazy<LoginsStorage>,
+        trackingProtectionPolicy: TrackingProtectionPolicy
     ): GeckoRuntime {
         if (runtime == null) {
-            runtime = createRuntime(context, storage)
+            runtime = createRuntime(context, storage, trackingProtectionPolicy)
         }
 
         return runtime!!
@@ -32,7 +35,8 @@ object GeckoProvider {
 
     private fun createRuntime(
         context: Context,
-        storage: Lazy<LoginsStorage>
+        storage: Lazy<LoginsStorage>,
+        policy: TrackingProtectionPolicy
     ): GeckoRuntime {
         val builder = GeckoRuntimeSettings.Builder()
 
@@ -44,6 +48,7 @@ object GeckoProvider {
         val runtimeSettings = builder
             .crashHandler(CrashHandlerService::class.java)
             .telemetryDelegate(GeckoAdapter())
+            .contentBlocking(policy.toContentBlockingSetting())
             .aboutConfigEnabled(Config.channel.isBeta)
             .debugLogging(Config.channel.isDebug)
             .build()

--- a/app/src/geckoNightly/java/org/mozilla/fenix/engine/GeckoProvider.kt
+++ b/app/src/geckoNightly/java/org/mozilla/fenix/engine/GeckoProvider.kt
@@ -5,7 +5,9 @@
 import android.content.Context
 import android.os.Bundle
 import mozilla.components.browser.engine.gecko.autofill.GeckoLoginDelegateWrapper
+import mozilla.components.browser.engine.gecko.ext.toContentBlockingSetting
 import mozilla.components.browser.engine.gecko.glean.GeckoAdapter
+import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
 import mozilla.components.concept.storage.LoginsStorage
 import mozilla.components.lib.crash.handler.CrashHandlerService
 import mozilla.components.service.sync.logins.GeckoLoginStorageDelegate
@@ -21,10 +23,11 @@ object GeckoProvider {
     @Synchronized
     fun getOrCreateRuntime(
         context: Context,
-        storage: Lazy<LoginsStorage>
+        storage: Lazy<LoginsStorage>,
+        trackingProtectionPolicy: TrackingProtectionPolicy
     ): GeckoRuntime {
         if (runtime == null) {
-            runtime = createRuntime(context, storage)
+            runtime = createRuntime(context, storage, trackingProtectionPolicy)
         }
 
         return runtime!!
@@ -32,7 +35,8 @@ object GeckoProvider {
 
     private fun createRuntime(
         context: Context,
-        storage: Lazy<LoginsStorage>
+        storage: Lazy<LoginsStorage>,
+        policy: TrackingProtectionPolicy
     ): GeckoRuntime {
         val builder = GeckoRuntimeSettings.Builder()
 
@@ -44,6 +48,7 @@ object GeckoProvider {
         val runtimeSettings = builder
             .crashHandler(CrashHandlerService::class.java)
             .telemetryDelegate(GeckoAdapter())
+            .contentBlocking(policy.toContentBlockingSetting())
             .debugLogging(Config.channel.isDebug)
             .aboutConfigEnabled(true)
             .build()

--- a/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -86,7 +86,11 @@ class Core(private val context: Context) {
         GeckoEngine(
             context,
             defaultSettings,
-            GeckoProvider.getOrCreateRuntime(context, lazyPasswordsStorage)
+            GeckoProvider.getOrCreateRuntime(
+                context,
+                lazyPasswordsStorage,
+                trackingProtectionPolicyFactory.createTrackingProtectionPolicy()
+            )
         ).also {
             WebCompatFeature.install(it)
 
@@ -108,7 +112,11 @@ class Core(private val context: Context) {
     val client: Client by lazy {
         GeckoViewFetchClient(
             context,
-            GeckoProvider.getOrCreateRuntime(context, lazyPasswordsStorage)
+            GeckoProvider.getOrCreateRuntime(
+                context,
+                lazyPasswordsStorage,
+                trackingProtectionPolicyFactory.createTrackingProtectionPolicy()
+            )
         )
     }
 


### PR DESCRIPTION
Requires https://github.com/mozilla-mobile/android-components/pull/7666 and https://bugzilla.mozilla.org/show_bug.cgi?id=1651454.

We set the ContentBlockingSettings directly on the GeckoRuntime now to
improve the startup of the engine.

This change has requirements from Android Components and GeckoView, so
we would only see the full perf benefits in Nightly as the changes ride
the train, although we might start to see some of them as we're updating
the GeckoProvider for the `geckoBeta` variant as well.

Co-authored-by: Arturo Mejia <arturomejiamarmol@gmail.com>
