### PR TITLE
Close #11355: Works with and defaults to China FxA/Sync services

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/FxaServer.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/FxaServer.kt
@@ -19,7 +19,11 @@ object FxaServer {
     fun config(context: Context): ServerConfig {
         val serverOverride = context.settings().overrideFxAServer
         val tokenServerOverride = context.settings().overrideSyncTokenServer.ifEmpty { null }
+        val useLocalFxAServer = context.settings().useLocalFxAServer
         if (serverOverride.isEmpty()) {
+            if (useLocalFxAServer) {
+                return ServerConfig(Server.CHINA, CLIENT_ID, REDIRECT_URL, tokenServerOverride)
+            }
             return ServerConfig(Server.RELEASE, CLIENT_ID, REDIRECT_URL, tokenServerOverride)
         }
         return ServerConfig(serverOverride, CLIENT_ID, REDIRECT_URL, tokenServerOverride)

--- a/app/src/main/java/org/mozilla/fenix/components/FxaServer.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/FxaServer.kt
@@ -7,6 +7,7 @@ import android.content.Context
 import android.util.Log
 import mozilla.components.service.fxa.ServerConfig
 import mozilla.components.service.fxa.ServerConfig.Server
+import org.mozilla.fenix.Config
 import org.mozilla.fenix.ext.settings
 import java.io.File
 
@@ -24,7 +25,7 @@ object FxaServer {
 
         // Try to read Fennec FxA state from fxa.aacount.json
         val haveReadFxAAccountJson = context.settings().haveReadFxAAccountJson
-        if (!haveReadFxAAccountJson) {
+        if (!haveReadFxAAccountJson && Config.channel.isMozillaOnline) {
             val fxaState = File("${context.filesDir}", "fxa.account.json")
             if (fxaState.exists()) {
                 if (!fxaState.readText().contains("firefox.com.cn") && (context.settings().useLocalFxAServer)) {
@@ -39,7 +40,7 @@ object FxaServer {
 
         if (serverOverride.isEmpty()) {
             // Figure out if we enable local server
-            if (useLocalFxAServer) {
+            if (useLocalFxAServer && Config.channel.isMozillaOnline) {
                 return ServerConfig(Server.CHINA, CLIENT_ID, REDIRECT_URL, tokenServerOverride)
             }
             return ServerConfig(Server.RELEASE, CLIENT_ID, REDIRECT_URL, tokenServerOverride)

--- a/app/src/main/java/org/mozilla/fenix/settings/PairFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/PairFragment.kt
@@ -15,11 +15,13 @@ import androidx.core.content.getSystemService
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.NavHostFragment.findNavController
 import androidx.navigation.fragment.findNavController
+import androidx.paging.Config
 import mozilla.components.feature.qr.QrFeature
 import mozilla.components.support.base.feature.UserInteractionHandler
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.requireComponents
+import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.showToolbar
 
 class PairFragment : Fragment(R.layout.fragment_pair), UserInteractionHandler {
@@ -67,7 +69,10 @@ class PairFragment : Fragment(R.layout.fragment_pair), UserInteractionHandler {
                         false
                     )
                 },
-                scanMessage = R.string.pair_instructions_2
+                scanMessage =
+                if (requireContext().settings().useLocalFxAServer && org.mozilla.fenix.Config.channel.isMozillaOnline)
+                    R.string.pair_instructions_2_cn
+                else R.string.pair_instructions_2
             ),
             owner = this,
             view = view

--- a/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
@@ -476,9 +476,11 @@ class SettingsFragment : PreferenceFragmentCompat() {
         val enabled =
             requireComponents.backgroundServices.accountManager.authenticatedAccount() == null
         val checked = settings.useLocalFxAServer
+        val visible = Config.channel.isMozillaOnline
         preferenceUseLocalFxAServer?.apply {
             isEnabled = enabled
             isChecked = checked
+            isVisible = visible
         }
     }
 
@@ -523,6 +525,11 @@ class SettingsFragment : PreferenceFragmentCompat() {
     private fun setupUseLocalFxaServerPreference() {
         val useLocalFxAServer = getPreferenceKey(R.string.pref_key_use_local_fxa_server)
         val preferenceUseLocalFxAServer = findPreference<SwitchPreference>(useLocalFxAServer)
+        val visible = Config.channel.isMozillaOnline
+
+        preferenceUseLocalFxAServer?.apply {
+            isVisible = visible
+        }
 
         preferenceUseLocalFxAServer?.onPreferenceChangeListener =
             Preference.OnPreferenceChangeListener { preference, newValue ->

--- a/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
@@ -470,12 +470,15 @@ class SettingsFragment : PreferenceFragmentCompat() {
     }
 
     private fun updateFxAUseLocalMenu() {
+        val settings = requireContext().settings()
         val preferenceUseLocalFxAServer =
             findPreference<SwitchPreference>(getPreferenceKey(R.string.pref_key_use_local_fxa_server))
         val enabled =
             requireComponents.backgroundServices.accountManager.authenticatedAccount() == null
+        val checked = settings.useLocalFxAServer
         preferenceUseLocalFxAServer?.apply {
             isEnabled = enabled
+            isChecked = checked
         }
     }
 

--- a/app/src/main/java/org/mozilla/fenix/settings/account/AccountUiView.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/account/AccountUiView.kt
@@ -26,7 +26,8 @@ class AccountUiView(
     private val scope: CoroutineScope,
     private val accountManager: FxaAccountManager,
     private val httpClient: Client,
-    private val updateFxASyncOverrideMenu: () -> Unit
+    private val updateFxASyncOverrideMenu: () -> Unit,
+    private val updateFxAUseLocalMenu: () -> Unit
 ) {
 
     private val preferenceSignIn =
@@ -48,6 +49,7 @@ class AccountUiView(
         val account = accountManager.authenticatedAccount()
 
         updateFxASyncOverrideMenu()
+        updateFxAUseLocalMenu()
 
         // Signed-in, no problems.
         if (account != null && !accountManager.accountNeedsReauth()) {

--- a/app/src/main/java/org/mozilla/fenix/settings/account/TurnOnSyncFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/account/TurnOnSyncFragment.kt
@@ -21,6 +21,7 @@ import mozilla.components.concept.sync.OAuthAccount
 import mozilla.components.support.ktx.android.content.hasCamera
 import mozilla.components.support.ktx.android.content.isPermissionGranted
 import mozilla.components.support.ktx.android.view.hideKeyboard
+import org.mozilla.fenix.Config
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.FenixSnackbar
@@ -114,7 +115,9 @@ class TurnOnSyncFragment : Fragment(), AccountObserver {
         view.signInScanButton.setOnClickListener(paringClickListener)
         view.signInEmailButton.setOnClickListener(signInClickListener)
         view.signInInstructions.text = HtmlCompat.fromHtml(
-            getString(R.string.sign_in_instructions),
+            if (requireContext().settings().useLocalFxAServer && Config.channel.isMozillaOnline)
+                getString(R.string.sign_in_instructions_cn)
+            else getString(R.string.sign_in_instructions),
             HtmlCompat.FROM_HTML_MODE_LEGACY
         )
 

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -864,6 +864,11 @@ class Settings(private val appContext: Context) : PreferencesHolder {
         default = false
     )
 
+    var useLocalFxAServer by booleanPreference(
+        appContext.getPreferenceKey(R.string.pref_key_use_local_fxa_server),
+        default = true
+    )
+
     var overrideFxAServer by stringPreference(
         appContext.getPreferenceKey(R.string.pref_key_override_fxa_server),
         default = ""

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -869,6 +869,27 @@ class Settings(private val appContext: Context) : PreferencesHolder {
         default = true
     )
 
+    fun switchUseLocalFxAServer() {
+        val key = appContext.getPreferenceKey(R.string.pref_key_use_local_fxa_server)
+        val newValue = !preferences.getBoolean(key, true)
+        preferences.edit()
+            .putBoolean(key, newValue)
+            .apply()
+    }
+
+    var haveReadFxAAccountJson by booleanPreference(
+        appContext.getPreferenceKey(R.string.pref_key_have_read_fxa_account_json),
+        default = false
+    )
+
+    fun switchHaveReadFxAAccountJson() {
+        val key = appContext.getPreferenceKey(R.string.pref_key_have_read_fxa_account_json)
+        val newValue = !preferences.getBoolean(key, false)
+        preferences.edit()
+            .putBoolean(key, newValue)
+            .apply()
+    }
+
     var overrideFxAServer by stringPreference(
         appContext.getPreferenceKey(R.string.pref_key_override_fxa_server),
         default = ""

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -296,6 +296,8 @@
     <string name="preferences_override_sync_tokenserver">自定义同步服务器</string>
     <!-- Toast shown after updating the FxA/Sync server override preferences -->
     <string name="toast_override_fxa_sync_server_done">已更改 Firefox 账户/同步服务器设置。退出应用程序以应用更改…</string>
+    <!-- Switch Preference for local/global fxa server -->
+    <string name="preferences_use_local_fxa_server">使用本地服务</string>
     <!-- Preference category for account information -->
     <string name="preferences_category_account">账户</string>
     <!-- Preference shown on banner to sign into account -->
@@ -487,6 +489,8 @@
     <!-- Pairing Feature strings -->
     <!-- Instructions on how to access pairing -->
     <string name="pair_instructions_2"><![CDATA[打开 <b>firefox.com/pair</b> 并扫描网站上的二维码]]></string>
+    <!-- Instructions on how to access pairing -->
+    <string name="pair_instructions_2_cn"><![CDATA[打开 <b>firefox.com.cn/pair</b> 并扫描网站上的二维码]]></string>
     <!-- Button to open camera for pairing -->
     <string name="pair_open_camera">打开相机</string>
     <!-- Button to cancel pairing -->
@@ -1277,6 +1281,8 @@
     <string name="sync_scan_code">扫码</string>
     <!-- Instructions on how to access pairing -->
     <string name="sign_in_instructions"><![CDATA[在计算机上使用 Firefox 打开 <b>https://firefox.com/pair</b>]]></string>
+    <!-- Instructions on how to access pairing -->
+    <string name="sign_in_instructions_cn"><![CDATA[在计算机上使用 Firefox 打开 <b>https://firefox.com.cn/pair</b>]]></string>
     <!-- Text shown for sign in pairing when ready -->
     <string name="sign_in_ready_for_scan">扫描就绪</string>
     <!-- Text shown for settings option for sign with pairing -->

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -47,6 +47,7 @@
     <string name="pref_key_sign_in" translatable="false">pref_key_sign_in</string>
     <string name="pref_key_account_auth_error" translatable="false">pref_key_account_auth_error</string>
     <string name="pref_key_use_local_fxa_server" translatable="false">pref_key_use_local_fxa_server</string>
+    <string name="pref_key_have_read_fxa_account_json" translatable="false">pref_key_have_read_fxa_account_json</string>
     <string name="pref_key_override_fxa_server" translatable="false">pref_key_override_fxa_server</string>
     <string name="pref_key_override_sync_tokenserver" translatable="false">pref_key_override_sync_tokenserver</string>
     <string name="pref_key_private_mode" translatable="false">pref_key_private_mode</string>

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -46,6 +46,7 @@
     <string name="pref_key_account" translatable="false">pref_key_account</string>
     <string name="pref_key_sign_in" translatable="false">pref_key_sign_in</string>
     <string name="pref_key_account_auth_error" translatable="false">pref_key_account_auth_error</string>
+    <string name="pref_key_use_local_fxa_server" translatable="false">pref_key_use_local_fxa_server</string>
     <string name="pref_key_override_fxa_server" translatable="false">pref_key_override_fxa_server</string>
     <string name="pref_key_override_sync_tokenserver" translatable="false">pref_key_override_sync_tokenserver</string>
     <string name="pref_key_private_mode" translatable="false">pref_key_private_mode</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -279,6 +279,8 @@
     <string name="preferences_override_sync_tokenserver">Custom Sync server</string>
     <!-- Toast shown after updating the FxA/Sync server override preferences -->
     <string name="toast_override_fxa_sync_server_done">Firefox Account/Sync server modified. Quitting the application to apply changes…</string>
+    <!-- Switch Preference for local/global fxa server -->
+    <string name="preferences_use_local_fxa_server">Use local service</string>
     <!-- Preference category for account information -->
     <string name="preferences_category_account">Account</string>
     <!-- Preference shown on banner to sign into account -->
@@ -467,6 +469,8 @@
     <!-- Pairing Feature strings -->
     <!-- Instructions on how to access pairing -->
     <string name="pair_instructions_2"><![CDATA[Scan the QR code shown at <b>firefox.com/pair</b>]]></string>
+    <!-- Instructions on how to access pairing -->
+    <string name="pair_instructions_2_cn"><![CDATA[Scan the QR code shown at <b>firefox.com.cn/pair</b>]]></string>
     <!-- Button to open camera for pairing -->
     <string name="pair_open_camera">Open Camera</string>
     <!-- Button to cancel pairing -->
@@ -1221,6 +1225,8 @@
     <string name="sync_scan_code">Scan the code</string>
     <!-- Instructions on how to access pairing -->
     <string name="sign_in_instructions"><![CDATA[On your computer open Firefox and go to <b>https://firefox.com/pair</b>]]></string>
+    <!-- Instructions on how to access pairing -->
+    <string name="sign_in_instructions_cn"><![CDATA[On your computer open Firefox and go to <b>https://firefox.com.cn/pair</b>]]></string>
     <!-- Text shown for sign in pairing when ready -->
     <string name="sign_in_ready_for_scan">Ready to scan</string>
     <!-- Text shown for settings option for sign with pairing -->

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -13,6 +13,11 @@
         android:summary="@string/preferences_sign_in_description"
         android:title="@string/preferences_sync" />
 
+    <androidx.preference.SwitchPreference
+            android:key="@string/pref_key_use_local_fxa_server"
+            android:title="@string/preferences_use_local_fxa_server"
+            android:defaultValue="true"/>
+    
     <androidx.preference.PreferenceCategory
         android:key="@string/pref_key_account_category"
         android:title="@string/preferences_category_account"

--- a/app/src/migration/java/org/mozilla/fenix/MigratingFenixApplication.kt
+++ b/app/src/migration/java/org/mozilla/fenix/MigratingFenixApplication.kt
@@ -22,6 +22,8 @@ class MigratingFenixApplication : FenixApplication() {
         }
     }
 
+    val fxaExpectChinaServers = Config.channel.isMozillaOnline
+
     val migrator by lazy {
         FennecMigrator.Builder(this, this.components.analytics.crashReporter)
             .migrateOpenTabs(this.components.core.sessionManager)
@@ -31,7 +33,7 @@ class MigratingFenixApplication : FenixApplication() {
                 this.components.core.pinnedSiteStorage
             )
             .migrateLogins(this.components.core.lazyPasswordsStorage)
-            .migrateFxa(lazy { this.components.backgroundServices.accountManager })
+            .migrateFxa(lazy { this.components.backgroundServices.accountManager }, fxaExpectChinaServers)
             .migrateAddons(
                 this.components.core.engine,
                 this.components.addonCollectionProvider,


### PR DESCRIPTION
- Add a switch in China build (_Config.channel.isMozillaOnline == true_) to allow users to switch between global/local sync services.

- Read fennec fxa state to keep the same server setting during update.

- Allow custom server auto login in China build during migration.

I have tried to write some tests about UI changes in the beginning but it seems there is some structure issue, so I dropped them and @bli-mozbj have tested the whole feature manually. If you feel they are necessary, maybe I can think more to overcome, or you can give me some suggestions about the tests.
