### PR TITLE
For #1146: Exract AccountUiView from settings

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/ext/String.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/String.kt
@@ -4,13 +4,11 @@
 
 package org.mozilla.fenix.ext
 
-import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.net.Uri
 import android.util.Patterns
 import android.webkit.URLUtil
-import androidx.core.graphics.drawable.RoundedBitmapDrawableFactory
 import androidx.core.net.toUri
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
@@ -113,16 +111,6 @@ fun String.simplifiedUrl(): String {
         }
     }
     return afterScheme
-}
-
-/**
- * Gets a rounded drawable from a URL if possible, else null.
- */
-suspend fun String.toRoundedDrawable(context: Context, client: Client) = bitmapForUrl(this, client)?.let { bitmap ->
-    RoundedBitmapDrawableFactory.create(context.resources, bitmap).also {
-        it.isCircular = true
-        it.setAntiAlias(true)
-    }
 }
 
 suspend fun bitmapForUrl(url: String, client: Client): Bitmap? = withContext(Dispatchers.IO) {

--- a/app/src/main/java/org/mozilla/fenix/settings/account/AccountSettingsInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/account/AccountSettingsInteractor.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.settings.account
 

--- a/app/src/main/java/org/mozilla/fenix/settings/account/AccountUiView.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/account/AccountUiView.kt
@@ -1,0 +1,103 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.settings.account
+
+import android.content.Context
+import androidx.appcompat.content.res.AppCompatResources
+import androidx.core.graphics.drawable.RoundedBitmapDrawableFactory
+import androidx.lifecycle.lifecycleScope
+import androidx.preference.Preference
+import androidx.preference.PreferenceCategory
+import androidx.preference.PreferenceFragmentCompat
+import kotlinx.coroutines.launch
+import mozilla.components.concept.fetch.Client
+import mozilla.components.concept.sync.Profile
+import mozilla.components.service.fxa.manager.FxaAccountManager
+import org.mozilla.fenix.R
+import org.mozilla.fenix.ext.bitmapForUrl
+import org.mozilla.fenix.settings.requirePreference
+
+class AccountUiView(
+    fragment: PreferenceFragmentCompat,
+    private val accountManager: FxaAccountManager,
+    private val httpClient: Client,
+    private val updateFxASyncOverrideMenu: () -> Unit
+) {
+
+    private val lifecycleScope = fragment.viewLifecycleOwner.lifecycleScope
+    private val preferenceSignIn =
+        fragment.requirePreference<Preference>(R.string.pref_key_sign_in)
+    private val preferenceFirefoxAccount =
+        fragment.requirePreference<AccountPreference>(R.string.pref_key_account)
+    private val preferenceFirefoxAccountAuthError =
+        fragment.requirePreference<AccountAuthErrorPreference>(R.string.pref_key_account_auth_error)
+    private val accountPreferenceCategory =
+        fragment.requirePreference<PreferenceCategory>(R.string.pref_key_account_category)
+
+    /**
+     * Updates the UI to reflect current account state.
+     * Possible conditions are logged-in without problems, logged-out, and logged-in but needs to re-authenticate.
+     */
+    fun updateAccountUIState(context: Context, profile: Profile?) {
+        val account = accountManager.authenticatedAccount()
+
+        updateFxASyncOverrideMenu()
+
+        // Signed-in, no problems.
+        if (account != null && !accountManager.accountNeedsReauth()) {
+            preferenceSignIn.isVisible = false
+
+            profile?.avatar?.url?.let { avatarUrl ->
+                lifecycleScope.launch {
+                    val roundedDrawable = toRoundedDrawable(avatarUrl, context)
+                    preferenceFirefoxAccount.icon =
+                        roundedDrawable ?: AppCompatResources.getDrawable(
+                            context,
+                            R.drawable.ic_account
+                        )
+                }
+            }
+
+            preferenceSignIn.onPreferenceClickListener = null
+            preferenceFirefoxAccountAuthError.isVisible = false
+            preferenceFirefoxAccount.isVisible = true
+            accountPreferenceCategory.isVisible = true
+
+            preferenceFirefoxAccount.displayName = profile?.displayName
+            preferenceFirefoxAccount.email = profile?.email
+
+            // Signed-in, need to re-authenticate.
+        } else if (account != null && accountManager.accountNeedsReauth()) {
+            preferenceFirefoxAccount.isVisible = false
+            preferenceFirefoxAccountAuthError.isVisible = true
+            accountPreferenceCategory.isVisible = true
+
+            preferenceSignIn.isVisible = false
+            preferenceSignIn.onPreferenceClickListener = null
+
+            preferenceFirefoxAccountAuthError.email = profile?.email
+
+            // Signed-out.
+        } else {
+            preferenceSignIn.isVisible = true
+            preferenceFirefoxAccount.isVisible = false
+            preferenceFirefoxAccountAuthError.isVisible = false
+            accountPreferenceCategory.isVisible = false
+        }
+    }
+
+    /**
+     * Gets a rounded drawable from a URL if possible, else null.
+     */
+    private suspend fun toRoundedDrawable(
+        url: String,
+        context: Context
+    ) = bitmapForUrl(url, httpClient)?.let { bitmap ->
+        RoundedBitmapDrawableFactory.create(context.resources, bitmap).apply {
+            isCircular = true
+            setAntiAlias(true)
+        }
+    }
+}


### PR DESCRIPTION
Trying to break up the settings fragment by moving out some views. In the future I plan to move more account settings logic to this view class.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture