### PR TITLE
For #12804: Set min height for search engine radio button

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/search/AddSearchEngineFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/search/AddSearchEngineFragment.kt
@@ -93,7 +93,7 @@ class AddSearchEngineFragment : Fragment(), CompoundButton.OnCheckedChangeListen
 
         availableEngines.forEachIndexed(setupSearchEngineItem)
 
-        val engineItem = makeCustomButton(layoutInflater, res = resources)
+        val engineItem = makeCustomButton(layoutInflater)
         engineItem.id = CUSTOM_INDEX
         engineItem.radio_button.isChecked = selectedIndex == CUSTOM_INDEX
         engineViews.add(engineItem)
@@ -249,12 +249,11 @@ class AddSearchEngineFragment : Fragment(), CompoundButton.OnCheckedChangeListen
         toggleCustomForm(selectedIndex == -1)
     }
 
-    private fun makeCustomButton(layoutInflater: LayoutInflater, res: Resources): View {
+    private fun makeCustomButton(layoutInflater: LayoutInflater): View {
         val wrapper = layoutInflater
             .inflate(R.layout.custom_search_engine_radio_button, null) as ConstraintLayout
         wrapper.setOnClickListener { wrapper.radio_button.isChecked = true }
         wrapper.radio_button.setOnCheckedChangeListener(this)
-        wrapper.minHeight = res.getDimensionPixelSize(R.dimen.radio_button_preference_height)
         return wrapper
     }
 
@@ -280,7 +279,6 @@ class AddSearchEngineFragment : Fragment(), CompoundButton.OnCheckedChangeListen
         engineIcon.setBounds(0, 0, iconSize, iconSize)
         wrapper.engine_icon.setImageDrawable(engineIcon)
         wrapper.overflow_menu.visibility = View.GONE
-        wrapper.minHeight = res.getDimensionPixelSize(R.dimen.radio_button_preference_height)
         return wrapper
     }
 

--- a/app/src/main/res/layout/custom_search_engine_radio_button.xml
+++ b/app/src/main/res/layout/custom_search_engine_radio_button.xml
@@ -7,6 +7,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_height="@dimen/search_engine_radio_button_height"
+    android:minHeight="@dimen/radio_button_preference_height"
     android:layout_width="match_parent"
     android:background="?android:selectableItemBackground"
     android:clickable="true"

--- a/app/src/main/res/layout/search_engine_radio_button.xml
+++ b/app/src/main/res/layout/search_engine_radio_button.xml
@@ -2,12 +2,12 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_height="@dimen/search_engine_radio_button_height"
     android:layout_width="match_parent"
+    android:minHeight="@dimen/radio_button_preference_height"
     android:background="?android:selectableItemBackground"
     android:clickable="true"
     android:focusable="true">
@@ -18,18 +18,14 @@
         android:importantForAccessibility="no"
         android:textAppearance="?android:attr/textAppearanceListItem"
         android:layout_marginStart="@dimen/search_bar_search_engine_icon_padding"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"/>
+        android:layout_gravity="center" />
     <ImageView
         android:id="@+id/engine_icon"
         android:importantForAccessibility="no"
         android:layout_width="@dimen/search_engine_engine_icon_height"
         android:layout_height="@dimen/search_engine_engine_icon_height"
         android:layout_marginStart="@dimen/search_bar_search_icon_margin"
-        app:layout_constraintStart_toEndOf="@id/radio_button"
-        app:layout_constraintTop_toTopOf="@id/radio_button"
-        app:layout_constraintBottom_toBottomOf="@id/radio_button" />
+        android:layout_gravity="center" />
     <TextView
         android:id="@+id/engine_text"
         android:textColor="?primaryText"
@@ -37,19 +33,15 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/radio_button_padding_horizontal"
         android:layout_marginEnd="@dimen/radio_button_padding_horizontal"
-        android:textAlignment="viewStart"
         android:textSize="16sp"
-        app:layout_constraintStart_toEndOf="@id/engine_icon"
-        app:layout_constraintTop_toTopOf="@id/engine_icon"
-        app:layout_constraintEnd_toEndOf="parent" />
+        tools:text="Google"
+        android:layout_weight="1"
+        android:layout_gravity="center" />
     <ImageButton
         android:id="@+id/overflow_menu"
         android:layout_width="@dimen/glyph_button_width"
         android:layout_height="@dimen/glyph_button_height"
         android:background="?android:attr/selectableItemBackgroundBorderless"
         android:contentDescription="@string/content_description_menu"
-        app:srcCompat="@drawable/ic_menu"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"/>
-</androidx.constraintlayout.widget.ConstraintLayout>
+        app:srcCompat="@drawable/ic_menu" />
+</LinearLayout>


### PR DESCRIPTION
I've added minHeight to `search_engine_radio_button` and moved minHeight used in `AddSearchEngineFragment` to `custom_search_engine_radio_button`.

![Screenshot_20200721-235025_Firefox_Preview](https://user-images.githubusercontent.com/17825767/88106228-d154d580-cbad-11ea-910a-8abbb8616cff.png)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [x] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

