### PR TITLE
For #12904 - Conditionally inflate SwipeGestureLayout in BaseBrowserFragment.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -30,9 +30,9 @@ object FeatureFlags {
     val tabTray = Config.channel.isNightlyOrDebug
 
     /**
-     * Enables swipe on toolbar to switch tabs
+     * Enables gestures on the browser chrome that depend on a [SwipeGestureLayout]
      */
-    val swipeToSwitchTabs = Config.channel.isNightlyOrDebug
+    val browserChromeGestures = Config.channel.isNightlyOrDebug
 
     /**
      * Enables viewing tab history

--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -168,7 +168,13 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Session
         require(arguments != null)
         customTabSessionId = arguments?.getString(EXTRA_SESSION_ID)
 
-        val view = inflater.inflate(R.layout.fragment_browser, container, false)
+        val view = if (FeatureFlags.browserChromeGestures) {
+            inflater.inflate(R.layout.browser_gesture_wrapper, container, false).apply {
+                inflater.inflate(R.layout.fragment_browser, this as SwipeGestureLayout, true)
+            }
+        } else {
+            inflater.inflate(R.layout.fragment_browser, container, false)
+        }
 
         val activity = activity as HomeActivity
         activity.themeManager.applyStatusBarTheme(activity)

--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -15,6 +15,7 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.snackbar.Snackbar
+import kotlinx.android.synthetic.main.browser_gesture_wrapper.*
 import kotlinx.android.synthetic.main.fragment_browser.*
 import kotlinx.android.synthetic.main.fragment_browser.view.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -74,7 +75,9 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
         val components = context.components
 
         return super.initializeUI(view)?.also {
-            if (FeatureFlags.swipeToSwitchTabs) {
+            // We need to wrap this whole thing in an if here because gestureLayout will not exist
+            // if the feature flag is off
+            if (FeatureFlags.browserChromeGestures) {
                 gestureLayout.addGestureListener(
                     ToolbarGestureHandler(
                         activity = requireActivity(),

--- a/app/src/main/res/layout/browser_gesture_wrapper.xml
+++ b/app/src/main/res/layout/browser_gesture_wrapper.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<org.mozilla.fenix.browser.SwipeGestureLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/gestureLayout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <org.mozilla.fenix.browser.TabPreview
+        android:id="@+id/tabPreview"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:clickable="false"
+        android:focusable="false"
+        android:visibility="gone" />
+</org.mozilla.fenix.browser.SwipeGestureLayout>

--- a/app/src/main/res/layout/fragment_browser.xml
+++ b/app/src/main/res/layout/fragment_browser.xml
@@ -2,66 +2,52 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<org.mozilla.fenix.browser.SwipeGestureLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/gestureLayout"
+    android:id="@+id/browserLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context="browser.BrowserFragment">
 
-    <androidx.coordinatorlayout.widget.CoordinatorLayout
-        android:id="@+id/browserLayout"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
-
-        <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
-            android:id="@+id/swipeRefresh"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:alpha="0"
-            app:layout_behavior="@string/appbar_scrolling_view_behavior">
-
-            <mozilla.components.concept.engine.EngineView
-                android:id="@+id/engineView"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:visibility="gone" />
-        </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
-
-
-        <ViewStub
-            android:id="@+id/stubFindInPage"
-            android:layout_width="match_parent"
-            android:layout_height="56dp"
-            android:layout_gravity="bottom"
-            android:inflatedId="@+id/findInPageView"
-            android:layout="@layout/stub_find_in_page" />
-
-        <include
-            android:id="@+id/viewDynamicDownloadDialog"
-            layout="@layout/download_dialog_layout"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_gravity="bottom"
-            android:visibility="gone" />
-
-        <mozilla.components.feature.readerview.view.ReaderViewControlsBar
-            android:id="@+id/readerViewControlsBar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_gravity="bottom"
-            android:background="?foundation"
-            android:elevation="24dp"
-            android:visibility="gone" />
-
-    </androidx.coordinatorlayout.widget.CoordinatorLayout>
-
-    <org.mozilla.fenix.browser.TabPreview
-        android:id="@+id/tabPreview"
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/swipeRefresh"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:clickable="false"
-        android:focusable="false"
+        android:alpha="0"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <mozilla.components.concept.engine.EngineView
+            android:id="@+id/engineView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:visibility="gone" />
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+
+
+    <ViewStub
+        android:id="@+id/stubFindInPage"
+        android:layout_width="match_parent"
+        android:layout_height="56dp"
+        android:layout_gravity="bottom"
+        android:inflatedId="@+id/findInPageView"
+        android:layout="@layout/stub_find_in_page" />
+
+    <include
+        android:id="@+id/viewDynamicDownloadDialog"
+        layout="@layout/download_dialog_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom"
         android:visibility="gone" />
-</org.mozilla.fenix.browser.SwipeGestureLayout>
+
+    <mozilla.components.feature.readerview.view.ReaderViewControlsBar
+        android:id="@+id/readerViewControlsBar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom"
+        android:background="?foundation"
+        android:elevation="24dp"
+        android:visibility="gone" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
Changing the root view of BaseBrowserFragment from a CoordinatorLayout
to a SwipeGestureLayout has caused some regressions, particularly in
snackbar behavior. Lets prevent those regressions from occuring in
builds where the feature flag for gestures is off by only adding the
SwipeGestureLayout when the feature flag is on.

Layout with feature flag on:
<img width="545" alt="Screen Shot 2020-07-24 at 8 50 21 AM" src="https://user-images.githubusercontent.com/6396431/88415346-30c00a80-cd93-11ea-99fb-bef919978faa.png">

Feature flag off:
<img width="545" alt="Screen Shot 2020-07-24 at 8 46 17 AM" src="https://user-images.githubusercontent.com/6396431/88415374-3ddcf980-cd93-11ea-90c3-50648bde791e.png">
