### PR TITLE
Closes #17118: Fix font spacing when long pressing a URL

### DIFF
--- a/app/src/main/res/layout/browser_toolbar_popup_window.xml
+++ b/app/src/main/res/layout/browser_toolbar_popup_window.xml
@@ -15,7 +15,7 @@
 
     <Button
         android:id="@+id/copy"
-        style="@style/Widget.MaterialComponents.Button.TextButton"
+        style="?android:attr/buttonBarButtonStyle"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:background="?selectableItemBackground"
@@ -28,7 +28,7 @@
 
     <Button
         android:id="@+id/paste"
-        style="@style/Widget.MaterialComponents.Button.TextButton"
+        style="?android:attr/buttonBarButtonStyle"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:background="?selectableItemBackground"
@@ -41,7 +41,7 @@
 
     <Button
         android:id="@+id/paste_and_go"
-        style="@style/Widget.MaterialComponents.Button.TextButton"
+        style="?android:attr/buttonBarButtonStyle"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:background="?selectableItemBackground"


### PR DESCRIPTION
Fixes #17118, reducing the font spacing to match the context menu (from now, I will refer as "button bar") of the page while long clicking a test. For that, I replaced `style="@style/Widget.MaterialComponents.Button.TextButton"` to `style="?android:attr/buttonBarButtonStyle"`, which ~is~ _should be_ equal to the OS definition.

Note that no extra changes were made in the text apart from the style (e.g., "text color" is still the same).

As this is a minor UI change, there's no need to include tests.

| Before | After |
|---|---|
| ![Screenshot_1608557822](https://user-images.githubusercontent.com/4348197/102782916-6c8aea80-439a-11eb-8bce-f605dbb01b3a.png) | ![Screenshot_1608557689](https://user-images.githubusercontent.com/4348197/102782966-87f5f580-439a-11eb-9816-6e9d82f7fb14.png) |

Now, for better comparison **(after changes)** between the "URL" and "Page" button bar:

| URL Button Bar | Page Button Bar |
|---|---|
| ![Screenshot_1608557689](https://user-images.githubusercontent.com/4348197/102783048-a8be4b00-439a-11eb-898b-d094ef9a9654.png) | ![Screenshot_1608557692](https://user-images.githubusercontent.com/4348197/102783073-afe55900-439a-11eb-9497-46d39cc086fe.png) |

| URL Button Bar Font | Page Button Bar Font |
|---|---|
| ![image](https://user-images.githubusercontent.com/4348197/102783399-208c7580-439b-11eb-9a5c-dc196ccef050.png) | ![image](https://user-images.githubusercontent.com/4348197/102783427-339f4580-439b-11eb-86bb-7befbd4c1554.png) |

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
