### PR TITLE
For #14487: Remove obsolete question and correct wrong word used

### DIFF
--- a/.github/ISSUE_TEMPLATE/---webcontent-issue-report.md
+++ b/.github/ISSUE_TEMPLATE/---webcontent-issue-report.md
@@ -13,9 +13,7 @@ assignees: ''
 
 ### Actual behavior
 
-### Does toggling Tracking Protection fix the issue? (Press the lock icon in the toolbar while on the site to see toggle)
-
-### Can you reproduce in [Firefox for Android](https://play.google.com/store/apps/details?id=org.mozilla.firefox)?
+### Does toggling Tracking Protection fix the issue? (Press the shield icon in the toolbar while on the site to see toggle)
 
 ### Can you reproduce in Chrome (or other non-Mozilla browser)?
 <!--- Note: If you can reproduce the same issue in Firefox for Android AND Chrome, this issue is very unlikely to be fixed by our teams. -->


### PR DESCRIPTION
The "Can you reproduce in Firefox for Android?"-question that is now obsolete since Fennec is EOL. Also, fenix uses the shield icon to open ETP toggle, and not the lock icon


### Pull Request checklist
Not relevant, no code changes
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
