### PR TITLE
For #13446 UI tests: wait for historyList to exist

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/HistoryTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/HistoryTest.kt
@@ -82,6 +82,7 @@ class HistoryTest {
             mDevice.waitForIdle()
         }.openThreeDotMenu {
         }.openHistory {
+            verifyHistoryListExists()
             historyListIdlingResource =
                 RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.history_list))
             IdlingRegistry.getInstance().register(historyListIdlingResource!!)
@@ -101,6 +102,7 @@ class HistoryTest {
             mDevice.waitForIdle()
         }.openThreeDotMenu {
         }.openHistory {
+            verifyHistoryListExists()
             historyListIdlingResource =
                 RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.history_list))
             IdlingRegistry.getInstance().register(historyListIdlingResource!!)
@@ -119,6 +121,7 @@ class HistoryTest {
             mDevice.waitForIdle()
         }.openThreeDotMenu {
         }.openHistory {
+            verifyHistoryListExists()
             historyListIdlingResource =
                 RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.history_list))
             IdlingRegistry.getInstance().register(historyListIdlingResource!!)
@@ -140,6 +143,7 @@ class HistoryTest {
             mDevice.waitForIdle()
         }.openThreeDotMenu {
         }.openHistory {
+            verifyHistoryListExists()
             historyListIdlingResource =
                 RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.history_list))
             IdlingRegistry.getInstance().register(historyListIdlingResource!!)
@@ -160,6 +164,7 @@ class HistoryTest {
             mDevice.waitForIdle()
         }.openThreeDotMenu {
         }.openHistory {
+            verifyHistoryListExists()
             historyListIdlingResource =
                 RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.history_list))
             IdlingRegistry.getInstance().register(historyListIdlingResource!!)
@@ -180,6 +185,7 @@ class HistoryTest {
             mDevice.waitForIdle()
         }.openThreeDotMenu {
         }.openHistory {
+            verifyHistoryListExists()
             historyListIdlingResource =
                 RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.history_list))
             IdlingRegistry.getInstance().register(historyListIdlingResource!!)
@@ -200,6 +206,7 @@ class HistoryTest {
             mDevice.waitForIdle()
         }.openThreeDotMenu {
         }.openHistory {
+            verifyHistoryListExists()
             historyListIdlingResource =
                 RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.history_list))
             IdlingRegistry.getInstance().register(historyListIdlingResource!!)
@@ -221,6 +228,7 @@ class HistoryTest {
             mDevice.waitForIdle()
         }.openThreeDotMenu {
         }.openHistory {
+            verifyHistoryListExists()
             historyListIdlingResource =
                 RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.history_list))
             IdlingRegistry.getInstance().register(historyListIdlingResource!!)
@@ -250,6 +258,7 @@ class HistoryTest {
 
         homeScreen { }.openThreeDotMenu {
         }.openHistory {
+            verifyHistoryListExists()
             historyListIdlingResource =
                 RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.history_list))
             IdlingRegistry.getInstance().register(historyListIdlingResource!!)
@@ -273,6 +282,7 @@ class HistoryTest {
             mDevice.waitForIdle()
         }.openThreeDotMenu {
         }.openHistory {
+            verifyHistoryListExists()
             historyListIdlingResource =
                 RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.history_list))
             IdlingRegistry.getInstance().register(historyListIdlingResource!!)
@@ -299,6 +309,7 @@ class HistoryTest {
         }.submitQuery(secondWebPage.url.toString()) {
         }.openThreeDotMenu {
         }.openHistory {
+            verifyHistoryListExists()
             historyListIdlingResource =
                 RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.history_list), 1)
             IdlingRegistry.getInstance().register(historyListIdlingResource!!)
@@ -326,6 +337,7 @@ class HistoryTest {
             mDevice.waitForIdle()
         }.openThreeDotMenu {
         }.openHistory {
+            verifyHistoryListExists()
             historyListIdlingResource =
                 RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.history_list))
             IdlingRegistry.getInstance().register(historyListIdlingResource!!)

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HistoryRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HistoryRobot.kt
@@ -39,6 +39,8 @@ class HistoryRobot {
         assertEmptyHistoryView()
     }
 
+    fun verifyHistoryListExists() = assertHistoryListExists()
+
     fun verifyVisitedTimeTitle() {
         mDevice.waitNotNull(
             Until.findObject(
@@ -130,6 +132,9 @@ private fun assertEmptyHistoryView() =
         )
     )
         .check(matches(withText("No history here")))
+
+private fun assertHistoryListExists() =
+    mDevice.findObject(UiSelector().resourceId("R.id.history_list")).waitForExists(waitingTime)
 
 private fun assertVisitedTimeTitle() =
     onView(withId(R.id.header_title)).check(matches(withText("Today")))


### PR DESCRIPTION
Tests in #13446 are failing because there might be some UI covering the app and is not visible in the Firebase recordings. Added an extra wait to see if this would permit the recordings to capture that when the tests fail.