### PR TITLE
For #15632: Improve checking open tabs logic to show collection button.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayView.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayView.kt
@@ -99,6 +99,14 @@ class TabTrayView(
 
     private val components = container.context.components
 
+    private val checkOpenTabs = {
+        if (isPrivateModeSelected) {
+            view.context.components.core.store.state.privateTabs.isNotEmpty()
+        } else {
+            view.context.components.core.store.state.normalTabs.isNotEmpty()
+        }
+    }
+
     init {
         components.analytics.metrics.track(Event.TabsTrayOpened)
 
@@ -213,14 +221,9 @@ class TabTrayView(
         tabTrayItemMenu =
             TabTrayItemMenu(
                 context = view.context,
-                shouldShowSaveToCollection = { tabs.isNotEmpty() && view.tab_layout.selectedTabPosition == 0 },
-                hasOpenTabs = {
-                    if (isPrivateModeSelected) {
-                        view.context.components.core.store.state.privateTabs.isNotEmpty()
-                    } else {
-                        view.context.components.core.store.state.normalTabs.isNotEmpty()
-                    }
-                }) {
+                shouldShowSaveToCollection = { checkOpenTabs.invoke() && view.tab_layout.selectedTabPosition == 0 },
+                hasOpenTabs = checkOpenTabs
+            ) {
                 when (it) {
                     is TabTrayItemMenu.Item.ShareAllTabs -> interactor.onShareTabsClicked(
                         isPrivateModeSelected


### PR DESCRIPTION
Check now considers selected tab tray mode.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
