### PR TITLE
Fixed link from clipboard open up from same URL on every new tab #15588

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/ContextMenusTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/ContextMenusTest.kt
@@ -129,6 +129,27 @@ class ContextMenusTest {
     }
 
     @Test
+    fun verifyContextCopyLinkNotDisplayedAfterApplied() {
+        val pageLinks = TestAssetHelper.getGenericAsset(mockWebServer, 4)
+        val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 3)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(pageLinks.url) {
+            mDevice.waitForIdle()
+            longClickMatchingText("Link 3")
+            verifyLinkContextMenuItems(genericURL.url)
+            clickContextCopyLink()
+            verifySnackBarText("Link copied to clipboard")
+        }.openNavigationToolbar {
+        }.visitLinkFromClipboard {
+            verifyUrl(genericURL.url.toString())
+        }.openTabDrawer {
+        }.openNewTab {
+            verifyFillLinkButton()
+        }
+    }
+
+    @Test
     fun verifyContextShareLink() {
         val pageLinks =
             TestAssetHelper.getGenericAsset(mockWebServer, 4)

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SearchRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SearchRobot.kt
@@ -187,6 +187,7 @@ class SearchRobot {
         onView(withContentDescription(expectedText))
     }
     fun verifyDefaultSearchEngine(expectedText: String) = assertDefaultSearchEngine(expectedText)
+    fun verifyFillLinkButton() = assertFillLinkButton()
 
     fun verifyEnginesListShortcutContains(rule: ComposeTestRule, searchEngineName: String) = assertEngineListShortcutContains(rule, searchEngineName)
 
@@ -533,7 +534,15 @@ private fun assertTranslatedFocusedNavigationToolbar(toolbarHintString: String) 
         ).waitForExists(waitingTime),
     )
 
+private fun assertFillLinkButton() {
+    mDevice.waitForIdle()
+    onView(withId(R.id.fill_link_from_clipboard))
+        .check(matches(withEffectiveVisibility(Visibility.GONE)))
+}
+
 private val awesomeBar =
     mDevice.findObject(UiSelector().resourceId("$packageName:id/mozac_browser_toolbar_edit_url_view"))
 
 private val voiceSearchButton = mDevice.findObject(UiSelector().description("Voice search"))
+
+private fun goBackButton() = onView(allOf(withContentDescription("Navigate up")))

--- a/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt
@@ -389,6 +389,7 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
                         from = BrowserDirection.FromSearchDialog,
                     )
             }
+            requireContext().components.clipboardHandler.text = null
         }
 
         val stubListener = ViewStub.OnInflateListener { _, inflated ->


### PR DESCRIPTION
### Description 
https://github.com/mozilla-mobile/fenix/issues/15588

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### Overview
The current behaviour reported on the ticket is below one:
![ezgif com-gif-maker](https://user-images.githubusercontent.com/18151158/95247371-b2113000-080d-11eb-8c20-0ef1e87288c5.gif)

After the changes, once we applied the link from clipboard this doesn't appear any more as a suggestion. 

Fixes #15588
Fixes #15588
Fixes #15588
Fixes #15588
Fixes #15588
Fixes #15588
Fixes #15588