### PR TITLE
For #16238 - Back button now dismisses Suggested Logins

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -969,6 +969,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler,
     override fun onBackPressed(): Boolean {
         return findInPageIntegration.onBackPressed() ||
                 fullScreenFeature.onBackPressed() ||
+                promptsFeature.onBackPressed() ||
                 sessionFeature.onBackPressed() ||
                 removeSessionIfNeeded()
     }


### PR DESCRIPTION
By using PromptFeature's onBackPressed the user can now press back to dismiss the Suggested Logins prompt without inadvertently navigating back

For https://github.com/mozilla-mobile/fenix/issues/16238
**Do not land before** https://github.com/mozilla-mobile/android-components/pull/9337


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes no tests as it is only a minor change.
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made.
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture


https://user-images.githubusercontent.com/60002907/103771334-3901be80-5030-11eb-9e4f-3afcda26e0b2.mp4

