### PR TITLE
For #12732: Match notification accent color with app theme

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/downloads/DownloadService.kt
+++ b/app/src/main/java/org/mozilla/fenix/downloads/DownloadService.kt
@@ -6,9 +6,11 @@ package org.mozilla.fenix.downloads
 
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.feature.downloads.AbstractFetchDownloadService
+import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
 
 class DownloadService : AbstractFetchDownloadService() {
     override val httpClient by lazy { components.core.client }
     override val store: BrowserStore by lazy { components.core.store }
+    override val style: Style by lazy { Style(R.color.notification_accent_color_normal_theme) }
 }

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -52,6 +52,7 @@
     <color name="search_suggestion_indicator_icon_bookmark_color_normal_theme">@color/search_suggestion_indicator_icon_bookmark_color_dark_theme</color>
     <color name="select_login_header_normal_theme">@color/accent_high_contrast_dark_theme</color>
     <color name="preference_section_header_normal_theme">@color/preference_section_header_dark_theme</color>
+    <color name="notification_accent_color_normal_theme">@color/accent_high_contrast_dark_theme</color>
 
     <color name="mozac_widget_favicon_background_normal_theme">@color/mozac_widget_favicon_background_dark_theme</color>
     <color name="mozac_widget_favicon_border_normal_theme">@color/mozac_widget_favicon_border_dark_theme</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -257,6 +257,7 @@
     <color name="select_login_header_normal_theme">@color/accent_bright_light_theme</color>
     <color name="mozac_widget_favicon_background_normal_theme">@color/mozac_widget_favicon_background_light_theme</color>
     <color name="mozac_widget_favicon_border_normal_theme">@color/mozac_widget_favicon_border_light_theme</color>
+    <color name="notification_accent_color_normal_theme">@color/accent_bright_light_theme</color>
 
     <!-- Tab tray -->
     <color name="tab_tray_item_text_normal_theme">@color/tab_tray_item_text_light_theme</color>


### PR DESCRIPTION
Related https://github.com/mozilla-mobile/fenix/pull/17231 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
