### PR TITLE
For #10690: re-enable editBookmarkTest

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
@@ -12,7 +12,6 @@ import mozilla.appservices.places.BookmarkRoot
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.R
@@ -151,7 +150,6 @@ class BookmarksTest {
         }
     }
 
-    @Ignore("Flaky test, temp disabled: https://github.com/mozilla-mobile/fenix/issues/10690")
     @Test
     fun editBookmarkTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
@@ -164,7 +162,6 @@ class BookmarksTest {
                 RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 1)
             IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
         }.openThreeDotMenu(defaultWebPage.url) {
-            IdlingRegistry.getInstance().unregister(bookmarksListIdlingResource!!)
         }.clickEdit {
             verifyEditBookmarksView()
             verifyBookmarkNameEditBox()
@@ -173,9 +170,6 @@ class BookmarksTest {
             changeBookmarkTitle(testBookmark.title)
             changeBookmarkUrl(testBookmark.url)
             saveEditBookmark()
-
-            IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
-
             verifyBookmarkTitle(testBookmark.title)
             verifyBookmarkedURL(testBookmark.url)
             verifyKeyboardHidden()

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BookmarksRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BookmarksRobot.kt
@@ -27,7 +27,6 @@ import androidx.test.uiautomator.By
 import androidx.test.uiautomator.Until
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.By.res
-import androidx.test.uiautomator.By.text
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiSelector
 import org.hamcrest.Matchers.allOf
@@ -58,10 +57,7 @@ class BookmarksRobot {
     }
 
     fun verifyBookmarkTitle(title: String) {
-        mDevice.waitNotNull(
-            Until.findObject(text(title)),
-            TestAssetHelper.waitingTime
-        )
+        mDevice.findObject(UiSelector().text(title)).waitForExists(waitingTime)
         assertBookmarkTitle(title)
     }
 
@@ -164,7 +160,7 @@ class BookmarksRobot {
 
     fun saveEditBookmark() {
         saveBookmarkButton().click()
-        mDevice.waitNotNull(Until.findObject(text("Bookmarks")))
+        mDevice.findObject(UiSelector().resourceId("R.id.bookmark_list")).waitForExists(waitingTime)
     }
 
     fun clickParentFolderSelector() = bookmarkFolderSelector().click()


### PR DESCRIPTION
An attempt to re-enable this old test: BookmarksTest.editBookmarkTest. Made some small tweaks and ran the tests with flank config about 70 times, all passed: https://github.com/mozilla-mobile/fenix/runs/1319866040 & https://github.com/mozilla-mobile/fenix/runs/1309113448
Let's hope this will work in the long run.