### PR TITLE
For #15853 - Always set fontSizeFactor setting with new text scale

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/AccessibilityFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/AccessibilityFragment.kt
@@ -45,7 +45,10 @@ class AccessibilityFragment : PreferenceFragmentCompat() {
             val components = preference.context.components
 
             // Value is mapped from 0->30 in steps of 1 so let's convert to float in range 0.5->2.0
-            val newTextScale = ((newTextSize * STEP_SIZE) + MIN_SCALE_VALUE).toFloat() / PERCENT_TO_DECIMAL
+            val newTextScale =
+                ((newTextSize * STEP_SIZE) + MIN_SCALE_VALUE).toFloat() / PERCENT_TO_DECIMAL
+
+            settings.fontSizeFactor = newTextScale
 
             // If scale is 100%, use the automatic font size adjustment
             val useAutoSize = newTextScale == 1F
@@ -54,7 +57,6 @@ class AccessibilityFragment : PreferenceFragmentCompat() {
 
             // If using manual sizing, update the engine settings with the new scale
             if (!useAutoSize) {
-                settings.fontSizeFactor = newTextScale
                 components.core.engine.settings.fontSizeFactor = newTextScale
             }
 


### PR DESCRIPTION
Since we're using this to know if we should do auto size now, we need to always be updating it in settings

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
