### PR TITLE
For #16249 - ClipboardHandler cleans up returned text

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/utils/ClipboardHandler.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/ClipboardHandler.kt
@@ -7,7 +7,9 @@ package org.mozilla.fenix.utils
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
+import androidx.annotation.VisibleForTesting
 import androidx.core.content.getSystemService
+import mozilla.components.support.utils.SafeUrl
 import mozilla.components.support.utils.WebURLFinder
 
 private const val MIME_TYPE_TEXT_PLAIN = "text/plain"
@@ -16,7 +18,7 @@ private const val MIME_TYPE_TEXT_HTML = "text/html"
 /**
  * A clipboard utility class that allows copying and pasting links/text to & from the clipboard
  */
-class ClipboardHandler(context: Context) {
+class ClipboardHandler(val context: Context) {
     private val clipboard = context.getSystemService<ClipboardManager>()!!
 
     var text: String?
@@ -25,7 +27,7 @@ class ClipboardHandler(context: Context) {
                 (clipboard.isPrimaryClipPlainText() ||
                         clipboard.isPrimaryClipHtmlText())
             ) {
-                return clipboard.firstPrimaryClipItem?.text.toString()
+                return firstSafePrimaryClipItemText
             }
             return null
         }
@@ -51,4 +53,8 @@ class ClipboardHandler(context: Context) {
 
     private val ClipboardManager.firstPrimaryClipItem: ClipData.Item?
         get() = primaryClip?.getItemAt(0)
+
+    @VisibleForTesting
+    internal val firstSafePrimaryClipItemText: String?
+        get() = SafeUrl.stripUnsafeUrlSchemes(context, clipboard.firstPrimaryClipItem?.text)
 }

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -30,4 +30,13 @@
         <item>@string/all</item>
         <item>@string/private_string</item>
     </string-array>
+
+    <string name="resource_scheme">"resource://"</string>
+    <string name="chrome_scheme">"chrome://</string>
+    <string name="about_scheme">"about:"</string>
+    <string-array name="mozac_url_schemes_blocklist" >
+        <item>@string/resource_scheme</item>
+        <item>@string/chrome_scheme</item>
+        <item>@string/about_scheme</item>
+    </string-array>
 </resources>

--- a/app/src/test/java/org/mozilla/fenix/utils/ClipboardHandlerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/utils/ClipboardHandlerTest.kt
@@ -7,7 +7,13 @@ package org.mozilla.fenix.utils
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.spyk
+import io.mockk.unmockkObject
+import io.mockk.verify
 import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.utils.SafeUrl
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -58,5 +64,34 @@ class ClipboardHandlerTest {
 
         clipboard.setPrimaryClip(ClipData.newHtmlText("Html", clipboardUrl, clipboardUrl))
         assertEquals(clipboardUrl, clipboardHandler.url)
+    }
+
+    @Test
+    fun `text should return firstSafePrimaryClipItemText`() {
+        val safeResult = "safeResult"
+        clipboard.setPrimaryClip(ClipData.newPlainText(clipboardUrl, clipboardText))
+        clipboardHandler = spyk(clipboardHandler)
+        every { clipboardHandler getProperty "firstSafePrimaryClipItemText" } propertyType String::class returns safeResult
+
+        val result = clipboardHandler.text
+
+        verify { clipboardHandler getProperty "firstSafePrimaryClipItemText" }
+        assertEquals(safeResult, result)
+    }
+
+    @Test
+    fun `firstSafePrimaryClipItemText should return the result of SafeUrl#stripUnsafeUrlSchemes`() {
+        mockkObject(SafeUrl)
+        try {
+            every { SafeUrl.stripUnsafeUrlSchemes(any(), any()) } returns "safeResult"
+            clipboard.setPrimaryClip(ClipData.newHtmlText("Html", clipboardUrl, clipboardUrl))
+
+            val result = clipboardHandler.firstSafePrimaryClipItemText
+
+            verify { SafeUrl.stripUnsafeUrlSchemes(testContext, clipboardUrl) }
+            assertEquals("safeResult", result)
+        } finally {
+            unmockkObject(SafeUrl)
+        }
     }
 }


### PR DESCRIPTION
Depends on https://github.com/mozilla-mobile/android-components/pull/9339

Recording showing one scheme - "about:" being automatically removed from the pasted text

<img src="https://user-images.githubusercontent.com/11428869/103784238-60618700-5042-11eb-809c-6110e3fc3e32.gif" width="33%" />

[video](https://drive.google.com/file/d/1Zo4SMI59H1pxSj4M4gQnwyc1QczvcH59/view?usp=sharing)


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
