### PR TITLE
For #17447: add intentional delay in cold start up in debug and nightly.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -40,6 +40,13 @@ object FeatureFlags {
     const val nimbusExperiments = false
 
     /**
+     * Enables an intentional regression to validate perftest alerting. See
+     * https://github.com/mozilla-mobile/fenix/issues/17447 for details. This
+     * is expected to be removed within several days.
+     */
+    val intentionalRegressionToValidatePerfTestAlerting = Config.channel.isNightlyOrDebug
+
+    /**
      * Enables the new MediaSession API.
      */
     @Suppress("MayBeConst")

--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -118,6 +118,13 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
 
     @CallSuper
     open fun setupInMainProcessOnly() {
+        // See feature flags kdoc for details.
+        if (FeatureFlags.intentionalRegressionToValidatePerfTestAlerting) {
+            logger.info("Intentional thread sleep. See #17447")
+            @Suppress("MagicNumber") // it's fine for a quick patch.
+            Thread.sleep(100)
+        }
+
         run {
             // Attention: Do not invoke any code from a-s in this scope.
             val megazordSetup = setupMegazord()


### PR DESCRIPTION
DO NOT LAND. We land Sunday afternoon. Please see #17447 for details.

I validated:
- that the log statement appeared in Nightly but not in Beta.
- that the local runtimes of our perftest increased (the median diff is 124ms)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
