### PR TITLE
For #15847: use Espresso's RecyclerView scrollTo action

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAboutTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAboutTest.kt
@@ -10,7 +10,6 @@ import okhttp3.mockwebserver.MockWebServer
 import org.junit.Rule
 import org.junit.Before
 import org.junit.After
-import org.junit.Ignore
 import org.junit.Test
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
@@ -70,7 +69,6 @@ class SettingsAboutTest {
 
     }
 
-    @Ignore("Intermittent failure, see: https://github.com/mozilla-mobile/fenix/issues/15847")
     @Test
     fun verifyAboutFirefoxPreview() {
         homeScreen {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
@@ -20,6 +20,7 @@ import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.Visibility
 import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
 import androidx.test.espresso.matcher.ViewMatchers.isCompletelyDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
@@ -425,15 +426,17 @@ private fun assertAboutHeading(): ViewInteraction {
 }
 
 private fun assertRateOnGooglePlay(): ViewInteraction {
-    scrollToElementByText("About Firefox Preview")
+    onView(withId(R.id.recycler_view))
+        .perform(RecyclerViewActions.scrollTo<RecyclerView.ViewHolder>(hasDescendant(withText("Rate on Google Play"))))
     return onView(withText("Rate on Google Play"))
         .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 }
 
 private fun assertAboutFirefoxPreview(): ViewInteraction {
-    scrollToElementByText("About Firefox Preview")
+    onView(withId(R.id.recycler_view))
+        .perform(RecyclerViewActions.scrollTo<RecyclerView.ViewHolder>(hasDescendant(withText("About Firefox Preview"))))
     return onView(withText("About Firefox Preview"))
-        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+        .check(matches(isDisplayed()))
 }
 
 fun swipeToBottom() = onView(withId(R.id.recycler_view)).perform(ViewActions.swipeUp())


### PR DESCRIPTION
Fixes and re-enables #15847.
Ran the solution 30 times on Firebase, all passed: https://github.com/mozilla-mobile/fenix/runs/1362989784, compared with the runs before the change: https://github.com/mozilla-mobile/fenix/runs/1347485985