### PR TITLE
Revert "No issue: remove * ac from codeowners."

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,9 +21,9 @@
 # the paths you specify in .gitignore:
 # http://www.benjaminoakes.com/git/2018/08/10/Testing-changes-to-GitHub-CODEOWNERS/
 
-# By default the fenix team will be the owner for everything in
+# By default the Android Components team will be the owner for everything in
 # the repo. Unless a later match takes precedence.
-* @mozilla-mobile/fenix
+* @mozilla-mobile/ACT @mozilla-mobile/fenix
 /.cron.yml @mozilla-mobile/releng @mozilla-mobile/fenix
 /.taskcluster.yml @mozilla-mobile/releng @mozilla-mobile/fenix
 /automation/ @mozilla-mobile/releng @mozilla-mobile/fenix


### PR DESCRIPTION
Reverts mozilla-mobile/fenix#15618
The consensus from A-C is that we help reviewing as much as possible.  Reverting this change.