### PR TITLE
Revert "Bug 1652979 - Stop producing fennecNightly, fenixNightly and …

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -72,6 +72,20 @@ android {
                 "sharedUserId": "org.mozilla.fenix.performancetest.sharedID"
             ]
         }
+        fenixNightly releaseTemplate >> {
+            applicationIdSuffix ".fenix.nightly"
+            buildConfigField "boolean", "USE_RELEASE_VERSIONING", "true"
+            def deepLinkSchemeValue = "fenix-nightly"
+            buildConfigField "String", "DEEP_LINK_SCHEME", "\"$deepLinkSchemeValue\""
+            manifestPlaceholders = ["deepLinkScheme": deepLinkSchemeValue]
+        }
+        fenixBeta releaseTemplate >> {
+            applicationIdSuffix ".fenix.beta"
+            buildConfigField "boolean", "USE_RELEASE_VERSIONING", "true"
+            def deepLinkSchemeValue = "fenix-beta"
+            buildConfigField "String", "DEEP_LINK_SCHEME", "\"$deepLinkSchemeValue\""
+            manifestPlaceholders = ["deepLinkScheme": deepLinkSchemeValue]
+        }
         fenixProduction releaseTemplate >> {
             applicationIdSuffix ".fenix"
             buildConfigField "boolean", "USE_RELEASE_VERSIONING", "true"
@@ -113,6 +127,23 @@ android {
                     "deepLinkScheme": deepLinkSchemeValue
             ]
         }
+        fennecNightly releaseTemplate >> {
+            buildConfigField "boolean", "USE_RELEASE_VERSIONING", "true"
+            applicationIdSuffix ".fennec_aurora"
+            def deepLinkSchemeValue = "fenix-nightly"
+            buildConfigField "String", "DEEP_LINK_SCHEME", "\"$deepLinkSchemeValue\""
+            manifestPlaceholders = [
+                    // This release type is meant to replace Firefox (Release channel) and therefore needs to inherit
+                    // its sharedUserId for all eternity. See:
+                    // https://searchfox.org/mozilla-central/search?q=moz_android_shared_id&case=false&regexp=false&path=
+                    // Shipping an app update without sharedUserId can have
+                    // fatal consequences. For example see:
+                    //  - https://issuetracker.google.com/issues/36924841
+                    //  - https://issuetracker.google.com/issues/36905922
+                    "sharedUserId": "org.mozilla.fennec.sharedID",
+                    "deepLinkScheme": deepLinkSchemeValue
+            ]
+        }
     }
 
     variantFilter { // There's a "release" build type that exists by default that we don't use (it's replaced by "nightly" and "beta")
@@ -126,17 +157,28 @@ android {
         // |--------------------|---------------|-----------|
         // | debug              | ✅            | ✅       | Both variants for testing and development.
         // | forPerformanceTest | ✅            | ✅       | Both variants unless the perf team only cares about Nightly (TBD).
-        // | fenixProduction    | ✅            | ❌       | Fenix Production (to be renamed `Nightly`) ships with GV Nightly
+        // | fenixNightly       | ✅            | ✅       | Built with both, but only the "geckoNightly" one is published to Google Play
+        // | fenixBeta          | ❌            | ✅       | Fenix Beta ships with GV Beta
+        // | fenixProduction    | ❌            | ✅       | Fenix Production ships with GV Beta
         // | fennecProduction   | ❌            | ✅       | Fenix build to replace production Firefox builds
         // | fennecBeta         | ❌            | ✅       | Fenix build to replace beta Firefox builds
+        // | fennecNightly      | ✅            | ❌       | Fenix build to replace Nightly Firefox builds
 
         def flavors = flavors*.name.toString().toLowerCase()
+
+        if (buildType.name == 'fenixBeta' && flavors.contains("geckonightly")) {
+            setIgnore true
+        }
 
         if (buildType.name == 'fenixProduction' && flavors.contains("geckobeta")) {
             setIgnore true
         }
 
         if ((buildType.name == 'fennecProduction' || buildType.name == 'fennecBeta') && flavors.contains("geckonightly")) {
+            setIgnore true
+        }
+
+        if (buildType.name == 'fennecNightly' && flavors.contains("geckobeta")) {
             setIgnore true
         }
     }
@@ -164,6 +206,10 @@ android {
     sourceSets {
         androidTest {
             resources.srcDirs += ['src/androidTest/resources']
+        }
+        fennecNightly {
+            java.srcDirs = ['src/migration/java']
+            manifest.srcFile "src/migration/AndroidManifest.xml"
         }
         fennecBeta {
             java.srcDirs = ['src/migration/java']

--- a/app/src/main/java/org/mozilla/fenix/Config.kt
+++ b/app/src/main/java/org/mozilla/fenix/Config.kt
@@ -7,10 +7,13 @@ package org.mozilla.fenix
 enum class ReleaseChannel {
     FenixDebug,
 
+    FenixNightly,
+    FenixBeta,
     FenixProduction,
 
     FennecProduction,
-    FennecBeta;
+    FennecBeta,
+    FennecNightly;
 
     val isReleased: Boolean
         get() = when (this) {
@@ -30,6 +33,8 @@ enum class ReleaseChannel {
 
     val isReleaseOrBeta: Boolean
         get() = when (this) {
+            FenixProduction -> true
+            FenixBeta -> true
             FennecProduction -> true
             FennecBeta -> true
             else -> false
@@ -38,11 +43,14 @@ enum class ReleaseChannel {
     val isBeta: Boolean
         get() = when (this) {
             FennecBeta -> true
+            FenixBeta -> true
             else -> false
         }
 
     val isNightlyOrDebug: Boolean
         get() = when (this) {
+            FenixNightly -> true
+            FennecNightly -> true
             FenixDebug -> true
             FenixProduction -> true
             else -> false
@@ -58,9 +66,12 @@ enum class ReleaseChannel {
 object Config {
     val channel = when (BuildConfig.BUILD_TYPE) {
         "fenixProduction" -> ReleaseChannel.FenixProduction
+        "fenixBeta" -> ReleaseChannel.FenixBeta
+        "fenixNightly" -> ReleaseChannel.FenixNightly
         "debug" -> ReleaseChannel.FenixDebug
         "fennecProduction" -> ReleaseChannel.FennecProduction
         "fennecBeta" -> ReleaseChannel.FennecBeta
+        "fennecNightly" -> ReleaseChannel.FennecNightly
 
         // Builds for local performance analysis, recording benchmarks, automation, etc.
         // This should be treated like a released channel because we want to test
@@ -75,6 +86,7 @@ object Config {
 }
 
 private val fennecChannels: List<ReleaseChannel> = listOf(
+    ReleaseChannel.FennecNightly,
     ReleaseChannel.FennecBeta,
     ReleaseChannel.FennecProduction
 )

--- a/app/src/main/java/org/mozilla/fenix/components/Analytics.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Analytics.kt
@@ -103,8 +103,11 @@ private fun getSentryProjectUrl(): String? {
     val baseUrl = "https://sentry.prod.mozaws.net/operations"
     return when (Config.channel) {
         ReleaseChannel.FenixProduction -> "$baseUrl/fenix"
+        ReleaseChannel.FenixBeta -> "$baseUrl/fenix-beta"
+        ReleaseChannel.FenixNightly -> "$baseUrl/fenix-nightly"
         ReleaseChannel.FennecProduction -> "$baseUrl/fenix-fennec"
         ReleaseChannel.FennecBeta -> "$baseUrl/fenix-fennec-beta"
+        ReleaseChannel.FennecNightly -> "$baseUrl/fenix-fennec-nightly"
         else -> null
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/AdjustMetricsService.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/AdjustMetricsService.kt
@@ -13,6 +13,7 @@ import com.adjust.sdk.AdjustConfig
 import com.adjust.sdk.LogLevel
 import org.mozilla.fenix.BuildConfig
 import org.mozilla.fenix.Config
+import org.mozilla.fenix.ReleaseChannel
 import org.mozilla.fenix.ext.settings
 
 class AdjustMetricsService(private val application: Application) : MetricsService {
@@ -22,7 +23,7 @@ class AdjustMetricsService(private val application: Application) : MetricsServic
         if ((BuildConfig.ADJUST_TOKEN.isNullOrBlank())) {
             Log.i(LOGTAG, "No adjust token defined")
 
-            if (Config.channel.isReleased) {
+            if (Config.channel.isReleased && Config.channel != ReleaseChannel.FennecNightly) {
                 throw IllegalStateException("No adjust token defined for release build")
             }
 

--- a/taskcluster/ci/browsertime/kind.yml
+++ b/taskcluster/ci/browsertime/kind.yml
@@ -82,7 +82,7 @@ job-defaults:
             - '--app=fenix'
             - '--browsertime'
             - '--cold'
-            - '--binary=org.mozilla.fenix'
+            - '--binary=org.mozilla.fenix.nightly'
             - '--activity=org.mozilla.fenix.IntentReceiverActivity'
             - '--download-symbols=ondemand'
             - '--browsertime-node=$MOZ_FETCHES_DIR/node/bin/node'

--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -93,6 +93,17 @@ jobs:
         treeherder:
             symbol: forPerformanceTest(B)
 
+    nightly:
+        attributes:
+            nightly: true
+        include-nightly-version: true
+        include-shippable-secrets: true
+        run:
+            geckoview-engine: geckoNightly
+            gradle-build-type: fenixNightly
+        treeherder:
+            symbol: nightly(B)
+
     nightly-simulation:
         attributes:
             nightly: false
@@ -101,22 +112,47 @@ jobs:
         include-shippable-secrets: true
         run:
             geckoview-engine: geckoNightly
-            gradle-build-type: fenixProduction
+            gradle-build-type: fennecNightly
         treeherder:
             symbol: nightlySim(B)
 
-    nightly:
+    beta:
+        attributes:
+            release-type: beta
+        include-release-version: true
+        include-shippable-secrets: true
+        filter-incomplete-translations: true
+        run:
+            geckoview-engine: geckoBeta
+            gradle-build-type: fenixBeta
+        run-on-tasks-for: [github-release]
+        treeherder:
+            symbol: beta(B)
+
+    # XXX `production` is now the new nightly. We keep this name around while we officially remove
+    # `nightly` and `fennec-nightly`
+    production:
         attributes:
             nightly: true
         include-nightly-version: true
         include-shippable-secrets: true
         run:
             geckoview-engine: geckoNightly
-            # XXX `fenixProduction` is now the new nightly.
             gradle-build-type: fenixProduction
-        run-on-tasks-for: []
+        run-on-tasks-for: [github-release]
         treeherder:
-            symbol: nightly(B)
+            symbol: production(B)
+
+    fennec-nightly:
+        attributes:
+            nightly: true
+        include-nightly-version: true
+        include-shippable-secrets: true
+        run:
+            geckoview-engine: geckoNightly
+            gradle-build-type: fennecNightly
+        treeherder:
+            symbol: nightlyFennec(B)
 
     fennec-beta:
         attributes:

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -2,6 +2,7 @@
 trust-domain: mobile
 treeherder:
     group-names:
+        'beta': 'Beta-related tasks'
         'betaFennec': 'Beta-related tasks with same APK configuration as Fennec'
         'Btime': 'Raptor-Browsertime tests'
         'bump': 'Bump dependencies'
@@ -11,6 +12,7 @@ treeherder:
         'I': 'Docker Image Builds'
         'nightly': 'Nightly-related tasks'
         'nightlySim': 'Nightly-related tasks that run on each github push'
+        'nightlyFennec': 'Nightly-related tasks with same APK configuration as Fennec'
         'production': 'Release-related tasks'
         'productionFennec': 'Production-related tasks with same APK configuration as Fennec'
         'Rap': 'Raptor tests'

--- a/taskcluster/ci/mark-as-shipped/kind.yml
+++ b/taskcluster/ci/mark-as-shipped/kind.yml
@@ -17,8 +17,8 @@ primary-dependency: push-apk
 group-by: build-type
 
 only-for-build-types:
-    - fennec-beta
-    - fennec-production
+    - fenix-beta
+    - fenix-production
 
 job-template:
     description: Mark Fenix as shipped in ship-it

--- a/taskcluster/ci/push-apk/kind.yml
+++ b/taskcluster/ci/push-apk/kind.yml
@@ -19,7 +19,7 @@ group-by: build-type
 only-for-build-types:
     - fennec-beta
     - fennec-production
-    - nightly
+    - production
 
 job-template:
     description: Publish Fenix
@@ -30,7 +30,7 @@ job-template:
             by-build-type:
                 fennec-beta: fennec-beta
                 fennec-production: fennec-production
-                nightly: production
+                production: production
         dep:
             by-level:
                 '3': false

--- a/taskcluster/ci/raptor/kind.yml
+++ b/taskcluster/ci/raptor/kind.yml
@@ -77,7 +77,7 @@ job-defaults:
             - './test-linux.sh'
             - '--cfg=mozharness/configs/raptor/android_hw_config.py'
             - '--app=fenix'
-            - '--binary=org.mozilla.fenix'
+            - '--binary=org.mozilla.fenix.nightly'
             - '--activity=org.mozilla.fenix.IntentReceiverActivity'
             - '--download-symbols=ondemand'
             - '--no-conditioned-profile'

--- a/taskcluster/ci/signing/kind.yml
+++ b/taskcluster/ci/signing/kind.yml
@@ -20,7 +20,7 @@ job-template:
     description: Sign Fenix
     worker-type:
         by-build-type:
-            (fennec-.+|nightly|android-test-nightly):
+            (fennec-.+|nightly|beta|production|android-test-nightly):
                 by-level:
                     '3': signing
                     default: dep-signing
@@ -32,20 +32,37 @@ job-template:
                     by-level:
                         '3': fennec-production-signing
                         default: dep-signing
+                fennec-nightly:
+                    by-level:
+                        '3': fennec-nightly-signing
+                        default: dep-signing
+                nightly:
+                    by-level:
+                        '3': nightly-signing
+                        default: dep-signing
                 android-test-nightly:
                     by-level:
-                        '3': production-signing
+                        '3': nightly-signing
                         default: dep-signing
                 performance-test: dep-signing
-                nightly:
+                beta:
+                    by-level:
+                        '3': beta-signing
+                        default: dep-signing
+                production:
                     by-level:
                         '3': production-signing
                         default: dep-signing
                 default: dep-signing
-    signing-format: autograph_apk
+    signing-format:
+      by-build-type:
+          # Fennec nightly cannot have the sha256 checksums. For more details, see
+          # https://github.com/mozilla-releng/scriptworker-scripts/pull/102#issue-349016967
+          fennec-nightly: autograph_apk_fennec_sha1
+          default: autograph_apk
     index:
         by-build-type:
-            (fennec-.+|performance-test|nightly|debug|nightly-simulation):
+            (fennec-.+|nightly|performance-test|beta|production|debug|nightly-simulation):
                 type: signing
             default: {}
     run-on-tasks-for:


### PR DESCRIPTION
…fenixBeta (#12225)"

This reverts commit 7e7d69cb8e4514c86c4677b3b18193c5cb66f884
PR https://github.com/mozilla-mobile/fenix/pull/12225

This caused the nightly FNPRMS tests to fail because the
`fennec-nightly` variant no longer exists. We could change the variant
but then the migration code is not covered. The least time consuming
solution for the FE perf team is to revert the change and atomically
implement the long term solution rather than making an intermediate
change now and another change after the long term solution arrives,
which would skew our dashboards (that we don't have the ability to
annotate) with multiple incomparable builds.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture