### PR TITLE
For #8765: shared selection item widget and bookmarks

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/LibrarySiteItemView.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/LibrarySiteItemView.kt
@@ -20,34 +20,6 @@ import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.increaseTapArea
 import org.mozilla.fenix.ext.loadIntoView
 
-/**
- * Interactor for items that can be selected on the bookmarks and history screens.
- */
-interface SelectionInteractor<T> {
-    /**
-     * Called when an item is tapped to open it.
-     * @param item the tapped item to open.
-     */
-    fun open(item: T)
-
-    /**
-     * Called when an item is long pressed and selection mode is started,
-     * or when selection mode has already started an an item is tapped.
-     * @param item the item to select.
-     */
-    fun select(item: T)
-
-    /**
-     * Called when a selected item is tapped in selection mode and should no longer be selected.
-     * @param item the item to deselect.
-     */
-    fun deselect(item: T)
-}
-
-interface SelectionHolder<T> {
-    val selectedItems: Set<T>
-}
-
 class LibrarySiteItemView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,

--- a/app/src/main/java/org/mozilla/fenix/library/SelectableWidgetSiteItem.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/SelectableWidgetSiteItem.kt
@@ -1,0 +1,135 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.library
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.view.isVisible
+import mozilla.components.concept.menu.MenuController
+import mozilla.components.concept.menu.Orientation
+import mozilla.components.ui.widgets.WidgetSiteItemView
+import org.mozilla.fenix.R
+
+/**
+ * Interactor for items that can be selected on the bookmarks and history screens.
+ */
+interface SelectionInteractor<T> {
+    /**
+     * Called when an item is tapped to open it.
+     * @param item the tapped item to open.
+     */
+    fun open(item: T)
+
+    /**
+     * Called when an item is long pressed and selection mode is started,
+     * or when selection mode has already started an an item is tapped.
+     * @param item the item to select.
+     */
+    fun select(item: T)
+
+    /**
+     * Called when a selected item is tapped in selection mode and should no longer be selected.
+     * @param item the item to deselect.
+     */
+    fun deselect(item: T)
+}
+
+interface SelectionHolder<T> {
+    val selectedItems: Set<T>
+}
+
+/**
+ * Shared UI widget that wraps [WidgetSiteItemView].
+ * Used for showing a website in a list of websites, while allowing items to be checked.
+ */
+class SelectableWidgetSiteItem(
+    root: ViewGroup,
+    inflater: LayoutInflater = LayoutInflater.from(root.context)
+) {
+
+    val context: Context get() = widget.context
+
+    /**
+     * The inner [WidgetSiteItemView] that is wrapped by this class.
+     */
+    val widget =
+        inflater.inflate(R.layout.site_list_item_selectable, root, false) as WidgetSiteItemView
+    private val checkmark: View =
+        inflater.inflate(R.layout.checkbox_item, widget, false)
+
+    init {
+        widget.addIconOverlay(checkmark)
+    }
+
+    /**
+     * Show a check mark above the icon if [isSelected] is true.
+     */
+    fun changeSelected(isSelected: Boolean) {
+        checkmark.isVisible = isSelected
+    }
+
+    /**
+     * Attaches a menu to this item and displays a 3-dot menu button.
+     *
+     * Only call this method if you want to show a menu. The button is hidden by default.
+     * Note that calls to [WidgetSiteItemView.setSecondaryButton] will replace the menu.
+     *
+     * @param menuController Menu controller to handle displaying a menu.
+     */
+    fun attachMenu(menuController: MenuController) {
+        widget.setSecondaryButton(
+            icon = R.drawable.ic_menu,
+            contentDescription = R.string.content_description_menu
+        ) {
+            menuController.show(
+                anchor = it,
+                orientation = Orientation.DOWN
+            )
+        }
+    }
+
+    /**
+     * Sets up selection click listeners.
+     *
+     * Only call this method if you want the user to select items in the list.
+     *
+     * @param item The item that is represented by this widget.
+     * @param holder Class that holds the currently selected items.
+     * @param interactor Interactor that handles selection events.
+     */
+    fun <T> setSelectionInteractor(
+        item: T,
+        holder: SelectionHolder<T>,
+        interactor: SelectionInteractor<T>
+    ) {
+        widget.setOnClickListener {
+            val selected = holder.selectedItems
+            when {
+                selected.isEmpty() -> interactor.open(item)
+                item in selected -> interactor.deselect(item)
+                else -> interactor.select(item)
+            }
+        }
+
+        widget.setOnLongClickListener {
+            if (holder.selectedItems.isEmpty()) {
+                interactor.select(item)
+                true
+            } else {
+                false
+            }
+        }
+
+        widget.iconView.setOnClickListener {
+            if (item in holder.selectedItems) {
+                interactor.deselect(item)
+            } else {
+                interactor.select(item)
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkAdapter.kt
@@ -14,7 +14,7 @@ import androidx.recyclerview.widget.RecyclerView
 import mozilla.appservices.places.BookmarkRoot
 import mozilla.components.concept.storage.BookmarkNode
 import mozilla.components.concept.storage.BookmarkNodeType
-import org.mozilla.fenix.library.LibrarySiteItemView
+import org.mozilla.fenix.library.SelectableWidgetSiteItem
 import org.mozilla.fenix.library.bookmarks.viewholders.BookmarkNodeViewHolder
 import org.mozilla.fenix.library.bookmarks.viewholders.BookmarkSeparatorViewHolder
 
@@ -91,19 +91,19 @@ class BookmarkAdapter(private val emptyView: View, private val interactor: Bookm
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
-        val view = LayoutInflater.from(parent.context).inflate(viewType, parent, false)
-
         return when (viewType) {
-            BookmarkNodeViewHolder.LAYOUT_ID ->
-                BookmarkNodeViewHolder(view as LibrarySiteItemView, interactor)
-            BookmarkSeparatorViewHolder.LAYOUT_ID ->
+            BookmarkNodeViewHolder.VIEW_TYPE ->
+                BookmarkNodeViewHolder(SelectableWidgetSiteItem(parent), interactor)
+            BookmarkSeparatorViewHolder.LAYOUT_ID -> {
+                val view = LayoutInflater.from(parent.context).inflate(viewType, parent, false)
                 BookmarkSeparatorViewHolder(view)
+            }
             else -> throw IllegalStateException("ViewType $viewType does not match to a ViewHolder")
         }
     }
 
     override fun getItemViewType(position: Int) = when (tree[position].type) {
-        BookmarkNodeType.ITEM, BookmarkNodeType.FOLDER -> BookmarkNodeViewHolder.LAYOUT_ID
+        BookmarkNodeType.ITEM, BookmarkNodeType.FOLDER -> BookmarkNodeViewHolder.VIEW_TYPE
         BookmarkNodeType.SEPARATOR -> BookmarkSeparatorViewHolder.LAYOUT_ID
     }
 

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/selectfolder/SelectBookmarkFolderAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/selectfolder/SelectBookmarkFolderAdapter.kt
@@ -4,18 +4,16 @@
 
 package org.mozilla.fenix.library.bookmarks.selectfolder
 
-import android.view.View
 import android.view.ViewGroup
-import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.content.ContextCompat
 import androidx.core.view.updatePaddingRelative
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import kotlinx.android.extensions.LayoutContainer
 import mozilla.components.concept.storage.BookmarkNode
+import mozilla.components.support.ktx.android.content.getDrawableWithTint
 import org.mozilla.fenix.R
-import org.mozilla.fenix.library.LibrarySiteItemView
+import org.mozilla.fenix.library.SelectableWidgetSiteItem
 import org.mozilla.fenix.library.bookmarks.BookmarkNodeWithDepth
 import org.mozilla.fenix.library.bookmarks.BookmarksSharedViewModel
 import org.mozilla.fenix.library.bookmarks.flatNodeList
@@ -33,16 +31,8 @@ class SelectBookmarkFolderAdapter(private val sharedViewModel: BookmarksSharedVi
         submitList(updatedData)
     }
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): BookmarkFolderViewHolder {
-        val view = LibrarySiteItemView(parent.context).apply {
-            layoutParams = ViewGroup.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.WRAP_CONTENT
-            )
-        }
-
-        return BookmarkFolderViewHolder(view)
-    }
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) =
+        BookmarkFolderViewHolder(SelectableWidgetSiteItem(parent))
 
     override fun onBindViewHolder(holder: BookmarkFolderViewHolder, position: Int) {
         val item = getItem(position)
@@ -60,34 +50,24 @@ class SelectBookmarkFolderAdapter(private val sharedViewModel: BookmarksSharedVi
     }
 
     class BookmarkFolderViewHolder(
-        val view: LibrarySiteItemView
-    ) : RecyclerView.ViewHolder(view), LayoutContainer {
-
-        override val containerView get() = view
-
-        init {
-            view.displayAs(LibrarySiteItemView.ItemType.FOLDER)
-            view.overflowView.visibility = View.GONE
-        }
+        private val viewWrapper: SelectableWidgetSiteItem
+    ) : RecyclerView.ViewHolder(viewWrapper.widget) {
 
         fun bind(folder: BookmarkNodeWithDepth, selected: Boolean, onSelect: (BookmarkNode) -> Unit) {
-            view.changeSelected(selected)
-            view.iconView.setImageDrawable(
-                AppCompatResources.getDrawable(
-                    containerView.context,
-                    R.drawable.ic_folder_icon
-                )?.apply {
-                    setTint(ContextCompat.getColor(containerView.context,
-                        R.color.primary_text_light_theme))
-                }
+            viewWrapper.changeSelected(selected)
+            viewWrapper.widget.iconView.setImageDrawable(
+                viewWrapper.context.getDrawableWithTint(
+                    R.drawable.ic_folder_icon,
+                    ContextCompat.getColor(viewWrapper.context, R.color.primary_text_light_theme)
+                )
             )
-            view.titleView.text = folder.node.title
-            view.setOnClickListener {
+            viewWrapper.widget.setText(label = folder.node.title.orEmpty(), caption = null)
+            viewWrapper.widget.setOnClickListener {
                 onSelect(folder.node)
             }
             val pxToIndent = view.resources.getDimensionPixelSize(R.dimen.bookmark_select_folder_indent)
             val padding = pxToIndent * minOf(MAX_DEPTH, folder.depth)
-            view.updatePaddingRelative(start = padding)
+            viewWrapper.widget.updatePaddingRelative(start = padding)
         }
 
         companion object {

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/selectfolder/SelectBookmarkFolderAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/selectfolder/SelectBookmarkFolderAdapter.kt
@@ -65,7 +65,8 @@ class SelectBookmarkFolderAdapter(private val sharedViewModel: BookmarksSharedVi
             viewWrapper.widget.setOnClickListener {
                 onSelect(folder.node)
             }
-            val pxToIndent = view.resources.getDimensionPixelSize(R.dimen.bookmark_select_folder_indent)
+            val pxToIndent = viewWrapper.widget.resources
+                .getDimensionPixelSize(R.dimen.bookmark_select_folder_indent)
             val padding = pxToIndent * minOf(MAX_DEPTH, folder.depth)
             viewWrapper.widget.updatePaddingRelative(start = padding)
         }

--- a/app/src/main/res/layout/checkbox_item.xml
+++ b/app/src/main/res/layout/checkbox_item.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!-- This Source Code Form is subject to the terms of the Mozilla Public
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"

--- a/app/src/main/res/layout/site_list_item_selectable.xml
+++ b/app/src/main/res/layout/site_list_item_selectable.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<mozilla.components.ui.widgets.WidgetSiteItemView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/site_list_item"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:minHeight="@dimen/mozac_widget_site_item_height"
+    android:background="?foundation"
+    android:foreground="?android:attr/selectableItemBackground" />

--- a/app/src/test/java/org/mozilla/fenix/library/SelectableWidgetSiteItemTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/SelectableWidgetSiteItemTest.kt
@@ -1,0 +1,164 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.library
+
+import android.view.LayoutInflater
+import android.view.View
+import io.mockk.Called
+import io.mockk.MockKAnnotations
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import mozilla.components.concept.menu.MenuController
+import mozilla.components.concept.menu.Orientation
+import mozilla.components.ui.widgets.WidgetSiteItemView
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mozilla.fenix.R
+
+class SelectableWidgetSiteItemTest {
+
+    @MockK private lateinit var inflater: LayoutInflater
+    @MockK(relaxed = true) private lateinit var siteItemView: WidgetSiteItemView
+    @MockK(relaxed = true) private lateinit var checkmark: View
+    private lateinit var selectableWidget: SelectableWidgetSiteItem
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this)
+
+        every { inflater.inflate(R.layout.site_list_item_selectable, any(), any()) } returns siteItemView
+        every { inflater.inflate(R.layout.checkbox_item, any(), any()) } returns checkmark
+
+        selectableWidget = SelectableWidgetSiteItem(mockk(), inflater)
+    }
+
+    @Test
+    fun `changeSelected adjusts the visibility of the checkmark`() {
+        selectableWidget.changeSelected(isSelected = true)
+        verify { checkmark.visibility = View.VISIBLE }
+
+        selectableWidget.changeSelected(isSelected = false)
+        verify { checkmark.visibility = View.GONE }
+    }
+
+    @Test
+    fun `attachMenu displays a menu button`() {
+        val menuController = mockk<MenuController> {
+            every { show(any(), orientation = Orientation.DOWN) } returns mockk()
+        }
+        selectableWidget.attachMenu(menuController)
+
+        val onClick = slot<(View) -> Unit>()
+        verify {
+            siteItemView.setSecondaryButton(
+                icon = R.drawable.ic_menu,
+                contentDescription = R.string.content_description_menu,
+                onClickListener = capture(onClick)
+            )
+        }
+
+        val secondaryButton = mockk<View>()
+        onClick.captured(secondaryButton)
+        verify { menuController.show(secondaryButton, orientation = Orientation.DOWN) }
+    }
+
+    @Test
+    fun `setSelectionInteractor sets up onClick listener`() {
+        val item = "test"
+        val interactor = mockk<SelectionInteractor<String>>(relaxed = true)
+        val onClick = slot<View.OnClickListener>()
+        every { siteItemView.setOnClickListener(capture(onClick)) } just Runs
+
+        // nothing selected
+        selectableWidget.setSelectionInteractor(
+            item,
+            MockSelectionHolder(emptySet()),
+            interactor
+        )
+        onClick.captured.onClick(siteItemView)
+        verify { interactor.open(item) }
+
+        // item selected
+        selectableWidget.setSelectionInteractor(
+            item,
+            MockSelectionHolder(setOf(item, "other")),
+            interactor
+        )
+        onClick.captured.onClick(siteItemView)
+        verify { interactor.deselect(item) }
+
+        // item not selected
+        selectableWidget.setSelectionInteractor(
+            item,
+            MockSelectionHolder(setOf("other")),
+            interactor
+        )
+        onClick.captured.onClick(siteItemView)
+        verify { interactor.select(item) }
+    }
+
+    @Test
+    fun `setSelectionInteractor sets up onLongClick listener`() {
+        val item = 10
+        val interactor = mockk<SelectionInteractor<Int>>(relaxed = true)
+        val onLongClick = slot<View.OnLongClickListener>()
+        every { siteItemView.setOnLongClickListener(capture(onLongClick)) } just Runs
+
+        // something selected
+        selectableWidget.setSelectionInteractor(
+            item,
+            MockSelectionHolder(setOf(item, 42)),
+            interactor
+        )
+        assertFalse(onLongClick.captured.onLongClick(siteItemView))
+        verify { interactor wasNot Called }
+
+        // nothing selected
+        selectableWidget.setSelectionInteractor(
+            item,
+            MockSelectionHolder(emptySet()),
+            interactor
+        )
+        assertTrue(onLongClick.captured.onLongClick(siteItemView))
+        verify { interactor.select(item) }
+    }
+
+    @Test
+    fun `setSelectionInteractor sets up icon click listener`() {
+        val item = mockk<Any>()
+        val interactor = mockk<SelectionInteractor<Any>>(relaxed = true)
+        val onClick = slot<View.OnClickListener>()
+        every { siteItemView.iconView.setOnClickListener(capture(onClick)) } just Runs
+
+        // item selected
+        selectableWidget.setSelectionInteractor(
+            item,
+            MockSelectionHolder(setOf(mockk(), item)),
+            interactor
+        )
+        onClick.captured.onClick(siteItemView)
+        verify { interactor.deselect(item) }
+
+        // item not selected
+        selectableWidget.setSelectionInteractor(
+            item,
+            MockSelectionHolder(setOf(mockk())),
+            interactor
+        )
+        onClick.captured.onClick(siteItemView)
+        verify { interactor.select(item) }
+    }
+
+    private class MockSelectionHolder<T>(
+        override val selectedItems: Set<T>
+    ) : SelectionHolder<T>
+}

--- a/app/src/test/java/org/mozilla/fenix/library/bookmarks/viewholders/BookmarkNodeViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/bookmarks/viewholders/BookmarkNodeViewHolderTest.kt
@@ -20,10 +20,7 @@ import mozilla.components.concept.storage.BookmarkNodeType
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
-import org.mozilla.fenix.ext.components
-import org.mozilla.fenix.ext.hideAndDisable
-import org.mozilla.fenix.ext.showAndEnable
-import org.mozilla.fenix.library.LibrarySiteItemView
+import org.mozilla.fenix.library.SelectableWidgetSiteItem
 import org.mozilla.fenix.library.bookmarks.BookmarkFragmentInteractor
 import org.mozilla.fenix.library.bookmarks.BookmarkFragmentState
 import org.mozilla.fenix.library.bookmarks.BookmarkPayload
@@ -31,7 +28,7 @@ import org.mozilla.fenix.library.bookmarks.BookmarkPayload
 class BookmarkNodeViewHolderTest {
 
     @MockK private lateinit var interactor: BookmarkFragmentInteractor
-    @MockK(relaxed = true) private lateinit var siteItemView: LibrarySiteItemView
+    @MockK(relaxed = true) private lateinit var siteItemView: SelectableWidgetSiteItem
     @MockK private lateinit var icons: BrowserIcons
     private lateinit var holder: BookmarkNodeViewHolder
 
@@ -68,10 +65,9 @@ class BookmarkNodeViewHolderTest {
 
         mockkStatic(AppCompatResources::class)
         every { AppCompatResources.getDrawable(any(), any()) } returns mockk(relaxed = true)
-        every { siteItemView.context.components.core.icons } returns icons
-        every { icons.loadIntoView(siteItemView.iconView, any()) } returns mockk()
+        every { icons.loadIntoView(siteItemView.widget.iconView, any()) } returns mockk()
 
-        holder = BookmarkNodeViewHolder(siteItemView, interactor)
+        holder = BookmarkNodeViewHolder(siteItemView, interactor, icons)
     }
 
     @After
@@ -86,11 +82,10 @@ class BookmarkNodeViewHolderTest {
 
         verify {
             siteItemView.setSelectionInteractor(item, mode, interactor)
-            siteItemView.titleView.text = item.title
-            siteItemView.urlView.text = item.url
-            siteItemView.overflowView.showAndEnable()
+            siteItemView.widget.setText(item.title!!, item.url)
+            siteItemView.attachMenu(any())
             siteItemView.changeSelected(false)
-            icons.loadIntoView(siteItemView.iconView, IconRequest(item.url!!))
+            icons.loadIntoView(siteItemView.widget.iconView, IconRequest(item.url!!))
         }
     }
 
@@ -101,9 +96,8 @@ class BookmarkNodeViewHolderTest {
 
         verify {
             siteItemView.setSelectionInteractor(item, mode, interactor)
-            siteItemView.titleView.text = item.title
-            siteItemView.urlView.text = item.url
-            siteItemView.overflowView.hideAndDisable()
+            siteItemView.widget.setText(item.title!!, item.url)
+            siteItemView.widget.removeSecondaryButton()
             siteItemView.changeSelected(true)
         }
     }
@@ -117,13 +111,12 @@ class BookmarkNodeViewHolderTest {
         )
 
         verify(inverse = true) {
-            siteItemView.titleView.text = item.title
-            siteItemView.urlView.text = item.url
-            siteItemView.overflowView.showAndEnable()
-            siteItemView.overflowView.hideAndDisable()
+            siteItemView.widget.setText(item.title!!, item.url)
+            siteItemView.attachMenu(any())
+            siteItemView.widget.removeSecondaryButton()
             siteItemView.changeSelected(any())
         }
-        verify { siteItemView.iconView wasNot Called }
+        verify { siteItemView.widget.iconView wasNot Called }
     }
 
     @Test
@@ -131,7 +124,7 @@ class BookmarkNodeViewHolderTest {
         val item = item.copy(title = null)
         holder.bind(item, BookmarkFragmentState.Mode.Normal(), BookmarkPayload())
 
-        verify { siteItemView.titleView.text = item.url }
+        verify { siteItemView.widget.setText(label = item.url!!, caption = null) }
     }
 
     @Test
@@ -139,7 +132,7 @@ class BookmarkNodeViewHolderTest {
         val item = item.copy(title = " ")
         holder.bind(item, BookmarkFragmentState.Mode.Normal(), BookmarkPayload())
 
-        verify { siteItemView.titleView.text = item.url }
+        verify { siteItemView.widget.setText(label = item.url!!, caption = null) }
     }
 
     @Test
@@ -157,7 +150,7 @@ class BookmarkNodeViewHolderTest {
             )
         )
 
-        verify { siteItemView.titleView.text = item.url }
+        verify { siteItemView.widget.setText(label = item.url!!, caption = null) }
     }
 
     @Test
@@ -175,7 +168,7 @@ class BookmarkNodeViewHolderTest {
             )
         )
 
-        verify { siteItemView.titleView.text = item.url }
+        verify { siteItemView.widget.setText(label = item.url!!, caption = null) }
     }
 
     @Test
@@ -183,16 +176,16 @@ class BookmarkNodeViewHolderTest {
         holder.bind(folder, BookmarkFragmentState.Mode.Normal(), BookmarkPayload())
 
         verify {
-            siteItemView.titleView.text = folder.title
-            siteItemView.overflowView.showAndEnable()
+            siteItemView.widget.setText(label = folder.title!!, caption = null)
+            siteItemView.attachMenu(any())
             siteItemView.changeSelected(false)
         }
 
         holder.bind(folder, BookmarkFragmentState.Mode.Selecting(setOf(folder)), BookmarkPayload())
 
         verify {
-            siteItemView.titleView.text = folder.title
-            siteItemView.overflowView.hideAndDisable()
+            siteItemView.widget.setText(label = folder.title!!, caption = null)
+            siteItemView.widget.removeSecondaryButton()
             siteItemView.changeSelected(true)
         }
     }
@@ -206,9 +199,9 @@ class BookmarkNodeViewHolderTest {
         )
 
         verify(inverse = true) {
-            siteItemView.titleView.text = folder.title
-            siteItemView.overflowView.showAndEnable()
-            siteItemView.overflowView.hideAndDisable()
+            siteItemView.widget.setText(label = folder.title!!, caption = null)
+            siteItemView.attachMenu(any())
+            siteItemView.widget.removeSecondaryButton()
             siteItemView.changeSelected(any())
         }
     }


### PR DESCRIPTION
Builds ontop of #13883 and #14308.

Sets up a wrapper around WidgetSiteItemView that can handle selection, and integrates it with bookmarks.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
