### PR TITLE
Issue #13270: Do not launch into Fennec's task anymore.

### DIFF
--- a/app/src/migration/AndroidManifest.xml
+++ b/app/src/migration/AndroidManifest.xml
@@ -19,12 +19,10 @@
         <activity-alias
             android:name="${applicationId}.App"
             android:targetActivity="org.mozilla.fenix.MigrationDecisionActivity"
-            android:taskAffinity="${applicationId}.BROWSER"
             tools:replace="android:targetActivity" />
 
         <activity
             android:name="org.mozilla.fenix.MigrationDecisionActivity"
-            android:taskAffinity="${applicationId}.BROWSER"
             android:exported="false" />
 
         <service android:name="org.mozilla.fenix.MigrationService" />


### PR DESCRIPTION
Initially we did this to avoid a duplicated task right after the migration from Fennec. We'd end up
with the original task from Fennec and the new one from Fenix; with the Fennec task still showing
Fennec in the app switcher, but launching Fenix once selected.

Anyhow, now on Android 11 this causes the Fenix task to get duplicated. The simple fix is to not
do any of that anymore. This may re-introduce the problem with the Fennec migration, but:
* We are at 100% rollout for quite some time. There are still users migrating, but the impact
  of the bug is much lower.
* The bug after the migration was only temporary. This bug here is happening every time you
  launch Fenix. So I'd rather fix this than a possible inconvenience right after the migration.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
