### PR TITLE
Fix #14950 - Make the "Add new tab" button visible in private mode on light theme

### DIFF
--- a/app/src/main/res/drawable/ic_new.xml
+++ b/app/src/main/res/drawable/ic_new.xml
@@ -8,6 +8,6 @@
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path
-        android:fillColor="?primaryText"
+        android:fillColor="@color/primary_text_normal_theme"
         android:pathData="M13,4a1,1 0,1 0,-2 0v7H4a1,1 0,1 0,0 2h7v7a1,1 0,1 0,2 0v-7h7a1,1 0,1 0,0 -2h-7V4z" />
 </vector>

--- a/app/src/main/res/drawable/ic_new.xml
+++ b/app/src/main/res/drawable/ic_new.xml
@@ -8,6 +8,6 @@
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path
-        android:fillColor="@color/primary_text_normal_theme"
+        android:fillColor="?primaryText"
         android:pathData="M13,4a1,1 0,1 0,-2 0v7H4a1,1 0,1 0,0 2h7v7a1,1 0,1 0,2 0v-7h7a1,1 0,1 0,0 -2h-7V4z" />
 </vector>

--- a/app/src/main/res/layout/component_tabstray.xml
+++ b/app/src/main/res/layout/component_tabstray.xml
@@ -139,6 +139,7 @@
             app:layout_constraintBottom_toBottomOf="@id/tab_layout"
             app:layout_constraintEnd_toStartOf="@id/tab_tray_overflow"
             app:layout_constraintTop_toTopOf="@id/tab_layout"
+            android:tint="@color/primary_text_normal_theme"
             app:srcCompat="@drawable/ic_new" />
 
         <ImageButton

--- a/app/src/main/res/layout/component_tabstray.xml
+++ b/app/src/main/res/layout/component_tabstray.xml
@@ -139,7 +139,7 @@
             app:layout_constraintBottom_toBottomOf="@id/tab_layout"
             app:layout_constraintEnd_toStartOf="@id/tab_tray_overflow"
             app:layout_constraintTop_toTopOf="@id/tab_layout"
-            android:tint="@color/primary_text_normal_theme"
+            app:tint="@color/primary_text_normal_theme"
             app:srcCompat="@drawable/ic_new" />
 
         <ImageButton


### PR DESCRIPTION
This PR fixes the issue I reported in #14950. For completeness I shall repeat the issue here as well.

When using the light theme and in private tabs mode, with accessibility settings enabled (ex: TalkBack), the "add new tab" button is impossible to see. See the screenshot below (before the fix version). If you download the image and inspect closely, you can see a white button on a very light background. The button exists and talkback can highlight it in green as seen. Note that the issue does not exist in a dark theme or in regular tabs mode, but only in light theme mode and in private tabs with accessibility setting such as TalkBack enabled.

The issue is because `android:fillColor="?primaryText"` is used in `ic_new.xml`. Instead, it should be `android:fillColor="@color/primary_text_normal_theme"`. This is because, in private tabs mode primary text color is white, and so it is conflicting with the light theme. So, we should use the primary text color that correctly changes for both light and dark theme.

### Screenshots
#### Before the fix
<img src="https://user-images.githubusercontent.com/17151327/92746622-558c3380-f37b-11ea-9e14-fffa2f789e31.png" width="350" /> 

#### After the fix
<img src="https://user-images.githubusercontent.com/17151327/92752030-7440f900-f380-11ea-8fa6-644aa0b44433.png" width="350" /> 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR is very trivial, so it does not include any test code. However, there is a visual test in terms of screeshots.
- [x] **Screenshots**: This PR includes screenshots of the fix for the hard to see add new tab button
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product. This code change improves user experience when using accessibility features (specifically TalkBack).

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
