### PR TITLE
Show undo snackbars with padding with static bottom toolbar

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -275,6 +275,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Session
                         {
                             requireComponents.useCases.tabsUseCases.undo.invoke()
                         },
+                        paddedForBottomToolbar = true,
                         operation = { }
                     )
                 }

--- a/app/src/main/java/org/mozilla/fenix/utils/Undo.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Undo.kt
@@ -60,6 +60,7 @@ fun CoroutineScope.allowUndo(
     // writing a volatile variable.
     val requestedUndo = AtomicBoolean(false)
 
+    @Suppress("ComplexCondition")
     fun showUndoSnackbar() {
         val snackbar = FenixSnackbar
             .make(
@@ -82,6 +83,7 @@ fun CoroutineScope.allowUndo(
 
         val shouldUseBottomToolbar = view.context.settings().shouldUseBottomToolbar
         val toolbarHeight = view.resources.getDimensionPixelSize(R.dimen.browser_toolbar_height)
+        val dynamicToolbarEnabled = view.context.settings().isDynamicToolbarEnabled
 
         snackbar.view.updatePadding(
             bottom = if (
@@ -92,7 +94,7 @@ fun CoroutineScope.allowUndo(
                 // can't intelligently position the snackbar on the upper most view.
                 // Ideally we should not pass ContentFrameLayout in, but it's the only
                 // way to display snackbars through a fragment transition.
-                view is ContentFrameLayout
+                (view is ContentFrameLayout || !dynamicToolbarEnabled)
             ) {
                 toolbarHeight
             } else {


### PR DESCRIPTION
This specifically fixes the close tab snackbar.  This commit mirrors
the logic when not using Undo from
9e876ebc44fa6c5688b84e7d2ef661cfea5d2cc9.  References #14982.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not

None needed

- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not

![Screenshot_20200920-231226](https://user-images.githubusercontent.com/848247/94136110-68385980-fe9f-11ea-82c2-89e2ab8f1f62.jpg)

- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

Unnecessary.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

@ekager Please review.