### PR TITLE
Fix AccountUiView ui failures

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
@@ -73,6 +73,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
 
         accountUiView = AccountUiView(
             fragment = this,
+            scope = lifecycleScope,
             accountManager = requireComponents.backgroundServices.accountManager,
             httpClient = requireComponents.core.client,
             updateFxASyncOverrideMenu = ::updateFxASyncOverrideMenu
@@ -135,6 +136,11 @@ class SettingsFragment : PreferenceFragmentCompat() {
 
         // Consider finish of `onResume` to be the point at which we consider this fragment as 'created'.
         creatingFragment = false
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        accountUiView.cancel()
     }
 
     private fun update(shouldUpdateAccountUIState: Boolean) {


### PR DESCRIPTION
Likely caused because I used `viewLifecycleScope` instead of `lifecycleScope` inside of `onCreate`. Added an additional cancel call to avoid memory leaks.