### PR TITLE
For #16775: Fallback to light mode drawable when ui mode is not resolved

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarIntegration.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarIntegration.kt
@@ -106,7 +106,7 @@ class DefaultToolbarIntegration(
                 Configuration.UI_MODE_NIGHT_YES -> {
                     AppCompatResources.getDrawable(context, R.drawable.shield_dark)
                 }
-                else -> null
+                else -> AppCompatResources.getDrawable(context, R.drawable.shield_light)
             }
 
         toolbar.display.indicators =


### PR DESCRIPTION
This is a speculative fix, as the OS response cannot be identified because we do not have a device to test on and the source code for Amazon Android 7.3.1.6 is no longer available on the official site (https://www.amazon.com/gp/help/customer/display.html?nodeId=200203720). Either way, a fallback value is indicated, as we use `!!` for the drawable on toolbar initialization.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
