### PR TITLE
Change enabled lint rules

### DIFF
--- a/app/lint.xml
+++ b/app/lint.xml
@@ -8,7 +8,13 @@
              Let's just ignore issues in the Sentry code since that is a third-party dependency anyways. -->
         <ignore path="**/sentry*.jar" />
     </issue>
+    <!-- Lints that don't apply to our translation process -->
     <issue id="MissingTranslation" severity="ignore" />
+    <issue id="PluralsCandidate" severity="ignore" />
+    <issue id="StringFormatCount" severity="ignore" />
+    <issue id="TypographyEllipsis" severity="ignore" />
     <issue id="ExtraTranslation" severity="warning" />
+    <!-- Lints that are disabled by default -->
+    <issue id="ConvertToWebp" severity="warning" />
 </lint>
 


### PR DESCRIPTION
We have lots of translation lints that we don't want, let's turn them off.

Experimenting with enabling a couple other lints.