### PR TITLE
Closes #12778: re-arranged steps to follow current flow in closeTabTest & closePrivateTabTest

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
@@ -10,13 +10,13 @@ import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
 import org.junit.BeforeClass
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.HomeActivityTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.helpers.TestHelper.sendSingleTapToScreen
+import org.mozilla.fenix.ui.robots.browserScreen
 import org.mozilla.fenix.ui.robots.homeScreen
 import org.mozilla.fenix.ui.robots.navigationToolbar
 import org.mozilla.fenix.ui.robots.notificationShade
@@ -148,7 +148,6 @@ class TabbedBrowsingTest {
     }
 
     @Test
-    @Ignore("For some reason this intermittently fails with the drawer :(")
     fun closeTabTest() {
         var genericURLS = TestAssetHelper.getGenericAssets(mockWebServer)
 
@@ -161,25 +160,39 @@ class TabbedBrowsingTest {
                 closeTabViaXButton("Test_Page_${index + 1}")
                 verifySnackBarText("Tab closed")
                 snackBarButtonClick("UNDO")
-//                verifyExistingOpenTabs("Test_Page_${index + 1}")
-//                verifyCloseTabsButton("Test_Page_${index + 1}")
-//                swipeTabRight("Test_Page_${index + 1}")
-//                verifySnackBarText("Tab closed")
-//                snackBarButtonClick("UNDO")
-//                verifyExistingOpenTabs("Test_Page_${index + 1}")
-//                verifyCloseTabsButton("Test_Page_${index + 1}")
-//                swipeTabLeft("Test_Page_${index + 1}")
-//                verifySnackBarText("Tab closed")
-//                snackBarButtonClick("UNDO")
+            }
+
+            mDevice.waitForIdle()
+
+            browserScreen {
+            }.openTabDrawer {
                 verifyExistingOpenTabs("Test_Page_${index + 1}")
-                verifyCloseTabsButton("Test_Page_${index + 1}")
+                swipeTabRight("Test_Page_${index + 1}")
+                verifySnackBarText("Tab closed")
+                snackBarButtonClick("UNDO")
+            }
+
+            mDevice.waitForIdle()
+
+            browserScreen {
+            }.openTabDrawer {
+                verifyExistingOpenTabs("Test_Page_${index + 1}")
+                swipeTabLeft("Test_Page_${index + 1}")
+                verifySnackBarText("Tab closed")
+                snackBarButtonClick("UNDO")
+            }
+
+            mDevice.waitForIdle()
+
+            browserScreen {
+            }.openTabDrawer {
+                verifyExistingOpenTabs("Test_Page_${index + 1}")
             }.openHomeScreen {
             }
         }
     }
 
     @Test
-    @Ignore("For some reason this intermittently fails with the drawer :(")
     fun closePrivateTabTest() {
         var genericURLS = TestAssetHelper.getGenericAssets(mockWebServer)
 
@@ -193,19 +206,34 @@ class TabbedBrowsingTest {
                 closeTabViaXButton("Test_Page_${index + 1}")
                 verifySnackBarText("Private tab closed")
                 snackBarButtonClick("UNDO")
-//                verifyExistingOpenTabs("Test_Page_${index + 1}")
-//                verifyCloseTabsButton("Test_Page_${index + 1}")
-//                swipeTabRight("Test_Page_${index + 1}")
-//                verifySnackBarText("Private tab closed")
-//                snackBarButtonClick("UNDO")
-//                verifyExistingOpenTabs("Test_Page_${index + 1}")
-//                verifyCloseTabsButton("Test_Page_${index + 1}")
-//                swipeTabLeft("Test_Page_${index + 1}")
-//                verifySnackBarText("Private tab closed")
-//                snackBarButtonClick("UNDO")
+            }
+
+            mDevice.waitForIdle()
+
+            browserScreen {
+            }.openTabDrawer {
                 verifyExistingOpenTabs("Test_Page_${index + 1}")
-                verifyCloseTabsButton("Test_Page_${index + 1}")
-            }.openHomeScreen {
+                swipeTabRight("Test_Page_${index + 1}")
+                verifySnackBarText("Private tab closed")
+                snackBarButtonClick("UNDO")
+            }
+
+            mDevice.waitForIdle()
+
+            browserScreen {
+            }.openTabDrawer {
+                verifyExistingOpenTabs("Test_Page_${index + 1}")
+                swipeTabLeft("Test_Page_${index + 1}")
+                verifySnackBarText("Private tab closed")
+                snackBarButtonClick("UNDO")
+            }
+
+            mDevice.waitForIdle()
+
+            browserScreen {
+            }.openTabDrawer {
+                verifyExistingOpenTabs("Test_Page_${index + 1}")
+                closeTabViaXButton("Test_Page_${index + 1}")
             }
         }
     }


### PR DESCRIPTION
The tabs drawer is hidden after closing the last tab so you need to re-open the tab drawer to see the tab restore with Undo.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture