### PR TITLE
Closes #9778: Site permission settings item height set to 48dp

### DIFF
--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -59,7 +59,7 @@
     <dimen name="section_header_height">48dp</dimen>
 
     <!--Quick Settings-->
-    <dimen name="quicksettings_item_height">28dp</dimen>
+    <dimen name="quicksettings_item_height">48dp</dimen>
     <dimen name="tracking_protection_item_height">48dp</dimen>
     <dimen name="tracking_protection_item_margin_end">16dp</dimen>
     <dimen name="tracking_protection_item_margin_bottom">18dp</dimen>


### PR DESCRIPTION
Increases Site Permission, Quick Settings item height to 48dp for compliance with "Google Accessibility Scanner". This is a small UI changed and no tests are required to change.

Fix #9778.

| Before | After |
|---|---|
| ![Screenshot_1608330811](https://user-images.githubusercontent.com/4348197/102667481-c5376900-4189-11eb-96ab-5291c322e831.png) | ![Screenshot_1608330664](https://user-images.githubusercontent.com/4348197/102667494-cb2d4a00-4189-11eb-9bad-890bffb08a8c.png) |

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
