### PR TITLE
Use "undo" implementation from Android Components.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -260,9 +260,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Session
                     )
                 },
                 onCloseTab = { closedSession ->
-                    val tab = store.state.findTab(closedSession.id)
-                        ?: return@DefaultBrowserToolbarController
-                    val isSelected = tab.id == context.components.core.store.state.selectedTabId
+                    val tab = store.state.findTab(closedSession.id) ?: return@DefaultBrowserToolbarController
 
                     val snackbarMessage = if (tab.content.private) {
                         requireContext().getString(R.string.snackbar_private_tab_closed)
@@ -275,11 +273,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Session
                         snackbarMessage,
                         requireContext().getString(R.string.snackbar_deleted_undo),
                         {
-                            sessionManager.add(
-                                closedSession,
-                                isSelected,
-                                engineSessionState = tab.engineState.engineSessionState
-                            )
+                            requireComponents.useCases.tabsUseCases.undo.invoke()
                         },
                         operation = { }
                     )

--- a/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -20,6 +20,7 @@ import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.session.engine.EngineMiddleware
 import mozilla.components.browser.session.storage.SessionStorage
+import mozilla.components.browser.session.undo.UndoMiddleware
 import mozilla.components.browser.state.action.RecentlyClosedAction
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.store.BrowserStore
@@ -69,6 +70,7 @@ import org.mozilla.fenix.search.telemetry.incontent.InContentTelemetry
 import org.mozilla.fenix.settings.SupportUtils
 import org.mozilla.fenix.settings.advanced.getSelectedLocale
 import org.mozilla.fenix.utils.Mockable
+import org.mozilla.fenix.utils.getUndoDelay
 import java.util.concurrent.TimeUnit
 
 /**
@@ -146,11 +148,16 @@ class Core(private val context: Context, private val crashReporter: CrashReporti
                 MediaMiddleware(context, MediaService::class.java),
                 DownloadMiddleware(context, DownloadService::class.java),
                 ReaderViewMiddleware(),
-                ThumbnailsMiddleware(thumbnailStorage)
+                ThumbnailsMiddleware(thumbnailStorage),
+                UndoMiddleware(::lookupSessionManager, context.getUndoDelay())
             ) + EngineMiddleware.create(engine, ::findSessionById)
         ).also {
             it.dispatch(RecentlyClosedAction.InitializeRecentlyClosedState)
         }
+    }
+
+    private fun lookupSessionManager(): SessionManager {
+        return sessionManager
     }
 
     private fun findSessionById(tabId: String): Session? {

--- a/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayDialogFragment.kt
@@ -260,10 +260,7 @@ class TabTrayDialogFragment : AppCompatDialogFragment(), UserInteractionHandler 
 
     private fun showUndoSnackbarForTab(sessionId: String) {
         val store = requireComponents.core.store
-        val sessionManager = requireComponents.core.sessionManager
-
         val tab = requireComponents.core.store.state.findTab(sessionId) ?: return
-        val session = sessionManager.findSessionById(sessionId) ?: return
 
         // Check if this is the last tab of this session type
         val isLastOpenTab =
@@ -272,8 +269,6 @@ class TabTrayDialogFragment : AppCompatDialogFragment(), UserInteractionHandler 
             dismissTabTrayAndNavigateHome(sessionId)
             return
         }
-
-        val isSelected = sessionId == requireComponents.core.store.state.selectedTabId ?: false
 
         val snackbarMessage = if (tab.content.private) {
             getString(R.string.snackbar_private_tab_closed)
@@ -286,12 +281,8 @@ class TabTrayDialogFragment : AppCompatDialogFragment(), UserInteractionHandler 
             snackbarMessage,
             getString(R.string.snackbar_deleted_undo),
             {
-                sessionManager.add(
-                    session,
-                    isSelected,
-                    engineSessionState = tab.engineState.engineSessionState
-                )
-                _tabTrayView?.scrollToTab(session.id)
+                requireComponents.useCases.tabsUseCases.undo.invoke()
+                _tabTrayView?.scrollToTab(tab.id)
             },
             operation = { },
             elevation = ELEVATION,

--- a/app/src/main/java/org/mozilla/fenix/utils/Undo.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Undo.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.fenix.utils
 
+import android.content.Context
 import android.view.View
 import androidx.appcompat.widget.ContentFrameLayout
 import androidx.core.view.updatePadding
@@ -18,6 +19,18 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 internal const val UNDO_DELAY = 3000L
 internal const val ACCESSIBLE_UNDO_DELAY = 15000L
+
+/**
+ * Get the recommended time an "undo" action should be available until it can automatically be
+ * dismissed. The delay may be different based on the accessibility settings of the device.
+ */
+fun Context.getUndoDelay(): Long {
+    return if (settings().accessibilityServicesEnabled) {
+        ACCESSIBLE_UNDO_DELAY
+    } else {
+        UNDO_DELAY
+    }
+}
 
 /**
  * Runs [operation] after giving user time (see [UNDO_DELAY]) to cancel it.
@@ -92,13 +105,7 @@ fun CoroutineScope.allowUndo(
         // Wait a bit, and if user didn't request cancellation, proceed with
         // requested operation and hide the snackbar.
         launch {
-            val lengthToDelay = if (view.context.settings().accessibilityServicesEnabled) {
-                ACCESSIBLE_UNDO_DELAY
-            } else {
-                UNDO_DELAY
-            }
-
-            delay(lengthToDelay)
+            delay(view.context.getUndoDelay())
 
             if (!requestedUndo.get()) {
                 snackbar.dismiss()


### PR DESCRIPTION
This is not the super fancy version yet - since we still need to restore into SessionManager and
haven't fully switched to BrowserStore yet. However AC having knowledge about "undo" and whether
it was performed or not, will help us with features like "recently closed tabs". And once we
can improve "undo", Fenix will get all the nice things automatically.

Requires:
~~https://github.com/mozilla-mobile/android-components/pull/8449~~ (Merged, waiting for Nightlies)



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
