### PR TITLE
Add dot notification for autoplay blocked content

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -368,10 +368,6 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler,
                 showQuickSettingsDialog()
             }
 
-            browserToolbarView.view.display.setOnPermissionIndicatorClickedListener {
-                showQuickSettingsDialog()
-            }
-
             browserToolbarView.view.display.setOnTrackingProtectionClickedListener {
                 context.metrics.track(Event.TrackingProtectionIconPressed)
                 showTrackingProtectionPanel()

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarView.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarView.kt
@@ -152,7 +152,10 @@ class BrowserToolbarView(
                     hint = secondaryTextColor,
                     separator = separatorColor,
                     trackingProtection = primaryTextColor,
-                    permissionHighlights = primaryTextColor
+                    highlight = ContextCompat.getColor(
+                        context,
+                        R.color.whats_new_notification_color
+                    )
                 )
 
                 display.hint = context.getString(R.string.search_hint)

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarIntegration.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarIntegration.kt
@@ -130,7 +130,7 @@ class DefaultToolbarIntegration(
             }
 
         if (FeatureFlags.permissionIndicatorsToolbar) {
-            toolbar.display.indicators += DisplayToolbar.Indicators.PERMISSION_HIGHLIGHTS
+            toolbar.display.indicators += DisplayToolbar.Indicators.HIGHLIGHT
         }
 
         toolbar.display.displayIndicatorSeparator =

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "71.0.20210118134928"
+    const val VERSION = "71.0.20210119143123"
 }


### PR DESCRIPTION
Needs https://github.com/mozilla-mobile/android-components/pull/9390

<img width="545" alt="image" src="https://user-images.githubusercontent.com/773158/104483993-be3c2480-5596-11eb-9c39-7fd257afa625.png">


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
