### PR TITLE
For #15279: add lazyMonitored to count # of components init

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/Analytics.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Analytics.kt
@@ -23,6 +23,7 @@ import org.mozilla.fenix.components.metrics.GleanMetricsService
 import org.mozilla.fenix.components.metrics.LeanplumMetricsService
 import org.mozilla.fenix.components.metrics.MetricController
 import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.perf.lazyMonitored
 import org.mozilla.fenix.utils.Mockable
 import org.mozilla.geckoview.BuildConfig.MOZ_APP_BUILDID
 import org.mozilla.geckoview.BuildConfig.MOZ_APP_VENDOR
@@ -36,7 +37,7 @@ import org.mozilla.geckoview.BuildConfig.MOZ_UPDATE_CHANNEL
 class Analytics(
     private val context: Context
 ) {
-    val crashReporter: CrashReporter by lazy {
+    val crashReporter: CrashReporter by lazyMonitored {
         val services = mutableListOf<CrashReporterService>()
 
         if (isSentryEnabled()) {
@@ -84,9 +85,9 @@ class Analytics(
         )
     }
 
-    val leanplumMetricsService by lazy { LeanplumMetricsService(context as Application) }
+    val leanplumMetricsService by lazyMonitored { LeanplumMetricsService(context as Application) }
 
-    val metrics: MetricController by lazy {
+    val metrics: MetricController by lazyMonitored {
         MetricController.create(
             listOf(
                 GleanMetricsService(context),

--- a/app/src/main/java/org/mozilla/fenix/components/BackgroundServices.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/BackgroundServices.kt
@@ -41,6 +41,7 @@ import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.components.metrics.MetricController
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.perf.lazyMonitored
 import org.mozilla.fenix.sync.SyncedTabsIntegration
 import org.mozilla.fenix.utils.Mockable
 import org.mozilla.fenix.utils.Settings
@@ -109,9 +110,11 @@ class BackgroundServices(
 
     val accountAbnormalities = AccountAbnormalities(context, crashReporter, strictMode)
 
-    val accountManager by lazy { makeAccountManager(context, serverConfig, deviceConfig, syncConfig, crashReporter) }
+    val accountManager by lazyMonitored {
+        makeAccountManager(context, serverConfig, deviceConfig, syncConfig, crashReporter)
+    }
 
-    val syncedTabsStorage by lazy {
+    val syncedTabsStorage by lazyMonitored {
         SyncedTabsStorage(accountManager, context.components.core.store, remoteTabsStorage.value)
     }
 
@@ -174,7 +177,7 @@ class BackgroundServices(
     /**
      * Provides notification functionality, manages notification channels.
      */
-    private val notificationManager by lazy {
+    private val notificationManager by lazyMonitored {
         NotificationManager(context)
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/components/Components.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Components.kt
@@ -22,6 +22,7 @@ import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.StrictModeManager
 import org.mozilla.fenix.components.metrics.AppStartupTelemetry
 import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.perf.lazyMonitored
 import org.mozilla.fenix.utils.ClipboardHandler
 import org.mozilla.fenix.utils.Mockable
 import org.mozilla.fenix.utils.Settings
@@ -39,7 +40,7 @@ private const val DAY_IN_MINUTES = 24 * 60L
  */
 @Mockable
 class Components(private val context: Context) {
-    val backgroundServices by lazy {
+    val backgroundServices by lazyMonitored {
         BackgroundServices(
             context,
             push,
@@ -51,10 +52,10 @@ class Components(private val context: Context) {
             strictMode
         )
     }
-    val services by lazy { Services(context, backgroundServices.accountManager) }
-    val core by lazy { Core(context, analytics.crashReporter, strictMode) }
-    val search by lazy { Search(context) }
-    val useCases by lazy {
+    val services by lazyMonitored { Services(context, backgroundServices.accountManager) }
+    val core by lazyMonitored { Core(context, analytics.crashReporter, strictMode) }
+    val search by lazyMonitored { Search(context) }
+    val useCases by lazyMonitored {
         UseCases(
             context,
             core.engine,
@@ -65,7 +66,7 @@ class Components(private val context: Context) {
             core.topSitesStorage
         )
     }
-    val intentProcessors by lazy {
+    val intentProcessors by lazyMonitored {
         IntentProcessors(
             context,
             core.sessionManager,
@@ -78,7 +79,7 @@ class Components(private val context: Context) {
         )
     }
 
-    val addonCollectionProvider by lazy {
+    val addonCollectionProvider by lazyMonitored {
         // Check if we have a customized (overridden) AMO collection (only supported in Nightly)
         if (Config.channel.isNightlyOrDebug && context.settings().amoCollectionOverrideConfigured()) {
             AddonCollectionProvider(
@@ -103,15 +104,15 @@ class Components(private val context: Context) {
         }
     }
 
-    val appStartupTelemetry by lazy { AppStartupTelemetry(analytics.metrics) }
+    val appStartupTelemetry by lazyMonitored { AppStartupTelemetry(analytics.metrics) }
 
     @Suppress("MagicNumber")
-    val addonUpdater by lazy {
+    val addonUpdater by lazyMonitored {
         DefaultAddonUpdater(context, AddonUpdater.Frequency(12, TimeUnit.HOURS))
     }
 
     @Suppress("MagicNumber")
-    val supportedAddonsChecker by lazy {
+    val supportedAddonsChecker by lazyMonitored {
         DefaultSupportedAddonsChecker(context, SupportedAddonsChecker.Frequency(12, TimeUnit.HOURS),
             onNotificationClickIntent = Intent(context, HomeActivity::class.java).apply {
                 action = Intent.ACTION_VIEW
@@ -121,22 +122,22 @@ class Components(private val context: Context) {
         )
     }
 
-    val addonManager by lazy {
+    val addonManager by lazyMonitored {
         AddonManager(core.store, core.engine, addonCollectionProvider, addonUpdater)
     }
 
-    val analytics by lazy { Analytics(context) }
-    val publicSuffixList by lazy { PublicSuffixList(context) }
-    val clipboardHandler by lazy { ClipboardHandler(context) }
-    val migrationStore by lazy { MigrationStore() }
-    val performance by lazy { PerformanceComponent() }
-    val push by lazy { Push(context, analytics.crashReporter) }
-    val wifiConnectionMonitor by lazy { WifiConnectionMonitor(context as Application) }
-    val strictMode by lazy { StrictModeManager(Config, this) }
+    val analytics by lazyMonitored { Analytics(context) }
+    val publicSuffixList by lazyMonitored { PublicSuffixList(context) }
+    val clipboardHandler by lazyMonitored { ClipboardHandler(context) }
+    val migrationStore by lazyMonitored { MigrationStore() }
+    val performance by lazyMonitored { PerformanceComponent() }
+    val push by lazyMonitored { Push(context, analytics.crashReporter) }
+    val wifiConnectionMonitor by lazyMonitored { WifiConnectionMonitor(context as Application) }
+    val strictMode by lazyMonitored { StrictModeManager(Config, this) }
 
-    val settings by lazy { Settings(context) }
+    val settings by lazyMonitored { Settings(context) }
 
-    val reviewPromptController by lazy {
+    val reviewPromptController by lazyMonitored {
         ReviewPromptController(
             context,
             FenixReviewSettings(settings)

--- a/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -293,14 +293,14 @@ class Core(
     // Use these for startup-path code, where we don't want to do any work that's not strictly necessary.
     // For example, this is how the GeckoEngine delegates (history, logins) are configured.
     // We can fully initialize GeckoEngine without initialized our storage.
-    val lazyHistoryStorage = lazy { PlacesHistoryStorage(context, crashReporter) }
-    val lazyBookmarksStorage = lazy { PlacesBookmarksStorage(context) }
-    val lazyPasswordsStorage = lazy { SyncableLoginsStorage(context, passwordsEncryptionKey) }
+    val lazyHistoryStorage = lazyMonitored { PlacesHistoryStorage(context, crashReporter) }
+    val lazyBookmarksStorage = lazyMonitored { PlacesBookmarksStorage(context) }
+    val lazyPasswordsStorage = lazyMonitored { SyncableLoginsStorage(context, passwordsEncryptionKey) }
 
     /**
      * The storage component to sync and persist tabs in a Firefox Sync account.
      */
-    val lazyRemoteTabsStorage = lazy { RemoteTabsStorage() }
+    val lazyRemoteTabsStorage = lazyMonitored { RemoteTabsStorage() }
 
     // For most other application code (non-startup), these wrappers are perfectly fine and more ergonomic.
     val historyStorage by lazyMonitored { lazyHistoryStorage.value }

--- a/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -303,9 +303,9 @@ class Core(
     val lazyRemoteTabsStorage = lazyMonitored { RemoteTabsStorage() }
 
     // For most other application code (non-startup), these wrappers are perfectly fine and more ergonomic.
-    val historyStorage by lazyMonitored { lazyHistoryStorage.value }
-    val bookmarksStorage by lazyMonitored { lazyBookmarksStorage.value }
-    val passwordsStorage by lazyMonitored { lazyPasswordsStorage.value }
+    val historyStorage: PlacesHistoryStorage get() = lazyHistoryStorage.value
+    val bookmarksStorage: PlacesBookmarksStorage get() = lazyBookmarksStorage.value
+    val passwordsStorage: SyncableLoginsStorage get() = lazyPasswordsStorage.value
 
     val tabCollectionStorage by lazyMonitored {
         TabCollectionStorage(

--- a/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -68,6 +68,7 @@ import org.mozilla.fenix.TelemetryMiddleware
 import org.mozilla.fenix.downloads.DownloadService
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.perf.lazyMonitored
 import org.mozilla.fenix.media.MediaService
 import org.mozilla.fenix.search.telemetry.ads.AdsTelemetry
 import org.mozilla.fenix.search.telemetry.incontent.InContentTelemetry
@@ -91,7 +92,7 @@ class Core(
      * The browser engine component initialized based on the build
      * configuration (see build variants).
      */
-    val engine: Engine by lazy {
+    val engine: Engine by lazyMonitored {
         val defaultSettings = DefaultSettings(
             requestInterceptor = AppRequestInterceptor(context),
             remoteDebuggingEnabled = context.settings().isRemoteDebuggingEnabled &&
@@ -137,7 +138,7 @@ class Core(
     /**
      * [Client] implementation to be used for code depending on `concept-fetch``
      */
-    val client: Client by lazy {
+    val client: Client by lazyMonitored {
         GeckoViewFetchClient(
             context,
             GeckoProvider.getOrCreateRuntime(
@@ -148,14 +149,14 @@ class Core(
         )
     }
 
-    private val sessionStorage: SessionStorage by lazy {
+    private val sessionStorage: SessionStorage by lazyMonitored {
         SessionStorage(context, engine = engine)
     }
 
     /**
      * The [BrowserStore] holds the global [BrowserState].
      */
-    val store by lazy {
+    val store by lazyMonitored {
         BrowserStore(
             middleware = listOf(
                 RecentlyClosedMiddleware(context, RECENTLY_CLOSED_MAX, engine),
@@ -186,12 +187,12 @@ class Core(
     /**
      * The [CustomTabsServiceStore] holds global custom tabs related data.
      */
-    val customTabsStore by lazy { CustomTabsServiceStore() }
+    val customTabsStore by lazyMonitored { CustomTabsServiceStore() }
 
     /**
      * The [RelationChecker] checks Digital Asset Links relationships for Trusted Web Activities.
      */
-    val relationChecker: RelationChecker by lazy {
+    val relationChecker: RelationChecker by lazyMonitored {
         StatementRelationChecker(StatementApi(client))
     }
 
@@ -201,7 +202,7 @@ class Core(
      * sessions from the [SessionStorage], and with a default session (about:blank) in
      * case all sessions/tabs are closed.
      */
-    val sessionManager by lazy {
+    val sessionManager by lazyMonitored {
         SessionManager(engine, store).also { sessionManager ->
             // Install the "icons" WebExtension to automatically load icons for every visited website.
             icons.install(engine, store)
@@ -260,26 +261,26 @@ class Core(
     /**
      * Icons component for loading, caching and processing website icons.
      */
-    val icons by lazy {
+    val icons by lazyMonitored {
         BrowserIcons(context, client)
     }
 
-    val metrics by lazy {
+    val metrics by lazyMonitored {
         context.components.analytics.metrics
     }
 
-    val adsTelemetry by lazy {
+    val adsTelemetry by lazyMonitored {
         AdsTelemetry(metrics)
     }
 
-    val searchTelemetry by lazy {
+    val searchTelemetry by lazyMonitored {
         InContentTelemetry(metrics)
     }
 
     /**
      * Shortcut component for managing shortcuts on the device home screen.
      */
-    val webAppShortcutManager by lazy {
+    val webAppShortcutManager by lazyMonitored {
         WebAppShortcutManager(
             context,
             client,
@@ -302,11 +303,11 @@ class Core(
     val lazyRemoteTabsStorage = lazy { RemoteTabsStorage() }
 
     // For most other application code (non-startup), these wrappers are perfectly fine and more ergonomic.
-    val historyStorage by lazy { lazyHistoryStorage.value }
-    val bookmarksStorage by lazy { lazyBookmarksStorage.value }
-    val passwordsStorage by lazy { lazyPasswordsStorage.value }
+    val historyStorage by lazyMonitored { lazyHistoryStorage.value }
+    val bookmarksStorage by lazyMonitored { lazyBookmarksStorage.value }
+    val passwordsStorage by lazyMonitored { lazyPasswordsStorage.value }
 
-    val tabCollectionStorage by lazy {
+    val tabCollectionStorage by lazyMonitored {
         TabCollectionStorage(
             context,
             sessionManager,
@@ -317,11 +318,11 @@ class Core(
     /**
      * A storage component for persisting thumbnail images of tabs.
      */
-    val thumbnailStorage by lazy { ThumbnailStorage(context) }
+    val thumbnailStorage by lazyMonitored { ThumbnailStorage(context) }
 
-    val pinnedSiteStorage by lazy { PinnedSiteStorage(context) }
+    val pinnedSiteStorage by lazyMonitored { PinnedSiteStorage(context) }
 
-    val topSitesStorage by lazy {
+    val topSitesStorage by lazyMonitored {
         val defaultTopSites = mutableListOf<Pair<String, String>>()
 
         strictMode.resetAfter(StrictMode.allowThreadDiskReads()) {
@@ -360,11 +361,11 @@ class Core(
         )
     }
 
-    val permissionStorage by lazy { PermissionStorage(context) }
+    val permissionStorage by lazyMonitored { PermissionStorage(context) }
 
-    val webAppManifestStorage by lazy { ManifestStorage(context) }
+    val webAppManifestStorage by lazyMonitored { ManifestStorage(context) }
 
-    val loginExceptionStorage by lazy { LoginExceptionStorage(context) }
+    val loginExceptionStorage by lazyMonitored { LoginExceptionStorage(context) }
 
     /**
      * Shared Preferences that encrypt/decrypt using Android KeyStore and lib-dataprotect for 23+
@@ -378,7 +379,7 @@ class Core(
             forceInsecure = !Config.channel.isNightlyOrDebug
         )
 
-    private val passwordsEncryptionKey by lazy {
+    private val passwordsEncryptionKey by lazyMonitored {
         getSecureAbove22Preferences().getString(PASSWORDS_KEY)
             ?: generateEncryptionKey(KEY_STRENGTH).also {
                 if (context.settings().passwordsEncryptionKeyGenerated &&

--- a/app/src/main/java/org/mozilla/fenix/components/IntentProcessors.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/IntentProcessors.kt
@@ -19,6 +19,7 @@ import mozilla.components.support.migration.MigrationIntentProcessor
 import mozilla.components.support.migration.state.MigrationStore
 import org.mozilla.fenix.customtabs.FennecWebAppIntentProcessor
 import org.mozilla.fenix.home.intent.FennecBookmarkShortcutsIntentProcessor
+import org.mozilla.fenix.perf.lazyMonitored
 import org.mozilla.fenix.utils.Mockable
 
 /**
@@ -39,26 +40,26 @@ class IntentProcessors(
     /**
      * Provides intent processing functionality for ACTION_VIEW and ACTION_SEND intents.
      */
-    val intentProcessor by lazy {
+    val intentProcessor by lazyMonitored {
         TabIntentProcessor(sessionManager, sessionUseCases.loadUrl, searchUseCases.newTabSearch, isPrivate = false)
     }
 
     /**
      * Provides intent processing functionality for ACTION_VIEW and ACTION_SEND intents in private tabs.
      */
-    val privateIntentProcessor by lazy {
+    val privateIntentProcessor by lazyMonitored {
         TabIntentProcessor(sessionManager, sessionUseCases.loadUrl, searchUseCases.newTabSearch, isPrivate = true)
     }
 
-    val customTabIntentProcessor by lazy {
+    val customTabIntentProcessor by lazyMonitored {
         CustomTabIntentProcessor(sessionManager, sessionUseCases.loadUrl, context.resources, isPrivate = false)
     }
 
-    val privateCustomTabIntentProcessor by lazy {
+    val privateCustomTabIntentProcessor by lazyMonitored {
         CustomTabIntentProcessor(sessionManager, sessionUseCases.loadUrl, context.resources, isPrivate = true)
     }
 
-    val externalAppIntentProcessors by lazy {
+    val externalAppIntentProcessors by lazyMonitored {
         listOf(
             TrustedWebActivityIntentProcessor(
                 sessionManager = sessionManager,
@@ -72,11 +73,11 @@ class IntentProcessors(
         )
     }
 
-    val fennecPageShortcutIntentProcessor by lazy {
+    val fennecPageShortcutIntentProcessor by lazyMonitored {
         FennecBookmarkShortcutsIntentProcessor(sessionManager, sessionUseCases.loadUrl)
     }
 
-    val migrationIntentProcessor by lazy {
+    val migrationIntentProcessor by lazyMonitored {
         MigrationIntentProcessor(migrationStore)
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/components/PerformanceComponent.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/PerformanceComponent.kt
@@ -6,10 +6,11 @@ package org.mozilla.fenix.components
 
 import mozilla.components.support.utils.RunWhenReadyQueue
 import org.mozilla.fenix.perf.VisualCompletenessQueue
+import org.mozilla.fenix.perf.lazyMonitored
 
 /**
  * Component group for all functionality related to performance.
  */
 class PerformanceComponent {
-    val visualCompletenessQueue by lazy { VisualCompletenessQueue(RunWhenReadyQueue()) }
+    val visualCompletenessQueue by lazyMonitored { VisualCompletenessQueue(RunWhenReadyQueue()) }
 }

--- a/app/src/main/java/org/mozilla/fenix/components/Push.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Push.kt
@@ -10,6 +10,7 @@ import mozilla.components.feature.push.PushConfig
 import mozilla.components.lib.crash.CrashReporter
 import mozilla.components.support.base.log.logger.Logger
 import org.mozilla.fenix.R
+import org.mozilla.fenix.perf.lazyMonitored
 import org.mozilla.fenix.push.FirebasePushService
 
 /**
@@ -17,7 +18,7 @@ import org.mozilla.fenix.push.FirebasePushService
  * push messaging (e.g. WebPush, SendTab).
  */
 class Push(context: Context, crashReporter: CrashReporter) {
-    val feature by lazy {
+    val feature by lazyMonitored {
         pushConfig?.let { config ->
             AutoPushFeature(
                 context = context,
@@ -28,13 +29,13 @@ class Push(context: Context, crashReporter: CrashReporter) {
         }
     }
 
-    private val pushConfig: PushConfig? by lazy {
+    private val pushConfig: PushConfig? by lazyMonitored {
         val logger = Logger("PushConfig")
         val projectIdKey = context.getString(R.string.pref_key_push_project_id)
         val resId = context.resources.getIdentifier(projectIdKey, "string", context.packageName)
         if (resId == 0) {
             logger.warn("No firebase configuration found; cannot support push service.")
-            return@lazy null
+            return@lazyMonitored null
         }
 
         logger.debug("Creating push configuration for autopush.")
@@ -42,5 +43,5 @@ class Push(context: Context, crashReporter: CrashReporter) {
         PushConfig(projectId)
     }
 
-    private val pushService by lazy { FirebasePushService() }
+    private val pushService by lazyMonitored { FirebasePushService() }
 }

--- a/app/src/main/java/org/mozilla/fenix/components/Search.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Search.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import mozilla.components.browser.search.SearchEngineManager
 import org.mozilla.fenix.components.searchengine.FenixSearchEngineProvider
+import org.mozilla.fenix.perf.lazyMonitored
 import org.mozilla.fenix.utils.Mockable
 
 /**
@@ -22,7 +23,7 @@ class Search(private val context: Context) {
     /**
      * This component provides access to a centralized registry of search engines.
      */
-    val searchEngineManager by lazy {
+    val searchEngineManager by lazyMonitored {
         SearchEngineManager(
             coroutineContext = IO,
             providers = listOf(provider)

--- a/app/src/main/java/org/mozilla/fenix/components/Services.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Services.kt
@@ -14,6 +14,7 @@ import mozilla.components.feature.app.links.AppLinksInterceptor
 import mozilla.components.service.fxa.manager.FxaAccountManager
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.getPreferenceKey
+import org.mozilla.fenix.perf.lazyMonitored
 import org.mozilla.fenix.settings.SupportUtils
 import org.mozilla.fenix.utils.Mockable
 
@@ -25,7 +26,7 @@ class Services(
     private val context: Context,
     private val accountManager: FxaAccountManager
 ) {
-    val accountsAuthFeature by lazy {
+    val accountsAuthFeature by lazyMonitored {
         FirefoxAccountsAuthFeature(accountManager, FxaServer.REDIRECT_URL) { context, authUrl ->
             CoroutineScope(Dispatchers.Main).launch {
                 val intent = SupportUtils.createAuthCustomTabIntent(context, authUrl)
@@ -34,7 +35,7 @@ class Services(
         }
     }
 
-    val appLinksInterceptor by lazy {
+    val appLinksInterceptor by lazyMonitored {
         AppLinksInterceptor(
             context,
             interceptLinkClicks = true,

--- a/app/src/main/java/org/mozilla/fenix/components/UseCases.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/UseCases.kt
@@ -22,6 +22,7 @@ import mozilla.components.feature.session.TrackingProtectionUseCases
 import mozilla.components.feature.tabs.TabsUseCases
 import mozilla.components.feature.top.sites.TopSitesStorage
 import mozilla.components.feature.top.sites.TopSitesUseCases
+import org.mozilla.fenix.perf.lazyMonitored
 import org.mozilla.fenix.utils.Mockable
 
 /**
@@ -42,17 +43,17 @@ class UseCases(
     /**
      * Use cases that provide engine interactions for a given browser session.
      */
-    val sessionUseCases by lazy { SessionUseCases(store, sessionManager) }
+    val sessionUseCases by lazyMonitored { SessionUseCases(store, sessionManager) }
 
     /**
      * Use cases that provide tab management.
      */
-    val tabsUseCases: TabsUseCases by lazy { TabsUseCases(store, sessionManager) }
+    val tabsUseCases: TabsUseCases by lazyMonitored { TabsUseCases(store, sessionManager) }
 
     /**
      * Use cases that provide search engine integration.
      */
-    val searchUseCases by lazy {
+    val searchUseCases by lazyMonitored {
         SearchUseCases(
             context,
             store,
@@ -64,22 +65,22 @@ class UseCases(
     /**
      * Use cases that provide settings management.
      */
-    val settingsUseCases by lazy { SettingsUseCases(engine, store) }
+    val settingsUseCases by lazyMonitored { SettingsUseCases(engine, store) }
 
-    val appLinksUseCases by lazy { AppLinksUseCases(context.applicationContext) }
+    val appLinksUseCases by lazyMonitored { AppLinksUseCases(context.applicationContext) }
 
-    val webAppUseCases by lazy {
+    val webAppUseCases by lazyMonitored {
         WebAppUseCases(context, sessionManager, shortcutManager)
     }
 
-    val downloadUseCases by lazy { DownloadsUseCases(store) }
+    val downloadUseCases by lazyMonitored { DownloadsUseCases(store) }
 
-    val contextMenuUseCases by lazy { ContextMenuUseCases(store) }
+    val contextMenuUseCases by lazyMonitored { ContextMenuUseCases(store) }
 
-    val trackingProtectionUseCases by lazy { TrackingProtectionUseCases(store, engine) }
+    val trackingProtectionUseCases by lazyMonitored { TrackingProtectionUseCases(store, engine) }
 
     /**
      * Use cases that provide top sites management.
      */
-    val topSitesUseCase by lazy { TopSitesUseCases(topSitesStorage) }
+    val topSitesUseCase by lazyMonitored { TopSitesUseCases(topSitesStorage) }
 }

--- a/app/src/main/java/org/mozilla/fenix/perf/LazyMonitored.kt
+++ b/app/src/main/java/org/mozilla/fenix/perf/LazyMonitored.kt
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.perf
+
+import mozilla.components.support.base.log.logger.Logger
+import java.util.concurrent.atomic.AtomicInteger
+
+private val logger = Logger("LazyMonitored")
+
+/**
+ * A container for the number of components initialized.
+ */
+object ComponentInitCount {
+    val count = AtomicInteger(0)
+}
+
+/**
+ * A convenience function for setting the [LazyMonitored] property delegate, which wraps
+ * [lazy] to add performance monitoring.
+ */
+fun <T> lazyMonitored(initializer: () -> T) = LazyMonitored(initializer)
+
+/**
+ * A wrapper around the [lazy] property delegate to monitor for performance related issues.
+ * For example, we can count the number of components initialized to see how the number of
+ * components initialized on start up impacts start up time.
+ */
+class LazyMonitored<T>(initializer: () -> T) {
+    // Lazy is thread safe.
+    private val lazyValue = lazy {
+        // We're unlikely to have 4 billion components so we don't handle overflow.
+        val componentInitCount = ComponentInitCount.count.incrementAndGet()
+
+        initializer().also {
+            @Suppress("UNNECESSARY_NOT_NULL_ASSERTION") // the compiler fails with !! but warns with !!.
+            val className = if (it == null) "null" else it!!::class.java.canonicalName
+            logger.debug("Init component #$componentInitCount: $className")
+        }
+    }
+
+    operator fun getValue(thisRef: Any?, property: KProperty<*>): T = lazyValue.value
+}

--- a/app/src/main/java/org/mozilla/fenix/perf/LazyMonitored.kt
+++ b/app/src/main/java/org/mozilla/fenix/perf/LazyMonitored.kt
@@ -27,7 +27,7 @@ fun <T> lazyMonitored(initializer: () -> T) = LazyMonitored(initializer)
  * For example, we can count the number of components initialized to see how the number of
  * components initialized on start up impacts start up time.
  */
-class LazyMonitored<T>(initializer: () -> T) {
+class LazyMonitored<T>(initializer: () -> T) : Lazy<T> {
     // Lazy is thread safe.
     private val lazyValue = lazy {
         // We're unlikely to have 4 billion components so we don't handle overflow.
@@ -40,5 +40,6 @@ class LazyMonitored<T>(initializer: () -> T) {
         }
     }
 
-    operator fun getValue(thisRef: Any?, property: KProperty<*>): T = lazyValue.value
+    override val value: T get() = lazyValue.value
+    override fun isInitialized(): Boolean = lazyValue.isInitialized()
 }

--- a/app/src/main/java/org/mozilla/fenix/perf/LazyMonitored.kt
+++ b/app/src/main/java/org/mozilla/fenix/perf/LazyMonitored.kt
@@ -20,14 +20,14 @@ object ComponentInitCount {
  * A convenience function for setting the [LazyMonitored] property delegate, which wraps
  * [lazy] to add performance monitoring.
  */
-fun <T> lazyMonitored(initializer: () -> T) = LazyMonitored(initializer)
+fun <T> lazyMonitored(initializer: () -> T): Lazy<T> = LazyMonitored(initializer)
 
 /**
  * A wrapper around the [lazy] property delegate to monitor for performance related issues.
  * For example, we can count the number of components initialized to see how the number of
  * components initialized on start up impacts start up time.
  */
-class LazyMonitored<T>(initializer: () -> T) : Lazy<T> {
+private class LazyMonitored<T>(initializer: () -> T) : Lazy<T> {
     // Lazy is thread safe.
     private val lazyValue = lazy {
         // We're unlikely to have 4 billion components so we don't handle overflow.

--- a/app/src/test/java/org/mozilla/fenix/perf/LazyMonitoredTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/perf/LazyMonitoredTest.kt
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.perf
+
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class LazyMonitoredTest {
+
+    private val componentInitCount get() = ComponentInitCount.count.get()
+
+    @Before
+    fun setUp() {
+        ComponentInitCount.count.set(0)
+    }
+
+    @Test
+    fun `WHEN using the convenience function THEN it returns a lazy monitored`() {
+        val actual = lazyMonitored { }
+        assertEquals(LazyMonitored::class, actual::class)
+    }
+
+    @Test
+    fun `WHEN accessing a lazy monitored THEN it returns the initializer value`() {
+        val actual by lazyMonitored { 4 }
+        assertEquals(4, actual)
+    }
+
+    @Test
+    fun `WHEN accessing a lazy monitored THEN the component init count is incremented`() {
+        assertEquals(0, componentInitCount)
+
+        val monitored by lazyMonitored { }
+        // We must access the value to trigger init.
+        @Suppress("UNUSED_EXPRESSION") monitored
+
+        assertEquals(1, componentInitCount)
+    }
+}

--- a/app/src/test/java/org/mozilla/fenix/perf/LazyMonitoredTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/perf/LazyMonitoredTest.kt
@@ -18,12 +18,6 @@ class LazyMonitoredTest {
     }
 
     @Test
-    fun `WHEN using the convenience function THEN it returns a lazy monitored`() {
-        val actual = lazyMonitored { }
-        assertEquals(LazyMonitored::class, actual::class)
-    }
-
-    @Test
     fun `WHEN accessing a lazy monitored THEN it returns the initializer value`() {
         val actual by lazyMonitored { 4 }
         assertEquals(4, actual)

--- a/config/detekt.yml
+++ b/config/detekt.yml
@@ -120,6 +120,8 @@ mozilla-detekt-rules:
   MozillaRunBlockingCheck:
     active: true
     excludes: "**/*Test.kt, **/*Spec.kt, **/test/**, **/androidTest/**"
+  MozillaUseLazyMonitored:
+    active: true
 
 empty-blocks:
   active: true

--- a/mozilla-detekt-rules/build.gradle
+++ b/mozilla-detekt-rules/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'kotlin'
 
 dependencies {
   compileOnly Deps.detektApi
+  implementation Deps.androidx_annotation
 
   // I didn't look thoroughly enough to really know what's going on here but I think
   // the detekt API uses jdk8 so if we provide jdk7, the dependency collision system

--- a/mozilla-detekt-rules/src/main/java/org/mozilla/fenix/detektrules/CustomRulesetProvider.kt
+++ b/mozilla-detekt-rules/src/main/java/org/mozilla/fenix/detektrules/CustomRulesetProvider.kt
@@ -7,6 +7,7 @@ package org.mozilla.fenix.detektrules
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+import org.mozilla.fenix.detektrules.perf.MozillaUseLazyMonitored
 
 class CustomRulesetProvider : RuleSetProvider {
     override val ruleSetId: String = "mozilla-detekt-rules"
@@ -17,7 +18,8 @@ class CustomRulesetProvider : RuleSetProvider {
             MozillaBannedPropertyAccess(config),
             MozillaStrictModeSuppression(config),
             MozillaCorrectUnitTestRunner(config),
-            MozillaRunBlockingCheck(config)
+            MozillaRunBlockingCheck(config),
+            MozillaUseLazyMonitored(config)
         )
     )
 }

--- a/mozilla-detekt-rules/src/main/java/org/mozilla/fenix/detektrules/perf/MozillaUseLazyMonitored.kt
+++ b/mozilla-detekt-rules/src/main/java/org/mozilla/fenix/detektrules/perf/MozillaUseLazyMonitored.kt
@@ -1,0 +1,86 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.detektrules.perf
+
+import androidx.annotation.VisibleForTesting
+import androidx.annotation.VisibleForTesting.PRIVATE
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.internal.PathFilters
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtPropertyDelegate
+
+private const val FUN_LAZY = "lazy"
+
+private const val ERROR_MESSAGE = "Please use `by lazyMonitored` instead of `by lazy` " +
+    "to declare application components (e.g. variables in Components.kt): it contains extra code to " +
+    "monitor for performance regressions. This change is not necessary for non-components."
+
+/**
+ * Prevents use of lazy in component groups files where lazyMonitored should be used instead.
+ */
+open class MozillaUseLazyMonitored(config: Config) : Rule(config) {
+    override val issue = Issue(
+        this::class.java.simpleName,
+        Severity.Performance,
+        "Prevents use of lazy in component groups files where lazyMonitored should be used instead",
+        Debt.FIVE_MINS
+    )
+
+    override val filters = PathFilters.of(
+        includes = COMPONENT_GROUP_FILES.map { "**$it" },
+        excludes = emptyList()
+    )
+
+    override fun visitPropertyDelegate(delegate: KtPropertyDelegate) {
+        super.visitPropertyDelegate(delegate)
+
+        val delegateFunction = delegate.expression?.node?.firstChildNode // the "lazy" in "by lazy { ..."
+        if (delegateFunction?.chars == FUN_LAZY) {
+            report(CodeSmell(issue, Entity.from(delegate), ERROR_MESSAGE))
+        }
+    }
+
+    override fun visitProperty(property: KtProperty) {
+        super.visitProperty(property)
+
+        // I only expect components to be declared as members, not at the top level or inside block scopes.
+        if (!property.isMember) return
+
+        val rightHandSideOfAssignment = property.initializer
+
+        // This is intended to catch `val example = lazy {` or `... lazy(`. It may be possible to
+        // make lazy not the first node to the right of the equal sign but it's probably uncommon
+        // enough that we don't handle that case.
+        val assignedFunction = rightHandSideOfAssignment?.firstChild
+        if (assignedFunction?.node?.chars == FUN_LAZY) {
+            report(CodeSmell(issue, Entity.from(property), ERROR_MESSAGE))
+        }
+    }
+
+    companion object {
+        /**
+         * All files that represent a "component group".
+         */
+        @VisibleForTesting(otherwise = PRIVATE)
+        val COMPONENT_GROUP_FILES = listOf(
+            "Analytics",
+            "BackgroundServices",
+            "Components",
+            "Core",
+            "IntentProcessors",
+            "PerformanceComponent",
+            "Push",
+            "Search",
+            "Services",
+            "UseCases"
+        ).map { "app/src/main/java/org/mozilla/fenix/components/$it.kt" }
+    }
+}

--- a/mozilla-detekt-rules/src/test/java/org/mozilla/fenix/detektrules/perf/MozillaUseLazyMonitoredTest.kt
+++ b/mozilla-detekt-rules/src/test/java/org/mozilla/fenix/detektrules/perf/MozillaUseLazyMonitoredTest.kt
@@ -1,0 +1,100 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.detektrules.perf
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.internal.PathFilters
+import io.gitlab.arturbosch.detekt.test.lint
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import java.io.File
+import java.nio.file.Paths
+
+internal class MozillaUseLazyMonitoredTest {
+
+    private lateinit var actualCheck: MozillaUseLazyMonitored
+    private lateinit var check: TestMozillaUseLazyMonitored
+
+    @BeforeEach
+    fun setUp() {
+        actualCheck = MozillaUseLazyMonitored(Config.empty)
+        check = TestMozillaUseLazyMonitored()
+    }
+
+    @Test
+    fun `GIVEN the hard-coded component group file paths THEN there are some to run the lint on`() {
+        assertFalse(MozillaUseLazyMonitored.COMPONENT_GROUP_FILES.isEmpty())
+    }
+
+    @Test
+    fun `GIVEN the hard-coded component group file paths THEN they all exist`() {
+        MozillaUseLazyMonitored.COMPONENT_GROUP_FILES.forEach { path ->
+            // The tests working directory is `<repo>/mozilla-detekt-rules` so we need to back out.
+            val modifiedPath = "../$path"
+
+            val errorMessage = "This lint rule hard-codes paths to files containing \"component groups\". " +
+                "One of these files - $path - no longer exists. Please update the check " +
+                "${MozillaUseLazyMonitored::class.java.simpleName} with the new path."
+            assertTrue(File(modifiedPath).exists(), errorMessage)
+        }
+    }
+
+    @Test
+    fun `GIVEN the hard-coded component group file paths THEN none of the files are ignored`() {
+        MozillaUseLazyMonitored.COMPONENT_GROUP_FILES.forEach {
+            assertTrue(actualCheck.filters?.isIgnored(Paths.get(it)) == false)
+        }
+    }
+
+    @Test
+    fun `GIVEN a snippet with lazyMonitored THEN there are no findings`() {
+        val text = getCodeInClass("val example by lazyMonitored { 4 }")
+        assertNoFindings(text)
+    }
+
+    @ParameterizedTest @ValueSource(strings = [
+        "val example by lazy { 4 }",
+        "val example    by    lazy    {    4    }",
+        "val example\nby\nlazy\n{\n4\n}"
+    ])
+    fun `GIVEN a snippet with by lazy THEN there is a finding`(innerText: String) {
+        val text = getCodeInClass(innerText)
+        assertOneFinding(text)
+    }
+
+    @ParameterizedTest @ValueSource(strings = [
+        "val example = lazy(::exampleFun)",
+        "val example   =   lazy   (  ::exampleFun)",
+        "val example\n=\nlazy\n(\n::exampleFun\n)"
+    ])
+    fun `GIVEN a snippet with = lazy THEN there is a finding`(innerText: String) {
+        val text = getCodeInClass(innerText)
+        assertOneFinding(text)
+    }
+
+    private fun assertNoFindings(text: String) {
+        val findings = check.lint(text)
+        assertEquals(0, findings.size)
+    }
+
+    private fun assertOneFinding(text: String) {
+        val findings = check.lint(text)
+        assertEquals(1, findings.size)
+        assertEquals(check.issue, findings[0].issue)
+    }
+}
+
+private fun getCodeInClass(text: String): String = """class Example() {
+    $text
+}"""
+
+class TestMozillaUseLazyMonitored : MozillaUseLazyMonitored(Config.empty) {
+    // If left on their own, the path filters will prevent us from running checks on raw strings.
+    // I'm not sure the best way to work around that so we just override the value.
+    override val filters: PathFilters? = null
+}


### PR DESCRIPTION
This PR relies on the changes from https://github.com/mozilla-mobile/fenix/pull/16101 to make the detekt tests run.

See https://github.com/mozilla-mobile/fenix/issues/15279#issuecomment-719853480 for motivations. This PR will implement lazyMonitored to count the number of components init and adds a lint rule to ensure new additions use it. ~~I would have liked to also add the automated test to count the number of usages but that would be best to land after https://github.com/mozilla-mobile/fenix/pull/16101.~~ Added to the PR

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
