### PR TITLE
For #15273: fix suspected syntax errors in codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,10 +18,10 @@
 # By default the Android Components team will be the owner for everything in
 # the repo. Unless a later match takes precedence.
 * @mozilla-mobile/ACT @mozilla-mobile/fenix
-/.cron.yml /@mozilla-mobile/releng @mozilla-mobile/fenix
-/.taskcluster.yml /@mozilla-mobile/releng @mozilla-mobile/fenix
+/.cron.yml @mozilla-mobile/releng @mozilla-mobile/fenix
+/.taskcluster.yml @mozilla-mobile/releng @mozilla-mobile/fenix
 /automation/ @mozilla-mobile/releng @mozilla-mobile/fenix
-/taskcluster/ /@mozilla-mobile/releng @mozilla-mobile/fenix
+/taskcluster/ @mozilla-mobile/releng @mozilla-mobile/fenix
 /.github/ @mozilla-mobile/releng @mozilla-mobile/fenix
 
 # --- PERFORMANCE START --- #

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,6 +14,12 @@
 # to their GitHub account, for example user@example.com.
 # https://help.github.com/articles/about-codeowners/
 
+# WARNING: if there is a single syntax error in this file, CODEOWNERS
+# WILL NOT WORK AT ALL. Please be careful when editing this file.
+#
+# You can use the technique described in this blog post to validate
+# the paths you specify in .gitignore:
+# http://www.benjaminoakes.com/git/2018/08/10/Testing-changes-to-GitHub-CODEOWNERS/
 
 # By default the Android Components team will be the owner for everything in
 # the repo. Unless a later match takes precedence.
@@ -30,6 +36,12 @@
 # these changes (for now) but to be aware of them. Please let us know
 # if the CODEOWNERS system makes this impractical. We're available at
 # #perf-android-frontend on Matrix.
+
+# The perf team is relying on CODEOWNERS to catch regressions. If
+# there is a single syntax error in the file, no rules will work.
+# Therefore, we make the Perfomance team code owners of this file.
+/.github/CODEOWNERS @mozilla-mobile/Performance
+
 /app/src/*/java/org/mozilla/fenix/perf/** @mozilla-mobile/Performance
 *.pro @mozilla-mobile/Performance
 *proguard* @mozilla-mobile/Performance


### PR DESCRIPTION
Assuming I fixed the syntax errors, this will re-enable codeowners for the entire repository. This seems fine for most rules but I'm concerned about the rule that will re-enable codeowners for every file for the AC team and for fenix:
```
* @mozilla-mobile/ACT @mozilla-mobile/fenix
```

@boek Should I remove this rule before landing this patch?

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
