### PR TITLE
For #16519: Add space above Delete History button

### DIFF
--- a/app/src/main/res/layout/history_list_item.xml
+++ b/app/src/main/res/layout/history_list_item.xml
@@ -13,8 +13,10 @@
         android:id="@+id/delete_button"
         style="@style/DestructiveButton"
         android:layout_marginHorizontal="16dp"
+        android:layout_marginTop="8dp"
         android:text="@string/history_delete_all"
-        android:visibility="gone" />
+        android:visibility="gone"
+        tools:visibility="visible" />
 
     <include layout="@layout/recently_closed_nav_item" />
 


### PR DESCRIPTION
add space above Delete Downloads and Delete History buttons



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture


**History**
![Screenshot_1610048204](https://user-images.githubusercontent.com/38375996/103939928-3b017580-5135-11eb-92aa-8a09962ca003.png)

For Downloads, the Delete Downloads button visibility is always false. I'm not sure if that's only temporary.