### PR TITLE
For #13300 - Adjust the 'Sharing a Collection' layout to prevent over…

### DIFF
--- a/app/src/main/res/layout/share_close.xml
+++ b/app/src/main/res/layout/share_close.xml
@@ -22,7 +22,6 @@
         android:contentDescription="@string/content_description_close_button"
         android:padding="12dp"
         app:iconTint="@color/neutral_text"
-        app:layout_constraintEnd_toStartOf="@id/title"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:srcCompat="@drawable/mozac_ic_close" />


### PR DESCRIPTION
…lapping of the close icon and 'Share' label in RTL

Note that the "Share" title is still constrained to start at the end of the
close button - I don't know why the previous extra constraint was causing the
differing behavior in LTR and RTL, but this seems to fix it.

![comparisons](https://user-images.githubusercontent.com/632915/92350105-8f201e80-f09d-11ea-9245-aca6e4efb00d.jpg)



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
