### PR TITLE
For #16376: assert view hierarchy depth & ConstraintLayout children on start up

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -51,7 +51,6 @@
 *StrictMode*kt @mozilla-mobile/Performance
 *ConstraintLayoutPerfDetector* @mozilla-mobile/Performance
 *MozillaRunBlockingCheck.kt @mozilla-mobile/Performance
-*StartupExcessiveResourceUseTest.kt @mozilla-mobile/Performance
 
 # We want to be aware of new features behind flags as well as features
 # about to be enabled.

--- a/app/src/androidTest/java/org/mozilla/fenix/perf/StartupExcessiveResourceUseTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/perf/StartupExcessiveResourceUseTest.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.fenix.ui
+package org.mozilla.fenix.perf
 
 import android.util.Log
 import android.view.View
@@ -16,10 +16,8 @@ import kotlinx.android.synthetic.main.activity_home.*
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
-import org.mozilla.fenix.perf.RunBlockingCounter
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.helpers.HomeActivityTestRule
-import org.mozilla.fenix.perf.ComponentInitCount
 
 // BEFORE INCREASING THESE VALUES, PLEASE CONSULT WITH THE PERF TEAM.
 private const val EXPECTED_SUPPRESSION_COUNT = 11
@@ -69,9 +67,7 @@ private val failureMsgRecyclerViewConstraintLayoutChildren = getErrorMessage(
  * RunBlocking is mostly used to return values to a thread from a coroutine. However, if that
  * coroutine takes too long, it can lead that thread to block every other operations.
  *
- * The perf team is code owners for this file so they should be notified when the count is modified.
- *
- * IF YOU UPDATE THE TEST NAME, UPDATE CODE OWNERS.
+ * The perf team is code owners for this package so they should be notified when the counts are modified.
  */
 class StartupExcessiveResourceUseTest {
     @get:Rule


### PR DESCRIPTION
For ConstraintLayout count assertion:

    I'm not convinced this is a useful test because the performance
    characteristics seem unfortunately nuanced: if the test fails, it implies
    you shouldn't add more but that isn't necessarily true (for example, if
    your RV child has a large depth). Furthermore, we haven't measured in a
    variety of circumstances that layouts like LinearLayout perform better
    as RecyclerView children so maybe it only held for the one small case we
    used it in.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
