### PR TITLE
For #12414 - Support sharing images through ShareDownloadFeature

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -58,6 +58,7 @@ import mozilla.components.feature.contextmenu.ContextMenuCandidate
 import mozilla.components.feature.contextmenu.ContextMenuFeature
 import mozilla.components.feature.downloads.DownloadsFeature
 import mozilla.components.feature.downloads.manager.FetchDownloadManager
+import mozilla.components.feature.downloads.share.ShareDownloadFeature
 import mozilla.components.feature.intent.ext.EXTRA_SESSION_ID
 import mozilla.components.feature.media.fullscreen.MediaSessionFullscreenFeature
 import mozilla.components.feature.privatemode.feature.SecureWindowFeature
@@ -161,6 +162,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
     private val sessionFeature = ViewBoundFeatureWrapper<SessionFeature>()
     private val contextMenuFeature = ViewBoundFeatureWrapper<ContextMenuFeature>()
     private val downloadsFeature = ViewBoundFeatureWrapper<DownloadsFeature>()
+    private val shareDownloadsFeature = ViewBoundFeatureWrapper<ShareDownloadFeature>()
     private val appLinksFeature = ViewBoundFeatureWrapper<AppLinksFeature>()
     private val promptsFeature = ViewBoundFeatureWrapper<PromptFeature>()
     private val findInPageIntegration = ViewBoundFeatureWrapper<FindInPageIntegration>()
@@ -429,6 +431,13 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
             )
         }
 
+        val shareDownloadFeature = ShareDownloadFeature(
+            context = context.applicationContext,
+            httpClient = context.components.core.client,
+            store = store,
+            tabId = customTabSessionId
+        )
+
         val downloadFeature = DownloadsFeature(
             context.applicationContext,
             store = store,
@@ -506,6 +515,12 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
         resumeDownloadDialogState(
             sessionManager.selectedSession?.id,
             store, view, context, toolbarHeight
+        )
+
+        shareDownloadsFeature.set(
+            shareDownloadFeature,
+            owner = this,
+            view = view
         )
 
         downloadsFeature.set(


### PR DESCRIPTION
Register a ViewBoundFeatureWrapper<ShareDownloadFeature> that will respond to "Share image" from the browser contextual menu

This fixes the breaking change introduced in AC - https://github.com/mozilla-mobile/android-components/pull/9420

Recording of the new "Share image" behavior:
<img src="https://user-images.githubusercontent.com/11428869/104742711-744c6d80-5753-11eb-8b32-b65a1b4230da.gif" width="40%" />
[video](https://drive.google.com/file/d/1W6T7lfU822BNfHKY_ej1ttn3UZO34Eie/view?usp=sharing)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
