### PR TITLE
For issue #17457: Prevent page refresh when tapping the security icon

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/quicksettings/WebsitePermissionsView.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/quicksettings/WebsitePermissionsView.kt
@@ -159,7 +159,8 @@ class WebsitePermissionsView(
                 adapter.setDropDownViewResource(R.layout.quicksetting_permission_spinner_dropdown)
                 viewHolder.status.adapter = adapter
 
-                viewHolder.status.setSelection(selectedIndex, false)
+                viewHolder.status.tag = permissionState.autoplayValue
+                viewHolder.status.setSelection(selectedIndex)
                 viewHolder.status.onItemSelectedListener =
                     object : AdapterView.OnItemSelectedListener {
                         override fun onItemSelected(
@@ -168,6 +169,14 @@ class WebsitePermissionsView(
                             position: Int,
                             id: Long
                         ) {
+                            // Unfortunately the spinner component triggers an selection event when initialized,
+                            // to avoid that, we are using the tag property to store the selected value and
+                            // be able to differentiate from an initialization event from a normal selection event
+                            // see https://stackoverflow.com/questions/21747917/undesired-onitemselected-calls/21751327#21751327
+                            if (viewHolder.status.selectedItem == viewHolder.status.tag) {
+                                return
+                            }
+                            viewHolder.status.tag = viewHolder.status.selectedItem
                             val type = viewHolder.status.selectedItem as AutoplayValue
                             interactor.onAutoplayChanged(type)
                         }

--- a/app/src/test/java/org/mozilla/fenix/settings/quicksettings/WebsitePermissionViewTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/quicksettings/WebsitePermissionViewTest.kt
@@ -195,6 +195,18 @@ class WebsitePermissionViewTest {
             0L
         )
 
-        verify { interactor.onAutoplayChanged(permissionView.status.selectedItem as AutoplayValue) }
+        // Selecting the same item should not trigger a selection event.
+        verify(exactly = 0) { interactor.onAutoplayChanged(permissionView.status.selectedItem as AutoplayValue) }
+
+        permissionView.status.setSelection(2)
+        permissionView.status.onItemSelectedListener!!.onItemSelected(
+            mock(),
+            permissionView.status,
+            2,
+            0L
+        )
+
+        // Selecting a different item from the selected one should trigger an selection event.
+        verify(exactly = 1) { interactor.onAutoplayChanged(permissionView.status.selectedItem as AutoplayValue) }
     }
 }


### PR DESCRIPTION
The issue was caused because unfortunately the [Android Spinner has a bug](
https://stackoverflow.com/questions/21747917/undesired-onitemselected-calls/), we get notified of an event selection when initializing the UI that subsequently triggers an page refresh, now we check for the initialization and ignore the first event. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
