### PR TITLE
Update to Android-Components 63.0.4.

### DIFF
--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "63.0.1"
+    const val VERSION = "63.0.4"
 }


### PR DESCRIPTION
This (automated) patch updates Android-Components to 63.0.4.