### PR TITLE
For #11465  - Fix default engine for widget voice search

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/search/SearchEngineListPreference.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/search/SearchEngineListPreference.kt
@@ -102,6 +102,10 @@ abstract class SearchEngineListPreference @JvmOverloads constructor(
             engineItem.tag = engineId
             if (engineId == selectedEngine) {
                 updateDefaultItem(engineItem.radio_button)
+                /* #11465 -> radio_button.isChecked = true does not trigger
+                * onSearchEngineSelected because searchEngineGroup has null views at that point.
+                * So we trigger it here.*/
+                onSearchEngineSelected(engine)
             }
             searchEngineGroup!!.addView(engineItem, layoutParams)
         }

--- a/app/src/main/java/org/mozilla/fenix/settings/search/SearchEngineListPreference.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/search/SearchEngineListPreference.kt
@@ -76,6 +76,11 @@ abstract class SearchEngineListPreference @JvmOverloads constructor(
             it.identifier == defaultEngine
         } ?: searchEngineList.list.first()).identifier
 
+        context.components.search.searchEngineManager.defaultSearchEngine =
+            searchEngineList.list.find {
+                it.identifier == selectedEngine
+            }
+
         searchEngineGroup!!.removeAllViews()
 
         val layoutInflater = LayoutInflater.from(context)


### PR DESCRIPTION
For https://github.com/mozilla-mobile/fenix/issues/11465

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR does not include any tests as it is only a minor change.
- [x] **Screenshots**: This PR includes a GIF.
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).
### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

![voice widget](https://user-images.githubusercontent.com/60002907/90891249-17c36d00-e3c4-11ea-89c2-1db3c610099d.gif)
