### PR TITLE
No issue: minimize Button...Detector violation location.

### DIFF
--- a/mozilla-lint-rules/src/main/java/org/mozilla/fenix/lintrules/ButtonStyleXmlDetector.kt
+++ b/mozilla-lint-rules/src/main/java/org/mozilla/fenix/lintrules/ButtonStyleXmlDetector.kt
@@ -58,7 +58,7 @@ class ButtonStyleXmlDetector : ResourceXmlDetector() {
         context.report(
             issue = ISSUE_XML_STYLE,
             scope = element,
-            location = context.getLocation(element),
+            location = context.getElementLocation(element),
             message = ERROR_MESSAGE
         )
     }


### PR DESCRIPTION
This changes the error highlighting from being the entire contents of
<Button ...> to just the first line of <Button>.

i.e. this:
![Screen Shot 2020-10-05 at 15 58 31](https://user-images.githubusercontent.com/759372/95140695-58810680-0724-11eb-812a-61efbd9163a5.png)

To this:
![image](https://user-images.githubusercontent.com/759372/95140675-4c954480-0724-11eb-979f-5d71f7ef0b62.png)

Which was recommended by some doc I read that I won't be able to find.

@ekager btw, I'm not sure why this one is warning since `style` is already declared (maybe it's because I'm on the old gradle plugin version).

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
