### PR TITLE
bugfix/#7716 - Fixed a11y for learn more button

### DIFF
--- a/app/src/main/res/layout/search_suggestions_onboarding.xml
+++ b/app/src/main/res/layout/search_suggestions_onboarding.xml
@@ -50,12 +50,13 @@
         android:id="@+id/learn_more"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:minHeight="48dp"
         android:text="@string/exceptions_empty_message_learn_more_link"
         android:textAppearance="?android:attr/textAppearanceSmall"
         android:textColor="?attr/accentHighContrast"
         android:textStyle="bold"
         app:layout_constraintBottom_toTopOf="@id/allow"
-        app:layout_constraintEnd_toEndOf="@id/title"
+        app:layout_constraintEnd_toStartOf="@id/dismiss"
         app:layout_constraintStart_toStartOf="@id/title"
         app:layout_constraintTop_toBottomOf="@id/text"
         tools:textColor="@color/accent_high_contrast_private_theme"/>
@@ -67,9 +68,9 @@
         android:layout_height="wrap_content"
         android:padding="12dp"
         android:text="@string/search_suggestions_onboarding_allow_button"
-        app:layout_constraintBottom_toBottomOf="parent"
+        android:layout_marginTop="20dp"
         app:layout_constraintEnd_toEndOf="@id/title"
-        app:layout_constraintTop_toBottomOf="@id/learn_more" />
+        app:layout_constraintTop_toBottomOf="@id/text" />
 
     <TextView
         android:id="@+id/dismiss"


### PR DESCRIPTION
In order to increase touch target to 48, I had to change the layout a little in order to preserve the initial design.
<img src="https://user-images.githubusercontent.com/1709373/88503298-f72d1080-cfd9-11ea-8246-e1894c5a268e.jpg" width="300px"/>

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
