### PR TITLE
bugfix/#12292 open correct Play store link in debug build

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
@@ -220,12 +220,18 @@ class SettingsFragment : PreferenceFragmentCompat() {
             }
             resources.getString(R.string.pref_key_rate) -> {
                 try {
-                    startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(SupportUtils.RATE_APP_URL)))
+                    val playStoreUrl =
+                        if (Config.channel.isDebug) SupportUtils.FIREFOX_NIGHTLY_PLAY_STORE_URL
+                        else SupportUtils.RATE_APP_URL
+                    startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(playStoreUrl)))
                 } catch (e: ActivityNotFoundException) {
                     // Device without the play store installed.
                     // Opening the play store website.
+                    val playStoreUrl =
+                        if (Config.channel.isDebug) SupportUtils.FENIX_RATE_APP_URL
+                        else SupportUtils.FENIX_PLAY_STORE_URL
                     (activity as HomeActivity).openToBrowserAndLoad(
-                        searchTermOrURL = SupportUtils.FENIX_PLAY_STORE_URL,
+                        searchTermOrURL = playStoreUrl,
                         newTab = true,
                         from = BrowserDirection.FromSettings
                     )

--- a/app/src/main/java/org/mozilla/fenix/settings/SupportUtils.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SupportUtils.kt
@@ -24,6 +24,7 @@ object SupportUtils {
     const val POCKET_TRENDING_URL = "https://getpocket.com/fenix-top-articles"
     const val WIKIPEDIA_URL = "https://www.wikipedia.org/"
     const val FENIX_PLAY_STORE_URL = "https://play.google.com/store/apps/details?id=${BuildConfig.APPLICATION_ID}"
+    const val FENIX_RATE_APP_URL = "https://play.google.com/store/apps/details?id=org.mozilla.fenix"
     const val FIREFOX_BETA_PLAY_STORE_URL = "market://details?id=org.mozilla.firefox_beta"
     const val FIREFOX_NIGHTLY_PLAY_STORE_URL = "market://details?id=org.mozilla.fenix"
     const val GOOGLE_URL = "https://www.google.com/"


### PR DESCRIPTION
This PR is just to run tests for @nikit19 's [PR](https://github.com/mozilla-mobile/fenix/pull/12293)

After clicking on rate on Google Play on a device that does not have Playstore

<img src="https://user-images.githubusercontent.com/20878145/86532073-9895da80-bee4-11ea-81f9-eddc7918fe19.png" width="300px"/>



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture