### PR TITLE
Introduce build flag for disabling optmization.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,6 +19,13 @@ import static org.gradle.api.tasks.testing.TestResult.ResultType
 
 android {
     compileSdkVersion Config.compileSdkVersion
+
+    if (project.hasProperty("testBuildType")) {
+        // Allowing to configure the test build type via command line flag (./gradlew -PtestBuildType=beta ..)
+        // in order to run UI tests against other build variants than debug in automation.
+        testBuildType project.property("testBuildType")
+    }
+
     defaultConfig {
         applicationId "org.mozilla"
         minSdkVersion Config.minSdkVersion

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,8 +46,10 @@ android {
     }
 
     def releaseTemplate = {
-        shrinkResources true
-        minifyEnabled true
+        // We allow disabling optimization by passing `-PdisableOptimization` to gradle. This is used
+        // in automation for UI testing non-debug builds.
+        shrinkResources !project.hasProperty("disableOptimization")
+        minifyEnabled !project.hasProperty("disableOptimization")
         proguardFiles 'proguard-android-optimize-3.5.0-modified.txt', 'proguard-rules.pro'
         matchingFallbacks = ['release'] // Use on the "release" build type in dependencies (AARs)
 


### PR DESCRIPTION
This patch introduces a build flag that can be passed to Gradle (`./gradlew -PdisableOptimization`) to disable optimizations (resource shrinking and minifying). This is needed to be able to run UI tests on non-debug builds in automation (Also see #16786).

CC: @JohanLorenzo, @isabelrios