### PR TITLE
Use Android-Components 63.0.0

### DIFF
--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "63.0.20201019143159"
+    const val VERSION = "63.0.0"
 }


### PR DESCRIPTION
This patch pins Fenix v83.0.0 to Android-Components 63.0.0