### PR TITLE
For #14119 - Add a setting to toggle the display of frequently visited top sites

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/CustomizationFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/CustomizationFragment.kt
@@ -9,7 +9,10 @@ import android.os.Build
 import android.os.Build.VERSION.SDK_INT
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatDelegate
+import androidx.preference.PreferenceCategory
 import androidx.preference.PreferenceFragmentCompat
+import androidx.preference.SwitchPreference
+import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.components.toolbar.ToolbarPosition
@@ -47,6 +50,7 @@ class CustomizationFragment : PreferenceFragmentCompat() {
         bindAutoBatteryTheme()
         setupRadioGroups()
         setupToolbarCategory()
+        setupHomeCategory()
     }
 
     private fun setupRadioGroups() {
@@ -128,5 +132,16 @@ class CustomizationFragment : PreferenceFragmentCompat() {
         bottomPreference.setCheckedWithoutClickListener(toolbarPosition == ToolbarPosition.BOTTOM)
 
         addToRadioGroup(topPreference, bottomPreference)
+    }
+
+    private fun setupHomeCategory() {
+        requirePreference<PreferenceCategory>(R.string.pref_home_category).apply {
+            isVisible = FeatureFlags.topFrecentSite
+        }
+        requirePreference<SwitchPreference>(R.string.pref_key_enable_top_frecent_sites).apply {
+            isVisible = FeatureFlags.topFrecentSite
+            isChecked = context.settings().showTopFrecentSites
+            onPreferenceChangeListener = SharedPreferenceUpdater()
+        }
     }
 }

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -122,6 +122,9 @@
     <string name="pref_key_auto_battery_theme" translatable="false">pref_key_auto_battery_theme</string>
     <string name="pref_key_follow_device_theme" translatable="false">pref_key_follow_device_theme</string>
 
+    <!-- Customization Settings -->
+    <string name="pref_home_category" translatable="false">pref_home_category</string>
+
     <!-- Tracking Protection Settings -->
     <string name="pref_key_etp_learn_more" translatable="false">pref_key_etp_learn_more</string>
     <string name="pref_key_tracking_protection_settings" translatable="false">pref_key_tracking_protection_settings</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -280,6 +280,8 @@
     <string name="preferences_toolbar">Toolbar</string>
     <!-- Preference for changing default theme to dark or light mode -->
     <string name="preferences_theme">Theme</string>
+    <!-- Preference for customizing the home screen -->
+    <string name="preferences_home">Home</string>
     <!-- Preference for settings related to visual options -->
     <string name="preferences_customize">Customize</string>
     <!-- Preference description for banner about signing in -->
@@ -1488,6 +1490,8 @@
     <string name="top_sites_max_limit_content">To add a new top site, remove one. Long press the site and select remove.</string>
     <!-- Confirmation dialog button text when top sites limit is reached. -->
     <string name="top_sites_max_limit_confirmation_button">OK, Got It</string>
+    <!-- Label for the show most visited sites preference -->
+    <string name="top_sites_toggle_top_frecent_sites">Show most visited sites</string>
 
     <!-- Content description for close button in collection placeholder. -->
     <string name="remove_home_collection_placeholder_content_description">Remove</string>

--- a/app/src/main/res/xml/customization_preferences.xml
+++ b/app/src/main/res/xml/customization_preferences.xml
@@ -5,10 +5,10 @@
 <androidx.preference.PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <androidx.preference.PreferenceCategory
+        android:layout="@layout/preference_cat_style"
         android:title="@string/preferences_theme"
-        app:iconSpaceReserved="false"
         app:allowDividerBelow="false"
-        android:layout="@layout/preference_cat_style">
+        app:iconSpaceReserved="false">
         <org.mozilla.fenix.settings.RadioButtonPreference
             android:defaultValue="@bool/underAPI28"
             android:key="@string/pref_key_light_theme"
@@ -33,15 +33,27 @@
     </androidx.preference.PreferenceCategory>
 
     <androidx.preference.PreferenceCategory
+        android:layout="@layout/preference_cat_style"
         android:title="@string/preferences_toolbar"
-        app:iconSpaceReserved="false"
         app:allowDividerAbove="false"
-        android:layout="@layout/preference_cat_style">
+        app:iconSpaceReserved="false">
         <org.mozilla.fenix.settings.RadioButtonPreference
             android:key="@string/pref_key_toolbar_top"
             android:title="@string/preference_top_toolbar" />
         <org.mozilla.fenix.settings.RadioButtonPreference
             android:key="@string/pref_key_toolbar_bottom"
             android:title="@string/preference_bottom_toolbar" />
+    </androidx.preference.PreferenceCategory>
+
+    <androidx.preference.PreferenceCategory
+        android:key="@string/pref_home_category"
+        android:layout="@layout/preference_cat_style"
+        android:title="@string/preferences_home"
+        app:allowDividerAbove="false"
+        app:iconSpaceReserved="false"
+        app:isPreferenceVisible="false">
+        <androidx.preference.SwitchPreference
+            android:key="@string/pref_key_enable_top_frecent_sites"
+            android:title="@string/top_sites_toggle_top_frecent_sites" />
     </androidx.preference.PreferenceCategory>
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
Fixes #14119 

<img width="441" alt="Screen Shot 2020-08-25 at 3 26 33 PM" src="https://user-images.githubusercontent.com/1190888/91218649-62582880-e6e7-11ea-9088-0cd451ed236d.png">

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### After merge
- [ ] **Milestone**: Make sure issues finished by this pull request are added to the [milestone](https://github.com/mozilla-mobile/fenix/milestones) of the version currently in development.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture