### PR TITLE
 #16345 Fix lingering share icon replacement

### DIFF
--- a/app/src/main/res/layout/tabstray_multiselect_items.xml
+++ b/app/src/main/res/layout/tabstray_multiselect_items.xml
@@ -32,7 +32,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/menu_multi_select"
         app:layout_constraintTop_toTopOf="parent"
-        app:srcCompat="@drawable/ic_hollow_share"
+        app:srcCompat="@drawable/ic_share_filled"
         app:tint="@color/contrast_text_normal_theme" />
 
     <ImageButton


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture


Hi @ekager, I'm a new contributor and I couldn't get master to build with `AAPT: error: resource drawable/ic_hollow_share (aka org.mozilla.fenix.debug:drawable/ic_hollow_share) not found.`. I read through issue #16345 and thought that you might have missed this instance.

![image](https://user-images.githubusercontent.com/3119646/99040586-5a13d900-25c4-11eb-9a29-be9ba0b38c0d.png)
