### PR TITLE
15276 Moving HomeActivity.onCreate to StartupManager.activityOnCreate for performance code ownership.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/browsingmode/BrowsingModeManager.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/browsingmode/BrowsingModeManager.kt
@@ -29,6 +29,8 @@ enum class BrowsingMode {
 
 interface BrowsingModeManager {
     var mode: BrowsingMode
+
+    fun addListener(action: (BrowsingMode) -> Unit)
 }
 
 /**
@@ -36,15 +38,17 @@ interface BrowsingModeManager {
  */
 class DefaultBrowsingModeManager(
     private var _mode: BrowsingMode,
-    private val settings: Settings,
-    private val modeDidChange: (BrowsingMode) -> Unit
+    private val settings: Settings
 ) : BrowsingModeManager {
 
+    var listener: (BrowsingMode) -> Unit = {}
     override var mode: BrowsingMode
         get() = _mode
         set(value) {
             _mode = value
-            modeDidChange(value)
+            listener(value)
             settings.lastKnownMode = value
         }
+
+    override fun addListener(action: (BrowsingMode) -> Unit) { listener = action }
 }

--- a/app/src/main/java/org/mozilla/fenix/customtabs/ExternalAppBrowserActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/ExternalAppBrowserActivity.kt
@@ -35,10 +35,6 @@ open class ExternalAppBrowserActivity : HomeActivity() {
 
     final override fun getIntentSessionId(intent: SafeIntent) = intent.getSessionId()
 
-    override fun startupTelemetryOnCreateCalled(safeIntent: SafeIntent, hasSavedInstanceState: Boolean) {
-        components.appStartupTelemetry.onExternalAppBrowserOnCreate(safeIntent, hasSavedInstanceState)
-    }
-
     override fun getNavDirections(
         from: BrowserDirection,
         customTabSessionId: String?

--- a/app/src/main/java/org/mozilla/fenix/perf/StartupManager.kt
+++ b/app/src/main/java/org/mozilla/fenix/perf/StartupManager.kt
@@ -1,0 +1,280 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.perf
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.widget.LinearLayout
+import androidx.annotation.VisibleForTesting
+import androidx.navigation.NavDestination
+import androidx.navigation.fragment.NavHostFragment
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import mozilla.components.browser.session.SessionManager
+import mozilla.components.feature.privatemode.notification.PrivateNotificationFeature
+import mozilla.components.support.ktx.android.arch.lifecycle.addObservers
+import mozilla.components.support.utils.SafeIntent
+import mozilla.components.support.utils.toSafeIntent
+import mozilla.components.support.webextensions.WebExtensionPopupFeature
+import org.mozilla.fenix.GleanMetrics.Metrics
+import org.mozilla.fenix.HomeActivity
+import org.mozilla.fenix.R
+import org.mozilla.fenix.browser.UriOpenedObserver
+import org.mozilla.fenix.browser.browsingmode.BrowsingMode
+import org.mozilla.fenix.browser.browsingmode.BrowsingModeManager
+import org.mozilla.fenix.browser.browsingmode.DefaultBrowsingModeManager
+import org.mozilla.fenix.components.metrics.BreadcrumbsRecorder
+import org.mozilla.fenix.components.metrics.Event
+import org.mozilla.fenix.customtabs.ExternalAppBrowserActivity
+import org.mozilla.fenix.ext.breadcrumb
+import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.home.intent.HomeIntentProcessor
+import org.mozilla.fenix.home.intent.StartSearchIntentProcessor
+import org.mozilla.fenix.session.PrivateNotificationService
+import org.mozilla.fenix.theme.DefaultThemeManager
+import org.mozilla.fenix.theme.ThemeManager
+import java.lang.ref.WeakReference
+import kotlin.reflect.KProperty0
+
+class StartupManager {
+
+    @Suppress("TooManyFunctions")
+    companion object {
+        @OptIn(ExperimentalCoroutinesApi::class)
+        @Suppress("LongParameterList", "LongMethod")
+        fun activityOnCreate(
+            activity: HomeActivity,
+            savedInstanceState: Bundle?,
+            isVisuallyComplete: Boolean,
+            webExtensionPopupFeature: WebExtensionPopupFeature,
+            getBreadcrumbMessage: (NavDestination) -> String,
+            externalSourceIntentProcessors: KProperty0<List<HomeIntentProcessor>>,
+            action: () -> Unit
+        ): StartupData {
+            var themeManager: ThemeManager?
+            var browsingModeManager: BrowsingModeManager?
+
+            activity.components.strictMode.attachListenerToDisablePenaltyDeath(activity.supportFragmentManager)
+            // There is disk read violations on some devices such as samsung and pixel for android 9/10
+            action()
+
+            // Diagnostic breadcrumb for "Display already aquired" crash:
+            // https://github.com/mozilla-mobile/android-components/issues/7960
+            activity.breadcrumb(
+                message = "onCreate()",
+                data = mapOf(
+                    "recreated" to (savedInstanceState != null).toString(),
+                    "intent" to (activity.intent?.action ?: "null")
+                )
+            )
+
+            activity.components.publicSuffixList.prefetch()
+
+            val pair = setupThemeAndBrowsingMode(getModeFromIntentOrLastKnown(activity.intent, activity), activity)
+            themeManager = pair.first
+            browsingModeManager = pair.second
+
+            browsingModeManager.addListener { newMode ->
+                themeManager.currentTheme = newMode
+            }
+
+            activity.setContentView(R.layout.activity_home)
+
+            val navHost = activity.supportFragmentManager
+                                        .findFragmentById(R.id.container) as NavHostFragment
+            // Must be after we set the content view
+            if (isVisuallyComplete) {
+                activity.components.performance.visualCompletenessQueue
+                    .attachViewToRunVisualCompletenessQueueLater(
+                        WeakReference(activity.findViewById<LinearLayout>(R.id.rootContainer))
+                    )
+            }
+
+            val sessionObserver = UriOpenedObserver(activity)
+
+            checkPrivateShortcutEntryPoint(activity.intent)
+            val privateNotificationObserver = PrivateNotificationFeature(
+                activity.applicationContext,
+                activity.components.core.store,
+                PrivateNotificationService::class
+            ).also {
+                it.start()
+            }
+
+            if (isActivityColdStarted(activity.intent, savedInstanceState)) {
+                externalSourceIntentProcessors.get().any {
+                    it.process(
+                        activity.intent,
+                        navHost.navController,
+                        activity.intent
+                    )
+                }
+            }
+
+            Performance.processIntentIfPerformanceTest(activity.intent, activity)
+
+            if (activity.settings().isTelemetryEnabled) {
+                activity.lifecycle.addObserver(
+                    BreadcrumbsRecorder(
+                        activity.components.analytics.crashReporter,
+                        navHost.navController, getBreadcrumbMessage
+                    )
+                )
+
+                val safeIntent = activity.intent?.toSafeIntent()
+                safeIntent
+                    ?.let(activity::getIntentSource)
+                    ?.also { activity.components.analytics.metrics.track(Event.OpenedApp(it)) }
+                // record on cold startup
+                safeIntent
+                    ?.let(::getIntentAllSource)
+                    ?.also { activity.components.analytics.metrics.track(Event.AppReceivedIntent(it)) }
+            }
+            activity.supportActionBar?.hide()
+
+            activity.lifecycle.addObservers(
+                webExtensionPopupFeature,
+                StartupTimeline.homeActivityLifecycleObserver
+            )
+
+            if (shouldAddToRecentsScreen(activity.intent)) {
+                activity.intent.removeExtra(HomeActivity.START_IN_RECENTS_SCREEN)
+                activity.moveTaskToBack(true)
+            }
+
+            captureSnapshotTelemetryMetrics(activity)
+
+            startupTelemetryOnCreateCalled(activity.intent.toSafeIntent(), savedInstanceState != null, activity)
+
+            StartupTimeline.onActivityCreateEndHome(activity) // DO NOT MOVE ANYTHING BELOW HERE.
+
+            return StartupData(sessionObserver, privateNotificationObserver, themeManager,
+                browsingModeManager)
+        }
+
+        private fun setupThemeAndBrowsingMode(
+            mode: BrowsingMode,
+            activity: Activity
+        ): Pair<ThemeManager, BrowsingModeManager> {
+            activity.settings().lastKnownMode = mode
+            val mBrowsingModeManager = createBrowsingModeManager(mode, activity)
+            val mThemeManager = createThemeManager(mBrowsingModeManager, activity)
+            mThemeManager.setActivityTheme(activity)
+            mThemeManager.applyStatusBarTheme(activity)
+            return Pair(mThemeManager, mBrowsingModeManager)
+        }
+
+        /**
+         * External sources such as 3rd party links and shortcuts use this function to enter
+         * private mode directly before the content view is created. Returns the mode set by the intent
+         * otherwise falls back to the last known mode.
+         */
+        private fun getModeFromIntentOrLastKnown(intent: Intent?, context: Context): BrowsingMode {
+            intent?.toSafeIntent()?.let {
+                if (it.hasExtra(HomeActivity.PRIVATE_BROWSING_MODE)) {
+                    val startPrivateMode = it.getBooleanExtra(HomeActivity.PRIVATE_BROWSING_MODE, false)
+                    return BrowsingMode.fromBoolean(isPrivate = startPrivateMode)
+                }
+            }
+            return context.settings().lastKnownMode
+        }
+
+        private fun checkPrivateShortcutEntryPoint(intent: Intent) {
+            if (intent.hasExtra(HomeActivity.OPEN_TO_SEARCH) &&
+                (intent.getStringExtra(HomeActivity.OPEN_TO_SEARCH) ==
+                        StartSearchIntentProcessor.STATIC_SHORTCUT_NEW_PRIVATE_TAB ||
+                        intent.getStringExtra(HomeActivity.OPEN_TO_SEARCH) ==
+                        StartSearchIntentProcessor.PRIVATE_BROWSING_PINNED_SHORTCUT)
+            ) {
+                PrivateNotificationService.isStartedFromPrivateShortcut = true
+            }
+        }
+
+        @VisibleForTesting
+        internal fun isActivityColdStarted(startingIntent: Intent, activityIcicle: Bundle?): Boolean {
+            // First time opening this activity in the task.
+            // Cold start / start from Recents after back press.
+            return activityIcicle == null &&
+                    // Activity was restarted from Recents after it was destroyed by Android while in background
+                    // in cases of memory pressure / "Don't keep activities".
+                    startingIntent.flags and Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY == 0
+        }
+
+        private fun getIntentAllSource(intent: SafeIntent): Event.AppReceivedIntent.Source? {
+            return when {
+                intent.isLauncherIntent -> Event.AppReceivedIntent.Source.APP_ICON
+                intent.action == Intent.ACTION_VIEW -> Event.AppReceivedIntent.Source.LINK
+                else -> Event.AppReceivedIntent.Source.UNKNOWN
+            }
+        }
+
+        /**
+         * Determines whether the activity should be pushed to be backstack
+         * (i.e., 'minimized' to the recents screen) upon starting.
+         * @param intent - The intent that started this activity.
+         *                 Is checked for having the 'START_IN_RECENTS_SCREEN'-extra.
+         * @return true if the activity should be started and pushed to the recents screen,
+         *         false otherwise.
+         */
+        private fun shouldAddToRecentsScreen(intent: Intent?): Boolean {
+            intent?.toSafeIntent()?.let {
+                return it.getBooleanExtra(HomeActivity.START_IN_RECENTS_SCREEN, false)
+            }
+            return false
+        }
+
+        private fun captureSnapshotTelemetryMetrics(activity: Activity) = CoroutineScope(Dispatchers.IO).launch {
+            // PWA
+            val recentlyUsedPwaCount = activity.components.core.webAppShortcutManager.recentlyUsedWebAppsCount(
+                activeThresholdMs = HomeActivity.PWA_RECENTLY_USED_THRESHOLD
+            )
+            if (recentlyUsedPwaCount == 0) {
+                Metrics.hasRecentPwas.set(false)
+            } else {
+                Metrics.hasRecentPwas.set(true)
+                // This metric's lifecycle is set to 'application', meaning that it gets reset upon
+                // application restart. Combined with the behaviour of the metric type itself (a growing counter),
+                // it's important that this metric is only set once per application's lifetime.
+                // Otherwise, we're going to over-count.
+                Metrics.recentlyUsedPwaCount.add(recentlyUsedPwaCount)
+            }
+        }
+
+        private fun createBrowsingModeManager(
+            initialMode: BrowsingMode,
+            activity: Activity
+        ): BrowsingModeManager {
+            return DefaultBrowsingModeManager(initialMode, activity.components.settings)
+        }
+
+        private fun startupTelemetryOnCreateCalled(
+            safeIntent: SafeIntent,
+            hasSavedInstanceState: Boolean,
+            activity: Activity
+        ) {
+            if (activity is ExternalAppBrowserActivity) {
+                activity.components.appStartupTelemetry.onExternalAppBrowserOnCreate(safeIntent, hasSavedInstanceState)
+            } else {
+                activity.components.appStartupTelemetry.onHomeActivityOnCreate(safeIntent, hasSavedInstanceState)
+            }
+        }
+
+        private fun createThemeManager(browsingModeManager: BrowsingModeManager, activity: Activity): ThemeManager {
+            return DefaultThemeManager(browsingModeManager.mode, activity)
+        }
+    }
+}
+
+data class StartupData(
+    var sessionObserve: SessionManager.Observer,
+    var privateNotificationService: PrivateNotificationFeature<PrivateNotificationService>,
+    var themeManager: ThemeManager,
+    var browsingModeManager: BrowsingModeManager
+)

--- a/app/src/test/java/org/mozilla/fenix/HomeActivityTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/HomeActivityTest.kt
@@ -23,6 +23,7 @@ import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+import org.mozilla.fenix.perf.StartupManager
 
 @RunWith(FenixRobolectricTestRunner::class)
 class HomeActivityTest {
@@ -70,12 +71,12 @@ class HomeActivityTest {
 
     @Test
     fun `isActivityColdStarted returns true for null savedInstanceState and not launched from history`() {
-        assertTrue(activity.isActivityColdStarted(Intent(), null))
+        assertTrue(StartupManager.isActivityColdStarted(Intent(), null))
     }
 
     @Test
     fun `isActivityColdStarted returns false for valid savedInstanceState and not launched from history`() {
-        assertFalse(activity.isActivityColdStarted(Intent(), Bundle()))
+        assertFalse(StartupManager.isActivityColdStarted(Intent(), Bundle()))
     }
 
     @Test
@@ -84,7 +85,7 @@ class HomeActivityTest {
             flags = flags or Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY
         }
 
-        assertFalse(activity.isActivityColdStarted(startingIntent, null))
+        assertFalse(StartupManager.isActivityColdStarted(startingIntent, null))
     }
 
     @Test
@@ -93,6 +94,6 @@ class HomeActivityTest {
             flags = flags or Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY
         }
 
-        assertFalse(activity.isActivityColdStarted(startingIntent, Bundle()))
+        assertFalse(StartupManager.isActivityColdStarted(startingIntent, Bundle()))
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/browser/browsingmode/DefaultBrowsingModeManagerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/browser/browsingmode/DefaultBrowsingModeManagerTest.kt
@@ -27,7 +27,8 @@ class DefaultBrowsingModeManagerTest {
     fun before() {
         MockKAnnotations.init(this)
 
-        manager = DefaultBrowsingModeManager(initMode, settings, callback)
+        manager = DefaultBrowsingModeManager(initMode, settings)
+        manager.addListener(callback)
         every { settings.lastKnownMode = any() } just Runs
     }
 

--- a/app/src/test/java/org/mozilla/fenix/browser/browsingmode/SimpleBrowsingModeManager.kt
+++ b/app/src/test/java/org/mozilla/fenix/browser/browsingmode/SimpleBrowsingModeManager.kt
@@ -6,4 +6,8 @@ package org.mozilla.fenix.browser.browsingmode
 
 data class SimpleBrowsingModeManager(
     override var mode: BrowsingMode
-) : BrowsingModeManager
+) : BrowsingModeManager {
+
+    var listener: (BrowsingMode) -> Unit = {}
+    override fun addListener(action: (BrowsingMode) -> Unit) { listener = action }
+}

--- a/app/src/test/java/org/mozilla/fenix/search/SearchFragmentStoreTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/search/SearchFragmentStoreTest.kt
@@ -43,6 +43,8 @@ class SearchFragmentStoreTest {
         MockKAnnotations.init(this)
         every { activity.browsingModeManager } returns object : BrowsingModeManager {
             override var mode: BrowsingMode = BrowsingMode.Normal
+            var listener: (BrowsingMode) -> Unit = {}
+            override fun addListener(action: (BrowsingMode) -> Unit) { listener = action }
         }
         every { components.settings } returns settings
         every { components.search.provider } returns searchProvider


### PR DESCRIPTION
The performance team has had issues tracking regression for our start up path. It's quite hard to keep track of everything being added. Therefore, we thought of allowing us to be code owners for logic that happens during the application startup. However, some of that code resides in `HomeActivity.onCreate` and becoming code owners of the whole `HomeActivity` file is quite excessive and would tag us as reviewers automatically on certain changes that wouldn't affect start up.

There are some changes in this PR that are more than just "moving" the code from `HomeActivity` to `StartupManager` such as `BrowsingModeManager`. I put up this PR right now to get some early reviews in case anyone had concerns about our idea.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
