### PR TITLE
For #15543 - Expand / collapse tabs tray depending on all tabs 

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayDialogFragment.kt
@@ -161,14 +161,13 @@ class TabTrayDialogFragment : AppCompatDialogFragment(), UserInteractionHandler 
 
         if (newConfig.orientation != currentOrientation) {
             tabTrayView.dismissMenu()
-            tabTrayView.expand()
+            tabTrayView.updateBottomSheetBehavior()
 
             if (requireContext().settings().gridTabView) {
                 // Update the number of columns to use in the grid view when the screen
                 // orientation changes.
                 tabTrayView.updateTabsTrayLayout()
             }
-
             currentOrientation = newConfig.orientation
         }
     }
@@ -205,8 +204,7 @@ class TabTrayDialogFragment : AppCompatDialogFragment(), UserInteractionHandler 
             ),
             store = tabTrayDialogStore,
             isPrivate = isPrivate,
-            startingInLandscape = requireContext().resources.configuration.orientation ==
-                    Configuration.ORIENTATION_LANDSCAPE,
+            isInLandscape = ::isInLandscape,
             lifecycleOwner = viewLifecycleOwner
         ) { private ->
             val filter: (TabSessionState) -> Boolean = { state -> private == state.content.private }
@@ -448,6 +446,10 @@ class TabTrayDialogFragment : AppCompatDialogFragment(), UserInteractionHandler 
                     collectionNameEditText.showKeyboard()
                 }
         }
+    }
+
+    private fun isInLandscape(): Boolean {
+        return requireContext().resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
     }
 
     companion object {


### PR DESCRIPTION
Now check all tabs - private or normal and decide whether to show the tabs tray
as expanded or collapsed depending on the highest number of tabs in any
category.
Also added support for the grid based tabs tray - will show tabs tray as
expanded if there are more than 3 or more tabs (normal or private) open
(this meaning two rows in the grid layout).

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**:  No tests. Small changes in a not yet tested component.
- [x] **Screenshots**: Tried to record screen but with this involving private mode much of the video is blaked out.
- [x] **Accessibility**: The code in this PR or does not include any user facing features

| List based layout  | Grid based layout |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/11428869/96576343-b8f27500-12da-11eb-8e7a-ab9a453cb86b.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/11428869/96576459-e3dcc900-12da-11eb-806a-accaf489342f.gif" width="300" /> |
| [video](https://drive.google.com/file/d/1_KzwLvbtcEphnSJdKZP89d9Xoc5FEp2q/view?usp=sharing) | [video](https://drive.google.com/file/d/1nGi1PDHlKeJFI0WrUGc-vGWNlcaJbfwY/view?usp=sharing) |

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
