### PR TITLE
Issue #13110 - fixed collection new name capitalization

### DIFF
--- a/app/src/main/res/layout/name_collection_dialog.xml
+++ b/app/src/main/res/layout/name_collection_dialog.xml
@@ -26,7 +26,7 @@
         android:layout_marginStart="24dp"
         android:layout_marginEnd="24dp"
         android:backgroundTint="?neutral"
-        android:inputType="text"
+        android:inputType="textCapSentences"
         android:singleLine="true"
         android:textAlignment="viewStart" />
 </LinearLayout>


### PR DESCRIPTION
Closes #13110 

Changes to `/app/src/main/res/layout/name_collection_dialog.xml`:

 - Modified `EditText` to include `android:inputType="textCapSentences"` instead of `android:inputType="text"`

Previously the collection name wouldn't be capitalized and now it is.

### Pull Request checklist
- [X] **Tests**: This PR includes thorough tests
- [X] **Screenshots**: This PR includes screenshots

Before:
![fenix-13110-before](https://user-images.githubusercontent.com/10947344/89563430-b9bb5500-d81b-11ea-8143-c06d7a13eacb.gif)
After
![fenix-13110-after](https://user-images.githubusercontent.com/10947344/89563441-bcb64580-d81b-11ea-8424-a24ea0ca6cdd.gif)


- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

I couldn't get Accesibility Scanner running on my device. This PR doesn't contain any UI changes.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture