### PR TITLE
Let Mergify know about the change of branch name

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -31,7 +31,7 @@ pull_request_rules:
         strict: smart
   - name: Release automation
     conditions:
-      - base~=releases_.*
+      - base~=releases[_/].*
       - author=github-actions[bot]
       # Listing checks manually beause we do not have a "push complete" check yet.
       - check-success=build-android-test-debug


### PR DESCRIPTION
This patch uses a new regular expression to match both the new and old-style branch names:

 - `releases/v85.0.0`
 - `releases_v85.0.0`

Tested in the Mergify test tool.
