### PR TITLE
For #16122 - Add a dark theme color for the top sites pin icon

### DIFF
--- a/app/src/main/res/layout/top_site_item.xml
+++ b/app/src/main/res/layout/top_site_item.xml
@@ -53,7 +53,7 @@
             android:layout_height="16dp"
             android:layout_gravity="center"
             android:background="@drawable/ic_pin"
-            android:backgroundTint="@color/top_site_pin_icon_normal_theme"/>
+            android:backgroundTint="@color/top_site_pin_icon_background_tint"/>
     </FrameLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/top_site_item.xml
+++ b/app/src/main/res/layout/top_site_item.xml
@@ -52,7 +52,8 @@
             android:layout_width="16dp"
             android:layout_height="16dp"
             android:layout_gravity="center"
-            android:background="@drawable/ic_pin" />
+            android:background="@drawable/ic_pin"
+            android:backgroundTint="@color/top_site_pin_icon_normal_theme"/>
     </FrameLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -77,6 +77,7 @@
     <color name="top_site_title_text">@color/top_site_title_text_dark_theme</color>
     <color name="top_site_pager_dot">#3A3944</color>
     <color name="top_site_pager_dot_selected">#5B5B66</color>
+    <color name="top_site_pin_icon_normal_theme">@color/top_site_pin_icon_dark_theme</color>
 
     <!-- Synced tabs colors-->
     <color name="synced_tabs_separator">@color/synced_tabs_separator_dark_theme</color>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -77,7 +77,7 @@
     <color name="top_site_title_text">@color/top_site_title_text_dark_theme</color>
     <color name="top_site_pager_dot">#3A3944</color>
     <color name="top_site_pager_dot_selected">#5B5B66</color>
-    <color name="top_site_pin_icon_normal_theme">@color/top_site_pin_icon_dark_theme</color>
+    <color name="top_site_pin_icon_background_tint">@color/violet_50</color>
 
     <!-- Synced tabs colors-->
     <color name="synced_tabs_separator">@color/synced_tabs_separator_dark_theme</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -281,6 +281,9 @@
     <color name="top_site_title_text">@color/top_site_title_text_light_theme</color>
     <color name="top_site_pager_dot">@color/photonLightGrey30</color>
     <color name="top_site_pager_dot_selected">@color/light_grey_50</color>
+    <color name="top_site_pin_icon_light_theme">@color/ink_20</color>
+    <color name="top_site_pin_icon_dark_theme">@color/violet_50</color>
+    <color name="top_site_pin_icon_normal_theme">@color/top_site_pin_icon_light_theme</color>
 
     <!-- Synced tabs colors-->
     <color name="synced_tabs_separator">@color/synced_tabs_separator_light_theme</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -281,9 +281,7 @@
     <color name="top_site_title_text">@color/top_site_title_text_light_theme</color>
     <color name="top_site_pager_dot">@color/photonLightGrey30</color>
     <color name="top_site_pager_dot_selected">@color/light_grey_50</color>
-    <color name="top_site_pin_icon_light_theme">@color/ink_20</color>
-    <color name="top_site_pin_icon_dark_theme">@color/violet_50</color>
-    <color name="top_site_pin_icon_normal_theme">@color/top_site_pin_icon_light_theme</color>
+    <color name="top_site_pin_icon_background_tint">@color/ink_20</color>
 
     <!-- Synced tabs colors-->
     <color name="synced_tabs_separator">@color/synced_tabs_separator_light_theme</color>


### PR DESCRIPTION
My first contribution, so I picked a "good first issue" before digging deeper. This PR changes the color of the pin icon in the top-left corner of top sites, to improve contrast and stand out from non-pinned sites, as reported in #16122.

Here's how it was **before** in light and dark theme:

![B-R-Screenshot_1603714106](https://user-images.githubusercontent.com/245615/97182030-4979fb00-179c-11eb-9ab7-aa2d6f9e5a47.png) ![B-R-Screenshot_1603714115](https://user-images.githubusercontent.com/245615/97182038-4d0d8200-179c-11eb-980c-788938f5116e.png)

And **after**:

![A-R-Screenshot_1603712908](https://user-images.githubusercontent.com/245615/97182067-54349000-179c-11eb-83aa-4e20d581731b.png) ![A-R-Screenshot_1603712919](https://user-images.githubusercontent.com/245615/97182073-55fe5380-179c-11eb-89da-1ee9c48070da.png)

This change doesn't require new tests, I think.