### PR TITLE
For #12240: Enable btime youtube-playback Fenix tests

### DIFF
--- a/taskcluster/ci/browsertime/kind.yml
+++ b/taskcluster/ci/browsertime/kind.yml
@@ -232,3 +232,15 @@ jobs:
         test-name: google-search-restaurants
         treeherder:
             symbol: 'Btime(tp6m-28-c)'
+
+    youtube-playback:
+        test-name: youtube-playback
+        run-visual-metrics: False
+        treeherder:
+            symbol: 'Btime(ytp)'
+        args:
+            by-abi:
+                # Bug 1558456 - Stop tracking youtube-playback-test on motoG5 for >1080p cases
+                armeabi-v7a:
+                    - '--test-url-params=exclude=1,2,9,10,17,18,21,22,26,28,30,32,39,40,47,48,55,56,63,64,71,72,79,80,83,84,89,90,95,96'
+                default: []

--- a/taskcluster/fenix_taskgraph/transforms/browsertime.py
+++ b/taskcluster/fenix_taskgraph/transforms/browsertime.py
@@ -94,7 +94,13 @@ def build_browsertime_task(config, tasks):
         run_visual_metrics = task.pop("run-visual-metrics", False)
         if run_visual_metrics:
             task["run"]["command"].append("--browsertime-video")
+            task["run"]["command"].append("--browsertime-no-ffwindowrecorder")
             task["attributes"]["run-visual-metrics"] = True
+
+        # taskcluster is merging task attributes with the default ones
+        # resulting the --cold extra option in the ytp warm tasks
+        if 'youtube-playback' in task["name"]:
+            task["run"]["command"].remove("--cold")
 
         yield task
 


### PR DESCRIPTION
Opening to run CI from #12334, other PR already has r+

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture