### PR TITLE
Bug 1645844 - Add  label to reports sent via the webcompat-reporter.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -111,7 +111,7 @@ class Core(private val context: Context, private val crashReporter: CrashReporti
              * This is consistent with both Fennec and Firefox Desktop.
              */
             if (Config.channel.isNightlyOrDebug || Config.channel.isBeta) {
-                WebCompatReporterFeature.install(it)
+                WebCompatReporterFeature.install(it, "fenix")
             }
         }
     }


### PR DESCRIPTION
We [recently](https://github.com/mozilla-mobile/android-components/pull/7987) added the ability to set custom `browser-XXX` labels in the WebCompat Reporter component. This PR sets the value for Fenix, so that reports automatically get a `browser-fenix` label, which makes our work a lot easier. :)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
