### PR TITLE
#16053: Fix crash when closing private tabs via notification 

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -180,7 +180,6 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
                 .attachViewToRunVisualCompletenessQueueLater(WeakReference(rootContainer))
         }
 
-        checkPrivateShortcutEntryPoint(intent)
         privateNotificationObserver = PrivateNotificationFeature(
             applicationContext,
             components.core.store,
@@ -601,17 +600,6 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
             return it.getBooleanExtra(START_IN_RECENTS_SCREEN, false)
         }
         return false
-    }
-
-    private fun checkPrivateShortcutEntryPoint(intent: Intent) {
-        if (intent.hasExtra(OPEN_TO_SEARCH) &&
-            (intent.getStringExtra(OPEN_TO_SEARCH) ==
-                    StartSearchIntentProcessor.STATIC_SHORTCUT_NEW_PRIVATE_TAB ||
-                    intent.getStringExtra(OPEN_TO_SEARCH) ==
-                    StartSearchIntentProcessor.PRIVATE_BROWSING_PINNED_SHORTCUT)
-        ) {
-            PrivateNotificationService.isStartedFromPrivateShortcut = true
-        }
     }
 
     private fun setupThemeAndBrowsingMode(mode: BrowsingMode) {

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarIntegration.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarIntegration.kt
@@ -141,7 +141,6 @@ class DefaultToolbarIntegration(
 
         val tabsAction = TabCounterToolbarButton(
             lifecycleOwner,
-            isPrivate,
             onItemTapped = {
                 interactor.onTabCounterMenuItemTapped(it)
             },


### PR DESCRIPTION
This prevents the "Display Already Acquired" crash when closing private tabs via our system notification. We're only launching to home if the app was in private mode. If we're in normal mode there's nothing to do as the outcome is essentially the same.

Also added a fix here for the incorrect tab count when re-opening the app after private tabs have been removed.