### PR TITLE
Fix the comment of TextViewAndroidSrcXmlDetector.

### DIFF
--- a/mozilla-lint-rules/src/main/java/org/mozilla/fenix/lintrules/TextViewAndroidSrcXmlDetector.kt
+++ b/mozilla-lint-rules/src/main/java/org/mozilla/fenix/lintrules/TextViewAndroidSrcXmlDetector.kt
@@ -23,7 +23,7 @@ import com.android.tools.lint.detector.api.XmlContext
 import org.w3c.dom.Element
 
 /**
- * A custom lint check that prohibits not using the app:srcCompat for ImageViews
+ * A custom lint check that prohibits not using the android:drawableX to define drawables in TextViews
  */
 class TextViewAndroidSrcXmlDetector : ResourceXmlDetector() {
     companion object {


### PR DESCRIPTION
The comment of `TextViewAndroidSrcXmlDetector` looks copied from `AndroidSrcXmlDetector`.
Fix it according to the explanation of this custom lint check.