### PR TITLE
Uplift: Block github tagging on push-apk

### DIFF
--- a/taskcluster/ci/github-release/kind.yml
+++ b/taskcluster/ci/github-release/kind.yml
@@ -10,6 +10,9 @@ transforms:
     - taskgraph.transforms.task:transforms
 
 kind-dependencies:
+    # To work around a race condition where if this runs before
+    # push-apk, push-apk fails to verify chain of trust
+    - push-apk
     - signing
 
 primary-dependency: signing


### PR DESCRIPTION
This is the same change as #15546 but then uplifted to the `releases/v82.0.0` branch.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
