### PR TITLE
For issue #12796: Ensure Cookie purging is only active in nightly or debug

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/TrackingProtectionPolicyFactory.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/TrackingProtectionPolicyFactory.kt
@@ -4,7 +4,10 @@
 
 package org.mozilla.fenix.components
 
+import androidx.annotation.VisibleForTesting
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
+import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicyForSessionTypes
+import org.mozilla.fenix.Config
 import org.mozilla.fenix.utils.Settings
 
 /**
@@ -34,9 +37,9 @@ class TrackingProtectionPolicyFactory(private val settings: Settings) {
             }
 
         return when {
-            normalMode && privateMode -> trackingProtectionPolicy
-            normalMode && !privateMode -> trackingProtectionPolicy.forRegularSessionsOnly()
-            !normalMode && privateMode -> trackingProtectionPolicy.forPrivateSessionsOnly()
+            normalMode && privateMode -> trackingProtectionPolicy.adaptPolicyToChannel()
+            normalMode && !privateMode -> trackingProtectionPolicy.adaptPolicyToChannel().forRegularSessionsOnly()
+            !normalMode && privateMode -> trackingProtectionPolicy.adaptPolicyToChannel().forPrivateSessionsOnly()
             else -> TrackingProtectionPolicy.none()
         }
     }
@@ -44,7 +47,8 @@ class TrackingProtectionPolicyFactory(private val settings: Settings) {
     private fun createCustomTrackingProtectionPolicy(): TrackingProtectionPolicy {
         return TrackingProtectionPolicy.select(
             cookiePolicy = getCustomCookiePolicy(),
-            trackingCategories = getCustomTrackingCategories()
+            trackingCategories = getCustomTrackingCategories(),
+            cookiePurging = Config.channel.isNightlyOrDebug
         ).let {
             if (settings.blockTrackingContentSelectionInCustomTrackingProtection == "private") {
                 it.forPrivateSessionsOnly()
@@ -90,4 +94,14 @@ class TrackingProtectionPolicyFactory(private val settings: Settings) {
 
         return categories.toTypedArray()
     }
+}
+
+@VisibleForTesting
+internal fun TrackingProtectionPolicyForSessionTypes.adaptPolicyToChannel(): TrackingProtectionPolicyForSessionTypes {
+    return TrackingProtectionPolicy.select(
+        trackingCategories = trackingCategories,
+        cookiePolicy = cookiePolicy,
+        strictSocialTrackingProtection = strictSocialTrackingProtection,
+        cookiePurging = Config.channel.isNightlyOrDebug
+    )
 }


### PR DESCRIPTION
We only want this feature active on nightly or debug for the moment.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture