### PR TITLE
Fixes #16271 - Fixes ripple being cut-off in Saved logins sort toolbar

### DIFF
--- a/app/src/main/res/layout/saved_logins_sort_items_toolbar_child.xml
+++ b/app/src/main/res/layout/saved_logins_sort_items_toolbar_child.xml
@@ -6,8 +6,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/sort_logins_menu_root"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:background="?android:attr/selectableItemBackgroundBorderless">
+    android:layout_height="?actionBarSize"
+    android:background="?android:attr/selectableItemBackground">
 
     <TextView
         android:id="@+id/toolbar_title"


### PR DESCRIPTION
For #16271

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

<hr>

@ekager , i'm not sure of the fix. One thing that needs to be carefully reviewed is the height of the toolbar view, i'm explicitly setting it to `?actionbarSize` as we need fixed height to fix this, when using a bordered item drawable. could be wrong here. :crossed_fingers:

PS: Unable to take screenshot cause of security constraints. 


