### PR TITLE
Fixes #16075 - Include a distribution_id in telemetry

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -850,6 +850,26 @@ metrics:
     notification_emails:
       - fenix-core@mozilla.com
     expires: "2021-08-01"
+  adjust_campaign:
+    type: string
+    lifetime: application
+    description: |
+      A string containing the Adjust campaign ID from which the user installed
+      Fenix. This will not send on the first session the user runs. If the
+      install is organic, this will be empty.
+    send_in_pings:
+      - metrics
+    bugs:
+      - https://github.com/mozilla-mobile/fenix/issues/1298
+      - https://github.com/mozilla-mobile/fenix/issues/9136
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/5579
+      - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - fenix-core@mozilla.com
+    expires: "2021-08-01"
   adjust_ad_group:
     type: string
     lifetime: application

--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -850,26 +850,6 @@ metrics:
     notification_emails:
       - fenix-core@mozilla.com
     expires: "2021-08-01"
-  adjust_campaign:
-    type: string
-    lifetime: application
-    description: |
-      A string containing the Adjust campaign ID from which the user installed
-      Fenix. This will not send on the first session the user runs. If the
-      install is organic, this will be empty.
-    send_in_pings:
-      - metrics
-    bugs:
-      - https://github.com/mozilla-mobile/fenix/issues/1298
-      - https://github.com/mozilla-mobile/fenix/issues/9136
-    data_reviews:
-      - https://github.com/mozilla-mobile/fenix/pull/5579
-      - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
-    data_sensitivity:
-      - technical
-    notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-08-01"
   adjust_ad_group:
     type: string
     lifetime: application
@@ -1036,6 +1016,23 @@ metrics:
     notification_emails:
       - fenix-core@mozilla.com
     expires: "2021-08-01"
+  distribution_id:
+    type: string
+    lifetime: application
+    description: |
+      A string containing the distribution identifier. This is currently used
+      to identify installs from Mozilla Online.
+    send_in_pings:
+      - metrics
+    bugs:
+      - https://github.com/mozilla-mobile/fenix/issues/16075
+    data_reviews:
+      - tbd
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - fenix-core@mozilla.com
+    expires: "2021-11-01"
 
 preferences:
   show_search_suggestions:

--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -1027,7 +1027,7 @@ metrics:
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/16075
     data_reviews:
-      - tbd
+      - https://github.com/mozilla-mobile/fenix/pull/16257
     data_sensitivity:
       - interaction
     notification_emails:


### PR DESCRIPTION
This patch introduces a `distribution_id` telemetry field. This is used to identify installs from Mozilla Online.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
