### PR TITLE
For #16424 - Focus the right item in tabs tray when using Talkback

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayDialogFragment.kt
@@ -291,7 +291,7 @@ class TabTrayDialogFragment : AppCompatDialogFragment(), UserInteractionHandler 
             getString(R.string.snackbar_deleted_undo),
             {
                 requireComponents.useCases.tabsUseCases.undo.invoke()
-                _tabTrayView?.scrollToTab(tab.id)
+                _tabTrayView?.scrollToSelectedBrowserTab(tab.id)
             },
             operation = { },
             elevation = ELEVATION,


### PR DESCRIPTION
To get the index of the current selected browser tab when using reverse layout
we should also account for items placed below of the browser tabs.
The patch here unifies the logic already used for some calls but not all.

![The-correct-tab-is-focused-for-a(1)](https://user-images.githubusercontent.com/11428869/98644792-aeefef00-2339-11eb-9392-1e1bb767d088.gif)
[video](https://drive.google.com/file/d/1PsM80I-EX1FjAR5PgCfHXjf5jiyycWLW/view?usp=sharing)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: No tests. Small modification in a not yet tested component.
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made.
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
