### PR TITLE
FNX-14490 ⁃ Default to email sign in if no camera

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
@@ -25,7 +25,6 @@ import mozilla.components.concept.sync.AccountObserver
 import mozilla.components.concept.sync.AuthType
 import mozilla.components.concept.sync.OAuthAccount
 import mozilla.components.concept.sync.Profile
-import mozilla.components.support.ktx.android.content.hasCamera
 import org.mozilla.fenix.BrowserDirection
 import org.mozilla.fenix.Config
 import org.mozilla.fenix.HomeActivity
@@ -189,16 +188,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
 
         val directions: NavDirections? = when (preference.key) {
             resources.getString(R.string.pref_key_sign_in) -> {
-                // App can be installed on devices with no camera modules. Like Android TV boxes.
-                // Let's skip presenting the option to sign in by scanning a qr code in this case
-                // and default to login with email and password.
-                if (requireContext().hasCamera()) {
-                    SettingsFragmentDirections.actionSettingsFragmentToTurnOnSyncFragment()
-                } else {
-                    requireComponents.services.accountsAuthFeature.beginAuthentication(requireContext())
-                    requireComponents.analytics.metrics.track(Event.SyncAuthUseEmail)
-                    null
-                }
+                SettingsFragmentDirections.actionSettingsFragmentToTurnOnSyncFragment()
             }
             resources.getString(R.string.pref_key_search_settings) -> {
                 SettingsFragmentDirections.actionSettingsFragmentToSearchEngineFragment()

--- a/app/src/main/java/org/mozilla/fenix/settings/logins/SyncLoginsPreferenceView.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/SyncLoginsPreferenceView.kt
@@ -4,21 +4,16 @@
 
 package org.mozilla.fenix.settings.logins
 
-import android.content.Context
 import androidx.lifecycle.LifecycleOwner
 import androidx.navigation.NavController
 import androidx.preference.Preference
 import mozilla.components.concept.sync.AccountObserver
 import mozilla.components.concept.sync.AuthType
 import mozilla.components.concept.sync.OAuthAccount
-import mozilla.components.feature.accounts.FirefoxAccountsAuthFeature
 import mozilla.components.service.fxa.SyncEngine
 import mozilla.components.service.fxa.manager.FxaAccountManager
 import mozilla.components.service.fxa.manager.SyncEnginesStorage
-import mozilla.components.support.ktx.android.content.hasCamera
 import org.mozilla.fenix.R
-import org.mozilla.fenix.components.metrics.Event
-import org.mozilla.fenix.components.metrics.MetricController
 import org.mozilla.fenix.settings.logins.fragment.SavedLoginsAuthFragmentDirections
 
 /**
@@ -28,9 +23,7 @@ class SyncLoginsPreferenceView(
     private val syncLoginsPreference: Preference,
     lifecycleOwner: LifecycleOwner,
     accountManager: FxaAccountManager,
-    private val navController: NavController,
-    private val accountsAuthFeature: FirefoxAccountsAuthFeature,
-    private val metrics: MetricController
+    private val navController: NavController
 ) {
 
     init {
@@ -75,15 +68,7 @@ class SyncLoginsPreferenceView(
         syncLoginsPreference.apply {
             summary = context.getString(R.string.preferences_passwords_sync_logins_sign_in)
             setOnPreferenceClickListener {
-                // App can be installed on devices with no camera modules. Like Android TV boxes.
-                // Let's skip presenting the option to sign in by scanning a qr code in this case
-                // and default to login with email and password.
-                if (context.hasCamera()) {
-                    navigateToTurnOnSyncFragment()
-                } else {
-                    navigateToPairWithEmail(context)
-                }
-
+                navigateToTurnOnSyncFragment()
                 true
             }
         }
@@ -116,10 +101,5 @@ class SyncLoginsPreferenceView(
     private fun navigateToTurnOnSyncFragment() {
         val directions = SavedLoginsAuthFragmentDirections.actionSavedLoginsAuthFragmentToTurnOnSyncFragment()
         navController.navigate(directions)
-    }
-
-    private fun navigateToPairWithEmail(context: Context) {
-        accountsAuthFeature.beginAuthentication(context)
-        metrics.track(Event.SyncAuthUseEmail)
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/SavedLoginsAuthFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/SavedLoginsAuthFragment.kt
@@ -145,9 +145,7 @@ class SavedLoginsAuthFragment : PreferenceFragmentCompat() {
             requirePreference(R.string.pref_key_password_sync_logins),
             lifecycleOwner = viewLifecycleOwner,
             accountManager = requireComponents.backgroundServices.accountManager,
-            navController = findNavController(),
-            accountsAuthFeature = requireComponents.services.accountsAuthFeature,
-            metrics = requireComponents.analytics.metrics
+            navController = findNavController()
         )
 
         togglePrefsEnabledWhileAuthenticating(enabled = true)

--- a/app/src/test/java/org/mozilla/fenix/settings/logins/SyncLoginsPreferenceViewTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/logins/SyncLoginsPreferenceViewTest.kt
@@ -12,24 +12,18 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkConstructor
-import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.unmockkConstructor
-import io.mockk.unmockkStatic
 import io.mockk.verify
 import mozilla.components.concept.sync.AccountObserver
-import mozilla.components.feature.accounts.FirefoxAccountsAuthFeature
 import mozilla.components.service.fxa.SyncEngine
 import mozilla.components.service.fxa.manager.FxaAccountManager
 import mozilla.components.service.fxa.manager.SyncEnginesStorage
-import mozilla.components.support.ktx.android.content.hasCamera
 import org.junit.After
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.mozilla.fenix.R
-import org.mozilla.fenix.components.metrics.Event
-import org.mozilla.fenix.components.metrics.MetricController
 import org.mozilla.fenix.settings.logins.fragment.SavedLoginsAuthFragmentDirections
 
 class SyncLoginsPreferenceViewTest {
@@ -38,8 +32,6 @@ class SyncLoginsPreferenceViewTest {
     @MockK private lateinit var lifecycleOwner: LifecycleOwner
     @MockK private lateinit var accountManager: FxaAccountManager
     @MockK(relaxed = true) private lateinit var navController: NavController
-    @MockK(relaxed = true) private lateinit var accountsAuthFeature: FirefoxAccountsAuthFeature
-    @MockK(relaxed = true) private lateinit var metrics: MetricController
     private lateinit var accountObserver: CapturingSlot<AccountObserver>
     private lateinit var clickListener: CapturingSlot<Preference.OnPreferenceClickListener>
 
@@ -95,11 +87,9 @@ class SyncLoginsPreferenceViewTest {
     }
 
     @Test
-    fun `needs login if account does not exist and device has camera`() {
+    fun `needs login if account does not exist`() {
         every { accountManager.authenticatedAccount() } returns null
         every { accountManager.accountNeedsReauth() } returns false
-        mockkStatic("mozilla.components.support.ktx.android.content.ContextKt")
-        every { any<Context>().hasCamera() } returns true
         createView()
 
         verify { syncLoginsPreference.summary = "Sign in to Sync" }
@@ -110,26 +100,6 @@ class SyncLoginsPreferenceViewTest {
                 SavedLoginsAuthFragmentDirections.actionSavedLoginsAuthFragmentToTurnOnSyncFragment()
             )
         }
-
-        unmockkStatic("mozilla.components.support.ktx.android.content.ContextKt")
-    }
-
-    @Test
-    fun `needs login if account does not exist and device does not have camera`() {
-        every { accountManager.authenticatedAccount() } returns null
-        every { accountManager.accountNeedsReauth() } returns false
-        createView()
-        mockkStatic("mozilla.components.support.ktx.android.content.ContextKt")
-        every { any<Context>().hasCamera() } returns false
-
-        verify { syncLoginsPreference.summary = "Sign in to Sync" }
-        assertTrue(clickListener.captured.onPreferenceClick(syncLoginsPreference))
-        verify {
-            accountsAuthFeature.beginAuthentication(any())
-            metrics.track(Event.SyncAuthUseEmail)
-        }
-
-        unmockkStatic("mozilla.components.support.ktx.android.content.ContextKt")
     }
 
     @Test
@@ -171,8 +141,6 @@ class SyncLoginsPreferenceViewTest {
         syncLoginsPreference,
         lifecycleOwner,
         accountManager,
-        navController,
-        accountsAuthFeature,
-        metrics
+        navController
     )
 }


### PR DESCRIPTION
App can be installed on devices with no camera modules. Like Android TV boxes.
Will skip presenting the option to sign in by scanning a qr code in this case
and default to login with email and password.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: No tests. Small change.
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made.
- [x] **Accessibility**: The code in this PR does not include any user facing features.


![DefaultToSignInWithEmail](https://user-images.githubusercontent.com/11428869/89426702-1bf45700-d743-11ea-98d6-c41ebcc531ff.gif)
[video](https://drive.google.com/file/d/1xnyJppfeRIK1-ufxyXjDI6kxQudGHJxG/view?usp=sharing)

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture