### PR TITLE
Update documentation on the epoch date used for version codes

### DIFF
--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -45,8 +45,8 @@ object Config {
     }
 
     private val fennecBaseVersionCode by lazy {
-        val format = SimpleDateFormat("YYYYMMDDHHMMSS", Locale.US)
-        val cutoff = format.parse("20150801000000")
+        val format = SimpleDateFormat("yyyyMMddHHmmss", Locale.US)
+        val cutoff = format.parse("20141228000000")
         val build = Date()
 
         Math.floor((build.time - cutoff.time) / (1000.0 * 60.0 * 60.0)).toInt()
@@ -56,6 +56,12 @@ object Config {
      * Generates a versionCode that follows the same rules like legacy Fennec builds.
      * Adapted from:
      * https://searchfox.org/mozilla-central/rev/34cb8d0a2a324043bcfc2c56f37b31abe7fb23a8/python/mozbuild/mozbuild/android_version_code.py
+     *
+     * There is a discrepancy between the epoch date used here (20141228)
+     * and the epoch used in Fennec (20150801) for historical reasons. We keep
+     * this discrepancy to avoid having Fenix version codes decrease.
+     * Note that the original Fennec implementation also had an inconsistency in
+     * the documented epoch date (20150901) and the effective epoch date (20150801).
      */
     @JvmStatic
     fun generateFennecVersionCode(abi: String): Int {
@@ -69,7 +75,7 @@ object Config {
         // 0111 1000 0010 tttt tttt tttt tttt txpg
         //
         // The 17 bits labelled 't' represent the number of hours since midnight on
-        // September 1, 2015.  (2015090100 in YYYYMMMDDHH format.)  This yields a
+        // December 28, 2014.  (2014122800 in yyyyMMddHH format.)  This yields a
         // little under 15 years worth of hourly build identifiers, since 2**17 / (366
         //         * 24) =~ 14.92.
         //


### PR DESCRIPTION
Addresses https://github.com/mozilla-mobile/fenix/issues/14031

This PR does not introduce any changes in behavior, but rather just adjusts code comments and changes two lines of date parsing code to be more clear about intent.

I have tested that the result of the new date parsing code and the old code are identical in a Kotlin playground environment, but I don't have sufficient familiarity with tooling here to introduce a test case.

There are no user-facing changes here, so no screenshots or accessibility concerns are included.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.
