### PR TITLE
For #12772 - Opt-out of scoped storage

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,7 @@
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:requestLegacyExternalStorage="true"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/NormalTheme"


### PR DESCRIPTION
Targeting Android 10 means we need to support scoped storage or we need to
opt-out of that using requestLegacyExternalStorage="true".

This patch adds the opting-out leaving investigations for what changes we need
for fully supporting scoped storage to be done in issue #12822.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: No tests, small change.
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR does not include any user facing features.

![OpeningDownloadsIsPossibleAgain](https://user-images.githubusercontent.com/11428869/88163463-617d3400-cc1b-11ea-9897-b83428199395.gif)
[Video](https://drive.google.com/file/d/1Ngp29IFhDMeL5ifs2N_UEdv57mTgfNvs/view?usp=sharing)

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture