### PR TITLE
For issue #16847 Show the autoplay icon in the toolbar

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -41,4 +41,9 @@ object FeatureFlags {
      * Enables the new MediaSession API.
      */
     val newMediaSessionApi = Config.channel.isNightlyOrDebug
+
+    /**
+     * Enabled showing site permission indicators in the toolbars.
+     */
+    val permissionIndicatorsToolbar = Config.channel.isNightlyOrDebug
 }

--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -126,6 +126,8 @@ import org.mozilla.fenix.wifi.SitePermissionsWifiIntegration
 import java.lang.ref.WeakReference
 import mozilla.components.feature.media.fullscreen.MediaFullscreenOrientationFeature
 import org.mozilla.fenix.FeatureFlags.newMediaSessionApi
+import org.mozilla.fenix.settings.PhoneFeature
+import org.mozilla.fenix.settings.quicksettings.QuickSettingsSheetDialogFragmentDirections
 
 /**
  * Base fragment extended by [BrowserFragment].
@@ -365,6 +367,10 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler,
 
             browserToolbarView.view.display.setOnSiteSecurityClickedListener {
                 showQuickSettingsDialog()
+            }
+
+            browserToolbarView.view.display.setOnPermissionIndicatorClickedListener {
+                navigateToAutoplaySetting()
             }
 
             browserToolbarView.view.display.setOnTrackingProtectionClickedListener {
@@ -1280,5 +1286,11 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler,
         if (_browserToolbarView != null) {
             browserToolbarView.setScrollFlags(enabled)
         }
+    }
+
+    private fun navigateToAutoplaySetting() {
+        val directions = QuickSettingsSheetDialogFragmentDirections
+            .actionGlobalSitePermissionsManagePhoneFeature(PhoneFeature.AUTOPLAY_AUDIBLE)
+        findNavController().navigate(directions)
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarView.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarView.kt
@@ -151,7 +151,8 @@ class BrowserToolbarView(
                     menu = primaryTextColor,
                     hint = secondaryTextColor,
                     separator = separatorColor,
-                    trackingProtection = primaryTextColor
+                    trackingProtection = primaryTextColor,
+                    permissionHighlights = primaryTextColor
                 )
 
                 display.hint = context.getString(R.string.search_hint)

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarIntegration.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarIntegration.kt
@@ -24,6 +24,7 @@ import mozilla.components.feature.toolbar.ToolbarPresenter
 import mozilla.components.lib.publicsuffixlist.PublicSuffixList
 import mozilla.components.support.base.feature.LifecycleAwareFeature
 import mozilla.components.support.ktx.android.view.hideKeyboard
+import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.settings
@@ -127,6 +128,10 @@ class DefaultToolbarIntegration(
                     DisplayToolbar.Indicators.EMPTY
                 )
             }
+
+        if (FeatureFlags.permissionIndicatorsToolbar) {
+            toolbar.display.indicators += DisplayToolbar.Indicators.PERMISSION_HIGHLIGHTS
+        }
 
         toolbar.display.displayIndicatorSeparator =
             context.settings().shouldUseTrackingProtection

--- a/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsManagePhoneFeatureFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsManagePhoneFeatureFragment.kt
@@ -28,6 +28,7 @@ import mozilla.components.feature.sitepermissions.SitePermissionsRules.Action.AS
 import mozilla.components.feature.sitepermissions.SitePermissionsRules.Action.BLOCKED
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.metrics.Event
+import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.showToolbar
@@ -213,6 +214,7 @@ class SitePermissionsManagePhoneFeatureFragment : Fragment() {
         requireComponents.analytics.metrics.track(Event.AutoPlaySettingChanged(setting))
         settings.setSitePermissionsPhoneFeatureAction(AUTOPLAY_AUDIBLE, audible)
         settings.setSitePermissionsPhoneFeatureAction(AUTOPLAY_INAUDIBLE, inaudible)
+        context?.components?.useCases?.sessionUseCases?.reload?.invoke()
     }
 
     private fun bindBlockedByAndroidContainer(rootView: View) {


### PR DESCRIPTION

Activates the autoplay indicator in the toolbar and allows users to change the setting. This is an initial work just to start
testing the feature in nightly. More work is needed to completed the feature for more info see https://github.com/mozilla-mobile/fenix/issues/16847.  

You can see an example of the initial [feature here](https://drive.google.com/file/d/174LY4_sPcrv4-9SoJ26Z6Udtxd0LVvKG/view)
 
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
