### PR TITLE
Refactored tabs tray grid item layout

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayView.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayView.kt
@@ -43,6 +43,7 @@ import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.tabstray.TabViewHolder
 import mozilla.components.feature.syncedtabs.SyncedTabsFeature
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
+import mozilla.components.support.ktx.android.util.dpToPx
 import org.mozilla.fenix.R
 import org.mozilla.fenix.browser.InfoBanner
 import org.mozilla.fenix.components.metrics.Event
@@ -373,6 +374,15 @@ class TabTrayView(
             }
 
             layoutManager = gridLayoutManager
+
+            // Ensure items have the same all around padding - 16 dp. Avoid the double spacing issue.
+            // A 8dp padding is already set in xml, pad the parent with the remaining needed 8dp.
+            updateLayoutParams<ConstraintLayout.LayoutParams> {
+                val padding = GRID_ITEM_PARENT_PADDING.dpToPx(resources.displayMetrics)
+                // Account for the already set bottom padding needed to accommodate the fab.
+                val bottomPadding = paddingBottom + padding
+                setPadding(padding, padding, padding, bottomPadding)
+            }
         }
     }
 
@@ -671,6 +681,8 @@ class TabTrayView(
         private const val SELECTION_DELAY = 500
         private const val NORMAL_HANDLE_PERCENT_WIDTH = 0.1F
         private const val COLUMN_WIDTH_DP = 180
+        // The remaining padding offset needed to provide a 16dp column spacing between the grid items.
+        const val GRID_ITEM_PARENT_PADDING = 8
     }
 }
 

--- a/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayViewHolder.kt
@@ -13,6 +13,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.appcompat.widget.AppCompatImageButton
 import androidx.core.content.ContextCompat
+import kotlinx.android.synthetic.main.tab_tray_grid_item.view.*
 import mozilla.components.browser.state.state.MediaState
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.browser.tabstray.TabViewHolder
@@ -79,7 +80,7 @@ class TabTrayViewHolder(
         updateUrl(tab)
         updateFavicon(tab)
         updateCloseButtonDescription(tab.title)
-        updateBackgroundColor(isSelected)
+        updateSelectedTabIndicator(isSelected)
 
         if (tab.thumbnail != null) {
             thumbnailView.setImageBitmap(tab.thumbnail)
@@ -170,9 +171,13 @@ class TabTrayViewHolder(
     }
 
     @VisibleForTesting
-    internal fun updateBackgroundColor(isSelected: Boolean) {
+    internal fun updateSelectedTabIndicator(isSelected: Boolean) {
         if (itemView.context.settings().gridTabView) {
-            // No need to set a background color in the item view for grid tabs.
+            itemView.tab_tray_grid_item.background = if (isSelected) {
+                AppCompatResources.getDrawable(itemView.context, R.drawable.tab_tray_grid_item_selected_border)
+            } else {
+                null
+            }
             return
         }
 

--- a/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayViewHolder.kt
@@ -62,6 +62,7 @@ class TabTrayViewHolder(
     @VisibleForTesting
     internal val urlView: TextView? = itemView.findViewById(R.id.mozac_browser_tabstray_url)
     private val playPauseButtonView: ImageButton = itemView.findViewById(R.id.play_pause_button)
+    private val closeButton: AppCompatImageButton = itemView.findViewById(R.id.mozac_browser_tabstray_close)
 
     override var tab: Tab? = null
 
@@ -86,6 +87,10 @@ class TabTrayViewHolder(
             thumbnailView.setImageBitmap(tab.thumbnail)
         } else {
             loadIntoThumbnailView(thumbnailView, tab.id)
+        }
+
+        if (itemView.context.settings().gridTabView) {
+            closeButton.increaseTapArea(GRID_ITEM_CLOSE_BUTTON_EXTRA_DPS)
         }
 
         // Media state
@@ -236,5 +241,6 @@ class TabTrayViewHolder(
 
     companion object {
         private const val PLAY_PAUSE_BUTTON_EXTRA_DPS = 24
+        private const val GRID_ITEM_CLOSE_BUTTON_EXTRA_DPS = 24
     }
 }

--- a/app/src/main/res/drawable/tab_tray_grid_item_selected_border.xml
+++ b/app/src/main/res/drawable/tab_tray_grid_item_selected_border.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<layer-list
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:bottom="4dp"
+        android:left="4dp"
+        android:right="4dp"
+        android:top="4dp">
+
+        <shape
+            android:shape="rectangle">
+
+            <stroke
+                android:width="4dp"
+                android:color="@color/photonViolet70" />
+
+            <corners android:radius="@dimen/tab_tray_grid_item_border_radius" />
+        </shape>
+
+    </item>
+
+</layer-list>

--- a/app/src/main/res/layout/component_tabstray.xml
+++ b/app/src/main/res/layout/component_tabstray.xml
@@ -181,6 +181,7 @@
         android:layout_height="0dp"
         android:clipToPadding="false"
         android:paddingBottom="140dp"
+        android:scrollbarStyle="outsideOverlay"
         android:scrollbars="vertical"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/tab_tray_grid_item.xml
+++ b/app/src/main/res/layout/tab_tray_grid_item.xml
@@ -13,6 +13,7 @@ A FrameLayout here is an efficient way of having a views stack while allowing:
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/tab_tray_grid_item"
     android:layout_width="match_parent"
     android:layout_height="202dp"
     android:clipChildren="false"

--- a/app/src/main/res/layout/tab_tray_grid_item.xml
+++ b/app/src/main/res/layout/tab_tray_grid_item.xml
@@ -70,8 +70,8 @@ A FrameLayout here is an efficient way of having a views stack while allowing:
 
             <androidx.appcompat.widget.AppCompatImageButton
                 android:id="@+id/mozac_browser_tabstray_close"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
                 android:background="?android:attr/selectableItemBackgroundBorderless"
                 android:contentDescription="@string/close_tab"
                 app:layout_constraintBottom_toTopOf="@+id/horizonatal_divider"

--- a/app/src/main/res/layout/tab_tray_grid_item.xml
+++ b/app/src/main/res/layout/tab_tray_grid_item.xml
@@ -2,114 +2,135 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+
+<!--
+A FrameLayout here is an efficient way of having a views stack while allowing:
+    - a sufficient enough canvas for the play button to be outside translated
+    without it getting clipped by the GridLayoutManager.
+    - enough padding for the primary view that needs to be displayed with a border around it.
+-->
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:layout_marginStart="8dp"
-    android:layout_marginTop="16dp"
-    android:layout_marginEnd="8dp"
-    app:cardBackgroundColor="@color/photonWhite"
-    app:cardCornerRadius="@dimen/tab_tray_grid_item_border_radius"
-    app:cardElevation="0dp"
-    app:strokeColor="@color/photonLightGrey30"
-    app:strokeWidth="1dp">
+    android:layout_height="202dp"
+    android:clipChildren="false"
+    android:clipToPadding="false"
+    android:importantForAccessibility="no"
+    android:padding="8dp">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/tab_item"
+    <com.google.android.material.card.MaterialCardView
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:importantForAccessibility="yes"
+        app:cardBackgroundColor="@color/photonWhite"
+        app:cardCornerRadius="@dimen/tab_tray_grid_item_border_radius"
+        app:cardElevation="0dp"
+        app:strokeColor="@color/photonLightGrey30"
+        app:strokeWidth="1dp">
 
-        <ImageButton
-            android:id="@+id/play_pause_button"
-            android:layout_width="24dp"
-            android:layout_height="24dp"
-            android:layout_marginTop="23dp"
-            android:background="?attr/selectableItemBackgroundBorderless"
-            android:contentDescription="@string/mozac_feature_media_notification_action_pause"
-            android:elevation="10dp"
-            android:visibility="gone"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:srcCompat="@drawable/media_state_play" />
-
-        <ImageView
-            android:id="@+id/mozac_browser_tabstray_favicon_icon"
-            android:layout_width="16dp"
-            android:layout_height="16dp"
-            android:layout_marginStart="8dp"
-            android:importantForAccessibility="no"
-            app:layout_constraintBottom_toTopOf="@id/horizonatal_divider"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <TextView
-            android:id="@+id/mozac_browser_tabstray_title"
-            android:layout_width="0dp"
-            android:layout_height="30dp"
-            android:layout_alignParentTop="true"
-            android:ellipsize="none"
-            android:fadingEdgeLength="25dp"
-            android:paddingHorizontal="7dp"
-            android:paddingVertical="5dp"
-            android:requiresFadingEdge="horizontal"
-            android:singleLine="true"
-            android:textColor="@color/photonInk80"
-            android:textSize="14sp"
-            android:visibility="visible"
-            app:layout_constraintEnd_toStartOf="@id/mozac_browser_tabstray_close"
-            app:layout_constraintStart_toEndOf="@id/mozac_browser_tabstray_favicon_icon"
-            app:layout_constraintTop_toTopOf="parent"
-            tools:text="Example Domain" />
-
-        <androidx.appcompat.widget.AppCompatImageButton
-            android:id="@+id/mozac_browser_tabstray_close"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:background="?android:attr/selectableItemBackgroundBorderless"
-            android:contentDescription="@string/close_tab"
-            app:layout_constraintBottom_toTopOf="@+id/horizonatal_divider"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:srcCompat="@drawable/mozac_ic_close"
-            app:tint="@color/photonInk80" />
-
-        <View
-            android:id="@+id/horizonatal_divider"
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/tab_item"
             android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:background="@color/photonLightGrey30"
-            app:layout_constraintTop_toBottomOf="@+id/mozac_browser_tabstray_title" />
-
-        <androidx.cardview.widget.CardView
-            android:id="@+id/mozac_browser_tabstray_card"
-            android:layout_width="match_parent"
-            android:layout_height="@dimen/tab_tray_grid_item_thumbnail_height"
-            android:backgroundTint="?tabTrayThumbnailItemBackground"
-            app:cardBackgroundColor="@color/photonWhite"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/horizonatal_divider">
+            android:layout_height="match_parent"
+            android:clipChildren="false"
+            android:clipToPadding="false">
 
             <ImageView
-                android:id="@+id/default_tab_thumbnail"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
+                android:id="@+id/mozac_browser_tabstray_favicon_icon"
+                android:layout_width="16dp"
+                android:layout_height="16dp"
+                android:layout_marginStart="8dp"
                 android:importantForAccessibility="no"
-                android:padding="22dp"
-                app:srcCompat="@drawable/mozac_ic_globe"
-                app:tint="?tabTrayThumbnailIcon" />
+                app:layout_constraintBottom_toTopOf="@id/horizonatal_divider"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
 
-            <mozilla.components.browser.tabstray.thumbnail.TabThumbnailView
-                android:id="@+id/mozac_browser_tabstray_thumbnail"
+            <TextView
+                android:id="@+id/mozac_browser_tabstray_title"
+                android:layout_width="0dp"
+                android:layout_height="30dp"
+                android:layout_alignParentTop="true"
+                android:ellipsize="none"
+                android:fadingEdgeLength="25dp"
+                android:paddingHorizontal="7dp"
+                android:paddingVertical="5dp"
+                android:requiresFadingEdge="horizontal"
+                android:singleLine="true"
+                android:textColor="@color/photonInk80"
+                android:textSize="14sp"
+                android:visibility="visible"
+                app:layout_constraintEnd_toStartOf="@id/mozac_browser_tabstray_close"
+                app:layout_constraintStart_toEndOf="@id/mozac_browser_tabstray_favicon_icon"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:text="Example Domain" />
+
+            <androidx.appcompat.widget.AppCompatImageButton
+                android:id="@+id/mozac_browser_tabstray_close"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="?android:attr/selectableItemBackgroundBorderless"
+                android:contentDescription="@string/close_tab"
+                app:layout_constraintBottom_toTopOf="@+id/horizonatal_divider"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:srcCompat="@drawable/mozac_ic_close"
+                app:tint="@color/photonInk80" />
+
+            <View
+                android:id="@+id/horizonatal_divider"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:contentDescription="@string/mozac_browser_tabstray_open_tab" />
+                android:layout_height="1dp"
+                android:background="@color/photonLightGrey30"
+                app:layout_constraintTop_toBottomOf="@+id/mozac_browser_tabstray_title" />
 
-            <include layout="@layout/checkbox_item" />
+            <androidx.cardview.widget.CardView
+                android:id="@+id/mozac_browser_tabstray_card"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/tab_tray_grid_item_thumbnail_height"
+                android:backgroundTint="?tabTrayThumbnailItemBackground"
+                app:cardBackgroundColor="@color/photonWhite"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/horizonatal_divider">
 
-        </androidx.cardview.widget.CardView>
+                <ImageView
+                    android:id="@+id/default_tab_thumbnail"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:importantForAccessibility="no"
+                    android:padding="22dp"
+                    app:srcCompat="@drawable/mozac_ic_globe"
+                    app:tint="?tabTrayThumbnailIcon" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+                <mozilla.components.browser.tabstray.thumbnail.TabThumbnailView
+                    android:id="@+id/mozac_browser_tabstray_thumbnail"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:contentDescription="@string/mozac_browser_tabstray_open_tab" />
 
-</com.google.android.material.card.MaterialCardView>
+                <include layout="@layout/checkbox_item" />
+
+            </androidx.cardview.widget.CardView>
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </com.google.android.material.card.MaterialCardView>
+
+    <ImageButton
+        android:id="@+id/play_pause_button"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_gravity="top|start"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:contentDescription="@string/mozac_feature_media_notification_action_pause"
+        android:elevation="10dp"
+        android:importantForAccessibility="yes"
+        android:translationX="-8dp"
+        android:translationY="-8dp"
+        android:visibility="gone"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/media_state_play" />
+</FrameLayout>


### PR DESCRIPTION
Refactored layout for the grid item of the tabs tray.
Since it needed new views (play button / border) placed at the exterior of the current items I've wrapped the previous in bigger FrameLayouts that should not affect performance but serve as a buffer space in which those items can extend.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: No tests. UI refactoring.
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made.
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

![NewGridLayout](https://user-images.githubusercontent.com/11428869/96288847-bf3bd500-0fec-11eb-8a8e-0052feccfc4d.gif)
[video](https://drive.google.com/file/d/11TSRErh_mQ1LWhGQfANfuiCkrVKbUpGu/view?usp=sharing)

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
