### PR TITLE
For #6521 - Remove auto sigin onboarding card

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/Mode.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/Mode.kt
@@ -59,12 +59,10 @@ class CurrentMode(
         if (account != null) {
             Mode.Onboarding(OnboardingState.SignedIn)
         } else {
-            val availableAccounts = accountManager.shareableAccounts(context)
-            if (availableAccounts.isEmpty()) {
-                Mode.Onboarding(OnboardingState.SignedOutNoAutoSignIn)
-            } else {
-                Mode.Onboarding(OnboardingState.SignedOutCanAutoSignIn(availableAccounts[0]))
-            }
+            Mode.Onboarding(OnboardingState.SignedOutNoAutoSignIn)
+            // The following other state is effectively disabled - #6521
+            // Code still exists in app for when it will be used again - #15694
+            // Mode.Onboarding(OnboardingState.SignedOutCanAutoSignIn(accountManager.shareableAccounts(context)[0]))
         }
     }
 

--- a/app/src/test/java/org/mozilla/fenix/home/ModeTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/ModeTest.kt
@@ -10,7 +10,6 @@ import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
 import mozilla.components.service.fxa.manager.FxaAccountManager
-import mozilla.components.service.fxa.sharing.ShareableAccount
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -79,18 +78,19 @@ class ModeTest {
         assertEquals(Mode.Onboarding(OnboardingState.SignedOutNoAutoSignIn), currentMode.getCurrentMode())
     }
 
-    @Test
-    fun `get current onboarding mode when can auto sign in`() {
-        val shareableAccount: ShareableAccount = mockk()
-        every { onboarding.userHasBeenOnboarded() } returns false
-        every { accountManager.authenticatedAccount() } returns null
-        every { accountManager.shareableAccounts(context) } returns listOf(shareableAccount)
-
-        assertEquals(
-            Mode.Onboarding(OnboardingState.SignedOutCanAutoSignIn(shareableAccount)),
-            currentMode.getCurrentMode()
-        )
-    }
+    // Temporarily disabled. See #6521
+    // @Test
+    // fun `get current onboarding mode when can auto sign in`() {
+    //     val shareableAccount: ShareableAccount = mockk()
+    //     every { onboarding.userHasBeenOnboarded() } returns false
+    //     every { accountManager.authenticatedAccount() } returns null
+    //     every { accountManager.shareableAccounts(context) } returns listOf(shareableAccount)
+    //
+    //     assertEquals(
+    //         Mode.Onboarding(OnboardingState.SignedOutCanAutoSignIn(shareableAccount)),
+    //         currentMode.getCurrentMode()
+    //     )
+    // }
 
     @Test
     fun `emit mode change`() {


### PR DESCRIPTION
With the Fennec -> Fenix migration complete there is no other Mozilla
application that would serve as a custom account provider hence the automatic
signin would not be possible.
Make this more obvious by commenting out the code that would trigger an
onboarding banner for it but keep the code in the app for when #15694 would add
to Fenix the ability to serve as a custom account provider.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: No tests. Small change.
- [x] **Screenshots**: No UI difference versus recent builds.
- [x] **Accessibility**: The code in this PR does not include any a11y user facing features.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
