### PR TITLE
For #14642: Use correct 'Close tabs' summary text for "After one month"

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -368,7 +368,7 @@ class Settings(private val appContext: Context) : PreferencesHolder {
             appContext.getString(R.string.close_tabs_after_one_week)
         }
         closeTabsAfterOneMonth -> {
-            appContext.getString(R.string.close_tabs_after_one_week)
+            appContext.getString(R.string.close_tabs_after_one_month)
         }
         else -> {
             appContext.getString(R.string.close_tabs_manually)


### PR DESCRIPTION
When "Close tabs" is set to "After one month" (`closeTabsAfterOneMonth`), use the correct summary string on the Settings page of "After one month" (`close_tabs_after_one_month`) instead of "After one week" (`close_tabs_after_one_week`).

Closes #14642.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
  * The code in question is covered by existing tests; this represents fixing an incorrect string
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
  * Screenshots are included in the linked issue: #14642
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.
  * No new user facing features, minor string change

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
