### PR TITLE
For #15796: Show device language under "Follow device language"

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/advanced/LocaleViewHolders.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/advanced/LocaleViewHolders.kt
@@ -39,7 +39,7 @@ class SystemLocaleViewHolder(
 
     override fun bind(locale: Locale) {
         locale_title_text.text = itemView.context.getString(R.string.default_locale_text)
-        locale_subtitle_text.visibility = View.GONE
+        locale_subtitle_text.text = locale.displayName.capitalize(Locale.getDefault())
         locale_selected_icon.isVisible = isCurrentLocaleSelected(locale, isDefault = true)
         itemView.setOnClickListener {
             interactor.onDefaultLocaleSelected()


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

Here is what it looks like now. My device language is English (United States).

![Screenshot_1602429825](https://user-images.githubusercontent.com/38375996/95682636-00984300-0bef-11eb-86e1-9ce8959f7a8b.png)
![Screenshot_1602429843](https://user-images.githubusercontent.com/38375996/95682638-02620680-0bef-11eb-87c7-7b1ef70875e8.png)
