### PR TITLE
For #15703 and #17133: allow ETP redirect trackers setting to be customized

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -27,11 +27,6 @@ object FeatureFlags {
     const val externalDownloadManager = true
 
     /**
-     * Enables ETP cookie purging
-     */
-    val etpCookiePurging = Config.channel.isNightlyOrDebug
-
-    /**
      * Enables the Nimbus experiments library, especially the settings toggle to opt-out of
      * all experiments.
      */

--- a/app/src/main/java/org/mozilla/fenix/components/TrackingProtectionPolicyFactory.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/TrackingProtectionPolicyFactory.kt
@@ -7,8 +7,6 @@ package org.mozilla.fenix.components
 import androidx.annotation.VisibleForTesting
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicyForSessionTypes
-import org.mozilla.fenix.Config
-import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.utils.Settings
 
 /**
@@ -49,7 +47,7 @@ class TrackingProtectionPolicyFactory(private val settings: Settings) {
         return TrackingProtectionPolicy.select(
             cookiePolicy = getCustomCookiePolicy(),
             trackingCategories = getCustomTrackingCategories(),
-            cookiePurging = Config.channel.isNightlyOrDebug
+            cookiePurging = getCustomCookiePurgingPolicy()
         ).let {
             if (settings.blockTrackingContentSelectionInCustomTrackingProtection == "private") {
                 it.forPrivateSessionsOnly()
@@ -95,6 +93,10 @@ class TrackingProtectionPolicyFactory(private val settings: Settings) {
 
         return categories.toTypedArray()
     }
+
+    private fun getCustomCookiePurgingPolicy(): Boolean {
+        return settings.blockRedirectTrackersInCustomTrackingProtection
+    }
 }
 
 @VisibleForTesting
@@ -103,6 +105,6 @@ internal fun TrackingProtectionPolicyForSessionTypes.adaptPolicyToChannel(): Tra
         trackingCategories = trackingCategories,
         cookiePolicy = cookiePolicy,
         strictSocialTrackingProtection = strictSocialTrackingProtection,
-        cookiePurging = FeatureFlags.etpCookiePurging
+        cookiePurging = cookiePurging
     )
 }

--- a/app/src/main/java/org/mozilla/fenix/settings/TrackingProtectionFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/TrackingProtectionFragment.kt
@@ -41,6 +41,7 @@ class TrackingProtectionFragment : PreferenceFragmentCompat() {
     private lateinit var customTrackingSelect: DropDownPreference
     private lateinit var customCryptominers: CheckBoxPreference
     private lateinit var customFingerprinters: CheckBoxPreference
+    private lateinit var customRedirectTrackers: CheckBoxPreference
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         setPreferencesFromResource(R.xml.tracking_protection_preferences, rootKey)
@@ -145,6 +146,9 @@ class TrackingProtectionFragment : PreferenceFragmentCompat() {
         customFingerprinters =
             requirePreference(R.string.pref_key_tracking_protection_custom_fingerprinters)
 
+        customRedirectTrackers =
+            requirePreference(R.string.pref_key_tracking_protection_redirect_trackers)
+
         customCookies.onPreferenceChangeListener = object : SharedPreferenceUpdater() {
             override fun onPreferenceChange(preference: Preference, newValue: Any?): Boolean {
                 customCookiesSelect.isVisible = !customCookies.isChecked
@@ -196,6 +200,14 @@ class TrackingProtectionFragment : PreferenceFragmentCompat() {
             }
         }
 
+        customRedirectTrackers.onPreferenceChangeListener = object : SharedPreferenceUpdater() {
+            override fun onPreferenceChange(preference: Preference, newValue: Any?): Boolean {
+                return super.onPreferenceChange(preference, newValue).also {
+                    updateTrackingProtectionPolicy()
+                }
+            }
+        }
+
         updateCustomOptionsVisibility()
 
         return radio
@@ -218,5 +230,6 @@ class TrackingProtectionFragment : PreferenceFragmentCompat() {
         customTrackingSelect.isVisible = isCustomSelected && customTracking.isChecked
         customCryptominers.isVisible = isCustomSelected
         customFingerprinters.isVisible = isCustomSelected
+        customRedirectTrackers.isVisible = isCustomSelected
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionBlockingFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionBlockingFragment.kt
@@ -10,7 +10,6 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.navArgs
 import kotlinx.android.synthetic.main.fragment_tracking_protection_blocking.*
-import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.showToolbar
@@ -23,7 +22,6 @@ class TrackingProtectionBlockingFragment :
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        category_redirect_trackers.isVisible = FeatureFlags.etpCookiePurging
 
         when (args.protectionMode) {
             TrackingProtectionMode.STANDARD -> {
@@ -41,6 +39,8 @@ class TrackingProtectionBlockingFragment :
                     settings.blockCookiesInCustomTrackingProtection
                 category_tracking_content.isVisible =
                     settings.blockTrackingContentInCustomTrackingProtection
+                category_redirect_trackers.isVisible =
+                    settings.blockRedirectTrackersInCustomTrackingProtection
             }
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionPanelView.kt
+++ b/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionPanelView.kt
@@ -18,6 +18,7 @@ import androidx.core.view.isVisible
 import kotlinx.android.extensions.LayoutContainer
 import kotlinx.android.synthetic.main.component_tracking_protection_panel.*
 import kotlinx.android.synthetic.main.component_tracking_protection_panel.details_blocking_header
+import kotlinx.android.synthetic.main.fragment_tracking_protection_blocking.*
 import kotlinx.android.synthetic.main.switch_with_description.view.*
 import mozilla.components.support.ktx.android.net.hostWithoutCommonPrefixes
 import org.mozilla.fenix.R
@@ -28,6 +29,7 @@ import org.mozilla.fenix.trackingprotection.TrackingProtectionCategory.CRYPTOMIN
 import org.mozilla.fenix.trackingprotection.TrackingProtectionCategory.FINGERPRINTERS
 import org.mozilla.fenix.trackingprotection.TrackingProtectionCategory.SOCIAL_MEDIA_TRACKERS
 import org.mozilla.fenix.trackingprotection.TrackingProtectionCategory.TRACKING_CONTENT
+import org.mozilla.fenix.trackingprotection.TrackingProtectionCategory.REDIRECT_TRACKERS
 
 /**
  * Interface for the TrackingProtectionPanelViewInteractor. This interface is implemented by objects that want
@@ -170,6 +172,9 @@ class TrackingProtectionPanelView(
         CRYPTOMINERS.name -> {
             if (cryptominers.isGone) cryptominers_loaded else cryptominers
         }
+        REDIRECT_TRACKERS.name -> {
+            if (redirect_trackers.isGone) redirect_trackers_loaded else redirect_trackers
+        }
         else -> null
     }
 
@@ -181,6 +186,7 @@ class TrackingProtectionPanelView(
         fingerprinters.isGone = bucketedTrackers.get(FINGERPRINTERS, true).isEmpty()
         tracking_content.isGone = bucketedTrackers.get(TRACKING_CONTENT, true).isEmpty()
         cryptominers.isGone = bucketedTrackers.get(CRYPTOMINERS, true).isEmpty()
+        redirect_trackers.isGone = bucketedTrackers.get(REDIRECT_TRACKERS, true).isEmpty()
 
         cross_site_tracking_loaded.isGone =
             bucketedTrackers.get(CROSS_SITE_TRACKING_COOKIES, false).isEmpty()
@@ -189,6 +195,7 @@ class TrackingProtectionPanelView(
         fingerprinters_loaded.isGone = bucketedTrackers.get(FINGERPRINTERS, false).isEmpty()
         tracking_content_loaded.isGone = bucketedTrackers.get(TRACKING_CONTENT, false).isEmpty()
         cryptominers_loaded.isGone = bucketedTrackers.get(CRYPTOMINERS, false).isEmpty()
+        redirect_trackers_loaded.isGone = bucketedTrackers.get(REDIRECT_TRACKERS, false).isEmpty()
     }
 
     private fun setCategoryClickListeners() {
@@ -202,6 +209,7 @@ class TrackingProtectionPanelView(
         fingerprinters_loaded.setOnClickListener(this)
         tracking_content_loaded.setOnClickListener(this)
         cryptominers_loaded.setOnClickListener(this)
+        redirect_trackers_loaded.setOnClickListener(this)
     }
 
     override fun onClick(v: View) {
@@ -263,6 +271,7 @@ class TrackingProtectionPanelView(
             R.id.cross_site_tracking, R.id.cross_site_tracking_loaded -> CROSS_SITE_TRACKING_COOKIES
             R.id.tracking_content, R.id.tracking_content_loaded -> TRACKING_CONTENT
             R.id.cryptominers, R.id.cryptominers_loaded -> CRYPTOMINERS
+            R.id.redirect_trackers, R.id.redirect_trackers_loaded -> REDIRECT_TRACKERS
             else -> null
         }
 
@@ -274,13 +283,15 @@ class TrackingProtectionPanelView(
             R.id.cross_site_tracking_loaded,
             R.id.fingerprinters_loaded,
             R.id.tracking_content_loaded,
-            R.id.cryptominers_loaded -> true
+            R.id.cryptominers_loaded,
+            R.id.redirect_trackers_loaded -> true
 
             R.id.social_media_trackers,
             R.id.fingerprinters,
             R.id.cross_site_tracking,
             R.id.tracking_content,
-            R.id.cryptominers -> false
+            R.id.cryptominers,
+            R.id.redirect_trackers -> false
             else -> false
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionStore.kt
+++ b/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionStore.kt
@@ -90,8 +90,18 @@ enum class TrackingProtectionCategory(
         R.string.etp_cryptominers_title,
         R.string.etp_cryptominers_description
     ),
-    FINGERPRINTERS(R.string.etp_fingerprinters_title, R.string.etp_fingerprinters_description),
-    TRACKING_CONTENT(R.string.etp_tracking_content_title, R.string.etp_tracking_content_description)
+    FINGERPRINTERS(
+        R.string.etp_fingerprinters_title,
+        R.string.etp_fingerprinters_description
+    ),
+    TRACKING_CONTENT(
+        R.string.etp_tracking_content_title,
+        R.string.etp_tracking_content_description
+    ),
+    REDIRECT_TRACKERS(
+        R.string.etp_redirect_trackers_title,
+        R.string.etp_redirect_trackers_description
+    )
 }
 
 /**

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -466,6 +466,11 @@ class Settings(private val appContext: Context) : PreferencesHolder {
         true
     )
 
+    val blockRedirectTrackersInCustomTrackingProtection by booleanPreference(
+        appContext.getPreferenceKey(R.string.pref_key_tracking_protection_redirect_trackers),
+        true
+    )
+
     val shouldUseFixedTopToolbar: Boolean
         get() {
             return touchExplorationIsEnabled || switchServiceIsEnabled

--- a/app/src/main/res/layout/component_tracking_protection_panel.xml
+++ b/app/src/main/res/layout/component_tracking_protection_panel.xml
@@ -100,6 +100,15 @@
             app:layout_constraintTop_toBottomOf="@id/social_media_trackers" />
 
         <TextView
+            android:id="@+id/redirect_trackers"
+            style="@style/QuickSettingsLargeText.Icon"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/tracking_protection_item_height"
+            android:text="@string/etp_redirect_trackers_title"
+            android:visibility="gone"
+            app:layout_constraintTop_toBottomOf="@id/tracking_content" />
+
+        <TextView
             android:id="@+id/not_blocking_header"
             style="@style/QuickSettingsText"
             android:layout_width="wrap_content"
@@ -156,6 +165,15 @@
             android:text="@string/etp_tracking_content_title"
             android:visibility="gone"
             app:layout_constraintTop_toBottomOf="@id/social_media_trackers_loaded" />
+
+        <TextView
+            android:id="@+id/redirect_trackers_loaded"
+            style="@style/QuickSettingsLargeText.Icon"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/tracking_protection_item_height"
+            android:text="@string/etp_redirect_trackers_title"
+            android:visibility="gone"
+            app:layout_constraintTop_toBottomOf="@id/tracking_content_loaded" />
 
         <View
             android:id="@+id/line_divider"

--- a/app/src/main/res/layout/fragment_tracking_protection_blocking.xml
+++ b/app/src/main/res/layout/fragment_tracking_protection_blocking.xml
@@ -80,7 +80,6 @@
             android:background="?android:attr/selectableItemBackground"
             android:clickable="true"
             android:focusable="true"
-            android:visibility="gone"
             app:categoryItemDescription="@string/etp_redirect_trackers_description"
             app:categoryItemTitle="@string/etp_redirect_trackers_title" />
     </LinearLayout>

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -149,6 +149,7 @@
     <string name="pref_key_tracking_protection_custom_tracking_content_select" translatable="false">pref_key_tracking_protection_custom_tracking_content_select</string>
     <string name="pref_key_tracking_protection_custom_cryptominers" translatable="false">pref_key_tracking_protection_custom_cryptominers</string>
     <string name="pref_key_tracking_protection_custom_fingerprinters" translatable="false">pref_key_tracking_protection_custom_fingerprinters</string>
+    <string name="pref_key_tracking_protection_redirect_trackers" translatable="false">pref_key_tracking_protection_redirect_trackers</string>
 
     <string name="pref_key_tracking_protection_onboarding" translatable="false">pref_key_tracking_protection_onboarding</string>
 

--- a/app/src/main/res/xml/tracking_protection_preferences.xml
+++ b/app/src/main/res/xml/tracking_protection_preferences.xml
@@ -70,6 +70,12 @@
         android:key="@string/pref_key_tracking_protection_custom_fingerprinters"
         android:layout="@layout/checkbox_left_preference_etp"
         android:title="@string/preference_enhanced_tracking_protection_custom_fingerprinters" />
+    <CheckBoxPreference
+        android:defaultValue="true"
+        android:dependency="@string/pref_key_tracking_protection_custom_option"
+        android:key="@string/pref_key_tracking_protection_redirect_trackers"
+        android:layout="@layout/checkbox_left_preference_etp"
+        android:title="@string/etp_redirect_trackers_title" />
 
     <Preference
         android:icon="@drawable/ic_internet"

--- a/app/src/test/java/org/mozilla/fenix/components/TrackingProtectionPolicyFactoryTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/TrackingProtectionPolicyFactoryTest.kt
@@ -13,7 +13,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.Config
-import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ReleaseChannel
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
@@ -346,7 +345,8 @@ class TrackingProtectionPolicyFactoryTest {
                 shouldBlockCookiesInCustom = true,
                 blockTrackingContent = false,
                 blockFingerprinters = true,
-                blockCryptominers = false
+                blockCryptominers = false,
+                blockRedirectTrackers = true
             )
         )
         val actual = factory.createTrackingProtectionPolicy(normalMode = true, privateMode = true)
@@ -359,7 +359,7 @@ class TrackingProtectionPolicyFactoryTest {
         val expected = TrackingProtectionPolicy.select(
             cookiePolicy = TrackingProtectionPolicy.CookiePolicy.ACCEPT_NONE,
             trackingCategories = allTrackingCategories,
-            cookiePurging = FeatureFlags.etpCookiePurging
+            cookiePurging = true
         )
 
         val factory = TrackingProtectionPolicyFactory(settingsForCustom(shouldBlockCookiesInCustom = true))
@@ -421,7 +421,8 @@ private fun settingsForCustom(
     blockCookiesSelection: String = "all", // values from R.array.cookies_options_entry_values
     blockTrackingContent: Boolean = true,
     blockFingerprinters: Boolean = true,
-    blockCryptominers: Boolean = true
+    blockCryptominers: Boolean = true,
+    blockRedirectTrackers: Boolean = true
 ): Settings = mockSettings(useStrict = false, useCustom = true).apply {
 
     every { blockTrackingContentSelectionInCustomTrackingProtection } returns blockTrackingContentInCustom
@@ -431,6 +432,7 @@ private fun settingsForCustom(
     every { blockTrackingContentInCustomTrackingProtection } returns blockTrackingContent
     every { blockFingerprintersInCustomTrackingProtection } returns blockFingerprinters
     every { blockCryptominersInCustomTrackingProtection } returns blockCryptominers
+    every { blockRedirectTrackersInCustomTrackingProtection } returns blockRedirectTrackers
 }
 
 private fun TrackingProtectionPolicy.assertPolicyEquals(

--- a/app/src/test/java/org/mozilla/fenix/trackingprotection/TrackingProtectionPanelInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/trackingprotection/TrackingProtectionPanelInteractorTest.kt
@@ -29,6 +29,22 @@ class TrackingProtectionPanelInteractorTest {
     }
 
     @Test
+    fun openDetailsForRedirectTrackers() {
+        val store: TrackingProtectionStore = mockk(relaxed = true)
+        val interactor =
+            TrackingProtectionPanelInteractor(store, mockk(), mockk())
+        interactor.openDetails(TrackingProtectionCategory.REDIRECT_TRACKERS, true)
+        verify {
+            store.dispatch(
+                TrackingProtectionAction.EnterDetailsMode(
+                    TrackingProtectionCategory.REDIRECT_TRACKERS,
+                    true
+                )
+            )
+        }
+    }
+
+    @Test
     fun selectTrackingProtectionSettings() {
         var openSettings = false
         val interactor = TrackingProtectionPanelInteractor(


### PR DESCRIPTION
For #15703, #17133 

- [x] add clickable Redirect Trackers category to the ETP panel on toolbar
- [x] add Redirect Trackers selectable ✅ category to `CUSTOM` list in settings (#13812 only added it to the (i) info lists for standard, strict, and custom) 
- [x] add/remove from CUSTOM (i) list to match others when ✅ checked
- [x] tests

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
