### PR TITLE
Update Mergify to also expect ui-test-x86-beta to succeed

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -74,6 +74,7 @@ pull_request_rules:
       - check-success=signing-beta-firebase
       - check-success=signing-nightly-simulation
       - check-success=test-debug
+      - check-success=ui-test-x86-beta
       - files~=(AndroidComponents.kt)
     actions:
       review:


### PR DESCRIPTION
This patch adds a condition for the `ui-test-x86-beta` task to succeed for automated GV updates. It should land together with #16786
