### PR TITLE
Closes #14053

### DIFF
--- a/app/src/main/res/layout/download_dialog_layout.xml
+++ b/app/src/main/res/layout/download_dialog_layout.xml
@@ -78,6 +78,7 @@
         android:backgroundTint="?accent"
         android:text="@string/mozac_feature_downloads_button_open"
         android:textAllCaps="false"
+        android:padding="16dp"
         android:textColor="?contrastText"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
Set the padding on the download action button since it didn't have a padding as the numbers of characters in the text of the button grew.

[https://ibb.co/rwgbJ03](Screenshot)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ tick ] **Tests**: This PR includes thorough tests
- [ ] **Screenshots**: This PR includes a screenshot of the changes made
- [ ] **Accessibility**: The code in this PR follows does not include any user facing features.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
