### PR TITLE
CI for #14644

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -368,7 +368,7 @@ class Settings(private val appContext: Context) : PreferencesHolder {
             appContext.getString(R.string.close_tabs_after_one_week)
         }
         closeTabsAfterOneMonth -> {
-            appContext.getString(R.string.close_tabs_after_one_week)
+            appContext.getString(R.string.close_tabs_after_one_month)
         }
         else -> {
             appContext.getString(R.string.close_tabs_manually)


### PR DESCRIPTION
For "closeTabsAfterOneMonth", use the correct summary string of
"close_tabs_after_one_month" instead of "close_tabs_after_one_week".

This fixes the Settings page "Close tabs" summary showing the wrong
tab duration when "Close tabs" is set to "After one month".

Closes #14642



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
