### PR TITLE
Closes #15434: Don't try to display a 'signed in' snackbar in a 'headless' mode

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/account/TurnOnSyncFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/account/TurnOnSyncFragment.kt
@@ -135,6 +135,11 @@ class TurnOnSyncFragment : Fragment(), AccountObserver {
     }
 
     override fun onAuthenticated(account: OAuthAccount, authType: AuthType) {
+        // If we're in a `shouldLoginJustWithEmail = true` state, we won't have a view available,
+        // and can't display a snackbar.
+        if (view == null) {
+            return
+        }
         val snackbarText = requireContext().getString(R.string.sync_syncing_in_progress)
         val snackbarLength = FenixSnackbar.LENGTH_SHORT
 


### PR DESCRIPTION
Ideally we shouldn't even be registering `TurnOnSyncFragment` as an account observer in this case, I think? This patch should be harmless enough though and stops us from crashing.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
