### PR TITLE
For #10683: Show longer tab titles

### DIFF
--- a/app/src/main/res/layout/tab_tray_item.xml
+++ b/app/src/main/res/layout/tab_tray_item.xml
@@ -32,6 +32,7 @@
         android:layout_height="@dimen/tab_tray_list_item_thumbnail_height"
         android:layout_marginStart="16dp"
         android:layout_marginTop="8dp"
+        android:layout_marginBottom="8dp"
         android:backgroundTint="?tabTrayThumbnailItemBackground"
         app:cardBackgroundColor="@color/photonWhite"
         app:layout_constraintStart_toStartOf="parent"
@@ -61,33 +62,37 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_alignParentTop="true"
+        android:layout_marginTop="24dp"
+        android:layout_marginStart="12dp"
         android:ellipsize="end"
-        android:lines="1"
-        android:paddingStart="16dp"
-        android:paddingTop="22dp"
         android:textColor="@color/tab_tray_item_text_normal_theme"
         android:textSize="16sp"
+        android:lineSpacingExtra="4sp"
+        android:maxLines="2"
         tools:text="Firefox"
         app:layout_constraintEnd_toStartOf="@id/mozac_browser_tabstray_close"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toEndOf="@id/mozac_browser_tabstray_card"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/mozac_browser_tabstray_url" />
 
     <TextView
         android:id="@+id/mozac_browser_tabstray_url"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_alignParentTop="true"
+        android:layout_marginTop="4dp"
+        android:layout_marginBottom="24dp"
+        android:layout_marginStart="12dp"
         android:ellipsize="end"
         android:lines="1"
-        android:paddingStart="16dp"
         android:textColor="@color/tab_tray_item_url_normal_theme"
         android:textSize="14sp"
         tools:text="firefox.com"
         app:layout_constraintEnd_toStartOf="@id/mozac_browser_tabstray_close"
-        app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toEndOf="@id/mozac_browser_tabstray_card"
-        app:layout_constraintTop_toBottomOf="@id/mozac_browser_tabstray_title" />
+        app:layout_constraintTop_toBottomOf="@id/mozac_browser_tabstray_title"
+        app:layout_constraintBottom_toBottomOf="parent"/>
 
     <androidx.appcompat.widget.AppCompatImageButton
         android:id="@+id/mozac_browser_tabstray_close"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -172,7 +172,7 @@
     <!-- Tabs Tray -->
     <dimen name="tab_tray_top_offset">40dp</dimen>
     <dimen name="tab_tray_list_item_thumbnail_width">92dp</dimen>
-    <dimen name="tab_tray_list_item_thumbnail_height">69dp</dimen>
+    <dimen name="tab_tray_list_item_thumbnail_height">72dp</dimen>
     <dimen name="tab_tray_grid_item_thumbnail_width">156dp</dimen>
     <dimen name="tab_tray_grid_item_thumbnail_height">156dp</dimen>
     <dimen name="tab_tray_grid_item_border_radius">8dp</dimen>


### PR DESCRIPTION
Also update tab tray item layout according to specs posted in the issue.
cc @mcarare because you reviewed the previous PR (#12684).

<img src="https://user-images.githubusercontent.com/46764284/96237774-fdf66e80-0f9d-11eb-9ba5-96668ca4c310.png" width=300 />


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
