### PR TITLE
For #8765: Use shared list widget in tab history

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabhistory/TabHistoryAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabhistory/TabHistoryAdapter.kt
@@ -8,6 +8,7 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
+import mozilla.components.ui.widgets.WidgetSiteItemView
 import org.mozilla.fenix.R
 
 data class TabHistoryItem(
@@ -23,7 +24,7 @@ class TabHistoryAdapter(
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TabHistoryViewHolder {
         val view = LayoutInflater.from(parent.context)
-            .inflate(R.layout.tab_history_list_item, parent, false)
+            .inflate(R.layout.site_list_item, parent, false) as WidgetSiteItemView
         return TabHistoryViewHolder(view, interactor)
     }
 

--- a/app/src/main/java/org/mozilla/fenix/tabhistory/TabHistoryViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabhistory/TabHistoryViewHolder.kt
@@ -4,40 +4,38 @@
 
 package org.mozilla.fenix.tabhistory
 
-import android.view.View
-import androidx.core.view.isVisible
-import kotlinx.android.synthetic.main.tab_history_list_item.*
+import androidx.recyclerview.widget.RecyclerView
+import mozilla.components.browser.icons.BrowserIcons
 import mozilla.components.support.ktx.android.content.getColorFromAttr
+import mozilla.components.ui.widgets.WidgetSiteItemView
 import org.mozilla.fenix.R
-import org.mozilla.fenix.library.LibrarySiteItemView
-import org.mozilla.fenix.utils.view.ViewHolder
+import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.loadIntoView
 
 class TabHistoryViewHolder(
-    view: View,
-    private val interactor: TabHistoryViewInteractor
-) : ViewHolder(view) {
+    private val view: WidgetSiteItemView,
+    private val interactor: TabHistoryViewInteractor,
+    private val icons: BrowserIcons = view.context.components.core.icons
+) : RecyclerView.ViewHolder(view) {
 
     private lateinit var item: TabHistoryItem
 
     init {
-        history_layout.setOnClickListener { interactor.goToHistoryItem(item) }
+        view.setOnClickListener { interactor.goToHistoryItem(item) }
     }
 
     fun bind(item: TabHistoryItem) {
         this.item = item
 
-        history_layout.displayAs(LibrarySiteItemView.ItemType.SITE)
-        history_layout.overflowView.isVisible = false
-        history_layout.titleView.text = item.title
-        history_layout.urlView.text = item.url
-        history_layout.loadFavicon(item.url)
+        view.setText(label = item.title, caption = item.url)
+        icons.loadIntoView(view.iconView, item.url)
 
         if (item.isSelected) {
-            history_layout.setBackgroundColor(
-                history_layout.context.getColorFromAttr(R.attr.tabHistoryItemSelectedBackground)
+            view.setBackgroundColor(
+                view.context.getColorFromAttr(R.attr.tabHistoryItemSelectedBackground)
             )
         } else {
-            history_layout.background = null
+            view.background = null
         }
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/tabhistory/TabHistoryAdapterTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabhistory/TabHistoryAdapterTest.kt
@@ -5,15 +5,13 @@
 package org.mozilla.fenix.tabhistory
 
 import android.content.Context
-import android.graphics.drawable.ColorDrawable
 import android.widget.FrameLayout
 import androidx.appcompat.view.ContextThemeWrapper
 import io.mockk.MockKAnnotations
 import io.mockk.impl.annotations.MockK
-import kotlinx.android.synthetic.main.history_list_item.*
-import mozilla.components.support.ktx.android.content.getColorFromAttr
+import io.mockk.spyk
+import io.mockk.verify
 import mozilla.components.support.test.robolectric.testContext
-import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -56,18 +54,13 @@ class TabHistoryAdapterTest {
     fun `creates and binds view holder`() {
         adapter.submitList(listOf(selectedItem, unselectedItem))
 
-        val holder = adapter.createViewHolder(parent, 0)
+        val holder = spyk(adapter.createViewHolder(parent, 0))
 
         adapter.bindViewHolder(holder, 0)
-        assertEquals("Mozilla", holder.history_layout.titleView.text)
-        assertEquals(
-            context.getColorFromAttr(R.attr.tabHistoryItemSelectedBackground),
-            (holder.history_layout.background as ColorDrawable).color
-        )
+        verify { holder.bind(selectedItem) }
 
         adapter.bindViewHolder(holder, 1)
-        assertEquals("Firefox", holder.history_layout.titleView.text)
-        assertEquals(null, holder.history_layout.background)
+        verify { holder.bind(unselectedItem) }
     }
 
     @Test

--- a/app/src/test/java/org/mozilla/fenix/tabhistory/TabHistoryViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabhistory/TabHistoryViewHolderTest.kt
@@ -10,28 +10,42 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import mozilla.components.browser.icons.BrowserIcons
+import mozilla.components.browser.icons.IconRequest
+import mozilla.components.ui.widgets.WidgetSiteItemView
 import org.junit.Before
 import org.junit.Test
-import org.mozilla.fenix.R
-import org.mozilla.fenix.library.LibrarySiteItemView
 
 class TabHistoryViewHolderTest {
 
-    @MockK private lateinit var view: View
+    @MockK(relaxed = true) private lateinit var view: WidgetSiteItemView
     @MockK private lateinit var interactor: TabHistoryViewInteractor
-    @MockK(relaxed = true) private lateinit var siteItemView: LibrarySiteItemView
+    @MockK private lateinit var icons: BrowserIcons
     private lateinit var holder: TabHistoryViewHolder
     private lateinit var onClick: CapturingSlot<View.OnClickListener>
+
+    private val selectedItem = TabHistoryItem(
+        title = "Mozilla",
+        url = "https://mozilla.org",
+        index = 0,
+        isSelected = true
+    )
+    private val unselectedItem = TabHistoryItem(
+        title = "Firefox",
+        url = "https://firefox.com",
+        index = 1,
+        isSelected = false
+    )
 
     @Before
     fun setup() {
         MockKAnnotations.init(this)
         onClick = slot()
 
-        every { siteItemView.setOnClickListener(capture(onClick)) } just Runs
-        every { view.findViewById<LibrarySiteItemView>(R.id.history_layout) } returns siteItemView
+        every { view.setOnClickListener(capture(onClick)) } just Runs
+        every { icons.loadIntoView(view.iconView, any()) } returns mockk()
 
-        holder = TabHistoryViewHolder(view, interactor)
+        holder = TabHistoryViewHolder(view, interactor, icons)
     }
 
     @Test
@@ -46,17 +60,18 @@ class TabHistoryViewHolderTest {
 
     @Test
     fun `binds title and url`() {
-        val item = TabHistoryItem(
-            title = "Firefox",
-            url = "https://firefox.com",
-            index = 1,
-            isSelected = false
-        )
-        holder.bind(item)
+        holder.bind(unselectedItem)
 
-        verify { siteItemView.displayAs(LibrarySiteItemView.ItemType.SITE) }
-        verify { siteItemView.titleView.text = "Firefox" }
-        verify { siteItemView.urlView.text = "https://firefox.com" }
-        verify { siteItemView.loadFavicon("https://firefox.com") }
+        verify { view.setText(label = "Firefox", caption = "https://firefox.com") }
+        verify { icons.loadIntoView(view.iconView, IconRequest("https://firefox.com")) }
+    }
+
+    @Test
+    fun `binds background`() {
+        holder.bind(selectedItem)
+        verify { view.setBackgroundColor(any()) }
+
+        holder.bind(unselectedItem)
+        verify { view.background = null }
     }
 }


### PR DESCRIPTION
Waiting on https://github.com/mozilla-mobile/android-components/pull/7900

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture