### PR TITLE
Upift For #14772: Crash in Downloads

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/downloads/DownloadFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/downloads/DownloadFragment.kt
@@ -42,7 +42,7 @@ class DownloadFragment : LibraryPageFragment<DownloadItem>(), UserInteractionHan
                 it.value.id.toString(),
                 it.value.fileName,
                 it.value.filePath,
-                it.value.contentLength.toString(),
+                it.value.contentLength?.toString() ?: "0",
                 it.value.contentType,
                 it.value.status
             )


### PR DESCRIPTION
As Cherry picking https://github.com/mozilla-mobile/fenix/pull/16508 will need to bring other commits that are not on `releases/v83.0.0`, I just extracted the fix, instead of bringing the whole commit.

Uplift for https://github.com/mozilla-mobile/fenix/pull/16508
More info: https://github.com/mozilla-mobile/fenix/issues/14772

Co-authored-by: Kate Glazko kglazko@mozilla.com



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
