### PR TITLE
For #14239: Notification for QR scan when permissions have been denied

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/search/SearchController.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchController.kt
@@ -4,7 +4,12 @@
 
 package org.mozilla.fenix.search
 
+import android.content.DialogInterface
 import android.content.Intent
+import android.os.Build
+import android.text.SpannableString
+import androidx.annotation.VisibleForTesting
+import androidx.appcompat.app.AlertDialog
 import androidx.navigation.NavController
 import mozilla.components.browser.search.SearchEngine
 import mozilla.components.browser.session.Session
@@ -29,6 +34,7 @@ import org.mozilla.fenix.utils.Settings
 /**
  * An interface that handles the view manipulation of the Search, triggered by the Interactor
  */
+@Suppress("TooManyFunctions")
 interface SearchController {
     fun handleUrlCommitted(url: String)
     fun handleEditingCancelled()
@@ -40,6 +46,7 @@ interface SearchController {
     fun handleExistingSessionSelected(session: Session)
     fun handleExistingSessionSelected(tabId: String)
     fun handleSearchShortcutsButtonClicked()
+    fun handleCameraPermissionsNeeded()
 }
 
 @Suppress("TooManyFunctions", "LongParameterList")
@@ -192,6 +199,51 @@ class DefaultSearchController(
         val session = sessionManager.findSessionById(tabId)
         if (session != null) {
             handleExistingSessionSelected(session)
+        }
+    }
+
+    /**
+     * Creates and shows an [AlertDialog] when camera permissions are needed.
+     *
+     * In versions above M, [AlertDialog.BUTTON_POSITIVE] takes the user to the app settings. This
+     * intent only exists in M and above. Below M, [AlertDialog.BUTTON_POSITIVE] routes to a SUMO
+     * help page to find the app settings.
+     *
+     * [AlertDialog.BUTTON_NEGATIVE] dismisses the dialog.
+     */
+    override fun handleCameraPermissionsNeeded() {
+        val dialog = buildDialog()
+        dialog.show()
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    fun buildDialog(): AlertDialog.Builder {
+        return AlertDialog.Builder(activity).apply {
+            val spannableText = SpannableString(
+                activity.resources.getString(R.string.camera_permissions_needed_message)
+            )
+            setMessage(spannableText)
+            setNegativeButton(R.string.camera_permissions_needed_negative_button_text) {
+                    dialog: DialogInterface, _ ->
+                dialog.cancel()
+            }
+            setPositiveButton(R.string.camera_permissions_needed_positive_button_text) {
+                    dialog: DialogInterface, _ ->
+                val intent: Intent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                    Intent(android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+                } else {
+                    SupportUtils.createCustomTabIntent(
+                        activity,
+                        SupportUtils.getSumoURLForTopic(
+                            activity,
+                            SupportUtils.SumoTopic.QR_CAMERA_ACCESS
+                        )
+                    )
+                }
+                dialog.cancel()
+                activity.startActivity(intent)
+            }
+            create()
         }
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/search/SearchController.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchController.kt
@@ -6,6 +6,7 @@ package org.mozilla.fenix.search
 
 import android.content.DialogInterface
 import android.content.Intent
+import android.net.Uri
 import android.os.Build
 import android.text.SpannableString
 import androidx.annotation.VisibleForTesting
@@ -240,6 +241,8 @@ class DefaultSearchController(
                         )
                     )
                 }
+                val uri = Uri.fromParts("package", activity.packageName, null)
+                intent.data = uri
                 dialog.cancel()
                 activity.startActivity(intent)
             }

--- a/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
@@ -413,7 +413,10 @@ class SearchFragment : Fragment(), UserInteractionHandler {
                         permissionDidUpdate = true
                     } else {
                         view?.search_scan_button?.isChecked = false
-                        showPermissionsNeededDialog()
+                        // if the permission hasn't been updated
+                        if (!permissionDidUpdate) {
+                            showPermissionsNeededDialog()
+                        }
                     }
                 }
             }

--- a/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
@@ -421,7 +421,6 @@ class SearchFragment : Fragment(), UserInteractionHandler {
         }
     }
 
-
     private fun showPermissionsNeededDialog() {
         AlertDialog.Builder(requireContext()).apply {
             val spannableText = SpannableString(
@@ -451,7 +450,6 @@ class SearchFragment : Fragment(), UserInteractionHandler {
             create()
         }.show()
     }
-
 
     private fun historyStorageProvider(): HistoryStorage? {
         return if (requireContext().settings().shouldShowHistorySuggestions) {

--- a/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
@@ -70,7 +70,6 @@ class SearchFragment : Fragment(), UserInteractionHandler {
     private var permissionDidUpdate = false
     private lateinit var searchStore: SearchFragmentStore
     private lateinit var searchInteractor: SearchInteractor
-    private val preferences = PreferenceManager.getDefaultSharedPreferences(context)
 
     private val speechIntent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH)
 
@@ -247,10 +246,11 @@ class SearchFragment : Fragment(), UserInteractionHandler {
         view.search_scan_button.setOnClickListener {
             toolbarView.view.clearFocus()
 
-            val cameraPermissionsDenied = preferences.getBoolean(
-                getPreferenceKey(R.string.pref_key_camera_permissions),
-                false
-            )
+            val cameraPermissionsDenied = PreferenceManager.getDefaultSharedPreferences(context)
+                .getBoolean(
+                    getPreferenceKey(R.string.pref_key_camera_permissions),
+                    false
+                )
 
             if (cameraPermissionsDenied) {
                 searchInteractor.onCameraPermissionsNeeded()
@@ -427,13 +427,15 @@ class SearchFragment : Fragment(), UserInteractionHandler {
                 context?.let { context: Context ->
                     if (context.isPermissionGranted(Manifest.permission.CAMERA)) {
                         permissionDidUpdate = true
-                        preferences.edit().putBoolean(
-                            getPreferenceKey(R.string.pref_key_camera_permissions), false
-                        ).apply()
+                        PreferenceManager.getDefaultSharedPreferences(context)
+                            .edit().putBoolean(
+                                getPreferenceKey(R.string.pref_key_camera_permissions), false
+                            ).apply()
                     } else {
-                        preferences.edit().putBoolean(
-                            getPreferenceKey(R.string.pref_key_camera_permissions), true
-                        ).apply()
+                        PreferenceManager.getDefaultSharedPreferences(context)
+                            .edit().putBoolean(
+                                getPreferenceKey(R.string.pref_key_camera_permissions), true
+                            ).apply()
                         resetFocus()
                     }
                 }

--- a/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchFragment.kt
@@ -11,9 +11,12 @@ import android.content.DialogInterface
 import android.content.Intent
 import android.graphics.Typeface.BOLD
 import android.graphics.Typeface.ITALIC
+import android.os.Build
 import android.os.Bundle
+import android.provider.Settings
 import android.speech.RecognizerIntent
 import android.speech.RecognizerIntent.EXTRA_RESULTS
+import android.text.SpannableString
 import android.text.style.StyleSpan
 import android.view.LayoutInflater
 import android.view.View
@@ -410,12 +413,45 @@ class SearchFragment : Fragment(), UserInteractionHandler {
                         permissionDidUpdate = true
                     } else {
                         view?.search_scan_button?.isChecked = false
+                        showPermissionsNeededDialog()
                     }
                 }
             }
             else -> super.onRequestPermissionsResult(requestCode, permissions, grantResults)
         }
     }
+
+
+    private fun showPermissionsNeededDialog() {
+        AlertDialog.Builder(requireContext()).apply {
+            val spannableText = SpannableString(
+                resources.getString(R.string.camera_permissions_needed_message)
+            )
+            setMessage(spannableText)
+            setNegativeButton(R.string.camera_permissions_needed_negative_button_text) {
+                    dialog: DialogInterface, _ ->
+                dialog.cancel()
+            }
+            setPositiveButton(R.string.camera_permissions_needed_positive_button_text) {
+                    dialog: DialogInterface, _ ->
+                val intent: Intent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                    Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+                } else {
+                    SupportUtils.createCustomTabIntent(
+                        requireContext(),
+                        SupportUtils.getSumoURLForTopic(
+                            requireContext(),
+                            SupportUtils.SumoTopic.QR_CAMERA_ACCESS
+                        )
+                    )
+                }
+                dialog.cancel()
+                startActivity(intent)
+            }
+            create()
+        }.show()
+    }
+
 
     private fun historyStorageProvider(): HistoryStorage? {
         return if (requireContext().settings().shouldShowHistorySuggestions) {

--- a/app/src/main/java/org/mozilla/fenix/search/SearchInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchInteractor.kt
@@ -13,6 +13,7 @@ import org.mozilla.fenix.search.toolbar.ToolbarInteractor
  * Interactor for the search screen
  * Provides implementations for the AwesomeBarView and ToolbarView
  */
+@Suppress("TooManyFunctions")
 class SearchInteractor(
     private val searchController: SearchController
 ) : AwesomeBarInteractor, ToolbarInteractor {
@@ -55,5 +56,9 @@ class SearchInteractor(
 
     override fun onExistingSessionSelected(tabId: String) {
         searchController.handleExistingSessionSelected(tabId)
+    }
+
+    fun onCameraPermissionsNeeded() {
+        searchController.handleCameraPermissionsNeeded()
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/searchdialog/SearchDialogController.kt
+++ b/app/src/main/java/org/mozilla/fenix/searchdialog/SearchDialogController.kt
@@ -4,7 +4,12 @@
 
 package org.mozilla.fenix.searchdialog
 
+import android.content.DialogInterface
 import android.content.Intent
+import android.os.Build
+import android.text.SpannableString
+import androidx.annotation.VisibleForTesting
+import androidx.appcompat.app.AlertDialog
 import androidx.navigation.NavController
 import mozilla.components.browser.search.SearchEngine
 import mozilla.components.browser.session.Session
@@ -166,10 +171,6 @@ class SearchDialogController(
         store.dispatch(SearchFragmentAction.ShowSearchShortcutEnginePicker(!isOpen))
     }
 
-    override fun handleCameraPermissionsNeeded() {
-        TODO("Not yet implemented")
-    }
-
     override fun handleClickSearchEngineSettings() {
         clearToolbarFocus()
         val directions = SearchDialogFragmentDirections.actionGlobalSearchEngineFragment()
@@ -188,6 +189,51 @@ class SearchDialogController(
         val session = sessionManager.findSessionById(tabId)
         if (session != null) {
             handleExistingSessionSelected(session)
+        }
+    }
+
+    /**
+     * Creates and shows an [AlertDialog] when camera permissions are needed.
+     *
+     * In versions above M, [AlertDialog.BUTTON_POSITIVE] takes the user to the app settings. This
+     * intent only exists in M and above. Below M, [AlertDialog.BUTTON_POSITIVE] routes to a SUMO
+     * help page to find the app settings.
+     *
+     * [AlertDialog.BUTTON_NEGATIVE] dismisses the dialog.
+     */
+    override fun handleCameraPermissionsNeeded() {
+        val dialog = buildDialog()
+        dialog.show()
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    fun buildDialog(): AlertDialog.Builder {
+        return AlertDialog.Builder(activity).apply {
+            val spannableText = SpannableString(
+                activity.resources.getString(R.string.camera_permissions_needed_message)
+            )
+            setMessage(spannableText)
+            setNegativeButton(R.string.camera_permissions_needed_negative_button_text) {
+                    dialog: DialogInterface, _ ->
+                dialog.cancel()
+            }
+            setPositiveButton(R.string.camera_permissions_needed_positive_button_text) {
+                    dialog: DialogInterface, _ ->
+                val intent: Intent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                    Intent(android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+                } else {
+                    SupportUtils.createCustomTabIntent(
+                        activity,
+                        SupportUtils.getSumoURLForTopic(
+                            activity,
+                            SupportUtils.SumoTopic.QR_CAMERA_ACCESS
+                        )
+                    )
+                }
+                dialog.cancel()
+                activity.startActivity(intent)
+            }
+            create()
         }
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/searchdialog/SearchDialogController.kt
+++ b/app/src/main/java/org/mozilla/fenix/searchdialog/SearchDialogController.kt
@@ -6,6 +6,7 @@ package org.mozilla.fenix.searchdialog
 
 import android.content.DialogInterface
 import android.content.Intent
+import android.net.Uri
 import android.os.Build
 import android.text.SpannableString
 import androidx.annotation.VisibleForTesting
@@ -213,9 +214,8 @@ class SearchDialogController(
                 activity.resources.getString(R.string.camera_permissions_needed_message)
             )
             setMessage(spannableText)
-            setNegativeButton(R.string.camera_permissions_needed_negative_button_text) {
-                    dialog: DialogInterface, _ ->
-                dialog.cancel()
+            setNegativeButton(R.string.camera_permissions_needed_negative_button_text) { _, _ ->
+                dismissDialog()
             }
             setPositiveButton(R.string.camera_permissions_needed_positive_button_text) {
                     dialog: DialogInterface, _ ->
@@ -230,6 +230,8 @@ class SearchDialogController(
                         )
                     )
                 }
+                val uri = Uri.fromParts("package", activity.packageName, null)
+                intent.data = uri
                 dialog.cancel()
                 activity.startActivity(intent)
             }

--- a/app/src/main/java/org/mozilla/fenix/searchdialog/SearchDialogController.kt
+++ b/app/src/main/java/org/mozilla/fenix/searchdialog/SearchDialogController.kt
@@ -166,6 +166,10 @@ class SearchDialogController(
         store.dispatch(SearchFragmentAction.ShowSearchShortcutEnginePicker(!isOpen))
     }
 
+    override fun handleCameraPermissionsNeeded() {
+        TODO("Not yet implemented")
+    }
+
     override fun handleClickSearchEngineSettings() {
         clearToolbarFocus()
         val directions = SearchDialogFragmentDirections.actionGlobalSearchEngineFragment()

--- a/app/src/main/java/org/mozilla/fenix/searchdialog/SearchDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/searchdialog/SearchDialogFragment.kt
@@ -375,18 +375,18 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
                 context?.let { context: Context ->
                     it.onPermissionsResult(permissions, grantResults)
                     if (!context.isPermissionGranted(Manifest.permission.CAMERA)) {
-                        view?.qr_scan_button?.isChecked = false
                         permissionsDenied = true
+                        dismissAndResetFocus()
                     }
                 }
             }
             else -> super.onRequestPermissionsResult(requestCode, permissions, grantResults)
         }
     }
-    
+
     private fun dismissAndResetFocus() {
-        toolbarView.view.edit.focus()
         view?.qr_scan_button?.isChecked = false
+        toolbarView.view.edit.focus()
         toolbarView.view.requestFocus()
     }
 
@@ -399,6 +399,7 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
             setNegativeButton(R.string.camera_permissions_needed_negative_button_text) {
                     dialog: DialogInterface, _ ->
                 dialog.cancel()
+                dismissAndResetFocus()
             }
             setPositiveButton(R.string.camera_permissions_needed_positive_button_text) {
                     dialog: DialogInterface, _ ->
@@ -418,6 +419,7 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
                 }
                 dialog.cancel()
                 requireActivity().startActivity(intent)
+                dismissAndResetFocus()
             }
             create()
         }.show()

--- a/app/src/main/java/org/mozilla/fenix/searchdialog/SearchDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/searchdialog/SearchDialogFragment.kt
@@ -33,7 +33,6 @@ import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
-import kotlinx.android.synthetic.main.fragment_search.view.*
 import kotlinx.android.synthetic.main.fragment_search_dialog.*
 import kotlinx.android.synthetic.main.fragment_search_dialog.fill_link_from_clipboard
 import kotlinx.android.synthetic.main.fragment_search_dialog.pill_wrapper
@@ -66,7 +65,6 @@ import org.mozilla.fenix.components.toolbar.ToolbarPosition
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.settings
-import org.mozilla.fenix.search.SearchFragment
 import org.mozilla.fenix.search.SearchFragmentAction
 import org.mozilla.fenix.search.SearchFragmentState
 import org.mozilla.fenix.search.SearchFragmentStore
@@ -88,7 +86,7 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
     private lateinit var toolbarView: ToolbarView
     private lateinit var awesomeBarView: AwesomeBarView
     private var firstUpdate = true
-    private var permissionsDenied = false
+    private var cameraPermissionsDenied = false
 
     private val qrFeature = ViewBoundFeatureWrapper<QrFeature>()
     private val speechIntent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH)
@@ -216,7 +214,7 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
 
             toolbarView.view.clearFocus()
             requireComponents.analytics.metrics.track(Event.QRScannerOpened)
-            if (permissionsDenied) {
+            if (cameraPermissionsDenied) {
                 showPermissionsNeededDialog()
             } else {
                 qrFeature.get()?.scan(R.id.search_wrapper)
@@ -375,7 +373,7 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
                 context?.let { context: Context ->
                     it.onPermissionsResult(permissions, grantResults)
                     if (!context.isPermissionGranted(Manifest.permission.CAMERA)) {
-                        permissionsDenied = true
+                        cameraPermissionsDenied = true
                         dismissAndResetFocus()
                     }
                 }
@@ -423,7 +421,6 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
             }
             create()
         }.show()
-        dismissAndResetFocus()
     }
 
     private fun setupConstraints(view: View) {

--- a/app/src/main/java/org/mozilla/fenix/settings/PairFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/PairFragment.kt
@@ -129,6 +129,15 @@ class PairFragment : Fragment(R.layout.fragment_pair), UserInteractionHandler {
         }
     }
 
+    /**
+     * Shows an [AlertDialog] when camera permissions are needed.
+     *
+     * In versions above M, [AlertDialog.BUTTON_POSITIVE] takes the user to the app settings. This
+     * intent only exists in M and above. Below M, [AlertDialog.BUTTON_POSITIVE] routes to a SUMO
+     * help page to find the app settings.
+     *
+     * [AlertDialog.BUTTON_NEGATIVE] dismisses the dialog.
+     */
     private fun showPermissionsNeededDialog() {
         AlertDialog.Builder(requireContext()).apply {
             val spannableText = SpannableString(

--- a/app/src/main/java/org/mozilla/fenix/settings/PairFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/PairFragment.kt
@@ -20,17 +20,19 @@ import androidx.core.content.getSystemService
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.NavHostFragment.findNavController
 import androidx.navigation.fragment.findNavController
+import androidx.preference.PreferenceManager
 import mozilla.components.feature.qr.QrFeature
 import mozilla.components.support.base.feature.UserInteractionHandler
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
 import org.mozilla.fenix.R
+import org.mozilla.fenix.ext.getPreferenceKey
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.showToolbar
 
 class PairFragment : Fragment(R.layout.fragment_pair), UserInteractionHandler {
 
     private val qrFeature = ViewBoundFeatureWrapper<QrFeature>()
-    private var cameraPermissionsDenied = false
+    private val preferences = PreferenceManager.getDefaultSharedPreferences(context)
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -67,6 +69,11 @@ class PairFragment : Fragment(R.layout.fragment_pair), UserInteractionHandler {
             scanMessage = R.string.pair_instructions_2),
             owner = this,
             view = view
+        )
+
+        val cameraPermissionsDenied = preferences.getBoolean(
+            getPreferenceKey(R.string.pref_key_camera_permissions),
+            false
         )
 
         qrFeature.withFeature {
@@ -109,8 +116,13 @@ class PairFragment : Fragment(R.layout.fragment_pair), UserInteractionHandler {
                     qrFeature.withFeature {
                         it.onPermissionsResult(permissions, grantResults)
                     }
+                    preferences.edit().putBoolean(
+                        getPreferenceKey(R.string.pref_key_camera_permissions), false
+                    ).apply()
                 } else {
-                    cameraPermissionsDenied = true
+                    preferences.edit().putBoolean(
+                        getPreferenceKey(R.string.pref_key_camera_permissions), true
+                    ).apply()
                     findNavController().popBackStack(R.id.turnOnSyncFragment, false)
                 }
             }

--- a/app/src/main/java/org/mozilla/fenix/settings/PairFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/PairFragment.kt
@@ -4,12 +4,17 @@
 
 package org.mozilla.fenix.settings
 
+import android.content.DialogInterface
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import android.os.VibrationEffect
 import android.os.Vibrator
+import android.provider.Settings
+import android.text.SpannableString
 import android.view.View
+import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
 import androidx.fragment.app.Fragment
@@ -100,9 +105,40 @@ class PairFragment : Fragment(R.layout.fragment_pair), UserInteractionHandler {
                         it.onPermissionsResult(permissions, grantResults)
                     }
                 } else {
+                    showPermissionsNeededDialog()
                     findNavController().popBackStack(R.id.turnOnSyncFragment, false)
                 }
             }
         }
+    }
+
+    private fun showPermissionsNeededDialog() {
+        AlertDialog.Builder(requireContext()).apply {
+            val spannableText = SpannableString(
+                resources.getString(R.string.camera_permissions_needed_message)
+            )
+            setMessage(spannableText)
+            setNegativeButton(R.string.camera_permissions_needed_negative_button_text) {
+                    dialog: DialogInterface, _ ->
+                dialog.cancel()
+            }
+            setPositiveButton(R.string.camera_permissions_needed_positive_button_text) {
+                    dialog: DialogInterface, _ ->
+                val intent: Intent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                    Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+                } else {
+                    SupportUtils.createCustomTabIntent(
+                        requireContext(),
+                        SupportUtils.getSumoURLForTopic(
+                            requireContext(),
+                            SupportUtils.SumoTopic.QR_CAMERA_ACCESS
+                        )
+                    )
+                }
+                dialog.cancel()
+                startActivity(intent)
+            }
+            create()
+        }.show()
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/settings/PairFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/PairFragment.kt
@@ -30,6 +30,7 @@ import org.mozilla.fenix.ext.showToolbar
 class PairFragment : Fragment(R.layout.fragment_pair), UserInteractionHandler {
 
     private val qrFeature = ViewBoundFeatureWrapper<QrFeature>()
+    private var cameraPermissionsDenied = false
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -69,7 +70,11 @@ class PairFragment : Fragment(R.layout.fragment_pair), UserInteractionHandler {
         )
 
         qrFeature.withFeature {
-            it.scan(R.id.pair_layout)
+            if (cameraPermissionsDenied) {
+                showPermissionsNeededDialog()
+            } else {
+                it.scan(R.id.pair_layout)
+            }
         }
     }
 
@@ -105,7 +110,7 @@ class PairFragment : Fragment(R.layout.fragment_pair), UserInteractionHandler {
                         it.onPermissionsResult(permissions, grantResults)
                     }
                 } else {
-                    showPermissionsNeededDialog()
+                    cameraPermissionsDenied = true
                     findNavController().popBackStack(R.id.turnOnSyncFragment, false)
                 }
             }

--- a/app/src/main/java/org/mozilla/fenix/settings/SupportUtils.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SupportUtils.kt
@@ -40,7 +40,8 @@ object SupportUtils {
         SEARCH_SUGGESTION("how-search-firefox-preview"),
         CUSTOM_SEARCH_ENGINES("custom-search-engines"),
         UPGRADE_FAQ("firefox-preview-upgrade-faqs"),
-        SYNC_SETUP("how-set-firefox-sync-firefox-preview")
+        SYNC_SETUP("how-set-firefox-sync-firefox-preview"),
+        QR_CAMERA_ACCESS("qr-camera-access")
     }
 
     enum class MozillaPage(internal val path: String) {

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -222,4 +222,6 @@
     <string name="pref_key_close_tabs_after_one_day" translatable="false">pref_key_close_tabs_after_one_day</string>
     <string name="pref_key_close_tabs_after_one_week" translatable="false">pref_key_close_tabs_after_one_week</string>
     <string name="pref_key_close_tabs_after_one_month" translatable="false">pref_key_close_tabs_after_one_month</string>
+
+    <string name="pref_key_camera_permissions" translatable="false">pref_key_camera_permissions</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1543,7 +1543,7 @@
     <!-- Content description for close button in collection placeholder. -->
     <string name="remove_home_collection_placeholder_content_description">Remove</string>
 
-    <!-- depcrecated: text for the firefox account onboarding card header
+    <!-- Deprecated: text for the firefox account onboarding card header
     The first parameter is the name of the app (e.g. Firefox Preview) -->
     <string name="onboarding_firefox_account_header">Get the most out of %s.</string>
 

--- a/app/src/test/java/org/mozilla/fenix/search/DefaultSearchControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/search/DefaultSearchControllerTest.kt
@@ -49,10 +49,6 @@ class DefaultSearchControllerTest {
     @MockK(relaxed = true) private lateinit var settings: Settings
     @MockK private lateinit var sessionManager: SessionManager
     @MockK(relaxed = true) private lateinit var clearToolbarFocus: () -> Unit
-//    @MockK(relaxed = true) private lateinit var dialogBuilder: AlertDialogBuilder
-//    @MockK(relaxed = true) private lateinit var dialog: AlertDialog
-    @MockK(relaxed = true) private lateinit var context: Context
-    @MockK(relaxed = true) private var config: Configuration = Configuration()
 
     private lateinit var controller: DefaultSearchController
 
@@ -68,7 +64,6 @@ class DefaultSearchControllerTest {
             every { id } returns R.id.searchFragment
         }
         every { MetricsUtils.createSearchEvent(searchEngine, activity, any()) } returns null
-        every { context.applicationContext.resources.configuration } returns config
         controller = DefaultSearchController(
             activity = activity,
             sessionManager = sessionManager,
@@ -340,7 +335,7 @@ class DefaultSearchControllerTest {
     }
 
     @Test
-    fun `show camera permissions denied dialog`() {
+    fun `show camera permissions needed dialog`() {
         val dialogBuilder: AlertDialogBuilder = mockk(relaxed = true)
 
         val spyController = spyk(controller)

--- a/app/src/test/java/org/mozilla/fenix/search/DefaultSearchControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/search/DefaultSearchControllerTest.kt
@@ -4,8 +4,6 @@
 
 package org.mozilla.fenix.search
 
-import android.content.Context
-import android.content.res.Configuration
 import androidx.appcompat.app.AlertDialog
 import androidx.navigation.NavController
 import androidx.navigation.NavDirections

--- a/app/src/test/java/org/mozilla/fenix/search/DefaultSearchControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/search/DefaultSearchControllerTest.kt
@@ -4,6 +4,9 @@
 
 package org.mozilla.fenix.search
 
+import android.content.Context
+import android.content.res.Configuration
+import androidx.appcompat.app.AlertDialog
 import androidx.navigation.NavController
 import androidx.navigation.NavDirections
 import io.mockk.MockKAnnotations
@@ -13,6 +16,7 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkObject
+import io.mockk.spyk
 import io.mockk.unmockkObject
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -32,6 +36,8 @@ import org.mozilla.fenix.components.metrics.MetricsUtils
 import org.mozilla.fenix.settings.SupportUtils
 import org.mozilla.fenix.utils.Settings
 
+typealias AlertDialogBuilder = AlertDialog.Builder
+
 @ExperimentalCoroutinesApi
 class DefaultSearchControllerTest {
 
@@ -43,6 +49,10 @@ class DefaultSearchControllerTest {
     @MockK(relaxed = true) private lateinit var settings: Settings
     @MockK private lateinit var sessionManager: SessionManager
     @MockK(relaxed = true) private lateinit var clearToolbarFocus: () -> Unit
+//    @MockK(relaxed = true) private lateinit var dialogBuilder: AlertDialogBuilder
+//    @MockK(relaxed = true) private lateinit var dialog: AlertDialog
+    @MockK(relaxed = true) private lateinit var context: Context
+    @MockK(relaxed = true) private var config: Configuration = Configuration()
 
     private lateinit var controller: DefaultSearchController
 
@@ -58,7 +68,7 @@ class DefaultSearchControllerTest {
             every { id } returns R.id.searchFragment
         }
         every { MetricsUtils.createSearchEvent(searchEngine, activity, any()) } returns null
-
+        every { context.applicationContext.resources.configuration } returns config
         controller = DefaultSearchController(
             activity = activity,
             sessionManager = sessionManager,
@@ -327,5 +337,17 @@ class DefaultSearchControllerTest {
 
         verify { sessionManager.select(any()) }
         verify { activity.openToBrowser(from = BrowserDirection.FromSearch) }
+    }
+
+    @Test
+    fun `show camera permissions denied dialog`() {
+        val dialogBuilder: AlertDialogBuilder = mockk(relaxed = true)
+
+        val spyController = spyk(controller)
+        every { spyController.buildDialog() } returns dialogBuilder
+
+        spyController.handleCameraPermissionsNeeded()
+
+        verify { dialogBuilder.show() }
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/searchdialog/SearchDialogControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/searchdialog/SearchDialogControllerTest.kt
@@ -13,6 +13,7 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkObject
+import io.mockk.spyk
 import io.mockk.unmockkObject
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -29,6 +30,7 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.components.metrics.MetricController
 import org.mozilla.fenix.components.metrics.MetricsUtils
+import org.mozilla.fenix.search.AlertDialogBuilder
 import org.mozilla.fenix.search.SearchFragmentAction
 import org.mozilla.fenix.settings.SupportUtils
 import org.mozilla.fenix.utils.Settings
@@ -341,5 +343,17 @@ class SearchDialogControllerTest {
 
         verify { sessionManager.select(any()) }
         verify { activity.openToBrowser(from = BrowserDirection.FromSearchDialog) }
+    }
+
+    @Test
+    fun `show camera permissions needed dialog`() {
+        val dialogBuilder: AlertDialogBuilder = mockk(relaxed = true)
+
+        val spyController = spyk(controller)
+        every { spyController.buildDialog() } returns dialogBuilder
+
+        spyController.handleCameraPermissionsNeeded()
+
+        verify { dialogBuilder.show() }
     }
 }


### PR DESCRIPTION
For #14239 


App permissions in settings: https://developer.android.com/reference/android/provider/Settings#ACTION_APPLICATION_DETAILS_SETTINGS 
Sumo article for versions lower than P (Android 9, API 28): https://support.mozilla.org/1/mobile/%VERSION%/%OS%/%LOCALE%/qr-camera-access

<img src="https://user-images.githubusercontent.com/43795363/91914051-d3b25100-ec7c-11ea-8463-a58a99de3c35.gif" width=300 />

todo
- [x] Search fragment
- [x] Search dialog fragment
- [x] FxA pair `PairFragment`
- [ ] tests
- [x] dialog pops up as soon as you deny permissions. use `permissionDidUpdate`
- [ ] put duplicate dialog code - where should this live? utils?

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
