### PR TITLE
Prepare for A-C Session[Manager] observable deprecation

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -156,6 +156,9 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
         ) {
             browserToolbarView.view
         }
+
+        @Suppress("DEPRECATION")
+        // TODO Use browser store instead of session observer: https://github.com/mozilla-mobile/fenix/issues/16945
         session?.register(toolbarSessionObserver, viewLifecycleOwner, autoPause = true)
 
         if (settings.shouldShowOpenInAppCfr && session != null) {
@@ -166,6 +169,8 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
                 appLinksUseCases = context.components.useCases.appLinksUseCases,
                 container = browserLayout as ViewGroup
             )
+            @Suppress("DEPRECATION")
+            // TODO Use browser store instead of session observer: https://github.com/mozilla-mobile/fenix/issues/16949
             session.register(
                 openInAppOnboardingObserver!!,
                 owner = this,
@@ -174,6 +179,8 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
         }
 
         if (!settings.userKnowsAboutPwas) {
+            @Suppress("DEPRECATION")
+            // TODO Use browser store instead of session observer: https://github.com/mozilla-mobile/fenix/issues/16946
             session?.register(
                 PwaOnboardingObserver(
                     navController = findNavController(),
@@ -193,6 +200,8 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
         // This observer initialized in onStart has a reference to fragment's view.
         // Prevent it leaking the view after the latter onDestroyView.
         if (openInAppOnboardingObserver != null) {
+            @Suppress("DEPRECATION")
+            // TODO Use browser store instead of session observer: https://github.com/mozilla-mobile/fenix/issues/16949
             getSessionById()?.unregister(openInAppOnboardingObserver!!)
             openInAppOnboardingObserver = null
         }

--- a/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionPanelDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionPanelDialogFragment.kt
@@ -71,7 +71,11 @@ class TrackingProtectionPanelDialogFragment : AppCompatDialogFragment(), UserInt
     ): View? {
         val view = inflateRootView(container)
         val session = requireComponents.core.sessionManager.findSessionById(args.sessionId)
+
+        @Suppress("DEPRECATION")
+        // TODO Use browser store instead of session observer: https://github.com/mozilla-mobile/fenix/issues/16944
         session?.register(sessionObserver, view = view)
+
         trackingProtectionStore = StoreProvider.get(this) {
             TrackingProtectionStore(
                 TrackingProtectionState(

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "70.0.20201209143130"
+    const val VERSION = "70.0.20201210110353"
 }


### PR DESCRIPTION
We're now ready to deprecate `SessionManager` and `Session` observables in A-C. There are only four `Session` observers left in Fenix where we need to suppress the warning. There's no more `SessionManager` observer!  🎉 

I've filed and linked to tickets for the remaining observers.

This will be needed once https://github.com/mozilla-mobile/android-components/pull/9175 lands.