### PR TITLE
Remove un-needed nullables

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserAnimator.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserAnimator.kt
@@ -18,6 +18,7 @@ import mozilla.components.concept.engine.EngineView
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.toolbar.ToolbarPosition
 import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.utils.Settings
 import java.lang.ref.WeakReference
 
 /**
@@ -29,6 +30,7 @@ class BrowserAnimator(
     private val engineView: WeakReference<EngineView>,
     private val swipeRefresh: WeakReference<View>,
     private val viewLifecycleScope: WeakReference<LifecycleCoroutineScope>,
+    private val settings: Settings,
     private val firstContentfulHappened: () -> Boolean
 ) {
 
@@ -39,7 +41,7 @@ class BrowserAnimator(
         get() = swipeRefresh.get()
 
     fun beginAnimateInIfNecessary() {
-        if (unwrappedSwipeRefresh?.context?.settings()?.waitToShowPageUntilFirstPaint == true) {
+        if (settings.waitToShowPageUntilFirstPaint) {
             if (firstContentfulHappened()) {
                 viewLifecycleScope.get()?.launch {
                     delay(ANIMATION_DELAY)

--- a/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
@@ -113,8 +113,11 @@ class SearchFragment : Fragment(), UserInteractionHandler {
             searchController
         )
 
-        awesomeBarView = AwesomeBarView(requireContext(), searchInteractor,
-            view.findViewById(R.id.awesomeBar))
+        awesomeBarView = AwesomeBarView(
+            activity,
+            searchInteractor,
+            view.findViewById(R.id.awesomeBar)
+        )
         setShortcutsChangedListener(CustomSearchEngineStore.PREF_FILE_SEARCH_ENGINES)
         setShortcutsChangedListener(FenixSearchEngineProvider.PREF_FILE_SEARCH_ENGINES)
 

--- a/app/src/main/java/org/mozilla/fenix/searchdialog/SearchDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/searchdialog/SearchDialogFragment.kt
@@ -99,12 +99,13 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
     ): View? {
         val args by navArgs<SearchDialogFragmentArgs>()
         val view = inflater.inflate(R.layout.fragment_search_dialog, container, false)
+        val activity = requireActivity() as HomeActivity
 
         requireComponents.analytics.metrics.track(Event.InteractWithSearchURLArea)
 
         store = SearchDialogFragmentStore(
             createInitialSearchFragmentState(
-                activity as HomeActivity,
+                activity,
                 requireComponents,
                 tabId = args.sessionId,
                 pastedText = args.pastedText,
@@ -114,7 +115,7 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
 
         interactor = SearchDialogInteractor(
             SearchDialogController(
-                activity = requireActivity() as HomeActivity,
+                activity = activity,
                 sessionManager = requireComponents.core.sessionManager,
                 store = store,
                 navController = findNavController(),
@@ -137,7 +138,7 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
         ).also(::addSearchButton)
 
         awesomeBarView = AwesomeBarView(
-            requireContext(),
+            activity,
             interactor,
             view.awesome_bar
         )

--- a/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsExceptionsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsExceptionsFragment.kt
@@ -118,8 +118,8 @@ class SitePermissionsExceptionsFragment :
         }
     }
 
-    override fun onClick(view: View?) {
-        val sitePermissions = view?.tag as SitePermissions
+    override fun onClick(view: View) {
+        val sitePermissions = view.tag as SitePermissions
         val directions = SitePermissionsExceptionsFragmentDirections
             .actionSitePermissionsToExceptionsToSitePermissionsDetails(sitePermissions)
         nav(R.id.sitePermissionsExceptionsFragment, directions)


### PR DESCRIPTION
There are various spots where we could hold a reference to a singleton or simply crash if an asset is missing.