### PR TITLE
For #14230: Stop redrawing all top sites when one is removed

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlAdapter.kt
@@ -45,7 +45,7 @@ sealed class AdapterItem(@LayoutRes val viewType: Int) {
     data class TopSitePager(val topSites: List<TopSite>) : AdapterItem(TopSitePagerViewHolder.LAYOUT_ID) {
         override fun sameAs(other: AdapterItem): Boolean {
             val newTopSites = (other as? TopSitePager) ?: return false
-            return newTopSites.topSites == this.topSites
+            return newTopSites.topSites.size == this.topSites.size
         }
 
         override fun contentsSameAs(other: AdapterItem): Boolean {
@@ -53,7 +53,7 @@ sealed class AdapterItem(@LayoutRes val viewType: Int) {
             if (newTopSites.topSites.size != this.topSites.size) return false
             val newSitesSequence = newTopSites.topSites.asSequence()
             val oldTopSites = this.topSites.asSequence()
-            return newSitesSequence.zip(oldTopSites).all { (new, old) -> new.title == old.title }
+            return newSitesSequence.zip(oldTopSites).all { (new, old) -> new == old }
         }
     }
 

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/TopSitePagerViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/TopSitePagerViewHolder.kt
@@ -36,7 +36,8 @@ class TopSitePagerViewHolder(
     }
 
     fun bind(topSites: List<TopSite>) {
-        topSitesPagerAdapter.updateData(topSites)
+        val chunkedTopSites = topSites.chunked(TOP_SITES_PER_PAGE)
+        topSitesPagerAdapter.submitList(chunkedTopSites)
 
         // Don't show any page indicator if there is only 1 page.
         val numPages = if (topSites.size > TOP_SITES_PER_PAGE) {

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/topsites/TopSitesPagerAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/topsites/TopSitesPagerAdapter.kt
@@ -6,21 +6,16 @@ package org.mozilla.fenix.home.sessioncontrol.viewholders.topsites
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import kotlinx.android.synthetic.main.component_top_sites.view.*
 import mozilla.components.feature.top.sites.TopSite
 import org.mozilla.fenix.home.sessioncontrol.TopSiteInteractor
 import org.mozilla.fenix.home.sessioncontrol.viewholders.TopSiteViewHolder
 
 class TopSitesPagerAdapter(
     private val interactor: TopSiteInteractor
-) : RecyclerView.Adapter<TopSiteViewHolder>() {
-
-    private var topSites: List<List<TopSite>> = listOf()
-
-    fun updateData(topSites: List<TopSite>) {
-        this.topSites = topSites.chunked(TOP_SITES_PER_PAGE)
-        notifyDataSetChanged()
-    }
+) : ListAdapter<List<TopSite>, TopSiteViewHolder>(DiffCallback) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TopSiteViewHolder {
         val view = LayoutInflater.from(parent.context)
@@ -29,12 +24,17 @@ class TopSitesPagerAdapter(
     }
 
     override fun onBindViewHolder(holder: TopSiteViewHolder, position: Int) {
-        holder.bind(this.topSites[position])
+        val adapter = holder.itemView.top_sites_list.adapter as TopSitesAdapter
+        adapter.submitList(getItem(position))
     }
 
-    override fun getItemCount(): Int = this.topSites.size
+    private object DiffCallback : DiffUtil.ItemCallback<List<TopSite>>() {
+        override fun areItemsTheSame(oldItem: List<TopSite>, newItem: List<TopSite>): Boolean {
+            return oldItem.size == newItem.size
+        }
 
-    companion object {
-        const val TOP_SITES_PER_PAGE = 8
+        override fun areContentsTheSame(oldItem: List<TopSite>, newItem: List<TopSite>): Boolean {
+            return newItem.zip(oldItem).all { (new, old) -> new == old }
+        }
     }
 }


### PR DESCRIPTION
In the `SessionControlAdapter.TopSitePager`, we need to be checking if the lists have changed (`sameAs`) or not before we look at the inner diff of the contents (`contentsSameAs`). Since the default implementation of equality on a list is to check the elements inside it as well, we were always returning `false` so they either top site list would refresh. What we really want is to have the adapter go into each top site and diff them separately.

With this fix though there are some other bugs that might have been hidden until now:
 - Updating one page of top sites, sometimes breaks the grid layout for the second page.
   - If we stick with a horizontal multi-row layout, we should strongly consider reducing the nested layouts we have here so we can reduce complexity and draw the top sites in one RecyclerView alone.
 - You can see frecent top sites move around the screen (usually on the second page) every time you revisit the homescreen.
   - I'm not sure how big of a deal it is, but in my testing where I was trying to trigger more frecent top site changes, the moving top sites with a visual pain for me.
 - There is still a smaller fade in animation as you can see the gifs below.
   - This is a larger improvement from the previous behaviour. We can better reduce this further with a combination of the changes above and also having a stable ID for our TopSites which now only come from pinned sites I believe.

@ekager I believe you worked a bit on the session adapter as well, so I wonder if you have any thoughts over here too.

| Before | After |
|--------|------|
| ![cMONEp](https://user-images.githubusercontent.com/1370580/93265168-31af6000-f776-11ea-95ca-46c5079e18e4.gif) | ![evXXpE](https://user-images.githubusercontent.com/1370580/93265157-2eb46f80-f776-11ea-924f-741c9c9e7c01.gif) |

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
