### PR TITLE
Nimbus-SDK-119 Get Nimbus server endpoint at build time.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,12 +79,12 @@ gen-external-apklibs
 # macOS
 .DS_Store
 
-# Token files
+# Secrets files, e.g. tokens
 .leanplum_token
 .adjust_token
 .sentry_token
 .mls_token
-
+.nimbus
 
 # Python Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ The known features that are disabled by default are:
 - Mozilla Location Services (also known as MLS)
 - Firebase Push Services
 - Telemetry (only disabled by default in debug builds)
+- Nimbus
 
 ## Pre-push hooks
 To reduce review turn-around time, we'd like all pushes to run tests locally. We'd
@@ -210,6 +211,15 @@ See a [demo of auto-publication workflow in action](https://www.youtube.com/watc
 In order to build successfully, you need to check out a commit in the dependency repository that has no breaking changes. The two best ways to do this are:
 - Run the `<android-components>/tools/list_compatible_dependency_versions.py` script to output a compatible commit
 - Check out the latest commit from master in this repository and the dependency repository. However, this may fail if there were breaking changes added recently to the dependency.
+
+### Using Nimbus servers during local development
+If you're working with the Nimbus experiments platform, by default for local development Fenix configures Nimbus to not use a server.
+
+If you wish to use a Nimbus server during local development, you can add a `https://` or `file://` endpoint to the `local.properties` file.
+
+- `nimbus.remote-settings.url`
+
+Testing experimental branches should be possible without a server.
 
 ### GeckoView
 Specify a relative path to your local `mozilla-central` checkout via `dependencySubstitutions.geckoviewTopsrcdir`,

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -331,6 +331,30 @@ android.applicationVariants.all { variant ->
         buildConfigField 'String', 'MLS_TOKEN', '""'
         println("X_X")
     }
+
+// -------------------------------------------------------------------------------------------------
+// Nimbus: Read endpoint from local.properties of a local file if it exists
+// -------------------------------------------------------------------------------------------------
+
+    print("Nimbus endpoint: ")
+
+    if (!isDebug) {
+        try {
+            def url = new File("${rootDir}/.nimbus").text.trim()
+            buildConfigField 'String', 'NIMBUS_ENDPOINT', '"' + url + '"'
+            println "(Added from .nimbus file)"
+        } catch (FileNotFoundException ignored) {
+            buildConfigField 'String', 'NIMBUS_ENDPOINT', 'null'
+            println("X_X")
+        }
+    } else if (gradle.hasProperty("localProperties.nimbus.remote-settings.url")) {
+        def url=gradle.getProperty("localProperties.nimbus.remote-settings.url")
+        buildConfigField 'String', 'NIMBUS_ENDPOINT', '"' + url + '"'
+        println "(Added from local.properties file)"
+    } else {
+        buildConfigField 'String', 'NIMBUS_ENDPOINT', 'null'
+        println("--")
+    }
 }
 
 androidExtensions {

--- a/app/src/main/java/org/mozilla/fenix/components/Analytics.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Analytics.kt
@@ -8,12 +8,14 @@ import android.app.Application
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import mozilla.components.lib.crash.CrashReporter
 import mozilla.components.lib.crash.service.CrashReporterService
 import mozilla.components.lib.crash.service.GleanCrashReporterService
 import mozilla.components.lib.crash.service.MozillaSocorroService
 import mozilla.components.lib.crash.service.SentryService
 import mozilla.components.service.nimbus.Nimbus
+import mozilla.components.service.nimbus.NimbusServerSettings
 import org.mozilla.fenix.BuildConfig
 import org.mozilla.fenix.Config
 import org.mozilla.fenix.FeatureFlags
@@ -103,7 +105,13 @@ class Analytics(
     }
 
     val experiments by lazyMonitored {
-        Nimbus(context, server = null).apply {
+        val url: String? = BuildConfig.NIMBUS_ENDPOINT
+        val serverSettings = if (!url.isNullOrBlank()) {
+            NimbusServerSettings(url = Uri.parse(url))
+        } else {
+            null
+        }
+        Nimbus(context, serverSettings).apply {
             if (FeatureFlags.nimbusExperiments) {
                 initialize()
                 // Global opt out state is stored in Nimbus, and shouldn't be toggled to `true`

--- a/taskcluster/fenix_taskgraph/transforms/build.py
+++ b/taskcluster/fenix_taskgraph/transforms/build.py
@@ -48,6 +48,7 @@ def add_shippable_secrets(config, tasks):
                 ('leanplum', '.leanplum_token'),
                 ('sentry_dsn', '.sentry_token'),
                 ('mls', '.mls_token'),
+                ('nimbus_url', '.nimbus'),
             )])
         else:
             dummy_secrets.extend([{


### PR DESCRIPTION
This PR builds on [AC##9024][1], and implements setting the Nimbus endpoints from [a secret set at build time][2].

For production use, this requires a secret named `nimbus_url` to be put into CI.

Note: Nimbus is currently behind a feature flag.

If developers wish to use a Nimbus server for local development, you can set the url by adding an entry into local.properties, e.g.:

```
nimbus.remote-settings.url=https://settings.stage.moz4ws.net
```

Without setting server, Nimbus will be able to function, except no experimental definitions will be fetched, and features under experiment will be configured as if not enrolled in the experiment.

[1]: https://github.com/mozilla-mobile/android-components/pull/9024
[2]: https://groups.google.com/a/mozilla.com/g/android-components-team/c/lAGVKQy8aiA/m/rY3uGAwhBAAJ

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
