### PR TITLE
For #15890 - Ensure app locale switcher works for Windows builds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -569,8 +569,8 @@ task buildTranslationArray {
     foundLocales.append("new String[]{")
 
     fileTree("src/main/res").visit { FileVisitDetails details ->
-        if(details.file.path.endsWith("/strings.xml")){
-            def languageCode = details.file.parent.tokenize('/').last().replaceAll('values-','').replaceAll('-r','-')
+        if(details.file.path.endsWith("${File.separator}strings.xml")){
+            def languageCode = details.file.parent.tokenize(File.separator).last().replaceAll('values-','').replaceAll('-r','-')
             languageCode = (languageCode == "values") ? "en-US" : languageCode
             foundLocales.append("\"").append(languageCode).append("\"").append(",")
         }


### PR DESCRIPTION
A hardcoded unix file separator prevented us from building a proper list of
locales for which we actually have packaged translations.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: No test. Small build script change.
- [x] **Screenshots**
- [x] **Accessibility**: The code in this PR follows does not include any user facing features.

<img src="https://user-images.githubusercontent.com/11428869/95987600-50b21800-0e30-11eb-8157-9d645a4b0800.png" width="350">


### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
