### PR TITLE
For #17377 - Fix for empty awesomeBar on searchFragment open

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt
@@ -313,22 +313,25 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
         }
 
         consumeFrom(store) {
-            val shouldShowAwesomebar =
-                !firstUpdate &&
-                it.query.isNotBlank() ||
-                it.showSearchShortcuts
-
-            awesome_bar?.visibility = if (shouldShowAwesomebar) View.VISIBLE else View.INVISIBLE
+            /*
+            * firstUpdate is used to make sure we keep the awesomebar hidden on the first run
+            *  of the searchFragmentDialog. We only turn it false after the user has changed the
+            *  query as consumeFrom may run several times on fragment start due to state updates.
+            * */
+            if (it.url != it.query) firstUpdate = false
+            awesome_bar?.visibility = if (shouldShowAwesomebar(it)) View.VISIBLE else View.INVISIBLE
             updateSearchSuggestionsHintVisibility(it)
             updateClipboardSuggestion(it, requireContext().components.clipboardHandler.url)
             updateToolbarContentDescription(it)
             updateSearchShortcutsIcon(it)
             toolbarView.update(it)
             awesomeBarView.update(it)
-            firstUpdate = false
             addVoiceSearchButton(it)
         }
     }
+
+    private fun shouldShowAwesomebar(searchFragmentState: SearchFragmentState) =
+        !firstUpdate && searchFragmentState.query.isNotBlank() || searchFragmentState.showSearchShortcuts
 
     private fun updateAccessibilityTraversalOrder() {
         val searchWrapperId = search_wrapper.id


### PR DESCRIPTION
The awesomeBar was set to stay hidden for the first consumeFrom(store) of the SearchDialogFragment.kt. However, recent changes send an additional store update when the view is created. To work around it we can take a look at AwesomeBarView.update(), we see that the awesomeBar suggestions get provided only if the query != url. So we can use the same method to keep the awesomeBar hidden until the user changes anything in the url.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes no tests as it is only a minor change
- [x] **Screenshots**: This PR includes screenshots or GIFs
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

https://user-images.githubusercontent.com/60002907/104474113-5c93ae80-55c6-11eb-8dd3-abd1b44cfb5f.mp4

