### PR TITLE
For #15559: Allow tabs to stretch in landscape mode for tablets.

### DIFF
--- a/app/src/main/res/layout/component_tabstray.xml
+++ b/app/src/main/res/layout/component_tabstray.xml
@@ -112,6 +112,7 @@
             android:id="@+id/tab_layout"
             android:layout_width="0dp"
             android:layout_height="80dp"
+            app:tabMaxWidth="0dp"
             android:background="@color/foundation_normal_theme"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"


### PR DESCRIPTION
This overrides the default tabMaxWidth of 264dp to allow for tabGravity="fill".

Screenshot with result after fix:
![Screenshot_1601469414](https://user-images.githubusercontent.com/48995920/94686019-e333c100-0332-11eb-952b-044b628dd7ad.png)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
