### PR TITLE
For #13856 - Prevent overscroll in swipe to switch tabs gesture

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/ToolbarGestureHandler.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/ToolbarGestureHandler.kt
@@ -91,27 +91,27 @@ class ToolbarGestureHandler(
         when (getDestination()) {
             is Destination.Tab -> {
                 // Restrict the range of motion for the views so you can't start a swipe in one direction
-                // then move your finger far enough in the other direction and make the content visually
-                // start sliding off screen the other way.
+                // then move your finger far enough or in the other direction and make the content visually
+                // start sliding off screen.
                 tabPreview.translationX = when (gestureDirection) {
                     GestureDirection.RIGHT_TO_LEFT -> min(
                         windowWidth.toFloat() + previewOffset,
                         tabPreview.translationX - distanceX
-                    )
+                    ).coerceAtLeast(0f)
                     GestureDirection.LEFT_TO_RIGHT -> max(
                         -windowWidth.toFloat() - previewOffset,
                         tabPreview.translationX - distanceX
-                    )
+                    ).coerceAtMost(0f)
                 }
                 contentLayout.translationX = when (gestureDirection) {
                     GestureDirection.RIGHT_TO_LEFT -> min(
                         0f,
                         contentLayout.translationX - distanceX
-                    )
+                    ).coerceAtLeast(-windowWidth.toFloat() - previewOffset)
                     GestureDirection.LEFT_TO_RIGHT -> max(
                         0f,
                         contentLayout.translationX - distanceX
-                    )
+                    ).coerceAtMost(windowWidth.toFloat() + previewOffset)
                 }
             }
             is Destination.None -> {


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

----------------------

This was going to be a fix for the overscroll crash: https://github.com/mozilla-mobile/fenix/issues/13856, however that crash no longer happens (maybe it should be marked as resolved?).
Still, even though the crash doesn't occur, the overscroll is still present. This pull request fixes it, similar how chrome does it, by disallowing the scrolling more than the window width + padding length.

1) To make it as simple as possible (only 4 lines) I used the ugly min(...).coerceAtLeast(...) / max(...).coerceAtMost(...) setup that was already used a few lines below. There is a cleaner version in another branch that can be applied if required https://github.com/TrianguloY/fenix/commit/f9da92d51a738ceb7c79e6e47f24a56bd9be64a1

2) Due to the minimal changes I didn't performed any automatic tests, only manual. If automatic tests must be run, I kindly ask for information about which ones and how to run them correctly.

3) The changes can be visualized in the following gifs: (Note: the tab outside the window seems like an android bug and isn't part of this pull request).
Original:
![original](https://user-images.githubusercontent.com/10616202/91476276-0df6a980-e89d-11ea-812a-e27f219489da.gif)
Modification:
![modification](https://user-images.githubusercontent.com/10616202/91476280-0fc06d00-e89d-11ea-888d-d9525e8b2948.gif)

4) This does not include any user facing features nor modify any current screen (other that prevent overscroll).
