### PR TITLE
 Closes #13262: Update AGP to 4 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -539,13 +539,13 @@ if (project.hasProperty("coverage")) {
 // -------------------------------------------------------------------------------------------------
 task printVariants {
     doLast {
-        def variants = android.applicationVariants.collect {[
-                apks: it.variantData.outputScope.apkDatas.collect {[
-                        abi: it.filters.find { it.filterType == 'ABI' }.identifier,
-                        fileName: it.outputFileName,
-                ]},
-                build_type: it.buildType.name,
-                name: it.name,
+        def variants = android.applicationVariants.collect { variant -> [
+            apks: variant.outputs.collect { output -> [
+                abi: output.getFilter(com.android.build.VariantOutput.FilterType.ABI),
+                fileName: output.outputFile.name
+            ]},
+            build_type: variant.buildType.name,
+            name: variant.name,
         ]}
         // AndroidTest is a special case not included above
         variants.add([

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -5,7 +5,7 @@
 object Versions {
     const val kotlin = "1.3.72"
     const val coroutines = "1.3.3"
-    const val android_gradle_plugin = "3.5.0"
+    const val android_gradle_plugin = "4.0.1"
     const val sentry = "1.7.10"
     const val leakcanary = "2.4"
     const val leanplum = "5.4.0"
@@ -234,7 +234,7 @@ object Deps {
 object RepoMatching {
     const val mozilla = "org\\.mozilla\\..*"
     const val androidx = "androidx\\..*"
-    const val comAndroid = "com\\.android\\..*"
+    const val comAndroid = "com\\.android.*"
     const val comGoogleFirebase = "com\\.google\\.firebase"
 
     /**


### PR DESCRIPTION
Builds upon #13263

- `android.applicationVariants[].variantData.outputScope.apkDatas` doesn't work on AGP 4, replaced with `android.applicationVariants[].outputs` which gets the same result
- `comAndroid` doesn't cover packages like `com.android:package`, changed the regex