### PR TITLE
Update mergify to recognize old and new task graphs for release builds

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -29,7 +29,7 @@ pull_request_rules:
       merge:
         method: rebase
         strict: smart
-  - name: Release automation (Release)
+  - name: Release automation (Old)
     conditions:
       - base~=releases[_/].*
       - author=github-actions[bot]
@@ -50,13 +50,13 @@ pull_request_rules:
     actions:
       review:
         type: APPROVE
-        message: Ship that Release ⛴
+        message: 🚢
       merge:
         method: rebase
         strict: smart
       delete_head_branch:
         force: false
-  - name: Release automation (Beta)
+  - name: Release automation (New)
     conditions:
       - base~=releases[_/].*
       - author=github-actions[bot]
@@ -78,7 +78,7 @@ pull_request_rules:
     actions:
       review:
         type: APPROVE
-        message: Ship that Beta 🚢
+        message: 🚢
       merge:
         method: rebase
         strict: smart

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -29,9 +29,9 @@ pull_request_rules:
       merge:
         method: rebase
         strict: smart
-  - name: Release automation
+  - name: Release automation (Release)
     conditions:
-      - base~=releases_.*
+      - base~=releases[_/].*
       - author=github-actions[bot]
       # Listing checks manually beause we do not have a "push complete" check yet.
       - check-success=build-android-test-debug
@@ -50,7 +50,35 @@ pull_request_rules:
     actions:
       review:
         type: APPROVE
-        message: 🚢
+        message: Ship that Release ⛴
+      merge:
+        method: rebase
+        strict: smart
+      delete_head_branch:
+        force: false
+  - name: Release automation (Beta)
+    conditions:
+      - base~=releases[_/].*
+      - author=github-actions[bot]
+      # Listing checks manually beause we do not have a "push complete" check yet.
+      - check-success=build-android-test-beta
+      - check-success=build-android-test-debug
+      - check-success=build-beta-firebase
+      - check-success=build-debug
+      - check-success=build-nightly-simulation
+      - check-success=lint-compare-locales
+      - check-success=lint-detekt
+      - check-success=lint-ktlint
+      - check-success=lint-lint
+      - check-success=signing-android-test-beta
+      - check-success=signing-beta-firebase
+      - check-success=signing-nightly-simulation
+      - check-success=test-debug
+      - files~=(AndroidComponents.kt)
+    actions:
+      review:
+        type: APPROVE
+        message: Ship that Beta 🚢
       merge:
         method: rebase
         strict: smart


### PR DESCRIPTION
This patch updates the Mergify config with separate rules for handling (automated) A-C updates. The build tasks & checks are slightly different, starting with 85. We can simplify this later when the `pr-complete` check comes back.

Tested against the following two PRs:

 - https://github.com/mozilla-mobile/fenix/pull/17105 (A-C update for `releases_v85.0.0` - New)
 - https://github.com/mozilla-mobile/fenix/pull/17079 (A-C update for `releases/v84.0.0` - Old)

The PR where these changes happened is most likely 

🤖