### PR TITLE
Fixes #16348 - Increase Gradle daemon memory size

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx4096m
+org.gradle.jvmargs=-Xmx6144m
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects


### PR DESCRIPTION
This patch increases Gradle's memory to 6GB (from 4GB) to hopefully avoid OutOfMemory exceptions during tests.

If this PR goes through properly then also uplift this to the active release and beta branch.