### PR TITLE
[UI Tests]No issue: Verify ETP toolbar shield icon is not displayed if ETP is OFF globally

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -215,4 +215,39 @@ class SmokeTest {
             }
         }
     }
+
+    @Test
+    fun verifyETPToolbarShieldIconIsNotDisplayedIfETPIsOFFGloballyTest() {
+        val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        homeScreen {
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openEnhancedTrackingProtectionSubMenu {
+            clickEnhancedTrackingProtectionDefaults()
+            verifyEnhancedTrackingProtectionOptionsGrayedOut()
+        }.goBackToHomeScreen {
+            navigationToolbar {
+            }.enterURLAndEnterToBrowser(defaultWebPage.url) {
+                verifyEnhancedTrackingProtectionPanelNotVisible()
+            }.openThreeDotMenu {
+            }.clickAddOnsReportSiteIssue {
+                verifyUrl("webcompat.com/issues/new")
+                verifyTabCounter("2")
+            }.openTabDrawer {
+            }.openHomeScreen {
+            }.openThreeDotMenu {
+            }.openSettings {
+            }.openEnhancedTrackingProtectionSubMenu {
+                clickEnhancedTrackingProtectionDefaults()
+            }.goBackToHomeScreen {
+            }.openTabDrawer {
+            }.openTab(defaultWebPage.title) {
+                clickEnhancedTrackingProtectionPanel()
+                verifyEnhancedTrackingProtectionSwitch()
+                // Turning off TP Switch results in adding the WebPage to exception list
+                clickEnhancedTrackingProtectionSwitchOffOn()
+            }
+        }
+    }
 }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -23,6 +23,7 @@ import androidx.test.espresso.matcher.ViewMatchers.isCompletelyDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withResourceName
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.By
@@ -144,6 +145,8 @@ class BrowserRobot {
 
     fun verifyEnhancedTrackingProtectionSwitch() = assertEnhancedTrackingProtectionSwitch()
 
+    fun clickEnhancedTrackingProtectionSwitchOffOn() = onView(withResourceName("switch_widget")).click()
+
     fun verifyProtectionSettingsButton() = assertProtectionSettingsButton()
 
     fun verifyEnhancedTrackingOptions() {
@@ -187,6 +190,8 @@ class BrowserRobot {
     }
 
     fun clickEnhancedTrackingProtectionPanel() = enhancedTrackingProtectionPanel().click()
+
+    fun verifyEnhancedTrackingProtectionPanelNotVisible() = assertEnhancedTrackingProtectionPanelNotVisible()
 
     fun clickContextOpenLinkInNewTab() {
         val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
@@ -419,6 +424,11 @@ private fun assertNavURLBar() = navURLBar()
     .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
 fun enhancedTrackingProtectionPanel() = onView(withId(R.id.mozac_browser_toolbar_tracking_protection_indicator))
+
+private fun assertEnhancedTrackingProtectionPanelNotVisible() {
+    enhancedTrackingProtectionPanel()
+        .check(matches(withEffectiveVisibility(Visibility.GONE)))
+}
 
 private fun assertEnhancedTrackingProtectionSwitch() {
     withText(R.id.trackingProtectionSwitch)

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
@@ -141,6 +141,7 @@ class SettingsRobot {
         }
 
         fun openEnhancedTrackingProtectionSubMenu(interact: SettingsSubMenuEnhancedTrackingProtectionRobot.() -> Unit): SettingsSubMenuEnhancedTrackingProtectionRobot.Transition {
+            scrollToElementByText("Enhanced Tracking Protection")
             fun enhancedTrackingProtectionButton() =
                 onView(withText("Enhanced Tracking Protection"))
             enhancedTrackingProtectionButton().click()

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuEnhancedTrackingProtectionRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuEnhancedTrackingProtectionRobot.kt
@@ -7,6 +7,7 @@ package org.mozilla.fenix.ui.robots
 import androidx.preference.R
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.Espresso.pressBack
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions
 import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
@@ -23,9 +24,11 @@ import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import org.hamcrest.CoreMatchers.allOf
+import org.hamcrest.CoreMatchers.not
 import org.mozilla.fenix.helpers.assertIsChecked
 import org.mozilla.fenix.helpers.click
 import org.mozilla.fenix.helpers.isChecked
+import org.mozilla.fenix.helpers.isEnabled
 
 /**
  * Implementation of Robot Pattern for the settings Enhanced Tracking Protection sub menu.
@@ -44,7 +47,11 @@ class SettingsSubMenuEnhancedTrackingProtectionRobot {
 
     fun verifyEnhancedTrackingProtectionOptions() = assertEnhancedTrackingProtectionOptions()
 
+    fun verifyEnhancedTrackingProtectionOptionsGrayedOut() = assertEnhancedTrackingProtectionOptionsGrayedOut()
+
     fun verifyEnhancedTrackingProtectionDefaults() = assertEnhancedTrackingProtectionDefaults()
+
+    fun clickEnhancedTrackingProtectionDefaults() = onView(withResourceName("switch_widget")).click()
 
     fun verifyRadioButtonDefaults() = assertRadioButtonDefaults()
 
@@ -60,6 +67,16 @@ class SettingsSubMenuEnhancedTrackingProtectionRobot {
 
     class Transition {
         val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())!!
+
+        fun goBackToHomeScreen(interact: HomeScreenRobot.() -> Unit): HomeScreenRobot.Transition {
+            // To settings
+            goBackButton().click()
+            // To HomeScreen
+            pressBack()
+
+            HomeScreenRobot().interact()
+            return HomeScreenRobot.Transition()
+        }
 
         fun goBack(interact: SettingsRobot.() -> Unit): SettingsRobot.Transition {
             goBackButton().click()
@@ -139,6 +156,31 @@ private fun assertEnhancedTrackingProtectionOptions() {
         "Choose which trackers and scripts to block."
     onView(withText(customText))
         .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+}
+
+private fun assertEnhancedTrackingProtectionOptionsGrayedOut() {
+    onView(withText("Standard (default)"))
+        .check(matches(not(isEnabled(true))))
+
+    val stdText = "Blocks fewer trackers. Pages will load normally."
+    onView(withText(stdText))
+        .check(matches(not(isEnabled(true))))
+
+    onView(withText("Strict"))
+        .check(matches(not(isEnabled(true))))
+
+    val strictText =
+        "Blocks more trackers, ads, and popups. Pages load faster, but some functionality might not work."
+    onView(withText(strictText))
+        .check(matches(not(isEnabled(true))))
+
+    onView(withText("Custom"))
+        .check(matches(not(isEnabled(true))))
+
+    val customText =
+        "Choose which trackers and scripts to block."
+    onView(withText(customText))
+        .check(matches(not(isEnabled(true))))
 }
 
 private fun assertEnhancedTrackingProtectionDefaults() {


### PR DESCRIPTION
This UI test is written according to [this](https://testrail.stage.mozaws.net/index.php?/cases/view/339720&group_by=cases:section_id&group_order=asc&group_id=44874) steps in Test Rail

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture