### PR TITLE
Cleanup locall publish flows for application-services

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -45,22 +45,14 @@ if (localProperties != null) {
 
     if (appServicesLocalPath != null) {
         log("Enabling automatic publication of application-services from: $appServicesLocalPath")
-        def publishAppServicesCmd = ["./automation/publish_to_maven_local_if_modified.py"]
-        // Application-services doesn't build on native Windows. However, it still makes sense to
-        // enable these workflows on Windows, even if it isn't quote as automatic as elsewhere -
-        // specifically, you must run the build command on WSL, but after that you can happily build
-        // and debug directly from within Android Studio on native Windows - but only after following
-        // https://github.com/mozilla/application-services/blob/master/docs/howtos/setup-android-build-environment.md#using-windows
-        // So rather than fail we make noise...
+        // Windows can't execute .py files directly, so we assume a "manually installed" python,
+        // which comes with a "py" launcher and respects the shebang line to specify the version.
+        def publishAppServicesCmd = [];
         if (System.properties['os.name'].toLowerCase().contains('windows')) {
-            log('NOTE: The autoPublish workflows do not work on native windows.');
-            log('You must manually ensure that the following command has completed successfully in WSL:');
-            log("> $publishAppServicesCmd");
-            log("(from the '$appServicesLocalPath' directory)");
-            log('Then restart the build');
-        } else {
-            runCmd(publishAppServicesCmd, appServicesLocalPath, "Published application-services for local development.", false)
+            publishAppServicesCmd << "py";
         }
+        publishAppServicesCmd << "./automation/publish_to_maven_local_if_modified.py";
+        runCmd(publishAppServicesCmd, appServicesLocalPath, "Published application-services for local development.", false)
     } else {
         log("Disabled auto-publication of application-services. Enable it by settings '$settingAppServicesPath' in local.properties")
     }
@@ -68,10 +60,8 @@ if (localProperties != null) {
     String androidComponentsLocalPath = localProperties.getProperty(settingAndroidComponentsPath)
 
     if (androidComponentsLocalPath != null) {
-        // android-components does build on native windows, so it doesn't get the special Windows treatment above.
-        // But it doesn't like executing .py files directly. We assume a "manually installed" python,
-        // which comes with a "py" launcher and respects the shebang line to specify the version.
         log("Enabling automatic publication of android-components from: $androidComponentsLocalPath")
+        // As above, hacks to execute .py files on Windows.
         def publishAcCmd = [];
         if (System.properties['os.name'].toLowerCase().contains('windows')) {
             publishAcCmd << "py";


### PR DESCRIPTION
Similar to what https://github.com/mozilla-mobile/android-components/pull/7609 does, this removes knowledge about what does and doesn't work on Windows into where the problem is (which is app-services)

cc @grigoryk 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture