### PR TITLE
For #17086 #17143: Temporarily turn off Nimbus

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuDataCollectionRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuDataCollectionRobot.kt
@@ -38,7 +38,9 @@ class SettingsSubMenuDataCollectionRobot {
         verifyDataCollectionOptions()
         verifyUsageAndTechnicalDataSwitchDefault()
         verifyMarketingDataSwitchDefault()
-        verifyExperimentsSwitchDefault()
+        // Temporarily disabled until https://github.com/mozilla-mobile/fenix/issues/17086 and
+        // https://github.com/mozilla-mobile/fenix/issues/17143 are resolved:
+        // verifyExperimentsSwitchDefault()
     }
 
     class Transition {
@@ -80,8 +82,10 @@ private fun assertDataCollectionOptions() {
     onView(withText(marketingDataText))
         .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
-    onView(withText(R.string.preference_experiments_2)).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-    onView(withText(R.string.preference_experiments_summary_2)).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+    // Temporarily disabled until https://github.com/mozilla-mobile/fenix/issues/17086 and
+    // https://github.com/mozilla-mobile/fenix/issues/17143 are resolved:
+    // onView(withText(R.string.preference_experiments_2)).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+    // onView(withText(R.string.preference_experiments_summary_2)).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 }
 
 private fun usageAndTechnicalDataButton() = onView(withText(R.string.preference_usage_data))

--- a/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -35,7 +35,14 @@ object FeatureFlags {
      * Enables the Nimbus experiments library, especially the settings toggle to opt-out of
      * all experiments.
      */
-    val nimbusExperiments = Config.channel.isNightlyOrDebug
+    // IMPORTANT: Only turn this back on once the following issues are resolved:
+    // - https://github.com/mozilla-mobile/fenix/issues/17086: Calls to
+    // getExperimentBranch seem to block on updateExperiments causing a
+    // large performance regression loading the home screen.
+    // - https://github.com/mozilla-mobile/fenix/issues/17143: Despite
+    // having wrapped getExperimentBranch/withExperiments in a catch-all
+    // users are still experiencing crashes.
+    const val nimbusExperiments = false
 
     /**
      * Enables the new MediaSession API.


### PR DESCRIPTION
We decided to temporarily disable Nimbus until performance issues and remaining crashes can be resolved. Note that this only solves the more severe performance regression loading the Home screen and affecting users, not the more minor regression introduced by the `Nimbus` constructor. The latter we should fix in January as well.