### PR TITLE
fix relpro schema

### DIFF
--- a/taskcluster/fenix_taskgraph/release_promotion.py
+++ b/taskcluster/fenix_taskgraph/release_promotion.py
@@ -92,9 +92,7 @@ def is_release_promotion_available(parameters):
             },
             "next_version": {
                 "type": "string",
-                "description": (
-                    "Next version.",
-                ),
+                "description": "Next version.",
                 "default": "",
             },
         },


### PR DESCRIPTION
The description needs to be a string. We accidentally made it a tuple.