### PR TITLE
For #6313 - Remove unneeded delay in BrowserAnimator

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserAnimator.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserAnimator.kt
@@ -12,7 +12,6 @@ import androidx.core.graphics.drawable.toDrawable
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleCoroutineScope
 import androidx.navigation.NavOptions
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import mozilla.components.concept.engine.EngineView
 import org.mozilla.fenix.R
@@ -38,11 +37,8 @@ class BrowserAnimator(
         get() = swipeRefresh.get()
 
     fun beginAnimateInIfNecessary() {
-        viewLifecycleScope.get()?.launch {
-            delay(ANIMATION_DELAY)
-            unwrappedEngineView?.asView()?.visibility = View.VISIBLE
-            unwrappedSwipeRefresh?.background = null
-        }
+        unwrappedEngineView?.asView()?.visibility = View.VISIBLE
+        unwrappedSwipeRefresh?.background = null
     }
 
     /**
@@ -81,8 +77,6 @@ class BrowserAnimator(
     }
 
     companion object {
-        private const val ANIMATION_DELAY = 100L
-
         fun getToolbarNavOptions(context: Context): NavOptions {
             val navOptions = NavOptions.Builder()
 


### PR DESCRIPTION
With https://github.com/mozilla-mobile/android-components/pull/8797 landed, the short white flash should now be gone, so we can remove the remaining animation delay (that was a hack to avoid seeing this)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
