### PR TITLE
For #11180  - Fix for tab tray FAB spot

### DIFF
--- a/app/src/main/res/layout/component_tabstray_fab.xml
+++ b/app/src/main/res/layout/component_tabstray_fab.xml
@@ -9,6 +9,7 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_gravity="bottom|end"
+    android:scrollbars="none"
     android:layout_margin="16dp"
     android:backgroundTint="@color/accent_normal_theme"
     android:contentDescription="@string/add_tab"


### PR DESCRIPTION
For https://github.com/mozilla-mobile/fenix/issues/11180
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR doesn't include any tests as it is only a minor change.
- [x] **Screenshots**: This PR includes a GIF.
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

![fix for tab tray fab](https://user-images.githubusercontent.com/60002907/91179863-ba932880-e6ef-11ea-8716-03cce9a23377.gif)
