### PR TITLE
For #15796 - show device language under follow device language

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/advanced/LocaleViewHolders.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/advanced/LocaleViewHolders.kt
@@ -39,7 +39,7 @@ class SystemLocaleViewHolder(
 
     override fun bind(locale: Locale) {
         locale_title_text.text = itemView.context.getString(R.string.default_locale_text)
-        locale_subtitle_text.visibility = View.GONE
+        locale_subtitle_text.text = locale.displayName.capitalize(Locale.getDefault())
         locale_selected_icon.isVisible = isCurrentLocaleSelected(locale, isDefault = true)
         itemView.setOnClickListener {
             interactor.onDefaultLocaleSelected()

--- a/app/src/test/java/org/mozilla/fenix/settings/advanced/LocaleViewHoldersTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/advanced/LocaleViewHoldersTest.kt
@@ -71,7 +71,7 @@ class LocaleViewHoldersTest {
         systemLocaleViewHolder.bind(selectedLocale)
 
         assertEquals("Follow device language", view.locale_title_text.text)
-        assertFalse(view.locale_subtitle_text.isVisible)
+        assertEquals("English (United States)", view.locale_subtitle_text.text)
         assertTrue(view.locale_selected_icon.isVisible)
     }
 


### PR DESCRIPTION
Fixes #15796. Original PR https://github.com/mozilla-mobile/fenix/pull/15838

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
