### PR TITLE
FNX-14468 ⁃ For #13156, #13280 - Use payloads to bind bookmark viewholders.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkAdapter.kt
@@ -16,18 +16,16 @@ import mozilla.components.concept.storage.BookmarkNode
 import mozilla.components.concept.storage.BookmarkNodeType
 import org.mozilla.fenix.R
 import org.mozilla.fenix.library.LibrarySiteItemView
-import org.mozilla.fenix.library.SelectionHolder
 import org.mozilla.fenix.library.bookmarks.viewholders.BookmarkFolderViewHolder
 import org.mozilla.fenix.library.bookmarks.viewholders.BookmarkItemViewHolder
 import org.mozilla.fenix.library.bookmarks.viewholders.BookmarkNodeViewHolder
 import org.mozilla.fenix.library.bookmarks.viewholders.BookmarkSeparatorViewHolder
 
-class BookmarkAdapter(val emptyView: View, val interactor: BookmarkViewInteractor) :
-    RecyclerView.Adapter<BookmarkNodeViewHolder>(), SelectionHolder<BookmarkNode> {
+class BookmarkAdapter(private val emptyView: View, private val interactor: BookmarkViewInteractor) :
+    RecyclerView.Adapter<BookmarkNodeViewHolder>() {
 
     private var tree: List<BookmarkNode> = listOf()
     private var mode: BookmarkFragmentState.Mode = BookmarkFragmentState.Mode.Normal()
-    override val selectedItems: Set<BookmarkNode> get() = mode.selectedItems
     private var isFirstRun = true
 
     fun updateData(tree: BookmarkNode?, mode: BookmarkFragmentState.Mode) {
@@ -85,8 +83,8 @@ class BookmarkAdapter(val emptyView: View, val interactor: BookmarkViewInteracto
             .inflate(R.layout.bookmark_list_item, parent, false) as LibrarySiteItemView
 
         return when (viewType) {
-            LibrarySiteItemView.ItemType.SITE.ordinal -> BookmarkItemViewHolder(view, interactor, this)
-            LibrarySiteItemView.ItemType.FOLDER.ordinal -> BookmarkFolderViewHolder(view, interactor, this)
+            LibrarySiteItemView.ItemType.SITE.ordinal -> BookmarkItemViewHolder(view, interactor)
+            LibrarySiteItemView.ItemType.FOLDER.ordinal -> BookmarkFolderViewHolder(view, interactor)
             LibrarySiteItemView.ItemType.SEPARATOR.ordinal -> BookmarkSeparatorViewHolder(view, interactor)
             else -> throw IllegalStateException("ViewType $viewType does not match to a ViewHolder")
         }

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkAdapter.kt
@@ -7,6 +7,7 @@ package org.mozilla.fenix.library.bookmarks
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.annotation.VisibleForTesting
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
@@ -49,7 +50,8 @@ class BookmarkAdapter(val emptyView: View, val interactor: BookmarkViewInteracto
         diffUtil.dispatchUpdatesTo(this)
     }
 
-    private class BookmarkDiffUtil(
+    @VisibleForTesting
+    internal class BookmarkDiffUtil(
         val old: List<BookmarkNode>,
         val new: List<BookmarkNode>,
         val oldMode: BookmarkFragmentState.Mode,

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragmentStore.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragmentStore.kt
@@ -9,6 +9,7 @@ import mozilla.components.concept.storage.BookmarkNode
 import mozilla.components.lib.state.Action
 import mozilla.components.lib.state.State
 import mozilla.components.lib.state.Store
+import org.mozilla.fenix.library.SelectionHolder
 
 class BookmarkFragmentStore(
     initialState: BookmarkFragmentState
@@ -32,8 +33,8 @@ data class BookmarkFragmentState(
     val isLoading: Boolean = true,
     val isSwipeToRefreshEnabled: Boolean = true
 ) : State {
-    sealed class Mode {
-        open val selectedItems = emptySet<BookmarkNode>()
+    sealed class Mode : SelectionHolder<BookmarkNode> {
+        override val selectedItems = emptySet<BookmarkNode>()
 
         data class Normal(val showMenu: Boolean = true) : Mode()
         data class Selecting(override val selectedItems: Set<BookmarkNode>) : Mode()

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkView.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkView.kt
@@ -139,7 +139,6 @@ class BookmarkView(
     }
 
     fun update(state: BookmarkFragmentState) {
-        val oldMode = mode
         tree = state.tree
         if (state.mode != mode) {
             mode = state.mode
@@ -149,9 +148,6 @@ class BookmarkView(
         }
 
         bookmarkAdapter.updateData(state.tree, mode)
-        if (state.mode != oldMode) {
-            bookmarkAdapter.notifyDataSetChanged()
-        }
 
         when (mode) {
             is BookmarkFragmentState.Mode.Normal -> {

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/viewholders/BookmarkFolderViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/viewholders/BookmarkFolderViewHolder.kt
@@ -12,7 +12,6 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.hideAndDisable
 import org.mozilla.fenix.ext.showAndEnable
 import org.mozilla.fenix.library.LibrarySiteItemView
-import org.mozilla.fenix.library.SelectionHolder
 import org.mozilla.fenix.library.bookmarks.BookmarkFragmentState
 import org.mozilla.fenix.library.bookmarks.BookmarkPayload
 import org.mozilla.fenix.library.bookmarks.BookmarkViewInteractor
@@ -23,8 +22,7 @@ import org.mozilla.fenix.library.bookmarks.inRoots
  */
 class BookmarkFolderViewHolder(
     view: LibrarySiteItemView,
-    interactor: BookmarkViewInteractor,
-    private val selectionHolder: SelectionHolder<BookmarkNode>
+    interactor: BookmarkViewInteractor
 ) : BookmarkNodeViewHolder(view, interactor) {
 
     override var item: BookmarkNode? = null
@@ -43,7 +41,7 @@ class BookmarkFolderViewHolder(
     override fun bind(item: BookmarkNode, mode: BookmarkFragmentState.Mode, payload: BookmarkPayload) {
         this.item = item
 
-        setSelectionListeners(item, selectionHolder)
+        setSelectionListeners(item, mode)
 
         if (!item.inRoots()) {
             setupMenu(item)
@@ -59,7 +57,7 @@ class BookmarkFolderViewHolder(
         }
 
         if (payload.selectedChanged) {
-            containerView.changeSelected(item in selectionHolder.selectedItems)
+            containerView.changeSelected(item in mode.selectedItems)
         }
 
         containerView.iconView.setImageDrawable(

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/viewholders/BookmarkFolderViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/viewholders/BookmarkFolderViewHolder.kt
@@ -14,6 +14,7 @@ import org.mozilla.fenix.ext.showAndEnable
 import org.mozilla.fenix.library.LibrarySiteItemView
 import org.mozilla.fenix.library.SelectionHolder
 import org.mozilla.fenix.library.bookmarks.BookmarkFragmentState
+import org.mozilla.fenix.library.bookmarks.BookmarkPayload
 import org.mozilla.fenix.library.bookmarks.BookmarkViewInteractor
 import org.mozilla.fenix.library.bookmarks.inRoots
 
@@ -28,28 +29,39 @@ class BookmarkFolderViewHolder(
 
     override var item: BookmarkNode? = null
 
+    init {
+        containerView.displayAs(LibrarySiteItemView.ItemType.FOLDER)
+    }
+
     override fun bind(
         item: BookmarkNode,
         mode: BookmarkFragmentState.Mode
     ) {
-        this.item = item
+        bind(item, mode, BookmarkPayload(true, true, true, true))
+    }
 
-        containerView.displayAs(LibrarySiteItemView.ItemType.FOLDER)
+    override fun bind(item: BookmarkNode, mode: BookmarkFragmentState.Mode, payload: BookmarkPayload) {
+        this.item = item
 
         setSelectionListeners(item, selectionHolder)
 
         if (!item.inRoots()) {
             setupMenu(item)
-            if (mode is BookmarkFragmentState.Mode.Selecting) {
-                containerView.overflowView.hideAndDisable()
-            } else {
-                containerView.overflowView.showAndEnable()
+            if (payload.modeChanged) {
+                if (mode is BookmarkFragmentState.Mode.Selecting) {
+                    containerView.overflowView.hideAndDisable()
+                } else {
+                    containerView.overflowView.showAndEnable()
+                }
             }
         } else {
             containerView.overflowView.visibility = View.GONE
         }
 
-        containerView.changeSelected(item in selectionHolder.selectedItems)
+        if (payload.selectedChanged) {
+            containerView.changeSelected(item in selectionHolder.selectedItems)
+        }
+
         containerView.iconView.setImageDrawable(
             AppCompatResources.getDrawable(
                 containerView.context,
@@ -63,6 +75,9 @@ class BookmarkFolderViewHolder(
                 )
             }
         )
-        containerView.titleView.text = item.title
+
+        if (payload.titleChanged) {
+            containerView.titleView.text = item.title
+        }
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/viewholders/BookmarkItemViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/viewholders/BookmarkItemViewHolder.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.fenix.library.bookmarks.viewholders
 
+import androidx.annotation.VisibleForTesting
 import mozilla.components.concept.storage.BookmarkNode
 import org.mozilla.fenix.ext.hideAndDisable
 import org.mozilla.fenix.ext.showAndEnable
@@ -66,7 +67,8 @@ class BookmarkItemViewHolder(
         setSelectionListeners(item, selectionHolder)
     }
 
-    private fun setColorsAndIcons(url: String?) {
+    @VisibleForTesting
+    internal fun setColorsAndIcons(url: String?) {
         if (url != null && url.startsWith("http")) {
             containerView.loadFavicon(url)
         } else {

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/viewholders/BookmarkItemViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/viewholders/BookmarkItemViewHolder.kt
@@ -9,7 +9,6 @@ import mozilla.components.concept.storage.BookmarkNode
 import org.mozilla.fenix.ext.hideAndDisable
 import org.mozilla.fenix.ext.showAndEnable
 import org.mozilla.fenix.library.LibrarySiteItemView
-import org.mozilla.fenix.library.SelectionHolder
 import org.mozilla.fenix.library.bookmarks.BookmarkFragmentState
 import org.mozilla.fenix.library.bookmarks.BookmarkPayload
 import org.mozilla.fenix.library.bookmarks.BookmarkViewInteractor
@@ -19,8 +18,7 @@ import org.mozilla.fenix.library.bookmarks.BookmarkViewInteractor
  */
 class BookmarkItemViewHolder(
     view: LibrarySiteItemView,
-    interactor: BookmarkViewInteractor,
-    private val selectionHolder: SelectionHolder<BookmarkNode>
+    interactor: BookmarkViewInteractor
 ) : BookmarkNodeViewHolder(view, interactor) {
 
     override var item: BookmarkNode? = null
@@ -50,7 +48,7 @@ class BookmarkItemViewHolder(
         }
 
         if (payload.selectedChanged) {
-            containerView.changeSelected(item in selectionHolder.selectedItems)
+            containerView.changeSelected(item in mode.selectedItems)
         }
 
         if (payload.titleChanged) {
@@ -64,7 +62,7 @@ class BookmarkItemViewHolder(
             setColorsAndIcons(item.url)
         }
 
-        setSelectionListeners(item, selectionHolder)
+        setSelectionListeners(item, mode)
     }
 
     @VisibleForTesting

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/viewholders/BookmarkItemViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/viewholders/BookmarkItemViewHolder.kt
@@ -10,6 +10,7 @@ import org.mozilla.fenix.ext.showAndEnable
 import org.mozilla.fenix.library.LibrarySiteItemView
 import org.mozilla.fenix.library.SelectionHolder
 import org.mozilla.fenix.library.bookmarks.BookmarkFragmentState
+import org.mozilla.fenix.library.bookmarks.BookmarkPayload
 import org.mozilla.fenix.library.bookmarks.BookmarkViewInteractor
 
 /**
@@ -23,27 +24,46 @@ class BookmarkItemViewHolder(
 
     override var item: BookmarkNode? = null
 
+    init {
+        containerView.displayAs(LibrarySiteItemView.ItemType.SITE)
+    }
+
     override fun bind(
         item: BookmarkNode,
         mode: BookmarkFragmentState.Mode
     ) {
+        bind(item, mode, BookmarkPayload(true, true, true, true))
+    }
+
+    override fun bind(item: BookmarkNode, mode: BookmarkFragmentState.Mode, payload: BookmarkPayload) {
         this.item = item
 
-        containerView.displayAs(LibrarySiteItemView.ItemType.SITE)
-
-        if (mode is BookmarkFragmentState.Mode.Selecting) {
-            containerView.overflowView.hideAndDisable()
-        } else {
-            containerView.overflowView.showAndEnable()
-        }
         setupMenu(item)
-        containerView.titleView.text = if (item.title.isNullOrBlank()) item.url else item.title
-        containerView.urlView.text = item.url
+
+        if (payload.modeChanged) {
+            if (mode is BookmarkFragmentState.Mode.Selecting) {
+                containerView.overflowView.hideAndDisable()
+            } else {
+                containerView.overflowView.showAndEnable()
+            }
+        }
+
+        if (payload.selectedChanged) {
+            containerView.changeSelected(item in selectionHolder.selectedItems)
+        }
+
+        if (payload.titleChanged) {
+            containerView.titleView.text = if (item.title.isNullOrBlank()) item.url else item.title
+        } else if (payload.urlChanged && item.title.isNullOrBlank()) {
+            containerView.titleView.text = item.url
+        }
+
+        if (payload.urlChanged) {
+            containerView.urlView.text = item.url
+            setColorsAndIcons(item.url)
+        }
 
         setSelectionListeners(item, selectionHolder)
-
-        containerView.changeSelected(item in selectionHolder.selectedItems)
-        setColorsAndIcons(item.url)
     }
 
     private fun setColorsAndIcons(url: String?) {

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/viewholders/BookmarkNodeViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/viewholders/BookmarkNodeViewHolder.kt
@@ -11,6 +11,7 @@ import org.mozilla.fenix.library.LibrarySiteItemView
 import org.mozilla.fenix.library.SelectionHolder
 import org.mozilla.fenix.library.bookmarks.BookmarkFragmentState
 import org.mozilla.fenix.library.bookmarks.BookmarkItemMenu
+import org.mozilla.fenix.library.bookmarks.BookmarkPayload
 import org.mozilla.fenix.library.bookmarks.BookmarkViewInteractor
 
 /**
@@ -26,6 +27,12 @@ abstract class BookmarkNodeViewHolder(
     abstract fun bind(
         item: BookmarkNode,
         mode: BookmarkFragmentState.Mode
+    )
+
+    abstract fun bind(
+        item: BookmarkNode,
+        mode: BookmarkFragmentState.Mode,
+        payload: BookmarkPayload
     )
 
     protected fun setSelectionListeners(item: BookmarkNode, selectionHolder: SelectionHolder<BookmarkNode>) {

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/viewholders/BookmarkSeparatorViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/viewholders/BookmarkSeparatorViewHolder.kt
@@ -7,6 +7,7 @@ package org.mozilla.fenix.library.bookmarks.viewholders
 import mozilla.components.concept.storage.BookmarkNode
 import org.mozilla.fenix.library.LibrarySiteItemView
 import org.mozilla.fenix.library.bookmarks.BookmarkFragmentState
+import org.mozilla.fenix.library.bookmarks.BookmarkPayload
 import org.mozilla.fenix.library.bookmarks.BookmarkViewInteractor
 
 /**
@@ -26,5 +27,13 @@ class BookmarkSeparatorViewHolder(
         this.item = item
         containerView.displayAs(LibrarySiteItemView.ItemType.SEPARATOR)
         setupMenu(item)
+    }
+
+    override fun bind(
+        item: BookmarkNode,
+        mode: BookmarkFragmentState.Mode,
+        payload: BookmarkPayload
+    ) {
+        bind(item, mode)
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkAdapterTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkAdapterTest.kt
@@ -9,6 +9,8 @@ import io.mockk.spyk
 import io.mockk.verifyOrder
 import mozilla.components.concept.storage.BookmarkNode
 import mozilla.components.concept.storage.BookmarkNodeType
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -18,6 +20,16 @@ import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 internal class BookmarkAdapterTest {
 
     private lateinit var bookmarkAdapter: BookmarkAdapter
+
+    private val item = BookmarkNode(
+        BookmarkNodeType.ITEM,
+        "456",
+        "123",
+        0,
+        "Mozilla",
+        "http://mozilla.org",
+        null
+    )
 
     @Before
     fun setup() {
@@ -30,7 +42,7 @@ internal class BookmarkAdapterTest {
     fun `update adapter from tree of bookmark nodes, null tree returns empty list`() {
         val tree = BookmarkNode(
             BookmarkNodeType.FOLDER, "123", null, 0, "Mobile", null, listOf(
-                BookmarkNode(BookmarkNodeType.ITEM, "456", "123", 0, "Mozilla", "http://mozilla.org", null),
+                item,
                 BookmarkNode(BookmarkNodeType.SEPARATOR, "789", "123", 1, null, null, null),
                 BookmarkNode(
                     BookmarkNodeType.ITEM,
@@ -51,5 +63,53 @@ internal class BookmarkAdapterTest {
             bookmarkAdapter.updateData(null, BookmarkFragmentState.Mode.Normal())
             bookmarkAdapter.notifyItemRangeRemoved(0, 3)
         }
+    }
+
+    @Test
+    fun `items are the same if they have the same guids`() {
+        assertTrue(createSingleItemDiffUtil(item, item).areItemsTheSame(0, 0))
+        assertTrue(
+            createSingleItemDiffUtil(
+                item,
+                item.copy(title = "Wikipedia.org", url = "https://www.wikipedia.org")
+            ).areItemsTheSame(0, 0)
+        )
+        assertFalse(
+            createSingleItemDiffUtil(
+                item,
+                item.copy(guid = "111")
+            ).areItemsTheSame(0, 0)
+        )
+    }
+
+    @Test
+    fun `equal items have same contents unless their selected state changes`() {
+        assertTrue(createSingleItemDiffUtil(item, item).areContentsTheSame(0, 0))
+        assertFalse(
+            createSingleItemDiffUtil(item, item.copy(position = 1)).areContentsTheSame(0, 0)
+        )
+        assertFalse(
+            createSingleItemDiffUtil(
+                item,
+                item,
+                oldMode = BookmarkFragmentState.Mode.Selecting(setOf(item))
+            ).areContentsTheSame(0, 0)
+        )
+        assertFalse(
+            createSingleItemDiffUtil(
+                item,
+                item,
+                newMode = BookmarkFragmentState.Mode.Selecting(setOf(item))
+            ).areContentsTheSame(0, 0)
+        )
+    }
+
+    private fun createSingleItemDiffUtil(
+        oldItem: BookmarkNode,
+        newItem: BookmarkNode,
+        oldMode: BookmarkFragmentState.Mode = BookmarkFragmentState.Mode.Normal(),
+        newMode: BookmarkFragmentState.Mode = BookmarkFragmentState.Mode.Normal()
+    ): BookmarkAdapter.BookmarkDiffUtil {
+        return BookmarkAdapter.BookmarkDiffUtil(listOf(oldItem), listOf(newItem), oldMode, newMode)
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/library/bookmarks/viewholders/BookmarkFolderViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/bookmarks/viewholders/BookmarkFolderViewHolderTest.kt
@@ -18,7 +18,6 @@ import org.junit.Test
 import org.mozilla.fenix.ext.hideAndDisable
 import org.mozilla.fenix.ext.showAndEnable
 import org.mozilla.fenix.library.LibrarySiteItemView
-import org.mozilla.fenix.library.SelectionHolder
 import org.mozilla.fenix.library.bookmarks.BookmarkFragmentInteractor
 import org.mozilla.fenix.library.bookmarks.BookmarkFragmentState
 import org.mozilla.fenix.library.bookmarks.BookmarkPayload
@@ -29,8 +28,6 @@ class BookmarkFolderViewHolderTest {
     private lateinit var interactor: BookmarkFragmentInteractor
     @MockK(relaxed = true)
     private lateinit var siteItemView: LibrarySiteItemView
-    @MockK(relaxed = true)
-    private lateinit var selectionHolder: SelectionHolder<BookmarkNode>
     private lateinit var holder: BookmarkFolderViewHolder
 
     private val folder = BookmarkNode(
@@ -50,7 +47,7 @@ class BookmarkFolderViewHolderTest {
         mockkStatic(AppCompatResources::class)
         every { AppCompatResources.getDrawable(any(), any()) } returns mockk(relaxed = true)
 
-        holder = BookmarkFolderViewHolder(siteItemView, interactor, selectionHolder)
+        holder = BookmarkFolderViewHolder(siteItemView, interactor)
     }
 
     @Test
@@ -63,7 +60,6 @@ class BookmarkFolderViewHolderTest {
             siteItemView.changeSelected(false)
         }
 
-        every { selectionHolder.selectedItems } returns setOf(folder)
         holder.bind(folder, BookmarkFragmentState.Mode.Selecting(setOf(folder)))
 
         verify {

--- a/app/src/test/java/org/mozilla/fenix/library/bookmarks/viewholders/BookmarkFolderViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/bookmarks/viewholders/BookmarkFolderViewHolderTest.kt
@@ -1,0 +1,91 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.library.bookmarks.viewholders
+
+import androidx.appcompat.content.res.AppCompatResources
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.verify
+import mozilla.components.concept.storage.BookmarkNode
+import mozilla.components.concept.storage.BookmarkNodeType
+import org.junit.Before
+import org.junit.Test
+import org.mozilla.fenix.ext.hideAndDisable
+import org.mozilla.fenix.ext.showAndEnable
+import org.mozilla.fenix.library.LibrarySiteItemView
+import org.mozilla.fenix.library.SelectionHolder
+import org.mozilla.fenix.library.bookmarks.BookmarkFragmentInteractor
+import org.mozilla.fenix.library.bookmarks.BookmarkFragmentState
+import org.mozilla.fenix.library.bookmarks.BookmarkPayload
+
+class BookmarkFolderViewHolderTest {
+
+    @MockK
+    private lateinit var interactor: BookmarkFragmentInteractor
+    @MockK(relaxed = true)
+    private lateinit var siteItemView: LibrarySiteItemView
+    @MockK(relaxed = true)
+    private lateinit var selectionHolder: SelectionHolder<BookmarkNode>
+    private lateinit var holder: BookmarkFolderViewHolder
+
+    private val folder = BookmarkNode(
+        type = BookmarkNodeType.FOLDER,
+        guid = "456",
+        parentGuid = "123",
+        position = 0,
+        title = "Folder",
+        url = null,
+        children = listOf()
+    )
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this)
+
+        mockkStatic(AppCompatResources::class)
+        every { AppCompatResources.getDrawable(any(), any()) } returns mockk(relaxed = true)
+
+        holder = BookmarkFolderViewHolder(siteItemView, interactor, selectionHolder)
+    }
+
+    @Test
+    fun `binds title and selected state`() {
+        holder.bind(folder, BookmarkFragmentState.Mode.Normal())
+
+        verify {
+            siteItemView.titleView.text = folder.title
+            siteItemView.overflowView.showAndEnable()
+            siteItemView.changeSelected(false)
+        }
+
+        every { selectionHolder.selectedItems } returns setOf(folder)
+        holder.bind(folder, BookmarkFragmentState.Mode.Selecting(setOf(folder)))
+
+        verify {
+            siteItemView.titleView.text = folder.title
+            siteItemView.overflowView.hideAndDisable()
+            siteItemView.changeSelected(true)
+        }
+    }
+
+    @Test
+    fun `bind with payload of no changes does not rebind views`() {
+        holder.bind(
+            folder,
+            BookmarkFragmentState.Mode.Normal(),
+            BookmarkPayload(false, false, false, false)
+        )
+
+        verify(inverse = true) {
+            siteItemView.titleView.text = folder.title
+            siteItemView.overflowView.showAndEnable()
+            siteItemView.overflowView.hideAndDisable()
+            siteItemView.changeSelected(any())
+        }
+    }
+}

--- a/app/src/test/java/org/mozilla/fenix/library/bookmarks/viewholders/BookmarkItemViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/bookmarks/viewholders/BookmarkItemViewHolderTest.kt
@@ -1,0 +1,147 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.library.bookmarks.viewholders
+
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.verify
+import mozilla.components.concept.storage.BookmarkNode
+import mozilla.components.concept.storage.BookmarkNodeType
+import org.junit.Before
+import org.junit.Test
+import org.mozilla.fenix.ext.hideAndDisable
+import org.mozilla.fenix.ext.showAndEnable
+import org.mozilla.fenix.library.LibrarySiteItemView
+import org.mozilla.fenix.library.SelectionHolder
+import org.mozilla.fenix.library.bookmarks.BookmarkFragmentInteractor
+import org.mozilla.fenix.library.bookmarks.BookmarkFragmentState
+import org.mozilla.fenix.library.bookmarks.BookmarkPayload
+
+class BookmarkItemViewHolderTest {
+
+    @MockK
+    private lateinit var interactor: BookmarkFragmentInteractor
+
+    @MockK(relaxed = true)
+    private lateinit var siteItemView: LibrarySiteItemView
+
+    @MockK(relaxed = true)
+    private lateinit var selectionHolder: SelectionHolder<BookmarkNode>
+    private lateinit var holder: BookmarkItemViewHolder
+
+    private val item = BookmarkNode(
+        type = BookmarkNodeType.ITEM,
+        guid = "456",
+        parentGuid = "123",
+        position = 0,
+        title = "Mozilla",
+        url = "https://www.mozilla.org",
+        children = listOf()
+    )
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this)
+        holder = BookmarkItemViewHolder(siteItemView, interactor, selectionHolder)
+    }
+
+    @Test
+    fun `binds views for unselected item`() {
+        holder.bind(item, BookmarkFragmentState.Mode.Normal())
+
+        verify {
+            siteItemView.setSelectionInteractor(item, selectionHolder, interactor)
+            siteItemView.titleView.text = item.title
+            siteItemView.urlView.text = item.url
+            siteItemView.overflowView.showAndEnable()
+            siteItemView.changeSelected(false)
+            holder.setColorsAndIcons(item.url)
+        }
+    }
+
+    @Test
+    fun `binds views for selected item`() {
+        every { selectionHolder.selectedItems } returns setOf(item)
+        holder.bind(item, BookmarkFragmentState.Mode.Selecting(setOf(item)))
+
+        verify {
+            siteItemView.setSelectionInteractor(item, selectionHolder, interactor)
+            siteItemView.titleView.text = item.title
+            siteItemView.urlView.text = item.url
+            siteItemView.overflowView.hideAndDisable()
+            siteItemView.changeSelected(true)
+            holder.setColorsAndIcons(item.url)
+        }
+    }
+
+    @Test
+    fun `bind with payload of no changes does not rebind views`() {
+        holder.bind(
+            item,
+            BookmarkFragmentState.Mode.Normal(),
+            BookmarkPayload(false, false, false, false)
+        )
+
+        verify(inverse = true) {
+            siteItemView.titleView.text = item.title
+            siteItemView.urlView.text = item.url
+            siteItemView.overflowView.showAndEnable()
+            siteItemView.overflowView.hideAndDisable()
+            siteItemView.changeSelected(any())
+            holder.setColorsAndIcons(item.url)
+        }
+    }
+
+    @Test
+    fun `binding an item with a null title uses the url as the title`() {
+        val item = item.copy(title = null)
+        holder.bind(item, BookmarkFragmentState.Mode.Normal())
+
+        verify { siteItemView.titleView.text = item.url }
+    }
+
+    @Test
+    fun `binding an item with a blank title uses the url as the title`() {
+        val item = item.copy(title = " ")
+        holder.bind(item, BookmarkFragmentState.Mode.Normal())
+
+        verify { siteItemView.titleView.text = item.url }
+    }
+
+    @Test
+    fun `rebinds title if item title is null and the item url has changed`() {
+        val item = item.copy(title = null)
+        holder.bind(
+            item,
+            BookmarkFragmentState.Mode.Normal(),
+            BookmarkPayload(
+                titleChanged = false,
+                urlChanged = true,
+                selectedChanged = false,
+                modeChanged = false
+            )
+        )
+
+        verify { siteItemView.titleView.text = item.url }
+    }
+
+    @Test
+    fun `rebinds title if item title is blank and the item url has changed`() {
+        val item = item.copy(title = " ")
+        holder.bind(
+            item,
+            BookmarkFragmentState.Mode.Normal(),
+            BookmarkPayload(
+                titleChanged = false,
+                urlChanged = true,
+                selectedChanged = false,
+                modeChanged = false
+            )
+        )
+
+        verify { siteItemView.titleView.text = item.url }
+    }
+}

--- a/app/src/test/java/org/mozilla/fenix/library/bookmarks/viewholders/BookmarkItemViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/bookmarks/viewholders/BookmarkItemViewHolderTest.kt
@@ -5,7 +5,6 @@
 package org.mozilla.fenix.library.bookmarks.viewholders
 
 import io.mockk.MockKAnnotations
-import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.verify
 import mozilla.components.concept.storage.BookmarkNode
@@ -15,7 +14,6 @@ import org.junit.Test
 import org.mozilla.fenix.ext.hideAndDisable
 import org.mozilla.fenix.ext.showAndEnable
 import org.mozilla.fenix.library.LibrarySiteItemView
-import org.mozilla.fenix.library.SelectionHolder
 import org.mozilla.fenix.library.bookmarks.BookmarkFragmentInteractor
 import org.mozilla.fenix.library.bookmarks.BookmarkFragmentState
 import org.mozilla.fenix.library.bookmarks.BookmarkPayload
@@ -28,8 +26,6 @@ class BookmarkItemViewHolderTest {
     @MockK(relaxed = true)
     private lateinit var siteItemView: LibrarySiteItemView
 
-    @MockK(relaxed = true)
-    private lateinit var selectionHolder: SelectionHolder<BookmarkNode>
     private lateinit var holder: BookmarkItemViewHolder
 
     private val item = BookmarkNode(
@@ -45,15 +41,16 @@ class BookmarkItemViewHolderTest {
     @Before
     fun setup() {
         MockKAnnotations.init(this)
-        holder = BookmarkItemViewHolder(siteItemView, interactor, selectionHolder)
+        holder = BookmarkItemViewHolder(siteItemView, interactor)
     }
 
     @Test
     fun `binds views for unselected item`() {
-        holder.bind(item, BookmarkFragmentState.Mode.Normal())
+        val mode = BookmarkFragmentState.Mode.Normal()
+        holder.bind(item, mode)
 
         verify {
-            siteItemView.setSelectionInteractor(item, selectionHolder, interactor)
+            siteItemView.setSelectionInteractor(item, mode, interactor)
             siteItemView.titleView.text = item.title
             siteItemView.urlView.text = item.url
             siteItemView.overflowView.showAndEnable()
@@ -64,11 +61,11 @@ class BookmarkItemViewHolderTest {
 
     @Test
     fun `binds views for selected item`() {
-        every { selectionHolder.selectedItems } returns setOf(item)
-        holder.bind(item, BookmarkFragmentState.Mode.Selecting(setOf(item)))
+        val mode = BookmarkFragmentState.Mode.Selecting(setOf(item))
+        holder.bind(item, mode)
 
         verify {
-            siteItemView.setSelectionInteractor(item, selectionHolder, interactor)
+            siteItemView.setSelectionInteractor(item, mode, interactor)
             siteItemView.titleView.text = item.title
             siteItemView.urlView.text = item.url
             siteItemView.overflowView.hideAndDisable()


### PR DESCRIPTION
Change the DiffUtil callback for bookmarks to use the generated equals()
method instead of only checking the title and url fields. This prevents
the BookmarkNode in our state from getting out of sync with the
BookmarkNode the viewholder is bound to.

https://streamable.com/wec9q2

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture