### PR TITLE
 For #10683 - Show long tab titles on two lines 

### DIFF
--- a/app/src/main/res/layout/tab_tray_item.xml
+++ b/app/src/main/res/layout/tab_tray_item.xml
@@ -36,12 +36,12 @@
 
         <ImageView
             android:id="@+id/default_tab_thumbnail"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:importantForAccessibility="no"
-            android:padding="22dp"
             android:src="@drawable/mozac_ic_globe"
-            android:tint="?tabTrayThumbnailIcon" />
+            android:tint="?tabTrayThumbnailIcon"
+            android:padding="22dp"
+            android:importantForAccessibility="no"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"/>
 
         <mozilla.components.browser.tabstray.thumbnail.TabThumbnailView
             android:id="@+id/mozac_browser_tabstray_thumbnail"

--- a/app/src/main/res/layout/tab_tray_item.xml
+++ b/app/src/main/res/layout/tab_tray_item.xml
@@ -59,7 +59,6 @@
         android:ellipsize="end"
         android:paddingStart="16dp"
         android:textColor="@color/tab_tray_item_text_normal_theme"
-        android:textSize="16sp"
         app:autoSizeTextType="uniform"
         app:autoSizeMinTextSize="16sp"
         android:maxLines="2"

--- a/app/src/main/res/layout/tab_tray_item.xml
+++ b/app/src/main/res/layout/tab_tray_item.xml
@@ -36,12 +36,12 @@
 
         <ImageView
             android:id="@+id/default_tab_thumbnail"
-            android:src="@drawable/mozac_ic_globe"
-            android:tint="?tabTrayThumbnailIcon"
-            android:padding="22dp"
-            android:importantForAccessibility="no"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"/>
+            android:layout_height="match_parent"
+            android:importantForAccessibility="no"
+            android:padding="22dp"
+            android:src="@drawable/mozac_ic_globe"
+            android:tint="?tabTrayThumbnailIcon" />
 
         <mozilla.components.browser.tabstray.thumbnail.TabThumbnailView
             android:id="@+id/mozac_browser_tabstray_thumbnail"
@@ -57,15 +57,18 @@
         android:layout_height="wrap_content"
         android:layout_alignParentTop="true"
         android:ellipsize="end"
-        android:lines="1"
         android:paddingStart="16dp"
-        android:paddingTop="22dp"
         android:textColor="@color/tab_tray_item_text_normal_theme"
         android:textSize="16sp"
+        app:autoSizeTextType="uniform"
+        app:autoSizeMinTextSize="16sp"
+        android:maxLines="2"
+        app:layout_constraintBottom_toTopOf="@id/mozac_browser_tabstray_url"
         app:layout_constraintEnd_toStartOf="@id/mozac_browser_tabstray_close"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toEndOf="@id/mozac_browser_tabstray_card"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_chainStyle="packed" />
 
     <TextView
         android:id="@+id/mozac_browser_tabstray_url"
@@ -77,6 +80,7 @@
         android:paddingStart="16dp"
         android:textColor="@color/tab_tray_item_url_normal_theme"
         android:textSize="14sp"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/mozac_browser_tabstray_close"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toEndOf="@id/mozac_browser_tabstray_card"


### PR DESCRIPTION
Closes #10683. 
This is achieved by doing three things:
1. Constrain the tab title and tab URL `TextView`s to the parent's top and bottom, centering them vertically in the `tab_item` `ContraintLayout`.
2. Add TextView autosizing to the tab title `TextView` to account for both situations, when the title has only one line and its maximum of two lines (this maximum is set with `android:maxLines`). Autosizing is supported all the way down to Android 4.0 (API Level 14), see details [here](https://developer.android.com/guide/topics/ui/look-and-feel/autosizing-textview).
3. Used a "packed" vertical chain to make sure that the tab title and tab URL stick together.

**Screenshot:**
<img src="https://user-images.githubusercontent.com/46764284/87836936-2e8d1600-c892-11ea-9641-9223e7adbe06.png" width="400" />

**Note**
I did not touch the thumbnail but I believe it would be good if it too was simply constrained vertically to the parent's top and bottom to make sure is centers exactly in the middle (vertically) of the `tab_item` `ContraintLayout`. Though that should probably be left for another issue/PR.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture