### PR TITLE
For #15758 ⁃ [Grid View] Add a divider between the tab item's title and thumbnail

### DIFF
--- a/app/src/main/res/layout/tab_tray_grid_item.xml
+++ b/app/src/main/res/layout/tab_tray_grid_item.xml
@@ -47,7 +47,7 @@
         <TextView
             android:id="@+id/mozac_browser_tabstray_title"
             android:layout_width="0dp"
-            android:layout_height="wrap_content"
+            android:layout_height="30dp"
             android:layout_alignParentTop="true"
             android:ellipsize="none"
             android:fadingEdgeLength="25dp"

--- a/app/src/main/res/layout/tab_tray_grid_item.xml
+++ b/app/src/main/res/layout/tab_tray_grid_item.xml
@@ -40,8 +40,8 @@
             android:layout_height="16dp"
             android:layout_marginStart="8dp"
             android:importantForAccessibility="no"
-            app:layout_constraintBottom_toTopOf="@id/mozac_browser_tabstray_card"
-            app:layout_constraintStart_toStartOf="@id/mozac_browser_tabstray_card"
+            app:layout_constraintBottom_toTopOf="@id/horizonatal_divider"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
         <TextView
@@ -69,21 +69,27 @@
             android:layout_height="wrap_content"
             android:background="?android:attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/close_tab"
-            app:layout_constraintBottom_toTopOf="@id/mozac_browser_tabstray_card"
-            app:layout_constraintEnd_toEndOf="@id/mozac_browser_tabstray_card"
+            app:layout_constraintBottom_toTopOf="@+id/horizonatal_divider"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             app:srcCompat="@drawable/mozac_ic_close"
             app:tint="@color/photonInk80" />
+
+        <View
+            android:id="@+id/horizonatal_divider"
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="@color/photonLightGrey30"
+            app:layout_constraintTop_toBottomOf="@+id/mozac_browser_tabstray_title" />
 
         <androidx.cardview.widget.CardView
             android:id="@+id/mozac_browser_tabstray_card"
             android:layout_width="match_parent"
             android:layout_height="@dimen/tab_tray_grid_item_thumbnail_height"
-            android:layout_marginTop="30dp"
             android:backgroundTint="?tabTrayThumbnailItemBackground"
             app:cardBackgroundColor="@color/photonWhite"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
+            app:layout_constraintTop_toBottomOf="@+id/horizonatal_divider">
 
             <ImageView
                 android:id="@+id/default_tab_thumbnail"


### PR DESCRIPTION
Fixes #15758 

<img width="440" alt="Screen Shot 2020-10-11 at 10 44 15 PM" src="https://user-images.githubusercontent.com/1190888/95699737-50890100-0c13-11eb-93c0-97985e91a9a0.png">


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
