### PR TITLE
For #13218: Fix settingsAddonsItemsTest

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAddonsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAddonsTest.kt
@@ -44,7 +44,6 @@ class SettingsAddonsTest {
     }
 
     // Walks through settings add-ons menu to ensure all items are present
-    @Ignore("Failing, see: https://github.com/mozilla-mobile/fenix/issues/13218")
     @Test
     fun settingsAddonsItemsTest() {
         homeScreen {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuMainRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuMainRobot.kt
@@ -31,6 +31,7 @@ import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
+import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers.allOf
@@ -350,10 +351,9 @@ class ThreeDotMenuMainRobot {
 
         fun openAddonsManagerMenu(interact: SettingsSubMenuAddonsManagerRobot.() -> Unit): SettingsSubMenuAddonsManagerRobot.Transition {
             clickAddonsManagerButton()
-            mDevice.waitNotNull(
-                Until.findObject(By.text("Recommended")),
-                waitingTime
-            )
+            mDevice.findObject(
+                UiSelector().text("Recommended")
+            ).waitForExists(waitingTime)
 
             SettingsSubMenuAddonsManagerRobot().interact()
             return SettingsSubMenuAddonsManagerRobot.Transition()


### PR DESCRIPTION
For #13218 – trying the other style of `wait` that @sv-ohorvath has used recently to maybe fix this flaky test.

```androidx.test.espresso.NoMatchingViewException: No views in hierarchy found matching: (with id: org.mozilla.fenix.debug:id/title and with text: is "Recommended")```

Passes locally. Let's try Firebase.