### PR TITLE
Issue #16648: Expose Nexus logs

### DIFF
--- a/taskcluster/ci/toolchain/android.yml
+++ b/taskcluster/ci/toolchain/android.yml
@@ -55,4 +55,8 @@ linux64-android-gradle-dependencies:
             # TODO do no hardcode
             ANDROID_SDK_ROOT: /builds/worker/fetches/android-sdk-linux
         max-run-time: 14400
+        artifacts:
+            - type: directory
+              name: public/logs/nexus
+              path: /opt/sonatype/nexus/logs
     worker-type: b-android-large


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture



**Issue:** #16648 
**Changes:** Added code to `toolchain-linux64-android-gradle-dependencies` to expose Nexus logs to better diagnose toolchain task failure.
**Tests:** I accidentally set up hooks after pushing my changes, so this has not been tested locally. Could someone explain to me how to manually run these tests?
**Screenshots:** No user facing work.
**Accessibility:** No user facing work.