### PR TITLE
For #16615: UI Smoke Tests for Recently Closed Tabs

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -42,6 +42,7 @@ class SmokeTest {
     private var awesomeBar: ViewVisibilityIdlingResource? = null
     private var searchSuggestionsIdlingResource: RecyclerViewIdlingResource? = null
     private var addonsListIdlingResource: RecyclerViewIdlingResource? = null
+    private var recentlyClosedTabsListIdlingResource: RecyclerViewIdlingResource? = null
     private val downloadFileName = "Globe.svg"
 
     // This finds the dialog fragment child of the homeFragment, otherwise the awesomeBar would return null
@@ -83,6 +84,10 @@ class SmokeTest {
 
         if (addonsListIdlingResource != null) {
             IdlingRegistry.getInstance().unregister(addonsListIdlingResource!!)
+        }
+
+        if (recentlyClosedTabsListIdlingResource != null) {
+            IdlingRegistry.getInstance().unregister(recentlyClosedTabsListIdlingResource!!)
         }
 
         deleteDownloadFromStorage(downloadFileName)
@@ -577,6 +582,195 @@ class SmokeTest {
         }.openThreeDotMenu {
         }.openReportSiteIssue {
             verifyUrl("webcompat.com/issues/new")
+        }
+    }
+
+    @Test
+    // This test verifies the Recently Closed Tabs List and items
+    fun verifyRecentlyClosedTabsListTest() {
+        val website = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        homeScreen {
+        }.openNavigationToolbar {
+        }.enterURLAndEnterToBrowser(website.url) {
+            mDevice.waitForIdle()
+        }.openTabDrawer {
+            closeTab()
+        }.openTabDrawer {
+        }.openRecentlyClosedTabs {
+            waitForListToExist()
+            recentlyClosedTabsListIdlingResource =
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.recently_closed_list), 1)
+            IdlingRegistry.getInstance().register(recentlyClosedTabsListIdlingResource!!)
+            verifyRecentlyClosedTabsMenuView()
+            IdlingRegistry.getInstance().unregister(recentlyClosedTabsListIdlingResource!!)
+            verifyRecentlyClosedTabsPageTitle("Test_Page_1")
+            verifyRecentlyClosedTabsUrl(website.url)
+        }
+    }
+
+    @Test
+    // Verifies the items from the overflow menu of Recently Closed Tabs
+    fun recentlyClosedTabsMenuItemsTest() {
+        val website = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        homeScreen {
+        }.openNavigationToolbar {
+        }.enterURLAndEnterToBrowser(website.url) {
+            mDevice.waitForIdle()
+        }.openTabDrawer {
+            closeTab()
+        }.openTabDrawer {
+        }.openRecentlyClosedTabs {
+            waitForListToExist()
+            recentlyClosedTabsListIdlingResource =
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.recently_closed_list), 1)
+            IdlingRegistry.getInstance().register(recentlyClosedTabsListIdlingResource!!)
+            verifyRecentlyClosedTabsMenuView()
+            IdlingRegistry.getInstance().unregister(recentlyClosedTabsListIdlingResource!!)
+            openRecentlyClosedTabsThreeDotMenu()
+            verifyRecentlyClosedTabsMenuCopy()
+            verifyRecentlyClosedTabsMenuShare()
+            verifyRecentlyClosedTabsMenuNewTab()
+            verifyRecentlyClosedTabsMenuPrivateTab()
+            verifyRecentlyClosedTabsMenuDelete()
+        }
+    }
+
+    @Test
+    // Verifies the Copy option from the Recently Closed Tabs overflow menu
+    fun copyRecentlyClosedTabsItemTest() {
+        val website = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        homeScreen {
+        }.openNavigationToolbar {
+        }.enterURLAndEnterToBrowser(website.url) {
+            mDevice.waitForIdle()
+        }.openTabDrawer {
+            closeTab()
+        }.openTabDrawer {
+        }.openRecentlyClosedTabs {
+            waitForListToExist()
+            recentlyClosedTabsListIdlingResource =
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.recently_closed_list), 1)
+            IdlingRegistry.getInstance().register(recentlyClosedTabsListIdlingResource!!)
+            verifyRecentlyClosedTabsMenuView()
+            IdlingRegistry.getInstance().unregister(recentlyClosedTabsListIdlingResource!!)
+            openRecentlyClosedTabsThreeDotMenu()
+            verifyRecentlyClosedTabsMenuCopy()
+            clickCopyRecentlyClosedTabs()
+            verifyCopyRecentlyClosedTabsSnackBarText()
+        }
+    }
+
+    @Test
+    // Verifies the Share option from the Recently Closed Tabs overflow menu
+    fun shareRecentlyClosedTabsItemTest() {
+        val website = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        homeScreen {
+        }.openNavigationToolbar {
+        }.enterURLAndEnterToBrowser(website.url) {
+            mDevice.waitForIdle()
+        }.openTabDrawer {
+            closeTab()
+        }.openTabDrawer {
+        }.openRecentlyClosedTabs {
+            waitForListToExist()
+            recentlyClosedTabsListIdlingResource =
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.recently_closed_list), 1)
+            IdlingRegistry.getInstance().register(recentlyClosedTabsListIdlingResource!!)
+            verifyRecentlyClosedTabsMenuView()
+            IdlingRegistry.getInstance().unregister(recentlyClosedTabsListIdlingResource!!)
+            openRecentlyClosedTabsThreeDotMenu()
+            verifyRecentlyClosedTabsMenuShare()
+            clickShareRecentlyClosedTabs()
+            verifyShareOverlay()
+            verifyShareTabTitle("Test_Page_1")
+            verifyShareTabUrl(website.url)
+            verifyShareTabFavicon()
+        }
+    }
+
+    @Test
+    // Verifies the Open in a new tab option from the Recently Closed Tabs overflow menu
+    fun openRecentlyClosedTabsInNewTabTest() {
+        val website = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        homeScreen {
+        }.openNavigationToolbar {
+        }.enterURLAndEnterToBrowser(website.url) {
+            mDevice.waitForIdle()
+        }.openTabDrawer {
+            closeTab()
+        }.openTabDrawer {
+        }.openRecentlyClosedTabs {
+            waitForListToExist()
+            recentlyClosedTabsListIdlingResource =
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.recently_closed_list), 1)
+            IdlingRegistry.getInstance().register(recentlyClosedTabsListIdlingResource!!)
+            verifyRecentlyClosedTabsMenuView()
+            IdlingRegistry.getInstance().unregister(recentlyClosedTabsListIdlingResource!!)
+            openRecentlyClosedTabsThreeDotMenu()
+            verifyRecentlyClosedTabsMenuNewTab()
+        }.clickOpenInNewTab {
+            verifyUrl(website.url.toString())
+        }.openTabDrawer {
+            verifyNormalModeSelected()
+        }
+    }
+
+    @Test
+    // Verifies the Open in a private tab option from the Recently Closed Tabs overflow menu
+    fun openRecentlyClosedTabsInNewPrivateTabTest() {
+        val website = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        homeScreen {
+        }.openNavigationToolbar {
+        }.enterURLAndEnterToBrowser(website.url) {
+            mDevice.waitForIdle()
+        }.openTabDrawer {
+            closeTab()
+        }.openTabDrawer {
+        }.openRecentlyClosedTabs {
+            waitForListToExist()
+            recentlyClosedTabsListIdlingResource =
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.recently_closed_list), 1)
+            IdlingRegistry.getInstance().register(recentlyClosedTabsListIdlingResource!!)
+            verifyRecentlyClosedTabsMenuView()
+            IdlingRegistry.getInstance().unregister(recentlyClosedTabsListIdlingResource!!)
+            openRecentlyClosedTabsThreeDotMenu()
+            verifyRecentlyClosedTabsMenuPrivateTab()
+        }.clickOpenInPrivateTab {
+            verifyUrl(website.url.toString())
+        }.openTabDrawer {
+            verifyPrivateModeSelected()
+        }
+    }
+
+    @Test
+    // Verifies the delete option from the Recently Closed Tabs overflow menu
+    fun deleteRecentlyClosedTabsItemTest() {
+        val website = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        homeScreen {
+        }.openNavigationToolbar {
+        }.enterURLAndEnterToBrowser(website.url) {
+            mDevice.waitForIdle()
+        }.openTabDrawer {
+            closeTab()
+        }.openTabDrawer {
+        }.openRecentlyClosedTabs {
+            waitForListToExist()
+            recentlyClosedTabsListIdlingResource =
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.recently_closed_list), 1)
+            IdlingRegistry.getInstance().register(recentlyClosedTabsListIdlingResource!!)
+            verifyRecentlyClosedTabsMenuView()
+            IdlingRegistry.getInstance().unregister(recentlyClosedTabsListIdlingResource!!)
+            openRecentlyClosedTabsThreeDotMenu()
+            verifyRecentlyClosedTabsMenuDelete()
+            clickDeleteCopyRecentlyClosedTabs()
+            verifyEmptyRecentlyClosedTabsList()
         }
     }
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/RecentlyClosedTabsRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/RecentlyClosedTabsRobot.kt
@@ -1,0 +1,222 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.ui.robots
+
+import android.net.Uri
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.Visibility
+import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withParent
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.uiautomator.UiSelector
+import org.hamcrest.Matchers
+import org.hamcrest.Matchers.allOf
+import org.mozilla.fenix.R
+import org.mozilla.fenix.helpers.TestAssetHelper
+import org.mozilla.fenix.helpers.click
+
+/**
+ * Implementation of Robot Pattern for the recently closed tabs menu.
+ */
+
+class RecentlyClosedTabsRobot {
+
+    fun waitForListToExist() =
+        mDevice.findObject(UiSelector().resourceId("org.mozilla.fenix.debug:id/recently_closed_list"))
+            .waitForExists(
+                TestAssetHelper.waitingTime
+            )
+
+    fun verifyRecentlyClosedTabsMenuView() = assertRecentlyClosedTabsMenuView()
+
+    fun verifyEmptyRecentlyClosedTabsList() = assertEmptyRecentlyClosedTabsList()
+
+    fun verifyRecentlyClosedTabsPageTitle(title: String) = assertRecentlyClosedTabsPageTitle(title)
+
+    fun verifyRecentlyClosedTabsUrl(expectedUrl: Uri) = assertPageUrl(expectedUrl)
+
+    fun openRecentlyClosedTabsThreeDotMenu() = recentlyClosedTabsThreeDotButton().click()
+
+    fun verifyRecentlyClosedTabsMenuCopy() = assertRecentlyClosedTabsMenuCopy()
+
+    fun verifyRecentlyClosedTabsMenuShare() = assertRecentlyClosedTabsMenuShare()
+
+    fun verifyRecentlyClosedTabsMenuNewTab() = assertRecentlyClosedTabsOverlayNewTab()
+
+    fun verifyRecentlyClosedTabsMenuPrivateTab() = assertRecentlyClosedTabsMenuPrivateTab()
+
+    fun verifyRecentlyClosedTabsMenuDelete() = assertRecentlyClosedTabsMenuDelete()
+
+    fun clickCopyRecentlyClosedTabs() = recentlyClosedTabsCopyButton().click()
+
+    fun clickShareRecentlyClosedTabs() = recentlyClosedTabsShareButton().click()
+
+    fun clickDeleteCopyRecentlyClosedTabs() = recentlyClosedTabsDeleteButton().click()
+
+    fun verifyCopyRecentlyClosedTabsSnackBarText() = assertCopySnackBarText()
+
+    fun verifyShareOverlay() = assertRecentlyClosedShareOverlay()
+
+    fun verifyShareTabFavicon() = assertRecentlyClosedShareFavicon()
+
+    fun verifyShareTabTitle(title: String) = assetRecentlyClosedShareTitle(title)
+
+    fun verifyShareTabUrl(expectedUrl: Uri) = assertRecentlyClosedShareUrl(expectedUrl)
+
+    class Transition {
+        fun clickOpenInNewTab(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
+            recentlyClosedTabsNewTabButton().click()
+
+            BrowserRobot().interact()
+            return BrowserRobot.Transition()
+        }
+
+        fun clickOpenInPrivateTab(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
+            recentlyClosedTabsNewPrivateTabButton().click()
+
+            BrowserRobot().interact()
+            return BrowserRobot.Transition()
+        }
+    }
+}
+
+private fun assertRecentlyClosedTabsMenuView() {
+    onView(
+        allOf(
+            withText("Recently closed tabs"),
+            withParent(withId(R.id.navigationToolbar))
+        )
+    )
+        .check(
+            matches(withEffectiveVisibility(Visibility.VISIBLE)))
+}
+
+private fun assertEmptyRecentlyClosedTabsList() =
+    onView(
+        allOf(
+            withId(R.id.recently_closed_empty_view),
+            withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)
+        )
+    )
+        .check(
+            matches(withText("No recently closed tabs here")))
+
+private fun assertPageUrl(expectedUrl: Uri) = onView(
+    allOf(
+        withId(R.id.url),
+        withEffectiveVisibility(
+            Visibility.VISIBLE
+        )
+    )
+)
+    .check(
+        matches(withText(Matchers.containsString(expectedUrl.toString()))))
+
+private fun recentlyClosedTabsPageTitle() = onView(
+    allOf(
+        withId(R.id.title),
+        withText("Test_Page_1")
+    )
+)
+
+private fun assertRecentlyClosedTabsPageTitle(title: String) {
+    recentlyClosedTabsPageTitle()
+        .check(
+            matches(withEffectiveVisibility(Visibility.VISIBLE)))
+        .check(
+            matches(withText(title)))
+}
+
+private fun recentlyClosedTabsThreeDotButton() =
+    onView(
+        allOf(
+            withId(R.id.overflow_menu),
+            withEffectiveVisibility(
+            Visibility.VISIBLE
+        )
+    )
+)
+
+private fun assertRecentlyClosedTabsMenuCopy() =
+    onView(withText("Copy"))
+        .check(
+            matches(
+                withEffectiveVisibility(Visibility.VISIBLE)))
+
+private fun assertRecentlyClosedTabsMenuShare() =
+    onView(withText("Share"))
+        .check(
+            matches(
+                withEffectiveVisibility(Visibility.VISIBLE)))
+
+private fun assertRecentlyClosedTabsOverlayNewTab() =
+    onView(withText("Open in new tab"))
+        .check(
+            matches(
+                withEffectiveVisibility(Visibility.VISIBLE))
+)
+
+private fun assertRecentlyClosedTabsMenuPrivateTab() =
+    onView(withText("Open in private tab"))
+        .check(
+            matches(
+                withEffectiveVisibility(Visibility.VISIBLE)
+        )
+    )
+
+private fun assertRecentlyClosedTabsMenuDelete() =
+    onView(withText("Delete"))
+        .check(
+            matches(
+                withEffectiveVisibility(Visibility.VISIBLE)
+    )
+)
+
+private fun recentlyClosedTabsCopyButton() = onView(withText("Copy"))
+
+private fun copySnackBarText() = onView(withId(R.id.snackbar_text))
+
+private fun assertCopySnackBarText() = copySnackBarText()
+    .check(
+        matches
+            (withText("URL copied")))
+
+private fun recentlyClosedTabsShareButton() = onView(withText("Share"))
+
+private fun assertRecentlyClosedShareOverlay() =
+    onView(withId(R.id.shareWrapper))
+        .check(
+            matches(ViewMatchers.isDisplayed()))
+
+private fun assetRecentlyClosedShareTitle(title: String) =
+    onView(withId(R.id.share_tab_title))
+        .check(
+            matches(ViewMatchers.isDisplayed()))
+        .check(
+            matches(withText(title)))
+
+private fun assertRecentlyClosedShareFavicon() =
+    onView(withId(R.id.share_tab_favicon))
+        .check(
+            matches(ViewMatchers.isDisplayed()))
+
+private fun assertRecentlyClosedShareUrl(expectedUrl: Uri) =
+    onView(
+        allOf(
+            withId(R.id.share_tab_url),
+            withEffectiveVisibility(Visibility.VISIBLE)
+        )
+    )
+        .check(
+            matches(withText(Matchers.containsString(expectedUrl.toString()))))
+
+private fun recentlyClosedTabsNewTabButton() = onView(withText("Open in new tab"))
+
+private fun recentlyClosedTabsNewPrivateTabButton() = onView(withText("Open in private tab"))
+
+private fun recentlyClosedTabsDeleteButton() = onView(withText("Delete"))

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/TabDrawerRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/TabDrawerRobot.kt
@@ -30,6 +30,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.By.text
 import androidx.test.uiautomator.UiDevice
+import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
 import androidx.test.uiautomator.Until.findObject
 import com.google.android.material.bottomsheet.BottomSheetBehavior
@@ -123,7 +124,8 @@ class TabDrawerRobot {
         }
 
         fun openTabDrawer(interact: TabDrawerRobot.() -> Unit): TabDrawerRobot.Transition {
-            org.mozilla.fenix.ui.robots.mDevice.waitForIdle()
+            mDevice.findObject(UiSelector().resourceId("org.mozilla.fenix.debug:id/tab_button"))
+                .waitForExists(waitingTime)
 
             tabsCounter().click()
 
@@ -225,6 +227,24 @@ class TabDrawerRobot {
                 TabDrawerRobot().interact()
             }
             return Transition()
+        }
+
+        fun openRecentlyClosedTabs(interact: RecentlyClosedTabsRobot.() -> Unit):
+                RecentlyClosedTabsRobot.Transition {
+
+            threeDotMenu().click()
+
+            val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+            mDevice.waitNotNull(
+                    Until.findObject(text("Recently closed tabs")),
+                    waitingTime
+            )
+
+            val menuRecentlyClosedTabs = mDevice.findObject(text("Recently closed tabs"))
+            menuRecentlyClosedTabs.click()
+
+            RecentlyClosedTabsRobot().interact()
+            return RecentlyClosedTabsRobot.Transition()
         }
     }
 }


### PR DESCRIPTION
Ran test on Firebase for 10 times and all passed. [Run](https://github.com/mozilla-mobile/fenix/pull/17350/checks?check_run_id=1668549254)

Also added a minor fix for the Tabs Counter because it was flaky.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
