### PR TITLE
For #12692 - Remove "www." prefix from tab URL in tab tray

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayViewHolder.kt
@@ -33,6 +33,9 @@ import org.mozilla.fenix.ext.removeTouchDelegate
 import org.mozilla.fenix.ext.showAndEnable
 import org.mozilla.fenix.ext.toTab
 
+
+private const val WWW = "www."
+
 /**
  * A RecyclerView ViewHolder implementation for "tab" items.
  */
@@ -159,7 +162,13 @@ class TabTrayViewHolder(
         // is done in the toolbar and awesomebar:
         // https://github.com/mozilla-mobile/fenix/issues/1824
         // https://github.com/mozilla-mobile/android-components/issues/6985
-        urlView?.text = tab.url.tryGetHostFromUrl().take(MAX_URI_LENGTH)
+        var hostname = tab.url.tryGetHostFromUrl()
+
+        if (hostname.startsWith(WWW)) {
+            hostname = hostname.replaceFirst(WWW, "")
+        }
+
+        urlView?.text = hostname.take(MAX_URI_LENGTH)
     }
 
     @VisibleForTesting


### PR DESCRIPTION
Closes #12692. 
Basically uses the same approach as https://github.com/mozilla-mobile/android-components/pull/6232, stripping "www." if the hostname starts with that.

**Screenshot:**

<img src="https://user-images.githubusercontent.com/46764284/87849721-05e53a80-c8eb-11ea-943b-d1cf72bc8e27.png" width="300" />

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture