### PR TITLE
Replaces verifyPageContent in UI tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
@@ -234,7 +234,7 @@ class BookmarksTest {
             IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
         }.openThreeDotMenu(defaultWebPage.url) {
         }.clickOpenInNewTab {
-            // verifyPageContent(defaultWebPage.content)
+            verifyUrl(defaultWebPage.url.toString())
         }.openTabDrawer {
             verifyNormalModeSelected()
         }
@@ -253,7 +253,7 @@ class BookmarksTest {
             IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
         }.openThreeDotMenu(defaultWebPage.url) {
         }.clickOpenInPrivateTab {
-            // verifyPageContent(defaultWebPage.content)
+            verifyUrl(defaultWebPage.url.toString())
         }.openTabDrawer {
             verifyPrivateModeSelected()
         }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/ContextMenusTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/ContextMenusTest.kt
@@ -61,7 +61,7 @@ class ContextMenusTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(pageLinks.url) {
-            // verifyPageContent(pageLinks.content)
+            mDevice.waitForIdle()
             longClickMatchingText("Link 1")
             verifyLinkContextMenuItems(genericURL.url)
             clickContextOpenLinkInNewTab()
@@ -83,7 +83,7 @@ class ContextMenusTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(pageLinks.url) {
-            // verifyPageContent(pageLinks.content)
+            mDevice.waitForIdle()
             longClickMatchingText("Link 2")
             verifyLinkContextMenuItems(genericURL.url)
             clickContextOpenLinkInPrivateTab()
@@ -105,7 +105,7 @@ class ContextMenusTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(pageLinks.url) {
-            // verifyPageContent(pageLinks.content)
+            mDevice.waitForIdle()
             longClickMatchingText("Link 3")
             verifyLinkContextMenuItems(genericURL.url)
             clickContextCopyLink()
@@ -125,12 +125,13 @@ class ContextMenusTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(pageLinks.url) {
-            // verifyPageContent(pageLinks.content)
+            mDevice.waitForIdle()
             longClickMatchingText("Link 1")
             verifyLinkContextMenuItems(genericURL.url)
             clickContextShareLink(genericURL.url) // verify share intent is matched with associated URL
         }
     }
+
     @Ignore("Intermittent: https://github.com/mozilla-mobile/fenix/issues/12367")
     @Test
     fun verifyContextOpenImageNewTab() {
@@ -141,7 +142,7 @@ class ContextMenusTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(pageLinks.url) {
-            // verifyPageContent(pageLinks.content)
+            mDevice.waitForIdle()
             longClickMatchingText("test_link_image")
             verifyLinkImageContextMenuItems(imageResource.url)
             clickContextOpenImageNewTab()
@@ -161,7 +162,7 @@ class ContextMenusTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(pageLinks.url) {
-            // verifyPageContent(pageLinks.content)
+            mDevice.waitForIdle()
             longClickMatchingText("test_link_image")
             verifyLinkImageContextMenuItems(imageResource.url)
             clickContextCopyImageLocation()
@@ -182,7 +183,7 @@ class ContextMenusTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(pageLinks.url) {
-            // verifyPageContent(pageLinks.content)
+            mDevice.waitForIdle()
             longClickMatchingText("test_link_image")
             verifyLinkImageContextMenuItems(imageResource.url)
             clickContextSaveImage()
@@ -209,7 +210,7 @@ class ContextMenusTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(pageLinks.url) {
-            // verifyPageContent(pageLinks.content)
+            mDevice.waitForIdle()
             longClickMatchingText("Link 1")
             verifyLinkContextMenuItems(genericURL.url)
             dismissContentContextMenu(genericURL.url)

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/DownloadTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/DownloadTest.kt
@@ -82,7 +82,7 @@ class DownloadTest {
 
         navigationToolbar {
         }.openNewTabAndEnterToBrowser(defaultWebPage.url) {
-            // verifyPageContent(defaultWebPage.content)
+            mDevice.waitForIdle()
             clickLinkMatchingText(defaultWebPage.content)
         }
 
@@ -100,7 +100,7 @@ class DownloadTest {
 
         navigationToolbar {
         }.openNewTabAndEnterToBrowser(defaultWebPage.url) {
-            // verifyPageContent(defaultWebPage.content)
+            mDevice.waitForIdle()
             clickLinkMatchingText(defaultWebPage.content)
         }
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/HistoryTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/HistoryTest.kt
@@ -19,6 +19,7 @@ import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.helpers.TestHelper.longTapSelectItem
 import org.mozilla.fenix.ui.robots.historyMenu
 import org.mozilla.fenix.ui.robots.homeScreen
+import org.mozilla.fenix.ui.robots.mDevice
 import org.mozilla.fenix.ui.robots.multipleSelectionToolbar
 import org.mozilla.fenix.ui.robots.navigationToolbar
 
@@ -70,7 +71,7 @@ class HistoryTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(firstWebPage.url) {
-            // verifyPageContent("Page content: 1")
+            mDevice.waitForIdle()
         }.openThreeDotMenu {
         }.openHistory {
             verifyHistoryMenuView()
@@ -86,7 +87,7 @@ class HistoryTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(firstWebPage.url) {
-            // verifyPageContent("Page content: 1")
+            mDevice.waitForIdle()
         }.openThreeDotMenu {
         }.openHistory {
         }.openThreeDotMenu {
@@ -101,7 +102,7 @@ class HistoryTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(firstWebPage.url) {
-            // verifyPageContent("Page content: 1")
+            mDevice.waitForIdle()
         }.openThreeDotMenu {
         }.openHistory {
         }.openThreeDotMenu {
@@ -119,12 +120,12 @@ class HistoryTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(firstWebPage.url) {
-            // verifyPageContent("Page content: 1")
+            mDevice.waitForIdle()
         }.openThreeDotMenu {
         }.openHistory {
         }.openThreeDotMenu {
         }.clickOpenInNormalTab {
-            // verifyPageContent(firstWebPage.content)
+            verifyUrl(firstWebPage.url.toString())
         }.openTabDrawer {
             verifyNormalModeSelected()
         }
@@ -136,12 +137,12 @@ class HistoryTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(firstWebPage.url) {
-            // verifyPageContent("Page content: 1")
+            mDevice.waitForIdle()
         }.openThreeDotMenu {
         }.openHistory {
         }.openThreeDotMenu {
         }.clickOpenInPrivateTab {
-            // verifyPageContent(firstWebPage.content)
+            verifyUrl(firstWebPage.url.toString())
         }.openTabDrawer {
             verifyPrivateModeSelected()
         }
@@ -153,7 +154,7 @@ class HistoryTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(firstWebPage.url) {
-            // verifyPageContent("Page content: 1")
+            mDevice.waitForIdle()
         }.openThreeDotMenu {
         }.openHistory {
         }.openThreeDotMenu {
@@ -168,7 +169,7 @@ class HistoryTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(firstWebPage.url) {
-            // verifyPageContent("Page content: 1")
+            mDevice.waitForIdle()
         }.openThreeDotMenu {
         }.openHistory {
             clickDeleteHistoryButton()
@@ -184,7 +185,7 @@ class HistoryTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(firstWebPage.url) {
-            // verifyPageContent("Page content: 1")
+            mDevice.waitForIdle()
         }.openThreeDotMenu {
         }.openHistory {
             longTapSelectItem(firstWebPage.url)
@@ -206,7 +207,7 @@ class HistoryTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(firstWebPage.url) {
-            // verifyPageContent("Page content: 1")
+            mDevice.waitForIdle()
         }.openTabDrawer {
             closeTab()
         }.openHomeScreen { }.openThreeDotMenu {
@@ -228,7 +229,7 @@ class HistoryTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(firstWebPage.url) {
-            // verifyPageContent("Page content: 1")
+            mDevice.waitForIdle()
         }.openThreeDotMenu {
         }.openHistory {
             longTapSelectItem(firstWebPage.url)
@@ -249,12 +250,11 @@ class HistoryTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(firstWebPage.url) {
-            // verifyPageContent("Page content: 1")
         }.openTabDrawer { }.openHomeScreen { }
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(secondWebPage.url) {
-            // verifyPageContent("Page content: 2")
+            mDevice.waitForIdle()
         }.openThreeDotMenu {
         }.openHistory {
             longTapSelectItem(firstWebPage.url)
@@ -277,7 +277,7 @@ class HistoryTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(firstWebPage.url) {
-            // verifyPageContent("Page content: 1")
+            mDevice.waitForIdle()
         }.openThreeDotMenu {
         }.openHistory {
             longTapSelectItem(firstWebPage.url)

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/MediaNotificationTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/MediaNotificationTest.kt
@@ -58,10 +58,8 @@ class MediaNotificationTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(videoTestPage.url) {
-            // verifyPageContent(videoTestPage.content)
+            mDevice.waitForIdle()
             clickMediaPlayerPlayButton()
-            waitForPlaybackToStart()
-            // verifyPageContent("Media file is playing")
         }.openNotificationShade {
             verifySystemNotificationExists(videoTestPage.title)
             clickMediaSystemNotificationControlButton("Pause")
@@ -92,7 +90,7 @@ class MediaNotificationTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(audioTestPage.url) {
-            // verifyPageContent(audioTestPage.content)
+            mDevice.waitForIdle()
             clickMediaPlayerPlayButton()
             waitForPlaybackToStart()
         }.openNotificationShade {
@@ -125,10 +123,9 @@ class MediaNotificationTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(audioTestPage.url) {
-            // verifyPageContent(audioTestPage.content)
+            mDevice.waitForIdle()
             clickMediaPlayerPlayButton()
             waitForPlaybackToStart()
-            // verifyPageContent("Media file is playing")
         }.openTabDrawer {
             verifyTabMediaControlButtonState("Pause")
             clickTabMediaControlButton()
@@ -146,10 +143,9 @@ class MediaNotificationTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(audioTestPage.url) {
-            // verifyPageContent(audioTestPage.content)
+            mDevice.waitForIdle()
             clickMediaPlayerPlayButton()
             waitForPlaybackToStart()
-            // verifyPageContent("Media file is playing")
         }.openNotificationShade {
             verifySystemNotificationExists("A site is playing media")
             clickMediaSystemNotificationControlButton("Pause")

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/NavigationToolbarTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/NavigationToolbarTest.kt
@@ -55,18 +55,12 @@ class NavigationToolbarTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(defaultWebPage.url) {
-            // verifyPageContent(defaultWebPage.content)
+            mDevice.waitForIdle()
         }.openNavigationToolbar {
         }.enterURLAndEnterToBrowser(nextWebPage.url) {
-            // verifyPageContent(nextWebPage.content)
-        }
-
-        // Re-open the three-dot menu for verification
-        navigationToolbar {
-        }.openThreeDotMenu {
-            verifyThreeDotMenuExists()
-        }.goBack {
-            // verifyPageContent(defaultWebPage.content)
+            verifyUrl(nextWebPage.url.toString())
+            mDevice.pressBack()
+            verifyUrl(defaultWebPage.url.toString())
         }
     }
 
@@ -77,12 +71,14 @@ class NavigationToolbarTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(defaultWebPage.url) {
-            // verifyPageContent(defaultWebPage.content)
+            mDevice.waitForIdle()
         }.openNavigationToolbar {
         }.enterURLAndEnterToBrowser(nextWebPage.url) {
-            // verifyPageContent(nextWebPage.content)
+            mDevice.waitForIdle()
+            verifyUrl(nextWebPage.url.toString())
             mDevice.pressBack()
-            // verifyPageContent(defaultWebPage.content)
+            mDevice.waitForIdle()
+            verifyUrl(defaultWebPage.url.toString())
         }
 
         // Re-open the three-dot menu for verification
@@ -91,7 +87,7 @@ class NavigationToolbarTest {
             verifyThreeDotMenuExists()
             verifyForwardButton()
         }.goForward {
-            // verifyPageContent(nextWebPage.content)
+            verifyUrl(nextWebPage.url.toString())
         }
     }
 
@@ -101,7 +97,7 @@ class NavigationToolbarTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(refreshWebPage.url) {
-            // verifyPageContent("DEFAULT")
+            mDevice.waitForIdle()
         }
 
         // Use refresh from the three-dot menu
@@ -110,7 +106,7 @@ class NavigationToolbarTest {
             verifyThreeDotMenuExists()
             verifyRefreshButton()
         }.refreshPage {
-            // verifyPageContent("REFRESHED")
+            verifyPageContent("REFRESHED")
         }
     }
 
@@ -120,7 +116,7 @@ class NavigationToolbarTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(defaultWebPage.url) {
-            // verifyPageContent(defaultWebPage.content)
+            verifyUrl(defaultWebPage.url.toString())
         }
     }
 
@@ -131,7 +127,7 @@ class NavigationToolbarTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(loremIpsumWebPage.url) {
-            // verifyPageContent(loremIpsumWebPage.content)
+            mDevice.waitForIdle()
         }
 
         navigationToolbar {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/ReaderViewTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/ReaderViewTest.kt
@@ -19,6 +19,7 @@ import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.ViewVisibilityIdlingResource
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
+import org.mozilla.fenix.ui.robots.mDevice
 
 /**
  *  Tests for verifying basic functionality of content context menus
@@ -70,7 +71,7 @@ class ReaderViewTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(readerViewPage.url) {
-            // verifyPageContent(readerViewPage.content)
+            mDevice.waitForIdle()
         }
 
         IdlingRegistry.getInstance().register(readerViewNotificationDot)
@@ -99,7 +100,7 @@ class ReaderViewTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(genericPage.url) {
-            // verifyPageContent(genericPage.content)
+            mDevice.waitForIdle()
         }
 
         readerViewRobot {
@@ -120,7 +121,7 @@ class ReaderViewTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(readerViewPage.url) {
-            // verifyPageContent(readerViewPage.content)
+            mDevice.waitForIdle()
         }
 
         IdlingRegistry.getInstance().register(readerViewNotificationDot)
@@ -152,7 +153,7 @@ class ReaderViewTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(readerViewPage.url) {
-            // verifyPageContent(readerViewPage.content)
+            mDevice.waitForIdle()
         }
 
         IdlingRegistry.getInstance().register(readerViewNotificationDot)
@@ -187,7 +188,7 @@ class ReaderViewTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(readerViewPage.url) {
-            // verifyPageContent(readerViewPage.content)
+            mDevice.waitForIdle()
         }
 
         IdlingRegistry.getInstance().register(readerViewNotificationDot)
@@ -222,7 +223,7 @@ class ReaderViewTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(readerViewPage.url) {
-            // verifyPageContent(readerViewPage.content)
+            mDevice.waitForIdle()
         }
 
         IdlingRegistry.getInstance().register(readerViewNotificationDot)
@@ -263,7 +264,7 @@ class ReaderViewTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(readerViewPage.url) {
-            // verifyPageContent(readerViewPage.content)
+            mDevice.waitForIdle()
         }
 
         IdlingRegistry.getInstance().register(readerViewNotificationDot)

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsBasicsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsBasicsTest.kt
@@ -133,27 +133,24 @@ class SettingsBasicsTest {
         homeScreen {
         }.openNavigationToolbar {
         }.enterURLAndEnterToBrowser(page1.url) {
-            // verifyPageContent(page1.content)
         }.openThreeDotMenu {
             clickAddBookmarkButton()
         }
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(page2.url) {
-            // verifyPageContent(page2.content)
         }.openThreeDotMenu {
             clickAddBookmarkButton()
         }
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(page3.url) {
-            // verifyPageContent(page3.content)
+            mDevice.waitForIdle()
         }
 
         navigationToolbar {
             verifyNoHistoryBookmarks()
         }
-
     }
 
     @Test

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/ShareButtonTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/ShareButtonTest.kt
@@ -50,7 +50,7 @@ class ShareButtonTest {
         //  - Visit a URL, wait until it's loaded
         navigationToolbar {
         }.enterURLAndEnterToBrowser(defaultWebPage.url) {
-            // verifyPageContent(defaultWebPage.content)
+            mDevice.waitForIdle()
         }
 
         // From the 3-dot menu next to the Select share menu

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -50,12 +50,10 @@ class SmokeTest {
         homeScreen {
             navigationToolbar {
             }.enterURLAndEnterToBrowser(defaultWebPage.url) {
-                // verifyPageContent(defaultWebPage.content)
+                mDevice.waitForIdle()
                 verifyNavURLBarItems()
             }.openNavigationToolbar {
             }.goBackToWebsite {
-                // Check disabled due to intermittent failures
-                // verifyPageContent(defaultWebPage.content)
             }.openTabDrawer {
                 verifyExistingTabList()
             }.openHomeScreen {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
@@ -66,7 +66,7 @@ class TabbedBrowsingTest {
 
         navigationToolbar {
         }.openNewTabAndEnterToBrowser(defaultWebPage.url) {
-            // verifyPageContent(defaultWebPage.content)
+            mDevice.waitForIdle()
             verifyTabCounter("1")
         }.openTabDrawer {
             verifyExistingTabList()
@@ -92,7 +92,7 @@ class TabbedBrowsingTest {
 
         navigationToolbar {
         }.openNewTabAndEnterToBrowser(defaultWebPage.url) {
-            // verifyPageContent(defaultWebPage.content)
+            mDevice.waitForIdle()
             verifyTabCounter("1")
         }.openTabDrawer {
             verifyExistingTabList()
@@ -110,7 +110,6 @@ class TabbedBrowsingTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(defaultWebPage.url) {
-            // verifyPageContent(defaultWebPage.content)
         }.openTabDrawer {
             verifyExistingTabList()
         }.openTabsListThreeDotMenu {
@@ -128,7 +127,6 @@ class TabbedBrowsingTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(defaultWebPage.url) {
-            // verifyPageContent(defaultWebPage.content)
         }.openTabDrawer {
             verifyPrivateModeSelected()
             verifyExistingTabList()
@@ -149,7 +147,6 @@ class TabbedBrowsingTest {
         genericURLS.forEachIndexed { index, element ->
             navigationToolbar {
             }.openNewTabAndEnterToBrowser(element.url) {
-                // verifyPageContent(element.content)
             }.openTabDrawer {
                 verifyExistingOpenTabs("Test_Page_${index + 1}")
                 verifyCloseTabsButton("Test_Page_${index + 1}")
@@ -182,7 +179,6 @@ class TabbedBrowsingTest {
         genericURLS.forEachIndexed { index, element ->
             navigationToolbar {
             }.openNewTabAndEnterToBrowser(element.url) {
-                // verifyPageContent(element.content)
             }.openTabDrawer {
                 verifyExistingOpenTabs("Test_Page_${index + 1}")
                 verifyCloseTabsButton("Test_Page_${index + 1}")

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/TopSitesTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/TopSitesTest.kt
@@ -53,7 +53,6 @@ class TopSitesTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(defaultWebPage.url) {
-            // verifyPageContent(defaultWebPage.content)
         }.openThreeDotMenu {
             verifyAddFirefoxHome()
         }.addToFirefoxHome {
@@ -72,7 +71,6 @@ class TopSitesTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(defaultWebPage.url) {
-            // verifyPageContent(defaultWebPage.content)
         }.openThreeDotMenu {
             verifyAddFirefoxHome()
         }.addToFirefoxHome {
@@ -82,7 +80,6 @@ class TopSitesTest {
             verifyExistingTopSitesList()
             verifyExistingTopSitesTabs(defaultWebPageTitle)
         }.openTopSiteTabWithTitle(title = defaultWebPageTitle) {
-            // verifyPageContent(defaultWebPage.content)
             verifyUrl(defaultWebPage.url.toString().replace("http://", ""))
         }.openTabDrawer {
         }.openHomeScreen {
@@ -103,7 +100,6 @@ class TopSitesTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(defaultWebPage.url) {
-            // verifyPageContent(defaultWebPage.content)
         }.openThreeDotMenu {
             verifyAddFirefoxHome()
         }.addToFirefoxHome {
@@ -126,7 +122,6 @@ class TopSitesTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(defaultWebPage.url) {
-            // verifyPageContent(defaultWebPage.content)
         }.openThreeDotMenu {
             verifyAddFirefoxHome()
         }.addToFirefoxHome {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -39,7 +39,6 @@ import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.helpers.Constants.LONG_CLICK_DURATION
 import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
-import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeShort
 import org.mozilla.fenix.helpers.click
 import org.mozilla.fenix.helpers.ext.waitNotNull
 
@@ -81,13 +80,11 @@ class BrowserRobot {
     /* Asserts that the text within DOM element with ID="testContent" has the given text, i.e.
     *  document.querySelector('#testContent').innerText == expectedText
     *
-    *  This function is not working at intended and needs a replacement.
     */
 
-    /* fun verifyPageContent(expectedText: String) {
-        // val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-        // mDevice.waitNotNull(Until.findObject(By.textContains(expectedText)), waitingTime)
-    }*/
+    fun verifyPageContent(expectedText: String) {
+        assertTrue(mDevice.findObject(UiSelector().text(expectedText)).waitForExists(waitingTime))
+    }
 
     fun verifyTabCounter(expectedText: String) {
         onView(withId(R.id.counter_text))
@@ -336,21 +333,13 @@ class BrowserRobot {
     }
 
     fun waitForPlaybackToStart() {
-        mDevice.waitNotNull(
-            hasObject(
-                text("Media file is playing")
-            ), waitingTimeShort
-        )
+        val playStateMessage = mDevice.findObject(UiSelector().text("Media file is playing"))
+        assertTrue(playStateMessage.waitForExists(waitingTime))
     }
 
     fun verifyMediaIsPaused() {
-        mDevice.waitNotNull(
-            hasObject(
-                text("Media file is paused")
-            ), waitingTimeShort
-        )
-
-        mDevice.findObject(UiSelector().text("Media file is paused")).exists()
+        val pausedStateMessage = mDevice.findObject(UiSelector().text("Media file is paused"))
+        assertTrue(pausedStateMessage.waitForExists(waitingTime))
     }
 
     class Transition {


### PR DESCRIPTION
For: https://github.com/mozilla-mobile/mobile-test-eng/issues/51
Replaced verifyPageContent with verifyUrl where it was fit.
Replaced with waitForIdle where it was only used to wait for the page load.
Changed the assertion method in verifyPageContent for verifying the page refresh. This assertion is also used now in MediaNotificationTest (the prior method returned a false positive) - I'll keep an eye on these for a while.
note:
Tests passed on running ~50 times on Firebase: https://github.com/mozilla-mobile/fenix/runs/857803644, https://github.com/mozilla-mobile/fenix/runs/858196969