### PR TITLE
[uplift] Bug 1608874 - part 3: Let fennec-production upload APKs on Google Play's alpha track

### DIFF
--- a/taskcluster/ci/push-apk/kind.yml
+++ b/taskcluster/ci/push-apk/kind.yml
@@ -28,10 +28,7 @@ job-template:
     description: Publish Fenix
     worker-type: push-apk
     worker:
-        commit:
-            by-build-type:
-                fennec-production: false
-                default: true
+        commit: true
         channel:
             by-build-type:
                 fennec-nightly: fennec-nightly

--- a/taskcluster/fenix_taskgraph/transforms/push_apk.py
+++ b/taskcluster/fenix_taskgraph/transforms/push_apk.py
@@ -18,7 +18,7 @@ transforms = TransformSequence()
 @transforms.add
 def resolve_keys(config, tasks):
     for task in tasks:
-        for key in ("worker.channel", "worker.commit", "worker.dep"):
+        for key in ("worker.channel", "worker.dep"):
             resolve_keyed_by(
                 task,
                 key,


### PR DESCRIPTION
Uplift of https://github.com/mozilla-mobile/fenix/commit/66d85913348bcd0e0689f5a0480434bf6c447792 to `releases/v79.0.0`.