### PR TITLE
For #8169 - Upgrade Mockwebserver

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/glean/BaselinePingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/glean/BaselinePingTest.kt
@@ -110,7 +110,7 @@ class BaselinePingTest {
         do {
             attempts += 1
             val request = server.takeRequest(20L, TimeUnit.SECONDS) ?: break
-            val docType = request.path.split("/")[3]
+            val docType = request.path!!.split("/")[3]
             if (pingName == docType) {
                 val parsedPayload = JSONObject(request.getPlainBody())
                 if (pingReason == null) {

--- a/app/src/androidTest/java/org/mozilla/fenix/screenshots/MenuScreenShotTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/screenshots/MenuScreenShotTest.kt
@@ -43,7 +43,7 @@ class MenuScreenShotTest : ScreenshotTest() {
     @Before
     fun setUp() {
         mockWebServer = MockWebServer().apply {
-            setDispatcher(AndroidAssetDispatcher())
+            dispatcher = AndroidAssetDispatcher()
             start()
         }
     }

--- a/app/src/androidTest/java/org/mozilla/fenix/syncintegration/SyncIntegrationTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/syncintegration/SyncIntegrationTest.kt
@@ -44,7 +44,7 @@ class SyncIntegrationTest {
     @Before
     fun setUp() {
         mockWebServer = MockWebServer().apply {
-            setDispatcher(AndroidAssetDispatcher())
+            dispatcher = AndroidAssetDispatcher()
             start()
         }
     }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
@@ -49,7 +49,7 @@ class BookmarksTest {
     @Before
     fun setUp() {
         mockWebServer = MockWebServer().apply {
-            setDispatcher(AndroidAssetDispatcher())
+            dispatcher = AndroidAssetDispatcher()
             start()
         }
     }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/ContextMenusTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/ContextMenusTest.kt
@@ -42,7 +42,7 @@ class ContextMenusTest {
     @Before
     fun setUp() {
         mockWebServer = MockWebServer().apply {
-            setDispatcher(AndroidAssetDispatcher())
+            dispatcher = AndroidAssetDispatcher()
             start()
         }
     }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/DeepLinkTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/DeepLinkTest.kt
@@ -43,7 +43,7 @@ class DeepLinkTest {
     @Before
     fun setUp() {
         mockWebServer = MockWebServer().apply {
-            setDispatcher(AndroidAssetDispatcher())
+            dispatcher = AndroidAssetDispatcher()
             start()
         }
     }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/DownloadTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/DownloadTest.kt
@@ -51,7 +51,7 @@ class DownloadTest {
     @Before
     fun setUp() {
         mockWebServer = MockWebServer().apply {
-            setDispatcher(AndroidAssetDispatcher())
+            dispatcher = AndroidAssetDispatcher()
             start()
         }
     }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/HistoryTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/HistoryTest.kt
@@ -41,7 +41,7 @@ class HistoryTest {
     @Before
     fun setUp() {
         mockWebServer = MockWebServer().apply {
-            setDispatcher(AndroidAssetDispatcher())
+            dispatcher = AndroidAssetDispatcher()
             start()
         }
     }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/MediaNotificationTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/MediaNotificationTest.kt
@@ -37,7 +37,7 @@ class MediaNotificationTest {
     @Before
     fun setUp() {
         mockWebServer = MockWebServer().apply {
-            setDispatcher(AndroidAssetDispatcher())
+            dispatcher = AndroidAssetDispatcher()
             start()
         }
     }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/NavigationToolbarTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/NavigationToolbarTest.kt
@@ -38,7 +38,7 @@ class NavigationToolbarTest {
     @Before
     fun setUp() {
         mockWebServer = MockWebServer().apply {
-            setDispatcher(AndroidAssetDispatcher())
+            dispatcher = AndroidAssetDispatcher()
             start()
         }
     }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/ReaderViewTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/ReaderViewTest.kt
@@ -41,7 +41,7 @@ class ReaderViewTest {
     @Before
     fun setUp() {
         mockWebServer = MockWebServer().apply {
-            setDispatcher(AndroidAssetDispatcher())
+            dispatcher = AndroidAssetDispatcher()
             start()
         }
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAboutTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAboutTest.kt
@@ -33,7 +33,7 @@ class SettingsAboutTest {
     @Before
     fun setUp() {
         mockWebServer = MockWebServer().apply {
-            setDispatcher(AndroidAssetDispatcher())
+            dispatcher = AndroidAssetDispatcher()
             start()
         }
     }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAddonsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAddonsTest.kt
@@ -39,7 +39,7 @@ class SettingsAddonsTest {
     @Before
     fun setUp() {
         mockWebServer = MockWebServer().apply {
-            setDispatcher(AndroidAssetDispatcher())
+            dispatcher = AndroidAssetDispatcher()
             start()
         }
     }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAdvancedTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAdvancedTest.kt
@@ -32,7 +32,7 @@ class SettingsAdvancedTest {
     @Before
     fun setUp() {
         mockWebServer = MockWebServer().apply {
-            setDispatcher(AndroidAssetDispatcher())
+            dispatcher = AndroidAssetDispatcher()
             start()
         }
     }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsBasicsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsBasicsTest.kt
@@ -39,7 +39,7 @@ class SettingsBasicsTest {
     @Before
     fun setUp() {
         mockWebServer = MockWebServer().apply {
-            setDispatcher(AndroidAssetDispatcher())
+            dispatcher = AndroidAssetDispatcher()
             start()
         }
     }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsDeveloperToolsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsDeveloperToolsTest.kt
@@ -33,7 +33,7 @@ class SettingsDeveloperToolsTest {
     @Before
     fun setUp() {
         mockWebServer = MockWebServer().apply {
-            setDispatcher(AndroidAssetDispatcher())
+            dispatcher = AndroidAssetDispatcher()
             start()
         }
     }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsPrivacyTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsPrivacyTest.kt
@@ -41,7 +41,7 @@ class SettingsPrivacyTest {
     @Before
     fun setUp() {
         mockWebServer = MockWebServer().apply {
-            setDispatcher(AndroidAssetDispatcher())
+            dispatcher = AndroidAssetDispatcher()
             start()
         }
     }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsSyncTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsSyncTest.kt
@@ -32,7 +32,7 @@ class SettingsSyncTest {
     @Before
     fun setUp() {
         mockWebServer = MockWebServer().apply {
-            setDispatcher(AndroidAssetDispatcher())
+            dispatcher = AndroidAssetDispatcher()
             start()
         }
     }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsTest.kt
@@ -32,7 +32,7 @@ class SettingsTest {
     @Before
     fun setUp() {
         mockWebServer = MockWebServer().apply {
-            setDispatcher(AndroidAssetDispatcher())
+            dispatcher = AndroidAssetDispatcher()
             start()
         }
     }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/ShareButtonTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/ShareButtonTest.kt
@@ -33,7 +33,7 @@ class ShareButtonTest {
     @Before
     fun setUp() {
         mockWebServer = MockWebServer().apply {
-            setDispatcher(AndroidAssetDispatcher())
+            dispatcher = AndroidAssetDispatcher()
             start()
         }
     }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -34,7 +34,7 @@ class SmokeTest {
     @Before
     fun setUp() {
         mockWebServer = MockWebServer().apply {
-            setDispatcher(AndroidAssetDispatcher())
+            dispatcher = AndroidAssetDispatcher()
             start()
         }
     }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/StrictEnhancedTrackingProtectionTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/StrictEnhancedTrackingProtectionTest.kt
@@ -42,7 +42,7 @@ class StrictEnhancedTrackingProtectionTest {
     @Before
     fun setUp() {
         mockWebServer = MockWebServer().apply {
-            setDispatcher(AndroidAssetDispatcher())
+            dispatcher = AndroidAssetDispatcher()
             start()
         }
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
@@ -49,7 +49,7 @@ class TabbedBrowsingTest {
     @Before
     fun setUp() {
         mockWebServer = MockWebServer().apply {
-            setDispatcher(AndroidAssetDispatcher())
+            dispatcher = AndroidAssetDispatcher()
             start()
         }
     }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/ThreeDotMenuMainTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/ThreeDotMenuMainTest.kt
@@ -32,7 +32,7 @@ class ThreeDotMenuMainTest {
     @Before
     fun setUp() {
         mockWebServer = MockWebServer().apply {
-            setDispatcher(AndroidAssetDispatcher())
+            dispatcher = AndroidAssetDispatcher()
             start()
         }
     }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/TopSitesTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/TopSitesTest.kt
@@ -36,7 +36,7 @@ class TopSitesTest {
     @Before
     fun setUp() {
         mockWebServer = MockWebServer().apply {
-            setDispatcher(AndroidAssetDispatcher())
+            dispatcher = AndroidAssetDispatcher()
             start()
         }
     }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -43,7 +43,7 @@ object Versions {
     const val junit = "5.5.2"
     const val mockk = "1.10.0"
 
-    const val mockwebserver = "3.11.0"
+    const val mockwebserver = "4.9.0"
     const val uiautomator = "2.2.0"
 
     const val google_ads_id_version = "16.0.0"


### PR DESCRIPTION
Upgrades Mockwebserver to 4.9.0 from 3.11.0 (!)

```setDispatcher``` was removed at some point in the API so all calls need to be updated. There was also an unsafe call warning in a Glean test after upgrading as well as in the dispatcher code itself.