### PR TITLE
For issue #12400 - Refresh swiped collection tab view

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -211,7 +211,8 @@ class HomeFragment : Fragment() {
                 hideOnboarding = ::hideOnboardingAndOpenSearch,
                 registerCollectionStorageObserver = ::registerCollectionStorageObserver,
                 showDeleteCollectionPrompt = ::showDeleteCollectionPrompt,
-                showTabTray = ::openTabTray
+                showTabTray = ::openTabTray,
+                handleSwipedItemDeletionCancel = ::handleSwipedItemDeletionCancel
             )
         )
         updateLayout(view)
@@ -557,12 +558,21 @@ class HomeFragment : Fragment() {
         }
     }
 
-    private fun showDeleteCollectionPrompt(tabCollection: TabCollection, title: String?, message: String) {
+    private fun showDeleteCollectionPrompt(
+        tabCollection: TabCollection,
+        title: String?,
+        message: String,
+        wasSwiped: Boolean,
+        handleSwipedItemDeletionCancel: () -> Unit
+    ) {
         val context = context ?: return
         AlertDialog.Builder(context).apply {
             setTitle(title)
             setMessage(message)
             setNegativeButton(R.string.tab_collection_dialog_negative) { dialog: DialogInterface, _ ->
+                if (wasSwiped) {
+                    handleSwipedItemDeletionCancel()
+                }
                 dialog.cancel()
             }
             setPositiveButton(R.string.tab_collection_dialog_positive) { dialog: DialogInterface, _ ->
@@ -949,6 +959,10 @@ class HomeFragment : Fragment() {
 
         view?.tab_button?.setCountWithAnimation(tabCount)
         view?.add_tabs_to_collections_button?.isVisible = tabCount > 0
+    }
+
+    private fun handleSwipedItemDeletionCancel() {
+        view?.sessionControlRecyclerView?.adapter?.notifyDataSetChanged()
     }
 
     companion object {

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlInteractor.kt
@@ -54,7 +54,7 @@ interface CollectionInteractor {
      * @param collection The collection of tabs that will be modified.
      * @param tab The tab to remove from the tab collection.
      */
-    fun onCollectionRemoveTab(collection: TabCollection, tab: Tab)
+    fun onCollectionRemoveTab(collection: TabCollection, tab: Tab, wasSwiped: Boolean)
 
     /**
      * Shares the tabs in the given tab collection. Called when a user clicks on the Collection
@@ -189,8 +189,8 @@ class SessionControlInteractor(
         controller.handleCollectionOpenTabsTapped(collection)
     }
 
-    override fun onCollectionRemoveTab(collection: TabCollection, tab: Tab) {
-        controller.handleCollectionRemoveTab(collection, tab)
+    override fun onCollectionRemoveTab(collection: TabCollection, tab: Tab, wasSwiped: Boolean) {
+        controller.handleCollectionRemoveTab(collection, tab, wasSwiped)
     }
 
     override fun onCollectionShareTabsClicked(collection: TabCollection) {

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SwipeToDeleteCallback.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SwipeToDeleteCallback.kt
@@ -29,7 +29,7 @@ class SwipeToDeleteCallback(
     override fun onSwiped(viewHolder: RecyclerView.ViewHolder, direction: Int) {
         when (viewHolder) {
             is TabInCollectionViewHolder -> {
-                interactor.onCollectionRemoveTab(viewHolder.collection, viewHolder.tab)
+                interactor.onCollectionRemoveTab(viewHolder.collection, viewHolder.tab, wasSwiped = true)
             }
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/TabInCollectionViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/TabInCollectionViewHolder.kt
@@ -53,7 +53,7 @@ class TabInCollectionViewHolder(
 
         list_item_action_button.increaseTapArea(buttonIncreaseDps)
         list_item_action_button.setOnClickListener {
-            interactor.onCollectionRemoveTab(collection, tab)
+            interactor.onCollectionRemoveTab(collection, tab, wasSwiped = false)
         }
     }
 

--- a/app/src/test/java/org/mozilla/fenix/home/SessionControlInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/SessionControlInteractorTest.kt
@@ -49,8 +49,8 @@ class SessionControlInteractorTest {
     fun onCollectionRemoveTab() {
         val collection: TabCollection = mockk(relaxed = true)
         val tab: Tab = mockk(relaxed = true)
-        interactor.onCollectionRemoveTab(collection, tab)
-        verify { controller.handleCollectionRemoveTab(collection, tab) }
+        interactor.onCollectionRemoveTab(collection, tab, false)
+        verify { controller.handleCollectionRemoveTab(collection, tab, false) }
     }
 
     @Test


### PR DESCRIPTION
Item is now refreshed by calling notifyDataSetChanged on the adapter when the last tab from the collection has been swiped away and the user cancels the deletion by pressing the cancel button from the dialog.
Also added a "wasSwiped" flag to onCollectionRemoveTab in order to check if the tab was deleted from a swipe action and not by pressing the "X" button.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture