### PR TITLE
Update Android Components to 70.0.20201210143138

### DIFF
--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "70.0.20201210143138"
+    const val VERSION = "70.0.20201210195250"
 }


### PR DESCRIPTION
AC upgrade that includes the Nimbus crash fix.