### PR TITLE
For #14980 - Effectively disable tabs tray STATE_HALF_EXPANDED

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/idlingresource/BottomSheetBehaviorStateIdlingResource.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/idlingresource/BottomSheetBehaviorStateIdlingResource.kt
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.helpers.idlingresource
+
+import android.view.View
+import androidx.test.espresso.IdlingResource
+import androidx.test.espresso.IdlingResource.ResourceCallback
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetBehavior.BottomSheetCallback
+
+class BottomSheetBehaviorStateIdlingResource(behavior: BottomSheetBehavior<*>) :
+    BottomSheetCallback(), IdlingResource {
+
+    private var isIdle: Boolean
+    private var callback: ResourceCallback? = null
+
+    override fun onStateChanged(bottomSheet: View, newState: Int) {
+        val wasIdle = isIdle
+        isIdle = isIdleState(newState)
+        if (!wasIdle && isIdle && callback != null) {
+            callback!!.onTransitionToIdle()
+        }
+    }
+
+    override fun onSlide(bottomSheet: View, slideOffset: Float) {
+        // no-op
+    }
+
+    override fun getName(): String {
+        return BottomSheetBehaviorStateIdlingResource::class.java.simpleName
+    }
+
+    override fun isIdleNow(): Boolean {
+        return isIdle
+    }
+
+    override fun registerIdleTransitionCallback(callback: ResourceCallback) {
+        this.callback = callback
+    }
+
+    private fun isIdleState(state: Int): Boolean {
+        return state != BottomSheetBehavior.STATE_DRAGGING &&
+            state != BottomSheetBehavior.STATE_SETTLING &&
+            // When detecting STATE_HALF_EXPANDED we immediately transit to STATE_HIDDEN.
+            // Consider this also an intermediary state so not idling.
+            state != BottomSheetBehavior.STATE_HALF_EXPANDED
+    }
+
+    init {
+        behavior.addBottomSheetCallback(this)
+        val state = behavior.state
+        isIdle = isIdleState(state)
+    }
+}

--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/matchers/BottomSheetBehaviorMatchers.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/matchers/BottomSheetBehaviorMatchers.kt
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.helpers.matchers
+
+import android.view.View
+import androidx.test.espresso.matcher.BoundedMatcher
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import org.hamcrest.Description
+
+class BottomSheetBehaviorStateMatcher(private val expectedState: Int) :
+    BoundedMatcher<View, View>(View::class.java) {
+
+    override fun describeTo(description: Description?) {
+        description?.appendText("BottomSheetBehavior in state: \"$expectedState\"")
+    }
+
+    override fun matchesSafely(item: View): Boolean {
+        val behavior = BottomSheetBehavior.from(item)
+        return behavior.state == expectedState
+    }
+}
+
+class BottomSheetBehaviorHalfExpandedMaxRatioMatcher(private val maxHalfExpandedRatio: Float) :
+    BoundedMatcher<View, View>(View::class.java) {
+
+    override fun describeTo(description: Description?) {
+        description?.appendText(
+            "BottomSheetBehavior with an at max halfExpandedRation: " +
+                "$maxHalfExpandedRatio"
+        )
+    }
+
+    override fun matchesSafely(item: View): Boolean {
+        val behavior = BottomSheetBehavior.from(item)
+        return behavior.halfExpandedRatio <= maxHalfExpandedRatio
+    }
+}

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
@@ -6,6 +6,7 @@ package org.mozilla.fenix.ui
 
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
@@ -251,6 +252,31 @@ class TabbedBrowsingTest {
             // Tap an empty spot on the app homescreen to make sure it's into focus
             sendSingleTapToScreen(20, 20)
             verifyHomeScreen()
+        }
+    }
+
+    @Test
+    fun verifyTabTrayNotShowingStateHalfExpanded() {
+        homeScreen { }.dismissOnboarding()
+
+        navigationToolbar {
+        }.openTabTray {
+            verifyNoTabsOpened()
+            // With no tabs opened the state should be STATE_COLLAPSED.
+            verifyBehaviorState(BottomSheetBehavior.STATE_COLLAPSED)
+            // Need to ensure the halfExpandedRatio is very small so that when in STATE_HALF_EXPANDED
+            // the tabTray will actually have a very small height (for a very short time) akin to being hidden.
+            verifyHalfExpandedRatio()
+        }.clickTopBar {
+        }.waitForTabTrayBehaviorToIdle {
+            // Touching the topBar would normally advance the tabTray to the next state.
+            // We don't want that.
+            verifyBehaviorState(BottomSheetBehavior.STATE_COLLAPSED)
+        }.advanceToHalfExpandedState {
+        }.waitForTabTrayBehaviorToIdle {
+            // TabTray should not be displayed in STATE_HALF_EXPANDED.
+            // When advancing to this state it should immediately be hidden.
+            verifyTabTrayIsClosed()
         }
     }
 

--- a/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayView.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayView.kt
@@ -116,6 +116,9 @@ class TabTrayView(
 
         toggleFabText(isPrivate)
 
+        view.topBar.setOnClickListener {
+            // no-op, consume the touch event to prevent it advancing the tray to the next state.
+        }
         behavior.addBottomSheetCallback(object : BottomSheetBehavior.BottomSheetCallback() {
             override fun onSlide(bottomSheet: View, slideOffset: Float) {
                 if (interactor.onModeRequested() is Mode.Normal && !hasAccessibilityEnabled) {
@@ -131,6 +134,10 @@ class TabTrayView(
                 if (newState == BottomSheetBehavior.STATE_HIDDEN) {
                     components.analytics.metrics.track(Event.TabsTrayClosed)
                     interactor.onTabTrayDismissed()
+                }
+                // We only support expanded and collapsed states. Don't allow STATE_HALF_EXPANDED.
+                else if (newState == BottomSheetBehavior.STATE_HALF_EXPANDED) {
+                    behavior.state = BottomSheetBehavior.STATE_HIDDEN
                 }
             }
         })

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -617,7 +617,8 @@
         <item name="behavior_fitToContents">false</item>
         <item name="behavior_expandedOffset">80</item>
         <item name="behavior_skipCollapsed">false</item>
-        <item name="behavior_halfExpandedRatio">0.4</item>
+        <!-- Effectively disable STATE_HALF_EXPANDED by having the tray have a minuscule height in this state -->
+        <item name="behavior_halfExpandedRatio">0.001</item>
     </style>
 
     <style name="TopSite.Favicon" parent="Mozac.Widgets.Favicon">


### PR DESCRIPTION
STATE_HALF_EXPANDED cannot be disabled while also keeping fitToContents = true
based on which the tabs tray layout is currently set.
To work around this we'll set a a minuscule height for the tab tray when in this
state and then immediately advance to STATE_HIDDEN so to make it imperceptible
to the users.

![TabsTrayNoHalfExpanded](https://user-images.githubusercontent.com/11428869/96586986-691baa00-12ea-11eb-8602-6e66d72f3ede.gif)
[video](https://drive.google.com/file/d/1xbmhxGKsJmZavrvCNWydzKYBGvrD7cAm/view?usp=sharing)


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: No tests. Small UI changes in a not yet tested component.
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made.
- [x] **Accessibility**: The code in this PR does not include any a11y user facing features.


### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
