### PR TITLE
For #16511: Change a11y parent of button without breaking the tab list.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/ext/View.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/View.kt
@@ -37,33 +37,16 @@ fun View.removeTouchDelegate() {
 }
 
 /**
- * Removes a child view from accessibility node info of an accessibility parent view.
- * If the child does not exist in the node, calling this has no effect.
+ * Sets the new a11y parent.
  */
-fun View.removeChildFromAccessibilityNodeInfo(child: View) {
+fun View.setNewAccessibilityParent(newParent: View) {
     this.accessibilityDelegate = object : View.AccessibilityDelegate() {
         override fun onInitializeAccessibilityNodeInfo(
             host: View?,
             info: AccessibilityNodeInfo?
         ) {
             super.onInitializeAccessibilityNodeInfo(host, info)
-            info?.removeChild(child)
-        }
-    }
-}
-
-/**
- * Add a child view to the accessibility node info of a view that becomes it's accessibility parent.
- * If the child already exists in the node, calling this has no effect.
- */
-fun View.addChildToAccessibilityNodeInfo(child: View) {
-    this.accessibilityDelegate = object : View.AccessibilityDelegate() {
-        override fun onInitializeAccessibilityNodeInfo(
-            host: View?,
-            info: AccessibilityNodeInfo?
-        ) {
-            super.onInitializeAccessibilityNodeInfo(host, info)
-            info?.addChild(child)
+            info?.setParent(newParent)
         }
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/tabtray/SaveToCollectionsButtonAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/SaveToCollectionsButtonAdapter.kt
@@ -13,8 +13,7 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import org.mozilla.fenix.R
-import org.mozilla.fenix.ext.addChildToAccessibilityNodeInfo
-import org.mozilla.fenix.ext.removeChildFromAccessibilityNodeInfo
+import org.mozilla.fenix.ext.setNewAccessibilityParent
 import org.mozilla.fenix.tabtray.SaveToCollectionsButtonAdapter.Item
 import org.mozilla.fenix.tabtray.SaveToCollectionsButtonAdapter.ViewHolder
 
@@ -45,9 +44,8 @@ class SaveToCollectionsButtonAdapter(
             ) {
                 super.onInitializeAccessibilityNodeInfo(host, info)
                 info?.collectionItemInfo = null
-                (holder.itemView.parentForAccessibility as View).apply {
-                    removeChildFromAccessibilityNodeInfo(holder.itemView)
-                    (this.parentForAccessibility as View).addChildToAccessibilityNodeInfo(holder.itemView)
+                (holder.itemView.parentForAccessibility.parentForAccessibility as? View)?.let {
+                    holder.itemView.setNewAccessibilityParent(it)
                 }
             }
         }


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
