### PR TITLE
For #12585: Dismiss tab tray menu on orientation changes

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayDialogFragment.kt
@@ -61,6 +61,7 @@ class TabTrayDialogFragment : AppCompatDialogFragment(), UserInteractionHandler 
 
     private val tabsFeature = ViewBoundFeatureWrapper<TabsFeature>()
     private var _tabTrayView: TabTrayView? = null
+    private var currentOrientation: Int? = null
     private val tabTrayView: TabTrayView
         get() = _tabTrayView!!
     private lateinit var tabTrayDialogStore: TabTrayDialogFragmentStore
@@ -154,9 +155,10 @@ class TabTrayDialogFragment : AppCompatDialogFragment(), UserInteractionHandler 
         val isLandscape = newConfig.orientation == Configuration.ORIENTATION_LANDSCAPE
         tabTrayView.setTopOffset(isLandscape)
 
-        if (isLandscape) {
+        if (newConfig.orientation != currentOrientation) {
             tabTrayView.dismissMenu()
             tabTrayView.expand()
+            currentOrientation = newConfig.orientation
         }
     }
 
@@ -168,6 +170,7 @@ class TabTrayDialogFragment : AppCompatDialogFragment(), UserInteractionHandler 
 
         val thumbnailLoader = ThumbnailLoader(requireContext().components.core.thumbnailStorage)
         val adapter = FenixTabsAdapter(requireContext(), thumbnailLoader)
+        currentOrientation = resources.configuration.orientation
 
         _tabTrayView = TabTrayView(
             view.tabLayout,


### PR DESCRIPTION
https://imgur.com/mwAYSBh

We currently dismiss menu on portrait -> landscape. This pr will dismiss menu on all cases (portrait -> landscape, landscape -> portrait).

Just an idea, feel free to close if you don't like.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [x] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture