### PR TITLE
Closes #11944: changes the way the system notifications are tested

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/DownloadTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/DownloadTest.kt
@@ -21,6 +21,7 @@ import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.ui.robots.downloadRobot
 import org.mozilla.fenix.ui.robots.homeScreen
 import org.mozilla.fenix.ui.robots.navigationToolbar
+import org.mozilla.fenix.ui.robots.notificationShade
 import java.io.File
 
 /**
@@ -92,10 +93,7 @@ class DownloadTest {
     }
 
     @Test
-    @Ignore("Temp disable flakey test - see: https://github.com/mozilla-mobile/fenix/issues/5462")
     fun testDownloadNotification() {
-        homeScreen { }.dismissOnboarding()
-
         val defaultWebPage = TestAssetHelper.getDownloadAsset(mockWebServer)
 
         navigationToolbar {
@@ -108,7 +106,13 @@ class DownloadTest {
             verifyDownloadPrompt()
         }.clickDownload {
             verifyDownloadNotificationPopup()
-            verifyDownloadNotificationShade()
         }
+
+        mDevice.openNotification()
+        notificationShade {
+            verifySystemNotificationExists("Download completed")
+        }
+        // close notification shade before the next test
+        mDevice.pressBack()
     }
 }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/DownloadRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/DownloadRobot.kt
@@ -37,8 +37,6 @@ class DownloadRobot {
 
     fun verifyDownloadNotificationPopup() = assertDownloadNotificationPopup()
 
-    fun verifyDownloadNotificationShade() = assertDownloadNotificationShade()
-
     fun verifyPhotosAppOpens() = assertPhotosOpens()
 
     class Transition {
@@ -96,17 +94,6 @@ fun downloadRobot(interact: DownloadRobot.() -> Unit): DownloadRobot.Transition 
 
 private fun assertDownloadPrompt() {
     mDevice.waitNotNull(Until.findObjects(By.res("org.mozilla.fenix.debug:id/download_button")))
-}
-
-private fun assertDownloadNotificationShade() {
-    val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-    mDevice.openNotification()
-    mDevice.waitNotNull(
-        Until.findObjects(By.text("Download completed")), TestAssetHelper.waitingTime
-    )
-
-    // Go home (no UIDevice closeNotification) to close notification shade
-    mDevice.pressHome()
 }
 
 private fun assertDownloadNotificationPopup() {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NotificationRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NotificationRobot.kt
@@ -1,11 +1,12 @@
 package org.mozilla.fenix.ui.robots
 
-import android.content.res.Resources
 import androidx.test.uiautomator.By.text
+import androidx.test.uiautomator.UiObjectNotFoundException
 import androidx.test.uiautomator.UiScrollable
 import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.ext.waitNotNull
 
@@ -17,23 +18,21 @@ class NotificationRobot {
             UiSelector().resourceId("com.android.systemui:id/notification_stack_scroller")
         )
 
-        mDevice.waitNotNull(
-            Until.hasObject(text(notificationMessage)),
-            waitingTime
-        )
+        val notificationFound: Boolean
 
-        var notificationFound = false
-        while (!notificationFound) {
-            try {
-                val notification = notificationTray().getChildByText(
-                    UiSelector().text(notificationMessage), notificationMessage,
-                    true
-                )
-                notification.exists()
-                notificationFound = true
-            } catch (e: Resources.NotFoundException) {
-                e.printStackTrace()
-            }
+        notificationFound = try {
+            notificationTray().getChildByText(
+                UiSelector().text(notificationMessage), notificationMessage, true
+            ).exists()
+        } catch (e: UiObjectNotFoundException) {
+            false
+        }
+
+        if (!notificationFound) {
+            // swipe 2 times to expand the silent notifications on API 28 and higher, single-swipe doesn't do it
+            notificationTray().swipeUp(2)
+            val notification = mDevice.findObject(UiSelector().textContains(notificationMessage))
+            assertTrue(notification.exists())
         }
     }
 


### PR DESCRIPTION
Firebase tests runs on API 28: https://github.com/mozilla-mobile/fenix/runs/1008390539 (which used to fail before this)
Tests passed locally on API 27.
