### PR TITLE
For #16339 - Initialize FxaAccountManager with also a CrashReporter

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/BackgroundServices.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/BackgroundServices.kt
@@ -109,7 +109,7 @@ class BackgroundServices(
 
     val accountAbnormalities = AccountAbnormalities(context, crashReporter, strictMode)
 
-    val accountManager by lazy { makeAccountManager(context, serverConfig, deviceConfig, syncConfig) }
+    val accountManager by lazy { makeAccountManager(context, serverConfig, deviceConfig, syncConfig, crashReporter) }
 
     val syncedTabsStorage by lazy {
         SyncedTabsStorage(accountManager, context.components.core.store, remoteTabsStorage.value)
@@ -120,7 +120,8 @@ class BackgroundServices(
         context: Context,
         serverConfig: ServerConfig,
         deviceConfig: DeviceConfig,
-        syncConfig: SyncConfig?
+        syncConfig: SyncConfig?,
+        crashReporter: CrashReporter?
     ) = FxaAccountManager(
         context,
         serverConfig,
@@ -136,7 +137,8 @@ class BackgroundServices(
             // Necessary to enable "Manage Account" functionality and ability to generate OAuth
             // codes for certain scopes.
             SCOPE_SESSION
-        )
+        ),
+        crashReporter
     ).also { accountManager ->
         // TODO this needs to change once we have a SyncManager
         context.settings().fxaHasSyncedItems = accountManager.authenticatedAccount()?.let {


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: No tests - the change here just passes a parameter.
- [x] **Screenshots**: Small code modifications, no UI changes.
As a manual test, when forcing an exception in FxaDeviceConstellation I now see in logs I/mozac/CrashReporter: Caught Exception report submitted to 1 services.
- [x] **Accessibility**: The code in this PR does not include any a11y user facing features.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
