### PR TITLE
Ability to rename top sites, closes #9548

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/TopSitesTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/TopSitesTest.kt
@@ -120,6 +120,31 @@ class TopSitesTest {
     }
 
     @Test
+    fun verifyRenameTopSite() {
+        val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+        val defaultWebPageTitle = "Test_Page_1"
+        val defaultWebPageTitleNew = "Test_Page_2"
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(defaultWebPage.url) {
+        }.openThreeDotMenu {
+            verifyAddFirefoxHome()
+        }.addToFirefoxHome {
+            verifySnackBarText("Added to top sites!")
+        }.openTabDrawer {
+        }.openNewTab {
+        }.dismiss {
+            verifyExistingTopSitesList()
+            verifyExistingTopSitesTabs(defaultWebPageTitle)
+        }.openContextMenuOnTopSitesWithTitle(defaultWebPageTitle) {
+            verifyTopSiteContextMenuItems()
+        }.renameTopSite(defaultWebPageTitleNew) {
+            verifyExistingTopSitesList()
+            verifyExistingTopSitesTabs(defaultWebPageTitleNew)
+        }
+    }
+
+    @Test
     fun verifyRemoveTopSite() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
         val defaultWebPageTitle = "Test_Page_1"

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
@@ -7,6 +7,7 @@
 package org.mozilla.fenix.ui.robots
 
 import android.graphics.Bitmap
+import android.widget.EditText
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.NoMatchingViewException
@@ -19,15 +20,7 @@ import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions.actionOnItem
 import androidx.test.espresso.matcher.ViewMatchers
-import androidx.test.espresso.matcher.ViewMatchers.Visibility
-import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
-import androidx.test.espresso.matcher.ViewMatchers.hasSibling
-import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
-import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
-import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
-import androidx.test.espresso.matcher.ViewMatchers.withHint
-import androidx.test.espresso.matcher.ViewMatchers.withId
-import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.By.text
@@ -36,9 +29,8 @@ import androidx.test.uiautomator.UiScrollable
 import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
 import androidx.test.uiautomator.Until.findObject
-import org.hamcrest.CoreMatchers.allOf
-import org.hamcrest.CoreMatchers.containsString
-import org.hamcrest.CoreMatchers.not
+import org.hamcrest.CoreMatchers.*
+import org.hamcrest.Matchers
 import org.junit.Assert
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.Search
@@ -445,10 +437,24 @@ class HomeScreenRobot {
             return BrowserRobot.Transition()
         }
 
+        fun renameTopSite(title: String, interact: HomeScreenRobot.() -> Unit): Transition {
+            onView(withText("Rename"))
+                .check((matches(withEffectiveVisibility(Visibility.VISIBLE))))
+                .perform(click())
+            onView(Matchers.allOf(withId(R.id.top_site_title), instanceOf(EditText::class.java)))
+                .perform(ViewActions.replaceText(title))
+            onView(withId(android.R.id.button1)).perform((click()))
+
+            HomeScreenRobot().interact()
+            return Transition()
+        }
+
         fun removeTopSite(interact: HomeScreenRobot.() -> Unit): Transition {
             onView(withText("Remove"))
                 .check((matches(withEffectiveVisibility(Visibility.VISIBLE))))
                 .perform(click())
+            
+            
 
             HomeScreenRobot().interact()
             return Transition()

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
@@ -20,7 +20,15 @@ import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions.actionOnItem
 import androidx.test.espresso.matcher.ViewMatchers
-import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.espresso.matcher.ViewMatchers.Visibility
+import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
+import androidx.test.espresso.matcher.ViewMatchers.hasSibling
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
+import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
+import androidx.test.espresso.matcher.ViewMatchers.withHint
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.By.text
@@ -29,7 +37,10 @@ import androidx.test.uiautomator.UiScrollable
 import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
 import androidx.test.uiautomator.Until.findObject
-import org.hamcrest.CoreMatchers.*
+import org.hamcrest.CoreMatchers.allOf
+import org.hamcrest.CoreMatchers.containsString
+import org.hamcrest.CoreMatchers.instanceOf
+import org.hamcrest.CoreMatchers.not
 import org.hamcrest.Matchers
 import org.junit.Assert
 import org.mozilla.fenix.R
@@ -453,8 +464,6 @@ class HomeScreenRobot {
             onView(withText("Remove"))
                 .check((matches(withEffectiveVisibility(Visibility.VISIBLE))))
                 .perform(click())
-            
-            
 
             HomeScreenRobot().interact()
             return Transition()

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
@@ -301,7 +301,7 @@ class DefaultSessionControlController(
             AlertDialog.Builder(it).apply {
                 setTitle(R.string.rename_top_site)
                 setView(customLayout)
-                setPositiveButton(R.string.top_sites_rename_dialog_ok) { _, _ ->
+                setPositiveButton(R.string.top_sites_rename_dialog_ok) { dialog, _ ->
                     val newTitle = topSiteLabelEditText.text.toString()
                     if (newTitle.isNotBlank()) {
                         viewLifecycleScope.launch(Dispatchers.IO) {
@@ -310,8 +310,11 @@ class DefaultSessionControlController(
                             }
                         }
                     }
+                    dialog.dismiss()
                 }
-                setNegativeButton(R.string.top_sites_rename_dialog_cancel, null)
+                setNegativeButton(R.string.top_sites_rename_dialog_cancel) { dialog, _ ->
+                    dialog.cancel()
+                }
             }.show().also {
                 topSiteLabelEditText.setSelection(0, topSiteLabelEditText.text.length)
                 topSiteLabelEditText.showKeyboard()

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
@@ -303,14 +303,13 @@ class DefaultSessionControlController(
                     .setView(customLayout).setPositiveButton(android.R.string.ok) { _, _ ->
                         val newTitle = topSiteLabelEditText.text.toString()
                         if (newTitle.isNotBlank()) {
-                            // TODO: it.metrics.track(Event.TopSiteRenamed)
                             viewLifecycleScope.launch(Dispatchers.IO) {
                                 with(activity.components.useCases.topSitesUseCase) {
                                     renameTopSites(topSite, newTitle)
                                 }
                             }
                         }
-                    }.setNegativeButton(android.R.string.cancel, null) 
+                    }.setNegativeButton(android.R.string.cancel, null)
                     .create().show().also {
                         topSiteLabelEditText.setSelection(0, topSiteLabelEditText.text.length)
                         topSiteLabelEditText.showKeyboard()

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
@@ -291,29 +291,30 @@ class DefaultSessionControlController(
     }
 
     override fun handleRenameTopSiteClicked(topSite: TopSite) {
-        if (topSite.id != null) {
-            activity.let {
-                val customLayout =
-                        LayoutInflater.from(it).inflate(R.layout.rename_top_site_dialog, null)
-                val topSiteLabelEditText: EditText =
-                        customLayout.findViewById(R.id.top_site_title)
-                topSiteLabelEditText.setText(topSite.title)
+        activity.let {
+            val customLayout =
+                    LayoutInflater.from(it).inflate(R.layout.top_sites_rename_dialog, null)
+            val topSiteLabelEditText: EditText =
+                    customLayout.findViewById(R.id.top_site_title)
+            topSiteLabelEditText.setText(topSite.title)
 
-                AlertDialog.Builder(it).setTitle(R.string.rename_top_site)
-                    .setView(customLayout).setPositiveButton(android.R.string.ok) { _, _ ->
-                        val newTitle = topSiteLabelEditText.text.toString()
-                        if (newTitle.isNotBlank()) {
-                            viewLifecycleScope.launch(Dispatchers.IO) {
-                                with(activity.components.useCases.topSitesUseCase) {
-                                    renameTopSites(topSite, newTitle)
-                                }
+            AlertDialog.Builder(it).apply {
+                setTitle(R.string.rename_top_site)
+                setView(customLayout)
+                setPositiveButton(R.string.top_sites_rename_dialog_ok) { _, _ ->
+                    val newTitle = topSiteLabelEditText.text.toString()
+                    if (newTitle.isNotBlank()) {
+                        viewLifecycleScope.launch(Dispatchers.IO) {
+                            with(activity.components.useCases.topSitesUseCase) {
+                                renameTopSites(topSite, newTitle)
                             }
                         }
-                    }.setNegativeButton(android.R.string.cancel, null)
-                    .create().show().also {
-                        topSiteLabelEditText.setSelection(0, topSiteLabelEditText.text.length)
-                        topSiteLabelEditText.showKeyboard()
                     }
+                }
+                setNegativeButton(R.string.top_sites_rename_dialog_cancel, null)
+            }.show().also {
+                topSiteLabelEditText.setSelection(0, topSiteLabelEditText.text.length)
+                topSiteLabelEditText.showKeyboard()
             }
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlInteractor.kt
@@ -157,6 +157,13 @@ interface TopSiteInteractor {
     fun onOpenInPrivateTabClicked(topSite: TopSite)
 
     /**
+     * Opens a dialog to rename the given top site. Called when an user clicks on the "Rename" top site menu item.
+     *
+     * @param topSite The top site that will be renamed.
+     */
+    fun onRenameTopSiteClicked(topSite: TopSite)
+
+    /**
      * Removes the given top site. Called when an user clicks on the "Remove" top site menu item.
      *
      * @param topSite The top site that will be removed.
@@ -208,6 +215,10 @@ class SessionControlInteractor(
 
     override fun onOpenInPrivateTabClicked(topSite: TopSite) {
         controller.handleOpenInPrivateTabClicked(topSite)
+    }
+
+    override fun onRenameTopSiteClicked(topSite: TopSite) {
+        controller.handleRenameTopSiteClicked(topSite)
     }
 
     override fun onRemoveTopSiteClicked(topSite: TopSite) {

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/topsites/TopSiteItemViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/topsites/TopSiteItemViewHolder.kt
@@ -127,7 +127,8 @@ class TopSiteItemMenu(
                     context.getString(R.string.remove_top_site)
                 } else {
                     context.getString(R.string.delete_from_history)
-                }
+                },
+                textColorResource = ThemeManager.resolveAttribute(R.attr.destructive, context)
             ) {
                 onItemTapped.invoke(Item.RemoveTopSite)
             }

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/topsites/TopSiteItemViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/topsites/TopSiteItemViewHolder.kt
@@ -22,7 +22,6 @@ import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.loadIntoView
 import org.mozilla.fenix.home.sessioncontrol.TopSiteInteractor
 import org.mozilla.fenix.settings.SupportUtils
-import org.mozilla.fenix.theme.ThemeManager
 import org.mozilla.fenix.utils.view.ViewHolder
 
 class TopSiteItemViewHolder(
@@ -127,8 +126,7 @@ class TopSiteItemMenu(
                     context.getString(R.string.remove_top_site)
                 } else {
                     context.getString(R.string.delete_from_history)
-                },
-                textColorResource = ThemeManager.resolveAttribute(R.attr.destructive, context)
+                }
             ) {
                 onItemTapped.invoke(Item.RemoveTopSite)
             }

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/topsites/TopSiteItemViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/topsites/TopSiteItemViewHolder.kt
@@ -22,6 +22,7 @@ import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.loadIntoView
 import org.mozilla.fenix.home.sessioncontrol.TopSiteInteractor
 import org.mozilla.fenix.settings.SupportUtils
+import org.mozilla.fenix.theme.ThemeManager
 import org.mozilla.fenix.utils.view.ViewHolder
 
 class TopSiteItemViewHolder(
@@ -41,6 +42,9 @@ class TopSiteItemViewHolder(
             val topSiteMenu = TopSiteItemMenu(view.context, topSite.type != FRECENT) { item ->
                 when (item) {
                     is TopSiteItemMenu.Item.OpenInPrivateTab -> interactor.onOpenInPrivateTabClicked(
+                        topSite
+                    )
+                    is TopSiteItemMenu.Item.RenameTopSite -> interactor.onRenameTopSiteClicked(
                         topSite
                     )
                     is TopSiteItemMenu.Item.RemoveTopSite -> interactor.onRemoveTopSiteClicked(
@@ -100,18 +104,24 @@ class TopSiteItemMenu(
 ) {
     sealed class Item {
         object OpenInPrivateTab : Item()
+        object RenameTopSite : Item()
         object RemoveTopSite : Item()
     }
 
     val menuBuilder by lazy { BrowserMenuBuilder(menuItems) }
 
     private val menuItems by lazy {
-        listOf(
+        listOfNotNull(
             SimpleBrowserMenuItem(
                 context.getString(R.string.bookmark_menu_open_in_private_tab_button)
             ) {
                 onItemTapped.invoke(Item.OpenInPrivateTab)
             },
+            if (isPinnedSite) SimpleBrowserMenuItem(
+                context.getString(R.string.rename_top_site)
+            ) {
+                onItemTapped.invoke(Item.RenameTopSite)
+            } else null,
             SimpleBrowserMenuItem(
                 if (isPinnedSite) {
                     context.getString(R.string.remove_top_site)

--- a/app/src/main/res/layout/rename_top_site_dialog.xml
+++ b/app/src/main/res/layout/rename_top_site_dialog.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <EditText
+        android:id="@+id/top_site_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="24dp"
+		android:layout_marginTop="16dp"
+        android:layout_marginEnd="24dp"
+        android:autofillHints="false"
+        android:backgroundTint="?neutral"
+        android:hint="@string/rename_top_site_hint"
+        android:inputType="textCapSentences"
+        android:singleLine="true"
+        android:textAlignment="viewStart" />
+</LinearLayout>

--- a/app/src/main/res/layout/top_sites_rename_dialog.xml
+++ b/app/src/main/res/layout/top_sites_rename_dialog.xml
@@ -7,16 +7,27 @@
     android:layout_height="wrap_content"
     android:orientation="vertical">
 
+    <TextView
+        android:id="@+id/rename_header"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="26dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="24dp"
+        android:text="@string/top_sites_rename_dialog_title"
+        android:textAllCaps="true"
+        android:textAppearance="@style/Body16TextStyle"
+        android:textColor="?secondaryText" />
+
     <EditText
         android:id="@+id/top_site_title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginStart="24dp"
-		android:layout_marginTop="16dp"
         android:layout_marginEnd="24dp"
         android:autofillHints="false"
         android:backgroundTint="?neutral"
-        android:hint="@string/rename_top_site_hint"
+        android:hint="@string/top_site_name_hint"
         android:inputType="textCapSentences"
         android:singleLine="true"
         android:textAlignment="viewStart" />

--- a/app/src/main/res/layout/top_sites_rename_dialog.xml
+++ b/app/src/main/res/layout/top_sites_rename_dialog.xml
@@ -8,7 +8,7 @@
     android:orientation="vertical">
 
     <TextView
-        android:id="@+id/rename_header"
+        android:id="@+id/name_header"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginStart="26dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -619,8 +619,12 @@
     <string name="collection_open_tabs">Open tabs</string>
     <!-- Hint for adding name of a collection -->
     <string name="collection_name_hint">Collection name</string>
-    <!-- Text for the menu button to remove a top site -->
-    <string name="remove_top_site">Remove</string>
+	<!-- Text for the menu button to rename a top site -->
+	<string name="rename_top_site">Rename</string>
+	<!-- Hint for renaming a top site -->
+	<string name="rename_top_site_hint">Top site title</string>
+	<!-- Text for the menu button to remove a top site -->
+	<string name="remove_top_site">Remove</string>
     <!-- Text for the menu button to delete a top site from history -->
     <string name="delete_from_history">Delete from history</string>
     <!-- Postfix for private WebApp titles, placeholder is replaced with app name -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1589,7 +1589,7 @@
 	<string name="top_sites_rename_dialog_title">Name</string>
 	<!-- Hint for renaming title of a top site -->
 	<string name="top_site_name_hint">Top site name</string>
-	<!-- Button caption to confirm the add-on collection configuration -->
+	<!-- Button caption to confirm the renaming of the top site. -->
 	<string name="top_sites_rename_dialog_ok">OK</string>
 	<!-- Dialog button text for canceling the rename top site prompt. -->
 	<string name="top_sites_rename_dialog_cancel">Cancel</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -621,8 +621,6 @@
     <string name="collection_name_hint">Collection name</string>
 	<!-- Text for the menu button to rename a top site -->
 	<string name="rename_top_site">Rename</string>
-	<!-- Hint for renaming a top site -->
-	<string name="rename_top_site_hint">Top site title</string>
 	<!-- Text for the menu button to remove a top site -->
 	<string name="remove_top_site">Remove</string>
     <!-- Text for the menu button to delete a top site from history -->
@@ -1587,6 +1585,14 @@
     <string name="top_sites_max_limit_confirmation_button">OK, Got It</string>
     <!-- Label for the show most visited sites preference -->
     <string name="top_sites_toggle_top_frecent_sites">Show most visited sites</string>
+	<!-- Title text displayed in the rename top site dialog. -->
+	<string name="top_sites_rename_dialog_title">Name</string>
+	<!-- Hint for renaming title of a top site -->
+	<string name="top_site_name_hint">Top site name</string>
+	<!-- Button caption to confirm the add-on collection configuration -->
+	<string name="top_sites_rename_dialog_ok">OK</string>
+	<!-- Dialog button text for canceling the rename top site prompt. -->
+	<string name="top_sites_rename_dialog_cancel">Cancel</string>
 
     <!-- Content description for close button in collection placeholder. -->
     <string name="remove_home_collection_placeholder_content_description">Remove</string>


### PR DESCRIPTION
The code in this PR uses my latest contribution to `android-components` and adds an UI to rename pinned top sites. I've written the UI test, and accessibility should be ok since I copied the new dialog from an existing one. I'm not so sure about are the new strings (I added English only, I guess Pontoon will automatically pick them up?), and telemetry (I tried to define a new event in YAML, but it failed the build task).

![Screenshot_1603839863](https://user-images.githubusercontent.com/245615/97371391-5f2d1480-18b1-11eb-892d-ec4918c2b111.png) ![Screenshot_1603839868](https://user-images.githubusercontent.com/245615/97371402-63f1c880-18b1-11eb-8c57-a2d03b765c04.png)
