### PR TITLE
Update bug numbers to URLs for activation ping

### DIFF
--- a/app/pings.yaml
+++ b/app/pings.yaml
@@ -12,8 +12,8 @@ activation:
     an hashed version of the Google Advertising ID.
   include_client_id: false
   bugs:
-    - 1538011
-    - 1501822
+    - https://bugzilla.mozilla.com/1538011/
+    - https://bugzilla.mozilla.com/1501822/
   data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/1707#issuecomment-486972209
   notification_emails:


### PR DESCRIPTION
Earlier versions of Glean supported bug numbers of the metadata, but this causes
ambiguity, particularly for Fenix where issues exist in both Bugzilla and
Github. This just updates the Bugzilla numbers to full URLs.

We made the use of numbers an error sometime ago, but neglected to enforce this
on "pings" in addition to "metrics".  A future version of `glean_parser` [1] will make
this an error and this will set Fenix up to be ready for that.

[1] https://github.com/mozilla/glean_parser/pull/262

This is metadata used only by other data tools, so doesn't affect the Fenix build.

Cc: @wlach

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
