### PR TITLE
Bug 1661667 - Disable conditioned profiles in the fenix branch.

### DIFF
--- a/taskcluster/ci/browsertime/kind.yml
+++ b/taskcluster/ci/browsertime/kind.yml
@@ -84,6 +84,7 @@ job-defaults:
             - '--app=fenix'
             - '--browsertime'
             - '--cold'
+            - '--no-conditioned-profile'
             - '--binary=org.mozilla.fenix'
             - '--activity=org.mozilla.fenix.IntentReceiverActivity'
             - '--download-symbols=ondemand'


### PR DESCRIPTION
This patch is for disabling conditioned profiles on the Fenix branch to try to fix some of the intermittents we are seeing here. They are disabled in mozilla-central at the moment as well.