### PR TITLE
Closes #16256: Introduce build flag for "Mozilla Online" variant.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,6 +36,13 @@ android {
         manifestPlaceholders = [
                 "deepLinkScheme": deepLinkSchemeValue
         ]
+
+        // Build flag for "Mozilla Online" variants. See `Config.isMozillaOnline`.
+        if (project.hasProperty("mozillaOnline") || gradle.hasProperty("localProperties.mozillaOnline")) {
+            buildConfigField "boolean", "MOZILLA_ONLINE", "true"
+        } else {
+            buildConfigField "boolean", "MOZILLA_ONLINE", "false"
+        }
     }
 
     def releaseTemplate = {

--- a/app/src/main/java/org/mozilla/fenix/Config.kt
+++ b/app/src/main/java/org/mozilla/fenix/Config.kt
@@ -52,6 +52,13 @@ enum class ReleaseChannel {
      */
     val isFenix: Boolean
         get() = !isFennec
+
+    /**
+     * Is this a "Mozilla Online" build of Fenix? "Mozilla Online" is the Chinese branch of Mozilla
+     * and this flag will be `true` for builds shipping to Chinese app stores.
+     */
+    val isMozillaOnline: Boolean
+        get() = BuildConfig.MOZILLA_ONLINE
 }
 
 object Config {


### PR DESCRIPTION
This patch introduces a build flag that can be used on demand on the command line (`./gradlew -PmozillaOnline [..}`) or
permanently when added to local.properties (`mozillaOnline`).

At runtime `Config.channel.isMozillaOnline` will return `true` if the flag was set at build time.