### PR TITLE
For #14619: Show half a tab top offset when scrolling to selected tab.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayView.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayView.kt
@@ -652,13 +652,15 @@ class TabTrayView(
 
             // We offset the tab index by the number of items in the other adapters.
             // We add the offset, because the layoutManager is initialized with `reverseLayout`.
-            // We also add 1 to display the tab item above the selected browser tab.
             val recyclerViewIndex = selectedBrowserTabIndex +
                 collectionsButtonAdapter.itemCount +
-                syncedTabsController.adapter.itemCount +
-                1
+                syncedTabsController.adapter.itemCount
 
             layoutManager?.scrollToPosition(recyclerViewIndex)
+            smoothScrollBy(
+                0,
+                - resources.getDimensionPixelSize(R.dimen.tab_tray_tab_item_height) / 2
+            )
         }
     }
 

--- a/app/src/main/res/layout/tab_tray_item.xml
+++ b/app/src/main/res/layout/tab_tray_item.xml
@@ -7,7 +7,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/tab_item"
     android:layout_width="match_parent"
-    android:layout_height="88dp"
+    android:layout_height="@dimen/tab_tray_tab_item_height"
     android:clickable="true"
     android:focusable="true"
     android:foreground="?android:selectableItemBackground">

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -171,6 +171,7 @@
 
     <!-- Tabs Tray -->
     <dimen name="tab_tray_top_offset">40dp</dimen>
+    <dimen name="tab_tray_tab_item_height">88dp</dimen>
     <dimen name="tab_tray_list_item_thumbnail_width">92dp</dimen>
     <dimen name="tab_tray_list_item_thumbnail_height">72dp</dimen>
     <dimen name="tab_tray_grid_item_thumbnail_width">156dp</dimen>


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

<img src = https://user-images.githubusercontent.com/48995920/96252713-1032d580-0fbb-11eb-8239-c77a28b4caa3.png width =45% >

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
