### PR TITLE
For #16500 - Ensure CardView clips ImageView on lower APIs

### DIFF
--- a/app/src/main/res/layout/tab_tray_grid_item.xml
+++ b/app/src/main/res/layout/tab_tray_grid_item.xml
@@ -88,6 +88,7 @@ A FrameLayout here is an efficient way of having a views stack while allowing:
 
             <androidx.cardview.widget.CardView
                 android:id="@+id/mozac_browser_tabstray_card"
+                style="@style/Widget.MaterialComponents.CardView"
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/tab_tray_grid_item_thumbnail_height"
                 android:backgroundTint="?tabTrayThumbnailItemBackground"


### PR DESCRIPTION
ImageViews are normally not clipped but extend to cover the entire width and
height set.
CardViews as a parent can help with that but on lower APIS they still need a
shapeAppearance which is a property already in the added style.

Screenshot from an Android API23 device, previously affected:
<img src="https://user-images.githubusercontent.com/11428869/98832441-81906780-2445-11eb-9949-fec5cc00e76e.png" width="30%">


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: No tests. Small layout change.
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made.
- [x] **Accessibility**: The code in this PR does not include any user facing features.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
