### PR TITLE
Closes #12893: fixed deleteAllHistoryTest

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/HistoryTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/HistoryTest.kt
@@ -11,7 +11,6 @@ import mozilla.components.browser.storage.sync.PlacesHistoryStorage
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
@@ -165,7 +164,6 @@ class HistoryTest {
         }
     }
 
-    @Ignore("Failing test: https://github.com/mozilla-mobile/fenix/issues/12893")
     @Test
     fun deleteAllHistoryTest() {
         val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HistoryRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HistoryRobot.kt
@@ -15,6 +15,7 @@ import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withParent
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.uiautomator.By
+import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
 import org.hamcrest.Matchers
 import org.hamcrest.Matchers.allOf
@@ -31,12 +32,10 @@ class HistoryRobot {
     fun verifyHistoryMenuView() = assertHistoryMenuView()
 
     fun verifyEmptyHistoryView() {
-        mDevice.waitNotNull(
-            Until.findObject(
-                By.text("No history here")
-            ),
-            waitingTime
-        )
+        mDevice.findObject(
+            UiSelector().text("No history here")
+        ).waitForExists(waitingTime)
+
         assertEmptyHistoryView()
     }
 


### PR DESCRIPTION
@AaronMT, please review when you can
I ran tests in this form on Firebase and all passed: 
https://github.com/mozilla-mobile/fenix/runs/923378190 & https://github.com/mozilla-mobile/fenix/runs/944964569
Also tried introducing a ViewVisibilityIdlingResource but it timed-out: https://github.com/mozilla-mobile/fenix/runs/923490590

The issue was that the "No history here" text wasn't displayed, or took to long to appear. See https://github.com/mozilla-mobile/fenix/issues/12893
Any idea why it wouldn't work well with IdlingResources?