### PR TITLE
For #17084: Use in-app browser switching dialog

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
@@ -5,6 +5,8 @@
 package org.mozilla.fenix.settings
 
 import android.annotation.SuppressLint
+import android.app.Activity
+import android.app.role.RoleManager
 import android.content.ActivityNotFoundException
 import android.content.DialogInterface
 import android.content.Intent
@@ -426,25 +428,63 @@ class SettingsFragment : PreferenceFragmentCompat() {
         setupAmoCollectionOverridePreference(requireContext().settings())
     }
 
+    /**
+     * For >=Q -> Use new RoleManager API to show in-app browser switching dialog.
+     * For <Q && >=N -> Navigate user to Android Default Apps Settings.
+     * For <N -> Open sumo page to show user how to change default app.
+     */
     private fun getClickListenerForMakeDefaultBrowser(): Preference.OnPreferenceClickListener {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            Preference.OnPreferenceClickListener {
-                val intent = Intent(android.provider.Settings.ACTION_MANAGE_DEFAULT_APPS_SETTINGS)
-                startActivity(intent)
-                true
+        return when {
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q -> {
+                Preference.OnPreferenceClickListener {
+                    requireContext().getSystemService(RoleManager::class.java).also {
+                        if (!it.isRoleHeld(RoleManager.ROLE_BROWSER)) {
+                            startActivityForResult(it.createRequestRoleIntent(RoleManager.ROLE_BROWSER), 0)
+                        } else {
+                            navigateUserToDefaultAppsSettings()
+                        }
+                    }
+                    true
+                }
             }
-        } else {
-            Preference.OnPreferenceClickListener {
-                (activity as HomeActivity).openToBrowserAndLoad(
-                    searchTermOrURL = SupportUtils.getSumoURLForTopic(
-                        requireContext(),
-                        SupportUtils.SumoTopic.SET_AS_DEFAULT_BROWSER
-                    ),
-                    newTab = true,
-                    from = BrowserDirection.FromSettings
-                )
-                true
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.N -> {
+                Preference.OnPreferenceClickListener {
+                    navigateUserToDefaultAppsSettings()
+                    true
+                }
             }
+            else -> {
+                Preference.OnPreferenceClickListener {
+                    (activity as HomeActivity).openToBrowserAndLoad(
+                            searchTermOrURL = SupportUtils.getSumoURLForTopic(
+                                    requireContext(),
+                                    SupportUtils.SumoTopic.SET_AS_DEFAULT_BROWSER
+                            ),
+                            newTab = true,
+                            from = BrowserDirection.FromSettings
+                    )
+                    true
+                }
+            }
+        }
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+
+        /*
+        If role manager doesn't show in-app browser changing dialog for a reason, navigate user to
+        Default Apps Settings.
+         */
+        if (resultCode == Activity.RESULT_CANCELED && requestCode == 0) {
+            navigateUserToDefaultAppsSettings()
+        }
+    }
+
+    private fun navigateUserToDefaultAppsSettings() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            val intent = Intent(android.provider.Settings.ACTION_MANAGE_DEFAULT_APPS_SETTINGS)
+            startActivity(intent)
         }
     }
 


### PR DESCRIPTION
https://user-images.githubusercontent.com/17825767/103143382-e36f0d00-4725-11eb-9387-d00d731502ee.mp4

I'm unable to differentiate if user selected "don't ask again" before or selected another browser. If the current behaviour okey, then it's fine.
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
