### PR TITLE
Closes #13219: Fixing long-tap delay for UI tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/HomeActivityTestRule.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/HomeActivityTestRule.kt
@@ -5,7 +5,9 @@
 package org.mozilla.fenix.helpers
 
 import androidx.test.espresso.intent.rule.IntentsTestRule
+import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.ActivityTestRule
+import androidx.test.uiautomator.UiDevice
 import org.mozilla.fenix.HomeActivity
 
 /**
@@ -16,7 +18,12 @@ import org.mozilla.fenix.HomeActivity
  */
 
 class HomeActivityTestRule(initialTouchMode: Boolean = false, launchActivity: Boolean = true) :
-    ActivityTestRule<HomeActivity>(HomeActivity::class.java, initialTouchMode, launchActivity)
+    ActivityTestRule<HomeActivity>(HomeActivity::class.java, initialTouchMode, launchActivity) {
+    override fun beforeActivityLaunched() {
+        super.beforeActivityLaunched()
+        setLongTapTimeout()
+    }
+}
 
 /**
  * A [org.junit.Rule] to handle shared test set up for tests on [HomeActivity]. This adds
@@ -26,5 +33,19 @@ class HomeActivityTestRule(initialTouchMode: Boolean = false, launchActivity: Bo
  * @param launchActivity See [IntentsTestRule]
  */
 
-class HomeActivityIntentTestRule(initialTouchMode: Boolean = false, launchActivity: Boolean = true) :
-    IntentsTestRule<HomeActivity>(HomeActivity::class.java, initialTouchMode, launchActivity)
+class HomeActivityIntentTestRule(
+    initialTouchMode: Boolean = false,
+    launchActivity: Boolean = true
+) :
+    IntentsTestRule<HomeActivity>(HomeActivity::class.java, initialTouchMode, launchActivity) {
+    override fun beforeActivityLaunched() {
+        super.beforeActivityLaunched()
+        setLongTapTimeout()
+    }
+}
+
+// changing the device preference for Touch and Hold delay, to avoid long-clicks instead of a single-click
+fun setLongTapTimeout() {
+    val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+    mDevice.executeShellCommand("settings put secure long_press_timeout 3000")
+}

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAboutTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAboutTest.kt
@@ -10,7 +10,6 @@ import okhttp3.mockwebserver.MockWebServer
 import org.junit.Rule
 import org.junit.Before
 import org.junit.After
-import org.junit.Ignore
 import org.junit.Test
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
@@ -69,7 +68,7 @@ class SettingsAboutTest {
         }
 
     }
-    @Ignore("Failing, see: https://github.com/mozilla-mobile/fenix/issues/13219")
+
     @Test
     fun verifyAboutFirefoxPreview() {
         homeScreen {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAboutRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAboutRobot.kt
@@ -222,7 +222,7 @@ private fun assertLibrariesUsed() {
         .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
         .perform(click())
 
-    onView(withId(R.id.action_bar)).check(matches(hasDescendant(withText(containsString("Firefox Preview | OSS Libraries")))))
+    onView(withId(R.id.toolbar)).check(matches(hasDescendant(withText(containsString("Firefox Preview | OSS Libraries")))))
     Espresso.pressBack()
 }
 


### PR DESCRIPTION
Changes the long-tap delay before starting the activity so it applies to all tests.
Fixed the Libraries menu toolbar resource ID because it has changed.