### PR TITLE
For #16759: Prevent crash on showing recently closed tabs info banner.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayView.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayView.kt
@@ -53,6 +53,7 @@ import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.updateAccessibilityCollectionInfo
 import org.mozilla.fenix.tabtray.SaveToCollectionsButtonAdapter.MultiselectModeChange
 import org.mozilla.fenix.tabtray.TabTrayDialogFragmentState.Mode
+import org.mozilla.fenix.utils.Settings
 import java.text.NumberFormat
 import kotlin.math.max
 import kotlin.math.roundToInt
@@ -266,11 +267,15 @@ class TabTrayView(
 
         adjustNewTabButtonsForNormalMode()
 
+        displayInfoBannerIfNeccessary(tabs, view.context.settings())
+    }
+
+    private fun displayInfoBannerIfNeccessary(tabs: List<TabSessionState>, settings: Settings) {
         @Suppress("ComplexCondition")
-        if (
-            view.context.settings().shouldShowGridViewBanner &&
-            view.context.settings().canShowCfr &&
-            view.context.settings().listTabView &&
+        val infoBanner = if (
+            settings.shouldShowGridViewBanner &&
+            settings.canShowCfr &&
+            settings.listTabView &&
             tabs.size >= TAB_COUNT_SHOW_CFR
         ) {
             InfoBanner(
@@ -280,17 +285,14 @@ class TabTrayView(
                 actionText = view.context.getString(R.string.tab_tray_grid_view_banner_positive_button_text),
                 container = view.infoBanner,
                 dismissByHiding = true,
-                dismissAction = { view.context.settings().shouldShowGridViewBanner = false }
+                dismissAction = { settings.shouldShowGridViewBanner = false }
             ) {
                 interactor.onGoToTabsSettings()
-                view.context.settings().shouldShowGridViewBanner = false
-            }.apply {
-                view.infoBanner.visibility = View.VISIBLE
-                showBanner()
+                settings.shouldShowGridViewBanner = false
             }
         } else if (
-            view.context.settings().shouldShowAutoCloseTabsBanner &&
-            view.context.settings().canShowCfr &&
+            settings.shouldShowAutoCloseTabsBanner &&
+            settings.canShowCfr &&
             tabs.size >= TAB_COUNT_SHOW_CFR
         ) {
             InfoBanner(
@@ -300,14 +302,18 @@ class TabTrayView(
                 actionText = view.context.getString(R.string.tab_tray_close_tabs_banner_positive_button_text),
                 container = view.infoBanner,
                 dismissByHiding = true,
-                dismissAction = { view.context.settings().shouldShowAutoCloseTabsBanner = false }
+                dismissAction = { settings.shouldShowAutoCloseTabsBanner = false }
             ) {
                 interactor.onGoToTabsSettings()
-                view.context.settings().shouldShowAutoCloseTabsBanner = false
-            }.apply {
-                view.infoBanner.visibility = View.VISIBLE
-                showBanner()
+                settings.shouldShowAutoCloseTabsBanner = false
             }
+        } else {
+            null
+        }
+
+        infoBanner?.apply {
+            view.infoBanner.visibility = View.VISIBLE
+            showBanner()
         }
     }
 


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
