### PR TITLE
For #12201 - forced sync layout callbacks to be on the main thread

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/sync/SyncedTabsLayout.kt
+++ b/app/src/main/java/org/mozilla/fenix/sync/SyncedTabsLayout.kt
@@ -10,6 +10,10 @@ import android.view.View
 import android.widget.FrameLayout
 import androidx.recyclerview.widget.LinearLayoutManager
 import kotlinx.android.synthetic.main.component_sync_tabs.view.*
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
 import mozilla.components.browser.storage.sync.SyncedDeviceTabs
 import mozilla.components.feature.syncedtabs.view.SyncedTabsView
 import org.mozilla.fenix.R
@@ -23,6 +27,7 @@ class SyncedTabsLayout @JvmOverloads constructor(
     override var listener: SyncedTabsView.Listener? = null
 
     private val adapter = SyncedTabsAdapter { listener?.onTabClicked(it) }
+    private val coroutineScope = CoroutineScope(Dispatchers.Main)
 
     init {
         inflate(getContext(), R.layout.component_sync_tabs, this)
@@ -34,42 +39,46 @@ class SyncedTabsLayout @JvmOverloads constructor(
     }
 
     override fun onError(error: SyncedTabsView.ErrorType) {
-        // We may still be displaying a "loading" spinner, hide it.
-        stopLoading()
+        coroutineScope.launch {
+            // We may still be displaying a "loading" spinner, hide it.
+            stopLoading()
 
-        val stringResId = when (error) {
-            SyncedTabsView.ErrorType.MULTIPLE_DEVICES_UNAVAILABLE -> R.string.synced_tabs_connect_another_device
-            SyncedTabsView.ErrorType.SYNC_ENGINE_UNAVAILABLE -> R.string.synced_tabs_enable_tab_syncing
-            SyncedTabsView.ErrorType.SYNC_UNAVAILABLE -> R.string.synced_tabs_connect_to_sync_account
-            SyncedTabsView.ErrorType.SYNC_NEEDS_REAUTHENTICATION -> R.string.synced_tabs_reauth
-            SyncedTabsView.ErrorType.NO_TABS_AVAILABLE -> R.string.synced_tabs_no_tabs
+            val stringResId = when (error) {
+                SyncedTabsView.ErrorType.MULTIPLE_DEVICES_UNAVAILABLE -> R.string.synced_tabs_connect_another_device
+                SyncedTabsView.ErrorType.SYNC_ENGINE_UNAVAILABLE -> R.string.synced_tabs_enable_tab_syncing
+                SyncedTabsView.ErrorType.SYNC_UNAVAILABLE -> R.string.synced_tabs_connect_to_sync_account
+                SyncedTabsView.ErrorType.SYNC_NEEDS_REAUTHENTICATION -> R.string.synced_tabs_reauth
+                SyncedTabsView.ErrorType.NO_TABS_AVAILABLE -> R.string.synced_tabs_no_tabs
+            }
+
+            sync_tabs_status.text = context.getText(stringResId)
+
+            synced_tabs_list.visibility = View.GONE
+            sync_tabs_status.visibility = View.VISIBLE
+
+            synced_tabs_pull_to_refresh.isEnabled = pullToRefreshEnableState(error)
         }
-
-        sync_tabs_status.text = context.getText(stringResId)
-
-        synced_tabs_list.visibility = View.GONE
-        sync_tabs_status.visibility = View.VISIBLE
-
-        synced_tabs_pull_to_refresh.isEnabled = pullToRefreshEnableState(error)
     }
 
     override fun displaySyncedTabs(syncedTabs: List<SyncedDeviceTabs>) {
-        synced_tabs_list.visibility = View.VISIBLE
-        sync_tabs_status.visibility = View.GONE
+        coroutineScope.launch {
+            synced_tabs_list.visibility = View.VISIBLE
+            sync_tabs_status.visibility = View.GONE
 
-        val allDeviceTabs = emptyList<SyncedTabsAdapter.AdapterItem>().toMutableList()
+            val allDeviceTabs = emptyList<SyncedTabsAdapter.AdapterItem>().toMutableList()
 
-        syncedTabs.forEach { (device, tabs) ->
-            if (tabs.isEmpty()) {
-                return@forEach
+            syncedTabs.forEach { (device, tabs) ->
+                if (tabs.isEmpty()) {
+                    return@forEach
+                }
+
+                val deviceTabs = tabs.map { SyncedTabsAdapter.AdapterItem.Tab(it) }
+
+                allDeviceTabs += listOf(SyncedTabsAdapter.AdapterItem.Device(device)) + deviceTabs
             }
 
-            val deviceTabs = tabs.map { SyncedTabsAdapter.AdapterItem.Tab(it) }
-
-            allDeviceTabs += listOf(SyncedTabsAdapter.AdapterItem.Device(device)) + deviceTabs
+            adapter.submitList(allDeviceTabs)
         }
-
-        adapter.submitList(allDeviceTabs)
     }
 
     override fun startLoading() {
@@ -81,6 +90,11 @@ class SyncedTabsLayout @JvmOverloads constructor(
 
     override fun stopLoading() {
         synced_tabs_pull_to_refresh.isRefreshing = false
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        coroutineScope.cancel()
     }
 
     companion object {


### PR DESCRIPTION
The account manager from AC works similar to the store that we have (so it has states and a reducer), however it delivers the result to consumers via old-school observer pattern, and since the reducer is on a different thread, all consumers are notified on that thread as well. 

This consumer needs to perform UI changes, so it's required to be on main thread for that to happen. I chose to set only this consumer on the main thread and not switch context in the account manager reducer, because some consumers do computation and should remain on the separate thread.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture