### PR TITLE
For #13127 - Make sure tabPreview is added after browserLayout.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -167,9 +167,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Session
         customTabSessionId = arguments?.getString(EXTRA_SESSION_ID)
 
         val view = if (FeatureFlags.browserChromeGestures) {
-            inflater.inflate(R.layout.browser_gesture_wrapper, container, false).apply {
-                inflater.inflate(R.layout.fragment_browser, this as SwipeGestureLayout, true)
-            }
+            inflater.inflate(R.layout.browser_gesture_wrapper, container, false)
         } else {
             inflater.inflate(R.layout.fragment_browser, container, false)
         }

--- a/app/src/main/res/layout/browser_gesture_wrapper.xml
+++ b/app/src/main/res/layout/browser_gesture_wrapper.xml
@@ -7,6 +7,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <include layout="@layout/fragment_browser" />
+
     <org.mozilla.fenix.browser.TabPreview
         android:id="@+id/tabPreview"
         android:layout_width="match_parent"


### PR DESCRIPTION
Turns out the ordering of the views does matter. Not sure how I didn't catch this.

https://streamable.com/r88ace

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture