### PR TITLE
No issue - Suppress new warnings from detekt update

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/collections/TabDiffUtil.kt
+++ b/app/src/main/java/org/mozilla/fenix/collections/TabDiffUtil.kt
@@ -10,6 +10,7 @@ import org.mozilla.fenix.home.Tab
 /**
  * Diff callback for comparing tab lists with selected state.
  */
+@Suppress("LongParameterList")
 internal class TabDiffUtil(
     private val old: List<Tab>,
     private val new: List<Tab>,

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
@@ -128,7 +128,7 @@ interface SessionControlController {
     fun handleCreateCollection()
 }
 
-@SuppressWarnings("TooManyFunctions", "LargeClass")
+@SuppressWarnings("TooManyFunctions", "LargeClass", "LongParameterList")
 class DefaultSessionControlController(
     private val activity: HomeActivity,
     private val engine: Engine,

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkController.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkController.kt
@@ -47,7 +47,7 @@ interface BookmarkController {
     fun handleBackPressed()
 }
 
-@SuppressWarnings("TooManyFunctions")
+@SuppressWarnings("TooManyFunctions", "LongParameterList")
 class DefaultBookmarkController(
     private val activity: HomeActivity,
     private val navController: NavController,


### PR DESCRIPTION
Seems like 09d0688e6483d0e2ca33009c7a77855f29b9556d caused some new warnings to pop up
