### PR TITLE
For issue #12387 - Display tab tray using its .show function

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragment.kt
@@ -51,6 +51,7 @@ import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.toShortUrl
 import org.mozilla.fenix.library.LibraryPageFragment
+import org.mozilla.fenix.tabtray.TabTrayDialogFragment
 import org.mozilla.fenix.utils.allowUndo
 
 /**
@@ -207,14 +208,14 @@ class BookmarkFragment : LibraryPageFragment<BookmarkNode>(), UserInteractionHan
             R.id.open_bookmarks_in_new_tabs_multi_select -> {
                 openItemsInNewTab { node -> node.url }
 
-                navigate(BookmarkFragmentDirections.actionGlobalTabTrayDialogFragment())
+                showTabTray()
                 metrics?.track(Event.OpenedBookmarksInNewTabs)
                 true
             }
             R.id.open_bookmarks_in_private_tabs_multi_select -> {
                 openItemsInNewTab(private = true) { node -> node.url }
 
-                navigate(BookmarkFragmentDirections.actionGlobalTabTrayDialogFragment())
+                showTabTray()
                 metrics?.track(Event.OpenedBookmarksInPrivateTabs)
                 true
             }
@@ -235,6 +236,11 @@ class BookmarkFragment : LibraryPageFragment<BookmarkNode>(), UserInteractionHan
             }
             else -> super.onOptionsItemSelected(item)
         }
+    }
+
+    private fun showTabTray() {
+        invokePendingDeletion()
+        TabTrayDialogFragment.show(parentFragmentManager)
     }
 
     private fun navigate(directions: NavDirections) {

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragment.kt
@@ -44,6 +44,7 @@ import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.showToolbar
 import org.mozilla.fenix.ext.toShortUrl
 import org.mozilla.fenix.library.LibraryPageFragment
+import org.mozilla.fenix.tabtray.TabTrayDialogFragment
 import org.mozilla.fenix.utils.allowUndo
 
 @SuppressWarnings("TooManyFunctions", "LargeClass")
@@ -184,9 +185,7 @@ class HistoryFragment : LibraryPageFragment<HistoryItem>(), UserInteractionHandl
                 selectedItem.url
             }
 
-            navigate(
-                HistoryFragmentDirections.actionGlobalTabTrayDialogFragment()
-            )
+            showTabTray()
             true
         }
         R.id.open_history_in_private_tabs_multi_select -> {
@@ -199,12 +198,16 @@ class HistoryFragment : LibraryPageFragment<HistoryItem>(), UserInteractionHandl
                 browsingModeManager.mode = BrowsingMode.Private
                 supportActionBar?.hide()
             }
-            navigate(
-                HistoryFragmentDirections.actionGlobalTabTrayDialogFragment()
-            )
+
+            showTabTray()
             true
         }
         else -> super.onOptionsItemSelected(item)
+    }
+
+    private fun showTabTray() {
+        invokePendingDeletion()
+        TabTrayDialogFragment.show(parentFragmentManager)
     }
 
     private fun getMultiSelectSnackBarMessage(historyItems: Set<HistoryItem>): String {


### PR DESCRIPTION
Replaced the global navigation action used for displaying the tab tray with the .show() function.

This change also makes it consistent with how the tab tray is shown in BaseBrowserFragment.

<img src = "https://user-images.githubusercontent.com/23737079/88027330-c06d7b00-cb3f-11ea-8708-ff5d32ea4e54.gif" width = "300">

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture