### PR TITLE
For #16614 - Ensure a stable order for the items in tabs tray.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabtray/SyncedTabsController.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/SyncedTabsController.kt
@@ -21,7 +21,6 @@ import mozilla.components.browser.storage.sync.SyncedDeviceTabs
 import mozilla.components.feature.syncedtabs.view.SyncedTabsView
 import mozilla.components.lib.state.ext.flowScoped
 import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
-import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.sync.ListenerDelegate
 import org.mozilla.fenix.sync.SyncedTabsAdapter
 import org.mozilla.fenix.sync.ext.toAdapterList
@@ -51,11 +50,7 @@ class SyncedTabsController(
                 .collect { mode ->
                     when (mode) {
                         is TabTrayDialogFragmentState.Mode.Normal -> {
-                            if (view.context.settings().gridTabView) {
-                                concatAdapter.addAdapter(adapter)
-                            } else {
-                                concatAdapter.addAdapter(0, adapter)
-                            }
+                            concatAdapter.addAdapter(adapter)
                         }
                         is TabTrayDialogFragmentState.Mode.MultiSelect -> {
                             concatAdapter.removeAdapter(adapter)

--- a/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayView.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayView.kt
@@ -192,13 +192,8 @@ class TabTrayView(
 
             tabsAdapter.tabTrayInteractor = interactor
             tabsAdapter.onTabsUpdated = {
-                if (view.context.settings().gridTabView) {
-                    concatAdapter.addAdapter(syncedTabsController.adapter)
-                    concatAdapter.addAdapter(collectionsButtonAdapter)
-                } else {
-                    concatAdapter.addAdapter(syncedTabsController.adapter)
-                    concatAdapter.addAdapter(collectionsButtonAdapter)
-                }
+                concatAdapter.addAdapter(collectionsButtonAdapter)
+                concatAdapter.addAdapter(syncedTabsController.adapter)
 
                 if (hasAccessibilityEnabled) {
                     tabsAdapter.notifyItemRangeChanged(0, tabs.size)

--- a/app/src/test/java/org/mozilla/fenix/tabtray/SyncedTabsControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabtray/SyncedTabsControllerTest.kt
@@ -25,7 +25,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.R
-import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.sync.SyncedTabsViewHolder
 import org.mozilla.fenix.tabtray.TabTrayDialogFragmentAction.EnterMultiSelectMode
@@ -56,7 +55,6 @@ class SyncedTabsControllerTest {
 
         concatAdapter = mockk()
         every { concatAdapter.addAdapter(any()) } returns true
-        every { concatAdapter.addAdapter(any(), any()) } returns true
         every { concatAdapter.removeAdapter(any()) } returns true
 
         store = TabTrayDialogFragmentStore(
@@ -130,22 +128,11 @@ class SyncedTabsControllerTest {
 
     @Test
     fun `concatAdapter updated on mode changes`() = testDispatcher.runBlockingTest {
-        // When returning from Multiselect while in grid view the adapter should be added at the end
-        every { view.context.settings().gridTabView } returns true
-
         store.dispatch(EnterMultiSelectMode).joinBlocking()
         verify { concatAdapter.removeAdapter(any()) }
 
         store.dispatch(ExitMultiSelectMode).joinBlocking()
+        // When returning from Multiselect the adapter should be added at the end
         verify { concatAdapter.addAdapter(any()) }
-
-        // When returning from Multiselect while in list view the adapter should be added at the front
-        every { view.context.settings().gridTabView } returns false
-
-        store.dispatch(EnterMultiSelectMode).joinBlocking()
-        verify { concatAdapter.removeAdapter(any()) }
-
-        store.dispatch(ExitMultiSelectMode).joinBlocking()
-        verify { concatAdapter.addAdapter(0, any()) }
     }
 }


### PR DESCRIPTION
Items should follow the following ordering:
- current session open tabs
- collections options - currently the "Select tabs" button
- synced tabs items

This order should also be kept after returning from Multiselect mode.

![StableOrderForTheTabTrayItems](https://user-images.githubusercontent.com/11428869/99422233-011bac00-2908-11eb-86ea-7e9157f9e086.gif)
[video](https://drive.google.com/file/d/1_-yyL58dsTqSCvpM5B5SJ9Hg817LTz8g/view?usp=sharing)



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests.
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made.
- [x] **Accessibility**: The code in this PR does not include any a11y user facing features.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
