### PR TITLE
Update strings in tab tray menu

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayItemMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayItemMenu.kt
@@ -13,6 +13,7 @@ import org.mozilla.fenix.ext.components
 
 class TabTrayItemMenu(
     private val context: Context,
+    private val shouldShowShareAllTabs: () -> Boolean,
     private val shouldShowSelectTabs: () -> Boolean,
     private val hasOpenTabs: () -> Boolean,
     private val onItemTapped: (Item) -> Unit = {}
@@ -43,7 +44,7 @@ class TabTrayItemMenu(
             ) {
                 context.components.analytics.metrics.track(Event.TabsTrayShareAllTabsPressed)
                 onItemTapped.invoke(Item.ShareAllTabs)
-            }.apply { visible = hasOpenTabs },
+            }.apply { visible = { shouldShowShareAllTabs() && hasOpenTabs() } },
 
             SimpleBrowserMenuItem(
                 context.getString(R.string.tab_tray_menu_tab_settings),

--- a/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayView.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayView.kt
@@ -226,6 +226,7 @@ class TabTrayView(
         tabTrayItemMenu =
             TabTrayItemMenu(
                 context = view.context,
+                shouldShowShareAllTabs = { checkOpenTabs.invoke() && view.tab_layout.selectedTabPosition == 0 },
                 shouldShowSelectTabs = { checkOpenTabs.invoke() && view.tab_layout.selectedTabPosition == 0 },
                 hasOpenTabs = checkOpenTabs
             ) {

--- a/app/src/main/res/menu/tab_tray_menu.xml
+++ b/app/src/main/res/menu/tab_tray_menu.xml
@@ -8,7 +8,7 @@
     <!-- Save to collection -->
     <item
         android:id="@+id/tab_tray_select_to_save_menu_item"
-        android:title="@string/tab_tray_menu_item_save"
+        android:title="@string/tab_tray_menu_select"
         app:showAsAction="never" />
 
     <!-- Share-->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -581,6 +581,8 @@
     <string name="tab_tray_title">Open Tabs</string>
     <!-- Text shown in the menu for saving tabs to a collection -->
     <string name="tab_tray_menu_item_save">Save to collection</string>
+    <!-- Text shown in the menu for the collection selector -->
+    <string name="tab_tray_menu_select">Select</string>
     <!-- Text shown in the menu for sharing all tabs -->
     <string name="tab_tray_menu_item_share">Share all tabs</string>
     <!-- Text shown in the menu to view recently closed tabs -->


### PR DESCRIPTION
Fix #16522: Replace `@string/tab_tray_menu_item_save` with "Select", Remove "Share all tabs" option from tab tray's private browsing menu

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

I used `bookmark_menu_select_button` as the reference for the "Select" text in all of the locales.

![image](https://user-images.githubusercontent.com/3119646/99117572-e1973180-2630-11eb-9614-496532086824.png)
