### PR TITLE
Reset nimbus telemetry identifiers on data prefs change.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/DataChoicesFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/DataChoicesFragment.kt
@@ -31,6 +31,10 @@ class DataChoicesFragment : PreferenceFragmentCompat() {
                 } else {
                     context.components.analytics.metrics.stop(MetricServiceType.Data)
                 }
+                // Reset experiment identifiers on both opt-in and opt-out; it's likely
+                // that in future we will need to pass in the new telemetry client_id
+                // to this method when the user opts back in.
+                context.components.analytics.experiments.resetTelemetryIdentifiers()
             } else if (key == getPreferenceKey(R.string.pref_key_marketing_telemetry)) {
                 if (context.settings().isMarketingTelemetryEnabled) {
                     context.components.analytics.metrics.start(MetricServiceType.Marketing)


### PR DESCRIPTION
~~This is just a skeleton PR to roadtest the API being proposed over in mozilla/nimbus-sdk#80 and https://github.com/travis79/android-components/pull/6~~

The Nimbus `resetTelemtryIdentifiers` API is now available for use in the latest android-components nightly, so this PR hooks it up to the telemetry controls in the Fenix app.