### PR TITLE
Increasing the "Scan" and "Search engine" option items from 40 dp, to…

### DIFF
--- a/app/src/main/res/layout/fragment_search_dialog.xml
+++ b/app/src/main/res/layout/fragment_search_dialog.xml
@@ -173,6 +173,7 @@
     <ToggleButton
         android:id="@+id/qr_scan_button"
         style="@style/search_pill"
+        android:layout_height="@dimen/search_fragment_toggleButton_height"
         android:layout_marginEnd="@dimen/search_fragment_scan_button_margin_end"
         android:textOff="@string/search_scan_button"
         android:textOn="@string/search_scan_button"
@@ -185,6 +186,7 @@
     <ToggleButton
         android:id="@+id/search_engines_shortcut_button"
         style="@style/search_pill"
+        android:layout_height="@dimen/search_fragment_toggleButton_height"
         android:textOff="@string/search_engine_button"
         android:textOn="@string/search_engine_button"
         app:drawableStartCompat="@drawable/ic_search"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -106,7 +106,8 @@
     <dimen name="search_fragment_clipboard_item_title_margin_start">8dp</dimen>
     <dimen name="search_fragment_shortcuts_label_margin_horizontal">18dp</dimen>
     <dimen name="search_fragment_shortcuts_label_margin_vertical">18dp</dimen>
-    <dimen name="search_fragment_pill_height">40dp</dimen>
+    <dimen name="search_fragment_pill_height">56dp</dimen>
+    <dimen name="search_fragment_toggleButton_height">48dp</dimen>
     <dimen name="search_fragment_pill_padding_start">20dp</dimen>
     <dimen name="search_fragment_pill_padding_end">16dp</dimen>
     <dimen name="search_fragment_pill_padding_vertical">4dp</dimen>


### PR DESCRIPTION
… 48 dp. Solution: #16829
Initial Imge of the layout
<img src="https://user-images.githubusercontent.com/50791485/102781881-66a70080-43be-11eb-9894-040be97c11eb.png"  height=200 width=400 />
Final image of layout
<img src="https://user-images.githubusercontent.com/50791485/102782371-43308580-43bf-11eb-85d3-c9477c166274.png" height=200 width=400 />

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
