### PR TITLE
For #14524: Disable ETP tests failing on AC 58 update

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/StrictEnhancedTrackingProtectionTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/StrictEnhancedTrackingProtectionTest.kt
@@ -8,6 +8,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.ext.settings
@@ -76,6 +77,7 @@ class StrictEnhancedTrackingProtectionTest {
         }
     }
 
+    @Ignore("Failing on AC 58 update: https://github.com/mozilla-mobile/fenix/issues/14524")
     @Test
     fun testStrictVisitContentNotification() {
         val trackingProtectionTest =
@@ -89,6 +91,7 @@ class StrictEnhancedTrackingProtectionTest {
         }.closeNotificationPopup {}
     }
 
+    @Ignore("Failing on AC 58 update: https://github.com/mozilla-mobile/fenix/issues/14524")
     @Test
     fun testStrictVisitContentShield() {
         val trackingProtectionTest =
@@ -106,6 +109,7 @@ class StrictEnhancedTrackingProtectionTest {
         }
     }
 
+    @Ignore("Failing on AC 58 update: https://github.com/mozilla-mobile/fenix/issues/14524")
     @Test
     fun testStrictVisitProtectionSheet() {
         val trackingProtectionTest =
@@ -125,6 +129,7 @@ class StrictEnhancedTrackingProtectionTest {
         }
     }
 
+    @Ignore("Failing on AC 58 update: https://github.com/mozilla-mobile/fenix/issues/14524")
     @Test
     fun testStrictVisitDisable() {
         val trackingProtectionTest =
@@ -156,6 +161,7 @@ class StrictEnhancedTrackingProtectionTest {
         }
     }
 
+    @Ignore("Failing on AC 58 update: https://github.com/mozilla-mobile/fenix/issues/14524")
     @Test
     fun testStrictVisitDisableExceptionToggle() {
         val trackingProtectionTest =
@@ -188,6 +194,7 @@ class StrictEnhancedTrackingProtectionTest {
         }
     }
 
+    @Ignore("Failing on AC 58 update: https://github.com/mozilla-mobile/fenix/issues/14524")
     @Test
     fun testStrictVisitSheetDetails() {
         val trackingProtectionTest =


### PR DESCRIPTION
Test report: https://console.firebase.google.com/project/moz-fenix/testlab/histories/bh.66b7091e15d53d45/matrices/8043842123572528467

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
