### PR TITLE
Bug 1676499 - Update perfherder data schema for visual metrics.

### DIFF
--- a/taskcluster/docker/visual-metrics/performance-artifact-schema.json
+++ b/taskcluster/docker/visual-metrics/performance-artifact-schema.json
@@ -7,6 +7,7 @@
                     "enum": [
                         "firefox",
                         "chrome",
+                        "chrome-m",
                         "chromium",
                         "fennec",
                         "geckoview",
@@ -122,7 +123,7 @@
                     "description": "Similar to extraOptions, except it does not break existing performance data series",
                     "items": {
                         "type": "string",
-                        "pattern": "^[a-zA-Z0-9]{1,24}$"
+                        "pattern": "^[a-zA-Z0-9-]{1,24}$"
                     },
                     "uniqueItems": true,
                     "maxItems": 14


### PR DESCRIPTION
This patch updates the schema used for validating visual metrics and it also adds a hyphen to the list of possible characters in the tags entries.

See this bug for more information: https://bugzilla.mozilla.org/show_bug.cgi?id=1676499

Try run for these changes: https://treeherder.mozilla.org/jobs?repo=try&tier=1%2C2%2C3&revision=40c831b4b9d0f1e2899d53dbe5bff8da229d6f35