### PR TITLE
For #13228: Removes Firebase service dependencies from all builds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -172,6 +172,12 @@ android {
     }
 }
 
+configurations {
+    // Removes unwanted Firebase services that we do not want running (MeasurementBrokerService).
+    // See https://github.com/mozilla-mobile/fenix/issues/13228
+    all*.exclude group: 'com.google.firebase', module: 'firebase-core'
+}
+
 android.applicationVariants.all { variant ->
 
 // -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
We no longer have the MeasurementBrokerService running when the private mode service is running. I've done some simple testing to ensure that WebPush (Firebase) still functions, but it would be better if we could get QA to test this out.

We should also not land this until after the beta release is cut so that it can ride the trains.

<img width="381" alt="Screen Shot 2020-08-25 at 3 41 59 PM" src="https://user-images.githubusercontent.com/1370580/91220989-02fc1780-e6eb-11ea-8140-78e6568e54a1.png">


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture