### PR TITLE
For #12433 - Allow synced tabs pull-to-refresh for non-critical account errors

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/sync/SyncedTabsLayout.kt
+++ b/app/src/main/java/org/mozilla/fenix/sync/SyncedTabsLayout.kt
@@ -46,7 +46,8 @@ class SyncedTabsLayout @JvmOverloads constructor(
 
         synced_tabs_list.visibility = View.GONE
         sync_tabs_status.visibility = View.VISIBLE
-        synced_tabs_pull_to_refresh.isEnabled = false
+
+        synced_tabs_pull_to_refresh.isEnabled = pullToRefreshEnableState(error)
     }
 
     override fun displaySyncedTabs(syncedTabs: List<SyncedDeviceTabs>) {
@@ -77,5 +78,20 @@ class SyncedTabsLayout @JvmOverloads constructor(
 
     override fun stopLoading() {
         synced_tabs_pull_to_refresh.isRefreshing = false
+    }
+
+    companion object {
+        internal fun pullToRefreshEnableState(error: SyncedTabsView.ErrorType) = when (error) {
+            // Disable "pull-to-refresh" when we clearly can't sync tabs, and user needs to take an
+            // action within the app.
+            SyncedTabsView.ErrorType.SYNC_UNAVAILABLE,
+            SyncedTabsView.ErrorType.SYNC_NEEDS_REAUTHENTICATION -> false
+
+            // Enable "pull-to-refresh" when an external event (e.g. connecting a desktop client,
+            // or enabling tabs sync, or connecting to a network) may resolve our problem.
+            SyncedTabsView.ErrorType.SYNC_ENGINE_UNAVAILABLE,
+            SyncedTabsView.ErrorType.MULTIPLE_DEVICES_UNAVAILABLE,
+            SyncedTabsView.ErrorType.NO_TABS_AVAILABLE -> true
+        }
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/sync/SyncedTabsLayoutTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/sync/SyncedTabsLayoutTest.kt
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.sync
+
+import mozilla.components.feature.syncedtabs.view.SyncedTabsView.ErrorType
+import org.junit.Assert.assertTrue
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class SyncedTabsLayoutTest {
+    @Test
+    fun `pull to refresh state`() {
+        assertTrue(SyncedTabsLayout.pullToRefreshEnableState(ErrorType.MULTIPLE_DEVICES_UNAVAILABLE))
+        assertTrue(SyncedTabsLayout.pullToRefreshEnableState(ErrorType.SYNC_ENGINE_UNAVAILABLE))
+        assertTrue(SyncedTabsLayout.pullToRefreshEnableState(ErrorType.NO_TABS_AVAILABLE))
+        assertFalse(SyncedTabsLayout.pullToRefreshEnableState(ErrorType.SYNC_NEEDS_REAUTHENTICATION))
+        assertFalse(SyncedTabsLayout.pullToRefreshEnableState(ErrorType.SYNC_UNAVAILABLE))
+    }
+}


### PR DESCRIPTION
This enables pull-to-refresh when we encounter errors that may be resolved by some external action, re-enabling network connection, enabling tab sync on a desktop device, etc.

Tagged @jonalmeida for review since he worked on this initially.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture