### PR TITLE
Fixes #12099 - Use bookmark keywords in browser searches

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/Components.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Components.kt
@@ -54,7 +54,8 @@ class Components(private val context: Context) {
             core.store,
             search.searchEngineManager,
             core.webAppShortcutManager,
-            core.topSitesStorage
+            core.topSitesStorage,
+            core.bookmarksStorage
         )
     }
     val intentProcessors by lazy {

--- a/app/src/main/java/org/mozilla/fenix/components/UseCases.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/UseCases.kt
@@ -9,6 +9,7 @@ import mozilla.components.browser.search.SearchEngineManager
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.Engine
+import mozilla.components.concept.storage.BookmarksStorage
 import mozilla.components.feature.app.links.AppLinksUseCases
 import mozilla.components.feature.contextmenu.ContextMenuUseCases
 import mozilla.components.feature.downloads.DownloadsUseCases
@@ -36,7 +37,8 @@ class UseCases(
     private val store: BrowserStore,
     private val searchEngineManager: SearchEngineManager,
     private val shortcutManager: WebAppShortcutManager,
-    private val topSitesStorage: TopSitesStorage
+    private val topSitesStorage: TopSitesStorage,
+    private val bookmarksStorage: BookmarksStorage
 ) {
     /**
      * Use cases that provide engine interactions for a given browser session.
@@ -51,7 +53,7 @@ class UseCases(
     /**
      * Use cases that provide search engine integration.
      */
-    val searchUseCases by lazy { SearchUseCases(context, store, searchEngineManager, sessionManager) }
+    val searchUseCases by lazy { SearchUseCases(context, store, searchEngineManager, sessionManager, bookmarksStorage) }
 
     /**
      * Use cases that provide settings management.

--- a/app/src/test/java/org/mozilla/fenix/components/TestComponents.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/TestComponents.kt
@@ -24,7 +24,8 @@ class TestComponents(private val context: Context) : Components(context) {
             core.store,
             search.searchEngineManager,
             core.webAppShortcutManager,
-            core.topSitesStorage
+            core.topSitesStorage,
+            core.bookmarksStorage
         )
     }
     override val intentProcessors by lazy { mockk<IntentProcessors>(relaxed = true) }


### PR DESCRIPTION
For the moment users are not able to view/add/modify bookmark keywords in Fenix
but they can in Firefox running on other platforms.
After syncing the bookmarks Fenix users will be able to use the same already
set keywords in Fenix and have the same search experience with included support
for query placeholders.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: No tests. Simple wiring of new dependencies.
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR or does not include any user facing features.

### This patch comes to integrate https://github.com/mozilla-mobile/android-components/pull/8375 which is a breaking change.

![BookmarkKeywordsInFenix](https://user-images.githubusercontent.com/11428869/92764534-2c7c9a80-f39d-11ea-8571-642194125028.gif)
[video demoing bookmark keywords in Fenix](https://drive.google.com/file/d/14Z9KEp8IgtkhQbs-dNjEgN_OKZNDmr83/view?usp=sharing)

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
