### PR TITLE
 Update Android Components, Kotlin, Gradle plugin

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -317,7 +317,31 @@ ext.gleanGenerateMarkdownDocs = true
 ext.gleanDocsDirectory = "$rootDir/docs"
 apply plugin: "org.mozilla.telemetry.glean-gradle-plugin"
 
+configurations {
+    // There's an interaction between Gradle's resolution of dependencies with different types
+    // (@jar, @aar) for `implementation` and `testImplementation` and with Android Studio's built-in
+    // JUnit test runner.  The runtime classpath in the built-in JUnit test runner gets the
+    // dependency from the `implementation`, which is type @aar, and therefore the JNA dependency
+    // doesn't provide the JNI dispatch libraries in the correct Java resource directories.  I think
+    // what's happening is that @aar type in `implementation` resolves to the @jar type in
+    // `testImplementation`, and that it wins the dependency resolution battle.
+    //
+    // A workaround is to add a new configuration which depends on the @jar type and to reference
+    // the underlying JAR file directly in `testImplementation`.  This JAR file doesn't resolve to
+    // the @aar type in `implementation`.  This works when invoked via `gradle`, but also sets the
+    // correct runtime classpath when invoked with Android Studio's built-in JUnit test runner.
+    // Success!
+    jnaForTest
+    // Robolectric, through `com.google.android.apps.common.testing.accessibility.framework`
+    // depends on an old version of protobuf that conflict with the Application Services one.
+    // See: https://github.com/mozilla/application-services/issues/2952
+    all*.exclude group: 'com.google.protobuf', module: 'protobuf-java'
+}
+
 dependencies {
+    jnaForTest Deps.jna
+    testImplementation files(configurations.jnaForTest.copyRecursive().files)
+
     debugImplementation Deps.mozilla_browser_engine_gecko_nightly
 
     nightlyImplementation Deps.mozilla_browser_engine_gecko_nightly

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -540,13 +540,13 @@ if (project.hasProperty("coverage")) {
 // -------------------------------------------------------------------------------------------------
 tasks.register('printVariants') {
     doLast {
-        def variants = android.applicationVariants.collect {[
-                apks: it.variantData.outputScope.apkDatas.collect {[
-                        abi: it.filters.find { it.filterType == 'ABI' }.identifier,
-                        fileName: it.outputFileName,
-                ]},
-                build_type: it.buildType.name,
-                name: it.name,
+        def variants = android.applicationVariants.collect { variant -> [
+            apks: variant.outputs.collect { output -> [
+                abi: output.getFilter(com.android.build.VariantOutput.FilterType.ABI),
+                fileName: output.outputFile.name
+            ]},
+            build_type: variant.buildType.name,
+            name: variant.name,
         ]}
         // AndroidTest is a special case not included above
         variants.add([

--- a/app/src/androidTest/java/org/mozilla/fenix/glean/BaselinePingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/glean/BaselinePingTest.kt
@@ -15,7 +15,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import mozilla.components.browser.engine.gecko.fetch.GeckoViewFetchClient
-import mozilla.components.concept.fetch.Client
 import mozilla.components.service.glean.Glean
 import mozilla.components.service.glean.config.Configuration
 import mozilla.components.service.glean.net.ConceptFetchHttpUploader
@@ -78,7 +77,7 @@ class BaselinePingTest {
         @JvmStatic
         fun setupOnce() {
             val httpClient = ConceptFetchHttpUploader(lazy {
-                GeckoViewFetchClient(ApplicationProvider.getApplicationContext()) as Client
+                GeckoViewFetchClient(ApplicationProvider.getApplicationContext())
             })
 
             // Fenix does not initialize the Glean SDK in tests/debug builds, but this test

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -229,9 +229,6 @@
         <activity android:name=".settings.account.AuthIntentReceiverActivity"
             android:exported="false" />
 
-        <activity android:name=".settings.about.AboutLibrariesActivity"
-            android:exported="false" />
-
         <service android:name=".media.MediaService"
             android:exported="false" />
 

--- a/app/src/main/java/org/mozilla/fenix/exceptions/login/LoginExceptionsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/exceptions/login/LoginExceptionsFragment.kt
@@ -16,6 +16,7 @@ import kotlinx.android.synthetic.main.fragment_exceptions.view.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.plus
+import mozilla.components.feature.logins.exceptions.LoginException
 import mozilla.components.lib.state.ext.consumeFrom
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.StoreProvider
@@ -61,7 +62,7 @@ class LoginExceptionsFragment : Fragment() {
 
     private fun subscribeToLoginExceptions() {
         requireComponents.core.loginExceptionStorage.getLoginExceptions().asLiveData()
-            .observe(viewLifecycleOwner) { exceptions ->
+            .observe<List<LoginException>>(viewLifecycleOwner) { exceptions ->
                 exceptionsStore.dispatch(ExceptionsFragmentAction.Change(exceptions))
             }
     }

--- a/app/src/main/java/org/mozilla/fenix/ext/TabCollection.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/TabCollection.kt
@@ -35,5 +35,5 @@ fun List<TabCollection>.getDefaultCollectionNumber(): Int {
         .map { it.title }
         .filter { it.matches(Regex("Collection\\s\\d+")) }
         .map { Integer.valueOf(it.split(" ")[DefaultCollectionCreationController.DEFAULT_COLLECTION_NUMBER_POSITION]) }
-        .max() ?: 0) + DefaultCollectionCreationController.DEFAULT_INCREMENT_VALUE
+        .maxOrNull() ?: 0) + DefaultCollectionCreationController.DEFAULT_INCREMENT_VALUE
 }

--- a/app/src/main/java/org/mozilla/fenix/share/ShareFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/share/ShareFragment.kt
@@ -26,6 +26,8 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.ext.getRootView
 import org.mozilla.fenix.ext.requireComponents
+import org.mozilla.fenix.share.listadapters.AppShareOption
+import org.mozilla.fenix.share.listadapters.SyncShareOption
 
 class ShareFragment : AppCompatDialogFragment() {
 
@@ -111,13 +113,13 @@ class ShareFragment : AppCompatDialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        viewModel.devicesList.observe(viewLifecycleOwner) { devicesShareOptions ->
+        viewModel.devicesList.observe<List<SyncShareOption>>(viewLifecycleOwner) { devicesShareOptions ->
             shareToAccountDevicesView.setShareTargets(devicesShareOptions)
         }
-        viewModel.appsList.observe(viewLifecycleOwner) { appsToShareTo ->
+        viewModel.appsList.observe<List<AppShareOption>>(viewLifecycleOwner) { appsToShareTo ->
             shareToAppsView.setShareTargets(appsToShareTo)
         }
-        viewModel.recentAppsList.observe(viewLifecycleOwner) { appsToShareTo ->
+        viewModel.recentAppsList.observe<List<AppShareOption>>(viewLifecycleOwner) { appsToShareTo ->
             shareToAppsView.setRecentShareTargets(appsToShareTo)
         }
     }

--- a/app/src/main/res/layout/fragment_add_on_internal_settings.xml
+++ b/app/src/main/res/layout/fragment_add_on_internal_settings.xml
@@ -5,9 +5,11 @@
 
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <mozilla.components.concept.engine.EngineView
+        tools:ignore="Instantiatable"
         android:id="@+id/addonSettingsEngineView"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />

--- a/app/src/main/res/layout/fragment_browser.xml
+++ b/app/src/main/res/layout/fragment_browser.xml
@@ -30,6 +30,7 @@
                 app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
                 <mozilla.components.concept.engine.EngineView
+                    tools:ignore="Instantiatable"
                     android:id="@+id/engineView"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "63.0.20201016221440"
+    const val VERSION = "63.0.20201019090011"
 }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -16,6 +16,7 @@ object Versions {
     const val leanplum = "5.4.0"
     const val osslicenses_plugin = "0.9.5"
     const val detekt = "1.9.1"
+    const val jna = "5.6.0"
 
     const val androidx_appcompat = "1.2.0-rc01"
     const val androidx_biometric = "1.1.0-beta01"
@@ -185,6 +186,8 @@ object Deps {
 
     const val adjust = "com.adjust.sdk:adjust-android:${Versions.adjust}"
     const val installreferrer = "com.android.installreferrer:installreferrer:${Versions.installreferrer}"
+
+    const val jna = "net.java.dev.jna:jna:${Versions.jna}@jar"
 
     const val junit = "junit:junit:${Versions.junit}"
     const val mockk = "io.mockk:mockk:${Versions.mockk}"

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -8,7 +8,7 @@ object Versions {
 
     // These versions are linked: lint should be X+23.Y.Z of gradle_plugin version, according to:
     // https://github.com/alexjlockwood/android-lint-checks-demo/blob/0245fc027463137b1b4afb97c5295d60dce998b6/dependencies.gradle#L3
-    const val android_gradle_plugin = "3.6.4"
+    const val android_gradle_plugin = "4.0.1"
     const val android_lint_api = "26.6.4"
 
     const val sentry = "1.7.10"

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -3,8 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object Versions {
-    const val kotlin = "1.3.72"
-    const val coroutines = "1.3.3"
+    const val kotlin = "1.4.10"
+    const val coroutines = "1.3.9"
 
     // These versions are linked: lint should be X+23.Y.Z of gradle_plugin version, according to:
     // https://github.com/alexjlockwood/android-lint-checks-demo/blob/0245fc027463137b1b4afb97c5295d60dce998b6/dependencies.gradle#L3

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -9,7 +9,7 @@ object Versions {
     // These versions are linked: lint should be X+23.Y.Z of gradle_plugin version, according to:
     // https://github.com/alexjlockwood/android-lint-checks-demo/blob/0245fc027463137b1b4afb97c5295d60dce998b6/dependencies.gradle#L3
     const val android_gradle_plugin = "4.0.1"
-    const val android_lint_api = "26.6.4"
+    const val android_lint_api = "27.0.1"
 
     const val sentry = "1.7.10"
     const val leakcanary = "2.4"
@@ -55,6 +55,7 @@ object Deps {
     const val tools_androidgradle = "com.android.tools.build:gradle:${Versions.android_gradle_plugin}"
     const val tools_kotlingradle = "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.kotlin}"
     const val kotlin_stdlib = "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${Versions.kotlin}"
+    const val kotlin_reflect = "org.jetbrains.kotlin:kotlin-reflect:${Versions.kotlin}"
     const val kotlin_coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.coroutines}"
     const val kotlin_coroutines_test = "org.jetbrains.kotlinx:kotlinx-coroutines-test:${Versions.coroutines}"
     const val kotlin_coroutines_android = "org.jetbrains.kotlinx:kotlinx-coroutines-android:${Versions.coroutines}"

--- a/mozilla-lint-rules/build.gradle
+++ b/mozilla-lint-rules/build.gradle
@@ -9,10 +9,16 @@ targetCompatibility = JavaVersion.VERSION_1_8
 sourceCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
-    compileOnly "org.jetbrains.kotlin:kotlin-stdlib:${Versions.kotlin}"
+    compileOnly Deps.kotlin_stdlib
+    compileOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${Versions.kotlin}"
+    compileOnly Deps.kotlin_reflect
+
     compileOnly "com.android.tools.lint:lint-api:${Versions.android_lint_api}"
     compileOnly "com.android.tools.lint:lint-checks:${Versions.android_lint_api}"
 
+    testImplementation Deps.kotlin_stdlib
+    testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${Versions.kotlin}"
+    testImplementation Deps.kotlin_reflect
     testImplementation "com.android.tools.lint:lint:${Versions.android_lint_api}"
     testImplementation "com.android.tools.lint:lint-tests:${Versions.android_lint_api}"
 }


### PR DESCRIPTION
Okay, here we go again. We landed the updates in AC again and this is the matching Fenix PR with the AC version bump and other required changes.