### PR TITLE
For #15296: Allow excluding bookmark subtrees when editing parent folder

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/Utils.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/Utils.kt
@@ -6,6 +6,7 @@ package org.mozilla.fenix.library.bookmarks
 
 import android.content.Context
 import mozilla.components.concept.storage.BookmarkNode
+import mozilla.components.concept.storage.BookmarkNodeType
 import org.mozilla.fenix.R
 
 fun rootTitles(context: Context, withMobileRoot: Boolean): Map<String, String> = if (withMobileRoot) {
@@ -34,4 +35,17 @@ fun friendlyRootTitle(
     !node.inRoots() -> node.title
     rootTitles.containsKey(node.title) -> rootTitles[node.title]
     else -> node.title
+}
+
+data class BookmarkNodeWithDepth(val depth: Int, val node: BookmarkNode, val parent: String?)
+
+fun BookmarkNode.flatNodeList(excludeSubtreeRoot: String?, depth: Int = 0): List<BookmarkNodeWithDepth> {
+    if (this.type != BookmarkNodeType.FOLDER || this.guid == excludeSubtreeRoot) {
+        return emptyList()
+    }
+    val newList = listOf(BookmarkNodeWithDepth(depth, this, this.parentGuid))
+    return newList + children
+        ?.filter { it.type == BookmarkNodeType.FOLDER }
+        ?.flatMap { it.flatNodeList(excludeSubtreeRoot = excludeSubtreeRoot, depth = depth + 1) }
+        .orEmpty()
 }

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/selectfolder/SelectBookmarkFolderAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/selectfolder/SelectBookmarkFolderAdapter.kt
@@ -14,29 +14,23 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.android.extensions.LayoutContainer
 import mozilla.components.concept.storage.BookmarkNode
-import mozilla.components.concept.storage.BookmarkNodeType
 import org.mozilla.fenix.R
 import org.mozilla.fenix.library.LibrarySiteItemView
+import org.mozilla.fenix.library.bookmarks.BookmarkNodeWithDepth
 import org.mozilla.fenix.library.bookmarks.BookmarksSharedViewModel
+import org.mozilla.fenix.library.bookmarks.flatNodeList
 import org.mozilla.fenix.library.bookmarks.selectfolder.SelectBookmarkFolderAdapter.BookmarkFolderViewHolder
-import org.mozilla.fenix.library.bookmarks.selectfolder.SelectBookmarkFolderAdapter.BookmarkNodeWithDepth
 
 class SelectBookmarkFolderAdapter(private val sharedViewModel: BookmarksSharedViewModel) :
     ListAdapter<BookmarkNodeWithDepth, BookmarkFolderViewHolder>(DiffCallback) {
 
     fun updateData(tree: BookmarkNode?, hideFolderGuid: String?) {
         val updatedData = tree
-            ?.convertToFolderDepthTree()
+            ?.flatNodeList(hideFolderGuid)
             ?.drop(1)
             .orEmpty()
 
-        val filteredData = if (hideFolderGuid != null && updatedData.isNotEmpty()) {
-            updatedData.filter { it.node.guid != hideFolderGuid }
-        } else {
-            updatedData
-        }
-
-        submitList(filteredData)
+        submitList(updatedData)
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): BookmarkFolderViewHolder {
@@ -99,16 +93,6 @@ class SelectBookmarkFolderAdapter(private val sharedViewModel: BookmarksSharedVi
         companion object {
             const val viewType = 1
         }
-    }
-
-    data class BookmarkNodeWithDepth(val depth: Int, val node: BookmarkNode, val parent: String?)
-
-    private fun BookmarkNode.convertToFolderDepthTree(depth: Int = 0): List<BookmarkNodeWithDepth> {
-        val newList = listOf(BookmarkNodeWithDepth(depth, this, this.parentGuid))
-        return newList + children
-            ?.filter { it.type == BookmarkNodeType.FOLDER }
-            ?.flatMap { it.convertToFolderDepthTree(depth = depth + 1) }
-            .orEmpty()
     }
 
     private fun getSelectedItemIndex(): Int? {

--- a/app/src/test/java/org/mozilla/fenix/library/bookmarks/UtilsKtTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/bookmarks/UtilsKtTest.kt
@@ -1,0 +1,147 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.library.bookmarks
+
+import mozilla.components.concept.storage.BookmarkNode
+import mozilla.components.concept.storage.BookmarkNodeType
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+
+@RunWith(FenixRobolectricTestRunner::class)
+class UtilsKtTest {
+    @Test
+    fun `friendly root titles`() {
+        val url = BookmarkNode(
+            BookmarkNodeType.ITEM,
+            "456",
+            "folder",
+            0,
+            "Mozilla",
+            "http://mozilla.org",
+            null
+        )
+        assertEquals("Mozilla", friendlyRootTitle(testContext, url))
+
+        val folder = BookmarkNode(
+            BookmarkNodeType.FOLDER,
+            "456",
+            "folder",
+            0,
+            "Folder",
+            null,
+            null
+        )
+        assertEquals("Folder", friendlyRootTitle(testContext, folder))
+
+        val root = folder.copy(guid = "root________", title = "root")
+        assertEquals("Bookmarks", friendlyRootTitle(testContext, root, withMobileRoot = true))
+        assertEquals("Desktop Bookmarks", friendlyRootTitle(testContext, root, withMobileRoot = false))
+
+        val mobileRoot = folder.copy(guid = "mobile______", title = "mobile")
+        assertEquals("Bookmarks", friendlyRootTitle(testContext, mobileRoot, withMobileRoot = true))
+        assertEquals("mobile", friendlyRootTitle(testContext, mobileRoot, withMobileRoot = false))
+
+        val menuRoot = folder.copy(guid = "menu________", title = "menu")
+        assertEquals("Bookmarks Menu", friendlyRootTitle(testContext, menuRoot, withMobileRoot = true))
+        assertEquals("Bookmarks Menu", friendlyRootTitle(testContext, menuRoot, withMobileRoot = false))
+
+        val toolbarRoot = folder.copy(guid = "toolbar_____", title = "toolbar")
+        assertEquals("Bookmarks Toolbar", friendlyRootTitle(testContext, toolbarRoot, withMobileRoot = true))
+        assertEquals("Bookmarks Toolbar", friendlyRootTitle(testContext, toolbarRoot, withMobileRoot = false))
+
+        val unfiledRoot = folder.copy(guid = "unfiled_____", title = "unfiled")
+        assertEquals("Other Bookmarks", friendlyRootTitle(testContext, unfiledRoot, withMobileRoot = true))
+        assertEquals("Other Bookmarks", friendlyRootTitle(testContext, unfiledRoot, withMobileRoot = false))
+
+        val almostRoot = folder.copy(guid = "notRoot________", title = "root")
+        assertEquals("root", friendlyRootTitle(testContext, almostRoot, withMobileRoot = true))
+        assertEquals("root", friendlyRootTitle(testContext, almostRoot, withMobileRoot = false))
+    }
+
+    @Test
+    fun `flatNodeList various cases`() {
+        val url = BookmarkNode(
+            BookmarkNodeType.ITEM,
+            "456",
+            "folder",
+            0,
+            "Mozilla",
+            "http://mozilla.org",
+            null
+        )
+        val url2 = BookmarkNode(
+            BookmarkNodeType.ITEM,
+            "8674",
+            "folder2",
+            0,
+            "Mozilla",
+            "http://mozilla.org",
+            null
+        )
+        assertEquals(emptyList<BookmarkNodeWithDepth>(), url.flatNodeList(null))
+
+        val root = BookmarkNode(
+            BookmarkNodeType.FOLDER,
+            "root",
+            null,
+            0,
+            "root",
+            null,
+            null
+        )
+        assertEquals(listOf(BookmarkNodeWithDepth(0, root, null)), root.flatNodeList(null))
+        assertEquals(emptyList<BookmarkNodeWithDepth>(), root.flatNodeList("root"))
+
+        val folder = BookmarkNode(
+            BookmarkNodeType.FOLDER,
+            "folder",
+            root.guid,
+            0,
+            "folder",
+            null,
+            listOf(url)
+        )
+
+        val folder3 = BookmarkNode(
+            BookmarkNodeType.FOLDER,
+            "folder3",
+            "folder2",
+            0,
+            "folder3",
+            null,
+            null
+        )
+
+        val folder2 = BookmarkNode(
+            BookmarkNodeType.FOLDER,
+            "folder2",
+            root.guid,
+            0,
+            "folder2",
+            null,
+            listOf(folder3, url2)
+        )
+
+        val rootWithChildren = root.copy(children = listOf(folder, folder2))
+        assertEquals(
+            listOf(
+                BookmarkNodeWithDepth(0, rootWithChildren, null),
+                BookmarkNodeWithDepth(1, folder, "root"),
+                BookmarkNodeWithDepth(1, folder2, "root"),
+                BookmarkNodeWithDepth(2, folder3, "folder2")
+            ), rootWithChildren.flatNodeList(null)
+        )
+
+        assertEquals(
+            listOf(
+                BookmarkNodeWithDepth(0, rootWithChildren, null),
+                BookmarkNodeWithDepth(1, folder, "root")
+            ), rootWithChildren.flatNodeList(excludeSubtreeRoot = "folder2")
+        )
+    }
+}


### PR DESCRIPTION
I'm really not a fan of how title overwriting and structure processing are mangled together,
but will leave clearing that up for another day.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
