### PR TITLE
FNX-14553 ⁃ For #7865: Enable about:config in geckoRelease

### DIFF
--- a/app/src/geckoRelease/java/org/mozilla/fenix/engine/GeckoProvider.kt
+++ b/app/src/geckoRelease/java/org/mozilla/fenix/engine/GeckoProvider.kt
@@ -52,7 +52,7 @@ object GeckoProvider {
             .telemetryDelegate(GeckoAdapter())
             // TODO: Fix me!
             // .contentBlocking(policy.toContentBlockingSetting())
-            .aboutConfigEnabled(Config.channel.isBeta)
+            .aboutConfigEnabled(true)
             .debugLogging(Config.channel.isDebug)
             .build()
 


### PR DESCRIPTION
This should fix #7865 by enabling `about:config` support unconditionally in `geckoRelease` builds, instead of just when they are also `isBeta` (which I think amounts to "never"). It's modeled after #5569.

There aren't any tests to update for this as far as I can tell; I don't think the runtime configuration generation is under test. `fenix/app/src/test/java/org/mozilla/fenix/engine` doesn't exist.

I'm hoping this doesn't need screenshots or an accessibility scan since it's just a config change controlling already-existing features.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture