### PR TITLE
Renamed Deps.mozilla_ui_publicsuffixlist to Deps.mozilla_lib_publicsuffixlist

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -469,7 +469,7 @@ dependencies {
 
     implementation Deps.mozilla_ui_colors
     implementation Deps.mozilla_ui_icons
-    implementation Deps.mozilla_ui_publicsuffixlist
+    implementation Deps.mozilla_lib_publicsuffixlist
     implementation Deps.mozilla_ui_widgets
 
     implementation Deps.mozilla_lib_crash

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -138,7 +138,7 @@ object Deps {
     const val mozilla_lib_push_firebase = "org.mozilla.components:lib-push-firebase:${Versions.mozilla_android_components}"
     const val mozilla_lib_dataprotect = "org.mozilla.components:lib-dataprotect:${Versions.mozilla_android_components}"
 
-    const val mozilla_ui_publicsuffixlist = "org.mozilla.components:lib-publicsuffixlist:${Versions.mozilla_android_components}"
+    const val mozilla_lib_publicsuffixlist = "org.mozilla.components:lib-publicsuffixlist:${Versions.mozilla_android_components}"
 
     const val mozilla_support_base = "org.mozilla.components:support-base:${Versions.mozilla_android_components}"
     const val mozilla_support_images = "org.mozilla.components:support-images:${Versions.mozilla_android_components}"


### PR DESCRIPTION
Fixes #13010 
Renamed Deps.mozilla_ui_publicsuffixlist to Deps.mozilla_lib_publicsuffixlist in the file /app/build.gradle 