### PR TITLE
Update Android Components version to 64.0.20201022151526

### DIFF
--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "63.0.20201019143159"
+    const val VERSION = "64.0.20201022151526"
 }


### PR DESCRIPTION
Opening this under my account to I can re-run TC tasks. Unit tests time out in https://github.com/mozilla-mobile/fenix/pull/16126/