### PR TITLE
For #13427 - Disable the "selected tab" decoration when in Multiselect

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabtray/FenixTabsAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/FenixTabsAdapter.kt
@@ -59,11 +59,20 @@ class FenixTabsAdapter(
     override fun onBindViewHolder(
         holder: TabViewHolder,
         position: Int,
-        payloads: MutableList<Any>
+        payloads: List<Any>
     ) {
         if (payloads.isNullOrEmpty()) {
             onBindViewHolder(holder, position)
             return
+        }
+
+        // Having non-empty payloads means we have to make a partial update.
+        // This currently only happens when changing between the Normal and MultiSelect modes
+        // when we want to either show the last opened tab as selected (default) or hide this ui decorator.
+        if (mode is TabTrayDialogFragmentState.Mode.Normal) {
+            super.onBindViewHolder(holder, position, listOf(PAYLOAD_HIGHLIGHT_SELECTED_ITEM))
+        } else {
+            super.onBindViewHolder(holder, position, listOf(PAYLOAD_DONT_HIGHLIGHT_SELECTED_ITEM))
         }
 
         holder.tab?.let { showCheckedIfSelected(it, holder.itemView) }
@@ -131,6 +140,11 @@ class FenixTabsAdapter(
     override fun onAttachedToRecyclerView(recyclerView: RecyclerView) {
         super.onAttachedToRecyclerView(recyclerView)
         tabsList = recyclerView
+    }
+
+    override fun isTabSelected(tabs: Tabs, position: Int): Boolean {
+        return mode is TabTrayDialogFragmentState.Mode.Normal &&
+                tabs.selectedIndex == position
     }
 
     private fun showCheckedIfSelected(tab: Tab, view: View) {

--- a/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayViewHolder.kt
@@ -174,10 +174,9 @@ class TabTrayViewHolder(
             .take(MAX_URI_LENGTH)
     }
 
-    @VisibleForTesting
-    internal fun updateSelectedTabIndicator(isSelected: Boolean) {
+    override fun updateSelectedTabIndicator(showAsSelected: Boolean) {
         if (itemView.context.settings().gridTabView) {
-            itemView.tab_tray_grid_item.background = if (isSelected) {
+            itemView.tab_tray_grid_item.background = if (showAsSelected) {
                 AppCompatResources.getDrawable(itemView.context, R.drawable.tab_tray_grid_item_selected_border)
             } else {
                 null
@@ -185,7 +184,7 @@ class TabTrayViewHolder(
             return
         }
 
-        val color = if (isSelected) {
+        val color = if (showAsSelected) {
             R.color.tab_tray_item_selected_background_normal_theme
         } else {
             R.color.tab_tray_item_background_normal_theme


### PR DESCRIPTION
Selecting a tab while in Multiselect would add a different decoration to the one
already set for the last tab opened and this would confuse users.
Let's avoid this.

After the changes here which are based on https://github.com/mozilla-mobile/android-components/pull/8894:
![selectAndCheck](https://user-images.githubusercontent.com/11428869/99394529-b38f4700-28e7-11eb-8784-8d2da2e6df98.gif)
[video](https://drive.google.com/file/d/1HAAG-Bn1qpbOlp0vHzH2QjZvnLzN2g4n/view?usp=sharing)


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR does not include any a11y user facing features.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
