### PR TITLE
Closes #16949: Refactor OpenInAppOnboardingObserver to use browser store

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/OpenInAppOnboardingObserver.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/OpenInAppOnboardingObserver.kt
@@ -7,10 +7,20 @@ package org.mozilla.fenix.browser
 import android.content.Context
 import android.view.ViewGroup
 import androidx.annotation.VisibleForTesting
+import androidx.lifecycle.LifecycleOwner
 import androidx.navigation.NavController
-import mozilla.components.browser.session.Session
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.mapNotNull
+import mozilla.components.browser.state.selector.selectedTab
+import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.feature.app.links.AppLinksUseCases
+import mozilla.components.lib.state.ext.flowScoped
+import mozilla.components.support.base.feature.LifecycleAwareFeature
 import mozilla.components.support.ktx.kotlin.tryGetHostFromUrl
+import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifAnyChanged
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.utils.Settings
@@ -18,51 +28,79 @@ import org.mozilla.fenix.utils.Settings
 /**
  * Displays an [InfoBanner] when a user visits a website that can be opened in an installed native app.
  */
+@ExperimentalCoroutinesApi
+@Suppress("LongParameterList")
 class OpenInAppOnboardingObserver(
     private val context: Context,
+    private val store: BrowserStore,
+    private val lifecycleOwner: LifecycleOwner,
     private val navController: NavController,
     private val settings: Settings,
     private val appLinksUseCases: AppLinksUseCases,
     private val container: ViewGroup
-) : Session.Observer {
+) : LifecycleAwareFeature {
+    private var scope: CoroutineScope? = null
+    private var currentUrl: String? = null
+    private var sessionDomainForDisplayedBanner: String? = null
 
-    @VisibleForTesting
-    internal var sessionDomainForDisplayedBanner: String? = null
     @VisibleForTesting
     internal var infoBanner: InfoBanner? = null
 
-    override fun onUrlChanged(session: Session, url: String) {
-        sessionDomainForDisplayedBanner?.let {
-            if (url.tryGetHostFromUrl() != it) {
-                infoBanner?.dismiss()
+    override fun start() {
+        scope = store.flowScoped(lifecycleOwner) { flow ->
+            flow.mapNotNull { state ->
+                state.selectedTab
+            }
+            .ifAnyChanged {
+                tab -> arrayOf(tab.content.url, tab.content.loading)
+            }
+            .collect { tab ->
+                if (tab.content.url != currentUrl) {
+                    sessionDomainForDisplayedBanner?.let {
+                        if (tab.content.url.tryGetHostFromUrl() != it) {
+                            infoBanner?.dismiss()
+                        }
+                    }
+                    currentUrl = tab.content.url
+                } else {
+                    // Loading state has changed
+                    maybeShowOpenInAppBanner(tab.content.url, tab.content.loading)
+                }
             }
         }
     }
 
-    override fun onLoadingStateChanged(session: Session, loading: Boolean) {
+    override fun stop() {
+        scope?.cancel()
+    }
+
+    private fun maybeShowOpenInAppBanner(url: String, loading: Boolean) {
         if (loading || settings.openLinksInExternalApp || !settings.shouldShowOpenInAppCfr) {
             return
         }
 
         val appLink = appLinksUseCases.appLinkRedirect
-
-        if (appLink(session.url).hasExternalApp()) {
-            infoBanner = InfoBanner(
-                context = context,
-                message = context.getString(R.string.open_in_app_cfr_info_message),
-                dismissText = context.getString(R.string.open_in_app_cfr_negative_button_text),
-                actionText = context.getString(R.string.open_in_app_cfr_positive_button_text),
-                container = container
-            ) {
-                val directions = BrowserFragmentDirections.actionBrowserFragmentToSettingsFragment(
-                    preferenceToScrollTo = context.getString(R.string.pref_key_open_links_in_external_app)
-                )
-                navController.nav(R.id.browserFragment, directions)
-            }
-
+        if (appLink(url).hasExternalApp()) {
+            infoBanner = createInfoBanner()
             infoBanner?.showBanner()
-            sessionDomainForDisplayedBanner = session.url.tryGetHostFromUrl()
+            sessionDomainForDisplayedBanner = url.tryGetHostFromUrl()
             settings.shouldShowOpenInAppBanner = false
+        }
+    }
+
+    @VisibleForTesting
+    internal fun createInfoBanner(): InfoBanner {
+        return InfoBanner(
+            context = context,
+            message = context.getString(R.string.open_in_app_cfr_info_message),
+            dismissText = context.getString(R.string.open_in_app_cfr_negative_button_text),
+            actionText = context.getString(R.string.open_in_app_cfr_positive_button_text),
+            container = container
+        ) {
+            val directions = BrowserFragmentDirections.actionBrowserFragmentToSettingsFragment(
+                preferenceToScrollTo = context.getString(R.string.pref_key_open_links_in_external_app)
+            )
+            navController.nav(R.id.browserFragment, directions)
         }
     }
 }


### PR DESCRIPTION
Follows the same pattern as https://github.com/mozilla-mobile/fenix/pull/17039 to refactor the observer. Logic is exactly the same as before, just migrated to use browser store, plus some test improvements.