### PR TITLE
No issue: remove inline from resetAfter

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/StrictModeManager.kt
+++ b/app/src/main/java/org/mozilla/fenix/StrictModeManager.kt
@@ -23,6 +23,9 @@ import org.mozilla.fenix.perf.Performance
 private const val MANUFACTURE_HUAWEI: String = "HUAWEI"
 private const val MANUFACTURE_ONE_PLUS: String = "OnePlus"
 
+private val logger = Performance.logger
+private val mainLooper = Looper.getMainLooper()
+
 /**
  * Manages strict mode settings for the application.
  */
@@ -32,16 +35,10 @@ class StrictModeManager(
     // Ideally, we'd pass in a more specific value but there is a circular dependency: StrictMode
     // is passed into Core but we'd need to pass in Core here. Instead, we take components and later
     // fetch the value we need from it.
-    //
-    // Public to be accessible by inline functions.
-    val components: Components
+    private val components: Components
 ) {
 
-    val logger = Performance.logger // public to be accessible by inline functions.
-    val mainLooper = Looper.getMainLooper() // public to be accessible by inline functions.
-
-    // This is public so it can be used by inline functions.
-    val isEnabledByBuildConfig = config.channel.isDebug
+    private val isEnabledByBuildConfig = config.channel.isDebug
 
     /**
      * The number of times StrictMode has been suppressed. StrictMode can be used to prevent main
@@ -114,7 +111,7 @@ class StrictModeManager(
      *
      * @return the value returned by [functionBlock].
      */
-    inline fun <R> resetAfter(policy: StrictMode.ThreadPolicy, functionBlock: () -> R): R {
+    fun <R> resetAfter(policy: StrictMode.ThreadPolicy, functionBlock: () -> R): R {
         // Calling resetAfter takes 1-2ms (unknown device) so we only execute it if StrictMode can
         // actually be enabled. https://github.com/mozilla-mobile/fenix/issues/11617
         return if (isEnabledByBuildConfig) {

--- a/app/src/main/java/org/mozilla/fenix/StrictModeManager.kt
+++ b/app/src/main/java/org/mozilla/fenix/StrictModeManager.kt
@@ -19,6 +19,7 @@ import androidx.fragment.app.FragmentManager
 import mozilla.components.support.ktx.android.os.resetAfter
 import org.mozilla.fenix.components.Components
 import org.mozilla.fenix.perf.Performance
+import org.mozilla.fenix.utils.Mockable
 
 private const val MANUFACTURE_HUAWEI: String = "HUAWEI"
 private const val MANUFACTURE_ONE_PLUS: String = "OnePlus"
@@ -29,6 +30,7 @@ private val mainLooper = Looper.getMainLooper()
 /**
  * Manages strict mode settings for the application.
  */
+@Mockable
 class StrictModeManager(
     config: Config,
 

--- a/app/src/test/java/org/mozilla/fenix/IntentReceiverActivityTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/IntentReceiverActivityTest.kt
@@ -17,6 +17,7 @@ import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
 import mozilla.components.feature.intent.processing.IntentProcessor
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -202,7 +203,10 @@ class IntentReceiverActivityTest {
         every { activity.settings() } returns settings
         every { activity.components.analytics } returns mockk(relaxed = true)
         every { activity.components.intentProcessors } returns intentProcessors
-        every { activity.components.strictMode } returns mockk(relaxed = true)
+
+        // For some reason, activity.components doesn't return application.components, which is the
+        // globally defined TestComponents, so we redirect it.
+        every { activity.components.strictMode } returns testContext.components.strictMode
     }
 
     private inline fun <reified T : IntentProcessor> mockIntentProcessor(): T {

--- a/app/src/test/java/org/mozilla/fenix/components/TestComponents.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/TestComponents.kt
@@ -6,6 +6,7 @@ package org.mozilla.fenix.components
 
 import android.content.Context
 import io.mockk.mockk
+import org.mozilla.fenix.helpers.TestStrictModeManager
 import org.mozilla.fenix.utils.ClipboardHandler
 import org.mozilla.fenix.utils.Settings
 
@@ -33,4 +34,6 @@ class TestComponents(private val context: Context) : Components(context) {
     override val clipboardHandler by lazy { ClipboardHandler(context) }
 
     override val settings by lazy { mockk<Settings>(relaxed = true) }
+
+    override val strictMode by lazy { TestStrictModeManager() }
 }

--- a/app/src/test/java/org/mozilla/fenix/helpers/TestStrictModeManager.kt
+++ b/app/src/test/java/org/mozilla/fenix/helpers/TestStrictModeManager.kt
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.helpers
+
+import android.os.StrictMode
+import io.mockk.mockk
+import org.mozilla.fenix.StrictModeManager
+
+/**
+ * A test version of [StrictModeManager]. This class is difficult to mock because of [resetAfter]
+ * so we provide a test implementation.
+ */
+class TestStrictModeManager : StrictModeManager(mockk(relaxed = true), mockk(relaxed = true)) {
+
+    // This method is hard to mock because this method needs to return the return value of the
+    // function passed in.
+    override fun <R> resetAfter(policy: StrictMode.ThreadPolicy, functionBlock: () -> R): R {
+        return functionBlock()
+    }
+}


### PR DESCRIPTION
I believe this was a premature optimization: it's unclear that it would
actually improve performance and yet  we had to add several weird
workarounds to make it work that broke encapsulation. It's also
possible it would be worse for the APK size because of excessive
inlining.

The difficulty in mocking StrictMode.resetAfter is concerning.
I'm starting to second-guess whether or not making strict mode manager a class
was a good idea.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
