### PR TITLE
For #15636 - Focus a11y collection on snackbar view tap

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -15,7 +15,9 @@ import android.view.Display.FLAG_SECURE
 import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
+import android.view.View.AccessibilityDelegate
 import android.view.ViewGroup
+import android.view.accessibility.AccessibilityEvent
 import android.widget.Button
 import android.widget.LinearLayout
 import android.widget.PopupWindow
@@ -953,6 +955,43 @@ class HomeFragment : Fragment() {
             border?.animate()?.alpha(1.0F)?.setStartDelay(ANIM_ON_SCREEN_DELAY)
                 ?.setDuration(FADE_ANIM_DURATION)
                 ?.setListener(listener)?.start()
+        }.invokeOnCompletion {
+            val a11yEnabled = context?.settings()?.accessibilityServicesEnabled ?: false
+            if (a11yEnabled) {
+                focusCollectionForTalkBack(indexOfCollection)
+            }
+        }
+    }
+
+    /**
+     * Will focus the collection with [indexOfCollection] for accessibility services.
+     * */
+    private fun focusCollectionForTalkBack(indexOfCollection: Int) {
+        viewLifecycleOwner.lifecycleScope.launch {
+            var focusedForAccessibility = false
+            view?.let { mainView ->
+                mainView.accessibilityDelegate = object : AccessibilityDelegate() {
+                    override fun onRequestSendAccessibilityEvent(
+                        host: ViewGroup,
+                        child: View,
+                        event: AccessibilityEvent
+                    ): Boolean {
+                        if (!focusedForAccessibility &&
+                            event.eventType == AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUSED
+                        ) {
+                            sessionControlView?.view?.findViewHolderForAdapterPosition(
+                                indexOfCollection
+                            )?.itemView?.let { viewToFocus ->
+                                focusedForAccessibility = true
+                                viewToFocus.requestFocus()
+                                viewToFocus.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_FOCUSED)
+                                return false
+                            }
+                        }
+                        return super.onRequestSendAccessibilityEvent(host, child, event)
+                    }
+                }
+            }
         }
     }
 

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -72,7 +72,7 @@
         android:padding="16dp"
         android:scrollbars="none"
         android:transitionGroup="false"
-        android:importantForAccessibility="no"
+        android:importantForAccessibility="yes"
         android:overScrollMode="never"
         tools:listheader="@layout/collection_header"
         tools:listitem="@layout/collection_home_list_row"


### PR DESCRIPTION
 With accessibility enabled, when adding a site to a collection and tapping "View" on the snackbar, we send a request for focus and an `AccessibilityEvent.TYPE_VIEW_FOCUSED` to the specified collection.

**For** https://github.com/mozilla-mobile/fenix/issues/15636

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR does not include any tests as it is only a minor change.
- [x] **Screenshots**: This PR includes a GIF.
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

![focus a11y collection](https://user-images.githubusercontent.com/60002907/101146823-29075100-3624-11eb-92d9-0fc5b1503652.gif)