### PR TITLE
For #15931: Sort Downloads from newest to oldest

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/downloads/DownloadFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/downloads/DownloadFragment.kt
@@ -8,8 +8,10 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.annotation.VisibleForTesting
 import kotlinx.android.synthetic.main.fragment_downloads.view.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.content.DownloadState
 import mozilla.components.feature.downloads.AbstractFetchDownloadService
 import mozilla.components.lib.state.ext.consumeFrom
@@ -37,20 +39,7 @@ class DownloadFragment : LibraryPageFragment<DownloadItem>(), UserInteractionHan
     ): View? {
         val view = inflater.inflate(R.layout.fragment_downloads, container, false)
 
-        val items = requireComponents.core.store.state.downloads.values
-            .sortedByDescending { it.createdTime } // sort from newest to oldest
-            .map {
-                DownloadItem(
-                    it.id,
-                    it.fileName,
-                    it.filePath,
-                    it.contentLength.toString(),
-                    it.contentType,
-                    it.status
-                )
-            }.filter {
-                it.status == DownloadState.Status.COMPLETED
-            }.filterNotExistsOnDisk()
+        val items = provideDownloads(requireComponents.core.store.state)
 
         downloadStore = StoreProvider.get(this) {
             DownloadFragmentStore(
@@ -71,6 +60,24 @@ class DownloadFragment : LibraryPageFragment<DownloadItem>(), UserInteractionHan
         downloadView = DownloadView(view.downloadsLayout, downloadInteractor)
 
         return view
+    }
+
+    @VisibleForTesting
+    internal fun provideDownloads(state: BrowserState): List<DownloadItem> {
+        return state.downloads.values
+            .sortedByDescending { it.createdTime } // sort from newest to oldest
+            .map {
+                DownloadItem(
+                    it.id,
+                    it.fileName,
+                    it.filePath,
+                    it.contentLength.toString(),
+                    it.contentType,
+                    it.status
+                )
+            }.filter {
+                it.status == DownloadState.Status.COMPLETED
+            }.filterNotExistsOnDisk()
     }
 
     override val selectedItems get() = downloadStore.state.mode.selectedItems

--- a/app/src/main/java/org/mozilla/fenix/library/downloads/DownloadFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/downloads/DownloadFragment.kt
@@ -37,18 +37,20 @@ class DownloadFragment : LibraryPageFragment<DownloadItem>(), UserInteractionHan
     ): View? {
         val view = inflater.inflate(R.layout.fragment_downloads, container, false)
 
-        val items = requireComponents.core.store.state.downloads.map {
-            DownloadItem(
-                it.value.id.toString(),
-                it.value.fileName,
-                it.value.filePath,
-                it.value.contentLength.toString(),
-                it.value.contentType,
-                it.value.status
-            )
-        }.filter {
-            it.status == DownloadState.Status.COMPLETED
-        }.filterNotExistsOnDisk()
+        val items = requireComponents.core.store.state.downloads.values
+            .sortedByDescending { it.createdTime } // sort from newest to oldest
+            .map {
+                DownloadItem(
+                    it.id,
+                    it.fileName,
+                    it.filePath,
+                    it.contentLength.toString(),
+                    it.contentType,
+                    it.status
+                )
+            }.filter {
+                it.status == DownloadState.Status.COMPLETED
+            }.filterNotExistsOnDisk()
 
         downloadStore = StoreProvider.get(this) {
             DownloadFragmentStore(

--- a/app/src/test/java/org/mozilla/fenix/library/downloads/DownloadFragmentTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/downloads/DownloadFragmentTest.kt
@@ -1,0 +1,107 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+   License, v. 2.0. If a copy of the MPL was not distributed with this
+   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.library.downloads
+
+import android.os.Environment
+import io.mockk.every
+import io.mockk.mockk
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.state.content.DownloadState
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+import java.io.File
+
+@Suppress("DEPRECATION")
+@RunWith(FenixRobolectricTestRunner::class)
+class DownloadFragmentTest {
+
+    @Test
+    fun `downloads are sorted from newest to oldest`() {
+
+        val downloadedFile1 = File(
+            Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS),
+            "1.pdf"
+        )
+
+        val downloadedFile2 = File(
+            Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS),
+            "2.pdf"
+        )
+
+        val downloadedFile3 = File(
+            Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS),
+            "3.pdf"
+        )
+
+        downloadedFile1.createNewFile()
+        downloadedFile2.createNewFile()
+        downloadedFile3.createNewFile()
+
+        val fragment = DownloadFragment()
+
+        val expectedList = listOf(
+            DownloadItem(
+                "3",
+                "3.pdf",
+                downloadedFile3.path,
+                "null",
+                null,
+                DownloadState.Status.COMPLETED
+            ),
+            DownloadItem(
+                "2",
+                "2.pdf",
+                downloadedFile2.path,
+                "null",
+                null,
+                DownloadState.Status.COMPLETED
+            ),
+            DownloadItem(
+                "1",
+                "1.pdf",
+                downloadedFile1.path,
+                "null",
+                null,
+                DownloadState.Status.COMPLETED
+            )
+        )
+
+        val state: BrowserState = mockk(relaxed = true)
+
+        every { state.downloads } returns mapOf(
+            "1" to DownloadState(
+                id = "1",
+                createdTime = 1,
+                url = "url",
+                fileName = "1.pdf",
+                status = DownloadState.Status.COMPLETED
+            ),
+            "2" to DownloadState(
+                id = "2",
+                createdTime = 2,
+                url = "url",
+                fileName = "2.pdf",
+                status = DownloadState.Status.COMPLETED
+            ),
+            "3" to DownloadState(
+                id = "3",
+                createdTime = 3,
+                url = "url",
+                fileName = "3.pdf",
+                status = DownloadState.Status.COMPLETED
+            )
+        )
+
+        val list = fragment.provideDownloads(state)
+
+        assertEquals(expectedList, list)
+
+        downloadedFile1.delete()
+        downloadedFile2.delete()
+        downloadedFile3.delete()
+    }
+}


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

Downloads are now sorted from newest to oldest based on **createdTime**.


This is how the downloads appear in the notifications on the phone (sorted from newest to oldest):
![Screenshot_1603711537](https://user-images.githubusercontent.com/38375996/97167114-f0f03100-178e-11eb-984e-d60405885258.png)


This is how the downloads now appear on Fenix (the same order as above):
![Screenshot_1603711558](https://user-images.githubusercontent.com/38375996/97167157-01a0a700-178f-11eb-96f7-f2f1a7e0cfba.png)