### PR TITLE
For #12857 - Use Collection title when sharing tabs collection

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
@@ -232,7 +232,10 @@ class DefaultSessionControlController(
     }
 
     override fun handleCollectionShareTabsClicked(collection: TabCollection) {
-        showShareFragment(collection.tabs.map { ShareData(url = it.url, title = it.title) })
+        showShareFragment(
+            collection.title,
+            collection.tabs.map { ShareData(url = it.url, title = it.title) }
+        )
         metrics.track(Event.CollectionShared)
     }
 
@@ -366,8 +369,9 @@ class DefaultSessionControlController(
         showTabTrayCollectionCreation()
     }
 
-    private fun showShareFragment(data: List<ShareData>) {
+    private fun showShareFragment(shareSubject: String, data: List<ShareData>) {
         val directions = HomeFragmentDirections.actionGlobalShareFragment(
+            shareSubject = shareSubject,
             data = data.toTypedArray()
         )
         navController.nav(R.id.homeFragment, directions)

--- a/app/src/main/java/org/mozilla/fenix/share/ShareController.kt
+++ b/app/src/main/java/org/mozilla/fenix/share/ShareController.kt
@@ -55,6 +55,7 @@ interface ShareController {
  * Default behavior of [ShareController]. Other implementations are possible.
  *
  * @param context [Context] used for various Android interactions.
+ * @param shareSubject desired message subject used when sharing through 3rd party apps, like email clients.
  * @param shareData the list of [ShareData]s that can be shared.
  * @param sendTabUseCases instance of [SendTabUseCases] which allows sending tabs to account devices.
  * @param snackbar - instance of [FenixSnackbar] for displaying styled snackbars
@@ -64,6 +65,7 @@ interface ShareController {
 @Suppress("TooManyFunctions")
 class DefaultShareController(
     private val context: Context,
+    private val shareSubject: String?,
     private val shareData: List<ShareData>,
     private val sendTabUseCases: SendTabUseCases,
     private val snackbar: FenixSnackbar,
@@ -90,7 +92,7 @@ class DefaultShareController(
 
         val intent = Intent(ACTION_SEND).apply {
             putExtra(EXTRA_TEXT, getShareText())
-            putExtra(EXTRA_SUBJECT, shareData.map { it.title }.joinToString(", "))
+            putExtra(EXTRA_SUBJECT, getShareSubject())
             type = "text/plain"
             flags = FLAG_ACTIVITY_NEW_TASK
             setClassName(app.packageName, app.activityName)
@@ -188,6 +190,9 @@ class DefaultShareController(
             url
         }
     }
+
+    @VisibleForTesting
+    internal fun getShareSubject() = shareSubject ?: shareData.map { it.title }.joinToString(", ")
 
     // Navigation between app fragments uses ShareTab as arguments. SendTabUseCases uses TabData.
     @VisibleForTesting

--- a/app/src/main/java/org/mozilla/fenix/share/ShareFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/share/ShareFragment.kt
@@ -67,6 +67,7 @@ class ShareFragment : AppCompatDialogFragment() {
         shareInteractor = ShareInteractor(
             DefaultShareController(
                 context = requireContext(),
+                shareSubject = args.shareSubject,
                 shareData = shareData,
                 snackbar = FenixSnackbar.make(
                     view = requireActivity().getRootView()!!,

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -677,6 +677,11 @@
             android:defaultValue="null"
             app:argType="string"
             app:nullable="true" />
+        <argument
+            android:name="shareSubject"
+            android:defaultValue="@null"
+            app:argType="string"
+            app:nullable="true" />
     </dialog>
     <dialog
         android:id="@+id/quickSettingsSheetDialogFragment"

--- a/app/src/test/java/org/mozilla/fenix/home/DefaultSessionControlControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/DefaultSessionControlControllerTest.kt
@@ -212,6 +212,7 @@ class DefaultSessionControlControllerTest {
     fun handleCollectionShareTabsClicked() {
         val collection = mockk<TabCollection> {
             every { tabs } returns emptyList()
+            every { title } returns ""
         }
         controller.handleCollectionShareTabsClicked(collection)
 


### PR DESCRIPTION
Avoided passing the subject for sharing a collection of tabs in the ShareData
object since ShareData is part of a web standard.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests.
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made.
- [x] **Accessibility**: The code in this PR does not include any user facing accessibility modifications.


![SharingAFenixCollection](https://user-images.githubusercontent.com/11428869/89916053-ccf56880-dbff-11ea-9732-71c27ebc9c1b.gif)
[video](https://drive.google.com/file/d/19EUv_1xmWtYIRGhYqXymm6C7CFcY6pvH/view?usp=sharing)

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture