### PR TITLE
Bump AC to 57.0.7

### DIFF
--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "57.0.6"
+    const val VERSION = "57.0.7"
 }


### PR DESCRIPTION
This patch bumps AC to 57.0.7. This only pulls in a newer GeckoView 81 release.