### PR TITLE
Use browser menu API with saved logins

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/logins/SavedLoginsSortingStrategyMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/SavedLoginsSortingStrategyMenu.kt
@@ -13,7 +13,7 @@ import org.mozilla.fenix.theme.ThemeManager
 
 class SavedLoginsSortingStrategyMenu(
     private val context: Context,
-    private val itemToHighlight: Item,
+    var itemToHighlight: Item,
     private val onItemTapped: (Item) -> Unit = {}
 ) {
     sealed class Item {
@@ -28,7 +28,6 @@ class SavedLoginsSortingStrategyMenu(
             SimpleBrowserMenuHighlightableItem(
                 label = context.getString(R.string.saved_logins_sort_strategy_alphabetically),
                 textColorResource = ThemeManager.resolveAttribute(R.attr.primaryText, context),
-                itemType = Item.AlphabeticallySort,
                 backgroundTint = context.getColorFromAttr(R.attr.colorControlHighlight),
                 isHighlighted = { itemToHighlight == Item.AlphabeticallySort }
             ) {
@@ -38,18 +37,11 @@ class SavedLoginsSortingStrategyMenu(
             SimpleBrowserMenuHighlightableItem(
                 label = context.getString(R.string.saved_logins_sort_strategy_last_used),
                 textColorResource = ThemeManager.resolveAttribute(R.attr.primaryText, context),
-                itemType = Item.LastUsedSort,
                 backgroundTint = context.getColorFromAttr(R.attr.colorControlHighlight),
                 isHighlighted = { itemToHighlight == Item.LastUsedSort }
             ) {
                 onItemTapped.invoke(Item.LastUsedSort)
             }
         )
-    }
-
-    internal fun updateMenu(itemToHighlight: Item) {
-        menuItems.forEach {
-            it.isHighlighted = { itemToHighlight == it.itemType }
-        }
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/SavedLoginsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/SavedLoginsFragment.kt
@@ -6,12 +6,12 @@ package org.mozilla.fenix.settings.logins.fragment
 
 import android.os.Bundle
 import android.view.LayoutInflater
+import android.view.Menu
+import android.view.MenuInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
 import android.view.inputmethod.EditorInfo
-import android.view.Menu
-import android.view.MenuInflater
 import android.widget.FrameLayout
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.SearchView
@@ -35,13 +35,13 @@ import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.showToolbar
 import org.mozilla.fenix.settings.logins.LoginsAction
 import org.mozilla.fenix.settings.logins.LoginsFragmentStore
-import org.mozilla.fenix.settings.logins.controller.LoginsListController
 import org.mozilla.fenix.settings.logins.LoginsListState
-import org.mozilla.fenix.settings.logins.interactor.SavedLoginsInteractor
 import org.mozilla.fenix.settings.logins.SavedLoginsSortingStrategyMenu
-import org.mozilla.fenix.settings.logins.view.SavedLoginsListView
 import org.mozilla.fenix.settings.logins.SortingStrategy
+import org.mozilla.fenix.settings.logins.controller.LoginsListController
 import org.mozilla.fenix.settings.logins.controller.SavedLoginsStorageController
+import org.mozilla.fenix.settings.logins.interactor.SavedLoginsInteractor
+import org.mozilla.fenix.settings.logins.view.SavedLoginsListView
 
 @SuppressWarnings("TooManyFunctions")
 class SavedLoginsFragment : Fragment() {
@@ -125,7 +125,8 @@ class SavedLoginsFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         consumeFrom(savedLoginsStore) {
-            sortingStrategyMenu.updateMenu(savedLoginsStore.state.highlightedItem)
+            sortingStrategyMenu.itemToHighlight = savedLoginsStore.state.highlightedItem
+            sortingStrategyPopupMenu.invalidate()
             savedLoginsListView.update(it)
         }
     }


### PR DESCRIPTION
For mozilla-mobile/android-components#7823

`itemType` is a bit of a hack to inject extra variables into the menu. It's unneeded because highlight menu already handles highlighting :)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture