### PR TITLE
Use new RestoreUseCase in A-C to handle tab timeouts

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -326,7 +326,7 @@ class Settings(private val appContext: Context) : PreferencesHolder {
         closeTabsAfterOneDay -> ONE_DAY_MS
         closeTabsAfterOneWeek -> ONE_WEEK_MS
         closeTabsAfterOneMonth -> ONE_MONTH_MS
-        else -> System.currentTimeMillis()
+        else -> Long.MAX_VALUE
     }
 
     enum class TabView {

--- a/app/src/test/java/org/mozilla/fenix/utils/SettingsTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/utils/SettingsTest.kt
@@ -236,27 +236,28 @@ class SettingsTest {
         // When just created
         // Then
         assertTrue(settings.manuallyCloseTabs)
+        assertEquals(Long.MAX_VALUE, settings.getTabTimeout())
 
         // When
         settings.manuallyCloseTabs = false
         settings.closeTabsAfterOneDay = true
 
         // Then
-        assertEquals(settings.getTabTimeout(), Settings.ONE_DAY_MS)
+        assertEquals(Settings.ONE_DAY_MS, settings.getTabTimeout())
 
         // When
         settings.closeTabsAfterOneDay = false
         settings.closeTabsAfterOneWeek = true
 
         // Then
-        assertEquals(settings.getTabTimeout(), Settings.ONE_WEEK_MS)
+        assertEquals(Settings.ONE_WEEK_MS, settings.getTabTimeout())
 
         // When
         settings.closeTabsAfterOneWeek = false
         settings.closeTabsAfterOneMonth = true
 
         // Then
-        assertEquals(settings.getTabTimeout(), Settings.ONE_MONTH_MS)
+        assertEquals(Settings.ONE_MONTH_MS, settings.getTabTimeout())
     }
 
     @Test

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "71.0.20210107143131"
+    const val VERSION = "71.0.20210107190115"
 }


### PR DESCRIPTION
Refactoring to use new A-C use case for removing timed out tabs. Timed out tabs now don't need to be restored before they're deleted, plus this prevents a race condition we had to work around before. When tabs are restored, timed out tabs are already removed.

Switching to Long.MAX_VALUE if the feature is disabled to make sure that by default no tabs will be discarded.