### PR TITLE
Bug 1678572 - A github-release shouldn't kick off releases if the bot…

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -104,7 +104,7 @@ tasks:
                 tasks_for in ["action", "cron"]
                 || (tasks_for == "github-pull-request" && pullRequestAction in ["opened", "reopened", "synchronize"])
                 || (tasks_for == "github-push" && head_branch[:10] != "refs/tags/") && (head_branch != "staging.tmp") && (head_branch != "trying.tmp")
-                || (tasks_for == "github-release" && releaseAction == "published")
+                || (tasks_for == "github-release" && releaseAction == "published" && (ownerEmail != "mozilla-release-automation-bot@users.noreply.github.com") && (ownerEmail != "mozilla-release-automation-bot-staging@users.noreply.github.com"))
               then:
                   $let:
                       level:


### PR DESCRIPTION
… made it

Full context at: https://bugzilla.mozilla.org/show_bug.cgi?id=1678572#c0

Kudos to @camd for the idea 👍 (I wanted to add you as a reviewer but the Github UI prevents me from doing so)