### PR TITLE
Issue #16780: Enable Firefox to handle intent category CATEGORY_APP_BROWSER 

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -43,7 +43,9 @@
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
+                <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.LAUNCHER" />
+                <category android:name="android.intent.category.APP_BROWSER" />
             </intent-filter>
 
             <meta-data

--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -81,6 +81,7 @@ import org.mozilla.fenix.home.intent.OpenBrowserIntentProcessor
 import org.mozilla.fenix.home.intent.OpenSpecificTabIntentProcessor
 import org.mozilla.fenix.home.intent.SpeechProcessingIntentProcessor
 import org.mozilla.fenix.home.intent.StartSearchIntentProcessor
+import org.mozilla.fenix.home.intent.AppBrowserIntentProcessor
 import org.mozilla.fenix.library.bookmarks.BookmarkFragmentDirections
 import org.mozilla.fenix.library.history.HistoryFragmentDirections
 import org.mozilla.fenix.library.recentlyclosed.RecentlyClosedFragmentDirections
@@ -144,7 +145,8 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
             StartSearchIntentProcessor(components.analytics.metrics),
             DeepLinkIntentProcessor(this, components.analytics.leanplumMetricsService),
             OpenBrowserIntentProcessor(this, ::getIntentSessionId),
-            OpenSpecificTabIntentProcessor(this)
+            OpenSpecificTabIntentProcessor(this),
+            AppBrowserIntentProcessor(this)
         )
     }
 

--- a/app/src/main/java/org/mozilla/fenix/home/intent/AppBrowserIntentProcessor.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/intent/AppBrowserIntentProcessor.kt
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.home.intent
+
+import android.content.Intent
+import androidx.navigation.NavController
+import mozilla.components.feature.intent.processing.IntentProcessor
+import org.mozilla.fenix.BrowserDirection
+import org.mozilla.fenix.HomeActivity
+import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.settings
+
+/**
+ * This handles the case where the browser is opened in response to [Intent.makeMainSelectorActivity]
+ * with action [Intent.ACTION_MAIN] and category [Intent.CATEGORY_APP_BROWSER].
+ */
+class AppBrowserIntentProcessor(
+    private val activity: HomeActivity
+) : HomeIntentProcessor {
+
+    override fun process(intent: Intent, navController: NavController, out: Intent): Boolean {
+        if (intent.selector?.action == Intent.ACTION_MAIN &&
+            intent.selector?.categories?.contains(Intent.CATEGORY_APP_BROWSER) == true &&
+            !intent.dataString.isNullOrEmpty()
+        ) {
+            val private = activity.settings().openLinksInAPrivateTab
+            if (getIntentProcessor(private).process(intent.toViewIntent())) {
+                activity.openToBrowser(BrowserDirection.FromGlobal)
+                return true
+            }
+        }
+
+        return false
+    }
+
+    private fun getIntentProcessor(private: Boolean): IntentProcessor {
+        return if (private) {
+            activity.components.intentProcessors.privateIntentProcessor
+        } else {
+            activity.components.intentProcessors.intentProcessor
+        }
+    }
+
+    private fun Intent.toViewIntent() = cloneFilter().apply {
+        action = Intent.ACTION_VIEW
+        removeCategory(Intent.CATEGORY_LAUNCHER)
+    }
+}

--- a/app/src/test/java/org/mozilla/fenix/home/intent/AppBrowserIntentProcessorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/intent/AppBrowserIntentProcessorTest.kt
@@ -100,6 +100,7 @@ class AppBrowserIntentProcessorTest {
         }
         Assert.assertTrue(processor.process(intent, navController, out))
 
+        verify { activity.components.intentProcessors.intentProcessor }
         verify { activity.openToBrowser(BrowserDirection.FromGlobal) }
         verify { navController wasNot Called }
         verify { out wasNot Called }
@@ -116,6 +117,7 @@ class AppBrowserIntentProcessorTest {
         }
         Assert.assertTrue(processor.process(intent, navController, out))
 
+        verify { activity.components.intentProcessors.privateIntentProcessor }
         verify { activity.openToBrowser(BrowserDirection.FromGlobal) }
         verify { navController wasNot Called }
         verify { out wasNot Called }

--- a/app/src/test/java/org/mozilla/fenix/home/intent/AppBrowserIntentProcessorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/intent/AppBrowserIntentProcessorTest.kt
@@ -1,0 +1,123 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.home.intent
+
+import android.content.Intent
+import android.net.Uri
+import androidx.navigation.NavController
+import io.mockk.Called
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.fenix.BrowserDirection
+import org.mozilla.fenix.HomeActivity
+import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+
+@RunWith(FenixRobolectricTestRunner::class)
+class AppBrowserIntentProcessorTest {
+
+    private lateinit var activity: HomeActivity
+    private lateinit var navController: NavController
+    private lateinit var out: Intent
+    private lateinit var processor: AppBrowserIntentProcessor
+    private lateinit var mockSelector: Intent
+
+    @Before
+    fun setup() {
+        activity = mockk(relaxed = true)
+        every { activity.components.intentProcessors.intentProcessor.process(any()) } returns true
+        every { activity.components.intentProcessors.privateIntentProcessor.process(any()) } returns true
+        every { activity.settings().openLinksInAPrivateTab } returns false
+        navController = mockk(relaxed = true)
+        out = mockk()
+        processor = AppBrowserIntentProcessor(activity)
+        mockSelector = Intent(Intent.ACTION_MAIN).apply {
+            addCategory(Intent.CATEGORY_APP_BROWSER)
+        }
+    }
+
+    @Test
+    fun `do not process blank intents`() {
+        Assert.assertFalse(processor.process(Intent(), navController, out))
+
+        verify { activity wasNot Called }
+        verify { navController wasNot Called }
+        verify { out wasNot Called }
+    }
+
+    @Test
+    fun `do not process when selector is null`() {
+        val intent = Intent().apply {
+            selector = null
+        }
+        Assert.assertFalse(processor.process(intent, navController, out))
+
+        verify { activity wasNot Called }
+        verify { navController wasNot Called }
+        verify { out wasNot Called }
+    }
+
+    @Test
+    fun `do not process when data is null`() {
+        val intent = Intent().apply {
+            selector = mockSelector
+            data = null
+        }
+        Assert.assertFalse(processor.process(intent, navController, out))
+
+        verify { activity wasNot Called }
+        verify { navController wasNot Called }
+        verify { out wasNot Called }
+    }
+
+    @Test
+    fun `do not process when data is empty`() {
+        val intent = Intent().apply {
+            selector = mockSelector
+            data = Uri.parse("")
+        }
+        Assert.assertFalse(processor.process(intent, navController, out))
+
+        verify { activity wasNot Called }
+        verify { navController wasNot Called }
+        verify { out wasNot Called }
+    }
+
+    @Test
+    fun `process app browser intents`() {
+        val intent = Intent(Intent.ACTION_MAIN).apply {
+            addCategory(Intent.CATEGORY_LAUNCHER)
+            selector = mockSelector
+            data = Uri.parse("https://www.mozilla.org/en-US/firefox/")
+        }
+        Assert.assertTrue(processor.process(intent, navController, out))
+
+        verify { activity.openToBrowser(BrowserDirection.FromGlobal) }
+        verify { navController wasNot Called }
+        verify { out wasNot Called }
+    }
+
+    @Test
+    fun `process app browser intents private`() {
+        every { activity.settings().openLinksInAPrivateTab } returns true
+
+        val intent = Intent(Intent.ACTION_MAIN).apply {
+            addCategory(Intent.CATEGORY_LAUNCHER)
+            selector = mockSelector
+            data = Uri.parse("https://www.mozilla.org/en-US/firefox/")
+        }
+        Assert.assertTrue(processor.process(intent, navController, out))
+
+        verify { activity.openToBrowser(BrowserDirection.FromGlobal) }
+        verify { navController wasNot Called }
+        verify { out wasNot Called }
+    }
+}


### PR DESCRIPTION
### Context:
In certain situations, developers need to force their intent to be opened in the browsers, instead of using `ACTION_VIEW`. This is done by using `CATEGORY_APP_BROWSER` with `makeMainSelectorActivity`.

**Currently, Chrome, Opera, Edge, and Brave handle this category.**

This can be reproduced using the code blow:
```kotlin
fun startBrowserIntent(uri: Uri) {
        val intent = Intent.makeMainSelectorActivity(Intent.ACTION_MAIN, Intent.CATEGORY_APP_BROWSER)
        intent.data = uri

        startActivity(intent)
}
```
More details and screenshots:  #16780

### PR Explanation:
Add AppBrowserIntentProcessor to handle category APP_BROWSER in the HomeActivity. Supports normal and private tabs.

AppBrowserIntentProcessor coverts the intent action to `ACTION_VIEW` then utlizes `TabIntentProcessor` for processing.

`CloneFilter` was used when converting to ViewIntent because we don't want to change the original intent as it will be used for analytics tracking.

Although do we want to track this type of intent to be ` Event.AppReceivedIntent.Source.LINK`? I see we're only tracking `Intent.ACTION_VIEW` as `Link`.

Closes #16780

### Testing:
1. Sent an intent from an external app using the code above or use the adb.
2. Verify firefox preview is on the list of browsers.
3. Open the link verify is loading properly. 
4. Toggle `Open links in a private tab` ON in the `Private browsing` settings. Retry from step 1 to step 3, verify the link is opened in private mode.

### Screenshots and gifs:
<img height="400" alt="test" src="https://user-images.githubusercontent.com/25991364/100636233-7c656080-32ff-11eb-9d70-8fa230a64d71.png">
normal tab:
<img height="400" alt="test" src="https://user-images.githubusercontent.com/25991364/100635943-24c6f500-32ff-11eb-9e2d-631f37fdc367.gif">
private tab:
<img height="400" alt="test" src="https://user-images.githubusercontent.com/25991364/100636070-4aec9500-32ff-11eb-9ffe-d93f94d1d97a.gif">

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests.
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made and an explanation of what it does.
- [x] **Accessibility**: The code in this PR does not include any user facing features. 

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
