### PR TITLE
For #11862 - Add swipe to show tab tray gesture for bottom toolbar.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -45,4 +45,9 @@ object FeatureFlags {
      * Enables ETP cookie purging
      */
     val etpCookiePurging = Config.channel.isNightlyOrDebug
+
+    /**
+     * Enables additional swipe gestures on the browser chrome.
+     */
+    val browserChromeGestures = Config.channel.isNightlyOrDebug
 }

--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -30,6 +30,7 @@ import mozilla.components.feature.tab.collections.TabCollection
 import mozilla.components.feature.tabs.WindowFeature
 import mozilla.components.support.base.feature.UserInteractionHandler
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
+import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.R
 import org.mozilla.fenix.addons.runIfFragmentIsAttached
 import org.mozilla.fenix.components.FenixSnackbar
@@ -40,6 +41,7 @@ import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.navigateSafe
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.gestures.ShowTabTrayGestureListener
 import org.mozilla.fenix.shortcut.PwaOnboardingObserver
 import org.mozilla.fenix.trackingprotection.TrackingProtectionOverlay
 
@@ -74,12 +76,22 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
         return super.initializeUI(view)?.also {
             if (context.settings().isSwipeToolbarToSwitchTabsEnabled) {
                 gestureLayout.addGestureListener(
-                    ToolbarGestureHandler(
+                    SwitchTabsGestureListener(
                         activity = requireActivity(),
                         contentLayout = browserLayout,
                         tabPreview = tabPreview,
                         toolbarLayout = browserToolbarView.view,
                         sessionManager = components.core.sessionManager
+                    )
+                )
+            }
+
+            if (FeatureFlags.browserChromeGestures) {
+                gestureLayout.addGestureListener(
+                    ShowTabTrayGestureListener(
+                        activity = requireActivity(),
+                        toolbarLayout = browserToolbarView.view,
+                        showTabTray = browserInteractor::onTabCounterClicked
                     )
                 )
             }

--- a/app/src/main/java/org/mozilla/fenix/gestures/GestureUtils.kt
+++ b/app/src/main/java/org/mozilla/fenix/gestures/GestureUtils.kt
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.gestures
+
+import android.graphics.PointF
+import android.view.View
+import androidx.core.graphics.contains
+import androidx.core.graphics.toPoint
+import org.mozilla.fenix.ext.getRectWithScreenLocation
+import org.mozilla.fenix.ext.getWindowInsets
+import org.mozilla.fenix.ext.settings
+
+/**
+ * Checks if a point is within the bounds of a toolbar view. This accounts for the overlap
+ * between the bottom toolbar and the system gesture area.
+ */
+fun PointF.isInToolbar(toolbar: View): Boolean {
+    val toolbarLocation = toolbar.getRectWithScreenLocation()
+    // In Android 10, the system gesture touch area overlaps the bottom of the toolbar, so
+    // lets make our swipe area taller by that amount
+    toolbar.getWindowInsets()?.let { insets ->
+        if (toolbar.context.settings().shouldUseBottomToolbar) {
+            toolbarLocation.top -= (insets.mandatorySystemGestureInsets.bottom - insets.stableInsetBottom)
+        }
+    }
+    return toolbarLocation.contains(toPoint())
+}

--- a/app/src/main/java/org/mozilla/fenix/gestures/ShowTabTrayGestureListener.kt
+++ b/app/src/main/java/org/mozilla/fenix/gestures/ShowTabTrayGestureListener.kt
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.gestures
+
+import android.app.Activity
+import android.graphics.PointF
+import android.view.View
+import android.view.ViewConfiguration
+import org.mozilla.fenix.components.toolbar.ToolbarPosition
+import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.isKeyboardVisible
+import kotlin.math.abs
+
+class ShowTabTrayGestureListener(
+    private val activity: Activity,
+    private val toolbarLayout: View,
+    private val showTabTray: () -> Unit
+) : SwipeGestureListener {
+
+    private val touchSlop = ViewConfiguration.get(activity).scaledTouchSlop
+    private val minimumFlingVelocity = ViewConfiguration.get(activity).scaledMinimumFlingVelocity
+
+    override fun onSwipeStarted(start: PointF, next: PointF): Boolean {
+        val dx = next.x - start.x
+        // negative dy = swiping up
+        val dy = next.y - start.y
+
+        return activity.components.settings.toolbarPosition == ToolbarPosition.BOTTOM &&
+            !toolbarLayout.isKeyboardVisible() && start.isInToolbar(toolbarLayout) &&
+            -dy >= touchSlop && abs(dx) < abs(dy)
+    }
+
+    override fun onSwipeUpdate(distanceX: Float, distanceY: Float) {
+        // Do nothing
+    }
+
+    override fun onSwipeFinished(velocityX: Float, velocityY: Float) {
+        // Negative velocityY = swiping up
+        if (-velocityY >= minimumFlingVelocity) {
+            showTabTray.invoke()
+        }
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/gestures/SwipeGestureLayout.kt
+++ b/app/src/main/java/org/mozilla/fenix/gestures/SwipeGestureLayout.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.fenix.browser
+package org.mozilla.fenix.gestures
 
 import android.content.Context
 import android.graphics.PointF

--- a/app/src/main/res/layout/fragment_browser.xml
+++ b/app/src/main/res/layout/fragment_browser.xml
@@ -2,7 +2,7 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<org.mozilla.fenix.browser.SwipeGestureLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<org.mozilla.fenix.gestures.SwipeGestureLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/gestureLayout"
@@ -79,4 +79,4 @@
         android:clickable="false"
         android:focusable="false"
         android:visibility="gone" />
-</org.mozilla.fenix.browser.SwipeGestureLayout>
+</org.mozilla.fenix.gestures.SwipeGestureLayout>

--- a/app/src/main/res/layout/home_gesture_wrapper.xml
+++ b/app/src/main/res/layout/home_gesture_wrapper.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<org.mozilla.fenix.gestures.SwipeGestureLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/gestureLayout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <include layout="@layout/fragment_home" />
+</org.mozilla.fenix.gestures.SwipeGestureLayout>


### PR DESCRIPTION
Fixes #11862, this is only for running the try 

- Create a new gestures package for classes that implement gestures that
  work on multiple screens

- Move SwipeGestureLayout to the gestures package

- Rename ToolbarGestureHandler to SwitchTabsGestureListener

- Gate swipe to show tab tray behind a feature flag

- Update home fragment snackbars to explicitly pass a
  CoordinatorLayout as the view to attach them to

- Extract common gesture function into utility file.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
