### PR TITLE
Update to new state API and update Mozilla Android Components version.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -55,6 +55,7 @@ import mozilla.appservices.places.BookmarkRoot
 import mozilla.components.browser.menu.view.MenuButton
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
+import mozilla.components.browser.state.selector.findTab
 import mozilla.components.browser.state.selector.getNormalOrPrivateTabs
 import mozilla.components.browser.state.selector.normalTabs
 import mozilla.components.browser.state.selector.privateTabs
@@ -471,16 +472,10 @@ class HomeFragment : Fragment() {
     private fun removeAllTabsAndShowSnackbar(sessionCode: String) {
         val tabs = sessionManager.sessionsOfType(private = sessionCode == ALL_PRIVATE_TABS).toList()
         val selectedIndex = sessionManager
-            .selectedSession?.let { sessionManager.sessions.indexOf(it) } ?: 0
+            .selectedSession?.let { sessionManager.sessions.indexOf(it) } ?: SessionManager.NO_SELECTION
 
         val snapshot = tabs
             .map(sessionManager::createSessionSnapshot)
-            .map {
-                it.copy(
-                    engineSession = null,
-                    engineSessionState = it.engineSession?.saveState()
-                )
-            }
             .let { SessionManager.Snapshot(it, selectedIndex) }
 
         tabs.forEach {
@@ -508,7 +503,7 @@ class HomeFragment : Fragment() {
     private fun removeTabAndShowSnackbar(sessionId: String) {
         sessionManager.findSessionById(sessionId)?.let { session ->
             val snapshot = sessionManager.createSessionSnapshot(session)
-            val state = snapshot.engineSession?.saveState()
+            val state = store.state.findTab(sessionId)?.engineState?.engineSessionState
             val isSelected =
                 session.id == requireComponents.core.store.state.selectedTabId ?: false
 

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "58.0.20200906130403"
+    const val VERSION = "58.0.20200907130126"
 }


### PR DESCRIPTION
The `EngineSessionState` of a tab is now always accessible through `tab.engineState.engineSessionState`. It will
never get cleared.

PR for change in AC: https://github.com/mozilla-mobile/android-components/issues/8255
For fixing: https://github.com/mozilla-mobile/fenix/issues/12436