### PR TITLE
Correctly disable telemetry at build time

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -49,6 +49,7 @@ import org.mozilla.fenix.push.WebPushEngineIntegration
 import org.mozilla.fenix.session.PerformanceActivityLifecycleCallbacks
 import org.mozilla.fenix.session.VisibilityLifecycleCallback
 import org.mozilla.fenix.utils.BrowsersCache
+import org.mozilla.fenix.BuildConfig
 
 /**
  *The main application class for Fenix. Records data to measure initialization performance.
@@ -80,7 +81,7 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
             return
         }
 
-        if (Config.channel.isFenix) {
+        if (Config.channel.isFenix && BuildConfig.TELEMETRY) {
             // We need to always initialize Glean and do it early here.
             // Note that we are only initializing Glean here for "fenix" builds. "fennec" builds
             // will initialize in MigratingFenixApplication because we first need to migrate the

--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -49,7 +49,6 @@ import org.mozilla.fenix.push.WebPushEngineIntegration
 import org.mozilla.fenix.session.PerformanceActivityLifecycleCallbacks
 import org.mozilla.fenix.session.VisibilityLifecycleCallback
 import org.mozilla.fenix.utils.BrowsersCache
-import org.mozilla.fenix.BuildConfig
 
 /**
  *The main application class for Fenix. Records data to measure initialization performance.


### PR DESCRIPTION
There are two flags that control whether telemetry is enabled:

- The runtime user preference (`settings().isTelemetryEnabled`)
- A build time flag (`BuildConfig.TELEMETRY`)

The build time flag defaults to `false` for `DEBUG` builds, but has also proven handy for forks of Fenix that don't wish to ever send telemetry, but appears to be currently broken.

I believe it use to work, but changes were made in order to send deletion request pings, and perform other cleanup tasks. To support that, `Glean.initialize` must always be called at startup, even if the user's preference is to not send telemetry.

However, in the case of builds with disabled telemetry, we don't need to call `Glean.initialize` at all ever.  This will have the effect of the user preference being ignored and telemetry never sent.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
