### PR TITLE
For #15402: Hide ETP pop-up if the toolbar is not visible

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionOverlay.kt
+++ b/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionOverlay.kt
@@ -63,7 +63,7 @@ class TrackingProtectionOverlay(
                 }
             }
             ToolbarPosition.TOP -> {
-                val appBarLayout = getToolbar().parent as AppBarLayout?
+                val appBarLayout = getToolbar().parent as? AppBarLayout
                 appBarLayout?.let { appBar ->
                     if(appBar.y != 0.toFloat()) {
                         return

--- a/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionOverlay.kt
+++ b/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionOverlay.kt
@@ -49,7 +49,7 @@ class TrackingProtectionOverlay(
 
     @Suppress("MagicNumber", "InflateParams")
     private fun showTrackingProtectionOnboarding() {
-        if (!getToolbar().hasWindowFocus()) return
+        if (getToolbar().translationY > 0) return
 
         val trackingOnboardingDialog = object : Dialog(context) {
             override fun onTouchEvent(event: MotionEvent): Boolean {

--- a/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionOverlay.kt
+++ b/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionOverlay.kt
@@ -54,13 +54,15 @@ class TrackingProtectionOverlay(
 
         if (!getToolbar().hasWindowFocus()) return
 
-        when (getToolbar().parent) {
-            is CoordinatorLayout -> {
+        val toolbarPosition = settings.toolbarPosition
+
+        when (toolbarPosition) {
+            ToolbarPosition.BOTTOM -> {
                 if(getToolbar().translationY > 0) {
                     return
                 }
             }
-            is AppBarLayout -> {
+            ToolbarPosition.TOP -> {
                 val appBarLayout = getToolbar().parent as AppBarLayout?
                 appBarLayout?.let { appBar ->
                     if(appBar.y != 0.toFloat()) {
@@ -82,7 +84,6 @@ class TrackingProtectionOverlay(
 
         val layout = LayoutInflater.from(context)
             .inflate(R.layout.tracking_protection_onboarding_popup, null)
-        val toolbarPosition = settings.toolbarPosition
 
         layout.drop_down_triangle.isVisible = toolbarPosition == ToolbarPosition.TOP
         layout.pop_up_triangle.isVisible = toolbarPosition == ToolbarPosition.BOTTOM

--- a/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionOverlay.kt
+++ b/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionOverlay.kt
@@ -13,8 +13,10 @@ import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.View
 import android.widget.ImageView
+import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.view.isVisible
 import androidx.core.view.marginTop
+import com.google.android.material.appbar.AppBarLayout
 import kotlinx.android.synthetic.main.tracking_protection_onboarding_popup.*
 import kotlinx.android.synthetic.main.tracking_protection_onboarding_popup.view.*
 import mozilla.components.browser.session.Session
@@ -49,7 +51,24 @@ class TrackingProtectionOverlay(
 
     @Suppress("MagicNumber", "InflateParams")
     private fun showTrackingProtectionOnboarding() {
-        if (getToolbar().translationY > 0) return
+
+        if (!getToolbar().hasWindowFocus()) return
+
+        when (getToolbar().parent) {
+            is CoordinatorLayout -> {
+                if(getToolbar().translationY > 0) {
+                    return
+                }
+            }
+            is AppBarLayout -> {
+                val appBarLayout = getToolbar().parent as AppBarLayout?
+                appBarLayout?.let { appBar ->
+                    if(appBar.y != 0.toFloat()) {
+                        return
+                    }
+                }
+            }
+        }
 
         val trackingOnboardingDialog = object : Dialog(context) {
             override fun onTouchEvent(event: MotionEvent): Boolean {

--- a/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionOverlay.kt
+++ b/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionOverlay.kt
@@ -13,7 +13,6 @@ import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.View
 import android.widget.ImageView
-import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.view.isVisible
 import androidx.core.view.marginTop
 import com.google.android.material.appbar.AppBarLayout
@@ -46,8 +45,8 @@ class TrackingProtectionOverlay(
 
     private fun shouldShowTrackingProtectionOnboarding(session: Session) =
         session.trackerBlockingEnabled &&
-                session.trackersBlocked.isNotEmpty() &&
-                settings.shouldShowTrackingProtectionCfr
+            session.trackersBlocked.isNotEmpty() &&
+            settings.shouldShowTrackingProtectionCfr
 
     @Suppress("MagicNumber", "InflateParams")
     private fun showTrackingProtectionOnboarding() {
@@ -58,14 +57,14 @@ class TrackingProtectionOverlay(
 
         when (toolbarPosition) {
             ToolbarPosition.BOTTOM -> {
-                if(getToolbar().translationY > 0) {
+                if (getToolbar().translationY > 0) {
                     return
                 }
             }
             ToolbarPosition.TOP -> {
                 val appBarLayout = getToolbar().parent as? AppBarLayout
                 appBarLayout?.let { appBar ->
-                    if(appBar.y != 0.toFloat()) {
+                    if (appBar.y != 0.toFloat()) {
                         return
                     }
                 }


### PR DESCRIPTION

![ETP](https://user-images.githubusercontent.com/47872289/95005944-269c6280-05b3-11eb-870e-4bd2ef90bf79.gif)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
