### PR TITLE
For #8343, #9709 - replace "phone" with "device" in translations

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingAutomaticSignInViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingAutomaticSignInViewHolder.kt
@@ -41,7 +41,7 @@ class OnboardingAutomaticSignInViewHolder(
     fun bind(account: ShareableAccount) {
         shareableAccount = account
         headerText.text = itemView.context.getString(
-            R.string.onboarding_firefox_account_auto_signin_header_2, account.email
+            R.string.onboarding_firefox_account_auto_signin_header_3, account.email
         )
         val icon = getDrawable(itemView.context, R.drawable.ic_onboarding_avatar_anonymous)
         headerText.putCompoundDrawablesRelativeWithIntrinsicBounds(start = icon)

--- a/app/src/main/res/layout/fragment_pwa_onboarding.xml
+++ b/app/src/main/res/layout/fragment_pwa_onboarding.xml
@@ -52,7 +52,7 @@
             android:layout_height="wrap_content"
             android:textColor="?primaryText"
             android:textSize="16sp"
-            android:text="@string/add_to_homescreen_description"
+            android:text="@string/add_to_homescreen_description_2"
             app:layout_constraintStart_toEndOf="@id/home_icon"
             app:layout_constraintTop_toTopOf="@id/home_icon"
             app:layout_constraintEnd_toEndOf="parent" />

--- a/app/src/main/res/layout/onboarding_automatic_signin.xml
+++ b/app/src/main/res/layout/onboarding_automatic_signin.xml
@@ -19,7 +19,7 @@
         android:drawablePadding="12dp"
         android:textAppearance="@style/Header16TextStyle"
         android:textColor="@color/onboarding_card_primary_text_dark"
-        tools:text="@string/onboarding_firefox_account_auto_signin_header_2" />
+        tools:text="@string/onboarding_firefox_account_auto_signin_header_3" />
 
     <Button
         android:id="@+id/fxa_sign_in_button"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1034,7 +1034,7 @@
     <!-- text for the firefox account onboarding card header when we detect you're already signed in to
         another Firefox browser. (The word `Firefox` should not be translated)
         The first parameter is the email of the detected user's account -->
-    <string name="onboarding_firefox_account_auto_signin_header_2">You are signed in as %s on another Firefox browser on this phone. Would you like to sign in with this account?</string>
+    <string name="onboarding_firefox_account_auto_signin_header_3">You are signed in as %s on another Firefox browser on this device. Would you like to sign in with this account?</string>
     <!-- text for the button to confirm automatic sign-in -->
     <string name="onboarding_firefox_account_auto_signin_confirm">Yes, sign me in</string>
     <!-- text for the automatic sign-in button while signing in is in process -->
@@ -1274,7 +1274,7 @@
     <!-- Placeholder text for the TextView in the Add to Homescreen dialog -->
     <string name="add_to_homescreen_text_placeholder">Shortcut name</string>
     <!-- Describes the add to homescreen functionality -->
-    <string name="add_to_homescreen_description">You can easily add this website to your phone’s Home screen to have instant access and browse faster with an app-like experience.</string>
+    <string name="add_to_homescreen_description_2">You can easily add this website to your device’s Home screen to have instant access and browse faster with an app-like experience.</string>
 
     <!-- Preference for managing the settings for logins and passwords in Fenix -->
     <string name="preferences_passwords_logins_and_passwords">Logins and passwords</string>
@@ -1533,4 +1533,8 @@
     <string name="no_collections_header1">Collect the things that matter to you</string>
     <!-- Deprecated: Label to describe what collections are to a new user without any collections -->
     <string name="no_collections_description1">Group together similar searches, sites, and tabs for quick access later.</string>
+    <!-- Deprecated: text for the firefox account onboarding card header when we detect you're already signed in to -->
+    <string name="onboarding_firefox_account_auto_signin_header_2">You are signed in as %s on another Firefox browser on this phone. Would you like to sign in with this account?</string>
+    <!-- Deprecated: Describes the add to homescreen functionality -->
+    <string name="add_to_homescreen_description">You can easily add this website to your phone’s Home screen to have instant access and browse faster with an app-like experience.</string>
 </resources>

--- a/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingAutomaticSignInViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingAutomaticSignInViewHolderTest.kt
@@ -62,7 +62,7 @@ class OnboardingAutomaticSignInViewHolderTest {
             every { email } returns "email@example.com"
         })
         assertEquals(
-            "You are signed in as email@example.com on another Firefox browser on this phone. Would you like to sign in with this account?",
+            "You are signed in as email@example.com on another Firefox browser on this device. Would you like to sign in with this account?",
             view.header_text.text
         )
         assertTrue(view.fxa_sign_in_button.isEnabled)


### PR DESCRIPTION
The change got approval in https://github.com/mozilla-mobile/fenix/issues/8343#issuecomment-620259024 for the one string, and #9709 is exactly the same for another string so it shouldn't need explicit approval.