### PR TITLE
Update mergify to use new release branch name format

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -31,7 +31,7 @@ pull_request_rules:
         strict: smart
   - name: Release automation
     conditions:
-      - base~=releases/.*
+      - base~=releases_.*
       - author=github-actions[bot]
       # Listing checks manually beause we do not have a "push complete" check yet.
       - check-success=build-android-test-debug


### PR DESCRIPTION
This patch updates the rule to use the `releases_...` branch name format.