### PR TITLE
For #14529 - Show a dialog when the top sites limit has been reached

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -293,7 +293,8 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Session
                 openInFenixIntent = openInFenixIntent,
                 bookmarkTapped = { viewLifecycleOwner.lifecycleScope.launch { bookmarkTapped(it) } },
                 scope = viewLifecycleOwner.lifecycleScope,
-                tabCollectionStorage = requireComponents.core.tabCollectionStorage
+                tabCollectionStorage = requireComponents.core.tabCollectionStorage,
+                topSitesStorage = requireComponents.core.topSitesStorage
             )
 
             _browserInteractor = BrowserInteractor(

--- a/app/src/main/java/org/mozilla/fenix/components/Components.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Components.kt
@@ -54,7 +54,7 @@ class Components(private val context: Context) {
             core.store,
             search.searchEngineManager,
             core.webAppShortcutManager,
-            core.topSiteStorage
+            core.topSitesStorage
         )
     }
     val intentProcessors by lazy {

--- a/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -265,7 +265,7 @@ class Core(private val context: Context, private val crashReporter: CrashReporti
 
     val pinnedSiteStorage by lazy { PinnedSiteStorage(context) }
 
-    val topSiteStorage by lazy {
+    val topSitesStorage by lazy {
         val defaultTopSites = mutableListOf<Pair<String, String>>()
 
         StrictMode.allowThreadDiskReads().resetPoliciesAfter {

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -199,7 +199,7 @@ class HomeFragment : Fragment() {
                     collections = components.core.tabCollectionStorage.cachedTabCollections,
                     expandedCollections = emptySet(),
                     mode = currentMode.getCurrentMode(),
-                    topSites = components.core.topSiteStorage.cachedTopSites,
+                    topSites = components.core.topSitesStorage.cachedTopSites,
                     tip = StrictMode.allowThreadDiskReads().resetPoliciesAfter {
                         FenixTipManager(
                             listOf(
@@ -219,7 +219,7 @@ class HomeFragment : Fragment() {
         topSitesFeature.set(
             feature = TopSitesFeature(
                 view = DefaultTopSitesView(homeFragmentStore),
-                storage = components.core.topSiteStorage,
+                storage = components.core.topSitesStorage,
                 config = ::getTopSitesConfig
             ),
             owner = this,
@@ -552,7 +552,7 @@ class HomeFragment : Fragment() {
             HomeFragmentAction.Change(
                 collections = components.core.tabCollectionStorage.cachedTabCollections,
                 mode = currentMode.getCurrentMode(),
-                topSites = components.core.topSiteStorage.cachedTopSites,
+                topSites = components.core.topSitesStorage.cachedTopSites,
                 tip = StrictMode.allowThreadDiskReads().resetPoliciesAfter {
                     FenixTipManager(
                         listOf(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1534,7 +1534,7 @@
     <!-- Title text displayed in the dialog when top sites limit is reached. -->
     <string name="top_sites_max_limit_title">Top site limit reached</string>
     <!-- Content description text displayed in the dialog when top sites limit is reached. -->
-    <string name="top_sites_max_limit_content">To add a new top site, remove one. Long press the site and select remove.</string>
+    <string name="top_sites_max_limit_content_2">To add a new top site, remove one. Touch and hold the site and select remove.</string>
     <!-- Confirmation dialog button text when top sites limit is reached. -->
     <string name="top_sites_max_limit_confirmation_button">OK, Got It</string>
     <!-- Label for the show most visited sites preference -->

--- a/app/src/test/java/org/mozilla/fenix/components/TestComponents.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/TestComponents.kt
@@ -24,7 +24,7 @@ class TestComponents(private val context: Context) : Components(context) {
             core.store,
             search.searchEngineManager,
             core.webAppShortcutManager,
-            core.topSiteStorage
+            core.topSitesStorage
         )
     }
     override val intentProcessors by lazy { mockk<IntentProcessors>(relaxed = true) }

--- a/app/src/test/java/org/mozilla/fenix/components/TestCore.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/TestCore.kt
@@ -27,5 +27,5 @@ class TestCore(context: Context, crashReporter: CrashReporting) : Core(context, 
     override val client = mockk<Client>()
     override val webAppShortcutManager = mockk<WebAppShortcutManager>()
     override val thumbnailStorage = mockk<ThumbnailStorage>()
-    override val topSiteStorage = mockk<DefaultTopSitesStorage>()
+    override val topSitesStorage = mockk<DefaultTopSitesStorage>()
 }

--- a/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarMenuControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarMenuControllerTest.kt
@@ -32,6 +32,7 @@ import mozilla.components.feature.search.SearchUseCases
 import mozilla.components.feature.session.SessionFeature
 import mozilla.components.feature.session.SessionUseCases
 import mozilla.components.feature.tab.collections.TabCollection
+import mozilla.components.feature.top.sites.DefaultTopSitesStorage
 import mozilla.components.feature.top.sites.TopSitesUseCases
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
 import mozilla.components.support.test.rule.MainCoroutineRule
@@ -83,6 +84,7 @@ class DefaultBrowserToolbarMenuControllerTest {
     @RelaxedMockK private lateinit var readerModeController: ReaderModeController
     @MockK private lateinit var sessionFeatureWrapper: ViewBoundFeatureWrapper<SessionFeature>
     @RelaxedMockK private lateinit var sessionFeature: SessionFeature
+    @RelaxedMockK private lateinit var topSitesStorage: DefaultTopSitesStorage
 
     @Before
     fun setUp() {
@@ -105,6 +107,7 @@ class DefaultBrowserToolbarMenuControllerTest {
             every { id } returns R.id.browserFragment
         }
         every { currentSession.id } returns "1"
+        every { settings.topSitesMaxLimit } returns 16
 
         val onComplete = slot<() -> Unit>()
         every { browserAnimator.captureEngineViewAndDrawStatically(capture(onComplete)) } answers { onComplete.captured.invoke() }
@@ -487,7 +490,8 @@ class DefaultBrowserToolbarMenuControllerTest {
         bookmarkTapped = bookmarkTapped,
         readerModeController = readerModeController,
         sessionManager = sessionManager,
-        sessionFeature = sessionFeatureWrapper
+        sessionFeature = sessionFeatureWrapper,
+        topSitesStorage = topSitesStorage
     ).apply {
         ioScope = scope
     }


### PR DESCRIPTION
Fixes #14529

<img width="441" alt="Screen Shot 2020-09-08 at 5 52 02 PM" src="https://user-images.githubusercontent.com/1190888/92531322-0d92d280-f1fc-11ea-9222-c0bd5f9b6352.png">

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
