### PR TITLE
For #12532: Align Settings -> Site permissions -> Sub-pages to 72dp keyline

### DIFF
--- a/app/src/main/res/layout/component_permissions_blocked_by_android.xml
+++ b/app/src/main/res/layout/component_permissions_blocked_by_android.xml
@@ -2,24 +2,24 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-
 <LinearLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:tools="http://schemas.android.com/tools"
-        android:id="@+id/permissions_blocked_container"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:layout_marginTop="16dp"
-        android:paddingStart="@dimen/radio_button_preference_horizontal"
-        android:paddingEnd="@dimen/radio_button_preference_horizontal"
-        android:visibility="gone"
-        tools:visibility="visible">
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/permissions_blocked_container"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:layout_marginTop="16dp"
+    android:paddingStart="@dimen/radio_button_preference_horizontal"
+    android:paddingEnd="@dimen/radio_button_preference_horizontal"
+    android:visibility="gone"
+    tools:visibility="visible">
 
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textAppearance="?android:attr/textAppearanceListItem"
+        android:layout_marginStart="@dimen/site_permissions_exceptions_item_height"
         android:text="@string/phone_feature_blocked_by_android"
         android:layout_marginBottom="16dp" />
 
@@ -27,21 +27,24 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textAppearance="?android:attr/textAppearanceListItemSmall"
+        android:layout_marginStart="@dimen/site_permissions_exceptions_item_height"
         android:text="@string/phone_feature_blocked_intro"
-        android:layout_marginBottom="16dp"/>
+        android:layout_marginBottom="16dp" />
 
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textAppearance="?android:attr/textAppearanceListItemSmall"
+        android:layout_marginStart="@dimen/site_permissions_exceptions_item_height"
         android:text="@string/phone_feature_blocked_step_settings"
-        android:layout_marginBottom="8dp"/>
+        android:layout_marginBottom="8dp" />
 
     <TextView
         android:id="@+id/blocked_by_android_permissions_label"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textAppearance="?android:attr/textAppearanceListItemSmall"
+        android:layout_marginStart="@dimen/site_permissions_exceptions_item_height"
         tools:text="@string/phone_feature_blocked_step_permissions"
         android:layout_marginBottom="8dp" />
 
@@ -50,7 +53,8 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:textAppearance="?android:attr/textAppearanceListItemSmall"
-        tools:text="@string/phone_feature_blocked_step_feature"/>
+        android:layout_marginStart="@dimen/site_permissions_exceptions_item_height"
+        tools:text="@string/phone_feature_blocked_step_feature" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/settings_button"

--- a/app/src/main/res/layout/fragment_manage_site_permissions_exceptions_feature_phone.xml
+++ b/app/src/main/res/layout/fragment_manage_site_permissions_exceptions_feature_phone.xml
@@ -6,18 +6,18 @@
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto">
-<LinearLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
+
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
         android:layout_marginTop="@dimen/radio_button_preference_vertical">
 
-    <RadioGroup
+        <RadioGroup
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
 
-        <RadioButton
+            <RadioButton
                 android:id="@+id/ask_to_allow_radio"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -26,13 +26,13 @@
                 android:background="?android:attr/selectableItemBackground"
                 android:button="@null"
                 app:drawableStartCompat="?android:attr/listChoiceIndicatorSingle"
-                android:drawablePadding="@dimen/radio_button_preference_drawable_padding"
+                android:drawablePadding="@dimen/preference_seek_bar_padding"
                 android:paddingTop="@dimen/radio_button_preference_vertical"
                 android:paddingStart="@dimen/radio_button_preference_horizontal"
                 android:paddingEnd="@dimen/radio_button_preference_horizontal"
-                android:paddingBottom="@dimen/radio_button_preference_vertical"/>
+                android:paddingBottom="@dimen/radio_button_preference_vertical" />
 
-        <RadioButton
+            <RadioButton
                 android:id="@+id/block_radio"
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/radio_button_preference_height"
@@ -41,15 +41,15 @@
                 android:background="?android:attr/selectableItemBackground"
                 android:button="@null"
                 app:drawableStartCompat="?android:attr/listChoiceIndicatorSingle"
-                android:drawablePadding="@dimen/radio_button_preference_drawable_padding"
+                android:drawablePadding="@dimen/preference_seek_bar_padding"
                 android:paddingTop="@dimen/radio_button_preference_vertical"
                 android:paddingStart="@dimen/radio_button_preference_horizontal"
                 android:paddingEnd="@dimen/radio_button_preference_horizontal"
-                android:paddingBottom="@dimen/radio_button_preference_vertical"/>
-    </RadioGroup>
+                android:paddingBottom="@dimen/radio_button_preference_vertical" />
+        </RadioGroup>
 
-    <include layout="@layout/layout_clear_permission_button"/>
-    <include layout="@layout/component_permissions_blocked_by_android"/>
+    <include layout="@layout/layout_clear_permission_button" />
+    <include layout="@layout/component_permissions_blocked_by_android" />
 
-</LinearLayout>
+    </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/fragment_manage_site_permissions_feature_phone.xml
+++ b/app/src/main/res/layout/fragment_manage_site_permissions_feature_phone.xml
@@ -7,76 +7,77 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent">
-<LinearLayout
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:orientation="vertical"
-    android:layout_marginTop="@dimen/radio_button_preference_vertical">
 
-    <RadioGroup
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:layout_marginTop="@dimen/radio_button_preference_vertical">
 
-        <RadioButton
-            android:id="@+id/ask_to_allow_radio"
+        <RadioGroup
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="?android:attr/selectableItemBackground"
-            android:button="@null"
-            android:drawablePadding="@dimen/radio_button_preference_drawable_padding"
-            android:paddingStart="@dimen/radio_button_preference_horizontal"
-            android:paddingTop="@dimen/radio_button_preference_vertical"
-            android:paddingEnd="@dimen/radio_button_preference_horizontal"
-            android:paddingBottom="@dimen/radio_button_preference_vertical"
-            android:textAppearance="?android:attr/textAppearanceListItem"
-            app:drawableStartCompat="?android:attr/listChoiceIndicatorSingle"
-            tools:text="@string/preference_option_phone_feature_ask_to_allow" />
+            android:layout_height="wrap_content">
 
-        <RadioButton
-            android:id="@+id/block_radio"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="?android:attr/selectableItemBackground"
-            android:button="@null"
-            android:drawablePadding="@dimen/radio_button_preference_drawable_padding"
-            android:paddingStart="@dimen/radio_button_preference_horizontal"
-            android:paddingTop="@dimen/radio_button_preference_vertical"
-            android:paddingEnd="@dimen/radio_button_preference_horizontal"
-            android:paddingBottom="@dimen/radio_button_preference_vertical"
-            android:textAppearance="?android:attr/textAppearanceListItem"
-            app:drawableStartCompat="?android:attr/listChoiceIndicatorSingle"
-            tools:text="@string/preference_option_phone_feature_blocked" />
+            <RadioButton
+                android:id="@+id/ask_to_allow_radio"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="?android:attr/selectableItemBackground"
+                android:button="@null"
+                android:drawablePadding="@dimen/preference_seek_bar_padding"
+                android:paddingStart="@dimen/radio_button_preference_horizontal"
+                android:paddingTop="@dimen/radio_button_preference_vertical"
+                android:paddingEnd="@dimen/radio_button_preference_horizontal"
+                android:paddingBottom="@dimen/radio_button_preference_vertical"
+                android:textAppearance="?android:attr/textAppearanceListItem"
+                app:drawableStartCompat="?android:attr/listChoiceIndicatorSingle"
+                tools:text="@string/preference_option_phone_feature_ask_to_allow" />
 
-        <RadioButton
-            android:id="@+id/third_radio"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="?android:attr/selectableItemBackground"
-            android:button="@null"
-            android:drawablePadding="@dimen/radio_button_preference_drawable_padding"
-            android:paddingStart="@dimen/radio_button_preference_horizontal"
-            android:paddingTop="@dimen/radio_button_preference_vertical"
-            android:paddingEnd="@dimen/radio_button_preference_horizontal"
-            android:paddingBottom="@dimen/radio_button_preference_vertical"
-            android:textAppearance="?android:attr/textAppearanceListItem"
-            app:drawableStartCompat="?android:attr/listChoiceIndicatorSingle" />
+            <RadioButton
+                android:id="@+id/block_radio"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="?android:attr/selectableItemBackground"
+                android:button="@null"
+                android:drawablePadding="@dimen/preference_seek_bar_padding"
+                android:paddingStart="@dimen/radio_button_preference_horizontal"
+                android:paddingTop="@dimen/radio_button_preference_vertical"
+                android:paddingEnd="@dimen/radio_button_preference_horizontal"
+                android:paddingBottom="@dimen/radio_button_preference_vertical"
+                android:textAppearance="?android:attr/textAppearanceListItem"
+                app:drawableStartCompat="?android:attr/listChoiceIndicatorSingle"
+                tools:text="@string/preference_option_phone_feature_blocked" />
 
-        <RadioButton
-            android:id="@+id/fourth_radio"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="?android:attr/selectableItemBackground"
-            android:button="@null"
-            android:drawablePadding="@dimen/radio_button_preference_drawable_padding"
-            android:paddingStart="@dimen/radio_button_preference_horizontal"
-            android:paddingTop="@dimen/radio_button_preference_vertical"
-            android:paddingEnd="@dimen/radio_button_preference_horizontal"
-            android:paddingBottom="@dimen/radio_button_preference_vertical"
-            android:textAppearance="?android:attr/textAppearanceListItem"
-            app:drawableStartCompat="?android:attr/listChoiceIndicatorSingle" />
-    </RadioGroup>
+            <RadioButton
+                android:id="@+id/third_radio"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="?android:attr/selectableItemBackground"
+                android:button="@null"
+                android:drawablePadding="@dimen/preference_seek_bar_padding"
+                android:paddingStart="@dimen/radio_button_preference_horizontal"
+                android:paddingTop="@dimen/radio_button_preference_vertical"
+                android:paddingEnd="@dimen/radio_button_preference_horizontal"
+                android:paddingBottom="@dimen/radio_button_preference_vertical"
+                android:textAppearance="?android:attr/textAppearanceListItem"
+                app:drawableStartCompat="?android:attr/listChoiceIndicatorSingle" />
 
-    <include layout="@layout/component_permissions_blocked_by_android"/>
+            <RadioButton
+                android:id="@+id/fourth_radio"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="?android:attr/selectableItemBackground"
+                android:button="@null"
+                android:drawablePadding="@dimen/preference_seek_bar_padding"
+                android:paddingStart="@dimen/radio_button_preference_horizontal"
+                android:paddingTop="@dimen/radio_button_preference_vertical"
+                android:paddingEnd="@dimen/radio_button_preference_horizontal"
+                android:paddingBottom="@dimen/radio_button_preference_vertical"
+                android:textAppearance="?android:attr/textAppearanceListItem"
+                app:drawableStartCompat="?android:attr/listChoiceIndicatorSingle" />
+        </RadioGroup>
 
-</LinearLayout>
+        <include layout="@layout/component_permissions_blocked_by_android"/>
+
+    </LinearLayout>
 </ScrollView>


### PR DESCRIPTION
cc @brampitoyo

This pr aligns texts to top bar.

Radio buttons looks misaligned because in ux mocks they are 24x24 but in Android's default one is 36x36. #12550

General
<img src="https://user-images.githubusercontent.com/17825767/87407867-67479980-c5cb-11ea-90ea-f9fed86a35b2.png" width="300">
Per Site
<img src="https://user-images.githubusercontent.com/17825767/87407864-66af0300-c5cb-11ea-9cfa-070ea1efd09c.png" width="300">


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [x] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture