### PR TITLE
Don't init glean in unit tests

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -12,8 +12,8 @@ import android.util.Log.INFO
 import androidx.annotation.CallSuper
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.content.getSystemService
-import androidx.work.Configuration.Provider
 import androidx.work.Configuration.Builder
+import androidx.work.Configuration.Provider
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
@@ -92,7 +92,7 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
         setupInMainProcessOnly()
     }
 
-    protected fun initializeGlean() {
+    protected open fun initializeGlean() {
         val telemetryEnabled = settings().isTelemetryEnabled
 
         logger.debug("Initializing Glean (uploadEnabled=$telemetryEnabled, isFennec=${Config.channel.isFennec})")

--- a/app/src/test/java/org/mozilla/fenix/helpers/FenixRobolectricTestApplication.kt
+++ b/app/src/test/java/org/mozilla/fenix/helpers/FenixRobolectricTestApplication.kt
@@ -4,7 +4,6 @@
 
 package org.mozilla.fenix.helpers
 
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.mozilla.fenix.FenixApplication
 import org.mozilla.fenix.components.TestComponents
 
@@ -17,8 +16,9 @@ class FenixRobolectricTestApplication : FenixApplication() {
 
     override val components = TestComponents(this)
 
+    override fun initializeGlean() = Unit
+
     override fun setupInAllProcesses() = Unit
 
-    @ExperimentalCoroutinesApi
     override fun setupInMainProcessOnly() = Unit
 }


### PR DESCRIPTION
Our unit tests rely on sending data to `MetricController` rather than Glean itself. Glean adds overhead and clutters our logs, it should be fine to turn it off in unit tests.