### PR TITLE
Closes #13242 : Add mozcn safebrowsing

### DIFF
--- a/app/src/geckoBeta/java/org/mozilla/fenix/engine/GeckoProvider.kt
+++ b/app/src/geckoBeta/java/org/mozilla/fenix/engine/GeckoProvider.kt
@@ -14,9 +14,14 @@ import org.mozilla.fenix.Config
 import org.mozilla.fenix.ext.components
 import org.mozilla.geckoview.GeckoRuntime
 import org.mozilla.geckoview.GeckoRuntimeSettings
+import org.mozilla.geckoview.ContentBlocking.SafeBrowsingProvider
 
 object GeckoProvider {
     private var runtime: GeckoRuntime? = null
+    const val CN_UPDATE_URL =
+        "https://sb.firefox.com.cn/downloads?client=SAFEBROWSING_ID&appver=%MAJOR_VERSION%&pver=2.2"
+    const val CN_GET_HASH_URL =
+        "https://sb.firefox.com.cn/gethash?client=SAFEBROWSING_ID&appver=%MAJOR_VERSION%&pver=2.2"
 
     @Synchronized
     fun getOrCreateRuntime(
@@ -51,6 +56,28 @@ object GeckoProvider {
             runtimeSettings.automaticFontSizeAdjustment = false
             val fontSize = settings.fontSizeFactor
             runtimeSettings.fontSizeFactor = fontSize
+        }
+
+        // Add safebrowsing providers for China
+        if (Config.channel.isMozillaOnline) {
+            val mozcn = SafeBrowsingProvider
+                .withName("mozcn")
+                .version("2.2")
+                .lists("m6eb-phish-shavar", "m6ib-phish-shavar")
+                .updateUrl(CN_UPDATE_URL)
+                .getHashUrl(CN_GET_HASH_URL)
+                .build()
+
+            runtimeSettings.contentBlocking.setSafeBrowsingProviders(mozcn,
+                // Keep the existing configuration
+                ContentBlocking.GOOGLE_SAFE_BROWSING_PROVIDER,
+                ContentBlocking.GOOGLE_LEGACY_SAFE_BROWSING_PROVIDER)
+
+            runtimeSettings.contentBlocking.setSafeBrowsingPhishingTable(
+                "m6eb-phish-shavar",
+                "m6ib-phish-shavar",
+                // Existing configuration
+                "goog-phish-proto")
         }
 
         val geckoRuntime = GeckoRuntime.create(context, runtimeSettings)

--- a/app/src/geckoNightly/java/org/mozilla/fenix/engine/GeckoProvider.kt
+++ b/app/src/geckoNightly/java/org/mozilla/fenix/engine/GeckoProvider.kt
@@ -14,9 +14,15 @@ import org.mozilla.fenix.Config
 import org.mozilla.fenix.ext.components
 import org.mozilla.geckoview.GeckoRuntime
 import org.mozilla.geckoview.GeckoRuntimeSettings
+import org.mozilla.geckoview.ContentBlocking
+import org.mozilla.geckoview.ContentBlocking.SafeBrowsingProvider
 
 object GeckoProvider {
     private var runtime: GeckoRuntime? = null
+    const val CN_UPDATE_URL =
+        "https://sb.firefox.com.cn/downloads?client=SAFEBROWSING_ID&appver=%MAJOR_VERSION%&pver=2.2"
+    const val CN_GET_HASH_URL =
+        "https://sb.firefox.com.cn/gethash?client=SAFEBROWSING_ID&appver=%MAJOR_VERSION%&pver=2.2"
 
     @Synchronized
     fun getOrCreateRuntime(
@@ -51,6 +57,28 @@ object GeckoProvider {
             runtimeSettings.automaticFontSizeAdjustment = false
             val fontSize = settings.fontSizeFactor
             runtimeSettings.fontSizeFactor = fontSize
+        }
+
+        // Add safebrowsing providers for China
+        if (Config.channel.isMozillaOnline) {
+            val mozcn = SafeBrowsingProvider
+                .withName("mozcn")
+                .version("2.2")
+                .lists("m6eb-phish-shavar", "m6ib-phish-shavar")
+                .updateUrl(CN_UPDATE_URL)
+                .getHashUrl(CN_GET_HASH_URL)
+                .build()
+
+            runtimeSettings.contentBlocking.setSafeBrowsingProviders(mozcn,
+                // Keep the existing configuration
+                ContentBlocking.GOOGLE_SAFE_BROWSING_PROVIDER,
+                ContentBlocking.GOOGLE_LEGACY_SAFE_BROWSING_PROVIDER)
+
+            runtimeSettings.contentBlocking.setSafeBrowsingPhishingTable(
+                "m6eb-phish-shavar",
+                "m6ib-phish-shavar",
+                // Existing configuration
+                "goog-phish-proto")
         }
 
         val geckoRuntime = GeckoRuntime.create(context, runtimeSettings)


### PR DESCRIPTION
This patch adds a runtime safe browsing provider`mozcn` for Mozilla online builds, using the build variant `Config.channel.isMozillaOnline`
