### PR TITLE
For #13765 - Fix TopSites item sizes

### DIFF
--- a/app/src/main/res/layout/component_top_sites.xml
+++ b/app/src/main/res/layout/component_top_sites.xml
@@ -3,18 +3,27 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
-<androidx.recyclerview.widget.RecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
+
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/top_sites_list"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_gravity="center_horizontal"
-    android:layout_marginBottom="8dp"
-    android:clipChildren="false"
-    android:clipToPadding="false"
-    android:overScrollMode="never"
-    android:nestedScrollingEnabled="false"
-    app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
-    app:spanCount="4"
-    tools:listitem="@layout/top_site_item" />
+    android:gravity="center_horizontal">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/top_sites_list"
+        android:layout_width="wrap_content"
+        android:minWidth="448dp"
+        android:layout_height="match_parent"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginBottom="8dp"
+        android:clipChildren="false"
+        android:clipToPadding="false"
+        android:overScrollMode="never"
+        android:nestedScrollingEnabled="false"
+        app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
+        app:spanCount="4"
+        tools:listitem="@layout/top_site_item" />
+</LinearLayout>

--- a/app/src/main/res/layout/component_top_sites.xml
+++ b/app/src/main/res/layout/component_top_sites.xml
@@ -3,7 +3,8 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
-
+<!--LinearLayout is used here because we are forced by the view pager
+to keep layout_width="match_parent"-->
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"

--- a/app/src/main/res/layout/top_site_item.xml
+++ b/app/src/main/res/layout/top_site_item.xml
@@ -5,14 +5,20 @@
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/top_site_item"
-    android:layout_width="64dp"
-    android:layout_height="wrap_content"
-    android:padding="8dp"
+    android:layout_width="match_parent"
+    android:layout_height="@dimen/top_sites_item_size"
+    android:layout_marginTop="@dimen/top_sites_item_margin_top"
     android:orientation="vertical">
+
+    <LinearLayout
+        android:layout_width="@dimen/top_sites_item_size"
+        android:layout_height="@dimen/top_sites_item_size"
+        android:layout_gravity="center_horizontal"
+        android:orientation="vertical">
 
     <ImageView
         android:id="@+id/favicon_image"
-        style="@style/Mozac.Widgets.Favicon"
+        style="@style/Mozac.Widgets.TopSite.Favicon"
         android:layout_gravity="center"
         android:importantForAccessibility="no" />
 
@@ -24,6 +30,7 @@
         android:singleLine="true"
         android:textColor="@color/top_site_title_text"
         android:textSize="10sp"
-        android:layout_marginTop="8dp" />
+        android:layout_marginTop="@dimen/top_sites_text_margin_top" />
+    </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/top_site_item.xml
+++ b/app/src/main/res/layout/top_site_item.xml
@@ -13,7 +13,7 @@
 
     <ImageView
         android:id="@+id/favicon_image"
-        style="@style/Mozac.Widgets.TopSite.Favicon"
+        style="@style/TopSite.Favicon"
         android:layout_gravity="center"
         android:importantForAccessibility="no" />
 

--- a/app/src/main/res/layout/top_site_item.xml
+++ b/app/src/main/res/layout/top_site_item.xml
@@ -7,14 +7,9 @@
     android:id="@+id/top_site_item"
     android:layout_width="match_parent"
     android:layout_height="@dimen/top_sites_item_size"
-    android:layout_marginTop="@dimen/top_sites_item_margin_top"
+    android:layout_marginBottom="@dimen/top_sites_item_margin_top"
     android:orientation="vertical">
 
-    <LinearLayout
-        android:layout_width="@dimen/top_sites_item_size"
-        android:layout_height="@dimen/top_sites_item_size"
-        android:layout_gravity="center_horizontal"
-        android:orientation="vertical">
 
     <ImageView
         android:id="@+id/favicon_image"
@@ -24,13 +19,13 @@
 
     <TextView
         android:id="@+id/top_site_title"
-        android:layout_width="match_parent"
+        android:layout_width="64dp"
         android:layout_height="wrap_content"
         android:gravity="center"
         android:singleLine="true"
+        android:layout_gravity="center_horizontal"
         android:textColor="@color/top_site_title_text"
         android:textSize="10sp"
         android:layout_marginTop="@dimen/top_sites_text_margin_top" />
-    </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -169,6 +169,13 @@
     <dimen name="saved_logins_item_margin_start">16dp</dimen>
     <dimen name="saved_logins_item_margin_end">48dp</dimen>
 
+    <!-- Top sites  -->
+    <dimen name="top_sites_favicon_size">40dp</dimen>
+    <dimen name="top_sites_favicon_padding">4dp</dimen>
+    <dimen name="top_sites_item_size">64dp</dimen>
+    <dimen name="top_sites_item_margin_top">12dp</dimen>
+    <dimen name="top_sites_text_margin_top">8dp</dimen>
+
     <!-- a11y -->
     <dimen name="accessibility_min_height">48dp</dimen>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -614,6 +614,14 @@
         <item name="behavior_halfExpandedRatio">0.4</item>
     </style>
 
+    <style name="Mozac.Widgets.TopSite.Favicon" parent="Mozac.Widgets.Favicon">
+        <item name="android:layout_width">@dimen/top_sites_favicon_size</item>
+        <item name="android:layout_height">@dimen/top_sites_favicon_size</item>
+        <item name="android:scaleType">fitCenter</item>
+        <item name="android:padding">@dimen/top_sites_favicon_padding</item>
+        <item name="android:background">@drawable/mozac_widget_favicon_background</item>
+    </style>
+
     <style name="TabTrayFab" parent="Widget.MaterialComponents.ExtendedFloatingActionButton">
         <item name="elevation">90dp</item>
         <item name="android:stateListAnimator">@null</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -614,7 +614,7 @@
         <item name="behavior_halfExpandedRatio">0.4</item>
     </style>
 
-    <style name="Mozac.Widgets.TopSite.Favicon" parent="Mozac.Widgets.Favicon">
+    <style name="TopSite.Favicon" parent="Mozac.Widgets.Favicon">
         <item name="android:layout_width">@dimen/top_sites_favicon_size</item>
         <item name="android:layout_height">@dimen/top_sites_favicon_size</item>
         <item name="android:scaleType">fitCenter</item>


### PR DESCRIPTION
Fixes #13765 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR doesn't include any tests as it is only a minor change.
- [x] **Screenshots**: This PR includes screenshots.
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture


I followed the specs in #13765 as best as I could, however the distance between columns needs to be variable(X value in the screenshot) otherwise wider devices will only have top sites on the left side of their screens. I have also added 12dp spacing between rows as it felt appropriate. You can find further screenshots from a Pixel 3XL (for both orientations) below, please let me know if any more changes are required. 
<img width="638" alt="Screenshot 2020-08-27 at 12 14 15" src="https://user-images.githubusercontent.com/60002907/91425152-7032b880-e863-11ea-947a-b351f565691a.png">
<img src="https://user-images.githubusercontent.com/60002907/91426101-b89ea600-e864-11ea-8fd0-547106850b19.png" width="400">
![device-2020-08-27-123731](https://user-images.githubusercontent.com/60002907/91426117-bdfbf080-e864-11ea-8b99-c06743b70e35.png)

