### PR TITLE
For #12871 - Use local TWA DAL API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,7 +83,6 @@ gen-external-apklibs
 .leanplum_token
 .adjust_token
 .sentry_token
-.digital_asset_links_token
 .mls_token
 
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -355,21 +355,6 @@ android.applicationVariants.all { variant ->
     }
 
 // -------------------------------------------------------------------------------------------------
-// Digital Asset Links: Read token from local file if it exists
-// -------------------------------------------------------------------------------------------------
-
-    print("Digital Asset Links token: ")
-
-    try {
-        def token = new File("${rootDir}/.digital_asset_links_token").text.trim()
-        buildConfigField 'String', 'DIGITAL_ASSET_LINKS_TOKEN', '"' + token + '"'
-        println "(Added from .digital_asset_links_token file)"
-    } catch (FileNotFoundException ignored) {
-        buildConfigField 'String', 'DIGITAL_ASSET_LINKS_TOKEN', 'null'
-        println("X_X")
-    }
-
-// -------------------------------------------------------------------------------------------------
 // MLS: Read token from local file if it exists
 // -------------------------------------------------------------------------------------------------
 

--- a/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -43,10 +43,10 @@ import mozilla.components.feature.webnotifications.WebNotificationFeature
 import mozilla.components.lib.dataprotect.SecureAbove22Preferences
 import mozilla.components.lib.dataprotect.generateEncryptionKey
 import mozilla.components.service.digitalassetlinks.RelationChecker
-import mozilla.components.service.digitalassetlinks.api.DigitalAssetLinksApi
+import mozilla.components.service.digitalassetlinks.local.StatementApi
+import mozilla.components.service.digitalassetlinks.local.StatementRelationChecker
 import mozilla.components.service.sync.logins.SyncableLoginsStorage
 import org.mozilla.fenix.AppRequestInterceptor
-import org.mozilla.fenix.BuildConfig.DIGITAL_ASSET_LINKS_TOKEN
 import org.mozilla.fenix.Config
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
@@ -147,7 +147,7 @@ class Core(private val context: Context) {
      * The [RelationChecker] checks Digital Asset Links relationships for Trusted Web Activities.
      */
     val relationChecker: RelationChecker by lazy {
-        DigitalAssetLinksApi(client, DIGITAL_ASSET_LINKS_TOKEN)
+        StatementRelationChecker(StatementApi(client))
     }
 
     /**

--- a/taskcluster/fenix_taskgraph/transforms/build.py
+++ b/taskcluster/fenix_taskgraph/transforms/build.py
@@ -45,7 +45,6 @@ def add_shippable_secrets(config, tasks):
             } for key, target_file in (
                 ('adjust', '.adjust_token'),
                 ('firebase', 'app/src/{}/res/values/firebase.xml'.format(gradle_build_type)),
-                ('digital_asset_links', '.digital_asset_links_token'),
                 ('leanplum', '.leanplum_token'),
                 ('sentry_dsn', '.sentry_token'),
                 ('mls', '.mls_token'),
@@ -56,7 +55,6 @@ def add_shippable_secrets(config, tasks):
                 "path": target_file,
             } for fake_value, target_file in (
                 ("faketoken", ".adjust_token"),
-                ("faketoken", ".digital_asset_links_token"),
                 ("fake:token", ".leanplum_token"),  # : is used by leanplum
                 ("faketoken", ".mls_token"),
                 ("https://fake@sentry.prod.mozaws.net/368", ".sentry_token"),


### PR DESCRIPTION
Who doesn't love acronyms? 

Let's move off the Google API and call website APIs directly. I've been testing this system in Sample Browser and trying this branch out too. Everything works well and we can remove the related API key.