### PR TITLE
Revert "Block github tagging on push-apk"

### DIFF
--- a/taskcluster/ci/github-release/kind.yml
+++ b/taskcluster/ci/github-release/kind.yml
@@ -10,9 +10,6 @@ transforms:
     - taskgraph.transforms.task:transforms
 
 kind-dependencies:
-    # To work around a race condition where if this runs before
-    # push-apk, push-apk fails to verify chain of trust
-    - push-apk
     - signing
 
 primary-dependency: signing


### PR DESCRIPTION
Reverts mozilla-mobile/fenix#15546

We don't need this workaround anymore because https://github.com/mozilla-releng/scriptworker-scripts/pull/276 was deployed to production. Moreover it caused CoT issues on the githubscript task: 

```
2020-10-06T12:01:42 CRITICAL - Chain of Trust verification error!
Traceback (most recent call last):
  File "/app/lib/python3.8/site-packages/scriptworker/cot/verify.py", line 1957, in verify_chain_of_trust
    await build_task_dependencies(chain, chain.task, chain.name, chain.task_id)
  File "/app/lib/python3.8/site-packages/scriptworker/cot/verify.py", line 629, in build_task_dependencies
    await build_link(chain, task_name, task_id)
  File "/app/lib/python3.8/site-packages/scriptworker/cot/verify.py", line 600, in build_link
    link.task = task_defn
  File "/app/lib/python3.8/site-packages/scriptworker/cot/verify.py", line 246, in task
    self.task_type = guess_task_type(self.name, self.task)
  File "/app/lib/python3.8/site-packages/scriptworker/cot/verify.py", line 393, in guess_task_type
    raise CoTError("Invalid task type for {}!".format(name))
scriptworker.exceptions.CoTError: 'Invalid task type for scriptworker:push-apk!'
2020-10-06T12:01:42    ERROR - Hit ScriptWorkerException: 'Invalid task type for scriptworker:push-apk!'
```

https://firefox-ci-tc.services.mozilla.com/tasks/CK6nWi48QRCpkvyH_UxiEQ/runs/0/logs/https%3A%2F%2Ffirefox-ci-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FCK6nWi48QRCpkvyH_UxiEQ%2Fruns%2F0%2Fartifacts%2Fpublic%2Flogs%2Fchain_of_trust.log