### PR TITLE
Create new android-test-beta build

### DIFF
--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -94,13 +94,14 @@ jobs:
             symbol: nightly(Bat)
 
     android-test-beta:
+        apk-artifact-template:
+            # 2 differences here: "androidTest/" is added and "{gradle_build_type}" is forced to "debug"
+            path: '/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/debug/{fileName}'
+        disable-optimization: true
         run:
             gradle-build-type: androidTest
             test-build-type: beta
         run-on-tasks-for: [github-push] # We want this on push so that we detect problem before triggering a new beta
-        apk-artifact-template:
-            # 2 differences here: "androidTest/" is added and "{gradle_build_type}" is forced to "debug"
-            path: '/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/debug/{fileName}'
         treeherder:
             symbol: beta(Bat)
 

--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -126,6 +126,7 @@ jobs:
         filter-incomplete-translations: true
         run:
             gradle-build-type: beta
+        run-on-tasks-for: [github-push] # We want this on push so that we detect problem before triggering a new beta
         treeherder:
             symbol: beta(B)
 

--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -54,6 +54,15 @@ jobs:
         treeherder:
             symbol: debug(B)
 
+    beta-firebase:
+        disable-optimization: true
+        run-on-tasks-for: [github-push] # We want this on push so that we detect problem before triggering a new beta
+        run:
+            gradle-build-type: beta
+            test-build-type: beta
+        treeherder:
+            symbol: beta(Bd)
+
     android-test-debug:
         attributes:
             code-review: true
@@ -87,9 +96,7 @@ jobs:
     android-test-beta:
         run:
             gradle-build-type: androidTest
-            test-build-type: beta
         run-on-tasks-for: [github-push] # We want this on push so that we detect problem before triggering a new beta
-        disable-optimization: true
         apk-artifact-template:
             # 2 differences here: "androidTest/" is added and "{gradle_build_type}" is forced to "debug"
             path: '/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/debug/{fileName}'
@@ -126,7 +133,6 @@ jobs:
         filter-incomplete-translations: true
         run:
             gradle-build-type: beta
-        run-on-tasks-for: [github-push] # We want this on push so that we detect problem before triggering a new beta
         treeherder:
             symbol: beta(B)
 

--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -66,10 +66,10 @@ jobs:
         treeherder:
             symbol: debug(Bat)
 
-    # android-test-nightly, while still being a debug build, is meant to be signed with the nightly
-    # key. The Firebase testing infrastructure requires both the androidTest APK and the APK under
-    # test to be signed with the same key. Thus, the nightly APK being signed with nightly means
-    # we need an androidTest APK with the same signature.
+    # android-test-nightly and android-test-beta, while still being debug builds, are meant to be signed
+    # with the nightly/beta key. The Firebase testing infrastructure requires both the androidTest APK
+    # and the APK under test to be signed with the same key. Thus, the nightly APK being signed with
+    # nightly means we need an androidTest APK with the same signature.
     #
     # TODO: See if we can tweak the signing kind to make 2 signing jobs out of a single `android-test`
     # job.
@@ -83,6 +83,18 @@ jobs:
             path: '/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/debug/{fileName}'
         treeherder:
             symbol: nightly(Bat)
+
+    android-test-beta:
+        run:
+            gradle-build-type: androidTest
+            test-build-type: beta
+        run-on-tasks-for: [github-push] # We want this on push so that we detect problem before triggering a new beta
+        disable-optimization: true
+        apk-artifact-template:
+            # 2 differences here: "androidTest/" is added and "{gradle_build_type}" is forced to "debug"
+            path: '/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/debug/{fileName}'
+        treeherder:
+            symbol: beta(Bat)
 
     nightly-simulation:
         attributes:

--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -61,7 +61,7 @@ jobs:
             gradle-build-type: beta
             test-build-type: beta
         treeherder:
-            symbol: beta(Bd)
+            symbol: beta(Bf)
 
     android-test-debug:
         attributes:

--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -95,8 +95,8 @@ jobs:
 
     android-test-beta:
         apk-artifact-template:
-            # 2 differences here: "androidTest/" is added and "{gradle_build_type}" is forced to "debug"
-            path: '/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/debug/{fileName}'
+            # 2 differences here: "androidTest/" is added and "{gradle_build_type}" is forced to "beta"
+            path: '/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/beta/{fileName}'
         disable-optimization: true
         run:
             gradle-build-type: androidTest

--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -88,15 +88,20 @@ jobs:
         run:
             gradle-build-type: androidTest
         apk-artifact-template:
-            # 2 differences here: "androidTest/" is added and "{gradle_build_type}" is forced to "debug"
+            # 2 differences here:
+            #  * "androidTest/" is added
+            #  * "{gradle_build_type}" is forced to "debug"
             path: '/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/debug/{fileName}'
         treeherder:
             symbol: nightly(Bat)
 
     android-test-beta:
         apk-artifact-template:
-            # 2 differences here: "androidTest/" is added and "{gradle_build_type}" is forced to "beta"
-            path: '/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/beta/{fileName}'
+            # 3 differences here:
+            #  * "androidTest/" is added
+            #  * "{gradle_build_type}" is forced to "beta"
+            #  * "{fileName}" is forced to "app-beta-androidTest.apk"
+            path: '/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/beta/app-beta-androidTest.apk'
         disable-optimization: true
         run:
             gradle-build-type: androidTest

--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -96,6 +96,7 @@ jobs:
     android-test-beta:
         run:
             gradle-build-type: androidTest
+            test-build-type: beta
         run-on-tasks-for: [github-push] # We want this on push so that we detect problem before triggering a new beta
         apk-artifact-template:
             # 2 differences here: "androidTest/" is added and "{gradle_build_type}" is forced to "debug"

--- a/taskcluster/ci/signing/kind.yml
+++ b/taskcluster/ci/signing/kind.yml
@@ -20,7 +20,7 @@ job-template:
     description: Sign Fenix
     worker-type:
         by-build-type:
-            (nightly|beta|release|android-test-nightly|android-test-beta):
+            (nightly|beta|release|android-test-nightly):
                 by-level:
                     '3': signing
                     default: dep-signing
@@ -49,7 +49,7 @@ job-template:
             # No test job runs on push against this build type. Although we do want nightly-simulation
             # signed to use it in the gecko trees.
             # We want beta on push so that we detect problem before shipping it
-            (nightly-simulation|beta|android-test-beta): [github-push]
+            (nightly-simulation|beta-firebase|android-test-beta): [github-push]
             default: []
     treeherder:
         job-symbol:

--- a/taskcluster/ci/signing/kind.yml
+++ b/taskcluster/ci/signing/kind.yml
@@ -20,7 +20,7 @@ job-template:
     description: Sign Fenix
     worker-type:
         by-build-type:
-            (nightly|beta|release|android-test-nightly):
+            (nightly|beta|release|android-test-nightly|android-test-beta):
                 by-level:
                     '3': signing
                     default: dep-signing
@@ -28,16 +28,12 @@ job-template:
     worker:
         signing-type:
             by-build-type:
-                (beta|release):
+                (beta|release|android-test-beta):
                     by-level:
                         '3': fennec-production-signing
                         default: dep-signing
-                android-test-nightly:
-                    by-level:
-                        '3': production-signing
-                        default: dep-signing
                 performance-test: dep-signing
-                nightly:
+                (nightly|android-test-nightly):
                     by-level:
                         '3': production-signing
                         default: dep-signing

--- a/taskcluster/ci/signing/kind.yml
+++ b/taskcluster/ci/signing/kind.yml
@@ -48,7 +48,8 @@ job-template:
         by-build-type:
             # No test job runs on push against this build type. Although we do want nightly-simulation
             # signed to use it in the gecko trees.
-            nightly-simulation: [github-push]
+            # We want beta on push so that we detect problem before shipping it
+            (nightly-simulation|beta|android-test-beta): [github-push]
             default: []
     treeherder:
         job-symbol:

--- a/taskcluster/ci/signing/kind.yml
+++ b/taskcluster/ci/signing/kind.yml
@@ -55,6 +55,7 @@ job-template:
         job-symbol:
             by-build-type:
                 android-test.+: Bats
+                beta-firebase: Bfs
                 default: Bs
         kind: build
         platform: android-all/opt

--- a/taskcluster/fenix_taskgraph/transforms/build.py
+++ b/taskcluster/fenix_taskgraph/transforms/build.py
@@ -76,6 +76,24 @@ def build_gradle_command(config, tasks):
 
         yield task
 
+@transforms.add
+def add_test_build_type(config, tasks):
+    for task in tasks:
+        test_build_type = task["run"].pop("test-build-type", "")
+        if test_build_type:
+            task["run"]["gradlew"].append(
+                "-PtestBuildType={}".format(test_build_type)
+            )
+        yield task
+
+
+@transforms.add
+def add_disable_optimization(config, tasks):
+    for task in tasks:
+        if task.pop("disable-optimization", False):
+            task["run"]["gradlew"].append("-PdisableOptimization")
+        yield task
+
 
 @transforms.add
 def add_nightly_version(config, tasks):

--- a/try_task_config.json
+++ b/try_task_config.json
@@ -1,0 +1,7 @@
+{
+    "parameters": {
+        "optimize_target_tasks": true,
+        "tasks_for": "github-push"
+    },
+    "version": 2
+}

--- a/try_task_config.json
+++ b/try_task_config.json
@@ -1,7 +1,0 @@
-{
-    "parameters": {
-        "optimize_target_tasks": true,
-        "tasks_for": "github-push"
-    },
-    "version": 2
-}


### PR DESCRIPTION
Blocks https://github.com/mozilla-mobile/fenix/pull/16786
Depends on https://github.com/mozilla-mobile/fenix/pull/16787 
Partly addresses https://github.com/mozilla-mobile/fenix/issues/16120

This PR creates 2 new build-types: `beta-firebase` and `android-test-beta`. `beta-firebase` is a beta-like build that is not optimized and meant to be used on the testing infra called Firebase. Let's build them on push for now. `android-test-beta` is a special APK that just contains the tests, as far as I understand. We cannot use the regular `android-test` build because Firebase expects package ID to follow this pattern.
 * APK under test: `some.package.id`
 * APK containing tests: `some.package.id.test`

So in the case of beta: 
 * APK under test: `org.mozilla.firefox_beta`
 * APK containing tests: `org.mozilla.firefox_beta.test`

These 2 APKs were manually tested on Firebase by @isabelrios. We will make the changes regarding tests in #16786. 

Let me know if I can provide more details