### PR TITLE
Call nimbus.updateExperiments on startup

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/Analytics.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Analytics.kt
@@ -122,6 +122,10 @@ class Analytics(
                     globalUserParticipation = enabled
                 }
                 context.settings().isExperimentationEnabled = globalUserParticipation
+
+                // Nimbus should look after downloading experiment definitions from remote settings
+                // on another thread, and making sure we don't hit the server each time we start.
+                updateExperiments()
             }
         }
     }


### PR DESCRIPTION
Fixes #16948.

This ensures that the experiment definitions are downloaded at startup.

Nimbus will probably not download experiments each time, but should look after deciding if this time it's time.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture