### PR TITLE
For #11561 - changed inactive heading and menu icon color in dark theme tabs tray

### DIFF
--- a/app/src/main/res/layout/component_tabstray.xml
+++ b/app/src/main/res/layout/component_tabstray.xml
@@ -150,7 +150,7 @@
             android:background="?android:attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/open_tabs_menu"
             android:visibility="visible"
-            app:tint="@color/accent_normal_theme"
+            app:tint="@color/tab_tray_heading_icon_menu_normal_theme"
             app:layout_constraintBottom_toBottomOf="@id/tab_layout"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="@id/tab_layout"

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -65,6 +65,7 @@
     <color name="tab_tray_item_media_background_normal_theme">@color/tab_tray_item_media_background_dark_theme</color>
     <color name="tab_tray_heading_icon_normal_theme">@color/tab_tray_heading_icon_dark_theme</color>
     <color name="tab_tray_heading_icon_inactive_normal_theme">@color/tab_tray_heading_icon_inactive_dark_theme</color>
+    <color name="tab_tray_heading_icon_menu_normal_theme">@color/tab_tray_heading_icon_menu_dark_theme</color>
     <color name="tab_tray_item_thumbnail_background_normal_theme">@color/tab_tray_item_thumbnail_background_dark_theme</color>
     <color name="tab_tray_item_thumbnail_icon_normal_theme">@color/tab_tray_item_thumbnail_icon_dark_theme</color>
     <color name="tab_tray_selected_mask_normal_theme">@color/tab_tray_selected_mask_dark_theme</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -75,6 +75,7 @@
     <color name="tab_tray_item_media_background_light_theme">#312A65</color>
     <color name="tab_tray_heading_icon_light_theme">@color/ink_20</color>
     <color name="tab_tray_heading_icon_inactive_light_theme">@color/ink_20_48a</color>
+    <color name="tab_tray_heading_icon_menu_light_theme">@color/accent_normal_theme</color>
     <color name="tab_tray_item_thumbnail_background_light_theme">@color/photonLightGrey10</color>
     <color name="tab_tray_item_thumbnail_icon_light_theme">@color/photonLightGrey60</color>
     <color name="tab_tray_selected_mask_light_theme">@color/violet_70_12a</color>
@@ -141,7 +142,8 @@
     <color name="tab_tray_item_divider_dark_theme">@color/photonDarkGrey10</color>
     <color name="tab_tray_item_media_background_dark_theme">#9059FF</color>
     <color name="tab_tray_heading_icon_dark_theme">@color/violet_50</color>
-    <color name="tab_tray_heading_icon_inactive_dark_theme">@color/violet_50_48a</color>
+    <color name="tab_tray_heading_icon_inactive_dark_theme">@color/photonLightGrey05</color>
+    <color name="tab_tray_heading_icon_menu_dark_theme">@color/photonLightGrey05</color>
     <color name="tab_tray_item_thumbnail_background_dark_theme">@color/photonDarkGrey50</color>
     <color name="tab_tray_item_thumbnail_icon_dark_theme">@color/photonDarkGrey05</color>
     <color name="tab_tray_selected_mask_dark_theme">@color/violet_50_32a</color>
@@ -264,6 +266,7 @@
     <color name="tab_tray_item_media_background_normal_theme">@color/tab_tray_item_media_background_light_theme</color>
     <color name="tab_tray_heading_icon_normal_theme">@color/tab_tray_heading_icon_light_theme</color>
     <color name="tab_tray_heading_icon_inactive_normal_theme">@color/tab_tray_heading_icon_inactive_light_theme</color>
+    <color name="tab_tray_heading_icon_menu_normal_theme">@color/tab_tray_heading_icon_menu_light_theme</color>
     <color name="tab_tray_item_thumbnail_background_normal_theme">@color/tab_tray_item_thumbnail_background_light_theme</color>
     <color name="tab_tray_item_thumbnail_icon_normal_theme">@color/tab_tray_item_thumbnail_icon_light_theme</color>
     <color name="tab_tray_selected_mask_normal_theme">@color/tab_tray_selected_mask_light_theme</color>


### PR DESCRIPTION
For #11561.

As requested by UX I changed the deselected state for the inactive heading icons and for the menu icon as well to Light Grey 5 in dark theme. Nothing was changed for the light theme.

Before:

![before](https://user-images.githubusercontent.com/1100614/91637778-2684d200-ea0b-11ea-8600-38e26f4c9e23.png)

After:

![after](https://user-images.githubusercontent.com/1100614/91637782-2a185900-ea0b-11ea-913e-a4b305e33ccf.png)