### PR TITLE
Bug 1685663 - Change the geckodriver index-search path.

### DIFF
--- a/taskcluster/ci/browsertime/kind.yml
+++ b/taskcluster/ci/browsertime/kind.yml
@@ -103,13 +103,11 @@ job-defaults:
 jobs:
     tp6m-1-cold:
         test-name: amazon
-        run-on-tasks-for: [github-pull-request]
         treeherder:
             symbol: 'Btime(tp6m-1-c)'
 
     tp6m-2-cold:
         test-name: google
-        run-on-tasks-for: [github-pull-request]
         web-render-only: False
         treeherder:
             symbol: 'Btime(tp6m-2-c)'

--- a/taskcluster/ci/browsertime/kind.yml
+++ b/taskcluster/ci/browsertime/kind.yml
@@ -103,11 +103,13 @@ job-defaults:
 jobs:
     tp6m-1-cold:
         test-name: amazon
+        run-on-tasks-for: [github-pull-request]
         treeherder:
             symbol: 'Btime(tp6m-1-c)'
 
     tp6m-2-cold:
         test-name: google
+        run-on-tasks-for: [github-pull-request]
         web-render-only: False
         treeherder:
             symbol: 'Btime(tp6m-2-c)'

--- a/taskcluster/ci/toolchain/gecko-derived.yml
+++ b/taskcluster/ci/toolchain/gecko-derived.yml
@@ -31,7 +31,7 @@ linux64-geckodriver:
     description: "Geckodriver toolchain"
     run:
         index-search:
-            - gecko.v2.mozilla-central.latest.geckodriver
+            - gecko.v2.mozilla-central.latest.geckodriver.linux64
 
 linux64-minidump-stackwalk:
     attributes:

--- a/taskcluster/ci/toolchain/gecko-derived.yml
+++ b/taskcluster/ci/toolchain/gecko-derived.yml
@@ -31,7 +31,7 @@ linux64-geckodriver:
     description: "Geckodriver toolchain"
     run:
         index-search:
-            - gecko.cache.level-3.toolchains.v3.linux64-geckodriver.latest
+            - gecko.v2.mozilla-central.latest.geckodriver
 
 linux64-minidump-stackwalk:
     attributes:


### PR DESCRIPTION
This patch changes the geckodriver used in the tests to the latest one in mozilla-central rather than the latest one from any level 3 repos.