### PR TITLE
Closes #16430: ExternalAppBrowserActivity should not handle incoming intents

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -397,8 +397,12 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
      */
     final override fun onNewIntent(intent: Intent?) {
         super.onNewIntent(intent)
-        intent ?: return
+        intent?.let {
+            handleNewIntent(it)
+        }
+    }
 
+    open fun handleNewIntent(intent: Intent) {
         // Diagnostic breadcrumb for "Display already aquired" crash:
         // https://github.com/mozilla-mobile/android-components/issues/7960
         breadcrumb(

--- a/app/src/main/java/org/mozilla/fenix/customtabs/ExternalAppBrowserActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/ExternalAppBrowserActivity.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.fenix.customtabs
 
+import android.content.Intent
 import androidx.navigation.NavDestination
 import androidx.navigation.NavDirections
 import kotlinx.android.synthetic.main.activity_home.*
@@ -47,6 +48,10 @@ open class ExternalAppBrowserActivity : HomeActivity() {
     }
 
     override fun navigateToBrowserOnColdStart() {
+        // No-op for external app
+    }
+
+    override fun handleNewIntent(intent: Intent) {
         // No-op for external app
     }
 

--- a/app/src/test/java/org/mozilla/fenix/customtabs/ExternalAppBrowserActivityTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/customtabs/ExternalAppBrowserActivityTest.kt
@@ -7,6 +7,7 @@ package org.mozilla.fenix.customtabs
 import android.content.Intent
 import android.os.Bundle
 import androidx.navigation.NavDirections
+import io.mockk.Called
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
@@ -56,6 +57,15 @@ class ExternalAppBrowserActivityTest {
         activity.navigateToBrowserOnColdStart()
 
         verify(exactly = 0) { activity.openToBrowser(BrowserDirection.FromGlobal, null) }
+    }
+
+    @Test
+    fun `handleNewIntent does nothing for external app browser activity`() {
+        val activity = spyk(ExternalAppBrowserActivity())
+        val intent: Intent = mockk(relaxed = true)
+
+        activity.handleNewIntent(intent)
+        verify { intent wasNot Called }
     }
 
     @Test


### PR DESCRIPTION
Just introducing `handleNewIntent` and making sure it's a NOOP for `ExternalAppBrowserActivity`.