### PR TITLE
For #14354: Update the search shortcuts icon on state update

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/searchdialog/SearchDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/searchdialog/SearchDialogFragment.kt
@@ -40,6 +40,7 @@ import mozilla.components.feature.qr.QrFeature
 import mozilla.components.lib.state.ext.consumeFrom
 import mozilla.components.support.base.feature.UserInteractionHandler
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
+import mozilla.components.support.ktx.android.content.getColorFromAttr
 import mozilla.components.support.ktx.android.content.hasCamera
 import mozilla.components.support.ktx.android.content.res.getSpanned
 import mozilla.components.support.ktx.android.view.hideKeyboard
@@ -253,6 +254,7 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
             updateSearchSuggestionsHintVisibility(it)
             updateClipboardSuggestion(it, requireContext().components.clipboardHandler.url)
             updateToolbarContentDescription(it)
+            updateSearchShortcutsIcon(it)
             toolbarView.update(it)
             awesomeBarView.update(it)
             firstUpdate = false
@@ -413,6 +415,20 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
         toolbarView.view.contentDescription =
             searchState.searchEngineSource.searchEngine.name + ", " + urlView.hint
         urlView?.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
+    }
+
+    private fun updateSearchShortcutsIcon(searchState: SearchFragmentState) {
+        view?.apply {
+            search_engines_shortcut_button.isVisible = searchState.areShortcutsAvailable
+
+            val showShortcuts = searchState.showSearchShortcuts
+            search_engines_shortcut_button.isChecked = showShortcuts
+
+            val color = if (showShortcuts) R.attr.contrastText else R.attr.primaryText
+            search_engines_shortcut_button.compoundDrawables[0]?.setTint(
+                requireContext().getColorFromAttr(color)
+            )
+        }
     }
 
     companion object {


### PR DESCRIPTION
I've copied `updateSearchShortcutsIcon` over from https://github.com/mozilla-mobile/fenix/blob/9a56dcd786c1b1e95ba6f205c290fc6bab45c9f9/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt#L432
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
