### PR TITLE
Ensure logins deletion

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/logins/LoginsFragmentStore.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/LoginsFragmentStore.kt
@@ -54,6 +54,12 @@ sealed class LoginsAction : Action {
     data class UpdateLoginsList(val list: List<SavedLogin>) : LoginsAction()
     data class UpdateCurrentLogin(val item: SavedLogin) : LoginsAction()
     data class SortLogins(val sortingStrategy: SortingStrategy) : LoginsAction()
+
+    /**
+     * Cleanup the list of logins currently shown and enter in a "loading" state
+     * until [UpdateLoginsList] is emitted with a new list of logins to be displayed.
+     */
+    data class LoginSelected(val item: SavedLogin) : LoginsAction()
 }
 
 /**
@@ -108,6 +114,13 @@ private fun savedLoginsStateReducer(
                 state.searchedForText,
                 action.sortingStrategy,
                 state
+            )
+        }
+        is LoginsAction.LoginSelected -> {
+            state.copy(
+                    isLoading = true,
+                    loginList = emptyList(),
+                    filteredItems = emptyList()
             )
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/settings/logins/LoginsFragmentStore.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/LoginsFragmentStore.kt
@@ -54,11 +54,6 @@ sealed class LoginsAction : Action {
     data class UpdateLoginsList(val list: List<SavedLogin>) : LoginsAction()
     data class UpdateCurrentLogin(val item: SavedLogin) : LoginsAction()
     data class SortLogins(val sortingStrategy: SortingStrategy) : LoginsAction()
-
-    /**
-     * Cleanup the list of logins currently shown and enter in a "loading" state
-     * until [UpdateLoginsList] is emitted with a new list of logins to be displayed.
-     */
     data class LoginSelected(val item: SavedLogin) : LoginsAction()
 }
 

--- a/app/src/main/java/org/mozilla/fenix/settings/logins/LoginsListViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/LoginsListViewHolder.kt
@@ -34,7 +34,7 @@ class LoginsListViewHolder(
         updateFavIcon(item.origin)
 
         view.setOnClickListener {
-            interactor.itemClicked(item)
+            interactor.onItemClicked(item)
         }
     }
 

--- a/app/src/main/java/org/mozilla/fenix/settings/logins/SavedLoginsView.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/SavedLoginsView.kt
@@ -9,11 +9,16 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.core.view.isVisible
+import androidx.navigation.NavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import kotlinx.android.extensions.LayoutContainer
 import kotlinx.android.synthetic.main.component_saved_logins.view.*
+import org.mozilla.fenix.BrowserDirection
 import org.mozilla.fenix.R
+import org.mozilla.fenix.components.metrics.Event
+import org.mozilla.fenix.components.metrics.MetricController
 import org.mozilla.fenix.ext.addUnderline
+import org.mozilla.fenix.settings.SupportUtils
 import org.mozilla.fenix.utils.Settings
 
 /**
@@ -40,7 +45,7 @@ class SavedLoginsView(
         with(view.saved_passwords_empty_learn_more) {
             movementMethod = LinkMovementMethod.getInstance()
             addUnderline()
-            setOnClickListener { interactor.onLearnMore() }
+            setOnClickListener { interactor.onLearnMoreClicked() }
         }
 
         with(view.saved_passwords_empty_message) {
@@ -54,6 +59,7 @@ class SavedLoginsView(
     }
 
     fun update(state: LoginsListState) {
+        // todo MVI views should not have logic. Needs refactoring.
         if (state.isLoading) {
             view.progress_bar.isVisible = true
         } else {
@@ -67,28 +73,45 @@ class SavedLoginsView(
 
 /**
  * Interactor for the saved logins screen
+ *
+ * @param savedLoginsController [SavedLoginsController] which will be delegated for all users interactions.
  */
 class SavedLoginsInteractor(
-    private val savedLoginsController: SavedLoginsController,
-    private val itemClicked: (SavedLogin) -> Unit,
-    private val learnMore: () -> Unit
+    private val savedLoginsController: SavedLoginsController
 ) {
-    fun itemClicked(item: SavedLogin) {
-        itemClicked.invoke(item)
+    fun onItemClicked(item: SavedLogin) {
         savedLoginsController.handleItemClicked(item)
     }
-    fun onLearnMore() {
-        learnMore.invoke()
+
+    fun onLearnMoreClicked() {
+        savedLoginsController.handleLearnMoreClicked()
     }
-    fun sort(sortingStrategy: SortingStrategy) {
+
+    fun onSortingStrategyChanged(sortingStrategy: SortingStrategy) {
         savedLoginsController.handleSort(sortingStrategy)
     }
 }
 
 /**
  * Controller for the saved logins screen
+ *
+ * @param store Store used to hold in-memory collection state.
+ * @param navController NavController manages app navigation within a NavHost.
+ * @param browserNavigator Controller allowing browser navigation to any Uri.
+ * @param settings SharedPreferences wrapper for easier usage.
+ * @param metrics Controller that handles telemetry events.
  */
-class SavedLoginsController(val store: LoginsFragmentStore, val settings: Settings) {
+class SavedLoginsController(
+    private val store: LoginsFragmentStore,
+    private val navController: NavController,
+    private val browserNavigator: (
+        searchTermOrURL: String,
+        newTab: Boolean,
+        from: BrowserDirection
+    ) -> Unit,
+    private val settings: Settings,
+    private val metrics: MetricController
+) {
     fun handleSort(sortingStrategy: SortingStrategy) {
         store.dispatch(LoginsAction.SortLogins(sortingStrategy))
         settings.savedLoginsSortingStrategy = sortingStrategy
@@ -96,5 +119,17 @@ class SavedLoginsController(val store: LoginsFragmentStore, val settings: Settin
 
     fun handleItemClicked(item: SavedLogin) {
         store.dispatch(LoginsAction.LoginSelected(item))
+        metrics.track(Event.OpenOneLogin)
+        navController.navigate(
+            SavedLoginsFragmentDirections.actionSavedLoginsFragmentToLoginDetailFragment(item.guid)
+        )
+    }
+
+    fun handleLearnMoreClicked() {
+        browserNavigator.invoke(
+            SupportUtils.getGenericSumoURLForTopic(SupportUtils.SumoTopic.SYNC_SETUP),
+            true,
+            BrowserDirection.FromSavedLoginsFragment
+        )
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/settings/logins/SavedLoginsView.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/SavedLoginsView.kt
@@ -75,6 +75,7 @@ class SavedLoginsInteractor(
 ) {
     fun itemClicked(item: SavedLogin) {
         itemClicked.invoke(item)
+        savedLoginsController.handleItemClicked(item)
     }
     fun onLearnMore() {
         learnMore.invoke()
@@ -91,5 +92,9 @@ class SavedLoginsController(val store: LoginsFragmentStore, val settings: Settin
     fun handleSort(sortingStrategy: SortingStrategy) {
         store.dispatch(LoginsAction.SortLogins(sortingStrategy))
         settings.savedLoginsSortingStrategy = sortingStrategy
+    }
+
+    fun handleItemClicked(item: SavedLogin) {
+        store.dispatch(LoginsAction.LoginSelected(item))
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/settings/logins/LoginsFragmentStoreTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/logins/LoginsFragmentStoreTest.kt
@@ -10,6 +10,7 @@ import mozilla.components.support.test.ext.joinBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class LoginsFragmentStoreTest {
@@ -122,5 +123,20 @@ class LoginsFragmentStoreTest {
         assertEquals(SavedLoginsSortingStrategyMenu.Item.LastUsedSort, store.state.highlightedItem)
         assertEquals("example", store.state.searchedForText)
         assertEquals(listOf(exampleLogin), store.state.filteredItems)
+    }
+
+    @Test
+    fun `LoginSelected action`() {
+        val store = LoginsFragmentStore(baseState.copy(
+                isLoading = false,
+                loginList = listOf(mockk()),
+                filteredItems = listOf(mockk())
+        ))
+
+        store.dispatch(LoginsAction.LoginSelected(mockk())).joinBlocking()
+
+        assertTrue(store.state.isLoading)
+        assertTrue(store.state.loginList.isEmpty())
+        assertTrue(store.state.filteredItems.isEmpty())
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/settings/logins/LoginsListViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/logins/LoginsListViewHolderTest.kt
@@ -52,6 +52,6 @@ class LoginsListViewHolderTest {
         holder.bind(baseLogin)
 
         view.performClick()
-        verify { interactor.itemClicked(baseLogin) }
+        verify { interactor.onItemClicked(baseLogin) }
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/settings/logins/SavedLoginsControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/logins/SavedLoginsControllerTest.kt
@@ -4,21 +4,30 @@
 
 package org.mozilla.fenix.settings.logins
 
+import androidx.navigation.NavController
 import io.mockk.mockk
 import io.mockk.verify
 import io.mockk.verifyAll
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mozilla.fenix.BrowserDirection
+import org.mozilla.fenix.components.metrics.Event
+import org.mozilla.fenix.components.metrics.MetricController
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+import org.mozilla.fenix.settings.SupportUtils
 import org.mozilla.fenix.utils.Settings
 
 @RunWith(FenixRobolectricTestRunner::class)
 class SavedLoginsControllerTest {
     private val store: LoginsFragmentStore = mockk(relaxed = true)
+    private val navController: NavController = mockk(relaxed = true)
+    private val browserNavigator: (String, Boolean, BrowserDirection) -> Unit = mockk(relaxed = true)
+
     private val settings: Settings = mockk(relaxed = true)
+    private val metrics: MetricController = mockk(relaxed = true)
     private val sortingStrategy: SortingStrategy = SortingStrategy.Alphabetically(testContext)
-    private val controller = SavedLoginsController(store, settings)
+    private val controller = SavedLoginsController(store, navController, browserNavigator, settings, metrics)
 
     @Test
     fun `GIVEN a sorting strategy, WHEN handleSort is called on the controller, THEN the correct action should be dispatched and the strategy saved in sharedPref`() {
@@ -38,12 +47,29 @@ class SavedLoginsControllerTest {
 
     @Test
     fun `GIVEN a SavedLogin, WHEN handleItemClicked is called for it, THEN LoginsAction$LoginSelected should be emitted`() {
-        val login: SavedLogin = mockk()
+        val login: SavedLogin = mockk(relaxed = true)
 
         controller.handleItemClicked(login)
 
         verifyAll {
             store.dispatch(LoginsAction.LoginSelected(login))
+            metrics.track(Event.OpenOneLogin)
+            navController.navigate(
+                    SavedLoginsFragmentDirections.actionSavedLoginsFragmentToLoginDetailFragment(login.guid)
+            )
+        }
+    }
+
+    @Test
+    fun `GIVEN the learn more option, WHEN handleLearnMoreClicked is called for it, then we should open the right support webpage`() {
+        controller.handleLearnMoreClicked()
+
+        verify {
+            browserNavigator.invoke(
+                SupportUtils.getGenericSumoURLForTopic(SupportUtils.SumoTopic.SYNC_SETUP),
+                true,
+                BrowserDirection.FromSavedLoginsFragment
+            )
         }
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/settings/logins/SavedLoginsControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/logins/SavedLoginsControllerTest.kt
@@ -6,6 +6,7 @@ package org.mozilla.fenix.settings.logins
 
 import io.mockk.mockk
 import io.mockk.verify
+import io.mockk.verifyAll
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -32,6 +33,17 @@ class SavedLoginsControllerTest {
                 )
             )
             settings.savedLoginsSortingStrategy = sortingStrategy
+        }
+    }
+
+    @Test
+    fun `GIVEN a SavedLogin, WHEN handleItemClicked is called for it, THEN LoginsAction$LoginSelected should be emitted`() {
+        val login: SavedLogin = mockk()
+
+        controller.handleItemClicked(login)
+
+        verifyAll {
+            store.dispatch(LoginsAction.LoginSelected(login))
         }
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/settings/logins/SavedLoginsInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/logins/SavedLoginsInteractorTest.kt
@@ -5,7 +5,6 @@
 package org.mozilla.fenix.settings.logins
 
 import io.mockk.mockk
-import io.mockk.verify
 import io.mockk.verifyAll
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Test
@@ -16,33 +15,35 @@ import kotlin.random.Random
 @RunWith(FenixRobolectricTestRunner::class)
 class SavedLoginsInteractorTest {
     private val controller: SavedLoginsController = mockk(relaxed = true)
-    private val savedLoginClicked: (SavedLogin) -> Unit = mockk(relaxed = true)
-    private val learnMore: () -> Unit = mockk(relaxed = true)
-    private val interactor = SavedLoginsInteractor(
-        controller,
-        savedLoginClicked,
-        learnMore
-    )
+    private val interactor = SavedLoginsInteractor(controller)
 
     @Test
-    fun itemClicked() {
+    fun `GIVEN a SavedLogin being clicked, WHEN the interactor is called for it, THEN it should just delegate the controller`() {
         val item = SavedLogin("mozilla.org", "username", "password", "id", Random.nextLong())
-        interactor.itemClicked(item)
+        interactor.onItemClicked(item)
 
         verifyAll {
-            savedLoginClicked.invoke(item)
             controller.handleItemClicked(item)
         }
     }
 
     @Test
-    fun `GIVEN a sorting strategy, WHEN sort method is called on the interactor, THEN controller should call handleSort with the same parameter`() {
+    fun `GIVEN a change in sorting strategy, WHEN the interactor is called for it, THEN it should just delegate the controller`() {
         val sortingStrategy: SortingStrategy = SortingStrategy.Alphabetically(testContext)
 
-        interactor.sort(sortingStrategy)
+        interactor.onSortingStrategyChanged(sortingStrategy)
 
-        verify {
+        verifyAll {
             controller.handleSort(sortingStrategy)
+        }
+    }
+
+    @Test
+    fun `GIVEN the learn more option is clicked, WHEN the interactor is called for it, THEN it should just delegate the controller`() {
+        interactor.onLearnMoreClicked()
+
+        verifyAll {
+            controller.handleLearnMoreClicked()
         }
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/settings/logins/SavedLoginsInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/logins/SavedLoginsInteractorTest.kt
@@ -6,6 +6,7 @@ package org.mozilla.fenix.settings.logins
 
 import io.mockk.mockk
 import io.mockk.verify
+import io.mockk.verifyAll
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -28,8 +29,9 @@ class SavedLoginsInteractorTest {
         val item = SavedLogin("mozilla.org", "username", "password", "id", Random.nextLong())
         interactor.itemClicked(item)
 
-        verify {
+        verifyAll {
             savedLoginClicked.invoke(item)
+            controller.handleItemClicked(item)
         }
     }
 


### PR DESCRIPTION
Currently when the user goes back to the list of saved logins from the detail view she will briefly see the previous list of logins, possible containing even the one just edited/deleted.
And in some situations, until we get the updated list of saved logins, users would be able to tap the same just deleted login to open in a detail view, this leading to a crash.

To resolve the above a solution would have been to use a nested nav-graph for all logins fragment and a ViewModel scoped to it. But by working with the same set of logins (which could have been updated from another device if synced) for possibly a longer time we would expose ourselves to strange concurrent modification issues.

The solution I went with is simply to clear the list of saved logins when the user selects a login to open in details view so that upon returning and until receiving an updated list from `components.core.passwordsStorage.list()` he would not see a potential obsolete list, but would see (possibly, very briefly) the "loading" ux.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests.
- [x] **Screenshots**: No screenshots. Tried to make a video but there is no apparent change, everything happening too fast on my device.
- [x] **Accessibility**: The code in this PR does not include any user facing features.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture