### PR TITLE
FNX-14530 ⁃ For #13149 - Add end padding to tab history title and url views.

### DIFF
--- a/app/src/main/res/layout/library_site_item.xml
+++ b/app/src/main/res/layout/library_site_item.xml
@@ -53,7 +53,8 @@
             app:layout_constraintStart_toEndOf="@id/icon"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toTopOf="@+id/url"
-            app:layout_constraintVertical_chainStyle="packed"/>
+            app:layout_constraintVertical_chainStyle="packed"
+            app:layout_goneMarginEnd="@dimen/library_item_icon_margin_horizontal" />
 
     <TextView
             android:id="@+id/url"
@@ -69,7 +70,8 @@
             app:layout_constraintEnd_toStartOf="@id/overflow_menu"
             app:layout_constraintStart_toEndOf="@id/icon"
             app:layout_constraintTop_toBottomOf="@+id/title"
-            app:layout_constraintBottom_toBottomOf="parent" />
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_goneMarginEnd="@dimen/library_item_icon_margin_horizontal" />
 
     <ImageButton
             android:id="@+id/overflow_menu"


### PR DESCRIPTION

<img src="https://user-images.githubusercontent.com/6396431/89558060-97e4b280-d7c8-11ea-8e4e-616d27d187b9.png" width=300 />
(Look at url of the fourth item)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture