### PR TITLE
For #16323 - Slightly larger corner radius for the outer border of a grid item

### DIFF
--- a/app/src/main/res/drawable/tab_tray_grid_item_selected_border.xml
+++ b/app/src/main/res/drawable/tab_tray_grid_item_selected_border.xml
@@ -19,7 +19,7 @@
                 android:width="4dp"
                 android:color="@color/photonViolet70" />
 
-            <corners android:radius="@dimen/tab_tray_grid_item_border_radius" />
+            <corners android:radius="@dimen/tab_tray_grid_item_outer_border_radius" />
         </shape>
 
     </item>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -179,6 +179,7 @@
     <dimen name="tab_tray_grid_item_thumbnail_width">156dp</dimen>
     <dimen name="tab_tray_grid_item_thumbnail_height">156dp</dimen>
     <dimen name="tab_tray_grid_item_border_radius">8dp</dimen>
+    <dimen name="tab_tray_grid_item_outer_border_radius">10dp</dimen>
     <dimen name="tab_tray_grid_item_selected_border_width">2dp</dimen>
     <dimen name="tab_tray_favicon_border_radius">4dp</dimen>
     <dimen name="tab_tray_multiselect_handle_height">11dp</dimen>


### PR DESCRIPTION
This would ensure the corners of the inner and outer borders are aligned, with
no empty space between them.

![image](https://user-images.githubusercontent.com/11428869/98100347-664bb800-1e99-11eb-9bf5-8faf33f77714.png)


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR does not include any a11y user facing features.


### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
