### PR TITLE
Closes #13759: In edit bookmarks, the x button disappears after pressing backspace

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/utils/ClearableEditText.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/ClearableEditText.kt
@@ -46,7 +46,9 @@ class ClearableEditText @JvmOverloads constructor(
      * Displays a clear icon if text has been entered.
      */
     override fun onTextChanged(text: CharSequence?, start: Int, lengthBefore: Int, lengthAfter: Int) {
-        val drawable = if (shouldShowClearButton(lengthAfter)) {
+        // lengthAfter has inconsistent behaviour when there are spaces in the entered text, so we'll use text.length.
+        val textLength = text?.length ?: 0
+        val drawable = if (shouldShowClearButton(textLength)) {
             AppCompatResources.getDrawable(context, R.drawable.ic_clear)?.apply {
                 colorFilter = createBlendModeColorFilterCompat(context.getColorFromAttr(R.attr.primaryText), SRC_IN)
             }


### PR DESCRIPTION
When pressing backspace over whitespace in a ClearableEditText, the clear icon would disappear. This was due to the inconsistent behavior of the lengthAfter parameter in onTextChanged(), which would reset itself when it encountered whitespace. I fixed this by using text.length. No tests required for this change.

### Before
![before](https://user-images.githubusercontent.com/31454851/90176612-dd782100-dd6e-11ea-8b65-bfca01dee80f.png)

### After
![after](https://user-images.githubusercontent.com/31454851/90176351-6a6eaa80-dd6e-11ea-887c-38aa970d2e46.png)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture