### PR TITLE
For #15910 - Adds back automatic toggle, disables slider when enabled 

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsBasicsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsBasicsTest.kt
@@ -85,7 +85,7 @@ class SettingsBasicsTest {
             verifyThemes()
         }.goBack {
         }.openAccessibilitySubMenu {
-            verifyMenuItems()
+            verifyAutomaticFontSizingMenuItems()
         }.goBack {
             // drill down to submenu
         }
@@ -181,7 +181,7 @@ class SettingsBasicsTest {
     }
 
     @Test
-    fun changeAccessibilitySettings() {
+    fun changeAccessibiltySettings() {
         // Goes through the settings and changes the default text on a webpage, then verifies if the text has changed.
         val fenixApp = activityIntentTestRule.activity.applicationContext as FenixApplication
         val webpage = getLoremIpsumAsset(mockWebServer).url
@@ -193,7 +193,8 @@ class SettingsBasicsTest {
         }.openThreeDotMenu {
         }.openSettings {
         }.openAccessibilitySubMenu {
-            verifyMenuItems()
+            clickFontSizingSwitch()
+            verifyNewMenuItems()
             changeTextSizeSlider(textSizePercentage)
             verifyTextSizePercentage(textSizePercentage)
         }.goBack {
@@ -201,6 +202,14 @@ class SettingsBasicsTest {
         }.openNavigationToolbar {
         }.enterURLAndEnterToBrowser(webpage) {
             checkTextSizeOnWebsite(textSizePercentage, fenixApp.components)
+        }.openTabDrawer {
+        }.openNewTab {
+        }.dismiss {
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openAccessibilitySubMenu {
+            clickFontSizingSwitch()
+            verifyNewMenuItemsAreGone()
         }
     }
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsBasicsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsBasicsTest.kt
@@ -10,9 +10,9 @@ import androidx.test.uiautomator.UiDevice
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
-import org.junit.Ignore
 import org.mozilla.fenix.FenixApplication
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
@@ -194,7 +194,7 @@ class SettingsBasicsTest {
         }.openSettings {
         }.openAccessibilitySubMenu {
             clickFontSizingSwitch()
-            verifyNewMenuItems()
+            verifyEnabledMenuItems()
             changeTextSizeSlider(textSizePercentage)
             verifyTextSizePercentage(textSizePercentage)
         }.goBack {
@@ -209,7 +209,7 @@ class SettingsBasicsTest {
         }.openSettings {
         }.openAccessibilitySubMenu {
             clickFontSizingSwitch()
-            verifyNewMenuItemsAreGone()
+            verifyMenuItemsAreDisabled()
         }
     }
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAccessibilityRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAccessibilityRobot.kt
@@ -21,6 +21,7 @@ import android.widget.TextView
 import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
 import androidx.test.espresso.ViewAssertion
+import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import org.hamcrest.CoreMatchers.allOf
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.espresso.matcher.ViewMatchers.withId
@@ -48,7 +49,13 @@ class SettingsSubMenuAccessibilityRobot {
         const val TEXT_SIZE = 16f
     }
 
-    fun verifyMenuItems() = assertMenuItems()
+    fun verifyAutomaticFontSizingMenuItems() = assertAutomaticFontSizingMenuItems()
+
+    fun clickFontSizingSwitch() = toggleFontSizingSwitch()
+
+    fun verifyNewMenuItems() = assertNewMenuItems()
+
+    fun verifyNewMenuItemsAreGone() = assertNewMenuItemsAreGone()
 
     fun changeTextSizeSlider(seekBarPercentage: Int) = adjustTextSizeSlider(seekBarPercentage)
 
@@ -69,7 +76,22 @@ class SettingsSubMenuAccessibilityRobot {
 
 val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
 
-private fun assertMenuItems() {
+private fun assertAutomaticFontSizingMenuItems() {
+    onView(withText("Automatic font sizing"))
+        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+    val strFont = "Font size will match your Android settings. Disable to manage font size here."
+    onView(withText(strFont))
+        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+}
+
+private fun toggleFontSizingSwitch() {
+    // Toggle font size to off
+    onView(withText("Automatic font sizing"))
+        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+        .perform(click())
+}
+
+private fun assertNewMenuItems() {
     assertFontSize()
     assertSliderBar()
 }
@@ -101,6 +123,22 @@ private fun adjustTextSizeSlider(seekBarPercentage: Int) {
 private fun assertTextSizePercentage(textSize: Int) {
     onView(withId(org.mozilla.fenix.R.id.sampleText))
         .check(textSizePercentageEquals(textSize))
+}
+
+private fun assertNewMenuItemsAreGone() {
+    onView(withText("Font Size")).check(doesNotExist())
+    val strFont = "Make text on websites larger or smaller"
+    onView(withText(strFont))
+        .check(doesNotExist())
+
+    onView(withId(org.mozilla.fenix.R.id.sampleText))
+        .check(doesNotExist())
+
+    onView(withId(org.mozilla.fenix.R.id.seekbar_value))
+        .check(doesNotExist())
+
+    onView(withId(org.mozilla.fenix.R.id.seekbar))
+        .check(doesNotExist())
 }
 
 private fun goBackButton() =

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAccessibilityRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAccessibilityRobot.kt
@@ -6,31 +6,32 @@
 
 package org.mozilla.fenix.ui.robots
 
-import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.action.ViewActions.click
-import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.platform.app.InstrumentationRegistry
-import androidx.test.uiautomator.UiDevice
 import android.view.KeyEvent
-import android.view.KeyEvent.KEYCODE_DPAD_RIGHT
-import android.view.KeyEvent.KEYCODE_DPAD_LEFT
 import android.view.KeyEvent.ACTION_DOWN
+import android.view.KeyEvent.KEYCODE_DPAD_LEFT
+import android.view.KeyEvent.KEYCODE_DPAD_RIGHT
 import android.view.View
 import android.widget.SeekBar
 import android.widget.TextView
+import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
 import androidx.test.espresso.ViewAssertion
-import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
-import org.hamcrest.CoreMatchers.allOf
-import androidx.test.espresso.matcher.ViewMatchers.withText
-import androidx.test.espresso.matcher.ViewMatchers.withId
-import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
-import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.Visibility
 import androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom
+import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
+import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
+import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.Matcher
 import org.mozilla.fenix.components.Components
+import org.mozilla.fenix.helpers.assertIsEnabled
+import org.mozilla.fenix.helpers.isEnabled
 import org.mozilla.fenix.ui.robots.SettingsSubMenuAccessibilityRobot.Companion.DECIMAL_CONVERSION
 import org.mozilla.fenix.ui.robots.SettingsSubMenuAccessibilityRobot.Companion.MIN_VALUE
 import org.mozilla.fenix.ui.robots.SettingsSubMenuAccessibilityRobot.Companion.STEP_SIZE
@@ -53,9 +54,9 @@ class SettingsSubMenuAccessibilityRobot {
 
     fun clickFontSizingSwitch() = toggleFontSizingSwitch()
 
-    fun verifyNewMenuItems() = assertNewMenuItems()
+    fun verifyEnabledMenuItems() = assertEnabledMenuItems()
 
-    fun verifyNewMenuItemsAreGone() = assertNewMenuItemsAreGone()
+    fun verifyMenuItemsAreDisabled() = assertMenuItemsAreDisabled()
 
     fun changeTextSizeSlider(seekBarPercentage: Int) = adjustTextSizeSlider(seekBarPercentage)
 
@@ -91,7 +92,7 @@ private fun toggleFontSizingSwitch() {
         .perform(click())
 }
 
-private fun assertNewMenuItems() {
+private fun assertEnabledMenuItems() {
     assertFontSize()
     assertSliderBar()
 }
@@ -99,9 +100,11 @@ private fun assertNewMenuItems() {
 private fun assertFontSize() {
     val view = onView(withText("Font Size"))
     view.check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+        .check(matches(isEnabled(true)))
     val strFont = "Make text on websites larger or smaller"
     onView(withText(strFont))
         .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+        .check(matches(isEnabled(true)))
 }
 
 private fun assertSliderBar() {
@@ -125,20 +128,18 @@ private fun assertTextSizePercentage(textSize: Int) {
         .check(textSizePercentageEquals(textSize))
 }
 
-private fun assertNewMenuItemsAreGone() {
-    onView(withText("Font Size")).check(doesNotExist())
+private fun assertMenuItemsAreDisabled() {
+    onView(withText("Font Size")).assertIsEnabled(false)
+
     val strFont = "Make text on websites larger or smaller"
-    onView(withText(strFont))
-        .check(doesNotExist())
 
-    onView(withId(org.mozilla.fenix.R.id.sampleText))
-        .check(doesNotExist())
+    onView(withText(strFont)).assertIsEnabled(false)
 
-    onView(withId(org.mozilla.fenix.R.id.seekbar_value))
-        .check(doesNotExist())
+    onView(withId(org.mozilla.fenix.R.id.sampleText)).assertIsEnabled(false)
 
-    onView(withId(org.mozilla.fenix.R.id.seekbar))
-        .check(doesNotExist())
+    onView(withId(org.mozilla.fenix.R.id.seekbar_value)).assertIsEnabled(false)
+
+    onView(withId(org.mozilla.fenix.R.id.seekbar)).assertIsEnabled(false)
 }
 
 private fun goBackButton() =

--- a/app/src/geckoBeta/java/org/mozilla/fenix/engine/GeckoProvider.kt
+++ b/app/src/geckoBeta/java/org/mozilla/fenix/engine/GeckoProvider.kt
@@ -47,7 +47,7 @@ object GeckoProvider {
             .build()
 
         val settings = context.components.settings
-        if (!settings.shouldUseAutoSize()) {
+        if (!settings.shouldUseAutoSize) {
             runtimeSettings.automaticFontSizeAdjustment = false
             val fontSize = settings.fontSizeFactor
             runtimeSettings.fontSizeFactor = fontSize

--- a/app/src/geckoNightly/java/org/mozilla/fenix/engine/GeckoProvider.kt
+++ b/app/src/geckoNightly/java/org/mozilla/fenix/engine/GeckoProvider.kt
@@ -47,7 +47,7 @@ object GeckoProvider {
             .build()
 
         val settings = context.components.settings
-        if (!settings.shouldUseAutoSize()) {
+        if (!settings.shouldUseAutoSize) {
             runtimeSettings.automaticFontSizeAdjustment = false
             val fontSize = settings.fontSizeFactor
             runtimeSettings.fontSizeFactor = fontSize

--- a/app/src/geckoRelease/java/org/mozilla/fenix/engine/GeckoProvider.kt
+++ b/app/src/geckoRelease/java/org/mozilla/fenix/engine/GeckoProvider.kt
@@ -57,7 +57,7 @@ object GeckoProvider {
             .build()
 
         val settings = context.components.settings
-        if (!settings.shouldUseAutoSize()) {
+        if (!settings.shouldUseAutoSize) {
             runtimeSettings.automaticFontSizeAdjustment = false
             val fontSize = settings.fontSizeFactor
             runtimeSettings.fontSizeFactor = fontSize

--- a/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -97,8 +97,8 @@ class Core(
             trackingProtectionPolicy = trackingProtectionPolicyFactory.createTrackingProtectionPolicy(),
             historyTrackingDelegate = HistoryDelegate(lazyHistoryStorage),
             preferredColorScheme = getPreferredColorScheme(),
-            automaticFontSizeAdjustment = context.settings().shouldUseAutoSize(),
-            fontInflationEnabled = context.settings().shouldUseAutoSize(),
+            automaticFontSizeAdjustment = context.settings().shouldUseAutoSize,
+            fontInflationEnabled = context.settings().shouldUseAutoSize,
             suspendMediaWhenInactive = false,
             forceUserScalableContent = context.settings().forceEnableZoom,
             loginAutofillEnabled = context.settings().shouldAutofillLogins

--- a/app/src/main/java/org/mozilla/fenix/settings/AccessibilityFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/AccessibilityFragment.kt
@@ -73,8 +73,9 @@ class AccessibilityFragment : PreferenceFragmentCompat() {
             if (!useAutoSize) {
                 components.core.engine.settings.fontSizeFactor = settings.fontSizeFactor
             }
-            // Show the manual sizing controls if automatic sizing is turned off.
-            textSizePreference.isVisible = !useAutoSize
+
+            // Enable the manual sizing controls if automatic sizing is turned off.
+            textSizePreference.isEnabled = !useAutoSize
 
             // Reload the current session to reflect the new text scale
             components.useCases.sessionUseCases.reload()

--- a/app/src/main/java/org/mozilla/fenix/settings/AccessibilityFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/AccessibilityFragment.kt
@@ -48,17 +48,33 @@ class AccessibilityFragment : PreferenceFragmentCompat() {
             val newTextScale =
                 ((newTextSize * STEP_SIZE) + MIN_SCALE_VALUE).toFloat() / PERCENT_TO_DECIMAL
 
+            // Save new text scale value. We assume auto sizing is off if this change listener was called.
             settings.fontSizeFactor = newTextScale
+            components.core.engine.settings.fontSizeFactor = newTextScale
 
-            // If scale is 100%, use the automatic font size adjustment
-            val useAutoSize = newTextScale == 1F
+            // Reload the current session to reflect the new text scale
+            components.useCases.sessionUseCases.reload()
+            true
+        }
+        textSizePreference.isEnabled = !requireContext().settings().shouldUseAutoSize
+
+        val useAutoSizePreference =
+            requirePreference<SwitchPreference>(R.string.pref_key_accessibility_auto_size)
+        useAutoSizePreference.setOnPreferenceChangeListener<Boolean> { preference, useAutoSize ->
+            val settings = preference.context.settings()
+            val components = preference.context.components
+
+            // Save the new setting value
+            settings.shouldUseAutoSize = useAutoSize
             components.core.engine.settings.automaticFontSizeAdjustment = useAutoSize
             components.core.engine.settings.fontInflationEnabled = useAutoSize
 
-            // If using manual sizing, update the engine settings with the new scale
+            // If using manual sizing, update the engine settings with the local saved setting
             if (!useAutoSize) {
-                components.core.engine.settings.fontSizeFactor = newTextScale
+                components.core.engine.settings.fontSizeFactor = settings.fontSizeFactor
             }
+            // Show the manual sizing controls if automatic sizing is turned off.
+            textSizePreference.isVisible = !useAutoSize
 
             // Reload the current session to reflect the new text scale
             components.useCases.sessionUseCases.reload()

--- a/app/src/main/java/org/mozilla/fenix/settings/TextPercentageSeekBarPreference.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/TextPercentageSeekBarPreference.kt
@@ -67,30 +67,37 @@ class TextPercentageSeekBarPreference @JvmOverloads constructor(
 ) : Preference(context, attrs, defStyleAttr, defStyleRes) {
     /* synthetic access */
     internal var mSeekBarValue: Int = 0
+
     /* synthetic access */
     internal var mMin: Int = 0
     private var mMax: Int = 0
     private var mSeekBarIncrement: Int = 0
+
     /* synthetic access */
     internal var mTrackingTouch: Boolean = false
+
     /* synthetic access */
     internal var mSeekBar: SeekBar? = null
     private var mSeekBarValueTextView: TextView? = null
     private var mExampleTextTextView: TextView? = null
+
     /**
      * Whether the SeekBar should respond to the left/right keys
      */
     /* synthetic access */
     var isAdjustable: Boolean = false
+
     /**
      * Whether to show the SeekBar value TextView next to the bar
      */
     private var mShowSeekBarValue: Boolean = false
+
     /**
      * Whether the SeekBarPreference should continuously save the Seekbar value while it is being dragged.
      */
     /* synthetic access */
     var updatesContinuously: Boolean = false
+
     /**
      * Listener reacting to the [SeekBar] changing value by the user
      */
@@ -273,6 +280,8 @@ class TextPercentageSeekBarPreference @JvmOverloads constructor(
         updateExampleTextValue(mSeekBarValue)
         updateLabelValue(mSeekBarValue)
         mSeekBar?.isEnabled = isEnabled
+        mSeekBarValueTextView?.alpha = if (isEnabled) 1F else HALF_ALPHA
+        mExampleTextTextView?.alpha = if (isEnabled) 1F else HALF_ALPHA
         mSeekBar?.let {
             it.thumbOffset = it.thumb.intrinsicWidth.div(2 * PI).roundToInt()
         }
@@ -461,6 +470,7 @@ class TextPercentageSeekBarPreference @JvmOverloads constructor(
     companion object {
         private const val TAG = "SeekBarPreference"
         private const val STEP_SIZE = 5
+        private const val HALF_ALPHA = 0.5F
         private const val MIN_VALUE = 50
         private const val DECIMAL_CONVERSION = 100f
         private const val TEXT_SIZE = 16f

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -315,11 +315,14 @@ class Settings(private val appContext: Context) : PreferencesHolder {
     val shouldShowSecurityPinWarning: Boolean
         get() = loginsSecureWarningCount.underMaxCount()
 
-    fun shouldUseAutoSize() = fontSizeFactor == 1F
-
     var shouldUseLightTheme by booleanPreference(
         appContext.getPreferenceKey(R.string.pref_key_light_theme),
         default = false
+    )
+
+    var shouldUseAutoSize by booleanPreference(
+        appContext.getPreferenceKey(R.string.pref_key_accessibility_auto_size),
+        default = true
     )
 
     var fontSizeFactor by floatPreference(

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -11,6 +11,7 @@
     <string name="pref_key_site_permissions" translatable="false">pref_key_site_permissions</string>
     <string name="pref_key_add_private_browsing_shortcut" translatable="false">pref_key_add_private_browsing_shortcut</string>
     <string name="pref_key_accessibility" translatable="false">pref_key_accessibility</string>
+    <string name="pref_key_accessibility_auto_size" translatable="false">pref_key_accessibility_auto_size</string>
     <string name="pref_key_accessibility_font_scale" translatable="false">pref_key_accessibility_font_scale</string>
     <string name="pref_key_accessibility_force_enable_zoom" translatable="false">pref_key_accessibility_force_enable_zoom</string>
     <string name="pref_key_advanced" translatable="false">pref_key_advanced</string>

--- a/app/src/main/res/xml/accessibility_preferences.xml
+++ b/app/src/main/res/xml/accessibility_preferences.xml
@@ -4,6 +4,11 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
+    <SwitchPreference
+        android:defaultValue="true"
+        android:key="@string/pref_key_accessibility_auto_size"
+        android:summary="@string/preference_accessibility_auto_size_summary"
+        android:title="@string/preference_accessibility_auto_size_2" />
     <!-- Custom Preference that scales from 50-200% by steps of 5 represented by 0-30 in steps of 1-->
     <org.mozilla.fenix.settings.TextPercentageSeekBarPreference
         android:defaultValue="10"
@@ -14,6 +19,7 @@
         android:title="@string/preference_accessibility_font_size_title"
         app:adjustable="true"
         app:iconSpaceReserved="false"
+        app:isPreferenceVisible="false"
         app:min="0"
         app:seekBarIncrement="1"
         app:showSeekBarValue="true" />

--- a/app/src/main/res/xml/accessibility_preferences.xml
+++ b/app/src/main/res/xml/accessibility_preferences.xml
@@ -18,8 +18,8 @@
         android:summary="@string/preference_accessibility_text_size_summary"
         android:title="@string/preference_accessibility_font_size_title"
         app:adjustable="true"
+        app:enabled="false"
         app:iconSpaceReserved="false"
-        app:isPreferenceVisible="false"
         app:min="0"
         app:seekBarIncrement="1"
         app:showSeekBarValue="true" />

--- a/app/src/test/java/org/mozilla/fenix/settings/ExtensionsTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/ExtensionsTest.kt
@@ -43,6 +43,9 @@ class ExtensionsTest {
         every {
             fragment.getString(R.string.pref_key_accessibility_force_enable_zoom)
         } returns "pref_key_accessibility_force_enable_zoom"
+        every {
+            fragment.getString(R.string.pref_key_accessibility_auto_size)
+        } returns "pref_key_accessibility_auto_size"
     }
 
     @Test
@@ -75,6 +78,11 @@ class ExtensionsTest {
         every {
             fragment.findPreference<SwitchPreference>("pref_key_accessibility_auto_size")
         } returns switchPreference
+
+        assertEquals(
+            switchPreference,
+            fragment.requirePreference<SwitchPreference>(R.string.pref_key_accessibility_auto_size)
+        )
     }
 
     @Test

--- a/app/src/test/java/org/mozilla/fenix/utils/SettingsTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/utils/SettingsTest.kt
@@ -259,6 +259,19 @@ class SettingsTest {
     }
 
     @Test
+    fun shouldUseAutoSize() {
+        // When just created
+        // Then
+        assertTrue(settings.shouldUseAutoSize)
+
+        // When
+        settings.shouldUseAutoSize = false
+
+        // Then
+        assertFalse(settings.shouldUseAutoSize)
+    }
+
+    @Test
     fun shouldAutofill() {
         // When just created
         // Then


### PR DESCRIPTION
We want to undo this and just disable the slider while auto is enabled 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
