### PR TITLE
Remove unneeded tint for ic_link

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarView.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarView.kt
@@ -93,9 +93,6 @@ class AwesomeBarView(
         val components = context.components
         val primaryTextColor = context.getColorFromAttr(R.attr.primaryText)
 
-        val draw = getDrawable(context, R.drawable.ic_link)!!
-        draw.colorFilter = createBlendModeColorFilterCompat(primaryTextColor, SRC_IN)
-
         val engineForSpeculativeConnects =
             if (!isBrowsingModePrivate()) components.core.engine else null
         sessionProvider =

--- a/app/src/main/res/layout/fragment_search_dialog.xml
+++ b/app/src/main/res/layout/fragment_search_dialog.xml
@@ -86,7 +86,6 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:importantForAccessibility="no"
-            app:tint="?primaryText"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"


### PR DESCRIPTION
Turns out we load this icon and don't do anything with it in AwesomeBarView.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
