### PR TITLE
For #12565 - Clean up search controller and add tests

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/search/SearchController.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchController.kt
@@ -9,6 +9,7 @@ import android.content.Intent
 import androidx.navigation.NavController
 import mozilla.components.browser.search.SearchEngine
 import mozilla.components.browser.session.Session
+import mozilla.components.browser.session.SessionManager
 import mozilla.components.support.ktx.kotlin.isUrl
 import org.mozilla.fenix.BrowserDirection
 import org.mozilla.fenix.HomeActivity
@@ -17,15 +18,14 @@ import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.components.metrics.Event.PerformedSearch.SearchAccessPoint.ACTION
 import org.mozilla.fenix.components.metrics.Event.PerformedSearch.SearchAccessPoint.NONE
 import org.mozilla.fenix.components.metrics.Event.PerformedSearch.SearchAccessPoint.SUGGESTION
+import org.mozilla.fenix.components.metrics.MetricController
 import org.mozilla.fenix.components.metrics.MetricsUtils
 import org.mozilla.fenix.components.searchengine.CustomSearchEngineStore
 import org.mozilla.fenix.crashes.CrashListActivity
-import org.mozilla.fenix.ext.components
-import org.mozilla.fenix.ext.metrics
 import org.mozilla.fenix.ext.navigateSafe
-import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.settings.SupportUtils
 import org.mozilla.fenix.settings.SupportUtils.MozillaPage.MANIFESTO
+import org.mozilla.fenix.utils.Settings
 
 /**
  * An interface that handles the view manipulation of the Search, triggered by the Interactor
@@ -43,11 +43,14 @@ interface SearchController {
     fun handleSearchShortcutsButtonClicked()
 }
 
-@Suppress("TooManyFunctions")
+@Suppress("TooManyFunctions", "LongParameterList")
 class DefaultSearchController(
     private val activity: HomeActivity,
+    private val sessionManager: SessionManager,
     private val store: SearchFragmentStore,
     private val navController: NavController,
+    private val settings: Settings,
+    private val metrics: MetricController,
     private val clearToolbarFocus: () -> Unit
 ) : SearchController {
 
@@ -77,7 +80,7 @@ class DefaultSearchController(
         val event = if (url.isUrl()) {
             Event.EnteredUrl(false)
         } else {
-            activity.settings().incrementActiveSearchCount()
+            settings.incrementActiveSearchCount()
 
             val searchAccessPoint = when (store.state.searchAccessPoint) {
                 NONE -> ACTION
@@ -93,7 +96,7 @@ class DefaultSearchController(
             }
         }
 
-        event?.let { activity.metrics.track(it) }
+        event?.let { metrics.track(it) }
     }
 
     override fun handleEditingCancelled() {
@@ -101,7 +104,6 @@ class DefaultSearchController(
     }
 
     override fun handleTextChanged(text: String) {
-        val settings = activity.settings()
         // Display the search shortcuts on each entry of the search fragment (see #5308)
         val textMatchesCurrentUrl = store.state.url == text
         val textMatchesCurrentSearch = store.state.searchTerms == text
@@ -130,11 +132,11 @@ class DefaultSearchController(
             from = BrowserDirection.FromSearch
         )
 
-        activity.metrics.track(Event.EnteredUrl(false))
+        metrics.track(Event.EnteredUrl(false))
     }
 
     override fun handleSearchTermsTapped(searchTerms: String) {
-        activity.settings().incrementActiveSearchCount()
+        settings.incrementActiveSearchCount()
 
         activity.openToBrowserAndLoad(
             searchTermOrURL = searchTerms,
@@ -156,14 +158,14 @@ class DefaultSearchController(
                 sap
             )
         }
-        event?.let { activity.metrics.track(it) }
+        event?.let { metrics.track(it) }
     }
 
     override fun handleSearchShortcutEngineSelected(searchEngine: SearchEngine) {
         store.dispatch(SearchFragmentAction.SearchShortcutEngineSelected(searchEngine))
         val isCustom =
             CustomSearchEngineStore.isCustomSearchEngine(activity, searchEngine.identifier)
-        activity.metrics.track(Event.SearchShortcutSelected(searchEngine, isCustom))
+        metrics.track(Event.SearchShortcutSelected(searchEngine, isCustom))
     }
 
     override fun handleSearchShortcutsButtonClicked() {
@@ -177,14 +179,14 @@ class DefaultSearchController(
     }
 
     override fun handleExistingSessionSelected(session: Session) {
-        activity.components.core.sessionManager.select(session)
+        sessionManager.select(session)
         activity.openToBrowser(
             from = BrowserDirection.FromSearch
         )
     }
 
     override fun handleExistingSessionSelected(tabId: String) {
-        val session = activity.components.core.sessionManager.findSessionById(tabId)
+        val session = sessionManager.findSessionById(tabId)
         if (session != null) {
             handleExistingSessionSelected(session)
         }

--- a/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
@@ -86,6 +86,7 @@ class SearchFragment : Fragment(), UserInteractionHandler {
         savedInstanceState: Bundle?
     ): View? {
         val activity = activity as HomeActivity
+        val settings = activity.settings()
         val args by navArgs<SearchFragmentArgs>()
 
         val tabId = args.sessionId
@@ -112,13 +113,13 @@ class SearchFragment : Fragment(), UserInteractionHandler {
                     defaultEngineSource = currentSearchEngine,
                     showSearchSuggestions = shouldShowSearchSuggestions(isPrivate),
                     showSearchSuggestionsHint = false,
-                    showSearchShortcuts = requireContext().settings().shouldShowSearchShortcuts &&
+                    showSearchShortcuts = settings.shouldShowSearchShortcuts &&
                             url.isEmpty() &&
                             areShortcutsAvailable,
                     areShortcutsAvailable = areShortcutsAvailable,
-                    showClipboardSuggestions = requireContext().settings().shouldShowClipboardSuggestions,
-                    showHistorySuggestions = requireContext().settings().shouldShowHistorySuggestions,
-                    showBookmarkSuggestions = requireContext().settings().shouldShowBookmarkSuggestions,
+                    showClipboardSuggestions = settings.shouldShowClipboardSuggestions,
+                    showHistorySuggestions = settings.shouldShowHistorySuggestions,
+                    showBookmarkSuggestions = settings.shouldShowBookmarkSuggestions,
                     tabId = tabId,
                     pastedText = args.pastedText,
                     searchAccessPoint = args.searchAccessPoint
@@ -128,8 +129,11 @@ class SearchFragment : Fragment(), UserInteractionHandler {
 
         val searchController = DefaultSearchController(
             activity = activity,
+            sessionManager = requireComponents.core.sessionManager,
             store = searchStore,
             navController = findNavController(),
+            settings = settings,
+            metrics = requireComponents.analytics.metrics,
             clearToolbarFocus = ::clearToolbarFocus
         )
 
@@ -163,7 +167,7 @@ class SearchFragment : Fragment(), UserInteractionHandler {
                 visible = {
                     currentSearchEngine.searchEngine.identifier.contains("google") &&
                         speechIsAvailable() &&
-                        requireContext().settings().shouldShowVoiceSearch
+                        settings.shouldShowVoiceSearch
                 },
                 listener = ::launchVoiceSearch
             )


### PR DESCRIPTION
Switched from using .context.components chains to passing dependencies into the constructor. Added additional tests.