### PR TITLE
[WIP] Refactoring custom search engine logic

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/searchengine/SearchEngineLocalizationProvider.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/searchengine/SearchEngineLocalizationProvider.kt
@@ -1,0 +1,88 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.components.searchengine
+
+import android.content.Context
+import androidx.annotation.VisibleForTesting
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import mozilla.components.browser.search.provider.AssetsSearchEngineProvider
+import mozilla.components.browser.search.provider.localization.LocaleSearchLocalizationProvider
+import mozilla.components.browser.search.provider.localization.SearchLocalizationProvider
+import mozilla.components.service.location.LocationService
+import mozilla.components.service.location.MozillaLocationService
+import mozilla.components.service.location.search.RegionSearchLocalizationProvider
+import org.mozilla.fenix.BuildConfig
+import org.mozilla.fenix.Config
+import org.mozilla.fenix.ext.components
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Handles localization for search engines
+ */
+open class SearchEngineLocalizationProvider(
+    private val context: Context,
+    coroutineContext: CoroutineContext
+) {
+    private val shouldMockMLS = Config.channel.isDebug || BuildConfig.MLS_TOKEN.isEmpty()
+
+    private val locationService: LocationService = if (shouldMockMLS) {
+        LocationService.dummy()
+    } else {
+        MozillaLocationService(
+            context,
+            context.components.core.client,
+            BuildConfig.MLS_TOKEN
+        )
+    }
+
+    // We have two search engine types: one based on MLS reported region, one based only on Locale.
+    // There are multiple steps involved in returning the default search engine for example.
+    // Simplest and most effective way to make sure the MLS engines do not mix with Locale based engines
+    // is to use the same type of engines for the entire duration of the app's run.
+    // See fenix/issues/11875
+    val isRegionCachedByLocationService = locationService.hasRegionCached()
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    open val searchLocalizationProvider: SearchLocalizationProvider =
+        RegionSearchLocalizationProvider(locationService)
+
+    private val loadedRegion =
+        CoroutineScope(coroutineContext).async { searchLocalizationProvider.determineRegion() }
+
+    // https://github.com/mozilla-mobile/fenix/issues/9935
+    // Adds a Locale search engine provider as a fallback in case the MLS lookup takes longer
+    // than the time it takes for a user to try to search.
+    private val fallbackLocationService: SearchLocalizationProvider = LocaleSearchLocalizationProvider()
+    private val fallBackProvider =
+        AssetsSearchEngineProvider(fallbackLocationService)
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    open val fallbackEngines =
+        CoroutineScope(coroutineContext).async { fallBackProvider.loadSearchEngines(context) }
+    private val fallbackRegion =
+        CoroutineScope(coroutineContext).async { fallbackLocationService.determineRegion() }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    suspend fun localeAwareInstalledEnginesKey(): String {
+        val tag = if (isRegionCachedByLocationService) {
+            val localization = loadedRegion.await()
+            val region = localization.region?.let {
+                if (it.isEmpty()) "" else "-$it"
+            }
+
+            "${localization.languageTag}$region"
+        } else {
+            val localization = fallbackRegion.await()
+            val region = localization.region?.let {
+                if (it.isEmpty()) "" else "-$it"
+            }
+
+            "${localization.languageTag}$region-fallback"
+        }
+
+        return "${FenixSearchEngineProvider.INSTALLED_ENGINES_KEY}-$tag"
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/settings/search/AddSearchEngineFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/search/AddSearchEngineFragment.kt
@@ -194,6 +194,7 @@ class AddSearchEngineFragment : Fragment(R.layout.fragment_add_search_engine),
                         searchQuery = searchString
                     )
                     requireComponents.search.provider.reload()
+
                     val successMessage = resources
                         .getString(R.string.search_add_custom_engine_success_message, name)
 
@@ -212,6 +213,20 @@ class AddSearchEngineFragment : Fragment(R.layout.fragment_add_search_engine),
             }
         }
     }
+
+//    private fun createCustomEngineItem(engineName: String) {
+//
+//        val engineItem = makeButtonFromSearchEngine(
+//            engine = engine,
+//            layoutInflater = layoutInflater,
+//            res = requireContext().resources
+//        )
+//        engineItem.id = index
+//        engineItem.tag = engineId
+//        engineItem.radio_button.isChecked = selectedIndex == index
+//        engineViews.add(engineItem)
+//        search_engine_group.addView(engineItem, layoutParams)
+//    }
 
     private fun installEngine(engine: SearchEngine) {
         viewLifecycleOwner.lifecycleScope.launch(Main) {

--- a/app/src/main/java/org/mozilla/fenix/settings/search/CustomSetPreferences.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/search/CustomSetPreferences.kt
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.settings.search
+
+import mozilla.components.support.ktx.android.content.PreferencesHolder
+import mozilla.components.support.ktx.android.content.StringSetPreference
+import kotlin.properties.ReadWriteProperty
+import kotlin.reflect.KProperty
+
+/**
+ * Property delegate for getting and setting a shared preference with a set containing a pair
+ * of strings.
+ *
+ * Example usage:
+ * ```
+ * class Settings : PreferenceHolder {
+ *     ...
+ *     var connectedDevices by customStringSetPreference("connected_devices", default = emptySet())
+ * }
+ * ```
+ */
+fun customStringSetPreference(key: String, default: Set<Pair<String, String>>)
+        : ReadWriteProperty<PreferencesHolder, Set<Pair<String, String>> =
+    CustomStringSetPreference(key, default)
+
+
+private class CustomStringSetPreference(
+    private val key: String,
+    private val default: Set<Pair<String, String>>
+) : ReadWriteProperty<PreferencesHolder, Set<Pair<String, String>> {
+
+    override fun getValue(thisRef: PreferencesHolder, property: KProperty<*>)
+            : Set<Pair<String, String>> =
+        thisRef.preferences.getValue(key, default) ?: default
+
+    override fun setValue(thisRef: PreferencesHolder, property: KProperty<*>, value: Set<String>) =
+        thisRef.preferences.edit().putValue(key, value).apply()
+}

--- a/app/src/main/java/org/mozilla/fenix/settings/search/EditCustomSearchEngineFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/search/EditCustomSearchEngineFragment.kt
@@ -38,8 +38,7 @@ import java.util.Locale
  */
 class EditCustomSearchEngineFragment
     : Fragment(R.layout.fragment_add_search_engine),
-      CoroutineScope by CoroutineScope(Job() + IO)
-{
+      CoroutineScope by CoroutineScope(Job() + IO) {
 
     private val args by navArgs<EditCustomSearchEngineFragmentArgs>()
 
@@ -153,7 +152,7 @@ class EditCustomSearchEngineFragment
         }
 
         val nameHasChanged = name != args.searchEngineIdentifier
-
+        val searchStringHasChanged = searchString != args
         val hasError = when {
             name.isEmpty() -> {
                 custom_search_engine_name_field.error = resources

--- a/app/src/main/java/org/mozilla/fenix/settings/search/SearchEngineListPreference.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/search/SearchEngineListPreference.kt
@@ -54,11 +54,11 @@ abstract class SearchEngineListPreference @JvmOverloads constructor(
     }
 
     suspend fun reload(context: Context) {
-        val installedEngines = context.components.search.provider.installedSearchEngines(context).list
-        val customEngines = context.components.search.provider.customSearchEngines.await().list
-
-        val fullList = installedEngines + customEngines
-        searchEngineList = SearchEngineList(list = fullList, default = fullList[0])
+        searchEngineList = context.components.search.provider.installedSearchEngines(context)
+//        val installedEngines = context.components.search.provider.installedSearchEngines(context).list
+//        val customEngines = context.components.search.provider.customSearchEngines.await().list
+//        val fullList = installedEngines + customEngines
+//        searchEngineList = SearchEngineList(list = fullList, default = null)
 
         refreshSearchEngineViews(context)
     }

--- a/app/src/main/java/org/mozilla/fenix/settings/search/SearchEngineListPreference.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/search/SearchEngineListPreference.kt
@@ -18,11 +18,9 @@ import androidx.core.view.isVisible
 import androidx.navigation.Navigation
 import androidx.preference.Preference
 import androidx.preference.PreferenceViewHolder
-import kotlinx.android.synthetic.main.search_engine_radio_button.view.engine_icon
-import kotlinx.android.synthetic.main.search_engine_radio_button.view.engine_text
-import kotlinx.android.synthetic.main.search_engine_radio_button.view.overflow_menu
-import kotlinx.android.synthetic.main.search_engine_radio_button.view.radio_button
+import kotlinx.android.synthetic.main.search_engine_radio_button.view.*
 import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.launch
 import mozilla.components.browser.search.SearchEngine
 import mozilla.components.browser.search.provider.SearchEngineList
 import org.mozilla.fenix.R
@@ -52,11 +50,16 @@ abstract class SearchEngineListPreference @JvmOverloads constructor(
     override fun onBindViewHolder(holder: PreferenceViewHolder?) {
         super.onBindViewHolder(holder)
         searchEngineGroup = holder!!.itemView.findViewById(R.id.search_engine_group)
-        reload(searchEngineGroup!!.context)
+        MainScope().launch { reload(searchEngineGroup!!.context) }
     }
 
-    fun reload(context: Context) {
-        searchEngineList = context.components.search.provider.installedSearchEngines(context)
+    suspend fun reload(context: Context) {
+        val installedEngines = context.components.search.provider.installedSearchEngines(context).list
+        val customEngines = context.components.search.provider.customSearchEngines.await().list
+
+        val fullList = installedEngines + customEngines
+        searchEngineList = SearchEngineList(list = fullList, default = fullList[0])
+
         refreshSearchEngineViews(context)
     }
 

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -219,6 +219,10 @@
     <string name="pref_key_is_in_search_widget_experiment" translatable="false">pref_key_is_in_search_widget_experiment</string>
     <string name="pref_key_show_search_widget_cfr" translatable="false">pref_key_show_search_widget_cfr</string>
 
+    <!--  Custom search engines  -->
+    <string name="pref_key_custom_search_engines" translatable="false">pref_custom_search_engines</string>
+    <string name="pref_key_file_search_engines" translatable="false">custom-search-engines</string>
+
     <string name="pref_key_default_browser" translatable="false">pref_key_default_browser</string>
 
     <string name="pref_key_login_exceptions" translatable="false">pref_key_login_exceptions</string>

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -5,7 +5,7 @@
     <string name="pref_key_make_default_browser" translatable="false">pref_key_make_default_browser</string>
     <string name="pref_key_search_settings" translatable="false">pref_key_search_settings</string>
     <string name="pref_key_search_engine" translatable="false">pref_key_search_engine</string>
-    <string name="pref_key_add_search_engine" translatable="false">pref_key_add_Search_engine</string>
+    <string name="pref_key_add_search_engine" translatable="false">pref_key_add_search_engine</string>
     <string name="pref_key_passwords" translatable="false">pref_key_passwords</string>
     <string name="pref_key_credit_cards_addresses" translatable="false">pref_key_credit_cards_addresses</string>
     <string name="pref_key_site_permissions" translatable="false">pref_key_site_permissions</string>

--- a/app/src/test/java/org/mozilla/fenix/components/searchengine/FenixSearchEngineProviderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/searchengine/FenixSearchEngineProviderTest.kt
@@ -72,7 +72,7 @@ class FenixSearchEngineProviderTest {
 
     @Test
     fun `GIVEN sharedprefs does not contain installed engines WHEN installedSearchEngineIdentifiers THEN defaultEngines + customEngines ids are returned`() = runBlockingTest {
-        val expectedDefaults = fenixSearchEngineProvider.baseSearchEngines.toIdSet()
+        val expectedDefaults = fenixSearchEngineProvider.localizedSearchEngines.toIdSet()
         val expectedCustom = fenixSearchEngineProvider.customSearchEngines.toIdSet()
         val expected = expectedDefaults + expectedCustom
 
@@ -103,7 +103,7 @@ class FakeFenixSearchEngineProvider(context: Context) : FenixSearchEngineProvide
     override val localizationProvider: SearchLocalizationProvider
         get() = LocaleSearchLocalizationProvider()
 
-    override var baseSearchEngines: Deferred<SearchEngineList>
+    override var localizedSearchEngines: Deferred<SearchEngineList>
         set(_) { throw NotImplementedError("Setting not currently supported on this fake") }
         get() {
             val google = mockSearchEngine(id = "google-b-1-m", n = "Google")


### PR DESCRIPTION
Related to #15080 
Waiting on AC changes: https://mozac.org/rfc/0002-search-state-in-browser-store (in progress, guesstimate to be finished next week)

We were only looking at the list of installed search engines when we created the list on the search settings. Custom engines were being created behind the scenes, but no UI was ever referencing it.

**Question:** for @boek Why is the `CustomSearchEngineStore` separate from the rest of the search engines?

todo: 
- [x] make sure the custom engine is being created
- [x] render the item on the `SearchEngineFragment`
- [x] when you select the search engine, make it the default
- [x] why does it change back to google as default when you nav away?
- [x] installed search engines should include default **and** custom
- [ ] search dialog fragment button should change correct thing in the provider

<img width="325" src="https://user-images.githubusercontent.com/43795363/94626396-a4ddc980-0280-11eb-8c0a-6d289c14e896.png">


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
