### PR TITLE
ExternalAppBrowserActivity: Handle missing tab and hand-off correctly.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarMenuController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarMenuController.kt
@@ -236,10 +236,16 @@ class DefaultBrowserToolbarMenuController(
                 sessionManager.select(customTabSession)
 
                 // Switch to the actual browser which should now display our new selected session
-                activity.startActivity(openInFenixIntent)
+                activity.startActivity(openInFenixIntent.apply {
+                    // We never want to launch the browser in the same task as the external app
+                    // activity. So we force a new task here. IntentReceiverActivity will do the
+                    // right thing and take care of routing to an already existing browser and avoid
+                    // cloning a new one.
+                    flags = flags or Intent.FLAG_ACTIVITY_NEW_TASK
+                })
 
-                // Close this activity since it is no longer displaying any session
-                activity.finish()
+                // Close this activity (and the task) since it is no longer displaying any session
+                activity.finishAndRemoveTask()
             }
             ToolbarMenu.Item.Quit -> {
                 // We need to show the snackbar while the browsing data is deleting (if "Delete

--- a/app/src/main/java/org/mozilla/fenix/customtabs/ExternalAppBrowserActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/ExternalAppBrowserActivity.kt
@@ -5,6 +5,7 @@
 package org.mozilla.fenix.customtabs
 
 import android.content.Intent
+import androidx.annotation.VisibleForTesting
 import androidx.navigation.NavDestination
 import androidx.navigation.NavDirections
 import kotlinx.android.synthetic.main.activity_home.*
@@ -111,16 +112,19 @@ open class ExternalAppBrowserActivity : HomeActivity() {
         }
     }
 
-    private fun hasExternalTab(): Boolean {
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal fun hasExternalTab(): Boolean {
         return getExternalTab() != null
     }
 
-    private fun getExternalTab(): SessionState? {
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal fun getExternalTab(): SessionState? {
         val id = getExternalTabId() ?: return null
         return components.core.store.state.findCustomTab(id)
     }
 
-    private fun getExternalTabId(): String? {
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal fun getExternalTabId(): String? {
         return getIntentSessionId(SafeIntent(intent))
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarMenuControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarMenuControllerTest.kt
@@ -513,7 +513,7 @@ class DefaultBrowserToolbarMenuControllerTest {
         verify { currentSession.customTabConfig = null }
         verify { sessionManager.select(currentSession) }
         verify { activity.startActivity(openInFenixIntent) }
-        verify { activity.finish() }
+        verify { activity.finishAndRemoveTask() }
     }
 
     @Test


### PR DESCRIPTION
This seems to fix the issue with apps that launch a custom tab with `FLAG_ACTIVITY_NEW_TASK` flag set (not sure why they do that) like Telegram. And it doesn't seem to have a negative effect on apps that use custom tabs as intended. But since there are multiple edge cases ... who really knows. Some additional 👀 and testing is appreciated here! :)

The first patch introduces a check when we resume ExternalAppBrowserActivity. Whenever we end up in a situation with a zombie task and the `ExternalAppBrowserActivity` having no tab to display, it falls back to displaying a (often partially broken) browser. This is not what we intended and sooner or later those multiple browser activities will end up showing the same tab and we crash with "display already acquired". With this check we bail out and finish the activity as well as remove the task - since those activities always have their own and we do not want to keep them around in the recent apps screen. This obviously doesn't fix the issue, but avoids making such a scenario even worse.

The second patch fixes the described issue. When switching to the browser we set `FLAG_ACTIVITY_NEW_TASK`. This will forces the browser out of the current task, we do not want the browser running in the task that the external app activity just ran in. This would be problematic if we'd launch HomeActivity directly since we could end up (temporarily) with multiple instances again. But this Intent goes through IntentReceiverActivity and this one will do the right thing and resume an already existing one. We then proceed to call `finishAndRemoveTask()` to get rid of everything. In situations where the third-party app (e.g. Telegram) launched a new task, this will get rid of that task. In situations where we were launched inside of the task of another application (e.g. Twitter), this will still only get rid of our potion and not turn down the third-party activities in that task.