### PR TITLE
For #16676 - Do not switch mode on last private tab via tab context menu

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt
@@ -13,7 +13,6 @@ import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.browser.BrowserAnimator.Companion.getToolbarNavOptions
 import org.mozilla.fenix.browser.BrowserFragmentDirections
-import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.browser.readermode.ReaderModeController
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.components.metrics.MetricController
@@ -108,8 +107,6 @@ class DefaultBrowserToolbarController(
                 sessionManager.selectedSession?.let {
                     // When closing the last tab we must show the undo snackbar in the home fragment
                     if (sessionManager.sessionsOfType(it.private).count() == 1) {
-                        // The tab tray always returns to normal mode so do that here too
-                        activity.browsingModeManager.mode = BrowsingMode.Normal
                         homeViewModel.sessionToDelete = it.id
                         navController.navigate(
                             BrowserFragmentDirections.actionGlobalHome()

--- a/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarControllerTest.kt
@@ -208,7 +208,6 @@ class DefaultBrowserToolbarControllerTest {
 
     @Test
     fun handleToolbarCloseTabPressWithLastPrivateSession() {
-        val browsingModeManager = SimpleBrowsingModeManager(BrowsingMode.Private)
         val item = TabCounterMenu.Item.CloseTab
         val sessions = listOf(
             mockk<Session> {
@@ -218,7 +217,6 @@ class DefaultBrowserToolbarControllerTest {
 
         every { currentSession.private } returns true
         every { sessionManager.sessions } returns sessions
-        every { activity.browsingModeManager } returns browsingModeManager
 
         val controller = createController()
         controller.handleTabCounterItemInteraction(item)
@@ -226,7 +224,6 @@ class DefaultBrowserToolbarControllerTest {
             homeViewModel.sessionToDelete = "1"
             navController.navigate(BrowserFragmentDirections.actionGlobalHome())
         }
-        assertEquals(BrowsingMode.Normal, browsingModeManager.mode)
     }
 
     @Test


### PR DESCRIPTION
We no longer do this in the tabs tray AFAICT and recreating while navigating seems like a bad idea.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
