### PR TITLE
Closes #14009: Fix onboarding 'Sign in to Firefox' ripple effect

### DIFF
--- a/app/src/main/res/drawable/onboarding_padded_background.xml
+++ b/app/src/main/res/drawable/onboarding_padded_background.xml
@@ -2,7 +2,7 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <ripple xmlns:android="http://schemas.android.com/apk/res/android"
-    android:color="?android:attr/colorControlHighlight">
+    android:color="@color/ripple_material_light">
     <item
         android:bottom="6dp"
         android:top="6dp">

--- a/app/src/main/res/drawable/onboarding_padded_background.xml
+++ b/app/src/main/res/drawable/onboarding_padded_background.xml
@@ -2,7 +2,7 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <ripple xmlns:android="http://schemas.android.com/apk/res/android"
-    android:color="@color/ripple_material_light">
+    android:color="@color/onboarding_padded_background_color">
     <item
         android:bottom="6dp"
         android:top="6dp">

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -372,6 +372,7 @@
     <color name="mozac_feature_readerview_selected">@color/accent_high_contrast_dark_theme</color>
 
     <!-- Onboarding colors -->
+    <color name="onboarding_padded_background_color">#1F000000</color>
     <color name="onboarding_card_background_dark">#20123A</color>
     <color name="onboarding_card_primary_text_dark">#FFFFFF</color>
     <color name="onboarding_card_button_background_dark">#F9F9FB</color>


### PR DESCRIPTION
Fixes #14009: The onboarding 'Sign in to Firefox' ripple effect **wasn't working on Dark Theme** - note it does work normally on light theme in the current version. The reason is that it was using the attribute `?android:attr/colorControlHighlight` which would be adapt based in the theme:

```xml
<color name="ripple_material_dark">#33ffffff</color>
<color name="ripple_material_light">#1f000000</color>
```

Because the `onboarding_manual_signin` has the same appearance and colors on both light + dark theme, the ripple effect would disappear due to the color of the 'Sign in to Firefox' button (`foundation_light_theme, #F9F9FB`), while using the Dark Theme. 

**EDIT:** My original solution was directly using the OS-defined color, which fails Lint as those are private colors ([see here](https://github.com/mozilla-mobile/fenix/pull/17169#issuecomment-749176572)). Therefore, I introduced an `onboarding_padded_background_color` that defines a custom color for the ripple that matches the OS-defined color. This color is exactly the same as before while using light theme (`#1F000000`), and there's no variation between light, dark or private themes.

| Light Theme | Dark Theme
|---|---|
| ![light_theme](https://user-images.githubusercontent.com/4348197/102791346-2c7e3480-43a7-11eb-8e5a-448910e0de4c.gif) | ![dark_theme](https://user-images.githubusercontent.com/4348197/102791382-3869f680-43a7-11eb-8a8b-5c3a87b45660.gif) |

This PR does not has any change on test as it is a minor UI change.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
