### PR TITLE
For #15847: disables verifyAboutFirefoxPreview UI test

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAboutTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAboutTest.kt
@@ -10,6 +10,7 @@ import okhttp3.mockwebserver.MockWebServer
 import org.junit.Rule
 import org.junit.Before
 import org.junit.After
+import org.junit.Ignore
 import org.junit.Test
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
@@ -69,6 +70,7 @@ class SettingsAboutTest {
 
     }
 
+    @Ignore("Intermittent failure, see: https://github.com/mozilla-mobile/fenix/issues/15847")
     @Test
     fun verifyAboutFirefoxPreview() {
         homeScreen {


### PR DESCRIPTION
Ran it a few times on Firebase and it seems this test failure has big chances of occurring: https://github.com/mozilla-mobile/fenix/runs/1347485985 so I'm going to disable it for now.