### PR TITLE
For #11800: Hide reveal and clear password icons if the password is empty when editing a saved login

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/EditLoginFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/EditLoginFragment.kt
@@ -237,6 +237,7 @@ class EditLoginFragment : Fragment(R.layout.fragment_edit_login) {
                 usernameChanged = true
                 validUsername = false
                 it.setErrorIconDrawable(R.drawable.mozac_ic_warning)
+                it.setErrorIconTintList(ColorStateList.valueOf(ContextCompat.getColor(requireContext(), R.color.design_error)))
                 it.error = context?.getString(R.string.saved_login_duplicate)
             }
         } else {

--- a/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/EditLoginFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/EditLoginFragment.kt
@@ -236,9 +236,9 @@ class EditLoginFragment : Fragment(R.layout.fragment_edit_login) {
             inputLayoutUsername?.let {
                 usernameChanged = true
                 validUsername = false
+                it.error = context?.getString(R.string.saved_login_duplicate)
                 it.setErrorIconDrawable(R.drawable.mozac_ic_warning)
                 it.setErrorIconTintList(ColorStateList.valueOf(ContextCompat.getColor(requireContext(), R.color.design_error)))
-                it.error = context?.getString(R.string.saved_login_duplicate)
             }
         } else {
             usernameChanged = true

--- a/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/EditLoginFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/EditLoginFragment.kt
@@ -241,7 +241,11 @@ class EditLoginFragment : Fragment(R.layout.fragment_edit_login) {
                 validUsername = false
                 it.error = context?.getString(R.string.saved_login_duplicate)
                 it.setErrorIconDrawable(R.drawable.mozac_ic_warning_with_bottom_padding)
-                it.setErrorIconTintList(ColorStateList.valueOf(ContextCompat.getColor(requireContext(), R.color.design_error)))
+                it.setErrorIconTintList(
+                    ColorStateList.valueOf(
+                        ContextCompat.getColor(requireContext(), R.color.design_error)
+                    )
+                )
                 clearUsernameTextButton.isVisible = false
             }
         } else {
@@ -258,7 +262,11 @@ class EditLoginFragment : Fragment(R.layout.fragment_edit_login) {
             validPassword = false
             layout.error = context?.getString(R.string.saved_login_password_required)
             layout.setErrorIconDrawable(R.drawable.mozac_ic_warning_with_bottom_padding)
-            layout.setErrorIconTintList(ColorStateList.valueOf(ContextCompat.getColor(requireContext(), R.color.design_error)))
+            layout.setErrorIconTintList(
+                ColorStateList.valueOf(
+                    ContextCompat.getColor(requireContext(), R.color.design_error)
+                )
+            )
         }
     }
 

--- a/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/EditLoginFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/EditLoginFragment.kt
@@ -170,6 +170,7 @@ class EditLoginFragment : Fragment(R.layout.fragment_edit_login) {
                         validUsername = true
                         inputLayoutUsername.error = null
                         inputLayoutUsername.errorIconDrawable = null
+                        clearUsernameTextButton.isVisible = true
                     }
                     else -> {
                         usernameChanged = true
@@ -239,12 +240,14 @@ class EditLoginFragment : Fragment(R.layout.fragment_edit_login) {
                 it.error = context?.getString(R.string.saved_login_duplicate)
                 it.setErrorIconDrawable(R.drawable.mozac_ic_warning_with_bottom_padding)
                 it.setErrorIconTintList(ColorStateList.valueOf(ContextCompat.getColor(requireContext(), R.color.design_error)))
+                clearUsernameTextButton.isVisible = false
             }
         } else {
             usernameChanged = true
             validUsername = true
             inputLayoutUsername.error = null
             inputLayoutUsername.errorIconDrawable = null
+            clearUsernameTextButton.isVisible = true
         }
     }
 

--- a/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/EditLoginFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/EditLoginFragment.kt
@@ -237,7 +237,7 @@ class EditLoginFragment : Fragment(R.layout.fragment_edit_login) {
                 usernameChanged = true
                 validUsername = false
                 it.error = context?.getString(R.string.saved_login_duplicate)
-                it.setErrorIconDrawable(R.drawable.mozac_ic_warning)
+                it.setErrorIconDrawable(R.drawable.mozac_ic_warning_with_bottom_padding)
                 it.setErrorIconTintList(ColorStateList.valueOf(ContextCompat.getColor(requireContext(), R.color.design_error)))
             }
         } else {

--- a/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/EditLoginFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/EditLoginFragment.kt
@@ -117,6 +117,8 @@ class EditLoginFragment : Fragment(R.layout.fragment_edit_login) {
 
         usernameChanged = false
         passwordChanged = false
+
+        clearUsernameTextButton.isEnabled = oldLogin.username.isNotEmpty()
     }
 
     private fun formatEditableValues() {

--- a/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/EditLoginFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/EditLoginFragment.kt
@@ -250,7 +250,7 @@ class EditLoginFragment : Fragment(R.layout.fragment_edit_login) {
         inputLayoutPassword?.let { layout ->
             validPassword = false
             layout.error = context?.getString(R.string.saved_login_password_required)
-            layout.setErrorIconDrawable(R.drawable.mozac_ic_warning)
+            layout.setErrorIconDrawable(R.drawable.mozac_ic_warning_with_bottom_padding)
             layout.setErrorIconTintList(ColorStateList.valueOf(ContextCompat.getColor(requireContext(), R.color.design_error)))
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/EditLoginFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/EditLoginFragment.kt
@@ -174,10 +174,10 @@ class EditLoginFragment : Fragment(R.layout.fragment_edit_login) {
                     }
                     else -> {
                         usernameChanged = true
-                        clearUsernameTextButton.isEnabled = true
                         setDupeError()
                     }
                 }
+                clearUsernameTextButton.isEnabled = u.toString().isNotEmpty()
                 setSaveButtonState()
             }
 

--- a/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/EditLoginFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/EditLoginFragment.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.fenix.settings.logins.fragment
 
+import android.content.res.ColorStateList
 import android.os.Bundle
 import android.text.Editable
 import android.text.InputType
@@ -13,6 +14,7 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import androidx.appcompat.view.menu.ActionMenuItemView
+import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
@@ -249,6 +251,7 @@ class EditLoginFragment : Fragment(R.layout.fragment_edit_login) {
             validPassword = false
             layout.error = context?.getString(R.string.saved_login_password_required)
             layout.setErrorIconDrawable(R.drawable.mozac_ic_warning)
+            layout.setErrorIconTintList(ColorStateList.valueOf(ContextCompat.getColor(requireContext(), R.color.design_error)))
         }
     }
 

--- a/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/EditLoginFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/EditLoginFragment.kt
@@ -244,6 +244,7 @@ class EditLoginFragment : Fragment(R.layout.fragment_edit_login) {
             usernameChanged = true
             validUsername = true
             inputLayoutUsername.error = null
+            inputLayoutUsername.errorIconDrawable = null
         }
     }
 

--- a/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/EditLoginFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/EditLoginFragment.kt
@@ -13,6 +13,7 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import androidx.appcompat.view.menu.ActionMenuItemView
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
@@ -140,7 +141,6 @@ class EditLoginFragment : Fragment(R.layout.fragment_edit_login) {
             passwordText.isCursorVisible = true
             passwordText.hasFocus()
             inputLayoutPassword.hasFocus()
-            it.isEnabled = false
         }
         revealPasswordButton.setOnClickListener {
             togglePasswordReveal(passwordText, revealPasswordButton)
@@ -192,7 +192,8 @@ class EditLoginFragment : Fragment(R.layout.fragment_edit_login) {
                 when {
                     p.toString().isEmpty() -> {
                         passwordChanged = true
-                        clearPasswordTextButton.isEnabled = false
+                        revealPasswordButton.isVisible = false
+                        clearPasswordTextButton.isVisible = false
                         setPasswordError()
                     }
                     p.toString() == oldLogin.password -> {
@@ -200,14 +201,16 @@ class EditLoginFragment : Fragment(R.layout.fragment_edit_login) {
                         validPassword = true
                         inputLayoutPassword.error = null
                         inputLayoutPassword.errorIconDrawable = null
-                        clearPasswordTextButton.isEnabled = true
+                        revealPasswordButton.isVisible = true
+                        clearPasswordTextButton.isVisible = true
                     }
                     else -> {
                         passwordChanged = true
                         validPassword = true
                         inputLayoutPassword.error = null
                         inputLayoutPassword.errorIconDrawable = null
-                        clearPasswordTextButton.isEnabled = true
+                        revealPasswordButton.isVisible = true
+                        clearPasswordTextButton.isVisible = true
                     }
                 }
                 setSaveButtonState()

--- a/app/src/main/res/drawable/mozac_ic_warning_with_bottom_padding.xml
+++ b/app/src/main/res/drawable/mozac_ic_warning_with_bottom_padding.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item
         android:drawable="@drawable/mozac_ic_warning"

--- a/app/src/main/res/drawable/mozac_ic_warning_with_bottom_padding.xml
+++ b/app/src/main/res/drawable/mozac_ic_warning_with_bottom_padding.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:drawable="@drawable/mozac_ic_warning"
+        android:bottom="14dp" />
+</layer-list>


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture


Before fix - Light Mode
![Before fix - Light Mode](https://user-images.githubusercontent.com/38375996/93721201-f4dcd200-fb96-11ea-9ddb-18a267fd3c5d.png)

Before fix - Dark Mode
![Before fix - Dark Mode](https://user-images.githubusercontent.com/38375996/93721203-f73f2c00-fb96-11ea-9498-aa8c5aadd958.png)

After fix - Light Mode
![After fix - Light Mode](https://user-images.githubusercontent.com/38375996/93721206-f8705900-fb96-11ea-9830-941f76f853cb.png)

After fix - Dark Mode
![After fix - Dark Mode](https://user-images.githubusercontent.com/38375996/93721205-f7d7c280-fb96-11ea-8da5-7b94844711db.png)