### PR TITLE
Move release locales to a separate config file.

### DIFF
--- a/automation/taskcluster/l10n/locales.py
+++ b/automation/taskcluster/l10n/locales.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 
 import re
 
-OPEN_LOCALES = "release_locales = ["
+OPEN_LOCALES = "locales = ["
 CLOSE_LOCALES = "]"
 
 def trim_to_locale(str):
@@ -18,11 +18,11 @@ def trim_to_locale(str):
     return match.group(1)
 
 
-# This file is a dumb parser that converts values from '/l10n.toml' to be easily consumed from
-# Python.
+# This file is a dumb parser that converts values from '/l10n-release.toml' to be easily
+# consumed from Python.
 #
-# 'l10n.toml' has a very simple structure, and it is reasonable to believe that this (very basic)
-# algorithm will continue to work as it is changed.
+# 'l10n-release.toml' has a very simple structure, and it is reasonable to believe that this
+# (very basic) algorithm will continue to work as it is changed.
 #
 # Alternatives to custom parsing that were considered:
 # - Using standard library module --- none exists to parse TOML
@@ -31,7 +31,7 @@ def trim_to_locale(str):
 # - Vendoring a TOML module --- large amount of code given the use case. Introduces a security
 #   risk
 def get_release_locales():
-    with open(r"l10n.toml") as f:
+    with open(r"l10n-release.toml") as f:
         file = f.read().splitlines()
 
     locales_opened = False
@@ -42,7 +42,7 @@ def get_release_locales():
     for line in file:
         if line == OPEN_LOCALES:
             locales_opened = True
-        elif line == CLOSE_LOCALES and locales_opened == True:
+        elif line == CLOSE_LOCALES:
             locales_closed = True
             break
         elif locales_opened:

--- a/l10n-release.toml
+++ b/l10n-release.toml
@@ -1,13 +1,12 @@
-
-basepath = "."
-
+# Locales that should be present in release builds
+# Locales that are at 70% or higher completion on https://pontoon.mozilla.org/projects/android-l10n/
+# should be in this list
 locales = [
   "an",
   "ar",
   "ast",
   "az",
   "be",
-  "bg",
   "bn",
   "br",
   "bs",
@@ -59,13 +58,10 @@ locales = [
   "lt",
   "ml",
   "mr",
-  "ms",
   "my",
   "nb-NO",
-  "ne-NP",
   "nl",
   "nn-NO",
-  "nv",
   "oc",
   "pa-IN",
   "pl",
@@ -87,21 +83,9 @@ locales = [
   "trs",
   "uk",
   "ur",
-  "uz",
   "vec",
   "vi",
   "zh-CN",
   "zh-TW",
 ]
 
-# Expose the following branches to localization
-# Changes to this list should be announced to the l10n team ahead of time.
-branches = [
-    "master",
-]
-
-[env]
-
-[[paths]]
-  reference = "app/src/main/res/values/strings.xml"
-  l10n = "app/src/main/res/values-{android_locale}/strings.xml"


### PR DESCRIPTION
Reverts 98d5ae6b899cab830f6b53fa103230f4c74ea0c4 and moves release locale list to a separate file