### PR TITLE
For #14443  - Hide topSites until they've loaded

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/ext/BrowserIcons.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/BrowserIcons.kt
@@ -4,8 +4,35 @@
 
 package org.mozilla.fenix.ext
 
+import android.graphics.drawable.Drawable
+import android.view.View
 import android.widget.ImageView
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import mozilla.components.browser.icons.BrowserIcons
 import mozilla.components.browser.icons.IconRequest
 
-fun BrowserIcons.loadIntoView(view: ImageView, url: String) = loadIntoView(view, IconRequest(url))
+fun BrowserIcons.loadIntoView(
+    view: ImageView,
+    url: String = "",
+    localImage: Drawable? = null,
+    iconCover: ImageView? = null
+): Job? {
+    if (localImage != null) view.setImageDrawable(localImage)
+    GlobalScope.launch {
+        if (url.isNotBlank()) {
+            loadIntoView(view = view, request = IconRequest(url))
+        }
+        delay(DELAY_UNTIL_REVEAL)
+        withContext(Dispatchers.Main) {
+            iconCover?.visibility = View.INVISIBLE
+        }
+    }
+    return null
+}
+
+const val DELAY_UNTIL_REVEAL = 250L

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/topsites/TopSiteItemViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/topsites/TopSiteItemViewHolder.kt
@@ -10,7 +10,11 @@ import android.view.MotionEvent
 import android.view.View
 import android.widget.PopupWindow
 import androidx.appcompat.content.res.AppCompatResources.getDrawable
-import kotlinx.android.synthetic.main.top_site_item.*
+import kotlinx.android.synthetic.main.top_site_item.favicon_cover
+import kotlinx.android.synthetic.main.top_site_item.favicon_image
+import kotlinx.android.synthetic.main.top_site_item.pin_indicator
+import kotlinx.android.synthetic.main.top_site_item.top_site_item
+import kotlinx.android.synthetic.main.top_site_item.top_site_title
 import mozilla.components.browser.menu.BrowserMenuBuilder
 import mozilla.components.browser.menu.item.SimpleBrowserMenuItem
 import mozilla.components.feature.top.sites.TopSite
@@ -71,16 +75,32 @@ class TopSiteItemViewHolder(
 
         when (topSite.url) {
             SupportUtils.POCKET_TRENDING_URL -> {
-                favicon_image.setImageDrawable(getDrawable(itemView.context, R.drawable.ic_pocket))
+                itemView.context.components.core.icons.loadIntoView(
+                    view = favicon_image,
+                    localImage = getDrawable(itemView.context, R.drawable.ic_pocket),
+                    iconCover = favicon_cover
+                )
             }
             SupportUtils.BAIDU_URL -> {
-                favicon_image.setImageDrawable(getDrawable(itemView.context, R.drawable.ic_baidu))
+                itemView.context.components.core.icons.loadIntoView(
+                    view = favicon_image,
+                    localImage = getDrawable(itemView.context, R.drawable.ic_baidu),
+                    iconCover = favicon_cover
+                )
             }
             SupportUtils.JD_URL -> {
-                favicon_image.setImageDrawable(getDrawable(itemView.context, R.drawable.ic_jd))
+                itemView.context.components.core.icons.loadIntoView(
+                    view = favicon_image,
+                    localImage = getDrawable(itemView.context, R.drawable.ic_jd),
+                    iconCover = favicon_cover
+                )
             }
             else -> {
-                itemView.context.components.core.icons.loadIntoView(favicon_image, topSite.url)
+                itemView.context.components.core.icons.loadIntoView(
+                    view = favicon_image,
+                    url = topSite.url,
+                    iconCover = favicon_cover
+                )
             }
         }
 

--- a/app/src/main/res/layout/top_site_item.xml
+++ b/app/src/main/res/layout/top_site_item.xml
@@ -21,6 +21,19 @@
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <ImageView
+        android:id="@+id/favicon_cover"
+        android:layout_height="32dp"
+        android:visibility="visible"
+        android:layout_width="32dp"
+        android:layout_gravity="center"
+        android:background="@color/top_site_loading_in_progress_cover"
+        android:importantForAccessibility="no"
+        app:layout_constraintBottom_toBottomOf="@+id/favicon_image"
+        app:layout_constraintEnd_toEndOf="@+id/favicon_image"
+        app:layout_constraintStart_toStartOf="@+id/favicon_image"
+        app:layout_constraintTop_toTopOf="@+id/favicon_image" />
+
     <TextView
         android:id="@+id/top_site_title"
         android:layout_width="64dp"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -284,6 +284,7 @@
     <color name="top_site_pager_dot">@color/photonLightGrey30</color>
     <color name="top_site_pager_dot_selected">@color/light_grey_50</color>
     <color name="top_site_pin_icon_background_tint">@color/ink_20</color>
+    <color name="top_site_loading_in_progress_cover">#7D7D7D</color>
 
     <!-- Synced tabs colors-->
     <color name="synced_tabs_separator">@color/synced_tabs_separator_light_theme</color>


### PR DESCRIPTION
Adds a gray cover imageView on top of each topSite icon that is removed after the topSites have loaded.

For https://github.com/mozilla-mobile/fenix/issues/14443

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR does not include any tests as it is only a minor change.
- [x] **Screenshots**: This PR includes a GIF.
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

![reveal topsites](https://user-images.githubusercontent.com/60002907/100872749-f71eaf00-34aa-11eb-9a5b-8cc6d1e385b0.gif)

