### PR TITLE
Switch to new feature-tab-collections API.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -19,6 +19,7 @@ import kotlinx.android.synthetic.main.fragment_browser.view.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.state.selector.findTab
+import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.thumbnails.BrowserThumbnails
 import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.feature.app.links.AppLinksUseCases
@@ -257,11 +258,11 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
     }
 
     private val collectionStorageObserver = object : TabCollectionStorage.Observer {
-        override fun onCollectionCreated(title: String, sessions: List<Session>, id: Long?) {
+        override fun onCollectionCreated(title: String, sessions: List<TabSessionState>, id: Long?) {
             showTabSavedToCollectionSnackbar(sessions.size, true)
         }
 
-        override fun onTabsAdded(tabCollection: TabCollection, sessions: List<Session>) {
+        override fun onTabsAdded(tabCollection: TabCollection, sessions: List<TabSessionState>) {
             showTabSavedToCollectionSnackbar(sessions.size)
         }
 

--- a/app/src/main/java/org/mozilla/fenix/collections/CollectionCreationFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/collections/CollectionCreationFragment.kt
@@ -55,10 +55,10 @@ class CollectionCreationFragment : DialogFragment() {
         collectionCreationInteractor = DefaultCollectionCreationInteractor(
             DefaultCollectionCreationController(
                 collectionCreationStore,
+                requireComponents.core.store,
                 ::dismiss,
                 requireComponents.analytics.metrics,
                 requireComponents.core.tabCollectionStorage,
-                requireComponents.core.sessionManager,
                 scope = lifecycleScope
             )
         )

--- a/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -346,7 +346,6 @@ class Core(
     val tabCollectionStorage by lazyMonitored {
         TabCollectionStorage(
             context,
-            sessionManager,
             strictMode
         )
     }

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -239,6 +239,7 @@ class HomeFragment : Fragment() {
                 sessionManager = sessionManager,
                 tabCollectionStorage = components.core.tabCollectionStorage,
                 addTabUseCase = components.useCases.tabsUseCases.addTab,
+                restoreUseCase = components.useCases.tabsUseCases.restore,
                 reloadUrlUseCase = components.useCases.sessionUseCases.reload,
                 fragmentStore = homeFragmentStore,
                 navController = findNavController(),

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
@@ -18,7 +18,7 @@ import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.engine.prompt.ShareData
 import mozilla.components.feature.session.SessionUseCases
 import mozilla.components.feature.tab.collections.TabCollection
-import mozilla.components.feature.tab.collections.ext.restore
+import mozilla.components.feature.tab.collections.ext.invoke
 import mozilla.components.feature.tabs.TabsUseCases
 import mozilla.components.feature.top.sites.TopSite
 import mozilla.components.support.ktx.android.view.showKeyboard
@@ -177,6 +177,7 @@ class DefaultSessionControlController(
     private val store: BrowserStore,
     private val tabCollectionStorage: TabCollectionStorage,
     private val addTabUseCase: TabsUseCases.AddNewTabUseCase,
+    private val restoreUseCase: TabsUseCases.RestoreUseCase,
     private val reloadUrlUseCase: SessionUseCases.ReloadUrlUseCase,
     private val fragmentStore: HomeFragmentStore,
     private val navController: NavController,
@@ -208,7 +209,8 @@ class DefaultSessionControlController(
 
     override fun handleCollectionOpenTabClicked(tab: ComponentTab) {
         dismissSearchDialogIfDisplayed()
-        sessionManager.restore(
+
+        restoreUseCase.invoke(
             activity,
             engine,
             tab,
@@ -229,7 +231,7 @@ class DefaultSessionControlController(
     }
 
     override fun handleCollectionOpenTabsTapped(collection: TabCollection) {
-        sessionManager.restore(
+        restoreUseCase.invoke(
             activity,
             engine,
             collection,

--- a/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayController.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayController.kt
@@ -9,11 +9,12 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import mozilla.appservices.places.BookmarkRoot
-import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
+import mozilla.components.browser.state.selector.findTab
 import mozilla.components.browser.state.selector.getNormalOrPrivateTabs
 import mozilla.components.browser.state.selector.normalTabs
 import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.base.profiler.Profiler
 import mozilla.components.concept.engine.prompt.ShareData
@@ -100,8 +101,8 @@ class DefaultTabTrayController(
     private val registerCollectionStorageObserver: () -> Unit,
     private val tabTrayDialogFragmentStore: TabTrayDialogFragmentStore,
     private val selectTabUseCase: TabsUseCases.SelectTabUseCase,
-    private val showChooseCollectionDialog: (List<Session>) -> Unit,
-    private val showAddNewCollectionDialog: (List<Session>) -> Unit,
+    private val showChooseCollectionDialog: (List<TabSessionState>) -> Unit,
+    private val showAddNewCollectionDialog: (List<TabSessionState>) -> Unit,
     private val showUndoSnackbarForTabs: () -> Unit,
     private val showBookmarksSnackbar: () -> Unit
 ) : TabTrayController {
@@ -129,7 +130,7 @@ class DefaultTabTrayController(
         metrics.track(Event.TabsTraySaveToCollectionPressed)
 
         val sessionList = selectedTabs.map {
-            sessionManager.findSessionById(it.id) ?: return
+            browserStore.state.findTab(it.id) ?: return
         }
 
         // Only register the observer right before moving to collection creation

--- a/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayDialogFragment.kt
@@ -86,11 +86,11 @@ class TabTrayDialogFragment : AppCompatDialogFragment(), UserInteractionHandler 
             else null
 
     private val collectionStorageObserver = object : TabCollectionStorage.Observer {
-        override fun onCollectionCreated(title: String, sessions: List<Session>, id: Long?) {
+        override fun onCollectionCreated(title: String, sessions: List<TabSessionState>, id: Long?) {
             showCollectionSnackbar(sessions.size, true, collectionToSelect = id)
         }
 
-        override fun onTabsAdded(tabCollection: TabCollection, sessions: List<Session>) {
+        override fun onTabsAdded(tabCollection: TabCollection, sessions: List<TabSessionState>) {
             showCollectionSnackbar(
                 sessions.size,
                 collectionToSelect = tabCollection.id
@@ -424,7 +424,7 @@ class TabTrayDialogFragment : AppCompatDialogFragment(), UserInteractionHandler 
         return true
     }
 
-    private fun showChooseCollectionDialog(sessionList: List<Session>) {
+    private fun showChooseCollectionDialog(sessionList: List<TabSessionState>) {
         context?.let {
             val tabCollectionStorage = it.components.core.tabCollectionStorage
             val collections =
@@ -467,7 +467,7 @@ class TabTrayDialogFragment : AppCompatDialogFragment(), UserInteractionHandler 
         }
     }
 
-    private fun showAddNewCollectionDialog(sessionList: List<Session>) {
+    private fun showAddNewCollectionDialog(sessionList: List<TabSessionState>) {
         context?.let {
             val tabCollectionStorage = it.components.core.tabCollectionStorage
             val customLayout =

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "70.0.20201215143131"
+    const val VERSION = "70.0.20201216094408"
 }

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "70.0.20201216094408"
+    const val VERSION = "71.0.20201216143107"
 }


### PR DESCRIPTION
This is in preparation for an upcoming change in AC:
https://github.com/mozilla-mobile/android-components/pull/9207

As a bonus `DefaultCollectionCreationController` no longer requires `SessionManager`.