### PR TITLE
For #15324 - Show tab settings and recently closed items in menu when no tabs

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
@@ -262,11 +262,11 @@ class TabbedBrowsingTest {
         }.openTabTray {
             verifyNoTabsOpened()
             verifyNewTabButton()
-            verifyTabTrayOverflowMenu(false)
+            verifyTabTrayOverflowMenu(true)
         }.toggleToPrivateTabs {
             verifyNoTabsOpened()
             verifyNewTabButton()
-            verifyTabTrayOverflowMenu(false)
+            verifyTabTrayOverflowMenu(true)
         }
     }
 


### PR DESCRIPTION
… no tabs


We were previously hiding the whole 3 dot menu when there were no tabs in the tabs tray. Now we will hide the specific ITEMS in the 3 dot menu that don't make sense with no tabs open (ie save to collection, share tabs, close all), and still show Tab Settings, Recently Closed.

I think this is a low risk uplift.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
