### PR TITLE
For #16461 - Ensure the proper items order after exiting Multiselect

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabtray/SyncedTabsController.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/SyncedTabsController.kt
@@ -21,6 +21,7 @@ import mozilla.components.browser.storage.sync.SyncedDeviceTabs
 import mozilla.components.feature.syncedtabs.view.SyncedTabsView
 import mozilla.components.lib.state.ext.flowScoped
 import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
+import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.sync.ListenerDelegate
 import org.mozilla.fenix.sync.SyncedTabsAdapter
 import org.mozilla.fenix.sync.ext.toAdapterList
@@ -50,7 +51,11 @@ class SyncedTabsController(
                 .collect { mode ->
                     when (mode) {
                         is TabTrayDialogFragmentState.Mode.Normal -> {
-                            concatAdapter.addAdapter(0, adapter)
+                            if (view.context.settings().gridTabView) {
+                                concatAdapter.addAdapter(adapter)
+                            } else {
+                                concatAdapter.addAdapter(0, adapter)
+                            }
                         }
                         is TabTrayDialogFragmentState.Mode.MultiSelect -> {
                             concatAdapter.removeAdapter(adapter)


### PR DESCRIPTION

![StableLayoutStructure](https://user-images.githubusercontent.com/11428869/98701677-39f4d780-2382-11eb-9189-d6c60209292f.gif)
[video](https://drive.google.com/file/d/1U9EdAKrwIwIPOPTHOY_geIHewfz6YqX5/view?usp=sharing)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes _thorough_ tests.
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made.
- [x] **Accessibility**: The code in this PR does not include any user facing features.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
