### PR TITLE
For #2792: Display bookmark folders on top of the bookmarks UI

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkAdapter.kt
@@ -26,16 +26,30 @@ class BookmarkAdapter(private val emptyView: View, private val interactor: Bookm
     private var isFirstRun = true
 
     fun updateData(tree: BookmarkNode?, mode: BookmarkFragmentState.Mode) {
+        // Display folders above all other bookmarks.
+        val allNodes = tree?.children.orEmpty()
+        val folders: MutableList<BookmarkNode> = mutableListOf()
+        val notFolders: MutableList<BookmarkNode> = mutableListOf()
+        allNodes.forEach {
+            if (it.type == BookmarkNodeType.FOLDER) {
+                folders.add(it)
+            } else {
+                notFolders.add(it)
+            }
+        }
+        val newTree = folders + notFolders
+
         val diffUtil = DiffUtil.calculateDiff(
             BookmarkDiffUtil(
                 this.tree,
-                tree?.children.orEmpty(),
+                newTree,
                 this.mode,
                 mode
             )
         )
 
-        this.tree = tree?.children.orEmpty()
+        this.tree = newTree
+
         isFirstRun = if (isFirstRun) false else {
             emptyView.isVisible = this.tree.isEmpty()
             false


### PR DESCRIPTION
This is a naive (read: maybe slowish? a single full pass + array smushing) way to do this, but it's very simple. I think getting this to go faster would require storage API level changes, so it'll do for now.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
