### PR TITLE
Fix a typo in metric expiry.

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -3284,7 +3284,7 @@ app_theme:
       - interaction
     notification_emails:
       - fenix-core@mozilla.com
-    expires: "2020-04-01"
+    expires: "2021-04-01"
 
 pocket:
   pocket_top_site_clicked:


### PR DESCRIPTION
This was changed to 2020-04-01 in b01dbeeebf2b54dabbb1b60916bee4ec2c837b5f

I assume this was just a typo, since a lot of metrics got changed to 2021-04-01
in the same commit.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
