### PR TITLE
Revert "Uplift: Block github tagging on push-apk"

### DIFF
--- a/taskcluster/ci/github-release/kind.yml
+++ b/taskcluster/ci/github-release/kind.yml
@@ -10,9 +10,6 @@ transforms:
     - taskgraph.transforms.task:transforms
 
 kind-dependencies:
-    # To work around a race condition where if this runs before
-    # push-apk, push-apk fails to verify chain of trust
-    - push-apk
     - signing
 
 primary-dependency: signing


### PR DESCRIPTION
Reverts mozilla-mobile/fenix#15702

See https://github.com/mozilla-mobile/fenix/pull/15748 