### PR TITLE
For #6313 - On first load, hides engineView until firstContentfulPaint

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -44,12 +44,6 @@ import org.mozilla.fenix.helpers.click
 import org.mozilla.fenix.helpers.ext.waitNotNull
 
 class BrowserRobot {
-
-    fun verifyBrowserScreen() {
-        onView(ViewMatchers.withResourceName("browserLayout"))
-            .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
-    }
-
     fun verifyCurrentPrivateSession(context: Context) {
         val session = context.components.core.sessionManager.selectedSession
         assertTrue("Current session is private", session?.private!!)
@@ -84,6 +78,10 @@ class BrowserRobot {
     */
 
     fun verifyPageContent(expectedText: String) {
+        mDevice.waitNotNull(
+            Until.findObject(By.res("org.mozilla.fenix.debug:id/engineView")),
+            waitingTime
+        )
         assertTrue(mDevice.findObject(UiSelector().text(expectedText)).waitForExists(waitingTime))
     }
 
@@ -145,7 +143,8 @@ class BrowserRobot {
 
     fun verifyEnhancedTrackingProtectionSwitch() = assertEnhancedTrackingProtectionSwitch()
 
-    fun clickEnhancedTrackingProtectionSwitchOffOn() = onView(withResourceName("switch_widget")).click()
+    fun clickEnhancedTrackingProtectionSwitchOffOn() =
+        onView(withResourceName("switch_widget")).click()
 
     fun verifyProtectionSettingsButton() = assertProtectionSettingsButton()
 
@@ -191,7 +190,8 @@ class BrowserRobot {
 
     fun clickEnhancedTrackingProtectionPanel() = enhancedTrackingProtectionPanel().click()
 
-    fun verifyEnhancedTrackingProtectionPanelNotVisible() = assertEnhancedTrackingProtectionPanelNotVisible()
+    fun verifyEnhancedTrackingProtectionPanelNotVisible() =
+        assertEnhancedTrackingProtectionPanelNotVisible()
 
     fun clickContextOpenLinkInNewTab() {
         val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
@@ -423,7 +423,8 @@ fun navURLBar() = onView(withId(R.id.mozac_browser_toolbar_url_view))
 private fun assertNavURLBar() = navURLBar()
     .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
-fun enhancedTrackingProtectionPanel() = onView(withId(R.id.mozac_browser_toolbar_tracking_protection_indicator))
+fun enhancedTrackingProtectionPanel() =
+    onView(withId(R.id.mozac_browser_toolbar_tracking_protection_indicator))
 
 private fun assertEnhancedTrackingProtectionPanelNotVisible() {
     enhancedTrackingProtectionPanel()

--- a/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -43,4 +43,9 @@ object FeatureFlags {
      * Enables the new search experience
      */
     val newSearchExperience = Config.channel.isDebug
+
+    /**
+     * Enables wait til first contentful paint
+     */
+    val waitUntilPaintToDraw = Config.channel.isDebug
 }

--- a/app/src/main/java/org/mozilla/fenix/settings/SecretSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SecretSettingsFragment.kt
@@ -30,5 +30,11 @@ class SecretSettingsFragment : PreferenceFragmentCompat() {
             isChecked = context.settings().useNewSearchExperience
             onPreferenceChangeListener = SharedPreferenceUpdater()
         }
+
+        requirePreference<SwitchPreference>(R.string.pref_key_wait_first_paint).apply {
+            isVisible = FeatureFlags.waitUntilPaintToDraw
+            isChecked = context.settings().waitToShowPageUntilFirstPaint
+            onPreferenceChangeListener = SharedPreferenceUpdater()
+        }
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -103,6 +103,12 @@ class Settings(private val appContext: Context) : PreferencesHolder {
         featureFlag = FeatureFlags.newSearchExperience
     )
 
+    var waitToShowPageUntilFirstPaint by featureFlagPreference(
+        appContext.getPreferenceKey(R.string.pref_key_wait_first_paint),
+        default = false,
+        featureFlag = FeatureFlags.waitUntilPaintToDraw
+    )
+
     var forceEnableZoom by booleanPreference(
         appContext.getPreferenceKey(R.string.pref_key_accessibility_force_enable_zoom),
         default = false

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -175,6 +175,8 @@
 
     <string name="pref_key_use_new_search_experience" translatable="false">pref_key_use_new_search_experience</string>
 
+    <string name="pref_key_wait_first_paint" translatable="false">pref_key_wait_first_paint</string>
+
     <string name="pref_key_debug_settings" translatable="false">pref_key_debug_settings</string>
 
     <string name="pref_key_open_tabs_count" translatable="false">pref_key_open_tabs_count</string>

--- a/app/src/main/res/values/static_strings.xml
+++ b/app/src/main/res/values/static_strings.xml
@@ -34,6 +34,8 @@
     <string name="preferences_debug_settings">Secret Settings</string>
     <!-- Label for the new search experience preference -->
     <string name="preferences_debug_settings_use_new_search_experience">Use New Search Experience</string>
+    <!-- Label for the wait until first paint preference -->
+    <string name="preferences_debug_settings_wait_first_paint">Wait Until First Paint To Show Page Content</string>
 
     <!-- Content description (not visible, for screen readers etc.) used to announce [LinkTextView]. -->
     <string name="link_text_view_type_announcement" translatable="false">link</string>

--- a/app/src/main/res/xml/secret_settings_preferences.xml
+++ b/app/src/main/res/xml/secret_settings_preferences.xml
@@ -9,4 +9,9 @@
         android:key="@string/pref_key_use_new_search_experience"
         android:title="@string/preferences_debug_settings_use_new_search_experience"
         app:iconSpaceReserved="false" />
+    <SwitchPreference
+        android:defaultValue="false"
+        android:key="@string/pref_key_wait_first_paint"
+        android:title="@string/preferences_debug_settings_wait_first_paint"
+        app:iconSpaceReserved="false" />
 </PreferenceScreen>


### PR DESCRIPTION
Cases I tested:
 - Open custom tab and then open in Fenix
 - Long press on link and open it and then switch to that tab 
 - Create shortcut and open it
 - Open PWA 
 - Create new tab
 - Search in existing tab 
 - Open link from Gmail via intent 
 - Send link from Pocket 
 - Send tab from desktop and open via notification

These all seem to work looking for feedback/ideas for other edge cases and entry points. 


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture