### PR TITLE
Fix failure in handleWhatsNewGetAnswersClicked

### DIFF
--- a/app/src/test/java/org/mozilla/fenix/home/DefaultSessionControlControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/DefaultSessionControlControllerTest.kt
@@ -292,9 +292,10 @@ class DefaultSessionControlControllerTest {
     @Test
     fun handleWhatsNewGetAnswersClicked() {
         controller.handleWhatsNewGetAnswersClicked()
+        val whatsNewUrl = SupportUtils.getWhatsNewUrl(activity)
         verify {
             activity.openToBrowserAndLoad(
-                searchTermOrURL = SupportUtils.getWhatsNewUrl(activity),
+                searchTermOrURL = whatsNewUrl,
                 newTab = true,
                 from = BrowserDirection.FromHome
             )


### PR DESCRIPTION
`getWhatsNewUrl` has different behaviour based on the release channel. Moving it outside the verify call should make everything work.