### PR TITLE
Closes #15432: Invoke UI updates on main thread in response to account events

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/logins/SyncLoginsPreferenceView.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/SyncLoginsPreferenceView.kt
@@ -7,6 +7,8 @@ package org.mozilla.fenix.settings.logins
 import androidx.lifecycle.LifecycleOwner
 import androidx.navigation.NavController
 import androidx.preference.Preference
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.launch
 import mozilla.components.concept.sync.AccountObserver
 import mozilla.components.concept.sync.AuthType
 import mozilla.components.concept.sync.OAuthAccount
@@ -28,10 +30,15 @@ class SyncLoginsPreferenceView(
 
     init {
         accountManager.register(object : AccountObserver {
-            override fun onAuthenticated(account: OAuthAccount, authType: AuthType) =
-                updateSyncPreferenceStatus()
-            override fun onLoggedOut() = updateSyncPreferenceNeedsLogin()
-            override fun onAuthenticationProblems() = updateSyncPreferenceNeedsReauth()
+            override fun onAuthenticated(account: OAuthAccount, authType: AuthType) {
+                MainScope().launch { updateSyncPreferenceStatus() }
+            }
+            override fun onLoggedOut() {
+                MainScope().launch { updateSyncPreferenceNeedsLogin() }
+            }
+            override fun onAuthenticationProblems() {
+                MainScope().launch { updateSyncPreferenceNeedsReauth() }
+            }
         }, owner = lifecycleOwner)
 
         val accountExists = accountManager.authenticatedAccount() != null


### PR DESCRIPTION
Account manager will call these observers on its own thread, which we can't use for UI updates.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
