### PR TITLE
For #14034: Add debug preference to override AMO collection in Nightly

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -886,6 +886,20 @@ class Settings(private val appContext: Context) : PreferencesHolder {
         default = ""
     )
 
+    var overrideAmoUser by stringPreference(
+        appContext.getPreferenceKey(R.string.pref_key_override_amo_user),
+        default = ""
+    )
+
+    var overrideAmoCollection by stringPreference(
+        appContext.getPreferenceKey(R.string.pref_key_override_amo_collection),
+        default = ""
+    )
+
+    fun amoCollectionOverrideConfigured(): Boolean {
+        return overrideAmoUser.isNotEmpty() || overrideAmoCollection.isNotEmpty()
+    }
+
     val topSitesSize by intPreference(
         appContext.getPreferenceKey(R.string.pref_key_top_sites_size),
         default = 0

--- a/app/src/main/res/layout/amo_collection_override_dialog.xml
+++ b/app/src/main/res/layout/amo_collection_override_dialog.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/linear_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+    <EditText
+        android:id="@+id/custom_amo_user"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/customize_addon_collection_user_hint"
+        android:singleLine="true"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginTop="8dp"
+        android:textColor="?primaryText"/>
+
+    <EditText
+        android:id="@+id/custom_amo_collection"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/customize_addon_collection_hint"
+        android:singleLine="true"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:textColor="?primaryText"/>
+
+</LinearLayout>

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -35,6 +35,8 @@
     <string name="pref_key_delete_browsing_data_on_quit_categories" translatable="false">pref_key_delete_browsing_data_on_quit_categories</string>
     <string name="pref_key_last_known_mode_private" translatable="false">pref_key_last_known_mode_private</string>
     <string name="pref_key_addons" translatable="false">pref_key_addons</string>
+    <string name="pref_key_override_amo_user" translatable="false">pref_key_override_amo_user</string>
+    <string name="pref_key_override_amo_collection" translatable="false">pref_key_override_amo_collection</string>
     <string name="pref_key_last_maintenance" translatable="false">pref_key_last_maintenance</string>
     <string name="pref_key_help" translatable="false">pref_key_help</string>
     <string name="pref_key_rate" translatable="false">pref_key_rate</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -337,6 +337,20 @@
     <!-- Preference for notifications -->
     <string name="preferences_notifications">Notifications</string>
 
+    <!-- Add-on Preferences -->
+    <!-- Preference to customize the configured AMO (addons.mozilla.org) collection -->
+    <string name="preferences_customize_amo_collection">Custom Add-on collection</string>
+    <!-- Button caption to confirm the add-on collection configuration -->
+    <string name="customize_addon_collection_ok">OK</string>
+    <!-- Button caption to abort the add-on collection configuration -->
+    <string name="customize_addon_collection_cancel">Cancel</string>
+    <!-- Hint displayed on input field for custom collection name -->
+    <string name="customize_addon_collection_hint">Collection name</string>
+    <!-- Hint displayed on input field for custom collection user ID-->
+    <string name="customize_addon_collection_user_hint">Collection owner (User ID)</string>
+    <!-- Toast shown after confirming the custom add-on collection configuration -->
+    <string name="toast_customize_addon_collection_done">Add-on collection modified. Quitting the application to apply changes…</string>
+
     <!-- Account Preferences -->
     <!-- Preference for triggering sync -->
     <string name="preferences_sync_now">Sync now</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -136,6 +136,11 @@
             android:key="@string/pref_key_addons"
             android:title="@string/preferences_addons" />
 
+        <androidx.preference.Preference
+            android:icon="@drawable/ic_addons_extensions"
+            android:key="@string/pref_key_override_amo_collection"
+            android:title="@string/preferences_customize_amo_collection"/>
+
         <androidx.preference.SwitchPreference
             android:defaultValue="false"
             android:icon="@drawable/ic_open_in_app"

--- a/app/src/test/java/org/mozilla/fenix/settings/SettingsFragmentTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/SettingsFragmentTest.kt
@@ -1,0 +1,76 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.settings
+
+import androidx.fragment.app.FragmentActivity
+import androidx.preference.Preference
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.fenix.R
+import org.mozilla.fenix.ext.getPreferenceKey
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+import org.mozilla.fenix.utils.Settings
+import org.robolectric.Robolectric
+
+@RunWith(FenixRobolectricTestRunner::class)
+class SettingsFragmentTest {
+
+    @Test
+    fun `Add-on collection override pref is visible if debug menu active`() {
+        val settingsFragment = SettingsFragment()
+        val activity = Robolectric.buildActivity(FragmentActivity::class.java).create().get()
+
+        activity.supportFragmentManager.beginTransaction()
+            .add(settingsFragment, "test")
+            .commitNow()
+
+        val preferenceAmoCollectionOverride = settingsFragment.findPreference<Preference>(
+            settingsFragment.getPreferenceKey(R.string.pref_key_override_amo_collection)
+        )
+
+        settingsFragment.setupAmoCollectionOverridePreference(mockk(relaxed = true))
+        assertNotNull(preferenceAmoCollectionOverride)
+        assertFalse(preferenceAmoCollectionOverride!!.isVisible)
+
+        val settings: Settings = mockk(relaxed = true)
+        every { settings.showSecretDebugMenuThisSession } returns true
+        settingsFragment.setupAmoCollectionOverridePreference(settings)
+        assertTrue(preferenceAmoCollectionOverride.isVisible)
+    }
+
+    @Test
+    fun `Add-on collection override pref is visible if already configured`() {
+        val settingsFragment = SettingsFragment()
+        val activity = Robolectric.buildActivity(FragmentActivity::class.java).create().get()
+
+        activity.supportFragmentManager.beginTransaction()
+            .add(settingsFragment, "test")
+            .commitNow()
+
+        val preferenceAmoCollectionOverride = settingsFragment.findPreference<Preference>(
+            settingsFragment.getPreferenceKey(R.string.pref_key_override_amo_collection)
+        )
+
+        settingsFragment.setupAmoCollectionOverridePreference(mockk(relaxed = true))
+        assertNotNull(preferenceAmoCollectionOverride)
+        assertFalse(preferenceAmoCollectionOverride!!.isVisible)
+
+        val settings: Settings = mockk(relaxed = true)
+        every { settings.showSecretDebugMenuThisSession } returns false
+
+        every { settings.amoCollectionOverrideConfigured() } returns false
+        settingsFragment.setupAmoCollectionOverridePreference(settings)
+        assertFalse(preferenceAmoCollectionOverride.isVisible)
+
+        every { settings.amoCollectionOverrideConfigured() } returns true
+        settingsFragment.setupAmoCollectionOverridePreference(settings)
+        assertTrue(preferenceAmoCollectionOverride.isVisible)
+    }
+}

--- a/app/src/test/java/org/mozilla/fenix/utils/SettingsTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/utils/SettingsTest.kt
@@ -576,4 +576,34 @@ class SettingsTest {
             settings.getSitePermissionsCustomSettingsRules()
         )
     }
+
+    @Test
+    fun overrideAmoCollection() {
+        // When just created
+        // Then
+        assertEquals("", settings.overrideAmoCollection)
+        assertFalse(settings.amoCollectionOverrideConfigured())
+
+        // When
+        settings.overrideAmoCollection = "testCollection"
+
+        // Then
+        assertEquals("testCollection", settings.overrideAmoCollection)
+        assertTrue(settings.amoCollectionOverrideConfigured())
+    }
+
+    @Test
+    fun overrideAmoUser() {
+        // When just created
+        // Then
+        assertEquals("", settings.overrideAmoUser)
+        assertFalse(settings.amoCollectionOverrideConfigured())
+
+        // When
+        settings.overrideAmoUser = "testAmoUser"
+
+        // Then
+        assertEquals("testAmoUser", settings.overrideAmoUser)
+        assertTrue(settings.amoCollectionOverrideConfigured())
+    }
 }


### PR DESCRIPTION
This allows customizing / overriding the configured AMO collection via a debug preference. With this it's possible for Nightly users to configure their own add-on collection.