### PR TITLE
For #15508: Show error when trying to save empty or invalid bookmark URL

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/edit/EditBookmarkFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/edit/EditBookmarkFragment.kt
@@ -5,7 +5,10 @@
 package org.mozilla.fenix.library.bookmarks.edit
 
 import android.content.DialogInterface
+import android.content.res.ColorStateList
 import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
@@ -13,6 +16,7 @@ import android.view.View
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.ViewModelProvider
@@ -134,6 +138,23 @@ class EditBookmarkFragment : Fragment(R.layout.fragment_edit_bookmark) {
                 placeCursorAtEnd()
                 showKeyboard()
             }
+
+            view.bookmarkUrlEdit.addTextChangedListener(object : TextWatcher {
+                override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
+                    // NOOP
+                }
+
+                override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+                    bookmarkUrlEdit.onTextChanged(s)
+
+                    inputLayoutBookmarkUrl.error = null
+                    inputLayoutBookmarkUrl.errorIconDrawable = null
+                }
+
+                override fun afterTextChanged(s: Editable?) {
+                    // NOOP
+                }
+            })
         }
     }
 
@@ -245,13 +266,24 @@ class EditBookmarkFragment : Fragment(R.layout.fragment_edit_bookmark) {
                         )
                     )
                 }
+                withContext(Main) {
+                    inputLayoutBookmarkUrl.error = null
+                    inputLayoutBookmarkUrl.errorIconDrawable = null
+
+                    findNavController().popBackStack()
+                }
             } catch (e: UrlParseFailed) {
                 withContext(Main) {
-                    bookmarkUrlEdit.error = getString(R.string.bookmark_invalid_url_error)
+                    inputLayoutBookmarkUrl.error = getString(R.string.bookmark_invalid_url_error)
+                    inputLayoutBookmarkUrl.setErrorIconDrawable(R.drawable.mozac_ic_warning_with_bottom_padding)
+                    inputLayoutBookmarkUrl.setErrorIconTintList(
+                        ColorStateList.valueOf(
+                            ContextCompat.getColor(requireContext(), R.color.design_error)
+                        )
+                    )
                 }
             }
         }
         progress_bar_bookmark.visibility = View.INVISIBLE
-        findNavController().popBackStack()
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/utils/ClearableEditText.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/ClearableEditText.kt
@@ -46,6 +46,10 @@ class ClearableEditText @JvmOverloads constructor(
      * Displays a clear icon if text has been entered.
      */
     override fun onTextChanged(text: CharSequence?, start: Int, lengthBefore: Int, lengthAfter: Int) {
+        onTextChanged(text)
+    }
+
+    fun onTextChanged(text: CharSequence?) {
         // lengthAfter has inconsistent behaviour when there are spaces in the entered text, so we'll use text.length.
         val textLength = text?.length ?: 0
         val drawable = if (shouldShowClearButton(textLength)) {

--- a/app/src/main/res/layout/fragment_edit_bookmark.xml
+++ b/app/src/main/res/layout/fragment_edit_bookmark.xml
@@ -59,19 +59,26 @@
         android:textColor="?primaryText"
         android:textSize="12sp" />
 
-    <org.mozilla.fenix.utils.ClearableEditText
-        android:id="@+id/bookmarkUrlEdit"
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/inputLayoutBookmarkUrl"
         android:layout_width="match_parent"
-        android:layout_height="@dimen/bookmark_edit_text_height"
-        android:layout_marginBottom="8dp"
-        android:drawablePadding="8dp"
-        android:ellipsize="none"
-        android:fadingEdgeLength="8dp"
-        android:inputType="textUri"
-        android:requiresFadingEdge="horizontal"
-        android:textColor="?secondaryText"
-        android:textSize="15sp"
-        tools:text="https://www.mozilla.org/en-US/" />
+        android:layout_height="wrap_content">
+
+        <org.mozilla.fenix.utils.ClearableEditText
+            android:id="@+id/bookmarkUrlEdit"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/bookmark_edit_text_height"
+            android:layout_marginBottom="8dp"
+            android:drawablePadding="8dp"
+            android:ellipsize="none"
+            android:fadingEdgeLength="8dp"
+            android:inputType="textUri"
+            android:requiresFadingEdge="horizontal"
+            android:textColor="?secondaryText"
+            android:textSize="15sp"
+            tools:text="https://www.mozilla.org/en-US/" />
+
+    </com.google.android.material.textfield.TextInputLayout>
 
     <TextView
         android:id="@+id/bookmark_folder_label"


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU  #architecture


To be consistent with the UI in the Saved Logins screen, I wrapped the ClearableEditText of the bookmark URL in a TextInputLayout. But to be able to clear the error in the input layout when the text is changed, I needed to add a TextChangedListener in EditBookmarkFragment. The problem with that is that when I override onTextChanged in the listener, the code in onTextChanged in ClearableEditText will not execute. To work around this problem, I moved the logic in onTextChanged in ClearableEditText to a separate function that I can call in onTextChanged in the listener, and then proceed to clear the error in the TextInputLayout after. Please let me know if there's a better way to approach this issue and if I overlooked anything.

![Edit Bookmark URL](https://user-images.githubusercontent.com/38375996/95019070-109ea880-066c-11eb-9d94-379297a1ed46.gif)
