### PR TITLE
For #16966: Remove unnecessary step from SmokeTest.mainMenuAddToHomeScreenTest

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -261,9 +261,7 @@ class SmokeTest {
             verifyShortcutNameField(defaultWebPage.title)
             clickAddShortcutButton()
             clickAddAutomaticallyButton()
-        }.openHomeScreenShortcut(defaultWebPage.title) {
-            verifyPageContent(defaultWebPage.content)
-        }
+        }.openHomeScreenShortcut(defaultWebPage.title) {}
     }
 
     @Test


### PR DESCRIPTION
For #16966: Removed a webpage content verification as it is too unstable for a smoke test. The test now only verifies that the homescreen shortcut is created.