### PR TITLE
String Uplifts for Firefox 85 Jan 15th

### DIFF
--- a/app/src/main/res/values-ast/strings.xml
+++ b/app/src/main/res/values-ast/strings.xml
@@ -591,6 +591,8 @@
     <string name="tab_tray_multiselect_share_content_description">Compartir les llingüetes abiertes</string>
     <!-- Content description for tabs tray multiselect menu -->
     <string name="tab_tray_multiselect_menu_content_description">Menú de llingüetes abiertes</string>
+    <!-- Content description (not visible, for screen readers etc.): Removes tab from collection button. Removes the selected tab from collection when pressed -->
+    <string name="remove_tab_from_collection">Desaniciar la llingüeta de la coleición</string>
     <!-- Text for button to enter multiselect mode in tabs tray -->
     <string name="tabs_tray_select_tabs">Esbillar llingüetes</string>
     <!-- Content description (not visible, for screen readers etc.): Close tab button. Closes the current session when pressed -->

--- a/app/src/main/res/values-br/strings.xml
+++ b/app/src/main/res/values-br/strings.xml
@@ -14,9 +14,9 @@
     <!-- Placeholder text shown in the search bar before a user enters text -->
     <string name="search_hint">Klask pe chomlecʼh</string>
     <!-- No Open Tabs Message Description -->
-    <string name="no_open_tabs_description">Diskouezet e vo amañ hocʼh ivinelloù digoret</string>
+    <string name="no_open_tabs_description">Diskouezet e vo amañ hocʼh ivinelloù digoret.</string>
     <!-- No Private Tabs Message Description -->
-    <string name="no_private_tabs_description">Diskouezet e vo amañ hocʼh ivinelloù prevez</string>
+    <string name="no_private_tabs_description">Diskouezet e vo amañ hocʼh ivinelloù prevez.</string>
     <!-- Default title for pinned Baidu top site that links to Baidu home page  -->
     <string name="default_top_site_baidu">Baidu</string>
     <!-- Default title for pinned JD top site that links to JD home page  -->
@@ -58,7 +58,9 @@
     <!-- Explanation for private browsing displayed to users on home view when they first enable private mode
         The first parameter is the name of the app defined in app_name (for example: Fenix) -->
     <string name="private_browsing_placeholder_description_2">%1$s a skarzh ho roll istor klask ha merdeiñ eus an ivinelloù prevez pa guitait anezho pe pa guitait an arload. Daoust ma ne lak ket acʼhanocʼh da vezañ dizanv evit al lecʼhiennoù pe evit ho pourchaser kenrouedad e vo aesocʼh da zercʼhel prevez ar pezh a rit enlinenn evit an dud all a implij an trevnad-mañ.</string>
-    <string name="private_browsing_common_myths">Mojennoù a vez alies diwar-benn ar merdeiñ prevez</string>
+    <string name="private_browsing_common_myths">
+       Mojennoù a vez alies diwar-benn ar merdeiñ prevez
+    </string>
     <!-- Delete session button to erase your history in a private session -->
     <string name="private_browsing_delete_session">Dilemel an estez</string>
 
@@ -154,7 +156,7 @@
     <!-- Browser menu button that open a share menu to share the current site -->
     <string name="browser_menu_share">Rannañ</string>
     <!-- Share menu title, displayed when a user is sharing their current site -->
-    <string name="menu_share_with">Rannañ gant...</string>
+    <string name="menu_share_with">Rannañ gant…</string>
     <!-- Browser menu button shown in custom tabs that opens the current tab in Fenix
         The first parameter is the name of the app defined in app_name (for example: Fenix) -->
     <string name="browser_menu_open_in_fenix">Digeriñ e %1$s</string>
@@ -292,7 +294,7 @@
     <!-- Preference for settings related to visual options -->
     <string name="preferences_customize">Personelaat</string>
     <!-- Preference description for banner about signing in -->
-    <string name="preferences_sign_in_description">Goubredit sinedoù, ar roll istor, ha muiocʼh cʼhoazh gant ho kont Firefox.</string>
+    <string name="preferences_sign_in_description">Goubredit sinedoù, ar roll istor, ha muiocʼh cʼhoazh gant ho kont Firefox</string>
     <!-- Preference shown instead of account display name while account profile information isn't available yet. -->
     <string name="preferences_account_default_name">Kont Firefox</string>
     <!-- Preference text for account title when there was an error syncing FxA -->
@@ -352,11 +354,14 @@
     <!-- Hint displayed on input field for custom collection user ID-->
     <string name="customize_addon_collection_user_hint">Perc’henn an dastumad (Naoudi an arveriad)</string>
     <!-- Toast shown after confirming the custom add-on collection configuration -->
-    <string name="toast_customize_addon_collection_done">Kemmet eo bet an dastumad askouezhioù. Kuitae vo an arload evit arloañ ar c’hemmoù...</string>
+    <string name="toast_customize_addon_collection_done">Kemmet eo bet an dastumad askouezhioù. Kuitaet e vo an arload evit arloañ ar c’hemmoù…</string>
 
     <!-- Add-on Installation from AMO-->
     <!-- Error displayed when user attempts to install an add-on from AMO (addons.mozilla.org) that is not supported -->
     <string name="addon_not_supported_error">Ne vez skoret an enlugellad-mañ</string>
+
+    <!-- Error displayed when user attempts to install an add-on from AMO (addons.mozilla.org) that is already installed -->
+    <string name="addon_already_installed">An enlugellad-mañ a zo bet staliet endeo</string>
 
     <!-- Account Preferences -->
     <!-- Preference for triggering sync -->
@@ -378,16 +383,16 @@
     <!-- Text shown when user enters empty device name -->
     <string name="empty_device_name_error">Anv an trevnad nʼhall ket bezañ goullo.</string>
     <!-- Label indicating that sync is in progress -->
-    <string name="sync_syncing_in_progress">O c’houbredañ...</string>
+    <string name="sync_syncing_in_progress">O c’houbredañ…</string>
     <!-- Label summary indicating that sync failed. The first parameter is the date stamp showing last time it succeeded -->
     <string name="sync_failed_summary">Goubredañ cʼhwitet. Berzh diwezhañ: %s</string>
 
     <!-- Label summary showing never synced -->
     <string name="sync_failed_never_synced_summary">Goubredañ cʼhwitet. Goubredañ diwezhañ: morse</string>
     <!-- Label summary the date we last synced. The first parameter is date stamp showing last time synced -->
-    <string name="sync_last_synced_summary">Goubredañ diwezhañ : %s</string>
+    <string name="sync_last_synced_summary">Goubredañ diwezhañ: %s</string>
     <!-- Label summary showing never synced -->
-    <string name="sync_never_synced_summary">Goubredañ diwezhañ : morse</string>
+    <string name="sync_never_synced_summary">Goubredañ diwezhañ: morse</string>
 
     <!-- Text for displaying the default device name.
         The first parameter is the application name, the second is the device manufacturer name
@@ -420,7 +425,7 @@
     <!-- Button in Exceptions Preference to turn on tracking protection for all sites (remove all exceptions) -->
     <string name="preferences_tracking_protection_exceptions_turn_on_for_all">Gweredekaat evit an holl lecʼhiennoù</string>
     <!-- Text displayed when there are no exceptions -->
-    <string name="exceptions_empty_message_description">An nemedennoù a laosk acʼhanocʼh diweredekaat ar gwarez heuliañ evit lecʼhiennoù ʼzo</string>
+    <string name="exceptions_empty_message_description">An nemedennoù a laosk acʼhanocʼh da ziweredekaat ar gwarez heuliañ evit lecʼhiennoù ʼzo.</string>
     <!-- Text displayed when there are no exceptions, with learn more link that brings users to a tracking protection SUMO page -->
     <string name="exceptions_empty_message_learn_more_link">Gouzout hirocʼh</string>
 
@@ -444,7 +449,7 @@
     <!-- Title for experiments preferences -->
     <string name="preference_experiments">Arnodoù</string>
     <!-- Summary for experiments preferences -->
-    <string name="preference_experiments_summary">Aotren Mozilla da staliañ ha da zastum roadennoù evit keweriusterioù arnodel.</string>
+    <string name="preference_experiments_summary">Aotren Mozilla da staliañ ha da zastum roadennoù evit keweriusterioù arnodel</string>
     <!-- Preference switch for crash reporter -->
     <string name="preferences_crash_reporter">Daneveller sacʼhadennoù</string>
     <!-- Preference switch for Mozilla location service -->
@@ -711,6 +716,12 @@
     <string name="download_delete_all">Goullonderiñ roll ar pellgargadurioù</string>
     <!-- Text for the dialog to confirm clearing all downloads -->
     <string name="download_delete_all_dialog">Sur oc’h e fell deoc’h skarzhañ ho pellgargadennoù?</string>
+    <!-- Text for the snackbar to confirm that multiple downloads items have been removed -->
+    <string name="download_delete_multiple_items_snackbar_1">Pellgargadurioù dilammet</string>
+    <!-- Text for the snackbar to confirm that a single download item has been removed. The first parameter is the name of the download item. -->
+    <string name="download_delete_single_item_snackbar">Dilamet %1$s</string>
+    <!-- Text shown when no download exists -->
+    <string name="download_empty_message_1">Restr pellgarget ebet</string>
     <!-- History multi select title in app bar
     The first parameter is the number of downloads selected -->
     <string name="download_multi_select_title">%1$d diuzet</string>
@@ -718,6 +729,10 @@
 
     <!-- History overflow menu open in new tab button -->
     <string name="download_menu_open">Digeriñ</string>
+
+
+    <!-- Text for the button to remove a single download item -->
+    <string name="download_delete_item_1">Dilemel</string>
 
 
     <!-- Crashes -->
@@ -748,7 +763,7 @@
     <!-- Confirmation message for a dialog confirming if the user wants to delete the selected folder -->
     <string name="bookmark_delete_folder_confirmation_dialog">Ha fellout a ra deocʼh dilemel an teuliad-mañ?</string>
     <!-- Confirmation message for a dialog confirming if the user wants to delete multiple items including folders. Parameter will be replaced by app name. -->
-    <string name="bookmark_delete_multiple_folders_confirmation_dialog">%s a zilamo an elfennoù diuzet</string>
+    <string name="bookmark_delete_multiple_folders_confirmation_dialog">%s a zilamo an elfennoù diuzet.</string>
     <!-- Snackbar title shown after a folder has been deleted. This first parameter is the name of the deleted folder -->
     <string name="bookmark_delete_folder_snackbar">Dilamet %1$s</string>
     <!-- Screen title for adding a bookmarks folder -->
@@ -841,6 +856,8 @@
     <string name="preference_phone_feature_notification">Rebuzadur</string>
     <!-- Preference for altering the persistent storage access for all websites -->
     <string name="preference_phone_feature_persistent_storage">Stokadur padus</string>
+    <!-- Preference for altering the EME access for all websites -->
+    <string name="preference_phone_feature_media_key_system_access">Endalc’had reoliet gant DRM</string>
     <!-- Label that indicates that a permission must be asked always -->
     <string name="preference_option_phone_feature_ask_to_allow">Goulenn an aotre</string>
     <!-- Label that indicates that a permission must be blocked -->
@@ -951,7 +968,7 @@
     <!-- Text for the warning message on the Add new device screen -->
     <string name="sync_add_new_device_message">Nʼeus trevnad ebet kennasket</string>
     <!-- Text for the button to learn about sending tabs -->
-    <string name="sync_add_new_device_learn_button">Gouzout hirocʼh a-zivout kas ivinelloù...</string>
+    <string name="sync_add_new_device_learn_button">Gouzout hirocʼh a-zivout ar cʼhas ivinelloù...</string>
     <!-- Text for the button to connect another device -->
     <string name="sync_add_new_device_connect_button">Kennaskañ un trevnad all…</string>
 
@@ -987,7 +1004,7 @@
     <!-- Text shown in snackbar action for viewing bookmarks -->
     <string name="snackbar_message_bookmarks_view">Gwelout</string>
     <!-- Text shown in snackbar when user adds a site to top sites -->
-    <string name="snackbar_added_to_top_sites">Ouzhpennet dʼal lecʼhiennoù gwellañ</string>
+    <string name="snackbar_added_to_top_sites">Ouzhpennet dʼal lecʼhiennoù pennañ</string>
     <!-- Text shown in snackbar when user closes a private tab -->
     <string name="snackbar_private_tab_closed">Ivinell prevez serret</string>
     <!-- Text shown in snackbar when user closes all private tabs -->

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -740,6 +740,8 @@
     <string name="download_delete_all">Smazat stažené soubory</string>
     <!-- Text for the dialog to confirm clearing all downloads -->
     <string name="download_delete_all_dialog">Opravdu chcete smazat všechny stažené soubory?</string>
+    <!-- Text for the snackbar to confirm that multiple downloads items have been removed -->
+    <string name="download_delete_multiple_items_snackbar_1">Stažené soubory smazány</string>
     <!-- Text for the snackbar to confirm that a single download item has been removed. The first parameter is the name of the download item. -->
     <string name="download_delete_single_item_snackbar">Soubor %1$s odebrán</string>
     <!-- Text shown when no download exists -->
@@ -878,6 +880,8 @@
     <string name="preference_phone_feature_location">Poloha</string>
     <!-- Preference for altering the notification access for all websites -->
     <string name="preference_phone_feature_notification">Oznámení</string>
+    <!-- Preference for altering the persistent storage access for all websites -->
+    <string name="preference_phone_feature_persistent_storage">Trvalé úložiště</string>
     <!-- Preference for altering the EME access for all websites -->
     <string name="preference_phone_feature_media_key_system_access">Obsah chráněný pomocí DRM</string>
     <!-- Label that indicates that a permission must be asked always -->
@@ -1053,6 +1057,8 @@
     <string name="qr_scanner_dialog_negative">ZAKÁZAT</string>
     <!-- Tab collection deletion prompt dialog message. Placeholder will be replaced with the collection name -->
     <string name="tab_collection_dialog_message">Opravdu chcete odstranit sbírku „%1$s“?</string>
+    <!-- Collection and tab deletion prompt dialog message. This will show when the last tab from a collection is deleted -->
+    <string name="delete_tab_and_collection_dialog_message">Odstraněním tohoto panelu smažete celou sbírku. Novou sbírku si můžete kdykoliv znovu vytvořit.</string>
     <!-- Collection and tab deletion prompt dialog title. Placeholder will be replaced with the collection name. This will show when the last tab from a collection is deleted -->
     <string name="delete_tab_and_collection_dialog_title">Smazat %1$s?</string>
     <!-- Tab collection deletion prompt dialog option to delete the collection -->

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -1188,4 +1188,329 @@
     <!-- text for the privacy notice onboarding card header -->
     <string name="onboarding_privacy_notice_header">A súa privacidade</string>
 
+    <!-- Content description (not visible, for screen readers etc.): Close onboarding screen -->
+    <string name="onboarding_close">Pechar</string>
+
+    <!-- text for the button to finish onboarding -->
+    <string name="onboarding_finish">Iniciar a navegación</string>
+
+    <!-- Onboarding theme -->
+    <!-- text for the theme picker onboarding card header -->
+    <string name="onboarding_theme_picker_header">Escolla o seu tema</string>
+    <!-- text for the theme picker onboarding card description -->
+    <string name="onboarding_theme_picker_description1">Aforre batería e vista activando o modo escuro.</string>
+    <!-- Automatic theme setting (will follow device setting) -->
+    <string name="onboarding_theme_automatic_title">Automático</string>
+    <!-- Summary of automatic theme setting (will follow device setting) -->
+    <string name="onboarding_theme_automatic_summary">Adáptase á configuración do dispositivo</string>
+    <!-- Theme setting for dark mode -->
+    <string name="onboarding_theme_dark_title">Tema escuro</string>
+    <!-- Theme setting for light mode -->
+    <string name="onboarding_theme_light_title">Tema claro</string>
+
+    <!-- Text shown in snackbar when multiple tabs have been sent to device -->
+    <string name="sync_sent_tabs_snackbar">Lapelas enviadas!</string>
+    <!-- Text shown in snackbar when one tab has been sent to device  -->
+    <string name="sync_sent_tab_snackbar">Lapelas enviadas!</string>
+    <!-- Text shown in snackbar when sharing tabs failed  -->
+    <string name="sync_sent_tab_error_snackbar">Foi imposíbel enviar</string>
+    <!-- Text shown in snackbar for the "retry" action that the user has after sharing tabs failed -->
+    <string name="sync_sent_tab_error_snackbar_action">TENTAR DE NOVO</string>
+    <!-- Title of QR Pairing Fragment -->
+    <string name="sync_scan_code">Escanear o código</string>
+    <!-- Instructions on how to access pairing -->
+    <string name="sign_in_instructions"><![CDATA[No seu computador, abra o Firefox e vaia a <b>https://firefox.com/pair</b>]]></string>
+    <!-- Text shown for sign in pairing when ready -->
+    <string name="sign_in_ready_for_scan">Listo para escanear</string>
+    <!-- Text shown for settings option for sign with pairing -->
+    <string name="sign_in_with_camera">Inicie sesión coa súa cámara</string>
+    <!-- Text shown for settings option for sign with email -->
+    <string name="sign_in_with_email">Use o correo electrónico no seu lugar</string>
+    <!-- Text shown for settings option for create new account text.'Firefox' intentionally hardcoded here.-->
+    <string name="sign_in_create_account_text"><![CDATA[Non ten unha conta? <u>Cree unha</u> para sincronizar o Firefox entre dispositivos.]]></string>
+    <!-- Text shown in confirmation dialog to sign out of account -->
+    <string name="sign_out_confirmation_message">Firefox deterá a sincronización coa súa conta, pero non eliminará ningún dos seus datos de navegación neste dispositivo.</string>
+    <!-- Text shown in confirmation dialog to sign out of account. The first parameter is the name of the app (e.g. Firefox Preview) -->
+    <string name="sign_out_confirmation_message_2">%s deterá a sincronización coa súa conta, pero non eliminará ningún dos seus datos de navegación neste dispositivo.</string>
+    <!-- Option to continue signing out of account shown in confirmation dialog to sign out of account -->
+    <string name="sign_out_disconnect">Desconectar</string>
+    <!-- Option to cancel signing out shown in confirmation dialog to sign out of account -->
+    <string name="sign_out_cancel">Cancelar</string>
+    <!-- Error message snackbar shown after the user tried to select a default folder which cannot be altered -->
+    <string name="bookmark_cannot_edit_root">Non é posíbel editar os cartafoles predeterminados</string>
+
+    <!-- Enhanced Tracking Protection -->
+    <!-- Link displayed in enhanced tracking protection panel to access tracking protection settings -->
+    <string name="etp_settings">Configuración de protección</string>
+    <!-- Preference title for enhanced tracking protection settings -->
+    <string name="preference_enhanced_tracking_protection">Protección mellorada contra o rastrexo</string>
+    <!-- Title for the description of enhanced tracking protection -->
+    <string name="preference_enhanced_tracking_protection_explanation_title">Navegar sen ser seguido</string>
+    <!-- Description of enhanced tracking protection. The first parameter is the name of the application (For example: Fenix) -->
+    <string name="preference_enhanced_tracking_protection_explanation">Manteña os seus datos para si mesmo. %s protexe de moitos dos rastreadores máis comúns que seguen o que vostede fai na Rede.</string>
+    <!-- Text displayed that links to website about enhanced tracking protection -->
+    <string name="preference_enhanced_tracking_protection_explanation_learn_more">Máis información</string>
+    <!-- Preference for enhanced tracking protection for the standard protection settings -->
+    <string name="preference_enhanced_tracking_protection_standard_default_1">Estándar (predeterminado)</string>
+    <!-- Preference description for enhanced tracking protection for the standard protection settings -->
+    <string name="preference_enhanced_tracking_protection_standard_description_3">Bloquea menos rastrexadores. As páxinas cárganse normalmente.</string>
+    <!--  Accessibility text for the Standard protection information icon  -->
+    <string name="preference_enhanced_tracking_protection_standard_info_button">O que resulta bloqueado pola protección de seguimento estándar</string>
+    <!-- Preference for enhanced tracking protection for the strict protection settings -->
+    <string name="preference_enhanced_tracking_protection_strict">Estrito</string>
+    <!-- Preference description for enhanced tracking protection for the strict protection settings -->
+    <string name="preference_enhanced_tracking_protection_strict_description_2">Bloquea máis rastreadores, anuncios e xanelas emerxentes. As páxinas cargan máis rápido, pero é posíbel que algunhas funcións non funcionen.</string>
+    <!--  Accessibility text for the Strict protection information icon  -->
+    <string name="preference_enhanced_tracking_protection_strict_info_button">O que resulta bloqueado pola protección de seguimento estrita</string>
+    <!-- Preference for enhanced tracking protection for the custom protection settings -->
+    <string name="preference_enhanced_tracking_protection_custom">Personalizado</string>
+    <!-- Preference description for enhanced tracking protection for the strict protection settings -->
+    <string name="preference_enhanced_tracking_protection_custom_description_2">Escolla os rastreadores e scripts que bloquear.</string>
+    <!--  Accessibility text for the Strict protection information icon  -->
+    <string name="preference_enhanced_tracking_protection_custom_info_button">O que resulta bloqueado pola protección de seguimento personalizada</string>
+    <!-- Header for categories that are being blocked by current Enhanced Tracking Protection settings -->
+    <!-- Preference for enhanced tracking protection for the custom protection settings for cookies-->
+    <string name="preference_enhanced_tracking_protection_custom_cookies">Cookies</string>
+    <!-- Option for enhanced tracking protection for the custom protection settings for cookies-->
+    <string name="preference_enhanced_tracking_protection_custom_cookies_1">Rastreadores entre sitios e de redes sociais</string>
+    <!-- Option for enhanced tracking protection for the custom protection settings for cookies-->
+    <string name="preference_enhanced_tracking_protection_custom_cookies_2">Cookies de sitios non visitados</string>
+    <!-- Option for enhanced tracking protection for the custom protection settings for cookies-->
+    <string name="preference_enhanced_tracking_protection_custom_cookies_3">Todas as cookies de terceiros (pode causar erros nos sitios web)</string>
+    <!-- Option for enhanced tracking protection for the custom protection settings for cookies-->
+    <string name="preference_enhanced_tracking_protection_custom_cookies_4">Todas as cookies (pode causar erros nos sitios web)</string>
+    <!-- Preference for enhanced tracking protection for the custom protection settings for tracking content -->
+    <string name="preference_enhanced_tracking_protection_custom_tracking_content">Contido de rastrexo</string>
+    <!-- Option for enhanced tracking protection for the custom protection settings for tracking content-->
+    <string name="preference_enhanced_tracking_protection_custom_tracking_content_1">En todas as lapelas</string>
+    <!-- Option for enhanced tracking protection for the custom protection settings for tracking content-->
+    <string name="preference_enhanced_tracking_protection_custom_tracking_content_2">Só nas lapelas privadas</string>
+    <!-- Option for enhanced tracking protection for the custom protection settings for tracking content-->
+    <string name="preference_enhanced_tracking_protection_custom_tracking_content_3">Só nas lapelas personalizadas</string>
+    <!-- Preference for enhanced tracking protection for the custom protection settings -->
+    <string name="preference_enhanced_tracking_protection_custom_cryptominers">Criptomineiros</string>
+    <!-- Preference for enhanced tracking protection for the custom protection settings -->
+    <string name="preference_enhanced_tracking_protection_custom_fingerprinters">Identificadores de pegadas dixitais</string>
+    <string name="enhanced_tracking_protection_blocked">Bloqueado</string>
+    <!-- Header for categories that are being not being blocked by current Enhanced Tracking Protection settings -->
+    <string name="enhanced_tracking_protection_allowed">Permitido</string>
+    <!-- Category of trackers (social media trackers) that can be blocked by Enhanced Tracking Protection -->
+    <string name="etp_social_media_trackers_title">Rastrexadores de redes sociais</string>
+    <!-- Description of social media trackers that can be blocked by Enhanced Tracking Protection -->
+    <string name="etp_social_media_trackers_description">Limita a capacidade das redes sociais para rastrexar a súa actividade de navegación pola web.</string>
+    <!-- Category of trackers (cross-site tracking cookies) that can be blocked by Enhanced Tracking Protection -->
+    <string name="etp_cookies_title">Cookies de rastrexo entre sitios</string>
+    <!-- Description of cross-site tracking cookies that can be blocked by Enhanced Tracking Protection -->
+    <string name="etp_cookies_description">Bloquea as cookies que as redes publicitarias e as empresas de análise utilizan para recompilar os seus datos de navegación en moitos sitios.</string>
+    <!-- Category of trackers (cryptominers) that can be blocked by Enhanced Tracking Protection -->
+    <string name="etp_cryptominers_title">Criptomineiros</string>
+    <!-- Description of cryptominers that can be blocked by Enhanced Tracking Protection -->
+    <string name="etp_cryptominers_description">Evita que os scripts maliciosos teñan acceso ao seu dispositivo para extraeren moeda dixital.</string>
+    <!-- Category of trackers (fingerprinters) that can be blocked by Enhanced Tracking Protection -->
+    <string name="etp_fingerprinters_title">Identificadores de pegadas dixitais</string>
+    <!-- Description of fingerprinters that can be blocked by Enhanced Tracking Protection -->
+    <string name="etp_fingerprinters_description">Evita que se recompilen datos de identificación única no dispositivo que se poden usar con fins de rastrexo.</string>
+    <!-- Category of trackers (tracking content) that can be blocked by Enhanced Tracking Protection -->
+    <string name="etp_tracking_content_title">Rastrexo de contido</string>
+    <!-- Description of tracking content that can be blocked by Enhanced Tracking Protection -->
+    <string name="etp_tracking_content_description">Detén a carga de anuncios, vídeos e outros contidos que conteñan código de seguimento. Pode afectar a algunhas funcións dos sitios web.</string>
+    <!-- Enhanced Tracking Protection Onboarding Message shown in a dialog above the toolbar. The first parameter is the name of the application (For example: Fenix) -->
+    <string name="etp_onboarding_cfr_message">Cada vez que o escudo é púrpura, %s bloqueou os rastreadores dun sitio. Toque para obter máis información.</string>
+    <!-- Enhanced Tracking Protection message that protection is currently on for this site -->
+    <string name="etp_panel_on">As proteccións están ACTIVADAS neste sitio</string>
+    <!-- Enhanced Tracking Protection message that protection is currently off for this site -->
+    <string name="etp_panel_off">As proteccións están DESACTIVADAS neste sitio</string>
+    <!-- Header for exceptions list for which sites enhanced tracking protection is always off -->
+    <string name="enhanced_tracking_protection_exceptions">A protección mellorada contra o rastrexo está desactivada para estes sitios</string>
+    <!-- Content description (not visible, for screen readers etc.): Navigate
+    back from ETP details (Ex: Tracking content) -->
+    <string name="etp_back_button_content_description">Retroceder no historial</string>
+    <!-- About page Your rights link text -->
+    <string name="about_your_rights">Os seus dereitos</string>
+    <!-- About page link text to open open source licenses screen -->
+    <string name="about_open_source_licenses">Bibliotecas de código aberto que usamos</string>
+    <!-- About page link text to open what's new link -->
+    <string name="about_whats_new">Novidades en %s</string>
+    <!-- Open source licenses page title
+    The first parameter is the app name -->
+    <string name="open_source_licenses_title">%s | Bibliotecas OSS</string>
+    <!-- Category of trackers (redirect trackers) that can be blocked by Enhanced Tracking Protection -->
+    <string name="etp_redirect_trackers_title">Seguidores de redirección</string>
+    <!-- Description of redirect tracker cookies that can be blocked by Enhanced Tracking Protection -->
+    <string name="etp_redirect_trackers_description">Limpa as cookies establecidas por redireccións a sitios web de seguimento coñecidos.</string>
+
+    <!-- About page link text to open support link -->
+    <string name="about_support">Asistencia técnica</string>
+
+    <!-- About page link text to list of past crashes (like about:crashes on desktop) -->
+    <string name="about_crashes">Quebras</string>
+    <!-- About page link text to open privacy notice link -->
+    <string name="about_privacy_notice">Aviso de privacidade</string>
+    <!-- About page link text to open know your rights link -->
+    <string name="about_know_your_rights">Coñeza os seus dereitos</string>
+    <!-- About page link text to open licensing information link -->
+    <string name="about_licensing_information">Información de licenciamento</string>
+    <!-- About page link text to open a screen with libraries that are used -->
+    <string name="about_other_open_source_libraries">Bibliotecas que empregamos</string>
+    <!-- Toast shown to the user when they are activating the secret dev menu
+        The first parameter is number of long clicks left to enable the menu -->
+    <string name="about_debug_menu_toast_progress">Menú de depuración: quedan %1$d clic(s) para habilitalo</string>
+    <string name="about_debug_menu_toast_done">Menú de depuración activado</string>
+
+    <!-- Content description of the tab counter toolbar button when one tab is open -->
+    <string name="tab_counter_content_description_one_tab">1 lapela</string>
+    <!-- Content description of the tab counter toolbar button when multiple tabs are open. First parameter will be replaced with the number of tabs (always more than one) -->
+    <string name="tab_counter_content_description_multi_tab">%d lapelas</string>
+
+    <!-- Browser long press popup menu -->
+    <!-- Copy the current url -->
+    <string name="browser_toolbar_long_press_popup_copy">Copiar</string>
+    <!-- Paste & go the text in the clipboard. '&amp;' is replaced with the ampersand symbol: & -->
+    <string name="browser_toolbar_long_press_popup_paste_and_go">Pegar e ir</string>
+    <!-- Paste the text in the clipboard -->
+    <string name="browser_toolbar_long_press_popup_paste">Pegar</string>
+    <!-- Snackbar message shown after an URL has been copied to clipboard. -->
+    <string name="browser_toolbar_url_copied_to_clipboard_snackbar">Copiouse o URL ao portapapeis</string>
+
+    <!-- Title text for the Add To Homescreen dialog -->
+    <string name="add_to_homescreen_title">Engadir á páxina de inicio</string>
+    <!-- Cancel button text for the Add to Homescreen dialog -->
+    <string name="add_to_homescreen_cancel">Cancelar</string>
+    <!-- Add button text for the Add to Homescreen dialog -->
+    <string name="add_to_homescreen_add">Engadir</string>
+    <!-- Continue to website button text for the first-time Add to Homescreen dialog -->
+    <string name="add_to_homescreen_continue">Continuar ao sitio web</string>
+    <!-- Placeholder text for the TextView in the Add to Homescreen dialog -->
+    <string name="add_to_homescreen_text_placeholder">Nome do atallo</string>
+    <!-- Describes the add to homescreen functionality -->
+    <string name="add_to_homescreen_description_2">Pode engadir facilmente este sitio web á pantalla de inicio do dispositivo para ter acceso instantáneo e navegar máis rápido cunha experiencia semellante á dunha aplicación.</string>
+
+    <!-- Preference for managing the settings for logins and passwords in Fenix -->
+    <string name="preferences_passwords_logins_and_passwords">Identificacións e contrasinais</string>
+    <!-- Preference for managing the saving of logins and passwords in Fenix -->
+    <string name="preferences_passwords_save_logins">Gardar Inicios de sesión e contrasinais</string>
+    <!-- Preference option for asking to save passwords in Fenix -->
+    <string name="preferences_passwords_save_logins_ask_to_save">Preguntar para gardar</string>
+    <!-- Preference option for never saving passwords in Fenix -->
+    <string name="preferences_passwords_save_logins_never_save">Non gardar nunca</string>
+    <!-- Preference for autofilling saved logins in Fenix -->
+    <string name="preferences_passwords_autofill">Completado automático</string>
+    <!-- Preference for syncing saved logins in Fenix -->
+    <string name="preferences_passwords_sync_logins">Sincronizar os inicios de sesión</string>
+    <!-- Syncing saved logins in Fenix is on -->
+    <string name="preferences_passwords_sync_logins_on">Activado</string>
+    <!-- Syncing saved logins in Fenix is off -->
+    <string name="preferences_passwords_sync_logins_off">Desactivado</string>
+    <!-- Syncing saved logins in Fenix needs reconnect to sync -->
+    <string name="preferences_passwords_sync_logins_reconnect">Conectar de novo</string>
+    <!-- Syncing saved logins in Fenix needs login -->
+    <string name="preferences_passwords_sync_logins_sign_in">Inicie sesión para sincronizar</string>
+    <!-- Preference to access list of saved logins -->
+    <string name="preferences_passwords_saved_logins">Identificacións gardadas</string>
+    <!-- Description of empty list of saved passwords. Placeholder is replaced with app name.  -->
+    <string name="preferences_passwords_saved_logins_description_empty_text">Os inicios de sesión que garde ou sincronice co %s aparecerán aquí.</string>
+    <!-- Preference to access list of saved logins -->
+    <string name="preferences_passwords_saved_logins_description_empty_learn_more_link">Obteña máis información sobre Sync.</string>
+    <!-- Preference to access list of login exceptions that we never save logins for -->
+    <string name="preferences_passwords_exceptions">Excepcións</string>
+    <!-- Empty description of list of login exceptions that we never save logins for -->
+    <string name="preferences_passwords_exceptions_description_empty">Aquí mostraranse os inicios de sesión e os contrasinais que non se garden.</string>
+    <!-- Description of list of login exceptions that we never save logins for -->
+    <string name="preferences_passwords_exceptions_description">Non se gardarán os inicios de sesión e os contrasinais para estes sitios.</string>
+    <!-- Text on button to remove all saved login exceptions -->
+    <string name="preferences_passwords_exceptions_remove_all">Eliminar todas as excepcións</string>
+    <!-- Hint for search box in logins list -->
+    <string name="preferences_passwords_saved_logins_search">Buscar inicios de sesións</string>
+    <!-- Option to sort logins list A-Z, alphabetically -->
+    <string name="preferences_passwords_saved_logins_alphabetically">Alfabeticamente</string>
+    <!-- Option to sort logins list by most recently used -->
+    <string name="preferences_passwords_saved_logins_recently_used">Usados recentemente</string>
+    <!-- The header for the site that a login is for -->
+    <string name="preferences_passwords_saved_logins_site">Sitio</string>
+    <!-- The header for the username for a login -->
+    <string name="preferences_passwords_saved_logins_username">Nome de usuario</string>
+    <!-- The header for the password for a login -->
+    <string name="preferences_passwords_saved_logins_password">Contrasinal</string>
+    <!-- Message displayed in security prompt to reenter a secret pin to access saved logins -->
+    <string name="preferences_passwords_saved_logins_enter_pin">Introduza de novo o seu PIN</string>
+    <!-- Message displayed in security prompt to access saved logins -->
+    <string name="preferences_passwords_saved_logins_enter_pin_description">Desbloquee para ver os seus inicios de sesión gardados</string>
+    <!-- Message displayed when a connection is insecure and we detect the user is entering a password -->
+    <string name="logins_insecure_connection_warning">Esta conexión non é segura. As identificacións introducidas aquí poderían estar comprometidas.</string>
+    <!-- Learn more link that will link to a page with more information displayed when a connection is insecure and we detect the user is entering a password -->
+    <string name="logins_insecure_connection_warning_learn_more">Máis información</string>
+    <!-- Prompt message displayed when Fenix detects a user has entered a password and user decides if Fenix should save it. The first parameter is the name of the application (For example: Fenix)  -->
+    <string name="logins_doorhanger_save">Desexa que %s garde este inicio de sesión?</string>
+    <!-- Positive confirmation that Fenix should save the new or updated login -->
+    <string name="logins_doorhanger_save_confirmation">Gardar</string>
+    <!-- Negative confirmation that Fenix should not save the new or updated login -->
+    <string name="logins_doorhanger_save_dont_save">Non gardar</string>
+    <!-- Shown in snackbar to tell user that the password has been copied -->
+    <string name="logins_password_copied">Copiouse o contrasinal ao portapapeis</string>
+    <!-- Shown in snackbar to tell user that the username has been copied -->
+    <string name="logins_username_copied">Copiouse o nome de usuario ao portapapeis</string>
+    <!-- Shown in snackbar to tell user that the site has been copied -->
+    <string name="logins_site_copied">Copiouse o sitio ao portapapeis</string>
+    <!-- Content Description (for screenreaders etc) read for the button to copy a password in logins-->
+    <string name="saved_logins_copy_password">Copiar contrasinal</string>
+    <!-- Content Description (for screenreaders etc) read for the button to clear a password while editing a login-->
+    <string name="saved_logins_clear_password">Limpar contrasinal</string>
+    <!-- Content Description (for screenreaders etc) read for the button to copy a username in logins -->
+    <string name="saved_login_copy_username">Copiar nome de usuario</string>
+    <!-- Content Description (for screenreaders etc) read for the button to clear a username while editing a login -->
+    <string name="saved_login_clear_username">Limpar nome de usuario</string>
+    <!-- Content Description (for screenreaders etc) read for the button to copy a site in logins -->
+    <string name="saved_login_copy_site">Copiar sitio</string>
+    <!-- Content Description (for screenreaders etc) read for the button to open a site in logins -->
+    <string name="saved_login_open_site">Abrir sitio no navegador</string>
+    <!-- Content Description (for screenreaders etc) read for the button to reveal a password in logins -->
+    <string name="saved_login_reveal_password">Mostrar contrasinal</string>
+    <!-- Content Description (for screenreaders etc) read for the button to hide a password in logins -->
+    <string name="saved_login_hide_password">Agochar contrasinal</string>
+    <!-- Message displayed in biometric prompt displayed for authentication before allowing users to view their logins -->
+    <string name="logins_biometric_prompt_message">Desbloquee para ver os seus inicios de sesión gardados</string>
+    <!-- Title of warning dialog if users have no device authentication set up -->
+    <string name="logins_warning_dialog_title">Protexa os seus inicios de sesión e contrasinais</string>
+    <!-- Message of warning dialog if users have no device authentication set up -->
+    <string name="logins_warning_dialog_message">Configure un patrón de bloqueo de dispositivo, PIN ou contrasinal para protexer os accesos e contrasinais gardados de que non se acceda se outra persoa ten o seu dispositivo.</string>
+    <!-- Negative button to ignore warning dialog if users have no device authentication set up -->
+    <string name="logins_warning_dialog_later">Máis tarde</string>
+    <!-- Positive button to send users to set up a pin of warning dialog if users have no device authentication set up -->
+    <string name="logins_warning_dialog_set_up_now">Configurar agora</string>
+    <!-- Title of PIN verification dialog to direct users to re-enter their device credentials to access their logins -->
+    <string name="logins_biometric_prompt_message_pin">Desbloquear o dispositivo</string>
+    <!-- Saved logins sorting strategy menu item -by name- (if selected, it will sort saved logins alphabetically) -->
+    <string name="saved_logins_sort_strategy_alphabetically">Nome (A-Z)</string>
+    <!-- Saved logins sorting strategy menu item -by last used- (if selected, it will sort saved logins by last used) -->
+    <string name="saved_logins_sort_strategy_last_used">Usado por última vez</string>
+    <!-- Content description (not visible, for screen readers etc.): Sort saved logins dropdown menu chevron icon -->
+    <string name="saved_logins_menu_dropdown_chevron_icon_content_description">Ordenar o menú de inicio de sesión</string>
+
+    <!-- Title of the Add search engine screen -->
+    <string name="search_engine_add_custom_search_engine_title">Engadir motor de busca</string>
+    <!-- Title of the Edit search engine screen -->
+    <string name="search_engine_edit_custom_search_engine_title">Editar motor de busca</string>
+
+    <!-- Content description (not visible, for screen readers etc.): Title for the button to add a search engine in the action bar -->
+    <string name="search_engine_add_button_content_description">Engadir</string>
+    <!-- Content description (not visible, for screen readers etc.): Title for the button to save a search engine in the action bar -->
+    <string name="search_engine_add_custom_search_engine_edit_button_content_description">Gardar</string>
+    <!-- Text for the menu button to edit a search engine -->
+    <string name="search_engine_edit">Editar</string>
+    <!-- Text for the menu button to delete a search engine -->
+    <string name="search_engine_delete">Eliminar</string>
+
+    <!-- Text for the button to create a custom search engine on the Add search engine screen -->
+    <string name="search_add_custom_engine_label_other">Outro</string>
+    <!-- Placeholder text shown in the Search Engine Name TextField before a user enters text -->
+    <string name="search_add_custom_engine_name_hint">Nome</string>
+    <!-- Placeholder text shown in the Search String TextField before a user enters text -->
+    <string name="search_add_custom_engine_search_string_hint">Cadea de busca para usar</string>
+    <!-- Description text for the Search String TextField. The %s is part of the string -->
+    <string name="search_add_custom_engine_search_string_example">Substitúír a consulta por «%s». Exemplo:\nhttps://www.google.com/search?q=</string>
+    <!-- Text for the button to learn more about adding a custom search engine -->
+    <string name="search_add_custom_engine_learn_more_label">Máis información</string>
+    <!-- Accessibility description for the form in which details about the custom search engine are entered -->
+    <string name="search_add_custom_engine_form_description">Detalles do motor de busca personalizado</string>
+
     </resources>

--- a/app/src/main/res/values-ka/strings.xml
+++ b/app/src/main/res/values-ka/strings.xml
@@ -151,8 +151,6 @@
     <string name="browser_menu_find_in_page">პოვნა გვერდზე</string>
     <!-- Browser menu button that creates a private tab -->
     <string name="browser_menu_private_tab">პირადი ჩანართი</string>
-    <!-- Browser menu button that creates a new tab -->
-    <string name="browser_menu_new_tab">ახალი ჩანართი</string>
     <!-- Browser menu button that saves the current tab to a collection -->
     <string name="browser_menu_save_to_collection_2">კრებულში შენახვა</string>
     <!-- Browser menu button that open a share menu to share the current site -->
@@ -360,6 +358,12 @@
     <string name="customize_addon_collection_user_hint">კრებულის მფლობელი (მომხმარებლის ID)</string>
     <!-- Toast shown after confirming the custom add-on collection configuration -->
     <string name="toast_customize_addon_collection_done">დამატებების კრებული შეიცვალა. დატოვეთ პროგრამა ცვლილებების ასასახად…</string>
+
+    <!-- Add-on Installation from AMO-->
+    <!-- Error displayed when user attempts to install an add-on from AMO (addons.mozilla.org) that is not supported -->
+    <string name="addon_not_supported_error">დამატება არაა მხარდაჭერილი</string>
+    <!-- Error displayed when user attempts to install an add-on from AMO (addons.mozilla.org) that is already installed -->
+    <string name="addon_already_installed">დამატება უკვე ჩადგმულია</string>
 
     <!-- Account Preferences -->
     <!-- Preference for triggering sync -->
@@ -718,18 +722,22 @@
     <string name="download_delete_all">ჩამოტვირთვების წაშლა</string>
     <!-- Text for the dialog to confirm clearing all downloads -->
     <string name="download_delete_all_dialog">ნამდვილად გსურთ წაიშალოს ჩამოტვირთვები?</string>
-    <!-- Text for the snackbar to confirm that multiple downloads items have been deleted -->
-    <string name="download_delete_multiple_items_snackbar">ჩამოტვირთვები წაიშალა</string>
+    <!-- Text for the snackbar to confirm that multiple downloads items have been removed -->
+    <string name="download_delete_multiple_items_snackbar_1">ჩამოტვირთვები მოცილებულია</string>
+    <!-- Text for the snackbar to confirm that a single download item has been removed. The first parameter is the name of the download item. -->
+    <string name="download_delete_single_item_snackbar">%1$s მოცილებულია</string>
     <!-- Text shown when no download exists -->
-    <string name="download_empty_message">ჩამოტვირთვები არაა</string>
+    <string name="download_empty_message_1">ჩამოტვირთული ფაილები არაა</string>
     <!-- History multi select title in app bar
     The first parameter is the number of downloads selected -->
     <string name="download_multi_select_title">შერჩეულია %1$d</string>
 
     <!-- History overflow menu open in new tab button -->
     <string name="download_menu_open">გახსნა</string>
-    <!-- Text for the button to delete a single history item -->
-    <string name="download_delete_item">წაშლა</string>
+
+
+    <!-- Text for the button to remove a single download item -->
+    <string name="download_delete_item_1">მოცილება</string>
 
 
     <!-- Crashes -->
@@ -855,6 +863,8 @@
     <string name="preference_phone_feature_notification">შეტყობინება</string>
     <!-- Preference for altering the persistent storage access for all websites -->
     <string name="preference_phone_feature_persistent_storage">მუდმივი მეხსიერება</string>
+    <!-- Preference for altering the EME access for all websites -->
+    <string name="preference_phone_feature_media_key_system_access">DRM-დაქვემდებარებული შიგთავსი</string>
     <!-- Label that indicates that a permission must be asked always -->
     <string name="preference_option_phone_feature_ask_to_allow">კითხვა ყოველ ჯერზე</string>
     <!-- Label that indicates that a permission must be blocked -->

--- a/app/src/main/res/values-sat/strings.xml
+++ b/app/src/main/res/values-sat/strings.xml
@@ -714,6 +714,12 @@
     <string name="download_delete_all">ᱰᱟᱩᱱᱞᱳᱰ ᱠᱚ ᱢᱮᱴᱟᱣ ᱢᱮ</string>
     <!-- Text for the dialog to confirm clearing all downloads -->
     <string name="download_delete_all_dialog">ᱟᱢ ᱡᱷᱚᱛᱚ ᱞᱮᱠᱷᱟ ᱛᱮ ᱟᱢᱟᱜ ᱰᱟᱩᱱᱞᱳᱰ ᱠᱚ ᱢᱮᱴᱟᱣ ᱥᱟᱱᱟᱢ ᱠᱟᱱᱟ ᱥᱮ?</string>
+    <!-- Text for the snackbar to confirm that multiple downloads items have been removed -->
+    <string name="download_delete_multiple_items_snackbar_1">ᱰᱟᱩᱱᱞᱳᱰᱠᱚ ᱚᱪᱚᱜᱮᱱᱟ</string>
+    <!-- Text for the snackbar to confirm that a single download item has been removed. The first parameter is the name of the download item. -->
+    <string name="download_delete_single_item_snackbar">%1$s ᱚᱪᱚᱜᱮᱱᱟ</string>
+    <!-- Text shown when no download exists -->
+    <string name="download_empty_message_1">ᱱᱚᱰᱮ ᱰᱟᱩᱱᱞᱳᱰ ᱟᱠᱟᱱ ᱨᱮᱫ ᱠᱚ ᱵᱚᱱᱩᱜ-ᱟ</string>
     <!-- History multi select title in app bar
     The first parameter is the number of downloads selected -->
     <string name="download_multi_select_title">%1$d ᱵᱟᱪᱷᱟᱣᱮᱱᱟ</string>

--- a/app/src/main/res/values-sat/strings.xml
+++ b/app/src/main/res/values-sat/strings.xml
@@ -14,7 +14,7 @@
     <!-- Placeholder text shown in the search bar before a user enters text -->
     <string name="search_hint">ᱥᱮᱸᱫᱽᱨᱟ ᱵᱟᱝᱠᱷᱟᱱ ᱴᱷᱤᱠᱟᱹᱬᱟ ᱟᱫᱮᱨ</string>
     <!-- No Open Tabs Message Description -->
-    <string name="no_open_tabs_description">ᱟᱢᱟᱜ ᱠᱷᱩᱞᱟᱹ ᱟᱠᱟᱱ ᱴᱮᱵ ᱠᱚ ᱫᱚ ᱱᱚᱰᱮ ᱫᱮᱠᱷᱟᱣᱼᱜᱟ ᱾</string>
+    <string name="no_open_tabs_description">ᱟᱢᱟᱜ ᱠᱷᱩᱞᱟᱹ ᱟᱠᱟᱱ ᱴᱮᱵ ᱠᱚ ᱫᱚ ᱱᱚᱰᱮ ᱫᱮᱠᱷᱟᱣᱜᱼᱟ ᱾</string>
     <!-- No Private Tabs Message Description -->
     <string name="no_private_tabs_description">ᱟᱢᱟᱜ ᱱᱤᱡᱚᱨᱟᱜ ᱴᱮᱵᱽ ᱠᱚ ᱫᱚ ᱱᱚᱰᱮ ᱩᱫᱩᱜ ᱦᱩᱭᱩᱜ-ᱟ ᱾</string>
     <!-- Default title for pinned Baidu top site that links to Baidu home page  -->
@@ -112,7 +112,7 @@
 
     <!-- Browser Fragment -->
     <!-- Content description (not visible, for screen readers etc.): Navigate to open tabs -->
-    <string name="browser_tabs_button">ᱡᱷᱤᱡ ᱴᱮᱵᱽ ᱠᱚ</string>
+    <string name="browser_tabs_button">ᱡᱷᱤᱡᱽ ᱟᱠᱟᱱ ᱴᱮᱵ ᱠᱚ</string>
     <!-- Content description (not visible, for screen readers etc.): Navigate backward (browsing history) -->
     <string name="browser_menu_back">ᱛᱟᱭᱚᱢ</string>
     <!-- Content description (not visible, for screen readers etc.): Navigate forward (browsing history) -->
@@ -266,7 +266,7 @@
     <!-- Preference for private browsing options -->
     <string name="preferences_private_browsing_options">ᱱᱤᱡᱮᱨᱟᱜ ᱵᱨᱟᱩᱡᱤᱝ</string>
     <!-- Preference for opening links in a private tab-->
-    <string name="preferences_open_links_in_a_private_tab">ᱞᱤᱸᱠ ᱠᱚ ᱱᱤᱡᱮᱨᱟᱜ ᱴᱮᱵ ᱨᱮ ᱡᱷᱤᱡ ᱢᱮ</string>
+    <string name="preferences_open_links_in_a_private_tab">ᱞᱤᱸᱠ ᱠᱚ ᱱᱤᱡᱮᱨᱟᱜ ᱴᱮᱵ ᱨᱮ ᱡᱷᱤᱡᱽ ᱢᱮ</string>
     <!-- Preference for allowing screenshots to be taken while in a private tab-->
     <string name="preferences_allow_screenshots_in_private_mode">ᱱᱤᱡᱮᱨᱟᱜ ᱵᱨᱟᱩᱡᱤᱝ ᱨᱮ ᱥᱠᱨᱤᱱᱥᱚᱴ ᱠᱚ ᱦᱮᱥᱟᱨᱤᱭᱟᱹ ᱢᱮ</string>
     <!-- Will inform the user of the risk of activating Allow screenshots in private browsing option -->
@@ -533,7 +533,7 @@
     <string name="content_description_close_button">ᱵᱚᱸᱫᱚᱭ ᱢᱮ</string>
 
     <!-- Option in library for Recently Closed Tabs -->
-    <string name="library_recently_closed_tabs">ᱱᱤᱛᱚᱜᱼᱟᱜ ᱵᱚᱸᱫᱚᱼᱟᱜ ᱴᱮᱵ ᱠᱚ</string>
+    <string name="library_recently_closed_tabs">ᱱᱤᱛᱚᱜᱽᱼᱟᱜ ᱵᱚᱸᱫᱚᱼᱟᱜ ᱴᱮᱵ ᱠᱚ</string>
     <!-- Option in library to open Recently Closed Tabs page -->
     <string name="recently_closed_show_full_history">ᱥᱟᱱᱟᱢ ᱦᱤᱛᱟᱹᱞ ᱫᱮᱠᱷᱟᱣᱢᱮ</string>
     <!-- Text to show users they have multiple tabs saved in the Recently Closed Tabs section of history.
@@ -544,7 +544,7 @@
     <string name="recently_closed_tab">%d ᱴᱮᱵ</string>
 
     <!-- Recently closed tabs screen message when there are no recently closed tabs -->
-    <string name="recently_closed_empty_message">ᱱᱤᱛᱚᱜᱼᱟᱜ ᱵᱚᱸᱫᱚᱼᱟᱜ ᱴᱮᱵ ᱠᱚ ᱵᱟᱹᱱᱩᱜ-ᱟ</string>
+    <string name="recently_closed_empty_message">ᱱᱤᱛᱚᱜᱽᱼᱟᱜ ᱵᱚᱸᱫᱚᱼᱟᱜ ᱴᱮᱵ ᱠᱚ ᱵᱟᱹᱱᱩᱜᱼᱟ</string>
 
     <!-- Tab Management -->
     <!-- Title of preference for tabs management -->
@@ -579,7 +579,7 @@
 
     <!-- Sessions -->
     <!-- Title for the list of tabs -->
-    <string name="tab_header_label">ᱡᱷᱤᱜ ᱴᱮᱵ ᱠᱚ</string>
+    <string name="tab_header_label">ᱡᱷᱤᱡᱽ ᱟᱠᱟᱱ ᱴᱮᱵ ᱠᱚ</string>
     <!-- Title for the list of tabs in the current private session -->
     <string name="tabs_header_private_title">ᱯᱨᱭᱣᱮᱴ ᱯᱟᱲᱤ</string>
     <!-- Title for the list of tabs in the current private session -->
@@ -591,7 +591,7 @@
     <!-- Text for the new tab button to indicate adding a new private tab in the tab -->
     <string name="tab_drawer_fab_content">ᱯᱨᱭᱣᱮᱴ</string>
     <!-- Text shown as the title of the open tab tray -->
-    <string name="tab_tray_title">ᱡᱷᱤᱜ ᱴᱮᱵ ᱠᱚ</string>
+    <string name="tab_tray_title">ᱡᱷᱤᱡᱽ ᱟᱠᱟᱱ ᱴᱮᱵ ᱠᱚ</string>
     <!-- Text shown in the menu for saving tabs to a collection -->
     <string name="tab_tray_menu_item_save">ᱛᱩᱢᱟᱹᱞ ᱨᱮ ᱥᱟᱸᱪᱟᱣ ᱢᱮ</string>
     <!-- Text shown in the menu for the collection selector -->
@@ -599,7 +599,7 @@
     <!-- Text shown in the menu for sharing all tabs -->
     <string name="tab_tray_menu_item_share">ᱡᱷᱚᱛᱚ ᱴᱮᱵ ᱠᱚ ᱦᱟᱹᱴᱧ ᱢᱮ</string>
     <!-- Text shown in the menu to view recently closed tabs -->
-    <string name="tab_tray_menu_recently_closed">ᱱᱤᱛᱚᱜᱼᱟᱜ ᱵᱚᱸᱫᱚᱼᱟᱜ ᱴᱮᱵ ᱠᱚ</string>
+    <string name="tab_tray_menu_recently_closed">ᱱᱤᱛᱚᱜᱽᱼᱟᱜ ᱵᱚᱸᱫᱚᱼᱟᱜ ᱴᱮᱵ ᱠᱚ</string>
     <!-- Text shown in the menu to view tab settings -->
     <string name="tab_tray_menu_tab_settings">ᱴᱮᱵ ᱨᱮᱭᱟᱜ ᱥᱟᱡᱟᱣ ᱠᱚ</string>
     <!-- Text shown in the menu for closing all tabs -->
@@ -653,7 +653,7 @@
     <!-- Text for the menu button to rename a collection -->
     <string name="collection_rename">ᱛᱩᱢᱟᱹᱞ ᱫᱚᱦᱲᱟ ᱧᱩᱛᱩᱢ ᱢᱮ</string>
     <!-- Text for the button to open tabs of the selected collection -->
-    <string name="collection_open_tabs">ᱡᱷᱤᱜ ᱴᱮᱵ ᱠᱚ</string>
+    <string name="collection_open_tabs">ᱡᱷᱤᱡᱽ ᱟᱠᱟᱱ ᱴᱮᱵ ᱠᱚ</string>
     <!-- Hint for adding name of a collection -->
     <string name="collection_name_hint">ᱛᱩᱢᱟᱹᱞ ᱧᱩᱛᱩᱢ</string>
     <!-- Text for the menu button to rename a top site -->
@@ -1433,7 +1433,7 @@
     <!-- Preference to access list of saved logins -->
     <string name="preferences_passwords_saved_logins">ᱥᱟᱸᱪᱟᱣᱠᱟᱱ ᱞᱚᱜᱤᱱ ᱠᱚ</string>
     <!-- Description of empty list of saved passwords. Placeholder is replaced with app name.  -->
-    <string name="preferences_passwords_saved_logins_description_empty_text">ᱞᱚᱜᱤᱱ ᱚᱠᱟ %s ᱨᱮ ᱥᱟᱸᱪᱟᱣ ᱟᱨ ᱥᱭᱸᱠ ᱥᱟᱱᱟᱢ ᱠᱟᱱᱟ ᱚᱱᱟ ᱠᱚ ᱱᱚᱰᱮ ᱫᱮᱠᱷᱟᱣᱼᱜᱟ ᱾</string>
+    <string name="preferences_passwords_saved_logins_description_empty_text">ᱞᱚᱜᱤᱱ ᱚᱠᱟ %s ᱨᱮ ᱥᱟᱸᱪᱟᱣ ᱟᱨ ᱥᱭᱸᱠ ᱥᱟᱱᱟᱢ ᱠᱟᱱᱟ ᱚᱱᱟ ᱠᱚ ᱱᱚᱰᱮ ᱫᱮᱠᱷᱟᱣᱜᱼᱟ ᱾</string>
     <!-- Preference to access list of saved logins -->
     <string name="preferences_passwords_saved_logins_description_empty_learn_more_link">ᱥᱭᱸᱠ ᱵᱟᱵᱚᱛ ᱡᱟᱹᱥᱛᱤ ᱵᱟᱰᱟᱭ ᱢᱮ ᱾</string>
     <!-- Preference to access list of login exceptions that we never save logins for -->

--- a/app/src/main/res/values-ta/strings.xml
+++ b/app/src/main/res/values-ta/strings.xml
@@ -358,7 +358,7 @@
     <!-- Label summary showing never synced -->
     <string name="sync_failed_never_synced_summary">ஒத்திசைவு தோல்வி. கடைசியாக ஒத்திசைக்கப்பட்டது: இல்லை</string>
     <!-- Label summary the date we last synced. The first parameter is date stamp showing last time synced -->
-    <string name="sync_last_synced_summary">கடைசி ஒத்திசைவு: %@</string>
+    <string name="sync_last_synced_summary">கடைசி ஒத்திசைவு: %s</string>
     <!-- Label summary showing never synced -->
     <string name="sync_never_synced_summary">கடைசி ஒத்திசைவு: இல்லை</string>
 

--- a/app/src/main/res/values-te/strings.xml
+++ b/app/src/main/res/values-te/strings.xml
@@ -262,6 +262,8 @@
     <string name="preferences_open_links_in_a_private_tab">లంకెలను అంతరంగిక ట్యాబులో తెరువు</string>
     <!-- Preference for allowing screenshots to be taken while in a private tab-->
     <string name="preferences_allow_screenshots_in_private_mode">అంతరంగిక విహరణలో తెరపట్లను అనుమతించు</string>
+    <!-- Will inform the user of the risk of activating Allow screenshots in private browsing option -->
+    <string name="preferences_screenshots_in_private_mode_disclaimer">అనుమతిస్తే, పలు అనువర్తనాలు తెరిచివున్నప్పుడు అంతరంగిక ట్యాబులు కూడా కనిపిస్తాయి</string>
     <!-- Preference for adding private browsing shortcut -->
     <string name="preferences_add_private_browsing_shortcut">అంతరంగిక విహరణ సత్వరమార్గాన్ని చేర్చు</string>
     <!-- Preference for accessibility -->
@@ -427,6 +429,8 @@
     <string name="preferences_marketing_data_description">%1$sలో మీరు ఏయే సౌలభ్యాలు వాడుకుంటున్నారనే డేటాను మా మొబైలు మార్కెటింగ్ విక్రేత లిన్‌ప్లమ్‌తో పంచుకుంటుంది.</string>
     <!-- Title for studies preferences -->
     <string name="preference_experiments_2">అధ్యయనాలు</string>
+    <!-- Summary for studies preferences -->
+    <string name="preference_experiments_summary_2">అధ్యయనాలను స్థాపించడానికి, నడపడానికి Mozillaకు అనుమతినిస్తుంది</string>
     <!-- Title for experiments preferences -->
     <string name="preference_experiments">ప్రయోగాలు</string>
 
@@ -479,6 +483,9 @@
     <!-- Gestures Preferences-->
     <!-- Preferences for using pull to refresh in a webpage -->
     <string name="preference_gestures_website_pull_to_refresh">రిఫ్రెష్ చేయడానికి లాగండి</string>
+
+    <!-- Preference for using the dynamic toolbar -->
+    <string name="preference_gestures_dynamic_toolbar">పనిముట్లపట్టీని దాచడానికి స్క్రోల్ చేయండి</string>
 
     <!-- Library -->
     <!-- Option in Library to open Sessions page -->

--- a/app/src/main/res/values-trs/strings.xml
+++ b/app/src/main/res/values-trs/strings.xml
@@ -21,10 +21,23 @@
     <!-- No Private Tabs Message Description -->
     <string name="no_private_tabs_description">Hiūj nan nāruguì\’ nej rakïj ñanj huì nīkājt.</string>
 
+    <!-- Default title for pinned Baidu top site that links to Baidu home page  -->
+    <string name="default_top_site_baidu">Baidu</string>
+    <!-- Default title for pinned JD top site that links to JD home page  -->
+    <string name="default_top_site_jd">JD</string>
     <!-- Message announced to the user when tab tray is selected with 1 tab -->
     <string name="open_tab_tray_single">1 nā\'nïn rakïj ñanj. Gūru\'man ra\'a da\' nādūnāt rakïj ñanj.</string>
     <!-- Message announced to the user when tab tray is selected with 0 or 2+ tabs -->
     <string name="open_tab_tray_plural">%1$s nā\'nïn nej rakïj ñanj. Gūru\'man ra\'a da\' nādūnāt nej rakïj ñanj.</string>
+
+    <!-- Tab tray multi select title in app bar. The first parameter is the number of tabs selected -->
+    <string name="tab_tray_multi_select_title">%1$d sa naguij</string>
+    <!-- Label of button in create collection dialog for creating a new collection  -->
+    <string name="tab_tray_add_new_collection">Nūtà\' \'ngō yi\'nïn\' nākàa</string>
+    <!-- Label of editable text in create collection dialog for naming a new collection  -->
+    <string name="tab_tray_add_new_collection_name">Si yugui</string>
+    <!-- Label of button in save to collection dialog for selecting a current collection  -->
+    <string name="tab_tray_select_collection">Nāguī sa màn yì\'nïn\'ïn</string>
 
     <!-- About content. The first parameter is the name of the application. (For example: Fenix) -->
     <string name="about_content">%1$s huin \’ngō sa giri Mozilla.</string>
@@ -47,14 +60,6 @@
     <string name="cfr_pos_button_text">Nūtà\' \'ngō aksêso dirêckto</string>
     <!-- Text for the negative button -->
     <string name="cfr_neg_button_text">Guruhuât nānj ân</string>
-
-    <!-- Search widget "contextual feature recommendation" (CFR) -->
-    <!-- Text for the main message. 'Firefox' intentionally hardcoded here.-->
-    <string name="search_widget_cfr_message">Gūchì\' hìo doj riña Firefox. Nūtà\' \'ngō widget riña pantayâ ayi\'ìt.</string>
-    <!-- Text for the positive button -->
-    <string name="search_widget_cfr_pos_button_text">Nūtà\' widget</string>
-    <!-- Text for the negative button -->
-    <string name="search_widget_cfr_neg_button_text">Sī ga\'ue akuan\' nïn</string>
 
     <!-- Home screen icons - Long press shortcuts -->
     <!-- Shortcut action to open new tab -->
@@ -107,8 +112,6 @@
     <string name="browser_menu_find_in_page">Nānà\'uì\' riña ñanj</string>
     <!-- Browser menu button that creates a private tab -->
     <string name="browser_menu_private_tab">Rakïj ñanj huìi</string>
-    <!-- Browser menu button that creates a new tab -->
-    <string name="browser_menu_new_tab">Rakïj ñanj nakàa</string>
     <!-- Browser menu button that saves the current tab to a collection -->
     <string name="browser_menu_save_to_collection_2">Na\'nïnj sà\' riña màn si yi\'nïnj</string>
 
@@ -167,7 +170,6 @@
     <!-- Search suggestion onboarding hint Learn more link text -->
     <string name="search_suggestions_onboarding_learn_more_link">Gāhuin chrūn doj</string>
 
-    <!-- Search Widget -->
     <!-- Text preview for smaller sized widgets -->
     <string name="search_widget_text_short">Nānà\'uì\'</string>
     <!-- Text preview for larger sized widgets -->
@@ -516,7 +518,7 @@
     <!-- Text for the button to open tabs of the selected collection -->
     <string name="collection_open_tabs">Nej Rakïj ñanj huā nî\'nïnj ïn</string>
     <!-- Text for the menu button to remove a top site -->
-    <string name="remove_top_site">Nādure\'</string>
+	<string name="remove_top_site">Nādure\'</string>
     <!-- Postfix for private WebApp titles, placeholder is replaced with app name -->
     <string name="pwa_site_controls_title_private">%1$s (Riña Huìi)</string>
 
@@ -559,6 +561,7 @@
     <string name="history_older">Sa nâ doj</string>
     <!-- Text shown when no history exists -->
     <string name="history_empty_message">Nitāj à\'ngō sa gini\'iājt</string>
+
 
     <!-- Crashes -->
     <!-- Title text displayed on the tab crash page. This first parameter is the name of the application (For example: Fenix) -->
@@ -715,10 +718,6 @@
     <string name="collections_header">Koleksiôn</string>
     <!-- Content description (not visible, for screen readers etc.): Opens the collection menu when pressed -->
     <string name="collection_menu_button_content_description">Si menû koleksiûn</string>
-    <!-- No Open Tabs Message Header -->
-    <string name="no_collections_header1">Nāran\' daran\' sa ni\'ñānj ruhuât</string>
-    <!-- Label to describe what collections are to a new user without any collections -->
-    <string name="no_collections_description1">Nāgi\'iaj chrē\' sa nana\'uî\'t, sitio nī nej rakïj ñanj guñā hua da\' ga\'ue gātū hìot ne\' rūkù.</string>
     <!-- Title for the "select tabs" step of the collection creator -->
     <string name="create_collection_select_tabs">Nāguī nej rakïj ñanj</string>
     <!-- Title for the "select collection" step of the collection creator -->
@@ -973,13 +972,6 @@
     <string name="onboarding_whats_new_description">Huā sa gāchìnj na\'ānjt rayi\'î nùhuin saj nadunâ hua %s aj. Gīni\'înt sa nadunâ ruhuâ raj.</string>
     <!-- text for underlined clickable link that is part of "what's new" onboarding card description that links to an FAQ -->
     <string name="onboarding_whats_new_description_linktext">Hiūj nan \'na\' nuguan\' ruhuât gīni\'înt</string>
-    <!-- text for the firefox account onboarding card header
-    The first parameter is the name of the app (e.g. Firefox Preview) -->
-    <string name="onboarding_firefox_account_header">Nārì\' daran\' sa nīkāj %s.</string>
-    <!-- text for the firefox account onboarding card header when we detect you're already signed in to
-        another Firefox browser. (The word `Firefox` should not be translated)
-        The first parameter is the email of the detected user's account -->
-    <string name="onboarding_firefox_account_auto_signin_header_2">Ngà gayì\'ìt sēsiûn ngà %s riña a\'ngô sa nana\'ui\' Firefox riña aga\' nab. Ruhuât gāyi\'ìt sēsiûn ngà kuendâ nan anj.</string>
     <!-- text for the button to confirm automatic sign-in -->
     <string name="onboarding_firefox_account_auto_signin_confirm">Gā\'ue, gāyì\'ìj sēsiûn</string>
     <!-- text for the automatic sign-in button while signing in is in process -->
@@ -1232,9 +1224,6 @@
     <!-- Placeholder text for the TextView in the Add to Homescreen dialog -->
     <string name="add_to_homescreen_text_placeholder">Si yūgui aksêso dīrêkto</string>
 
-    <!-- Describes the add to homescreen functionality -->
-    <string name="add_to_homescreen_description">Gā\'ue nāchrūnt sitiô nan riña pajinâ ayi\'ìt riña aga\' a\'min nīkājt da\' ga\'ue hìo gātūt riñanj dàj rû\' \'iaj \'ngō aplikāsiûn</string>
-
     <!-- Preference for managing the settings for logins and passwords in Fenix -->
     <string name="preferences_passwords_logins_and_passwords">Nej riña gayi\'ìt sēsiûn nī nej da\'nga\' huìi</string>
     <!-- Preference for managing the saving of logins and passwords in Fenix -->
@@ -1468,8 +1457,6 @@
     <string name="saved_login_duplicate">Ngà huā \'ngō riña gayì\'ìt sēsiûn gù\'nàj dàdanj</string>
 
     <!-- Synced Tabs -->
-    <!-- Text displayed when user is not logged into a Firefox Account -->
-    <string name="synced_tabs_connect_to_sync_account">Gātū ngà a\'ngô kuendâ Firefox</string>
     <!-- Text displayed to ask user to connect another device as no devices found with account -->
     <string name="synced_tabs_connect_another_device">Gātū ngà a\'ngô aga\'a.</string>
     <!-- Text displayed asking user to re-authenticate -->
@@ -1486,20 +1473,20 @@
     <!-- Top Sites -->
     <!-- Title text displayed in the dialog when top sites limit is reached. -->
     <string name="top_sites_max_limit_title">Ngà guchî\'t riña da\'uît gūchì\'t guendâ nej sitiô ña’ān doj</string>
-    <!-- Content description text displayed in the dialog when top sites limit is reached. -->
-    <string name="top_sites_max_limit_content">Guendâ gānatà\' \'ngō sitiô arâj sun nīchrà\'t doj, nādure\' \'ngòj. Gūru\'man ra\'a riña sitio nī gūru\'man ra\'a nādurê\'.</string>
     <!-- Confirmation dialog button text when top sites limit is reached. -->
     <string name="top_sites_max_limit_confirmation_button">Ga\'ue, ngà garâj da\'nga\' ruhuâj</string>
 
-    <!-- DEPRECATED STRINGS -->
-    <!-- Button in the search view that lets a user search by using a shortcut -->
-    <string name="search_shortcuts_button">Nānà\'uì\' a\'ngô hiūj u</string>
+    <!-- Deprecated: text for the firefox account onboarding card header
+    The first parameter is the name of the app (e.g. Firefox Preview) -->
+    <string name="onboarding_firefox_account_header">Nārì\' daran\' sa nīkāj %s.</string>
 
-    <!-- DEPRECATED: Header displayed when selecting a shortcut search engine -->
-    <string name="search_shortcuts_search_with">Nānà\'uì\' ngà</string>
+    <!-- Deprecated: No Open Tabs Message Header -->
+    <string name="no_collections_header1">Nāran\' daran\' sa ni\'ñānj ruhuât</string>
+    <!-- Deprecated: Label to describe what collections are to a new user without any collections -->
+    <string name="no_collections_description1">Nāgi\'iaj chrē\' sa nana\'uî\'t, sitio nī nej rakïj ñanj guñā hua da\' ga\'ue gātū hìot ne\' rūkù.</string>
+    <!-- Deprecated: text for the firefox account onboarding card header when we detect you're already signed in to -->
+    <string name="onboarding_firefox_account_auto_signin_header_2">Ngà gayì\'ìt sēsiûn ngà %s riña a\'ngô sa nana\'ui\' Firefox riña aga\' nab. Ruhuât gāyi\'ìt sēsiûn ngà kuendâ nan anj.</string>
+    <!-- Deprecated: Describes the add to homescreen functionality -->
+    <string name="add_to_homescreen_description">Gā\'ue nāchrūnt sitiô nan riña pajinâ ayi\'ìt riña aga\' a\'min nīkājt da\' ga\'ue hìo gātūt riñanj dàj rû\' \'iaj \'ngō aplikāsiûn</string>
 
-    <!-- Header displayed when selecting a shortcut search engine -->
-    <string name="search_shortcuts_search_with_2">Hìaj nī, nānà\'uì\' ngà:</string>
-    <!-- Preference title for switch preference to show search shortcuts -->
-    <string name="preferences_show_search_shortcuts">Dīgân riña a\'ngô hiūj ga\'ue nānà\'uì\'</string>
     </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -473,7 +473,7 @@
     <!-- Header of the Turn on Sync preference view -->
     <string name="preferences_sync">Увімкнути синхронізацію</string>
     <!-- Preference for pairing -->
-    <string name="preferences_sync_pair">Скануйте код в Firefox на комп’ютері</string>
+    <string name="preferences_sync_pair">Скануйте код у Firefox на комп’ютері</string>
     <!-- Preference for account login -->
     <string name="preferences_sync_sign_in">Увійти</string>
     <!-- Preference for reconnecting to FxA sync -->

--- a/app/src/main/res/values-ur/strings.xml
+++ b/app/src/main/res/values-ur/strings.xml
@@ -282,6 +282,8 @@
     <string name="preferences_theme">تھیم</string>
     <!-- Preference for customizing the home screen -->
     <string name="preferences_home">ابتدائی صفحہ</string>
+    <!-- Preference for gestures based actions -->
+    <string name="preferences_gestures">اشارے</string>
     <!-- Preference for settings related to visual options -->
     <string name="preferences_customize">تخصیص کریں</string>
     <!-- Preference description for banner about signing in -->
@@ -320,6 +322,8 @@
     <string name="preferences_search_synced_tabs"></string>
     <!-- Preference for account settings -->
     <string name="preferences_account_settings">اکاؤنٹ کی سیٹنگز</string>
+    <!-- Preference for enabling url autocomplete-->
+    <string name="preferences_enable_autocomplete_urls">خودکار تکميلURLs </string>
     <!-- Preference for open links in third party apps -->
     <string name="preferences_open_links_in_apps">ایپس میں ربط کھولیں</string>
 
@@ -473,6 +477,9 @@
     <string name="preference_auto_battery_theme">بیٹری سیور کے ذریعہ مرتب کردہ</string>
     <!-- Preference for using following device theme -->
     <string name="preference_follow_device_theme">آلہ کے تھیم پر عمل کریں</string>
+
+    <!-- Preference for showing the opened tabs by swiping up on the toolbar-->
+    <string name="preference_gestures_swipe_toolbar_show_tabs">ٹیبز کو کھولنے کے لئے ٹول بار کو سوائپ کریں</string>
 
     <!-- Library -->
     <!-- Option in Library to open Sessions page -->


### PR DESCRIPTION
String Uplifts for Firefox 85 Jan 15th.

I followed the same steps as from https://github.com/mozilla-mobile/fenix/pull/17371 but the script bailed out with errors (conflicts) for previously uplifted string changes. I wonder if this is because we merged that PR incorrectly and as a result the script could not figure out that those commits were already handled?

For this update I looked at the script dry-run output and then manually ran:

```
git cherry-pick 7fc0ef53794d263881e8c3e106dab5d54ca1b78c -x
git cherry-pick 6a84eed5527f54f466e39d03140f18f6bef286ca -x
git cherry-pick 837eaa32824d6b77012bdb549118adea8a2f1ce9 -x
git cherry-pick 2a19967a326ae5b31d8ea254069fa70844b70c0f -x
```

Which is what the script also does. Let's document better what the exact steps are for next time.
