### PR TITLE
Use a smaller request code for WebAuthnFeature

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/WebAuthnFeature.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/WebAuthnFeature.kt
@@ -56,6 +56,6 @@ class WebAuthnFeature(
     }
 
     companion object {
-        const val ACTIVITY_REQUEST_CODE = 1337
+        const val ACTIVITY_REQUEST_CODE = 10
     }
 }


### PR DESCRIPTION
We can't see the private API that we interact with on the OS, but after
some internal investigation it appears that there might be an upper
limit to the request code we can use.

For now, let's try a value similar to that used in the GVE code to see
our requests are failing because of that.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
