### PR TITLE
CI for #14830

### DIFF
--- a/app/src/main/res/layout/download_dialog_layout.xml
+++ b/app/src/main/res/layout/download_dialog_layout.xml
@@ -78,6 +78,7 @@
         android:backgroundTint="?accent"
         android:text="@string/mozac_feature_downloads_button_open"
         android:textAllCaps="false"
+        android:padding="16dp"
         android:textColor="?contrastText"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
Set the padding on the download action button as it didn't have a padding as the numbers of characters in the text of the button grew.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
