### PR TITLE
For #13071 - Only return to home when session doesn't have parent ses…

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -104,7 +104,6 @@ import org.mozilla.fenix.ext.hideToolbar
 import org.mozilla.fenix.ext.metrics
 import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.requireComponents
-import org.mozilla.fenix.ext.sessionsOfType
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.home.SharedViewModel
 import org.mozilla.fenix.theme.ThemeManager
@@ -835,14 +834,11 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Session
                 sessionManager.remove(session)
                 true
             } else {
-                val isLastSession =
-                    sessionManager.sessionsOfType(private = session.private).count() == 1
                 if (session.hasParentSession) {
                     sessionManager.remove(session, true)
                 }
-                // We want to return to home if this removed session was the last session of its type
-                // and didn't have a parent session to select.
-                val goToOverview = isLastSession && !session.hasParentSession
+                // We want to return to home if this session didn't have a parent session to select.
+                val goToOverview = !session.hasParentSession
                 !goToOverview
             }
         }


### PR DESCRIPTION
…sion to select

Tested to make sure it covers cases: 
1. Opening help page from home and pressing back -> no parent session, goes home 
2. Open private tab via context menu, switch to it and press back -> selects normal parent session, doesn't go home 


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture