### PR TITLE
For #12509: Set height of remove addon button to 36dp

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/addons/InstalledAddonDetailsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/addons/InstalledAddonDetailsFragment.kt
@@ -8,13 +8,13 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Switch
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.Navigation
 import androidx.navigation.findNavController
 import androidx.navigation.fragment.findNavController
+import com.google.android.material.switchmaterial.SwitchMaterial
 import kotlinx.android.synthetic.main.fragment_installed_add_on_details.view.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -301,7 +301,7 @@ class InstalledAddonDetailsFragment : Fragment() {
         view.remove_add_on.isClickable = clickable
     }
 
-    private fun Switch.setState(checked: Boolean) {
+    private fun SwitchMaterial.setState(checked: Boolean) {
         val text = if (checked) {
             R.string.mozac_feature_addons_enabled
         } else {

--- a/app/src/main/res/layout/fragment_installed_add_on_details.xml
+++ b/app/src/main/res/layout/fragment_installed_add_on_details.xml
@@ -19,7 +19,7 @@
             android:visibility="gone"
             android:orientation="vertical">
 
-            <Switch
+            <com.google.android.material.switchmaterial.SwitchMaterial
                 android:id="@+id/enable_switch"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -34,7 +34,7 @@
                 android:textColor="?primaryText"
                 android:textSize="16sp" />
 
-            <Switch
+            <com.google.android.material.switchmaterial.SwitchMaterial
                 android:id="@+id/allow_in_private_browsing_switch"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -93,7 +93,7 @@
                 android:textSize="16sp"
                 app:drawableStartCompat="@drawable/ic_permission" />
 
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/remove_add_on"
                 style="@style/DestructiveButton"
                 android:layout_marginHorizontal="16dp"


### PR DESCRIPTION
For: https://github.com/mozilla-mobile/fenix/issues/12509#issuecomment-657995677

Compared with other buttons using "Destructive Button" style and all of them are MaterialButton so i switched this too to Material and it got fixed.
Also switches giving warning for "use AppCompat switch or Material switch" so i switched switches to Material.

![Screenshot_1594715312](https://user-images.githubusercontent.com/17825767/87403366-71ff3000-c5c5-11ea-8e95-e2a33b7b332e.png)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [x] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture