### PR TITLE
Fixes for A-C: Move EngineSession to BrowserState

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import mozilla.appservices.Megazord
 import mozilla.components.browser.session.Session
+import mozilla.components.browser.state.action.SystemAction
 import mozilla.components.concept.push.PushProcessor
 import mozilla.components.feature.addons.update.GlobalAddonDependencyProvider
 import mozilla.components.lib.crash.CrashReporter
@@ -318,7 +319,7 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
 
         runOnlyInMainProcess {
             components.core.icons.onTrimMemory(level)
-            components.core.sessionManager.onTrimMemory(level)
+            components.core.store.dispatch(SystemAction.LowMemoryAction(level))
         }
     }
 

--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -59,7 +59,6 @@ import mozilla.components.feature.readerview.ReaderViewFeature
 import mozilla.components.feature.session.FullScreenFeature
 import mozilla.components.feature.session.PictureInPictureFeature
 import mozilla.components.feature.session.SessionFeature
-import mozilla.components.feature.session.SessionUseCases
 import mozilla.components.feature.session.SwipeRefreshFeature
 import mozilla.components.feature.session.behavior.EngineViewBottomBehavior
 import mozilla.components.feature.sitepermissions.SitePermissions
@@ -481,7 +480,6 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Session
                 feature = SessionFeature(
                     requireComponents.core.store,
                     requireComponents.useCases.sessionUseCases.goBack,
-                    requireComponents.useCases.engineSessionUseCases,
                     view.engineView,
                     customTabSessionId
                 ),
@@ -536,7 +534,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Session
             fullScreenFeature.set(
                 feature = FullScreenFeature(
                     requireComponents.core.store,
-                    SessionUseCases(sessionManager),
+                    requireComponents.useCases.sessionUseCases,
                     customTabSessionId,
                     ::viewportFitChange,
                     ::fullScreenChanged

--- a/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -15,7 +15,9 @@ import kotlinx.coroutines.withContext
 import mozilla.components.browser.engine.gecko.GeckoEngine
 import mozilla.components.browser.engine.gecko.fetch.GeckoViewFetchClient
 import mozilla.components.browser.icons.BrowserIcons
+import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
+import mozilla.components.browser.session.engine.EngineMiddleware
 import mozilla.components.browser.session.storage.SessionStorage
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.store.BrowserStore
@@ -134,8 +136,12 @@ class Core(private val context: Context) {
                 DownloadMiddleware(context, DownloadService::class.java),
                 ReaderViewMiddleware(),
                 ThumbnailsMiddleware(thumbnailStorage)
-            )
+            ) + EngineMiddleware.create(engine, ::findSessionById)
         )
+    }
+
+    private fun findSessionById(tabId: String): Session? {
+        return sessionManager.findSessionById(tabId)
     }
 
     /**
@@ -184,7 +190,7 @@ class Core(private val context: Context) {
 
                 // Now that we have restored our previous state (if there's one) let's setup auto saving the state while
                 // the app is used.
-                sessionStorage.autoSave(sessionManager)
+                sessionStorage.autoSave(store)
                     .periodicallyInForeground(interval = 30, unit = TimeUnit.SECONDS)
                     .whenGoingToBackground()
                     .whenSessionsChange()

--- a/app/src/main/java/org/mozilla/fenix/components/UseCases.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/UseCases.kt
@@ -7,7 +7,6 @@ package org.mozilla.fenix.components
 import android.content.Context
 import mozilla.components.browser.search.SearchEngineManager
 import mozilla.components.browser.session.SessionManager
-import mozilla.components.browser.session.usecases.EngineSessionUseCases
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.Engine
 import mozilla.components.feature.app.links.AppLinksUseCases
@@ -39,7 +38,7 @@ class UseCases(
     /**
      * Use cases that provide engine interactions for a given browser session.
      */
-    val sessionUseCases by lazy { SessionUseCases(sessionManager) }
+    val sessionUseCases by lazy { SessionUseCases(store, sessionManager) }
 
     /**
      * Use cases that provide tab management.
@@ -49,7 +48,7 @@ class UseCases(
     /**
      * Use cases that provide search engine integration.
      */
-    val searchUseCases by lazy { SearchUseCases(context, searchEngineManager, sessionManager) }
+    val searchUseCases by lazy { SearchUseCases(context, store, searchEngineManager, sessionManager) }
 
     /**
      * Use cases that provide settings management.
@@ -65,8 +64,6 @@ class UseCases(
     val downloadUseCases by lazy { DownloadsUseCases(store) }
 
     val contextMenuUseCases by lazy { ContextMenuUseCases(store) }
-
-    val engineSessionUseCases by lazy { EngineSessionUseCases(sessionManager) }
 
     val trackingProtectionUseCases by lazy { TrackingProtectionUseCases(store, engine) }
 }


### PR DESCRIPTION
Preparing for breaking changes in A-C: https://github.com/mozilla-mobile/android-components/pull/8121

We continue our refactoring to browser store/state. This part moves the engine session to the `BrowserStore` entirely, and no longer keeps it in `SessionManager`. The goal is to get rid of `SessionManager` eventually.