### PR TITLE
Create ToolbarPosition enum

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -92,6 +92,7 @@ import org.mozilla.fenix.components.toolbar.BrowserToolbarViewInteractor
 import org.mozilla.fenix.components.toolbar.DefaultBrowserToolbarController
 import org.mozilla.fenix.components.toolbar.SwipeRefreshScrollingViewBehavior
 import org.mozilla.fenix.components.toolbar.ToolbarIntegration
+import org.mozilla.fenix.components.toolbar.ToolbarPosition
 import org.mozilla.fenix.downloads.DownloadService
 import org.mozilla.fenix.downloads.DynamicDownloadDialog
 import org.mozilla.fenix.ext.components
@@ -262,7 +263,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Session
 
             _browserToolbarView = BrowserToolbarView(
                 container = view.browserLayout,
-                shouldUseBottomToolbar = context.settings().shouldUseBottomToolbar,
+                toolbarPosition = context.settings().toolbarPosition,
                 interactor = browserInteractor,
                 customTabSession = customTabSessionId?.let { sessionManager.findSessionById(it) },
                 lifecycleOwner = viewLifecycleOwner
@@ -675,10 +676,10 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Session
     private fun initializeEngineView(toolbarHeight: Int) {
         engineView.setDynamicToolbarMaxHeight(toolbarHeight)
 
-        val behavior = if (requireContext().settings().shouldUseBottomToolbar) {
-            EngineViewBottomBehavior(context, null)
-        } else {
-            SwipeRefreshScrollingViewBehavior(requireContext(), null, engineView, browserToolbarView)
+        val context = requireContext()
+        val behavior = when (context.settings().toolbarPosition) {
+            ToolbarPosition.BOTTOM -> EngineViewBottomBehavior(context, null)
+            ToolbarPosition.TOP -> SwipeRefreshScrollingViewBehavior(context, null, engineView, browserToolbarView)
         }
 
         (swipeRefresh.layoutParams as CoordinatorLayout.LayoutParams).behavior = behavior
@@ -836,7 +837,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Session
      * Returns the layout [android.view.Gravity] for the quick settings and ETP dialog.
      */
     protected fun getAppropriateLayoutGravity(): Int =
-        if (context?.settings()?.shouldUseBottomToolbar == true) Gravity.BOTTOM else Gravity.TOP
+        context?.settings()?.toolbarPosition?.androidGravity ?: Gravity.BOTTOM
 
     /**
      * Updates the site permissions rules based on user settings.

--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserAnimator.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserAnimator.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import mozilla.components.concept.engine.EngineView
 import org.mozilla.fenix.R
+import org.mozilla.fenix.components.toolbar.ToolbarPosition
 import org.mozilla.fenix.ext.settings
 import java.lang.ref.WeakReference
 
@@ -155,12 +156,15 @@ class BrowserAnimator(
         fun getToolbarNavOptions(context: Context): NavOptions {
             val navOptions = NavOptions.Builder()
 
-            if (!context.settings().shouldUseBottomToolbar) {
-                navOptions.setEnterAnim(R.anim.fade_in)
-                navOptions.setExitAnim(R.anim.fade_out)
-            } else {
-                navOptions.setEnterAnim(R.anim.fade_in_up)
-                navOptions.setExitAnim(R.anim.fade_out_down)
+            when (context.settings().toolbarPosition) {
+                ToolbarPosition.TOP -> {
+                    navOptions.setEnterAnim(R.anim.fade_in)
+                    navOptions.setExitAnim(R.anim.fade_out)
+                }
+                ToolbarPosition.BOTTOM -> {
+                    navOptions.setEnterAnim(R.anim.fade_in_up)
+                    navOptions.setExitAnim(R.anim.fade_out_down)
+                }
             }
 
             return navOptions.build()

--- a/app/src/main/java/org/mozilla/fenix/cfr/SearchWidgetCFR.kt
+++ b/app/src/main/java/org/mozilla/fenix/cfr/SearchWidgetCFR.kt
@@ -11,7 +11,6 @@ import android.graphics.drawable.ColorDrawable
 import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
-import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.core.view.marginTop
 import kotlinx.android.synthetic.main.search_widget_cfr.view.*
@@ -21,6 +20,7 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.components.SearchWidgetCreator
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.components.metrics.MetricController
+import org.mozilla.fenix.components.toolbar.ToolbarPosition
 import org.mozilla.fenix.utils.Settings
 
 /**
@@ -50,18 +50,14 @@ class SearchWidgetCFR(
         val searchWidgetCFRDialog = Dialog(context)
         val layout = LayoutInflater.from(context)
             .inflate(R.layout.search_widget_cfr, null)
-        val isBottomToolbar = settings.shouldUseBottomToolbar
+        val toolbarPosition = settings.toolbarPosition
 
-        layout.drop_down_triangle.isGone = isBottomToolbar
-        layout.pop_up_triangle.isVisible = isBottomToolbar
+        layout.drop_down_triangle.isVisible = toolbarPosition == ToolbarPosition.TOP
+        layout.pop_up_triangle.isVisible = toolbarPosition == ToolbarPosition.BOTTOM
 
         val toolbar = getToolbar()
 
-        val gravity = if (isBottomToolbar) {
-            Gravity.CENTER_HORIZONTAL or Gravity.BOTTOM
-        } else {
-            Gravity.CENTER_HORIZONTAL or Gravity.TOP
-        }
+        val gravity = Gravity.CENTER_HORIZONTAL or toolbarPosition.androidGravity
 
         layout.cfr_neg_button.setOnClickListener {
             metrics.track(Event.SearchWidgetCFRNotNowPressed)

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
@@ -50,6 +50,7 @@ import org.mozilla.fenix.GleanMetrics.TopSites
 import org.mozilla.fenix.GleanMetrics.TrackingProtection
 import org.mozilla.fenix.GleanMetrics.UserSpecifiedSearchEngines
 import org.mozilla.fenix.GleanMetrics.VoiceSearch
+import org.mozilla.fenix.components.toolbar.ToolbarPosition
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.utils.BrowsersCache
@@ -724,10 +725,9 @@ class GleanMetricsService(private val context: Context) : MetricsService {
             }
 
             toolbarPosition.set(
-                if (context.settings().shouldUseBottomToolbar) {
-                    Event.ToolbarPositionChanged.Position.BOTTOM.name
-                } else {
-                    Event.ToolbarPositionChanged.Position.TOP.name
+                when (context.settings().toolbarPosition) {
+                    ToolbarPosition.BOTTOM -> Event.ToolbarPositionChanged.Position.BOTTOM.name
+                    ToolbarPosition.TOP -> Event.ToolbarPositionChanged.Position.TOP.name
                 }
             )
         }

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/TabCounterToolbarButton.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/TabCounterToolbarButton.kt
@@ -113,10 +113,9 @@ class TabCounterToolbarButton(
         )
 
         return BrowserMenuBuilder(
-            if (context.settings().shouldUseBottomToolbar) {
-                menuItems.reversed()
-            } else {
-                menuItems
+            when (context.settings().toolbarPosition) {
+                ToolbarPosition.BOTTOM -> menuItems.reversed()
+                ToolbarPosition.TOP -> menuItems
             }
         ).build(context)
     }

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarPosition.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarPosition.kt
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.components.toolbar
+
+import android.view.Gravity
+
+/**
+ * Fenix lets the browser toolbar be placed at either the top or the bottom of the screen.
+ * This enum represents the posible positions.
+ *
+ * @property androidGravity [Gravity] value corresponding to the position.
+ * Used to position related elements such as a CFR tooltip.
+ */
+enum class ToolbarPosition(val androidGravity: Int) {
+    BOTTOM(Gravity.BOTTOM),
+    TOP(Gravity.TOP)
+}

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingToolbarPositionPickerViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingToolbarPositionPickerViewHolder.kt
@@ -10,6 +10,7 @@ import kotlinx.android.synthetic.main.onboarding_toolbar_position_picker.view.*
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.components.metrics.Event.OnboardingToolbarPosition.Position
+import org.mozilla.fenix.components.toolbar.ToolbarPosition
 import org.mozilla.fenix.ext.asActivity
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.onboarding.OnboardingRadioButton
@@ -29,10 +30,9 @@ class OnboardingToolbarPositionPickerViewHolder(view: View) : RecyclerView.ViewH
         radioBottomToolbar.addIllustration(view.toolbar_bottom_image)
 
         val settings = view.context.components.settings
-        radio = if (settings.shouldUseBottomToolbar) {
-            radioBottomToolbar
-        } else {
-            radioTopToolbar
+        radio = when (settings.toolbarPosition) {
+            ToolbarPosition.BOTTOM -> radioBottomToolbar
+            ToolbarPosition.TOP -> radioTopToolbar
         }
         radio.updateRadioValue(true)
 

--- a/app/src/main/java/org/mozilla/fenix/settings/CustomizationFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/CustomizationFragment.kt
@@ -12,6 +12,7 @@ import androidx.appcompat.app.AppCompatDelegate
 import androidx.preference.PreferenceFragmentCompat
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.metrics.Event
+import org.mozilla.fenix.components.toolbar.ToolbarPosition
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.settings
@@ -122,8 +123,9 @@ class CustomizationFragment : PreferenceFragmentCompat() {
             ))
         }
 
-        topPreference.setCheckedWithoutClickListener(!requireContext().settings().shouldUseBottomToolbar)
-        bottomPreference.setCheckedWithoutClickListener(requireContext().settings().shouldUseBottomToolbar)
+        val toolbarPosition = requireContext().settings().toolbarPosition
+        topPreference.setCheckedWithoutClickListener(toolbarPosition == ToolbarPosition.TOP)
+        bottomPreference.setCheckedWithoutClickListener(toolbarPosition == ToolbarPosition.BOTTOM)
 
         addToRadioGroup(topPreference, bottomPreference)
     }

--- a/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionOverlay.kt
+++ b/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionOverlay.kt
@@ -13,7 +13,6 @@ import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.View
 import android.widget.ImageView
-import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.core.view.marginTop
 import kotlinx.android.synthetic.main.tracking_protection_onboarding_popup.*
@@ -22,6 +21,7 @@ import mozilla.components.browser.session.Session
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.components.metrics.MetricController
+import org.mozilla.fenix.components.toolbar.ToolbarPosition
 import org.mozilla.fenix.ext.increaseTapArea
 import org.mozilla.fenix.utils.Settings
 
@@ -63,10 +63,10 @@ class TrackingProtectionOverlay(
 
         val layout = LayoutInflater.from(context)
             .inflate(R.layout.tracking_protection_onboarding_popup, null)
-        val isBottomToolbar = settings.shouldUseBottomToolbar
+        val toolbarPosition = settings.toolbarPosition
 
-        layout.drop_down_triangle.isGone = isBottomToolbar
-        layout.pop_up_triangle.isVisible = isBottomToolbar
+        layout.drop_down_triangle.isVisible = toolbarPosition == ToolbarPosition.TOP
+        layout.pop_up_triangle.isVisible = toolbarPosition == ToolbarPosition.BOTTOM
 
         layout.onboarding_message.text =
             context.getString(
@@ -91,11 +91,7 @@ class TrackingProtectionOverlay(
 
         val xOffset = triangleMarginStartPx + triangleWidthPx / 2
 
-        val gravity = if (isBottomToolbar) {
-            Gravity.START or Gravity.BOTTOM
-        } else {
-            Gravity.START or Gravity.TOP
-        }
+        val gravity = Gravity.START or toolbarPosition.androidGravity
 
         trackingOnboardingDialog.apply {
             setContentView(layout)

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -29,6 +29,7 @@ import org.mozilla.fenix.Config
 import org.mozilla.fenix.R
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.components.metrics.MozillaProductDetector
+import org.mozilla.fenix.components.toolbar.ToolbarPosition
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.getPreferenceKey
 import org.mozilla.fenix.settings.PhoneFeature
@@ -462,6 +463,9 @@ class Settings(private val appContext: Context) : PreferencesHolder {
         // Default accessibility users to top toolbar
         default = !touchExplorationIsEnabled && !switchServiceIsEnabled
     )
+
+    val toolbarPosition: ToolbarPosition
+        get() = if (shouldUseBottomToolbar) ToolbarPosition.BOTTOM else ToolbarPosition.TOP
 
     /**
      * Check each active accessibility service to see if it can perform gestures, if any can,

--- a/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingToolbarPositionPickerViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingToolbarPositionPickerViewHolderTest.kt
@@ -15,6 +15,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.components.toolbar.ToolbarPosition
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.utils.Settings
 
@@ -34,7 +35,7 @@ class OnboardingToolbarPositionPickerViewHolderTest {
 
     @Test
     fun `bottom illustration should select corresponding radio button`() {
-        every { settings.shouldUseBottomToolbar } returns false
+        every { settings.toolbarPosition } returns ToolbarPosition.TOP
         OnboardingToolbarPositionPickerViewHolder(view)
         assertTrue(view.toolbar_top_radio_button.isChecked)
         assertFalse(view.toolbar_bottom_radio_button.isChecked)
@@ -46,7 +47,7 @@ class OnboardingToolbarPositionPickerViewHolderTest {
 
     @Test
     fun `top illustration should select corresponding radio button`() {
-        every { settings.shouldUseBottomToolbar } returns true
+        every { settings.toolbarPosition } returns ToolbarPosition.BOTTOM
         OnboardingToolbarPositionPickerViewHolder(view)
         assertFalse(view.toolbar_top_radio_button.isChecked)
         assertTrue(view.toolbar_bottom_radio_button.isChecked)


### PR DESCRIPTION
Using an enum makes code much easier to read because the top/bottom association is more obvious. This just adds a new getter to `Settings` without changing the backing field.

```kt
        // Before
        val isBottomToolbar = Settings.getInstance(context).shouldUseBottomToolbar

        layout.drop_down_triangle.isGone = isBottomToolbar
        layout.pop_up_triangle.isVisible = isBottomToolbar
```

```kt
        // After
        val toolbarPosition = context.settings().toolbarPosition

        layout.drop_down_triangle.isVisible = toolbarPosition == ToolbarPosition.TOP
        layout.pop_up_triangle.isVisible = toolbarPosition == ToolbarPosition.BOTTOM
```