### PR TITLE
Update gradle properties.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -179,7 +179,14 @@ android {
         unitTests.returnDefaultValues = true
 
         unitTests.all {
-            jvmArgs '-Xmx2g'
+            // We keep running into memory issues when running our tests. With this config we
+            // reserve more memory and also create a new process after every 80 test classes. This
+            // is a band-aid solution and eventually we should try to find and fix the leaks
+            // instead. :)
+            maxParallelForks = 2
+            forkEvery = 80
+            maxHeapSize = "2048m"
+            minHeapSize = "1024m"
         }
     }
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -177,6 +177,10 @@ android {
 
     testOptions {
         unitTests.returnDefaultValues = true
+
+        unitTests.all {
+            jvmArgs '-Xmx2g'
+        }
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,11 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx6144m
+
+# Inspired by androidx:
+# https://android.googlesource.com/platform/frameworks/support/+/androidx-master-dev/gradle.properties
+org.gradle.jvmargs=-Xmx8g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC
+
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
@@ -18,4 +22,12 @@ android.enableJetifier=true
 android.enableR8=true
 android.enableR8.fullMode=true
 android.enableUnitTestBinaryResources=false
-org.gradle.parallel=false
+
+org.gradle.parallel=true
+
+# Allow running multiple Kotlin compilers in parallel
+kotlin.parallel.tasks.in.project=true
+
+# Enabling this flag fixed many random automation build errors in Android Components. So we
+# should try it here too. :)
+android.forceJacocoOutOfProcess=true

--- a/taskcluster/scripts/toolchain/android-gradle-dependencies.sh
+++ b/taskcluster/scripts/toolchain/android-gradle-dependencies.sh
@@ -24,7 +24,7 @@ GRADLE_ARGS="--parallel -PgoogleRepo=$NEXUS_PREFIX/google/ -PjcenterRepo=$NEXUS_
 ./gradlew $GRADLE_ARGS assemble assembleAndroidTest testClasses ktlint detekt
 # Some tests may be flaky, although they still download dependencies. So we let the following
 # command fail, if needed.
-set +e; ./gradlew $GRADLE_ARGS -Pcoverage test mozilla-detekt-rules:test mozilla-lint-rules:test; set -e
+set +e; ./gradlew $GRADLE_ARGS -Pcoverage testDebug mozilla-detekt-rules:test mozilla-lint-rules:test; set -e
 
 
 # ./gradlew lint is missing because of https://github.com/mozilla-mobile/fenix/issues/10439. So far,


### PR DESCRIPTION
The toolchain task is failing on `master`. Here I am trying a couple of things:

* Create a heap dump on "out of memory"
* Use parallel GC (androidx seems to enable that for their repo)
* Enable parallel gradle tasks and kotlin compiler runs
* Force jacoco out of process (which has helped fixing a bunch of problems in AC).