### PR TITLE
For #15725: Set up preferences in onCreatePreferences instead of onResume

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/CustomizationFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/CustomizationFragment.kt
@@ -34,12 +34,13 @@ class CustomizationFragment : PreferenceFragmentCompat() {
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         setPreferencesFromResource(R.xml.customization_preferences, rootKey)
+
+        setupPreferences()
     }
 
     override fun onResume() {
         super.onResume()
         showToolbar(getString(R.string.preferences_customize))
-        setupPreferences()
     }
 
     private fun setupPreferences() {


### PR DESCRIPTION
set up preferences in onCreatePreferences instead of onResume so that their visibility is determined before the screen appears rather than after



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture


Before:
![before](https://user-images.githubusercontent.com/38375996/97897015-903c9780-1d3e-11eb-9649-c6bb55b77106.gif)


After:
![after](https://user-images.githubusercontent.com/38375996/97897069-a0547700-1d3e-11eb-9834-b84e39d3bbe7.gif)
