### PR TITLE
Closes #16302: Use larger heap size when running unit tests and fork new process after every 80 test classes.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -177,6 +177,17 @@ android {
 
     testOptions {
         unitTests.returnDefaultValues = true
+
+        unitTests.all {
+            // We keep running into memory issues when running our tests. With this config we
+            // reserve more memory and also create a new process after every 80 test classes. This
+            // is a band-aid solution and eventually we should try to find and fix the leaks
+            // instead. :)
+            maxParallelForks = 2
+            forkEvery = 80
+            maxHeapSize = "2048m"
+            minHeapSize = "1024m"
+        }
     }
 }
 


### PR DESCRIPTION
After multiple tests this seems the best option to work around the memory issues in automation. Now we are running 2 test processes in parallel (locally this is much faster) and assign them more heap memory. Then after every 80 test classes, we throw the process away and create a new one. This way memory cannot build up over multiple tests.

Of course this is only band-aid and it looks like there's a leak to be fixed. But right now it's unclear where that leak is and whether it's even in our code (or in Robolectric for example).