### PR TITLE
Bug 1670284 - Enable webrender for all tests and run a subset without webrender.

### DIFF
--- a/taskcluster/ci/browsertime/kind.yml
+++ b/taskcluster/ci/browsertime/kind.yml
@@ -37,7 +37,7 @@ job-defaults:
                     subject: '[{product_name}] Raptor-Browsertime job "{task_name}" failed'
                     to-addresses: [perftest-alerts@mozilla.com]
             default: {}
-    run-on-tasks-for: [github-pull-request]
+    run-on-tasks-for: []
     treeherder:
         kind: test
         tier: 2

--- a/taskcluster/ci/browsertime/kind.yml
+++ b/taskcluster/ci/browsertime/kind.yml
@@ -72,6 +72,7 @@ job-defaults:
               type: directory
     run-visual-metrics: True
     chimera: True
+    web-render-only: True
     run:
         using: run-task
         checkout: false
@@ -106,6 +107,7 @@ jobs:
 
     tp6m-2-cold:
         test-name: google
+        web-render-only: False
         treeherder:
             symbol: 'Btime(tp6m-2-c)'
 
@@ -126,6 +128,7 @@ jobs:
 
     tp6m-6-cold:
         test-name: amazon-search
+        web-render-only: False
         treeherder:
             symbol: 'Btime(tp6m-6-c)'
 
@@ -151,6 +154,7 @@ jobs:
 
     tp6m-11-cold:
         test-name: microsoft-support
+        web-render-only: False
         treeherder:
             symbol: 'Btime(tp6m-11-c)'
 
@@ -161,6 +165,7 @@ jobs:
 
     tp6m-13-cold:
         test-name: espn
+        web-render-only: False
         treeherder:
             symbol: 'Btime(tp6m-13-c)'
 
@@ -171,6 +176,7 @@ jobs:
 
     tp6m-15-cold:
         test-name: facebook
+        web-render-only: False
         treeherder:
             symbol: 'Btime(tp6m-15-c)'
 
@@ -196,6 +202,7 @@ jobs:
 
     tp6m-20-cold:
         test-name: youtube-watch
+        web-render-only: False
         treeherder:
             symbol: 'Btime(tp6m-20-c)'
 
@@ -216,6 +223,7 @@ jobs:
 
     tp6m-24-cold:
         test-name: allrecipes
+        web-render-only: False
         treeherder:
             symbol: 'Btime(tp6m-24-c)'
 

--- a/taskcluster/ci/browsertime/kind.yml
+++ b/taskcluster/ci/browsertime/kind.yml
@@ -37,7 +37,7 @@ job-defaults:
                     subject: '[{product_name}] Raptor-Browsertime job "{task_name}" failed'
                     to-addresses: [perftest-alerts@mozilla.com]
             default: {}
-    run-on-tasks-for: []
+    run-on-tasks-for: [github-pull-request]
     treeherder:
         kind: test
         tier: 2

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -4,6 +4,7 @@ treeherder:
     group-names:
         'beta': 'Beta-related tasks with same APK configuration as Fennec'
         'Btime': 'Raptor-Browsertime tests'
+        'Btime-wr': 'Raptor-Browsertime tests with webrender enabled'
         'bump': 'Bump dependencies'
         'debug': 'Builds made for testing'
         'Fetch': 'Fetch and store content'

--- a/taskcluster/fenix_taskgraph/transforms/browsertime.py
+++ b/taskcluster/fenix_taskgraph/transforms/browsertime.py
@@ -119,6 +119,7 @@ def enable_webrender(config, tasks):
         task["run"]["command"].append("--enable-webrender")
         task["name"] += "-wr"
         task["description"] += "-wr"
+        task['extra']['treeherder']["groupSymbol"] += "-wr"
         yield task
 
 

--- a/taskcluster/fenix_taskgraph/transforms/browsertime.py
+++ b/taskcluster/fenix_taskgraph/transforms/browsertime.py
@@ -119,8 +119,15 @@ def enable_webrender(config, tasks):
         task["run"]["command"].append("--enable-webrender")
         task["name"] += "-wr"
         task["description"] += "-wr"
+
+        # Setup group symbol
         group, sym = task["treeherder"]["symbol"].split("(")
         task["treeherder"]["symbol"] = "{}-wr({})".format(group, sym[:-1])
+
+        # Setup the platform name
+        platform, plttype = task["treeherder"]["platform"].split("/")
+        task["treeherder"]["platform"] = "{}-qr/{}".format(platform, plttype)
+
         yield task
 
 

--- a/taskcluster/fenix_taskgraph/transforms/browsertime.py
+++ b/taskcluster/fenix_taskgraph/transforms/browsertime.py
@@ -119,7 +119,9 @@ def enable_webrender(config, tasks):
         task["run"]["command"].append("--enable-webrender")
         task["name"] += "-wr"
         task["description"] += "-wr"
-        task["treeherder"].setdefault("groupSymbol", "Btime") += "-wr"
+        task["treeherder"]["groupSymbol"] = "{}-wr".format(
+            task["treeherder"].get("groupSymbol", "Btime")
+        )
         yield task
 
 

--- a/taskcluster/fenix_taskgraph/transforms/browsertime.py
+++ b/taskcluster/fenix_taskgraph/transforms/browsertime.py
@@ -119,9 +119,8 @@ def enable_webrender(config, tasks):
         task["run"]["command"].append("--enable-webrender")
         task["name"] += "-wr"
         task["description"] += "-wr"
-        task["treeherder"]["groupSymbol"] = "{}-wr".format(
-            task["treeherder"].get("groupSymbol", "Btime")
-        )
+        group, sym = task["treeherder"]["symbol"].split("(")
+        task["treeherder"]["symbol"] = "{}-wr({})".format(group, sym[:-1])
         yield task
 
 

--- a/taskcluster/fenix_taskgraph/transforms/browsertime.py
+++ b/taskcluster/fenix_taskgraph/transforms/browsertime.py
@@ -119,7 +119,9 @@ def enable_webrender(config, tasks):
         task["run"]["command"].append("--enable-webrender")
         task["name"] += "-wr"
         task["description"] += "-wr"
-        task['extra']['treeherder']["groupSymbol"] += "-wr"
+        task.setdefault("extra", {}).setdefault(
+            "treeherder", {}
+        ).setdefault("groupSymbol", "Btime") += "-wr"
         yield task
 
 

--- a/taskcluster/fenix_taskgraph/transforms/browsertime.py
+++ b/taskcluster/fenix_taskgraph/transforms/browsertime.py
@@ -119,9 +119,7 @@ def enable_webrender(config, tasks):
         task["run"]["command"].append("--enable-webrender")
         task["name"] += "-wr"
         task["description"] += "-wr"
-        task.setdefault("extra", {}).setdefault(
-            "treeherder", {}
-        ).setdefault("groupSymbol", "Btime") += "-wr"
+        task["treeherder"].setdefault("groupSymbol", "Btime") += "-wr"
         yield task
 
 

--- a/taskcluster/fenix_taskgraph/transforms/browsertime.py
+++ b/taskcluster/fenix_taskgraph/transforms/browsertime.py
@@ -124,10 +124,6 @@ def enable_webrender(config, tasks):
         group, sym = task["treeherder"]["symbol"].split("(")
         task["treeherder"]["symbol"] = "{}-wr({})".format(group, sym[:-1])
 
-        # Setup the platform name
-        platform, plttype = task["treeherder"]["platform"].split("/")
-        task["treeherder"]["platform"] = "{}-qr/{}".format(platform, plttype)
-
         yield task
 
 

--- a/taskcluster/fenix_taskgraph/transforms/browsertime.py
+++ b/taskcluster/fenix_taskgraph/transforms/browsertime.py
@@ -46,6 +46,16 @@ def add_variants(config, tasks):
 
 
 @transforms.add
+def enable_webrender(config, tasks):
+    for task in tasks:
+        if not task.pop("web-render-only", False):
+            newtask = copy.deepcopy(task)
+            yield newtask
+        task["run"]["command"].append("--enable-webrender")
+        yield task
+
+
+@transforms.add
 def build_browsertime_task(config, tasks):
     for task in tasks:
         signing = task.pop("primary-dependency")

--- a/taskcluster/fenix_taskgraph/transforms/browsertime.py
+++ b/taskcluster/fenix_taskgraph/transforms/browsertime.py
@@ -52,6 +52,8 @@ def enable_webrender(config, tasks):
             newtask = copy.deepcopy(task)
             yield newtask
         task["run"]["command"].append("--enable-webrender")
+        task["name"] += "-wr"
+        task["description"] += "-wr"
         yield task
 
 

--- a/taskcluster/fenix_taskgraph/transforms/browsertime.py
+++ b/taskcluster/fenix_taskgraph/transforms/browsertime.py
@@ -46,18 +46,6 @@ def add_variants(config, tasks):
 
 
 @transforms.add
-def enable_webrender(config, tasks):
-    for task in tasks:
-        if not task.pop("web-render-only", False):
-            newtask = copy.deepcopy(task)
-            yield newtask
-        task["run"]["command"].append("--enable-webrender")
-        task["name"] += "-wr"
-        task["description"] += "-wr"
-        yield task
-
-
-@transforms.add
 def build_browsertime_task(config, tasks):
     for task in tasks:
         signing = task.pop("primary-dependency")
@@ -119,6 +107,18 @@ def build_browsertime_task(config, tasks):
         if 'youtube-playback' in task["name"]:
             task["run"]["command"].remove("--cold")
 
+        yield task
+
+
+@transforms.add
+def enable_webrender(config, tasks):
+    for task in tasks:
+        if not task.pop("web-render-only", False):
+            newtask = copy.deepcopy(task)
+            yield newtask
+        task["run"]["command"].append("--enable-webrender")
+        task["name"] += "-wr"
+        task["description"] += "-wr"
         yield task
 
 


### PR DESCRIPTION
This patch flips our default settings for tests to use webrender. It also adds a subset of tests that were identified as "high-value" to run without webrender until we are fully switched to use webrender.