### PR TITLE
For #17073: Stop observers after test run

### DIFF
--- a/app/src/test/java/org/mozilla/fenix/browser/OpenInAppOnboardingObserverTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/browser/OpenInAppOnboardingObserverTest.kt
@@ -23,6 +23,7 @@ import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.feature.app.links.AppLinksUseCases
 import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.rule.MainCoroutineRule
+import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -75,6 +76,11 @@ class OpenInAppOnboardingObserverTest {
             container = container
         ))
         every { openInAppOnboardingObserver.createInfoBanner() } returns infoBanner
+    }
+
+    @After
+    fun teardown() {
+        openInAppOnboardingObserver.stop()
     }
 
     @Test

--- a/app/src/test/java/org/mozilla/fenix/shortcut/PwaOnboardingObserverTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/shortcut/PwaOnboardingObserverTest.kt
@@ -20,6 +20,7 @@ import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.feature.pwa.WebAppUseCases
 import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.rule.MainCoroutineRule
+import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -64,6 +65,11 @@ class PwaOnboardingObserverTest {
             settings = settings,
             webAppUseCases = webAppUseCases
         )
+    }
+
+    @After
+    fun teardown() {
+        pwaOnboardingObserver.stop()
     }
 
     @Test


### PR DESCRIPTION
Test failed again in https://github.com/mozilla-mobile/fenix/runs/1603080054. I forgot to stop the observer after tests finish so an observer of a previous test can interfere with the test currently running.