### PR TITLE
For #16248 - Cleanup error pages of inlined code

### DIFF
--- a/app/src/main/assets/highRiskErrorPages.js
+++ b/app/src/main/assets/highRiskErrorPages.js
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Handles the parsing of the ErrorPages URI and then passes them to injectValues
+ */
+function parseQuery(queryString) {
+    if (queryString[0] === '?') {
+        queryString = queryString.substr(1);
+    }
+    const query = Object.fromEntries(new URLSearchParams(queryString).entries());
+    injectValues(query);
+};
+
+/**
+ * Updates the HTML elements based on the queryMap
+ */
+function injectValues(queryMap) {
+    // Go through each element and inject the values
+    document.title = queryMap.title;
+    document.getElementById('errorTitleText').innerHTML = queryMap.title;
+    document.getElementById('errorShortDesc').innerHTML = queryMap.description;
+
+    // If no image is passed in, remove the element so as not to leave an empty iframe
+    const errorImage = document.getElementById('errorImage');
+    if (!queryMap.image) {
+        errorImage.remove();
+    } else  {
+        errorImage.src = "resource://android/assets/" + queryMap.image;
+    }
+}
+
+document.addEventListener('DOMContentLoaded', function () {
+    if (window.history.length == 1) {
+        document.getElementById('backButton').style.display = 'none';
+    } else {
+        document.getElementById('backButton').addEventListener('click', () => window.history.back() );
+    }
+});
+
+parseQuery(document.documentURI);

--- a/app/src/main/assets/high_risk_error_pages.html
+++ b/app/src/main/assets/high_risk_error_pages.html
@@ -8,6 +8,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width; user-scalable=false;" />
+    <meta http-equiv="Content-Security-Policy" content="default-src resource:; object-src 'none'" />
     <link rel="stylesheet" type="text/css" href="shared_error_style.css" />
     <link rel="stylesheet" type="text/css" href="high_risk_error_style.css" />
   </head>
@@ -29,14 +30,9 @@
       </div>
 
       <!-- Back Button -->
-      <button id="backButton" onclick="window.history.back()">Go back</button>
+      <button id="backButton">Go back</button>
     </div>
   </body>
 
-  <script src="./errorPageScripts.js"></script>
-  <script type="text/javascript">
-    if (window.history.length == 1) {
-        document.getElementById('backButton').style.display = 'none';
-    }
-  </script>
+  <script src="./highRiskErrorPages.js"></script>
 </html>

--- a/app/src/main/assets/lowMediumErrorPages.js
+++ b/app/src/main/assets/lowMediumErrorPages.js
@@ -1,0 +1,116 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Handles the parsing of the ErrorPages URI and then passes them to injectValues
+ */
+function parseQuery(queryString) {
+    if (queryString[0] === '?') {
+        queryString = queryString.substr(1);
+    }
+    const query = Object.fromEntries(new URLSearchParams(queryString).entries());
+    injectValues(query);
+    updateShowSSL(query);
+};
+
+/**
+ * Updates the HTML elements based on the queryMap
+ */
+function injectValues(queryMap) {
+    // Go through each element and inject the values
+    document.title = queryMap.title;
+    document.getElementById('errorTitleText').innerHTML = queryMap.title;
+    document.getElementById('errorShortDesc').innerHTML = queryMap.description;
+    document.getElementById('errorTryAgain').innerHTML = queryMap.button;
+    document.getElementById('advancedButton').innerHTML = queryMap.badCertAdvanced;
+    document.getElementById('badCertTechnicalInfo').innerHTML = queryMap.badCertTechInfo;
+    document.getElementById('advancedPanelBackButton').innerHTML = queryMap.badCertGoBack;
+    document.getElementById('advancedPanelAcceptButton').innerHTML = queryMap.badCertAcceptTemporary;
+
+   // If no image is passed in, remove the element so as not to leave an empty iframe
+    const errorImage = document.getElementById('errorImage');
+    if (!queryMap.image) {
+        errorImage.remove();
+    } else  {
+        errorImage.src = "resource://android/assets/" + queryMap.image;
+    }
+};
+
+let advancedVisible = false;
+
+/**
+ * Used to show or hide the "advanced" button based on the validity of the SSL certificate
+ */
+function updateShowSSL(queryMap) {
+    /** @type {'true' | 'false'} */
+    const showSSL = queryMap.showSSL;
+    if (typeof document.addCertException === 'undefined') {
+        document.getElementById('advancedButton').style.display='none';
+    } else {
+        if (showSSL === 'true') {
+            document.getElementById('advancedButton').style.display='block';
+        } else {
+            document.getElementById('advancedButton').style.display='none';
+        }
+    }
+};
+
+/**
+ * Used to display information about the SSL certificate in `error_pages.html`
+ */
+function toggleAdvancedAndScroll() {
+    const advancedPanel = document.getElementById('badCertAdvancedPanel');
+    if (advancedVisible) {
+        advancedPanel.style.display='none';
+    } else {
+        advancedPanel.style.display='block';
+    }
+    advancedVisible = !advancedVisible;
+
+    const horizontalLine = document.getElementById("horizontalLine");
+    const advancedPanelAcceptButton = document.getElementById(
+        "advancedPanelAcceptButton"
+    );
+    const badCertAdvancedPanel = document.getElementById(
+        "badCertAdvancedPanel"
+    );
+
+    // We know that the button is being displayed
+    if (badCertAdvancedPanel.style.display === "block") {
+        horizontalLine.hidden = false;
+        advancedPanelAcceptButton.scrollIntoView({
+            behavior: "smooth",
+            block: "center",
+            inline: "nearest",
+       });
+    } else {
+        horizontalLine.hidden = true;
+    }
+};
+
+/**
+ * Used to bypass an SSL pages in `error_pages.html`
+ */
+async function acceptAndContinue(temporary) {
+    try {
+        await document.addCertException(temporary);
+        location.reload();
+    } catch (error) {
+        console.error("Unexpected error: " + error);
+    }
+};
+
+document.addEventListener('DOMContentLoaded', function () {
+    if (window.history.length == 1) {
+        document.getElementById('advancedPanelBackButton').style.display = 'none';
+    } else {
+        document.getElementById('advancedPanelBackButton').addEventListener('click', () => window.history.back());
+    }
+
+    document.getElementById('errorTryAgain').addEventListener('click', () => window.location.reload());
+    document.getElementById('advancedButton').addEventListener('click', toggleAdvancedAndScroll);
+    document.getElementById('advancedPanelAcceptButton').addEventListener('click', () => acceptAndContinue(true));
+});
+
+parseQuery(document.documentURI);

--- a/app/src/main/assets/low_and_medium_risk_error_pages.html
+++ b/app/src/main/assets/low_and_medium_risk_error_pages.html
@@ -8,6 +8,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width; user-scalable=false;" />
+    <meta http-equiv="Content-Security-Policy" content="default-src resource:; object-src 'none'" />
     <link rel="stylesheet" type="text/css" href="shared_error_style.css" />
     <link
       rel="stylesheet"
@@ -33,13 +34,12 @@
       </div>
 
       <!-- Retry Button -->
-      <button id="errorTryAgain" onclick="window.location.reload()"></button>
+      <button id="errorTryAgain"></button>
 
       <!-- Advanced Button -->
       <button
         id="advancedButton"
         class="buttonSecondary hidden"
-        onclick="toggleAdvancedAndScroll()"
       ></button>
 
       <hr id="horizontalLine" hidden />
@@ -52,7 +52,6 @@
           >
             <button
               id="advancedPanelBackButton"
-              onClick="window.history.back()"
             ></button>
           </div>
           <div
@@ -62,7 +61,6 @@
             <button
               id="advancedPanelAcceptButton"
               class="buttonSecondary"
-              onClick="acceptAndContinue(true)"
             ></button>
           </div>
         </div>
@@ -100,5 +98,5 @@
     }
   </script>
 
-  <script src="./errorPageScripts.js"></script>
+    <script src="./lowMediumErrorPages.js"></script>
 </html>

--- a/app/src/main/java/org/mozilla/fenix/AppRequestInterceptor.kt
+++ b/app/src/main/java/org/mozilla/fenix/AppRequestInterceptor.kt
@@ -72,7 +72,7 @@ class AppRequestInterceptor(
             htmlResource = riskLevel.htmlRes
         )
 
-        return RequestInterceptor.ErrorResponse.Uri(errorPageUri)
+        return RequestInterceptor.ErrorResponse(errorPageUri)
     }
 
     /**

--- a/app/src/test/java/org/mozilla/fenix/AppRequestInterceptorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/AppRequestInterceptorTest.kt
@@ -200,7 +200,7 @@ class AppRequestInterceptorTest {
 
     private fun createActualErrorPage(error: ErrorType): String {
         val errorPage = interceptor.onErrorRequest(session = mockk(), errorType = error, uri = null)
-                as RequestInterceptor.ErrorResponse.Uri
+                as RequestInterceptor.ErrorResponse
         return errorPage.uri
     }
 

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "69.0.20201203202830"
+    const val VERSION = "69.0.20201204143142"
 }


### PR DESCRIPTION
Also streamlined the js code.
The errorPageScripts.js from AC had too much or too little of what we needed.

Needs https://github.com/mozilla-mobile/android-components/issues/9091

After which the error pages in Fenix should still work
<img src="https://user-images.githubusercontent.com/11428869/101034287-15f07480-3583-11eb-8948-db595d5e6bd4.gif" width="33%" />
[video](https://drive.google.com/file/d/18u0roSEAxLwb-ZwaV2BAQ1LLhF_ANBwE/view?usp=sharing)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes tests.
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made.
- [x] **Accessibility**: The code in this PR does not include any a11y user facing features.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
