### PR TITLE
For #12983: Fix deep link scheme for nightly builds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -75,7 +75,7 @@ android {
         fenixProduction releaseTemplate >> {
             applicationIdSuffix ".fenix"
             buildConfigField "boolean", "USE_RELEASE_VERSIONING", "true"
-            def deepLinkSchemeValue = "fenix"
+            def deepLinkSchemeValue = "fenix-nightly"
             buildConfigField "String", "DEEP_LINK_SCHEME", "\"$deepLinkSchemeValue\""
             manifestPlaceholders = ["deepLinkScheme": deepLinkSchemeValue]
         }


### PR DESCRIPTION
When we simplified our variants, our deep link scheme for nightly was lost.

cc: @JohanLorenzo , @pocmo for reference since you both worked on simplifying the variants as well.
