### PR TITLE
Issue #15731 - Enable `tg` on release locales.

### DIFF
--- a/l10n-release.toml
+++ b/l10n-release.toml
@@ -78,6 +78,7 @@ locales = [
   "sv-SE",
   "ta",
   "te",
+  "tg",
   "th",
   "tr",
   "trs",


### PR DESCRIPTION
We needed to add `tg` to the release locales list so that it will be built in release builds. Will need uplift to 82-RC.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
