### PR TITLE
For #15937 - Remove topFrecentSite feature flag

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -22,11 +22,6 @@ object FeatureFlags {
     val syncedTabsInTabsTray = Config.channel.isNightlyOrDebug
 
     /**
-     * Enables showing the top frequently visited sites
-     */
-    const val topFrecentSite = true
-
-    /**
      * Shows the grid view settings for the tabs tray.
      */
     val showGridViewInTabsSettings = Config.channel.isNightlyOrDebug

--- a/app/src/main/java/org/mozilla/fenix/settings/CustomizationFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/CustomizationFragment.kt
@@ -9,7 +9,6 @@ import android.os.Build
 import android.os.Build.VERSION.SDK_INT
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatDelegate
-import androidx.preference.PreferenceCategory
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreference
 import org.mozilla.fenix.FeatureFlags
@@ -136,11 +135,7 @@ class CustomizationFragment : PreferenceFragmentCompat() {
     }
 
     private fun setupHomeCategory() {
-        requirePreference<PreferenceCategory>(R.string.pref_home_category).apply {
-            isVisible = FeatureFlags.topFrecentSite
-        }
         requirePreference<SwitchPreference>(R.string.pref_key_enable_top_frecent_sites).apply {
-            isVisible = FeatureFlags.topFrecentSite
             isChecked = context.settings().showTopFrecentSites
             onPreferenceChangeListener = SharedPreferenceUpdater()
         }

--- a/app/src/main/java/org/mozilla/fenix/settings/SecretSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SecretSettingsFragment.kt
@@ -31,12 +31,6 @@ class SecretSettingsFragment : PreferenceFragmentCompat() {
             onPreferenceChangeListener = SharedPreferenceUpdater()
         }
 
-        requirePreference<SwitchPreference>(R.string.pref_key_enable_top_frecent_sites).apply {
-            isVisible = FeatureFlags.topFrecentSite
-            isChecked = context.settings().showTopFrecentSites
-            onPreferenceChangeListener = SharedPreferenceUpdater()
-        }
-
         requirePreference<SwitchPreference>(R.string.pref_key_wait_first_paint).apply {
             isVisible = FeatureFlags.waitUntilPaintToDraw
             isChecked = context.settings().waitToShowPageUntilFirstPaint

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -100,10 +100,9 @@ class Settings(private val appContext: Context) : PreferencesHolder {
     override val preferences: SharedPreferences =
         appContext.getSharedPreferences(FENIX_PREFERENCES, MODE_PRIVATE)
 
-    var showTopFrecentSites by featureFlagPreference(
+    var showTopFrecentSites by booleanPreference(
         appContext.getPreferenceKey(R.string.pref_key_enable_top_frecent_sites),
-        default = true,
-        featureFlag = FeatureFlags.topFrecentSite
+        default = true
     )
 
     var numberOfAppLaunches by intPreference(

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -128,7 +128,6 @@
     <string name="pref_key_follow_device_theme" translatable="false">pref_key_follow_device_theme</string>
 
     <!-- Customization Settings -->
-    <string name="pref_home_category" translatable="false">pref_home_category</string>
     <string name="pref_key_website_pull_to_refresh" translatable="false">pref_key_website_pull_to_refresh</string>
     <string name="pref_key_dynamic_toolbar" translatable="false">pref_key_dynamic_toolbar</string>
     <string name="pref_key_swipe_toolbar_switch_tabs" translatable="false">pref_key_swipe_toolbar_switch_tabs</string>

--- a/app/src/main/res/values/static_strings.xml
+++ b/app/src/main/res/values/static_strings.xml
@@ -34,8 +34,6 @@
     <string name="preferences_debug_settings">Secret Settings</string>
     <!-- Label for the show grid view in tabs setting preference -->
     <string name="preferences_debug_settings_show_grid_view_tabs_settings">Show Grid View in Tabs Settings</string>
-    <!-- Label for the show top frequently visited sites preference -->
-    <string name="preferences_debug_settings_enable_top_frecent_sites">Show Top Frequently Visited Sites</string>
     <!-- Label for the wait until first paint preference -->
     <string name="preferences_debug_settings_wait_first_paint">Wait Until First Paint To Show Page Content</string>
     <!-- Label for showing Synced Tabs in the tabs tray -->

--- a/app/src/main/res/xml/customization_preferences.xml
+++ b/app/src/main/res/xml/customization_preferences.xml
@@ -46,12 +46,10 @@
     </androidx.preference.PreferenceCategory>
 
     <androidx.preference.PreferenceCategory
-        android:key="@string/pref_home_category"
         android:layout="@layout/preference_cat_style"
         android:title="@string/preferences_home"
         app:allowDividerAbove="true"
-        app:iconSpaceReserved="false"
-        app:isPreferenceVisible="false">
+        app:iconSpaceReserved="false">
         <androidx.preference.SwitchPreference
             android:key="@string/pref_key_enable_top_frecent_sites"
             android:title="@string/top_sites_toggle_top_frecent_sites" />
@@ -74,6 +72,6 @@
         <androidx.preference.SwitchPreference
             android:key="@string/pref_key_swipe_toolbar_show_tabs"
             android:title="@string/preference_gestures_swipe_toolbar_show_tabs"
-            app:isPreferenceVisible="false"/>
+            app:isPreferenceVisible="false" />
     </androidx.preference.PreferenceCategory>
 </androidx.preference.PreferenceScreen>

--- a/app/src/main/res/xml/customization_preferences.xml
+++ b/app/src/main/res/xml/customization_preferences.xml
@@ -62,7 +62,8 @@
         app:iconSpaceReserved="false">
         <androidx.preference.SwitchPreference
             android:key="@string/pref_key_website_pull_to_refresh"
-            android:title="@string/preference_gestures_website_pull_to_refresh" />
+            android:title="@string/preference_gestures_website_pull_to_refresh"
+            app:isPreferenceVisible="false" />
         <androidx.preference.SwitchPreference
             android:key="@string/pref_key_dynamic_toolbar"
             android:title="@string/preference_gestures_dynamic_toolbar" />

--- a/app/src/main/res/xml/secret_settings_preferences.xml
+++ b/app/src/main/res/xml/secret_settings_preferences.xml
@@ -11,11 +11,6 @@
         app:iconSpaceReserved="false" />
     <SwitchPreference
         android:defaultValue="false"
-        android:key="@string/pref_key_enable_top_frecent_sites"
-        android:title="@string/preferences_debug_settings_enable_top_frecent_sites"
-        app:iconSpaceReserved="false" />
-    <SwitchPreference
-        android:defaultValue="false"
         android:key="@string/pref_key_wait_first_paint"
         android:title="@string/preferences_debug_settings_wait_first_paint"
         app:iconSpaceReserved="false" />


### PR DESCRIPTION
Fixes #15937. Also, removes some unused preferences and makes the customization setting more stable by not having preferences hide/show after the view is created.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
