### PR TITLE
For #15284: Process root titles when creating new folders

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/DesktopFolders.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/DesktopFolders.kt
@@ -11,36 +11,15 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
 
 class DesktopFolders(
-    context: Context,
+    private val context: Context,
     private val showMobileRoot: Boolean
 ) {
-
     private val bookmarksStorage = context.components.core.bookmarksStorage
-
-    private val bookmarksTitle = context.getString(R.string.library_bookmarks)
 
     /**
      * Map of [BookmarkNode.title] to translated strings.
      */
-    private val rootTitles: Map<String, String> = if (showMobileRoot) {
-        mapOf(
-            "root" to bookmarksTitle,
-            "mobile" to bookmarksTitle,
-            "menu" to context.getString(R.string.library_desktop_bookmarks_menu),
-            "toolbar" to context.getString(R.string.library_desktop_bookmarks_toolbar),
-            "unfiled" to context.getString(R.string.library_desktop_bookmarks_unfiled)
-        )
-    } else {
-        mapOf(
-            "root" to context.getString(R.string.library_desktop_bookmarks_root),
-            "menu" to context.getString(R.string.library_desktop_bookmarks_menu),
-            "toolbar" to context.getString(R.string.library_desktop_bookmarks_toolbar),
-            "unfiled" to context.getString(R.string.library_desktop_bookmarks_unfiled)
-        )
-    }
-
-    fun withRootTitle(node: BookmarkNode): BookmarkNode =
-        if (rootTitles.containsKey(node.title)) node.copy(title = rootTitles[node.title]) else node
+    private val rootTitles = rootTitles(context, showMobileRoot)
 
     suspend fun withOptionalDesktopFolders(node: BookmarkNode): BookmarkNode {
         return when (node.guid) {
@@ -103,7 +82,7 @@ class DesktopFolders(
         return listOf(
             mobileRoot.copy(
                 children = mobileChildren,
-                title = bookmarksTitle
+                title = context.getString(R.string.library_bookmarks)
             )
         )
     }

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/Utils.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/Utils.kt
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.library.bookmarks
+
+import android.content.Context
+import mozilla.components.concept.storage.BookmarkNode
+import org.mozilla.fenix.R
+
+fun rootTitles(context: Context, withMobileRoot: Boolean): Map<String, String> = if (withMobileRoot) {
+    mapOf(
+        "root" to context.getString(R.string.library_bookmarks),
+        "mobile" to context.getString(R.string.library_bookmarks),
+        "menu" to context.getString(R.string.library_desktop_bookmarks_menu),
+        "toolbar" to context.getString(R.string.library_desktop_bookmarks_toolbar),
+        "unfiled" to context.getString(R.string.library_desktop_bookmarks_unfiled)
+    )
+} else {
+    mapOf(
+        "root" to context.getString(R.string.library_desktop_bookmarks_root),
+        "menu" to context.getString(R.string.library_desktop_bookmarks_menu),
+        "toolbar" to context.getString(R.string.library_desktop_bookmarks_toolbar),
+        "unfiled" to context.getString(R.string.library_desktop_bookmarks_unfiled)
+    )
+}
+
+fun friendlyRootTitle(
+    context: Context,
+    node: BookmarkNode,
+    withMobileRoot: Boolean = true,
+    rootTitles: Map<String, String> = rootTitles(context, withMobileRoot)
+) = when {
+    !node.inRoots() -> node.title
+    rootTitles.containsKey(node.title) -> rootTitles[node.title]
+    else -> node.title
+}

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/addfolder/AddBookmarkFolderFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/addfolder/AddBookmarkFolderFragment.kt
@@ -29,6 +29,7 @@ import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.showToolbar
 import org.mozilla.fenix.library.bookmarks.BookmarksSharedViewModel
+import org.mozilla.fenix.library.bookmarks.friendlyRootTitle
 
 /**
  * Menu to create a new bookmark folder.
@@ -58,12 +59,13 @@ class AddBookmarkFolderFragment : Fragment(R.layout.fragment_edit_bookmark) {
         showToolbar(getString(R.string.bookmark_add_folder_fragment_label))
 
         viewLifecycleOwner.lifecycleScope.launch(Main) {
+            val context = requireContext()
             sharedViewModel.selectedFolder = withContext(IO) {
                 sharedViewModel.selectedFolder
-                    ?: requireComponents.core.bookmarksStorage.getTree(BookmarkRoot.Mobile.id)
+                    ?: requireComponents.core.bookmarksStorage.getBookmark(BookmarkRoot.Mobile.id)
             }
 
-            bookmarkParentFolderSelector.text = sharedViewModel.selectedFolder!!.title
+            bookmarkParentFolderSelector.text = friendlyRootTitle(context, sharedViewModel.selectedFolder!!)
             bookmarkParentFolderSelector.setOnClickListener {
                 nav(
                     R.id.bookmarkAddFolderFragment,

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/edit/EditBookmarkFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/edit/EditBookmarkFragment.kt
@@ -45,7 +45,7 @@ import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.setToolbarColors
 import org.mozilla.fenix.ext.toShortUrl
 import org.mozilla.fenix.library.bookmarks.BookmarksSharedViewModel
-import org.mozilla.fenix.library.bookmarks.DesktopFolders
+import org.mozilla.fenix.library.bookmarks.friendlyRootTitle
 
 /**
  * Menu to edit the name, URL, and location of a bookmark item.
@@ -88,9 +88,6 @@ class EditBookmarkFragment : Fragment(R.layout.fragment_edit_bookmark) {
                     sharedViewModel.selectedFolder
                 } else {
                     bookmarkNode?.parentGuid?.let { bookmarksStorage.getBookmark(it) }
-                }?.let {
-                    // No-op for non-root nodes, and copies a node with a friendly title otherwise.
-                    DesktopFolders(context, showMobileRoot = true).withRootTitle(it)
                 }
             }
 
@@ -113,7 +110,7 @@ class EditBookmarkFragment : Fragment(R.layout.fragment_edit_bookmark) {
             }
 
             bookmarkParent?.let { node ->
-                bookmarkParentFolderSelector.text = node.title
+                bookmarkParentFolderSelector.text = friendlyRootTitle(context, node)
             }
 
             bookmarkParentFolderSelector.setOnClickListener {

--- a/app/src/test/java/org/mozilla/fenix/library/bookmarks/DesktopFoldersTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/bookmarks/DesktopFoldersTest.kt
@@ -45,24 +45,20 @@ class DesktopFoldersTest {
 
     @Test
     fun `withRootTitle and do showMobileRoot`() {
-        val desktopFolders = DesktopFolders(context, showMobileRoot = true)
-
-        assertEquals(testContext.getString(R.string.library_bookmarks), desktopFolders.withRootTitle(mockNodeWithTitle("root")).title)
-        assertEquals(testContext.getString(R.string.library_bookmarks), desktopFolders.withRootTitle(mockNodeWithTitle("mobile")).title)
-        assertEquals(testContext.getString(R.string.library_desktop_bookmarks_menu), desktopFolders.withRootTitle(mockNodeWithTitle("menu")).title)
-        assertEquals(testContext.getString(R.string.library_desktop_bookmarks_toolbar), desktopFolders.withRootTitle(mockNodeWithTitle("toolbar")).title)
-        assertEquals(testContext.getString(R.string.library_desktop_bookmarks_unfiled), desktopFolders.withRootTitle(mockNodeWithTitle("unfiled")).title)
+        assertEquals(testContext.getString(R.string.library_bookmarks), friendlyRootTitle(context, mockNodeWithTitle("root")))
+        assertEquals(testContext.getString(R.string.library_bookmarks), friendlyRootTitle(context, mockNodeWithTitle("mobile")))
+        assertEquals(testContext.getString(R.string.library_desktop_bookmarks_menu), friendlyRootTitle(context, mockNodeWithTitle("menu")))
+        assertEquals(testContext.getString(R.string.library_desktop_bookmarks_toolbar), friendlyRootTitle(context, mockNodeWithTitle("toolbar")))
+        assertEquals(testContext.getString(R.string.library_desktop_bookmarks_unfiled), friendlyRootTitle(context, mockNodeWithTitle("unfiled")))
     }
 
     @Test
     fun `withRootTitle and do not showMobileRoot`() {
-        val desktopFolders = DesktopFolders(context, showMobileRoot = false)
-
-        assertEquals(testContext.getString(R.string.library_desktop_bookmarks_root), desktopFolders.withRootTitle(mockNodeWithTitle("root")).title)
-        assertEquals(mockNodeWithTitle("mobile"), desktopFolders.withRootTitle(mockNodeWithTitle("mobile")))
-        assertEquals(testContext.getString(R.string.library_desktop_bookmarks_menu), desktopFolders.withRootTitle(mockNodeWithTitle("menu")).title)
-        assertEquals(testContext.getString(R.string.library_desktop_bookmarks_toolbar), desktopFolders.withRootTitle(mockNodeWithTitle("toolbar")).title)
-        assertEquals(testContext.getString(R.string.library_desktop_bookmarks_unfiled), desktopFolders.withRootTitle(mockNodeWithTitle("unfiled")).title)
+        assertEquals(testContext.getString(R.string.library_desktop_bookmarks_root), friendlyRootTitle(context, mockNodeWithTitle("root"), false))
+        assertEquals(mockNodeWithTitle("mobile").title, friendlyRootTitle(context, mockNodeWithTitle("mobile"), false))
+        assertEquals(testContext.getString(R.string.library_desktop_bookmarks_menu), friendlyRootTitle(context, mockNodeWithTitle("menu"), false))
+        assertEquals(testContext.getString(R.string.library_desktop_bookmarks_toolbar), friendlyRootTitle(context, mockNodeWithTitle("toolbar"), false))
+        assertEquals(testContext.getString(R.string.library_desktop_bookmarks_unfiled), friendlyRootTitle(context, mockNodeWithTitle("unfiled"), false))
     }
 
     @Test


### PR DESCRIPTION
This also simplifies how we do this. We're no longer creating instances of `DesktopFolder` class
nor creating copies of BookmarkNodes just to display root titles correctly for the 'edit folder' UI.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
