### PR TITLE
For #13390  - Fix for stuck readerMode appearance controls

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/readermode/ReaderModeController.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/readermode/ReaderModeController.kt
@@ -27,7 +27,10 @@ class DefaultReaderModeController(
     private val isPrivate: Boolean = false
 ) : ReaderModeController {
     override fun hideReaderView() {
-        readerViewFeature.withFeature { it.hideReaderView() }
+        readerViewFeature.withFeature {
+            it.hideReaderView()
+            it.hideControls()
+        }
     }
 
     override fun showReaderView() {

--- a/app/src/test/java/org/mozilla/fenix/browser/readermode/DefaultReaderModeControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/browser/readermode/DefaultReaderModeControllerTest.kt
@@ -54,6 +54,7 @@ class DefaultReaderModeControllerTest {
         every { readerViewFeature.hideReaderView() } returns Unit
         every { readerViewFeature.showReaderView() } returns Unit
         every { readerViewFeature.showControls() } returns Unit
+        every { readerViewFeature.hideControls() } returns Unit
     }
 
     @Test
@@ -61,6 +62,7 @@ class DefaultReaderModeControllerTest {
         val controller = DefaultReaderModeController(featureWrapper, readerViewControlsBar)
         controller.hideReaderView()
         verify { readerViewFeature.hideReaderView() }
+        verify { readerViewFeature.hideControls() }
     }
 
     @Test


### PR DESCRIPTION
For https://github.com/mozilla-mobile/fenix/issues/13390

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests.
- [x] **Screenshots**: This PR includes GIF.
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

![fix stuck reader controls](https://user-images.githubusercontent.com/60002907/90106486-28cf0700-dd50-11ea-9e79-2b87181204dd.gif)
