### PR TITLE
16373 Count the # of inflations done on startup

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/perf/StartupExcessiveResourceUseTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/perf/StartupExcessiveResourceUseTest.kt
@@ -25,6 +25,7 @@ private const val EXPECTED_RUNBLOCKING_COUNT = 2
 private const val EXPECTED_COMPONENT_INIT_COUNT = 42
 private const val EXPECTED_VIEW_HIERARCHY_DEPTH = 12
 private const val EXPECTED_RECYCLER_VIEW_CONSTRAINT_LAYOUT_CHILDREN = 4
+private const val EXPECTED_NUMBER_OF_INFLATION = 12
 
 private val failureMsgStrictMode = getErrorMessage(
     shortName = "StrictMode suppression",
@@ -54,6 +55,11 @@ private val failureMsgRecyclerViewConstraintLayoutChildren = getErrorMessage(
 ) + "Please note that we're not sure if this is a useful metric to assert: with your feedback, " +
     "we'll find out over time if it is or is not."
 
+private val failureMsgNumberOfInflation = getErrorMessage(
+    shortName = "Number of inflation on start up doesn't match expected count",
+    implications = "The number of inflation can negatively impact start up time. Having more inflations" +
+            "will most likely mean we're adding extra work on the UI thread."
+)
 /**
  * A performance test to limit the number of StrictMode suppressions and number of runBlocking used
  * on startup.
@@ -90,6 +96,8 @@ class StartupExcessiveResourceUseTest {
         val actualViewHierarchyDepth = countAndLogViewHierarchyDepth(rootView, 1)
         val actualRecyclerViewConstraintLayoutChildren = countRecyclerViewConstraintLayoutChildren(rootView, null)
 
+        val actualNumberOfInflations = InflationCounter.inflationCount.get()
+
         assertEquals(failureMsgStrictMode, EXPECTED_SUPPRESSION_COUNT, actualSuppresionCount)
         assertEquals(failureMsgRunBlocking, EXPECTED_RUNBLOCKING_COUNT, actualRunBlocking)
         assertEquals(failureMsgComponentInit, EXPECTED_COMPONENT_INIT_COUNT, actualComponentInitCount)
@@ -99,6 +107,7 @@ class StartupExcessiveResourceUseTest {
             EXPECTED_RECYCLER_VIEW_CONSTRAINT_LAYOUT_CHILDREN,
             actualRecyclerViewConstraintLayoutChildren
         )
+        assertEquals(failureMsgNumberOfInflation, EXPECTED_COMPONENT_INIT_COUNT, actualNumberOfInflations)
     }
 }
 

--- a/app/src/androidTest/java/org/mozilla/fenix/perf/StartupExcessiveResourceUseTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/perf/StartupExcessiveResourceUseTest.kt
@@ -107,7 +107,7 @@ class StartupExcessiveResourceUseTest {
             EXPECTED_RECYCLER_VIEW_CONSTRAINT_LAYOUT_CHILDREN,
             actualRecyclerViewConstraintLayoutChildren
         )
-        assertEquals(failureMsgNumberOfInflation, EXPECTED_COMPONENT_INIT_COUNT, actualNumberOfInflations)
+        assertEquals(failureMsgNumberOfInflation, EXPECTED_NUMBER_OF_INFLATION, actualNumberOfInflations)
     }
 }
 

--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -831,7 +831,7 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
     override fun getSystemService(name: String): Any? {
         if (LAYOUT_INFLATER_SERVICE == name) {
             if (inflater == null) {
-                inflater = PerformanceInflater(LayoutInflater.from(baseContext).cloneInContext(this), this)
+                inflater = PerformanceInflater(LayoutInflater.from(baseContext), this)
             }
             return inflater
         }

--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -14,6 +14,7 @@ import android.os.SystemClock
 import android.text.format.DateUtils
 import android.util.AttributeSet
 import android.view.KeyEvent
+import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewConfiguration
 import android.view.WindowManager
@@ -89,6 +90,7 @@ import org.mozilla.fenix.library.bookmarks.DesktopFolders
 import org.mozilla.fenix.library.history.HistoryFragmentDirections
 import org.mozilla.fenix.library.recentlyclosed.RecentlyClosedFragmentDirections
 import org.mozilla.fenix.perf.Performance
+import org.mozilla.fenix.perf.PerformanceInflater
 import org.mozilla.fenix.perf.StartupTimeline
 import org.mozilla.fenix.search.SearchDialogFragmentDirections
 import org.mozilla.fenix.session.PrivateNotificationService
@@ -137,6 +139,8 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
     private val webExtensionPopupFeature by lazy {
         WebExtensionPopupFeature(components.core.store, ::openPopup)
     }
+
+    private var inflater : LayoutInflater?  = null
 
     private val navHost by lazy {
         supportFragmentManager.findFragmentById(R.id.container) as NavHostFragment
@@ -822,6 +826,16 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
         base.components.strictMode.resetAfter(StrictMode.allowThreadDiskReads()) {
             super.attachBaseContext(base)
         }
+    }
+
+    override fun getSystemService(name: String): Any? {
+        if(LAYOUT_INFLATER_SERVICE == name){
+            if(inflater == null) {
+                inflater = PerformanceInflater(LayoutInflater.from(baseContext).cloneInContext(this), this)
+            }
+            return inflater
+        }
+        return super.getSystemService(name)
     }
 
     protected open fun createBrowsingModeManager(initialMode: BrowsingMode): BrowsingModeManager {

--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -140,7 +140,7 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
         WebExtensionPopupFeature(components.core.store, ::openPopup)
     }
 
-    private var inflater : LayoutInflater?  = null
+    private var inflater: LayoutInflater? = null
 
     private val navHost by lazy {
         supportFragmentManager.findFragmentById(R.id.container) as NavHostFragment
@@ -829,8 +829,8 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
     }
 
     override fun getSystemService(name: String): Any? {
-        if(LAYOUT_INFLATER_SERVICE == name){
-            if(inflater == null) {
+        if (LAYOUT_INFLATER_SERVICE == name) {
+            if (inflater == null) {
                 inflater = PerformanceInflater(LayoutInflater.from(baseContext).cloneInContext(this), this)
             }
             return inflater

--- a/app/src/main/java/org/mozilla/fenix/perf/PerformanceInflater.kt
+++ b/app/src/main/java/org/mozilla/fenix/perf/PerformanceInflater.kt
@@ -12,7 +12,6 @@ import android.view.ViewGroup
 import org.mozilla.fenix.ext.getAndIncrementNoOverflow
 import java.util.concurrent.atomic.AtomicInteger
 
-
 /**
  * Counts the number of inflations fenix does. This class behaves only as an inflation counter since
  * it takes the `inflater` that is given by the base system. This is done in order not to change
@@ -25,7 +24,7 @@ open class PerformanceInflater(
 ) : LayoutInflater(
     inflater,
     context
-){
+) {
 
     private val sClassPrefixList = arrayOf(
         "android.widget.",
@@ -48,6 +47,7 @@ open class PerformanceInflater(
      * it hardcodes the prefix as "android.view." this means that a xml element such as
      * ImageButton will crash the app using android.view.ImageButton.
      */
+    @Suppress("EmptyCatchBlock")
     @Throws(ClassNotFoundException::class)
     override fun onCreateView(name: String?, attrs: AttributeSet?): View? {
         for (prefix in sClassPrefixList) {
@@ -57,13 +57,10 @@ open class PerformanceInflater(
                     return view
                 }
             } catch (e: ClassNotFoundException) {
-
             }
         }
         return super.onCreateView(name, attrs)
     }
-
-
 }
 
 object InflationCounter {

--- a/app/src/main/java/org/mozilla/fenix/perf/PerformanceInflater.kt
+++ b/app/src/main/java/org/mozilla/fenix/perf/PerformanceInflater.kt
@@ -19,7 +19,10 @@ import java.util.concurrent.atomic.AtomicInteger
  * the behavior of the app since all we want to do is count the inflations done.
  *
  */
-open class PerformanceInflater(val inflater: LayoutInflater, context: Context) : LayoutInflater(
+open class PerformanceInflater(
+    val inflater: LayoutInflater,
+    context: Context
+) : LayoutInflater(
     inflater,
     context
 ){

--- a/app/src/main/java/org/mozilla/fenix/perf/PerformanceInflater.kt
+++ b/app/src/main/java/org/mozilla/fenix/perf/PerformanceInflater.kt
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.perf
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import org.mozilla.fenix.ext.getAndIncrementNoOverflow
+import java.util.concurrent.atomic.AtomicInteger
+
+
+/**
+ * Counts the number of inflations fenix does. This class behaves only as an inflation counter since
+ * it takes the `inflater` that is given by the base system. This is done in order not to change
+ * the behavior of the app since all we want to do is count the inflations done.
+ *
+ */
+open class PerformanceInflater(val inflater: LayoutInflater, context: Context) : LayoutInflater(
+    inflater,
+    context
+){
+
+    private val sClassPrefixList = arrayOf(
+        "android.widget.",
+        "android.webkit.",
+        "android.app."
+    )
+
+    override fun cloneInContext(newContext: Context?): LayoutInflater {
+        return PerformanceInflater(inflater, newContext!!)
+    }
+
+    override fun inflate(resource: Int, root: ViewGroup?, attachToRoot: Boolean): View {
+        InflationCounter.inflationCount.getAndIncrementNoOverflow()
+        return super.inflate(resource, root, attachToRoot)
+    }
+
+    /**
+     * This code was taken from the PhoneLayoutInflater.java (Similarly, AsyncLayoutInflater
+     * implements it the exact same way too). Looking at the `super.OnCreateView(name, attrs)`,
+     * it hardcodes the prefix as "android.view." this means that a xml element such as
+     * ImageButton will crash the app using android.view.ImageButton.
+     */
+    @Throws(ClassNotFoundException::class)
+    override fun onCreateView(name: String?, attrs: AttributeSet?): View? {
+        for (prefix in sClassPrefixList) {
+            try {
+                val view = createView(name, prefix, attrs)
+                if (view != null) {
+                    return view
+                }
+            } catch (e: ClassNotFoundException) {
+
+            }
+        }
+        return super.onCreateView(name, attrs)
+    }
+
+
+}
+
+object InflationCounter {
+    val inflationCount = AtomicInteger(0)
+}

--- a/app/src/main/java/org/mozilla/fenix/perf/PerformanceInflater.kt
+++ b/app/src/main/java/org/mozilla/fenix/perf/PerformanceInflater.kt
@@ -9,10 +9,10 @@ import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.annotation.VisibleForTesting
 import org.mozilla.fenix.ext.getAndIncrementNoOverflow
+import java.lang.reflect.Modifier.PRIVATE
 import java.util.concurrent.atomic.AtomicInteger
-
-
 
 private val classPrefixList = arrayOf(
         "android.widget.",
@@ -43,10 +43,15 @@ open class PerformanceInflater(
     }
 
     /**
-     * This code was taken from the PhoneLayoutInflater.java (Similarly, AsyncLayoutInflater
-     * implements it the exact same way too). Looking at the `super.OnCreateView(name, attrs)`,
+     * This code was taken from the PhoneLayoutInflater.java located in the android source code
+     * (Similarly, AsyncLayoutInflater implements it the exact same way too which can be found in the
+     * Android Framework). This piece of code was taken from the other inflaters implemented by Android
+     * since we do not want to change the inflater behavior except to count the number of inflations
+     * that our app is doing for performance purposes. Looking at the `super.OnCreateView(name, attrs)`,
      * it hardcodes the prefix as "android.view." this means that a xml element such as
-     * ImageButton will crash the app using android.view.ImageButton.
+     * ImageButton will crash the app using android.view.ImageButton. This method only works with
+     * XML tag that contains no prefix. This means that views such as androidx.recyclerview... will not
+     * work with this method.
      */
     @Suppress("EmptyCatchBlock")
     @Throws(ClassNotFoundException::class)
@@ -64,6 +69,7 @@ open class PerformanceInflater(
     }
 }
 
+@VisibleForTesting(otherwise = PRIVATE)
 object InflationCounter {
     val inflationCount = AtomicInteger(0)
 }

--- a/app/src/main/java/org/mozilla/fenix/perf/PerformanceInflater.kt
+++ b/app/src/main/java/org/mozilla/fenix/perf/PerformanceInflater.kt
@@ -26,7 +26,7 @@ private val classPrefixList = arrayOf(
  *
  */
 open class PerformanceInflater(
-    val inflater: LayoutInflater,
+    inflater: LayoutInflater,
     context: Context
 ) : LayoutInflater(
     inflater,
@@ -63,6 +63,7 @@ open class PerformanceInflater(
                     return view
                 }
             } catch (e: ClassNotFoundException) {
+                // We want the super class to inflate if ever the view can't be inflated here
             }
         }
         return super.onCreateView(name, attrs)

--- a/app/src/main/java/org/mozilla/fenix/perf/PerformanceInflater.kt
+++ b/app/src/main/java/org/mozilla/fenix/perf/PerformanceInflater.kt
@@ -12,6 +12,13 @@ import android.view.ViewGroup
 import org.mozilla.fenix.ext.getAndIncrementNoOverflow
 import java.util.concurrent.atomic.AtomicInteger
 
+
+
+private val classPrefixList = arrayOf(
+        "android.widget.",
+        "android.webkit.",
+        "android.app."
+)
 /**
  * Counts the number of inflations fenix does. This class behaves only as an inflation counter since
  * it takes the `inflater` that is given by the base system. This is done in order not to change
@@ -26,14 +33,8 @@ open class PerformanceInflater(
     context
 ) {
 
-    private val sClassPrefixList = arrayOf(
-        "android.widget.",
-        "android.webkit.",
-        "android.app."
-    )
-
     override fun cloneInContext(newContext: Context?): LayoutInflater {
-        return PerformanceInflater(inflater, newContext!!)
+        return PerformanceInflater(this, newContext!!)
     }
 
     override fun inflate(resource: Int, root: ViewGroup?, attachToRoot: Boolean): View {
@@ -50,7 +51,7 @@ open class PerformanceInflater(
     @Suppress("EmptyCatchBlock")
     @Throws(ClassNotFoundException::class)
     override fun onCreateView(name: String?, attrs: AttributeSet?): View? {
-        for (prefix in sClassPrefixList) {
+        for (prefix in classPrefixList) {
             try {
                 val view = createView(name, prefix, attrs)
                 if (view != null) {

--- a/app/src/test/java/org/mozilla/fenix/perf/PerformanceInflaterTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/perf/PerformanceInflaterTest.kt
@@ -1,0 +1,82 @@
+package org.mozilla.fenix.perf
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.FrameLayout
+import io.mockk.every
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.fenix.R
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+import java.io.File
+
+@RunWith(FenixRobolectricTestRunner::class)
+class PerformanceInflaterTest {
+
+    private lateinit var perfInflater : MockInflater
+
+    private val layoutNotToTest = setOf(
+        "fragment_browser",
+        "fragment_add_on_internal_settings"
+    )
+
+    private val layoutWithMerge = setOf(
+        "mozac_ui_tabcounter_layout",
+        "tabstray_multiselect_items",
+        "tab_preview",
+        "tracking_protection_category"
+    )
+
+    @Before
+    fun setup() {
+        InflationCounter.inflationCount.set(0)
+
+        perfInflater = MockInflater(LayoutInflater.from(testContext), testContext)
+    }
+
+    @Test
+    fun `WHEN we inflate a view, the inflation counter should increase`() {
+        assertEquals(0, InflationCounter.inflationCount.get())
+        perfInflater.inflate(R.layout.fragment_home, null, false)
+        assertEquals(1, InflationCounter.inflationCount.get())
+    }
+
+    @Test
+    fun `WHEN inflating one of our resource file, the inflater should not crash`(){
+        val fileList = File("./src/main/res/layout").listFiles()
+        if(fileList != null){
+            for(file in fileList){
+                val layoutName = file.name.split(".")[0]
+                val layoutId = testContext.resources.getIdentifier(
+                    layoutName,
+                    "layout",
+                    testContext.packageName
+                )
+                if(layoutId != -1 && !layoutNotToTest.contains(layoutName)){
+                    perfInflater.inflate(layoutId, FrameLayout(testContext), true)
+                }
+            }
+        }
+    }
+}
+
+private class MockInflater(
+    inflater: LayoutInflater,
+    context: Context
+) : PerformanceInflater(
+    inflater,
+    context
+) {
+
+    override fun onCreateView(name: String?, attrs: AttributeSet?): View? {
+        if(name!!.contains("fragment")) {
+            return FrameLayout(testContext)
+        }
+        return super.onCreateView(name, attrs)
+    }
+}

--- a/app/src/test/java/org/mozilla/fenix/perf/PerformanceInflaterTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/perf/PerformanceInflaterTest.kt
@@ -5,7 +5,6 @@ import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.FrameLayout
-import io.mockk.every
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -18,7 +17,7 @@ import java.io.File
 @RunWith(FenixRobolectricTestRunner::class)
 class PerformanceInflaterTest {
 
-    private lateinit var perfInflater : MockInflater
+    private lateinit var perfInflater: MockInflater
 
     private val layoutNotToTest = setOf(
         "fragment_browser",
@@ -47,17 +46,17 @@ class PerformanceInflaterTest {
     }
 
     @Test
-    fun `WHEN inflating one of our resource file, the inflater should not crash`(){
+    fun `WHEN inflating one of our resource file, the inflater should not crash`() {
         val fileList = File("./src/main/res/layout").listFiles()
-        if(fileList != null){
-            for(file in fileList){
+        if (fileList != null) {
+            for (file in fileList) {
                 val layoutName = file.name.split(".")[0]
                 val layoutId = testContext.resources.getIdentifier(
                     layoutName,
                     "layout",
                     testContext.packageName
                 )
-                if(layoutId != -1 && !layoutNotToTest.contains(layoutName)){
+                if (layoutId != -1 && !layoutNotToTest.contains(layoutName)) {
                     perfInflater.inflate(layoutId, FrameLayout(testContext), true)
                 }
             }
@@ -74,7 +73,7 @@ private class MockInflater(
 ) {
 
     override fun onCreateView(name: String?, attrs: AttributeSet?): View? {
-        if(name!!.contains("fragment")) {
+        if (name!!.contains("fragment")) {
             return FrameLayout(testContext)
         }
         return super.onCreateView(name, attrs)

--- a/app/src/test/java/org/mozilla/fenix/perf/PerformanceInflaterTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/perf/PerformanceInflaterTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.perf
 
 import android.content.Context
@@ -32,7 +36,7 @@ class PerformanceInflaterTest {
     }
 
     @Test
-    fun `WHEN we inflate a view, the inflation counter should increase`() {
+    fun `WHEN we inflate a view,THEN the inflation counter should increase`() {
         assertEquals(0, InflationCounter.inflationCount.get())
         perfInflater.inflate(R.layout.fragment_home, null, false)
         assertEquals(1, InflationCounter.inflationCount.get())

--- a/app/src/test/java/org/mozilla/fenix/perf/PerformanceInflaterTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/perf/PerformanceInflaterTest.kt
@@ -24,13 +24,6 @@ class PerformanceInflaterTest {
         "fragment_add_on_internal_settings"
     )
 
-    private val layoutWithMerge = setOf(
-        "mozac_ui_tabcounter_layout",
-        "tabstray_multiselect_items",
-        "tab_preview",
-        "tracking_protection_category"
-    )
-
     @Before
     fun setup() {
         InflationCounter.inflationCount.set(0)


### PR DESCRIPTION
The perf team has been trying to improve the regression that happen on startup. One idea was to reduce the # of inflations. This PR aims at counting how many we do on start up at the moment and try to not go above that.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
