### PR TITLE
Sign android-test-beta with the dep key

### DIFF
--- a/taskcluster/ci/signing/kind.yml
+++ b/taskcluster/ci/signing/kind.yml
@@ -28,7 +28,7 @@ job-template:
     worker:
         signing-type:
             by-build-type:
-                (beta|release|android-test-beta):
+                (beta|release):
                     by-level:
                         '3': fennec-production-signing
                         default: dep-signing


### PR DESCRIPTION
Since it is used with beta-firebase which is also dep-signed

Fixes the busted decision task which was caused by #16814 : 

```
[task 2020-12-04T10:38:25.791Z] 2020-12-04 10:38:25,791 - INFO - Creating task with taskId TTfM8ZDIRBWuufIe5UZxhA for signing-android-test-beta
[task 2020-12-04T10:38:25.822Z] 2020-12-04 10:38:25,822 - ERROR - Client ID task-client/MXIsG9MvQTyCwKFNFYTsCQ/0/on/us-west-1/i-0593948ce6f56a9df/until/1607079379.227 does not have sufficient scopes and is missing the following scopes:
[task 2020-12-04T10:38:25.822Z] 
[task 2020-12-04T10:38:25.822Z] '''
[task 2020-12-04T10:38:25.822Z] project:mobile:fenix:releng:signing:cert:fennec-production-signing
[task 2020-12-04T10:38:25.822Z] '''
```


https://treeherder.mozilla.org/logviewer?job_id=323556131&repo=fenix&lineNumber=2994 
https://treeherder.mozilla.org/jobs?repo=fenix&revision=9420febe595343851985b042e02359f363140bb8&selectedTaskRun=MXIsG9MvQTyCwKFNFYTsCQ.0
