### PR TITLE
Closes #17045: Crash caused by calling consumeFlow on wrong thread

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -230,10 +230,8 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler,
 
         observeTabSelection(requireComponents.core.store)
 
-        lifecycleScope.launch(IO) {
-            if (!onboarding.userHasBeenOnboarded()) {
-                observeTabSource(requireComponents.core.store)
-            }
+        if (!onboarding.userHasBeenOnboarded()) {
+            observeTabSource(requireComponents.core.store)
         }
 
         requireContext().accessibilityManager.addAccessibilityStateChangeListener(this)

--- a/app/src/test/java/org/mozilla/fenix/onboarding/FenixOnboardingTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/onboarding/FenixOnboardingTest.kt
@@ -14,12 +14,17 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.components.metrics.MetricController
 import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+import org.mozilla.fenix.helpers.perf.TestStrictModeManager
 import org.mozilla.fenix.onboarding.FenixOnboarding.Companion.CURRENT_ONBOARDING_VERSION
 import org.mozilla.fenix.onboarding.FenixOnboarding.Companion.LAST_VERSION_ONBOARDING_KEY
+import org.mozilla.fenix.perf.StrictModeManager
 
+@RunWith(FenixRobolectricTestRunner::class)
 class FenixOnboardingTest {
 
     private lateinit var onboarding: FenixOnboarding
@@ -36,6 +41,7 @@ class FenixOnboardingTest {
         every { preferences.edit() } returns preferencesEditor
         every { metrics.track(any()) } returns Unit
         every { context.components.analytics.metrics } returns metrics
+        every { context.components.strictMode } returns TestStrictModeManager() as StrictModeManager
         every { context.getSharedPreferences(any(), MODE_PRIVATE) } returns preferences
 
         onboarding = FenixOnboarding(context)


### PR DESCRIPTION
`consumeFlow` must be called on the main thread, otherwise there's a chance that lifecycle observer will run on whatever thread `consumeFlow` is called on. This can cause our features to start on a wrong thread, causing #17045 and many other issues.