### PR TITLE
Don't run tasks for mergify branches on push

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -103,7 +103,7 @@ tasks:
               $if: >
                 tasks_for in ["action", "cron"]
                 || (tasks_for == "github-pull-request" && pullRequestAction in ["opened", "reopened", "synchronize"])
-                || (tasks_for == "github-push" && head_branch[:10] != "refs/tags/") && (head_branch != "staging.tmp") && (head_branch != "trying.tmp")
+                || (tasks_for == "github-push" && head_branch[:10] != "refs/tags/") && (head_branch != "staging.tmp") && (head_branch != "trying.tmp") && (head_branch[:8] != "mergify/")
                 || (tasks_for == "github-release" && releaseAction == "published" && (ownerEmail != "mozilla-release-automation-bot@users.noreply.github.com") && (ownerEmail != "mozilla-release-automation-bot-staging@users.noreply.github.com"))
               then:
                   $let:


### PR DESCRIPTION
While investigating the issues in https://github.com/mozilla-mobile/fenix/pull/17480 I noticed that we run tasks on `mergify` branches. As far as I can tell, these are useless for two reasons:
1) They always go through pull requests, which will run the same tasks (after we add mergify as a collaborator)
2) Signing always fails, because Chain of Trust fails to find committer data. Eg:
```
2021-01-15T10:40:16 CRITICAL - Chain of Trust verification error!
Traceback (most recent call last):
  File "/app/lib/python3.8/site-packages/scriptworker/cot/verify.py", line 1965, in verify_chain_of_trust
    await verify_task_types(chain)
  File "/app/lib/python3.8/site-packages/scriptworker/cot/verify.py", line 1724, in verify_task_types
    await valid_task_types[task_type](chain, obj)
  File "/app/lib/python3.8/site-packages/scriptworker/cot/verify.py", line 1648, in verify_parent_task
    await verify_parent_task_definition(chain, link)
  File "/app/lib/python3.8/site-packages/scriptworker/cot/verify.py", line 1519, in verify_parent_task_definition
    jsone_context, tmpl = await get_jsone_context_and_template(chain, parent_link, decision_link, tasks_for)
  File "/app/lib/python3.8/site-packages/scriptworker/cot/verify.py", line 1489, in get_jsone_context_and_template
    jsone_context = await populate_jsone_context(chain, parent_link, decision_link, tasks_for)
  File "/app/lib/python3.8/site-packages/scriptworker/cot/verify.py", line 1259, in populate_jsone_context
    jsone_context.update(await _get_additional_github_push_jsone_context(decision_link))
  File "/app/lib/python3.8/site-packages/scriptworker/cot/verify.py", line 1162, in _get_additional_github_push_jsone_context
    committer_login = commit_data["committer"]["login"]
TypeError: 'NoneType' object is not subscriptable
```

We should just not run them, unless my assumption that they always go through pull requests is wrong.