### PR TITLE
Update Android Components version to 71.0.20210108190105

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -516,7 +516,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler,
             appLinksFeature.set(
                 feature = AppLinksFeature(
                     context,
-                    sessionManager = sessionManager,
+                    store = store,
                     sessionId = customTabSessionId,
                     fragmentManager = parentFragmentManager,
                     launchInApp = { context.settings().openLinksInExternalApp },

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "71.0.20210107190115"
+    const val VERSION = "71.0.20210108190105"
 }


### PR DESCRIPTION
Manual upgrade to address breaking API change in app links feature.