### PR TITLE
Closes #13038: Fix three dot menu dissapearing after multi-select

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/viewholders/BookmarkFolderViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/viewholders/BookmarkFolderViewHolder.kt
@@ -36,7 +36,7 @@ class BookmarkFolderViewHolder(
 
         if (!item.inRoots()) {
             setupMenu(item)
-            if (selectionHolder.selectedItems.isEmpty()) {
+            if (item !in selectionHolder.selectedItems) {
                 containerView.overflowView.showAndEnable()
             } else {
                 containerView.overflowView.hideAndDisable()

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/viewholders/BookmarkItemViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/viewholders/BookmarkItemViewHolder.kt
@@ -27,7 +27,7 @@ class BookmarkItemViewHolder(
 
         containerView.displayAs(LibrarySiteItemView.ItemType.SITE)
 
-        if (selectionHolder.selectedItems.isEmpty()) {
+        if (item !in selectionHolder.selectedItems) {
             containerView.overflowView.showAndEnable()
         } else {
             containerView.overflowView.hideAndDisable()


### PR DESCRIPTION
Hi, this is my attempt at fixing #13038. The issue bugged me so much that i just fixed it myself. I tested it on my device and the issue seems to be fixed. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture