### PR TITLE
Closes #12971 - Show collection saved snackbar above...

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayDialogFragment.kt
@@ -71,7 +71,11 @@ class TabTrayDialogFragment : AppCompatDialogFragment(), UserInteractionHandler 
     private lateinit var tabTrayDialogStore: TabTrayDialogFragmentStore
 
     private val snackbarAnchor: View?
-        get() = if (tabTrayView.fabView.new_tab_button.isVisible) tabTrayView.fabView.new_tab_button
+        get() = if (tabTrayView.fabView.new_tab_button.isVisible || tabTrayView.mode != Mode.Normal) tabTrayView.fabView.new_tab_button
+        /* During selection of the tabs to the collection, the FAB is not visible,
+           which leads to not attaching a needed AnchorView. That's why, we're not only checking, if it's not visible,
+           but also if we're not in a "Normal" mode, so after selecting tabs for a collection, we're pushing snackbar
+           above the FAB, as we're switching from "Multiselect" to "Normal". */
         else null
 
     private val collectionStorageObserver = object : TabCollectionStorage.Observer {

--- a/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayDialogFragment.kt
@@ -71,7 +71,8 @@ class TabTrayDialogFragment : AppCompatDialogFragment(), UserInteractionHandler 
     private lateinit var tabTrayDialogStore: TabTrayDialogFragmentStore
 
     private val snackbarAnchor: View?
-        get() = if (tabTrayView.fabView.new_tab_button.isVisible || tabTrayView.mode != Mode.Normal) tabTrayView.fabView.new_tab_button
+        get() = if (tabTrayView.fabView.new_tab_button.isVisible ||
+                    tabTrayView.mode != Mode.Normal) tabTrayView.fabView.new_tab_button
         /* During selection of the tabs to the collection, the FAB is not visible,
            which leads to not attaching a needed AnchorView. That's why, we're not only checking, if it's not visible,
            but also if we're not in a "Normal" mode, so after selecting tabs for a collection, we're pushing snackbar


### PR DESCRIPTION
… FAB via attaching "snackbarAnchor" also when TabTrayViewDialogFragmentState.Mode != Normal.

Closes #12971 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

![Screencast](https://user-images.githubusercontent.com/11944411/97816233-2667b380-1c94-11eb-8f8a-557a0a084b7e.gif)

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
