### PR TITLE
For #12571: Rename shortcuts to search engine on search screen

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/metrics/Metrics.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/Metrics.kt
@@ -236,7 +236,7 @@ sealed class Event {
             context.getString(R.string.pref_key_search_bookmarks),
             context.getString(R.string.pref_key_search_browsing_history),
             context.getString(R.string.pref_key_show_clipboard_suggestions),
-            context.getString(R.string.pref_key_show_search_shortcuts),
+            context.getString(R.string.pref_key_show_search_engine_shortcuts),
             context.getString(R.string.pref_key_open_links_in_a_private_tab),
             context.getString(R.string.pref_key_sync_logins),
             context.getString(R.string.pref_key_sync_bookmarks),

--- a/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
@@ -268,7 +268,7 @@ class SearchFragment : Fragment(), UserInteractionHandler {
             qrFeature.get()?.scan(R.id.container)
         }
 
-        view.search_shortcuts_button.setOnClickListener {
+        view.search_engines_shortcut_button.setOnClickListener {
             searchInteractor.onSearchShortcutsButtonClicked()
         }
 
@@ -400,7 +400,7 @@ class SearchFragment : Fragment(), UserInteractionHandler {
     }
 
     private fun updateSearchWithLabel(searchState: SearchFragmentState) {
-        search_with_shortcuts.visibility =
+        search_engine_shortcut.visibility =
             if (searchState.showSearchShortcuts) View.VISIBLE else View.GONE
     }
 
@@ -450,19 +450,19 @@ class SearchFragment : Fragment(), UserInteractionHandler {
             findViewById<View>(R.id.search_suggestions_onboarding)?.isVisible = state.showSearchSuggestionsHint
 
             search_suggestions_onboarding_divider?.isVisible =
-                search_with_shortcuts.isVisible && state.showSearchSuggestionsHint
+                search_engine_shortcut.isVisible && state.showSearchSuggestionsHint
         }
     }
 
     private fun updateSearchShortcutsIcon(searchState: SearchFragmentState) {
         view?.apply {
-            search_shortcuts_button.isVisible = searchState.areShortcutsAvailable
+            search_engines_shortcut_button.isVisible = searchState.areShortcutsAvailable
 
             val showShortcuts = searchState.showSearchShortcuts
-            search_shortcuts_button.isChecked = showShortcuts
+            search_engines_shortcut_button.isChecked = showShortcuts
 
             val color = if (showShortcuts) R.attr.contrastText else R.attr.primaryText
-            search_shortcuts_button.compoundDrawables[0]?.setTint(
+            search_engines_shortcut_button.compoundDrawables[0]?.setTint(
                 requireContext().getColorFromAttr(color)
             )
         }

--- a/app/src/main/java/org/mozilla/fenix/settings/search/SearchEngineFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/search/SearchEngineFragment.kt
@@ -38,7 +38,7 @@ class SearchEngineFragment : PreferenceFragmentCompat() {
             }
 
         val showSearchShortcuts =
-            requirePreference<SwitchPreference>(R.string.pref_key_show_search_shortcuts).apply {
+            requirePreference<SwitchPreference>(R.string.pref_key_show_search_engine_shortcuts).apply {
                 isChecked = context.settings().shouldShowSearchShortcuts
             }
 

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -305,7 +305,7 @@ class Settings(private val appContext: Context) : PreferencesHolder {
     )
 
     val shouldShowSearchShortcuts by booleanPreference(
-        appContext.getPreferenceKey(R.string.pref_key_show_search_shortcuts),
+        appContext.getPreferenceKey(R.string.pref_key_show_search_engine_shortcuts),
         default = false
     )
 

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -52,7 +52,7 @@
                 android:fadingEdgeLength="40dp"
                 android:nestedScrollingEnabled="false"
                 android:requiresFadingEdge="vertical"
-                app:layout_constraintTop_toBottomOf="@id/search_with_shortcuts"
+                app:layout_constraintTop_toBottomOf="@id/search_engine_shortcut"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 mozac:awesomeBarDescriptionTextColor="?secondaryText"
@@ -139,8 +139,8 @@
                 app:layout_constraintTop_toBottomOf="@id/fill_link_from_clipboard" />
 
             <TextView
-                android:id="@+id/search_with_shortcuts"
-                style="@style/SearchShortcutsLabelStyle"
+                android:id="@+id/search_engine_shortcut"
+                style="@style/SearchEngineShortcutsLabelStyle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/search_fragment_shortcuts_label_margin_horizontal"
@@ -150,14 +150,14 @@
                 android:text="@string/search_engines_search_with"
                 app:layout_constraintStart_toStartOf="@id/scrollable_area"
                 app:layout_constraintTop_toBottomOf="@id/awesomeBar_barrier"
-                tools:text="This time, search with:" />
+                tools:text="@string/search_engines_search_with" />
 
             <androidx.constraintlayout.widget.Barrier
                 android:id="@+id/awesomeBar_barrier"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 app:barrierDirection="bottom"
-                app:constraint_referenced_ids="fill_link_from_clipboard,search_with_shortcuts,search_suggestions_onboarding" />
+                app:constraint_referenced_ids="fill_link_from_clipboard,search_engine_shortcut,search_suggestions_onboarding" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
@@ -195,10 +195,10 @@
             app:drawableStartCompat="@drawable/ic_qr" />
 
         <ToggleButton
-            android:id="@+id/search_shortcuts_button"
+            android:id="@+id/search_engines_shortcut_button"
             style="@style/search_pill"
-            android:textOff="@string/search_engines_shortcut_button"
-            android:textOn="@string/search_engines_shortcut_button"
+            android:textOff="@string/search_engine_button"
+            android:textOn="@string/search_engine_button"
             app:drawableStartCompat="@drawable/ic_search" />
     </LinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -86,7 +86,7 @@
 
     <!-- Search Settings -->
     <string name="pref_key_search_engine_list" translatable="false">pref_key_search_engine_list</string>
-    <string name="pref_key_show_search_shortcuts" translatable="false">pref_key_show_search_shortcuts</string>
+    <string name="pref_key_show_search_engine_shortcuts" translatable="false">pref_key_show_search_engine_shortcuts</string>
     <string name="pref_key_show_search_suggestions" translatable="false">pref_key_show_search_suggestions</string>
     <string name="pref_key_show_clipboard_suggestions" translatable="false">pref_key_show_clipboard_suggestions</string>
     <string name="pref_key_search_browsing_history" translatable="false">pref_key_search_browsing_history</string>
@@ -94,7 +94,8 @@
     <string name="pref_key_show_search_suggestions_in_private" translatable="false">pref_key_show_search_suggestions_in_private</string>
     <string name="pref_key_show_search_suggestions_in_private_onboarding" translatable="false">pref_key_show_search_suggestions_in_privateonboarding</string>
     <string name="pref_key_show_voice_search" translatable="false">pref_key_show_voice_search</string>
-
+    <!--  Deprecated  -->
+    <string name="pref_key_show_search_shortcuts" translatable="false">pref_key_show_search_shortcuts</string>
 
     <!-- Site Permissions Settings -->
     <string name="pref_key_optimize" translatable="false">pref_key_optimize</string>

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -94,8 +94,6 @@
     <string name="pref_key_show_search_suggestions_in_private" translatable="false">pref_key_show_search_suggestions_in_private</string>
     <string name="pref_key_show_search_suggestions_in_private_onboarding" translatable="false">pref_key_show_search_suggestions_in_privateonboarding</string>
     <string name="pref_key_show_voice_search" translatable="false">pref_key_show_voice_search</string>
-    <!--  Deprecated  -->
-    <string name="pref_key_show_search_shortcuts" translatable="false">pref_key_show_search_shortcuts</string>
 
     <!-- Site Permissions Settings -->
     <string name="pref_key_optimize" translatable="false">pref_key_optimize</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -167,8 +167,8 @@
     <!-- Search Fragment -->
     <!-- Button in the search view that lets a user search by scanning a QR code -->
     <string name="search_scan_button">Scan</string>
-    <!-- Button in the search view that lets a user search by using a shortcut -->
-    <string name="search_engines_shortcut_button">Search Engine</string>
+    <!-- Button in the search view that lets a user change their search engine -->
+    <string name="search_engine_button">Search engine</string>
     <!-- Button in the search view when shortcuts are displayed that takes a user to the search engine settings -->
     <string name="search_shortcuts_engine_settings">Search engine settings</string>
     <!-- Header displayed when selecting a shortcut search engine -->
@@ -1456,12 +1456,12 @@
     <string name="top_sites_max_limit_confirmation_button">OK, Got It</string>
 
     <!-- DEPRECATED STRINGS -->
-    <!-- Button in the search view that lets a user search by using a shortcut -->
+    <!-- DEPRECATED: Button in the search view that lets a user search by using a shortcut -->
     <string name="search_shortcuts_button">Shortcuts</string>
     <!-- DEPRECATED: Header displayed when selecting a shortcut search engine -->
     <string name="search_shortcuts_search_with">Search with</string>
-    <!-- Header displayed when selecting a shortcut search engine -->
+    <!-- DEPRECATED: Header displayed when selecting a shortcut search engine -->
     <string name="search_shortcuts_search_with_2">This time, search with:</string>
-    <!-- Preference title for switch preference to show search shortcuts -->
+    <!-- DEPRECATED: Preference title for switch preference to show search shortcuts -->
     <string name="preferences_show_search_shortcuts">Show search shortcuts</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1464,4 +1464,6 @@
     <string name="search_shortcuts_search_with_2">This time, search with:</string>
     <!-- DEPRECATED: Preference title for switch preference to show search shortcuts -->
     <string name="preferences_show_search_shortcuts">Show search shortcuts</string>
+    <!-- DEPRECATED: Button in the search view that lets a user search by using a shortcut -->
+    <string name="search_engines_shortcut_button">Search Engine</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -455,7 +455,7 @@
         <item name="android:elevation">0dp</item>
     </style>
 
-    <style name="SearchShortcutsLabelStyle">
+    <style name="SearchEngineShortcutsLabelStyle">
         <item name="android:fontFamily">@font/metropolis_semibold</item>
         <item name="android:letterSpacing">0.15</item>
         <item name="android:textAllCaps">true</item>

--- a/app/src/main/res/xml/search_preferences.xml
+++ b/app/src/main/res/xml/search_preferences.xml
@@ -26,7 +26,7 @@
         android:layout="@layout/preference_cat_style">
         <SwitchPreference
             android:defaultValue="true"
-            android:key="@string/pref_key_show_search_shortcuts"
+            android:key="@string/pref_key_show_search_engine_shortcuts"
             android:title="@string/preferences_show_search_engines" />
         <SwitchPreference
             android:defaultValue="true"


### PR DESCRIPTION
- Changes preference keys to match new wording 
- Do not delete old strings, mark as deprecated instead
```
<!-- DEPRECATED: Header displayed when selecting a shortcut search engine -->
      <string name="search_shortcuts_search_with">Search with</string>
```
```
<!-- DEPRECATED: Header displayed when selecting a shortcut search engine -->
      <string name="search_shortcuts_search_with_2">This time, search with:</string> 
```
```
<!-- DEPRECATED: Button in the search view that lets a user search by using a shortcut -->
      <string name="search_shortcuts_button">Shortcuts</string> 
```
```
<!-- DEPRECATED: Button in the search view that lets a user search by using a shortcut -->
    <string name="search_engines_shortcut_button">Search Engine</string>
```
```
<!-- DEPRECATED: Preference title for switch preference to show search shortcuts -->
    <string name="preferences_show_search_shortcuts">Show search shortcuts</string>
```

- Add new strings with design consistency 
  - `search_shortcuts_search_with` _**not replaced**_ - we don't use this anywhere
  - `search_shortcuts_search_with_2` replaced with `search_engines_search_with`
  - `search_shortcuts_button` and `search_engines_shortcut_button` replaced with `search_engine_button`
  - `preferences_show_search_shortcuts` replaced with `preferences_show_search_engines`

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture