### PR TITLE
No issue: remove * ac from codeowners.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,9 +21,9 @@
 # the paths you specify in .gitignore:
 # http://www.benjaminoakes.com/git/2018/08/10/Testing-changes-to-GitHub-CODEOWNERS/
 
-# By default the Android Components team will be the owner for everything in
+# By default the fenix team will be the owner for everything in
 # the repo. Unless a later match takes precedence.
-* @mozilla-mobile/ACT @mozilla-mobile/fenix
+* @mozilla-mobile/fenix
 /.cron.yml @mozilla-mobile/releng @mozilla-mobile/fenix
 /.taskcluster.yml @mozilla-mobile/releng @mozilla-mobile/fenix
 /automation/ @mozilla-mobile/releng @mozilla-mobile/fenix


### PR DESCRIPTION
rocketsroger and I agreed this may be undesireable due to the increased
notifications. If we remove it and someone complains, we can re-add it.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
