### PR TITLE
Feature Flag: Enable ETP Cookie Purging on all channels

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -49,5 +49,5 @@ object FeatureFlags {
     /**
      * Enables ETP cookie purging
      */
-    val etpCookiePurging = Config.channel.isNightlyOrDebug
+    val etpCookiePurging = true
 }

--- a/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -49,5 +49,5 @@ object FeatureFlags {
     /**
      * Enables ETP cookie purging
      */
-    val etpCookiePurging = true
+    const val etpCookiePurging = true
 }


### PR DESCRIPTION
This patch, to be uplifted to the `releases/v82` branch, enables _ETP Cookie Purging_ on all channels.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
