### PR TITLE
Move settings in components

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/StrictEnhancedTrackingProtectionTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/StrictEnhancedTrackingProtectionTest.kt
@@ -46,7 +46,7 @@ class StrictEnhancedTrackingProtectionTest {
             start()
         }
 
-        InstrumentationRegistry.getInstrumentation().context.settings().setStrictETP()
+        activityTestRule.activity.settings().setStrictETP()
 
         // Reset on-boarding notification for each test
         TestHelper.setPreference(

--- a/app/src/geckoBeta/java/org/mozilla/fenix/engine/GeckoProvider.kt
+++ b/app/src/geckoBeta/java/org/mozilla/fenix/engine/GeckoProvider.kt
@@ -10,7 +10,7 @@ import mozilla.components.concept.storage.LoginsStorage
 import mozilla.components.lib.crash.handler.CrashHandlerService
 import mozilla.components.service.sync.logins.GeckoLoginStorageDelegate
 import org.mozilla.fenix.Config
-import org.mozilla.fenix.utils.Settings
+import org.mozilla.fenix.ext.components
 import org.mozilla.geckoview.GeckoRuntime
 import org.mozilla.geckoview.GeckoRuntimeSettings
 
@@ -48,9 +48,10 @@ object GeckoProvider {
             .debugLogging(Config.channel.isDebug)
             .build()
 
-        if (!Settings.getInstance(context).shouldUseAutoSize) {
+        val settings = context.components.settings
+        if (!settings.shouldUseAutoSize) {
             runtimeSettings.automaticFontSizeAdjustment = false
-            val fontSize = Settings.getInstance(context).fontSizeFactor
+            val fontSize = settings.fontSizeFactor
             runtimeSettings.fontSizeFactor = fontSize
         }
 

--- a/app/src/geckoNightly/java/org/mozilla/fenix/engine/GeckoProvider.kt
+++ b/app/src/geckoNightly/java/org/mozilla/fenix/engine/GeckoProvider.kt
@@ -10,7 +10,7 @@ import mozilla.components.concept.storage.LoginsStorage
 import mozilla.components.lib.crash.handler.CrashHandlerService
 import mozilla.components.service.sync.logins.GeckoLoginStorageDelegate
 import org.mozilla.fenix.Config
-import org.mozilla.fenix.utils.Settings
+import org.mozilla.fenix.ext.components
 import org.mozilla.geckoview.GeckoRuntime
 import org.mozilla.geckoview.GeckoRuntimeSettings
 
@@ -48,9 +48,10 @@ object GeckoProvider {
             .aboutConfigEnabled(true)
             .build()
 
-        if (!Settings.getInstance(context).shouldUseAutoSize) {
+        val settings = context.components.settings
+        if (!settings.shouldUseAutoSize) {
             runtimeSettings.automaticFontSizeAdjustment = false
-            val fontSize = Settings.getInstance(context).fontSizeFactor
+            val fontSize = settings.fontSizeFactor
             runtimeSettings.fontSizeFactor = fontSize
         }
 

--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -47,7 +47,6 @@ import org.mozilla.fenix.push.WebPushEngineIntegration
 import org.mozilla.fenix.session.PerformanceActivityLifecycleCallbacks
 import org.mozilla.fenix.session.VisibilityLifecycleCallback
 import org.mozilla.fenix.utils.BrowsersCache
-import org.mozilla.fenix.utils.Settings
 
 /**
  *The main application class for Fenix. Records data to measure initialization performance.
@@ -355,8 +354,7 @@ open class FenixApplication : LocaleAwareApplication() {
                     _, engineSession, url ->
                         val shouldCreatePrivateSession =
                             components.core.sessionManager.selectedSession?.private
-                                ?: Settings.instance?.openLinksInAPrivateTab
-                                ?: false
+                                ?: components.settings.openLinksInAPrivateTab
 
                         val session = Session(url, shouldCreatePrivateSession)
                         components.core.sessionManager.add(session, true, engineSession)

--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -26,7 +26,6 @@ import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.NavigationUI
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.google.android.gms.tasks.Tasks.call
 import kotlinx.android.synthetic.main.activity_home.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -65,7 +64,6 @@ import org.mozilla.fenix.browser.browsingmode.BrowsingModeManager
 import org.mozilla.fenix.browser.browsingmode.DefaultBrowsingModeManager
 import org.mozilla.fenix.components.metrics.BreadcrumbsRecorder
 import org.mozilla.fenix.components.metrics.Event
-import org.mozilla.fenix.trackingprotectionexceptions.TrackingProtectionExceptionsFragmentDirections
 import org.mozilla.fenix.ext.alreadyOnDestination
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.nav
@@ -87,8 +85,8 @@ import org.mozilla.fenix.session.NotificationSessionObserver
 import org.mozilla.fenix.settings.SettingsFragmentDirections
 import org.mozilla.fenix.settings.TrackingProtectionFragmentDirections
 import org.mozilla.fenix.settings.about.AboutFragmentDirections
-import org.mozilla.fenix.settings.logins.fragment.SavedLoginsAuthFragmentDirections
 import org.mozilla.fenix.settings.logins.fragment.LoginDetailFragmentDirections
+import org.mozilla.fenix.settings.logins.fragment.SavedLoginsAuthFragmentDirections
 import org.mozilla.fenix.settings.search.AddSearchEngineFragmentDirections
 import org.mozilla.fenix.settings.search.EditCustomSearchEngineFragmentDirections
 import org.mozilla.fenix.share.AddNewDeviceFragmentDirections
@@ -97,6 +95,7 @@ import org.mozilla.fenix.tabtray.FenixTabsAdapter
 import org.mozilla.fenix.tabtray.TabTrayDialogFragment
 import org.mozilla.fenix.theme.DefaultThemeManager
 import org.mozilla.fenix.theme.ThemeManager
+import org.mozilla.fenix.trackingprotectionexceptions.TrackingProtectionExceptionsFragmentDirections
 import org.mozilla.fenix.utils.BrowsersCache
 import org.mozilla.fenix.utils.RunWhenReadyQueue
 
@@ -575,7 +574,7 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
     }
 
     protected open fun createBrowsingModeManager(initialMode: BrowsingMode): BrowsingModeManager {
-        return DefaultBrowsingModeManager(initialMode) { newMode ->
+        return DefaultBrowsingModeManager(initialMode, components.settings) { newMode ->
             themeManager.currentTheme = newMode
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/addons/InstalledAddonDetailsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/addons/InstalledAddonDetailsFragment.kt
@@ -25,7 +25,6 @@ import mozilla.components.feature.addons.ui.translatedName
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.showToolbar
-import org.mozilla.fenix.utils.Settings
 
 /**
  * An activity to show the details of a installed add-on.
@@ -191,8 +190,7 @@ class InstalledAddonDetailsFragment : Fragment() {
                     val components = it.context.components
                     val shouldCreatePrivateSession =
                         components.core.store.state.selectedTab?.content?.private
-                            ?: Settings.instance?.openLinksInAPrivateTab
-                            ?: false
+                            ?: components.settings.openLinksInAPrivateTab
 
                     if (shouldCreatePrivateSession) {
                         components.useCases.tabsUseCases.addPrivateTab(settingUrl)

--- a/app/src/main/java/org/mozilla/fenix/browser/browsingmode/BrowsingModeManager.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/browsingmode/BrowsingModeManager.kt
@@ -36,6 +36,7 @@ interface BrowsingModeManager {
  */
 class DefaultBrowsingModeManager(
     private var _mode: BrowsingMode,
+    private val settings: Settings,
     private val modeDidChange: (BrowsingMode) -> Unit
 ) : BrowsingModeManager {
 
@@ -44,6 +45,6 @@ class DefaultBrowsingModeManager(
         set(value) {
             _mode = value
             modeDidChange(value)
-            Settings.instance?.lastKnownMode = value
+            settings.lastKnownMode = value
         }
 }

--- a/app/src/main/java/org/mozilla/fenix/components/BackgroundServices.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/BackgroundServices.kt
@@ -40,6 +40,7 @@ import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.sync.SyncedTabsIntegration
 import org.mozilla.fenix.utils.Mockable
 import org.mozilla.fenix.utils.RunWhenReadyQueue
+import org.mozilla.fenix.utils.Settings
 
 /**
  * Component group for background services. These are the components that need to be accessed from within a
@@ -103,7 +104,7 @@ class BackgroundServices(
     }
 
     private val telemetryAccountObserver = TelemetryAccountObserver(
-        context,
+        context.settings(),
         context.components.analytics.metrics
     )
 
@@ -178,8 +179,8 @@ class BackgroundServices(
 }
 
 @VisibleForTesting(otherwise = PRIVATE)
-class TelemetryAccountObserver(
-    private val context: Context,
+internal class TelemetryAccountObserver(
+    private val settings: Settings,
     private val metricController: MetricController
 ) : AccountObserver {
     override fun onAuthenticated(account: OAuthAccount, authType: AuthType) {
@@ -211,12 +212,12 @@ class TelemetryAccountObserver(
                 metricController.track(Event.SyncAuthOtherExternal)
         }
         // Used by Leanplum as a context variable.
-        context.settings().fxaSignedIn = true
+        settings.fxaSignedIn = true
     }
 
     override fun onLoggedOut() {
         metricController.track(Event.SyncAuthSignOut)
         // Used by Leanplum as a context variable.
-        context.settings().fxaSignedIn = false
+        settings.fxaSignedIn = false
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/components/Components.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Components.kt
@@ -20,6 +20,7 @@ import org.mozilla.fenix.BuildConfig
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.utils.ClipboardHandler
 import org.mozilla.fenix.utils.Mockable
+import org.mozilla.fenix.utils.Settings
 import org.mozilla.fenix.wifi.WifiConnectionMonitor
 import java.util.concurrent.TimeUnit
 
@@ -107,4 +108,6 @@ class Components(private val context: Context) {
     val performance by lazy { PerformanceComponent() }
     val push by lazy { Push(context, analytics.crashReporter) }
     val wifiConnectionMonitor by lazy { WifiConnectionMonitor(context.getSystemService()!!) }
+
+    val settings by lazy { Settings(context) }
 }

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
@@ -24,15 +24,14 @@ import mozilla.components.browser.state.selector.findTab
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.storage.BookmarksStorage
 import mozilla.components.support.ktx.android.content.getColorFromAttr
-import org.mozilla.fenix.R
 import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.HomeActivity
+import org.mozilla.fenix.R
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.ext.asActivity
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.theme.ThemeManager
-import org.mozilla.fenix.utils.Settings
 
 /**
  * Builds the toolbar object used with the 3-dot menu in the browser fragment.
@@ -160,7 +159,7 @@ class DefaultToolbarMenu(
         // Predicates that are called once, during screen init
         val shouldShowSaveToCollection = (context.asActivity() as? HomeActivity)
             ?.browsingModeManager?.mode == BrowsingMode.Normal
-        val shouldDeleteDataOnQuit = Settings.getInstance(context)
+        val shouldDeleteDataOnQuit = context.components.settings
             .shouldDeleteBrowsingDataOnQuit
 
         val menuItems = listOfNotNull(

--- a/app/src/main/java/org/mozilla/fenix/ext/Context.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/Context.kt
@@ -12,8 +12,6 @@ import android.view.ViewGroup
 import androidx.annotation.StringRes
 import mozilla.components.browser.search.SearchEngineManager
 import mozilla.components.support.locale.LocaleManager
-import org.mozilla.fenix.BuildConfig
-import org.mozilla.fenix.Config
 import org.mozilla.fenix.FenixApplication
 import org.mozilla.fenix.components.Components
 import org.mozilla.fenix.components.metrics.MetricController
@@ -60,8 +58,7 @@ fun Context.getPreferenceKey(@StringRes resourceId: Int): String =
 fun Context.getRootView(): View? =
     asActivity()?.window?.decorView?.findViewById<View>(android.R.id.content) as? ViewGroup
 
-fun Context.settings(isCrashReportEnabledInBuild: Boolean = BuildConfig.CRASH_REPORTING && Config.channel.isReleased) =
-    Settings.getInstance(this, isCrashReportEnabledInBuild)
+fun Context.settings() = Settings.getInstance(this)
 
 /**
  * Used to catch IllegalArgumentException that is thrown when

--- a/app/src/main/java/org/mozilla/fenix/ext/Context.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/Context.kt
@@ -16,7 +16,6 @@ import org.mozilla.fenix.FenixApplication
 import org.mozilla.fenix.components.Components
 import org.mozilla.fenix.components.metrics.MetricController
 import org.mozilla.fenix.settings.advanced.getSelectedLocale
-import org.mozilla.fenix.utils.Settings
 import java.lang.String.format
 import java.util.Locale
 
@@ -58,7 +57,7 @@ fun Context.getPreferenceKey(@StringRes resourceId: Int): String =
 fun Context.getRootView(): View? =
     asActivity()?.window?.decorView?.findViewById<View>(android.R.id.content) as? ViewGroup
 
-fun Context.settings() = Settings.getInstance(this)
+fun Context.settings() = components.settings
 
 /**
  * Used to catch IllegalArgumentException that is thrown when

--- a/app/src/main/java/org/mozilla/fenix/home/HomeMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeMenu.kt
@@ -26,7 +26,6 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.theme.ThemeManager
-import org.mozilla.fenix.utils.Settings
 import org.mozilla.fenix.whatsnew.WhatsNew
 
 class HomeMenu(
@@ -153,40 +152,29 @@ class HomeMenu(
             null
         }
 
+        val settings = context.components.settings
+
+        val menuItems = listOfNotNull(
+            if (settings.shouldDeleteBrowsingDataOnQuit) quitItem else null,
+            settingsItem,
+            BrowserMenuDivider(),
+            if (FeatureFlags.syncedTabs) syncedTabsItem else null,
+            bookmarksItem,
+            historyItem,
+            BrowserMenuDivider(),
+            addons,
+            BrowserMenuDivider(),
+            whatsNewItem,
+            helpItem,
+            accountAuthItem
+        ).also { items ->
+            items.getHighlight()?.let { onHighlightPresent(it) }
+        }
+
         if (shouldUseBottomToolbar) {
-            listOfNotNull(
-                accountAuthItem,
-                helpItem,
-                whatsNewItem,
-                BrowserMenuDivider(),
-                addons,
-                BrowserMenuDivider(),
-                historyItem,
-                bookmarksItem,
-                if (FeatureFlags.syncedTabs) syncedTabsItem else null,
-                BrowserMenuDivider(),
-                settingsItem,
-                if (Settings.getInstance(context).shouldDeleteBrowsingDataOnQuit) quitItem else null
-            ).also { items ->
-                items.getHighlight()?.let { onHighlightPresent(it) }
-            }
+            menuItems.reversed()
         } else {
-            listOfNotNull(
-                if (Settings.getInstance(context).shouldDeleteBrowsingDataOnQuit) quitItem else null,
-                settingsItem,
-                BrowserMenuDivider(),
-                if (FeatureFlags.syncedTabs) syncedTabsItem else null,
-                bookmarksItem,
-                historyItem,
-                BrowserMenuDivider(),
-                addons,
-                BrowserMenuDivider(),
-                whatsNewItem,
-                helpItem,
-                accountAuthItem
-            ).also { items ->
-                items.getHighlight()?.let { onHighlightPresent(it) }
-            }
+            menuItems
         }
     }
 

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingToolbarPositionPickerViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingToolbarPositionPickerViewHolder.kt
@@ -12,11 +12,12 @@ import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.components.metrics.Event.OnboardingToolbarPosition.Position
 import org.mozilla.fenix.ext.asActivity
 import org.mozilla.fenix.ext.components
-import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.onboarding.OnboardingRadioButton
 import org.mozilla.fenix.utils.view.addToRadioGroup
 
 class OnboardingToolbarPositionPickerViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+
+    private val metrics = view.context.components.analytics.metrics
 
     init {
         val radioTopToolbar = view.toolbar_top_radio_button
@@ -27,7 +28,8 @@ class OnboardingToolbarPositionPickerViewHolder(view: View) : RecyclerView.ViewH
         radioTopToolbar.addIllustration(view.toolbar_top_image)
         radioBottomToolbar.addIllustration(view.toolbar_bottom_image)
 
-        radio = if (view.context.settings().shouldUseBottomToolbar) {
+        val settings = view.context.components.settings
+        radio = if (settings.shouldUseBottomToolbar) {
             radioBottomToolbar
         } else {
             radioTopToolbar
@@ -35,28 +37,24 @@ class OnboardingToolbarPositionPickerViewHolder(view: View) : RecyclerView.ViewH
         radio.updateRadioValue(true)
 
         radioBottomToolbar.onClickListener {
-            itemView.context.components.analytics.metrics
-                .track(Event.OnboardingToolbarPosition(Position.BOTTOM))
+            metrics.track(Event.OnboardingToolbarPosition(Position.BOTTOM))
 
             itemView.context.asActivity()?.recreate()
         }
 
         view.toolbar_bottom_image.setOnClickListener {
-            itemView.context.components.analytics.metrics
-                .track(Event.OnboardingToolbarPosition(Position.BOTTOM))
+            metrics.track(Event.OnboardingToolbarPosition(Position.BOTTOM))
 
             radioBottomToolbar.performClick()
         }
 
         radioTopToolbar.onClickListener {
-            itemView.context.components.analytics.metrics
-                .track(Event.OnboardingToolbarPosition(Position.TOP))
+            metrics.track(Event.OnboardingToolbarPosition(Position.TOP))
             itemView.context.asActivity()?.recreate()
         }
 
         view.toolbar_top_image.setOnClickListener {
-            itemView.context.components.analytics.metrics
-                .track(Event.OnboardingToolbarPosition(Position.TOP))
+            metrics.track(Event.OnboardingToolbarPosition(Position.TOP))
             radioTopToolbar.performClick()
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/perf/Performance.kt
+++ b/app/src/main/java/org/mozilla/fenix/perf/Performance.kt
@@ -8,8 +8,8 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.os.BatteryManager
+import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.onboarding.FenixOnboarding
-import org.mozilla.fenix.utils.Settings
 import android.provider.Settings as AndroidSettings
 
 /**
@@ -67,13 +67,13 @@ object Performance {
      * Disables the tracking protection popup. However, TP is still on.
      */
     private fun disableTrackingProtectionPopups(context: Context) {
-        Settings.getInstance(context).isOverrideTPPopupsForPerformanceTest = true
+        context.components.settings.isOverrideTPPopupsForPerformanceTest = true
     }
 
     /**
      * Disables the first time PWA popup.
      */
     private fun disableFirstTimePWAPopup(context: Context) {
-        Settings.getInstance(context).userKnowsAboutPwas = true
+        context.components.settings.userKnowsAboutPwas = true
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsSheetDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsSheetDialogFragment.kt
@@ -37,7 +37,6 @@ import org.mozilla.fenix.IntentReceiverActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.settings.PhoneFeature
-import org.mozilla.fenix.utils.Settings
 import com.google.android.material.R as MaterialR
 
 /**
@@ -62,6 +61,7 @@ class QuickSettingsSheetDialogFragment : AppCompatDialogFragment() {
         savedInstanceState: Bundle?
     ): View {
         val context = requireContext()
+        val components = context.components
         val rootView = inflateRootView(container)
 
         quickSettingsStore = QuickSettingsFragmentStore.createStore(
@@ -70,7 +70,7 @@ class QuickSettingsSheetDialogFragment : AppCompatDialogFragment() {
             websiteTitle = args.title,
             isSecured = args.isSecured,
             permissions = args.sitePermissions,
-            settings = Settings.getInstance(context),
+            settings = components.settings,
             certificateName = args.certificateName
         )
 
@@ -79,12 +79,12 @@ class QuickSettingsSheetDialogFragment : AppCompatDialogFragment() {
             quickSettingsStore = quickSettingsStore,
             ioScope = viewLifecycleOwner.lifecycleScope + Dispatchers.IO,
             navController = findNavController(),
-            session = context.components.core.sessionManager.findSessionById(args.sessionId),
+            session = components.core.sessionManager.findSessionById(args.sessionId),
             sitePermissions = args.sitePermissions,
-            settings = Settings.getInstance(context),
-            permissionStorage = context.components.core.permissionStorage,
-            reload = context.components.useCases.sessionUseCases.reload,
-            addNewTab = context.components.useCases.tabsUseCases.addTab,
+            settings = components.settings,
+            permissionStorage = components.core.permissionStorage,
+            reload = components.useCases.sessionUseCases.reload,
+            addNewTab = components.useCases.tabsUseCases.addTab,
             requestRuntimePermissions = { permissions ->
                 requestPermissions(permissions, REQUEST_CODE_QUICK_SETTINGS_PERMISSIONS)
                 tryToRequestPermissions = true

--- a/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionOverlay.kt
+++ b/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionOverlay.kt
@@ -22,7 +22,6 @@ import mozilla.components.browser.session.Session
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.components.metrics.MetricController
-import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.increaseTapArea
 import org.mozilla.fenix.utils.Settings
 
@@ -56,7 +55,7 @@ class TrackingProtectionOverlay(
             override fun onTouchEvent(event: MotionEvent): Boolean {
 
                 if (event.action == MotionEvent.ACTION_DOWN) {
-                    context.components.analytics.metrics.track(Event.ContextualHintETPOutsideTap)
+                    metrics.track(Event.ContextualHintETPOutsideTap)
                 }
                     return super.onTouchEvent(event)
                 }

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -46,7 +46,7 @@ private const val AUTOPLAY_USER_SETTING = "AUTOPLAY_USER_SETTING"
  * @param appContext Reference to application context.
  */
 @Suppress("LargeClass", "TooManyFunctions")
-class Settings private constructor(private val appContext: Context) : PreferencesHolder {
+class Settings(private val appContext: Context) : PreferencesHolder {
 
     companion object {
         const val showLoginsSecureWarningSyncMaxCount = 1
@@ -86,18 +86,6 @@ class Settings private constructor(private val appContext: Context) : Preference
             // Users from older versions may have saved invalid values. Migrate them to BLOCKED
             ASK_TO_ALLOW_INT -> AutoplayAction.BLOCKED
             else -> throw InvalidParameterException("$this is not a valid SitePermissionsRules.AutoplayAction")
-        }
-
-        @VisibleForTesting
-        internal var instance: Settings? = null
-
-        @JvmStatic
-        @Synchronized
-        fun getInstance(context: Context): Settings {
-            if (instance == null) {
-                instance = Settings(context.applicationContext)
-            }
-            return instance ?: throw AssertionError("Instance cleared")
         }
     }
 

--- a/app/src/test/java/org/mozilla/fenix/HomeActivityTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/HomeActivityTest.kt
@@ -6,6 +6,8 @@ package org.mozilla.fenix
 
 import android.content.Intent
 import android.os.Bundle
+import io.mockk.every
+import io.mockk.spyk
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.utils.toSafeIntent
 import org.junit.Assert.assertEquals
@@ -13,6 +15,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.HomeActivity.Companion.PRIVATE_BROWSING_MODE
@@ -24,10 +27,17 @@ import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 @RunWith(FenixRobolectricTestRunner::class)
 class HomeActivityTest {
 
+    private lateinit var activity: HomeActivity
+
+    @Before
+    fun setup() {
+        activity = spyk(HomeActivity())
+
+        every { activity.applicationContext } returns testContext
+    }
+
     @Test
     fun getIntentSource() {
-        val activity = HomeActivity()
-
         val launcherIntent = Intent(Intent.ACTION_MAIN).apply {
             addCategory(Intent.CATEGORY_LAUNCHER)
         }.toSafeIntent()
@@ -42,8 +52,6 @@ class HomeActivityTest {
 
     @Test
     fun `getModeFromIntentOrLastKnown returns mode from settings when intent does not set`() {
-        val activity = HomeActivity()
-
         testContext.settings().lastKnownMode = BrowsingMode.Private
 
         assertEquals(testContext.settings().lastKnownMode, activity.getModeFromIntentOrLastKnown(null))
@@ -51,8 +59,6 @@ class HomeActivityTest {
 
     @Test
     fun `getModeFromIntentOrLastKnown returns mode from intent when set`() {
-        val activity = HomeActivity()
-
         testContext.settings().lastKnownMode = BrowsingMode.Normal
 
         val intent = Intent()
@@ -64,21 +70,16 @@ class HomeActivityTest {
 
     @Test
     fun `isActivityColdStarted returns true for null savedInstanceState and not launched from history`() {
-        val activity = HomeActivity()
-
         assertTrue(activity.isActivityColdStarted(Intent(), null))
     }
 
     @Test
     fun `isActivityColdStarted returns false for valid savedInstanceState and not launched from history`() {
-        val activity = HomeActivity()
-
         assertFalse(activity.isActivityColdStarted(Intent(), Bundle()))
     }
 
     @Test
     fun `isActivityColdStarted returns false for null savedInstanceState and launched from history`() {
-        val activity = HomeActivity()
         val startingIntent = Intent().apply {
             flags = flags or Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY
         }
@@ -88,7 +89,6 @@ class HomeActivityTest {
 
     @Test
     fun `isActivityColdStarted returns false for null savedInstanceState and not launched from history`() {
-        val activity = HomeActivity()
         val startingIntent = Intent().apply {
             flags = flags or Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY
         }

--- a/app/src/test/java/org/mozilla/fenix/browser/browsingmode/DefaultBrowsingModeManagerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/browser/browsingmode/DefaultBrowsingModeManagerTest.kt
@@ -5,14 +5,19 @@
 package org.mozilla.fenix.browser.browsingmode
 
 import io.mockk.MockKAnnotations
+import io.mockk.Runs
+import io.mockk.every
 import io.mockk.impl.annotations.MockK
+import io.mockk.just
 import io.mockk.verify
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
+import org.mozilla.fenix.utils.Settings
 
 class DefaultBrowsingModeManagerTest {
 
+    @MockK lateinit var settings: Settings
     @MockK(relaxed = true) lateinit var callback: (BrowsingMode) -> Unit
     lateinit var manager: BrowsingModeManager
 
@@ -21,7 +26,9 @@ class DefaultBrowsingModeManagerTest {
     @Before
     fun before() {
         MockKAnnotations.init(this)
-        manager = DefaultBrowsingModeManager(initMode, callback)
+
+        manager = DefaultBrowsingModeManager(initMode, settings, callback)
+        every { settings.lastKnownMode = any() } just Runs
     }
 
     @Test
@@ -46,8 +53,10 @@ class DefaultBrowsingModeManagerTest {
 
         manager.mode = BrowsingMode.Private
         assertEquals(BrowsingMode.Private, manager.mode)
+        verify { settings.lastKnownMode = BrowsingMode.Private }
 
         manager.mode = BrowsingMode.Normal
         assertEquals(BrowsingMode.Normal, manager.mode)
+        verify { settings.lastKnownMode = BrowsingMode.Normal }
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/components/TestComponents.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/TestComponents.kt
@@ -7,6 +7,7 @@ package org.mozilla.fenix.components
 import android.content.Context
 import io.mockk.mockk
 import org.mozilla.fenix.utils.ClipboardHandler
+import org.mozilla.fenix.utils.Settings
 
 class TestComponents(private val context: Context) : Components(context) {
     override val backgroundServices by lazy {
@@ -29,4 +30,6 @@ class TestComponents(private val context: Context) : Components(context) {
     override val analytics by lazy { Analytics(context) }
 
     override val clipboardHandler by lazy { ClipboardHandler(context) }
+
+    override val settings by lazy { mockk<Settings>(relaxed = true) }
 }

--- a/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarControllerTest.kt
@@ -543,7 +543,10 @@ class DefaultBrowserToolbarControllerTest {
 
     @Test
     fun handleToolbarNewTabPress() = runBlockingTest {
-        val browsingModeManager: BrowsingModeManager = DefaultBrowsingModeManager(BrowsingMode.Private) {}
+        val browsingModeManager: BrowsingModeManager = DefaultBrowsingModeManager(
+            BrowsingMode.Private,
+            mockk(relaxed = true)
+        ) {}
         val item = TabCounterMenuItem.NewTab(false)
 
         every { activity.browsingModeManager } returns browsingModeManager
@@ -556,7 +559,10 @@ class DefaultBrowserToolbarControllerTest {
 
     @Test
     fun handleToolbarNewPrivateTabPress() = runBlockingTest {
-        val browsingModeManager: BrowsingModeManager = DefaultBrowsingModeManager(BrowsingMode.Normal) {}
+        val browsingModeManager: BrowsingModeManager = DefaultBrowsingModeManager(
+            BrowsingMode.Normal,
+            mockk(relaxed = true)
+        ) {}
         val item = TabCounterMenuItem.NewTab(true)
 
         every { activity.browsingModeManager } returns browsingModeManager

--- a/app/src/test/java/org/mozilla/fenix/helpers/FenixRobolectricTestApplication.kt
+++ b/app/src/test/java/org/mozilla/fenix/helpers/FenixRobolectricTestApplication.kt
@@ -4,7 +4,6 @@
 
 package org.mozilla.fenix.helpers
 
-import io.mockk.spyk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.mozilla.fenix.FenixApplication
 import org.mozilla.fenix.components.TestComponents
@@ -16,7 +15,7 @@ import org.mozilla.fenix.components.TestComponents
  */
 class FenixRobolectricTestApplication : FenixApplication() {
 
-    override val components = spyk(TestComponents(this))
+    override val components = TestComponents(this)
 
     override fun setupInAllProcesses() = Unit
 

--- a/app/src/test/java/org/mozilla/fenix/helpers/FenixRobolectricTestApplication.kt
+++ b/app/src/test/java/org/mozilla/fenix/helpers/FenixRobolectricTestApplication.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.fenix.helpers
 
+import io.mockk.spyk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.mozilla.fenix.FenixApplication
 import org.mozilla.fenix.components.TestComponents
@@ -15,7 +16,7 @@ import org.mozilla.fenix.components.TestComponents
  */
 class FenixRobolectricTestApplication : FenixApplication() {
 
-    override val components = TestComponents(this)
+    override val components = spyk(TestComponents(this))
 
     override fun setupInAllProcesses() = Unit
 

--- a/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingToolbarPositionPickerViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingToolbarPositionPickerViewHolderTest.kt
@@ -7,7 +7,6 @@ package org.mozilla.fenix.home.sessioncontrol.viewholders.onboarding
 import android.view.LayoutInflater
 import android.view.View
 import io.mockk.every
-import io.mockk.mockk
 import kotlinx.android.synthetic.main.onboarding_toolbar_position_picker.view.*
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertFalse
@@ -15,7 +14,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mozilla.fenix.components.metrics.MetricController
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.utils.Settings
@@ -24,18 +22,14 @@ import org.mozilla.fenix.utils.Settings
 class OnboardingToolbarPositionPickerViewHolderTest {
 
     private lateinit var view: View
-    private lateinit var metrics: MetricController
     private lateinit var settings: Settings
 
     @Before
     fun setup() {
+        val components = testContext.components
         view = LayoutInflater.from(testContext)
             .inflate(OnboardingToolbarPositionPickerViewHolder.LAYOUT_ID, null)
-        metrics = mockk(relaxed = true)
-        settings = mockk(relaxed = true)
-
-        every { testContext.components.settings } returns settings
-        every { testContext.components.analytics.metrics } returns metrics
+        settings = components.settings
     }
 
     @Test

--- a/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingToolbarPositionPickerViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingToolbarPositionPickerViewHolderTest.kt
@@ -10,12 +10,13 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.android.synthetic.main.onboarding_toolbar_position_picker.view.*
 import mozilla.components.support.test.robolectric.testContext
-import org.junit.After
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mozilla.fenix.components.metrics.MetricController
+import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.utils.Settings
 
@@ -23,20 +24,18 @@ import org.mozilla.fenix.utils.Settings
 class OnboardingToolbarPositionPickerViewHolderTest {
 
     private lateinit var view: View
+    private lateinit var metrics: MetricController
     private lateinit var settings: Settings
 
     @Before
     fun setup() {
         view = LayoutInflater.from(testContext)
             .inflate(OnboardingToolbarPositionPickerViewHolder.LAYOUT_ID, null)
+        metrics = mockk(relaxed = true)
         settings = mockk(relaxed = true)
 
-        Settings.instance = settings
-    }
-
-    @After
-    fun teardown() {
-        Settings.instance = null
+        every { testContext.components.settings } returns settings
+        every { testContext.components.analytics.metrics } returns metrics
     }
 
     @Test

--- a/app/src/test/java/org/mozilla/fenix/search/DefaultSearchControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/search/DefaultSearchControllerTest.kt
@@ -35,7 +35,6 @@ import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.settings.SupportUtils
 import org.mozilla.fenix.utils.Settings
-import org.mozilla.fenix.whatsnew.clear
 
 @ExperimentalCoroutinesApi
 @RunWith(FenixRobolectricTestRunner::class)
@@ -48,10 +47,10 @@ class DefaultSearchControllerTest {
     private val searchEngine: SearchEngine = mockk(relaxed = true)
     private val metrics: MetricController = mockk(relaxed = true)
     private val sessionManager: SessionManager = mockk(relaxed = true)
+    private val settings: Settings = mockk(relaxed = true)
     private val clearToolbarFocus: (() -> Unit) = mockk(relaxed = true)
 
     private lateinit var controller: DefaultSearchController
-    private lateinit var settings: Settings
 
     @Before
     fun setUp() {
@@ -60,6 +59,7 @@ class DefaultSearchControllerTest {
         every { store.state.searchEngineSource.searchEngine } returns searchEngine
         every { activity.metrics } returns metrics
         every { activity.components.core.sessionManager } returns sessionManager
+        every { activity.components.settings } returns settings
 
         controller = DefaultSearchController(
             activity = activity,
@@ -67,8 +67,6 @@ class DefaultSearchControllerTest {
             navController = navController,
             clearToolbarFocus = clearToolbarFocus
         )
-
-        settings = testContext.settings().apply { testContext.settings().clear() }
     }
 
     @Test
@@ -154,10 +152,7 @@ class DefaultSearchControllerTest {
     @Test
     fun `show search shortcuts when setting enabled AND query empty`() {
         val text = ""
-        testContext.settings().preferences
-                .edit()
-                .putBoolean(testContext.getString(R.string.pref_key_show_search_shortcuts), true)
-                .apply()
+        every { settings.shouldShowSearchShortcuts } returns true
 
         controller.handleTextChanged(text)
 
@@ -168,10 +163,7 @@ class DefaultSearchControllerTest {
     fun `show search shortcuts when setting enabled AND query equals url`() {
         val text = "mozilla.org"
         every { store.state.url } returns "mozilla.org"
-        testContext.settings().preferences
-                .edit()
-                .putBoolean(testContext.getString(R.string.pref_key_show_search_shortcuts), true)
-                .apply()
+        every { settings.shouldShowSearchShortcuts } returns true
 
         controller.handleTextChanged(text)
 
@@ -189,10 +181,7 @@ class DefaultSearchControllerTest {
 
     @Test
     fun `do not show search shortcuts when setting disabled AND query empty AND url not matching query`() {
-        testContext.settings().preferences
-            .edit()
-            .putBoolean(testContext.getString(R.string.pref_key_show_search_shortcuts), false)
-            .apply()
+        every { settings.shouldShowSearchShortcuts } returns false
 
         assertFalse(testContext.settings().shouldShowSearchShortcuts)
 
@@ -205,10 +194,7 @@ class DefaultSearchControllerTest {
 
     @Test
     fun `do not show search shortcuts when setting disabled AND query non-empty`() {
-        testContext.settings().preferences
-            .edit()
-            .putBoolean(testContext.getString(R.string.pref_key_show_search_shortcuts), false)
-            .apply()
+        every { settings.shouldShowSearchShortcuts } returns false
 
         assertFalse(testContext.settings().shouldShowSearchShortcuts)
 

--- a/app/src/test/java/org/mozilla/fenix/utils/SettingsTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/utils/SettingsTest.kt
@@ -4,7 +4,6 @@
 
 package org.mozilla.fenix.utils
 
-import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import mozilla.components.feature.sitepermissions.SitePermissionsRules
 import mozilla.components.feature.sitepermissions.SitePermissionsRules.Action.ALLOWED
 import mozilla.components.feature.sitepermissions.SitePermissionsRules.Action.ASK_TO_ALLOW
@@ -19,6 +18,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.ext.clearAndCommit
 import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.settings.PhoneFeature
 import org.mozilla.fenix.settings.deletebrowsingdata.DeleteBrowsingDataOnQuitType
 
@@ -101,28 +101,6 @@ class SettingsTest {
 
         // Then
         assertEquals("Mozilla", settings.defaultSearchEngineName)
-    }
-
-    @Test
-    fun isCrashReportingEnabled_enabledInBuild() {
-        // When
-        clearExistingInstance()
-        val settings = testContext.settings(true)
-            .apply(Settings::clear)
-
-        // Then
-        assertTrue(settings.isCrashReportingEnabled)
-    }
-
-    @Test
-    fun isCrashReportingEnabled_disabledInBuild() {
-        // When
-        clearExistingInstance()
-        val settings = testContext.settings(false)
-            .apply(Settings::clear)
-
-        // Then
-        assertFalse(settings.isCrashReportingEnabled)
     }
 
     @Test
@@ -523,10 +501,6 @@ class SettingsTest {
             settings.getSitePermissionsCustomSettingsRules()
         )
     }
-}
-
-private fun clearExistingInstance() {
-    Settings.instance = null
 }
 
 private fun Settings.clear() {

--- a/app/src/test/java/org/mozilla/fenix/utils/SettingsTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/utils/SettingsTest.kt
@@ -16,8 +16,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mozilla.fenix.ext.clearAndCommit
-import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.settings.PhoneFeature
 import org.mozilla.fenix.settings.deletebrowsingdata.DeleteBrowsingDataOnQuitType
@@ -27,9 +25,18 @@ class SettingsTest {
 
     lateinit var settings: Settings
 
+    private val defaultPermissions = SitePermissionsRules(
+        camera = ASK_TO_ALLOW,
+        location = ASK_TO_ALLOW,
+        microphone = ASK_TO_ALLOW,
+        notification = ASK_TO_ALLOW,
+        autoplayAudible = AutoplayAction.BLOCKED,
+        autoplayInaudible = AutoplayAction.BLOCKED
+    )
+
     @Before
     fun setUp() {
-        settings = testContext.settings().apply(Settings::clear)
+        settings = Settings(testContext)
     }
 
     @Test
@@ -429,7 +436,7 @@ class SettingsTest {
         // When just created
         // Then
         assertEquals(
-            defaultPermissions(),
+            defaultPermissions,
             settings.getSitePermissionsCustomSettingsRules()
         )
     }
@@ -441,7 +448,7 @@ class SettingsTest {
 
         // Then
         assertEquals(
-            defaultPermissions().copy(camera = BLOCKED),
+            defaultPermissions.copy(camera = BLOCKED),
             settings.getSitePermissionsCustomSettingsRules()
         )
     }
@@ -453,7 +460,7 @@ class SettingsTest {
 
         // Then
         assertEquals(
-            defaultPermissions().copy(notification = BLOCKED),
+            defaultPermissions.copy(notification = BLOCKED),
             settings.getSitePermissionsCustomSettingsRules()
         )
     }
@@ -465,7 +472,7 @@ class SettingsTest {
 
         // Then
         assertEquals(
-            defaultPermissions().copy(location = BLOCKED),
+            defaultPermissions.copy(location = BLOCKED),
             settings.getSitePermissionsCustomSettingsRules()
         )
     }
@@ -477,7 +484,7 @@ class SettingsTest {
 
         // Then
         assertEquals(
-            defaultPermissions().copy(microphone = BLOCKED),
+            defaultPermissions.copy(microphone = BLOCKED),
             settings.getSitePermissionsCustomSettingsRules()
         )
     }
@@ -487,7 +494,7 @@ class SettingsTest {
         settings.setSitePermissionsPhoneFeatureAction(PhoneFeature.AUTOPLAY_AUDIBLE, ALLOWED)
 
         assertEquals(
-            defaultPermissions().copy(autoplayAudible = ALLOWED),
+            defaultPermissions.copy(autoplayAudible = ALLOWED),
             settings.getSitePermissionsCustomSettingsRules()
         )
     }
@@ -497,21 +504,8 @@ class SettingsTest {
         settings.setSitePermissionsPhoneFeatureAction(PhoneFeature.AUTOPLAY_INAUDIBLE, ALLOWED)
 
         assertEquals(
-            defaultPermissions().copy(autoplayInaudible = ALLOWED),
+            defaultPermissions.copy(autoplayInaudible = ALLOWED),
             settings.getSitePermissionsCustomSettingsRules()
         )
     }
 }
-
-private fun Settings.clear() {
-    preferences.clearAndCommit()
-}
-
-private fun defaultPermissions() = SitePermissionsRules(
-    camera = ASK_TO_ALLOW,
-    location = ASK_TO_ALLOW,
-    microphone = ASK_TO_ALLOW,
-    notification = ASK_TO_ALLOW,
-    autoplayAudible = AutoplayAction.BLOCKED,
-    autoplayInaudible = AutoplayAction.BLOCKED
-)

--- a/app/src/test/java/org/mozilla/fenix/whatsnew/WhatsNewStorageTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/whatsnew/WhatsNewStorageTest.kt
@@ -4,25 +4,24 @@
 
 package org.mozilla.fenix.whatsnew
 
-import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+import androidx.preference.PreferenceManager
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.ext.clearAndCommit
-import org.mozilla.fenix.utils.Settings
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
 @RunWith(FenixRobolectricTestRunner::class)
 class WhatsNewStorageTest {
+
     private lateinit var storage: SharedPreferenceWhatsNewStorage
-    private lateinit var settings: Settings
 
     @Before
     fun setUp() {
         storage = SharedPreferenceWhatsNewStorage(testContext)
-        settings = Settings.getInstance(testContext)
-            .apply(Settings::clear)
+        PreferenceManager.getDefaultSharedPreferences(testContext).clearAndCommit()
     }
 
     @Test
@@ -56,8 +55,4 @@ class WhatsNewStorageTest {
     companion object {
         const val DAY_IN_MILLIS = 3600 * 1000 * 24
     }
-}
-
-fun Settings.clear() {
-    preferences.clearAndCommit()
 }

--- a/app/src/test/java/org/mozilla/fenix/whatsnew/WhatsNewTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/whatsnew/WhatsNewTest.kt
@@ -4,24 +4,24 @@ package org.mozilla.fenix.whatsnew
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+import androidx.preference.PreferenceManager
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mozilla.fenix.ext.settings
-import org.mozilla.fenix.utils.Settings
+import org.mozilla.fenix.ext.clearAndCommit
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
 @RunWith(FenixRobolectricTestRunner::class)
 class WhatsNewTest {
+
     private lateinit var storage: SharedPreferenceWhatsNewStorage
-    private lateinit var settings: Settings
 
     @Before
     fun setup() {
         storage = SharedPreferenceWhatsNewStorage(testContext)
-        settings = testContext.settings().apply(Settings::clear)
+        PreferenceManager.getDefaultSharedPreferences(testContext).clearAndCommit()
         WhatsNew.wasUpdatedRecently = null
     }
 


### PR DESCRIPTION
## Summary

We set up our dependencies inside the `Components` class, except for `Settings`. This PR moves the Settings class into Components.

## Motivation

The `Settings` class is a singleton that isn't easily mocked. Tests involving settings vary from using static mocks, overriding the singleton, and manipulating the internal SharedPreferences. Moving it into `Components` makes it easier to write tests by just using normal mocks.

`Settings` is probably a singleton just for historic reasons. A Settings singleton existed in Focus long before we had any components, and from there it made it to Fenix.