### PR TITLE
Upgrade to A-C 54.0.4

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -490,9 +490,8 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Session
 
             sessionFeature.set(
                 feature = SessionFeature(
-                    requireComponents.core.store,
+                    requireComponents.core.sessionManager,
                     requireComponents.useCases.sessionUseCases.goBack,
-                    requireComponents.useCases.engineSessionUseCases,
                     view.engineView,
                     customTabSessionId
                 ),

--- a/app/src/main/java/org/mozilla/fenix/components/UseCases.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/UseCases.kt
@@ -7,7 +7,6 @@ package org.mozilla.fenix.components
 import android.content.Context
 import mozilla.components.browser.search.SearchEngineManager
 import mozilla.components.browser.session.SessionManager
-import mozilla.components.browser.session.usecases.EngineSessionUseCases
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.Engine
 import mozilla.components.feature.app.links.AppLinksUseCases
@@ -65,8 +64,6 @@ class UseCases(
     val downloadUseCases by lazy { DownloadsUseCases(store) }
 
     val contextMenuUseCases by lazy { ContextMenuUseCases(store) }
-
-    val engineSessionUseCases by lazy { EngineSessionUseCases(sessionManager) }
 
     val trackingProtectionUseCases by lazy { TrackingProtectionUseCases(store, engine) }
 }

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "54.0.3"
+    const val VERSION = "54.0.4"
 }


### PR DESCRIPTION
We still need to release 54.0.4. This is just preparing the changes needed as we back out a refactoring that landed.