### PR TITLE
Closes #10911: idling resource registration timing issues

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/RecyclerViewIdlingResource.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/RecyclerViewIdlingResource.kt
@@ -3,13 +3,13 @@ package org.mozilla.fenix.helpers
 import androidx.test.espresso.IdlingResource
 import androidx.test.espresso.IdlingResource.ResourceCallback
 
-class RecyclerViewIdlingResource constructor(private val recycler: androidx.recyclerview.widget.RecyclerView) :
+class RecyclerViewIdlingResource constructor(private val recycler: androidx.recyclerview.widget.RecyclerView, val minItemCount: Int = 0) :
     IdlingResource {
 
     private var callback: ResourceCallback? = null
 
     override fun isIdleNow(): Boolean {
-        if (recycler.adapter != null && recycler.adapter!!.itemCount > 0) {
+        if (recycler.adapter != null && recycler.adapter!!.itemCount > minItemCount) {
             if (callback != null) {
                 callback!!.onTransitionToIdle()
             }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
@@ -113,7 +113,7 @@ class BookmarksTest {
         }.openThreeDotMenu {
         }.openBookmarks {
             bookmarksListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list))
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 1)
             IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
 
             verifyBookmarkedURL(defaultWebPage.url.toString())
@@ -121,21 +121,19 @@ class BookmarksTest {
         }
     }
 
-    @Ignore("Intermittent failures: https://github.com/mozilla-mobile/fenix/issues/10911")
     @Test
     fun createBookmarkFolderTest() {
         homeScreen {
         }.openThreeDotMenu {
         }.openBookmarks {
-            clickAddFolderButton()
-            verifyKeyboardVisible()
-            addNewFolderName(bookmarksFolderName)
-            saveNewFolder()
-
             bookmarksListIdlingResource =
                 RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list))
             IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
 
+            clickAddFolderButton()
+            verifyKeyboardVisible()
+            addNewFolderName(bookmarksFolderName)
+            saveNewFolder()
             verifyFolderTitle(bookmarksFolderName)
             verifyKeyboardHidden()
         }
@@ -163,7 +161,7 @@ class BookmarksTest {
         }.openThreeDotMenu {
         }.openBookmarks {
             bookmarksListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list))
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 1)
             IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
         }.openThreeDotMenu(defaultWebPage.url) {
             IdlingRegistry.getInstance().unregister(bookmarksListIdlingResource!!)
@@ -193,7 +191,7 @@ class BookmarksTest {
         }.openThreeDotMenu {
         }.openBookmarks {
             bookmarksListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list))
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 1)
             IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
         }.openThreeDotMenu(defaultWebPage.url) {
         }.clickCopy {
@@ -210,7 +208,7 @@ class BookmarksTest {
         }.openThreeDotMenu {
         }.openBookmarks {
             bookmarksListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list))
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 1)
             IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
         }.openThreeDotMenu(defaultWebPage.url) {
         }.clickShare {
@@ -230,7 +228,7 @@ class BookmarksTest {
         }.openThreeDotMenu {
         }.openBookmarks {
             bookmarksListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list))
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 1)
             IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
         }.openThreeDotMenu(defaultWebPage.url) {
         }.clickOpenInNewTab {
@@ -249,7 +247,7 @@ class BookmarksTest {
         }.openThreeDotMenu {
         }.openBookmarks {
             bookmarksListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list))
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 1)
             IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
         }.openThreeDotMenu(defaultWebPage.url) {
         }.clickOpenInPrivateTab {
@@ -268,9 +266,10 @@ class BookmarksTest {
         }.openThreeDotMenu {
         }.openBookmarks {
             bookmarksListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list))
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 1)
             IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
         }.openThreeDotMenu(defaultWebPage.url) {
+            IdlingRegistry.getInstance().unregister(bookmarksListIdlingResource!!)
         }.clickDelete {
             verifyDeleteSnackBarText()
             verifyUndoDeleteSnackBarButton()
@@ -306,7 +305,7 @@ class BookmarksTest {
         }.openThreeDotMenu {
         }.openBookmarks {
             bookmarksListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list))
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 1)
             IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
 
             longTapSelectItem(defaultWebPage.url)
@@ -336,7 +335,7 @@ class BookmarksTest {
         }.openThreeDotMenu {
         }.openBookmarks {
             bookmarksListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list))
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 1)
             IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
 
             longTapSelectItem(defaultWebPage.url)
@@ -359,7 +358,7 @@ class BookmarksTest {
         }.openThreeDotMenu {
         }.openBookmarks {
             bookmarksListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list))
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 1)
             IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
 
             longTapSelectItem(defaultWebPage.url)
@@ -384,11 +383,12 @@ class BookmarksTest {
         }.openThreeDotMenu {
         }.openBookmarks {
             bookmarksListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list))
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 1)
             IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
 
             longTapSelectItem(firstWebPage.url)
             longTapSelectItem(secondWebPage.url)
+            IdlingRegistry.getInstance().unregister(bookmarksListIdlingResource!!)
             openActionBarOverflowOrOptionsMenu(activityTestRule.activity)
         }
 
@@ -410,7 +410,7 @@ class BookmarksTest {
         }.openThreeDotMenu {
         }.openBookmarks {
             bookmarksListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list))
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 1)
             IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
 
             longTapSelectItem(defaultWebPage.url)
@@ -466,7 +466,7 @@ class BookmarksTest {
         }.openThreeDotMenu {
         }.openBookmarks {
             bookmarksListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list))
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 1)
             IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
         }.openThreeDotMenu(defaultWebPage.url) {
             IdlingRegistry.getInstance().unregister(bookmarksListIdlingResource!!)

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BookmarksRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BookmarksRobot.kt
@@ -35,6 +35,7 @@ import org.hamcrest.Matchers.containsString
 import org.junit.Assert.assertEquals
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.TestAssetHelper
+import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.click
 import org.mozilla.fenix.helpers.ext.waitNotNull
 
@@ -52,10 +53,7 @@ class BookmarksRobot {
     fun verifyBookmarkedURL(url: String) = assertBookmarkURL(url)
 
     fun verifyFolderTitle(title: String) {
-        mDevice.waitNotNull(
-            Until.findObject(text(title)),
-            TestAssetHelper.waitingTime
-        )
+        mDevice.findObject(UiSelector().text(title)).waitForExists(waitingTime)
         assertFolderTitle(title)
     }
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuMainRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuMainRobot.kt
@@ -164,7 +164,7 @@ class ThreeDotMenuMainRobot {
 
         fun openBookmarks(interact: BookmarksRobot.() -> Unit): BookmarksRobot.Transition {
             onView(withId(R.id.mozac_browser_menu_recyclerView)).perform(ViewActions.swipeDown())
-            mDevice.waitNotNull(Until.findObject(By.text("Bookmarks")), waitingTime)
+            mDevice.findObject(UiSelector().resourceId("R.id.bookmark_list")).waitForExists(waitingTime)
             bookmarksButton().click()
 
             BookmarksRobot().interact()


### PR DESCRIPTION
The Idling resource registration after saving the new folder was returning a null bookmarks list because the AddBookmarksFolderFragment wasn't yet closed and done saving.
Added a minItemCount to the RecyclerViewIdlingResource constructor to wait for all the items expected to be on the list.