### PR TITLE
For #13761: Add a11y change listener after toolbar is initialized.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -188,6 +188,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Session
 
     final override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         browserInitialized = initializeUI(view) != null
+        requireContext().accessibilityManager.addAccessibilityStateChangeListener(this)
     }
 
     @Suppress("ComplexMethod", "LongMethod")
@@ -756,7 +757,6 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Session
         super.onStart()
         requireComponents.core.sessionManager.register(this, this, autoPause = true)
         sitePermissionWifiIntegration.get()?.maybeAddWifiConnectedListener()
-        requireContext().accessibilityManager.addAccessibilityStateChangeListener(this)
     }
 
     @CallSuper
@@ -1062,9 +1062,9 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Session
      */
     override fun onDestroyView() {
         super.onDestroyView()
+        requireContext().accessibilityManager.removeAccessibilityStateChangeListener(this)
         _browserToolbarView = null
         _browserInteractor = null
-        requireContext().accessibilityManager.removeAccessibilityStateChangeListener(this)
     }
 
     companion object {


### PR DESCRIPTION
Also removed it before reference is removed in onDestroy.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture