### PR TITLE
FNX2-15653:checks blanks name in homescreen shortcut name

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/shortcut/CreateShortcutFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/shortcut/CreateShortcutFragment.kt
@@ -5,6 +5,7 @@
 package org.mozilla.fenix.shortcut
 
 import android.os.Bundle
+import android.text.Editable
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -41,7 +42,7 @@ class CreateShortcutFragment : DialogFragment() {
 
             cancel_button.setOnClickListener { dismiss() }
             add_button.setOnClickListener {
-                val text = shortcut_text.text.toString()
+                val text = shortcut_text.text.toString().trim()
                 requireActivity().lifecycleScope.launch {
                     requireComponents.useCases.webAppUseCases.addToHomescreen(text)
                 }
@@ -57,9 +58,12 @@ class CreateShortcutFragment : DialogFragment() {
     }
 
     private fun updateAddButtonEnabledState() {
-        add_button.isEnabled = shortcut_text.text.isNotEmpty()
-        add_button.alpha = if (shortcut_text.text.isNotEmpty()) ENABLED_ALPHA else DISABLED_ALPHA
+        val text = shortcut_text.text
+        add_button.isEnabled = isTextValid(text)
+        add_button.alpha = if (isTextValid(text)) ENABLED_ALPHA else DISABLED_ALPHA
     }
+
+    private fun isTextValid(text: Editable) = text.isNotEmpty() && !text.isBlank()
 
     companion object {
         private const val ENABLED_ALPHA = 1.0f


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

**### Fixes the following issue(s)**

- fixes - [15653](https://github.com/mozilla-mobile/fenix/issues/13069)

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture



@NotWoods 
The test is not Done as
   - this fix deals with `CreateShortcutFragment` part . 
  
Screenshot:
<img width="274" alt="Screenshot 2020-08-20 at 2 26 16 PM" src="https://user-images.githubusercontent.com/47107708/90750886-12e2b880-e2f3-11ea-8f51-586987c2584f.png">   <img width="289" alt="Screenshot 2020-08-20 at 2 39 57 PM" src="https://user-images.githubusercontent.com/47107708/90750918-1b3af380-e2f3-11ea-9fa8-9bdbddd0e303.png">





