### PR TITLE
Closes #17548: Use browser store exclusively in tab tray

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabhistory/TabHistoryController.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabhistory/TabHistoryController.kt
@@ -5,7 +5,6 @@
 package org.mozilla.fenix.tabhistory
 
 import androidx.navigation.NavController
-import mozilla.components.browser.session.SessionManager
 import mozilla.components.feature.session.SessionUseCases
 
 interface TabHistoryController {
@@ -15,15 +14,16 @@ interface TabHistoryController {
 class DefaultTabHistoryController(
     private val navController: NavController,
     private val goToHistoryIndexUseCase: SessionUseCases.GoToHistoryIndexUseCase,
-    private val customTabId: String? = null,
-    private val sessionManager: SessionManager
+    private val customTabId: String? = null
 ) : TabHistoryController {
 
     override fun handleGoToHistoryItem(item: TabHistoryItem) {
         navController.navigateUp()
-        goToHistoryIndexUseCase.invoke(
-            item.index,
-            session = customTabId?.let { sessionManager.findSessionById(customTabId) }
-                ?: sessionManager.selectedSession)
+
+        if (customTabId != null) {
+            goToHistoryIndexUseCase.invoke(item.index, customTabId)
+        } else {
+            goToHistoryIndexUseCase.invoke(item.index)
+        }
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/tabhistory/TabHistoryDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabhistory/TabHistoryDialogFragment.kt
@@ -12,7 +12,6 @@ import androidx.navigation.fragment.findNavController
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
-import kotlinx.android.synthetic.main.activity_home.*
 import kotlinx.android.synthetic.main.fragment_tab_history_dialog.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.collect
@@ -22,7 +21,6 @@ import mozilla.components.lib.state.ext.flowScoped
 import mozilla.components.support.ktx.android.content.getColorFromAttr
 import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
 import org.mozilla.fenix.R
-import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.requireComponents
 
 class TabHistoryDialogFragment : BottomSheetDialogFragment() {
@@ -46,8 +44,7 @@ class TabHistoryDialogFragment : BottomSheetDialogFragment() {
         val controller = DefaultTabHistoryController(
             navController = findNavController(),
             goToHistoryIndexUseCase = requireComponents.useCases.sessionUseCases.goToHistoryIndex,
-            customTabId = customTabSessionId,
-            sessionManager = container.requireContext().components.core.sessionManager
+            customTabId = customTabSessionId
         )
         val tabHistoryView = TabHistoryView(
             container = tabHistoryLayout,

--- a/app/src/main/java/org/mozilla/fenix/tabtray/FenixTabsAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/FenixTabsAdapter.kt
@@ -12,6 +12,7 @@ import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.android.synthetic.main.checkbox_item.view.*
 import kotlinx.android.synthetic.main.tab_tray_item.view.*
+import mozilla.components.browser.state.selector.findTab
 import mozilla.components.browser.tabstray.TabViewHolder
 import mozilla.components.browser.tabstray.TabsAdapter
 import mozilla.components.concept.base.images.ImageLoader
@@ -108,7 +109,7 @@ class FenixTabsAdapter(
             showCheckedIfSelected(tab, holder.itemView)
 
             val tabIsPrivate =
-                context.components.core.sessionManager.findSessionById(tab.id)?.private == true
+                context.components.core.store.state.findTab(tab.id)?.content?.private == true
             if (!tabIsPrivate) {
                 holder.itemView.setOnLongClickListener {
                     if (mode is TabTrayDialogFragmentState.Mode.Normal) {

--- a/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayController.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayController.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import mozilla.appservices.places.BookmarkRoot
-import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.state.selector.findTab
 import mozilla.components.browser.state.selector.getNormalOrPrivateTabs
 import mozilla.components.browser.state.selector.normalTabs
@@ -63,7 +62,6 @@ interface TabTrayController {
  *
  * @param activity [Activity] the current activity.
  * @param profiler [Profiler] used for profiling.
- * @param sessionManager [HomeActivity] used for retrieving a list of sessions.
  * @param browserStore [BrowserStore] holds the global [BrowserState].
  * @param browsingModeManager [HomeActivity] used for registering browsing mode.
  * @param tabCollectionStorage [TabCollectionStorage] storage for saving collections.
@@ -87,7 +85,6 @@ interface TabTrayController {
 class DefaultTabTrayController(
     private val activity: HomeActivity,
     private val profiler: Profiler?,
-    private val sessionManager: SessionManager,
     private val browserStore: BrowserStore,
     private val browsingModeManager: BrowsingModeManager,
     private val tabCollectionStorage: TabCollectionStorage,

--- a/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayDialogFragment.kt
@@ -34,6 +34,8 @@ import kotlinx.coroutines.plus
 import mozilla.appservices.places.BookmarkRoot
 import mozilla.components.browser.session.Session
 import mozilla.components.browser.state.selector.findTab
+import mozilla.components.browser.state.selector.getNormalOrPrivateTabs
+import mozilla.components.browser.state.selector.normalTabs
 import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.thumbnails.loader.ThumbnailLoader
 import mozilla.components.feature.tab.collections.TabCollection
@@ -53,7 +55,6 @@ import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.getDefaultCollectionNumber
 import org.mozilla.fenix.ext.metrics
-import org.mozilla.fenix.ext.normalSessionSize
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.home.HomeScreenViewModel
@@ -137,11 +138,12 @@ class TabTrayDialogFragment : AppCompatDialogFragment(), UserInteractionHandler 
     private fun removeIfNotLastTab(sessionId: String) {
         // We only want to *immediately* remove a tab if there are more than one in the tab tray
         // If there is only one, the HomeFragment handles deleting the tab (to better support snackbars)
-        val sessionManager = view?.context?.components?.core?.sessionManager
-        val sessionToRemove = sessionManager?.findSessionById(sessionId)
-
-        if (sessionManager?.sessions?.filter { sessionToRemove?.private == it.private }?.size != 1) {
-            requireComponents.useCases.tabsUseCases.removeTab(sessionId)
+        val browserStore = requireComponents.core.store
+        val sessionToRemove = browserStore.state.findTab(sessionId)
+        sessionToRemove?.let {
+            if (browserStore.state.getNormalOrPrivateTabs(it.content.private).size != 1) {
+                requireComponents.useCases.tabsUseCases.removeTab(sessionId)
+            }
         }
     }
 
@@ -204,7 +206,6 @@ class TabTrayDialogFragment : AppCompatDialogFragment(), UserInteractionHandler 
                 DefaultTabTrayController(
                     activity = activity,
                     profiler = activity.components.core.engine.profiler,
-                    sessionManager = activity.components.core.sessionManager,
                     browserStore = activity.components.core.store,
                     tabsUseCases = activity.components.useCases.tabsUseCases,
                     ioScope = lifecycleScope + Dispatchers.IO,
@@ -444,7 +445,7 @@ class TabTrayDialogFragment : AppCompatDialogFragment(), UserInteractionHandler 
                         tabCollectionStorage.addTabsToCollection(collection, sessionList)
                         it.metrics.track(
                             Event.CollectionTabsAdded(
-                                it.components.core.sessionManager.normalSessionSize(),
+                                it.components.core.store.state.normalTabs.size,
                                 sessionList.size
                             )
                         )
@@ -490,7 +491,7 @@ class TabTrayDialogFragment : AppCompatDialogFragment(), UserInteractionHandler 
                         )
                         it.metrics.track(
                             Event.CollectionSaved(
-                                it.components.core.sessionManager.normalSessionSize(),
+                                it.components.core.store.state.normalTabs.size,
                                 sessionList.size
                             )
                         )

--- a/app/src/test/java/org/mozilla/fenix/tabtray/DefaultTabTrayControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabtray/DefaultTabTrayControllerTest.kt
@@ -18,8 +18,6 @@ import io.mockk.verify
 import io.mockk.verifyOrder
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineScope
-import mozilla.components.browser.session.Session
-import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.state.state.createTab
@@ -41,14 +39,12 @@ import org.mozilla.fenix.browser.browsingmode.BrowsingModeManager
 import org.mozilla.fenix.components.TabCollectionStorage
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.components.metrics.MetricController
-import org.mozilla.fenix.ext.sessionsOfType
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class DefaultTabTrayControllerTest {
     private val activity: HomeActivity = mockk(relaxed = true)
     private val profiler: Profiler? = mockk(relaxed = true)
     private val navController: NavController = mockk()
-    private val sessionManager: SessionManager = mockk(relaxed = true)
     private val browsingModeManager: BrowsingModeManager = mockk(relaxed = true)
     private val dismissTabTray: (() -> Unit) = mockk(relaxed = true)
     private val dismissTabTrayAndNavigateHome: ((String) -> Unit) = mockk(relaxed = true)
@@ -72,16 +68,6 @@ class DefaultTabTrayControllerTest {
     private val tab1 = createTab(url = "http://firefox.com", id = "5678")
     private val tab2 = createTab(url = "http://mozilla.org", id = "1234")
 
-    private val session = Session(
-        "mozilla.org",
-        true
-    )
-
-    private val nonPrivateSession = Session(
-        "mozilla.org",
-        false
-    )
-
     @Before
     fun setUp() {
         mockkStatic("org.mozilla.fenix.ext.SessionManagerKt")
@@ -92,15 +78,7 @@ class DefaultTabTrayControllerTest {
             )
         )
 
-        every { sessionManager.sessionsOfType(private = true) } returns listOf(session).asSequence()
-        every { sessionManager.sessionsOfType(private = false) } returns listOf(nonPrivateSession).asSequence()
-        every { sessionManager.createSessionSnapshot(any()) } returns SessionManager.Snapshot.Item(
-            session
-        )
-        every { sessionManager.findSessionById("1234") } returns session
-        every { sessionManager.remove(any()) } just Runs
         every { tabCollectionStorage.cachedTabCollections } returns cachedTabCollections
-        every { sessionManager.selectedSession } returns nonPrivateSession
         every { navController.navigate(any<NavDirections>()) } just Runs
         every { navController.currentDestination } returns currentDestination
         every { currentDestination.id } returns R.id.browserFragment
@@ -109,7 +87,6 @@ class DefaultTabTrayControllerTest {
         controller = DefaultTabTrayController(
             activity = activity,
             profiler = profiler,
-            sessionManager = sessionManager,
             browserStore = store,
             browsingModeManager = browsingModeManager,
             tabCollectionStorage = tabCollectionStorage,

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "71.0.20210120143040"
+    const val VERSION = "71.0.20210120190424"
 }


### PR DESCRIPTION
I've also refactored the `TabHistoryDialog` here. Refactoring is straight forward, just replacing `SessionManager` reads with the store.