### PR TITLE
For #17364: Make search suggestion hint scrollable and avoid overlapping other elements.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt
@@ -467,8 +467,15 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
                 clear(pill_wrapper.id, BOTTOM)
                 connect(pill_wrapper.id, BOTTOM, toolbar.id, TOP)
 
+                clear(awesome_bar.id, TOP)
+                clear(awesome_bar.id, BOTTOM)
+                connect(awesome_bar.id, TOP, search_suggestions_hint.id, BOTTOM)
+                connect(awesome_bar.id, BOTTOM, pill_wrapper.id, TOP)
+
                 clear(search_suggestions_hint.id, TOP)
+                clear(search_suggestions_hint.id, BOTTOM)
                 connect(search_suggestions_hint.id, TOP, PARENT_ID, TOP)
+                connect(search_suggestions_hint.id, BOTTOM, search_hint_bottom_barrier.id, TOP)
 
                 clear(fill_link_from_clipboard.id, TOP)
                 connect(fill_link_from_clipboard.id, BOTTOM, pill_wrapper.id, TOP)

--- a/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt
@@ -483,7 +483,10 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
 
     private fun updateSearchSuggestionsHintVisibility(state: SearchFragmentState) {
         view?.apply {
-            val showHint = state.showSearchSuggestionsHint && !state.showSearchShortcuts
+            val showHint = state.showSearchSuggestionsHint &&
+                    !state.showSearchShortcuts &&
+                    state.url != state.query
+
             findViewById<View>(R.id.search_suggestions_hint)?.isVisible = showHint
             search_suggestions_hint_divider?.isVisible = showHint
         }

--- a/app/src/main/res/layout/fragment_search_dialog.xml
+++ b/app/src/main/res/layout/fragment_search_dialog.xml
@@ -5,12 +5,12 @@
 <androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/search_wrapper"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fitsSystemWindows="true"
-    android:background="?attr/scrimBackground"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    android:background="?attr/scrimBackground">
     <mozilla.components.browser.toolbar.BrowserToolbar
         android:id="@+id/toolbar"
         android:layout_width="0dp"
@@ -29,6 +29,36 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"/>
+
+    <ViewStub
+        android:id="@+id/search_suggestions_hint"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:inflatedId="@id/search_suggestions_hint"
+        android:layout="@layout/search_suggestions_hint"
+        app:layout_constraintBottom_toTopOf="@id/search_hint_bottom_barrier"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/toolbar"
+        app:layout_constraintHeight_default="wrap"/>
+
+    <View
+        android:id="@+id/search_suggestions_hint_divider"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="?neutralFaded"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="@id/search_suggestions_hint"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <androidx.constraintlayout.widget.Barrier
+        android:id="@+id/search_hint_bottom_barrier"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:barrierDirection="top"
+        app:constraint_referenced_ids="awesome_bar,pill_wrapper"/>
+
     <mozilla.components.browser.awesomebar.BrowserAwesomeBar
         xmlns:mozac="http://schemas.android.com/apk/res-auto"
         android:id="@+id/awesome_bar"
@@ -43,37 +73,9 @@
         app:layout_constraintBottom_toTopOf="@+id/pill_wrapper"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/top_barrier"
+        app:layout_constraintTop_toBottomOf="@id/search_suggestions_hint"
         mozac:awesomeBarDescriptionTextColor="?secondaryText"
         mozac:awesomeBarTitleTextColor="?primaryText" />
-
-    <ViewStub
-        android:id="@+id/search_suggestions_hint"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:inflatedId="@id/search_suggestions_hint"
-        android:layout="@layout/search_suggestions_hint"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/toolbar" />
-
-    <androidx.constraintlayout.widget.Barrier
-        android:id="@+id/top_barrier"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:barrierDirection="bottom"
-        app:constraint_referenced_ids="search_suggestions_hint"/>
-
-
-    <View
-        android:id="@+id/search_suggestions_hint_divider"
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:background="?neutralFaded"
-        android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="@id/search_suggestions_hint"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent" />
 
     <View
         android:id="@+id/fill_link_from_clipboard"

--- a/app/src/main/res/layout/search_suggestions_hint.xml
+++ b/app/src/main/res/layout/search_suggestions_hint.xml
@@ -2,91 +2,104 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/scrollView"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:background="?attr/foundation"
-    android:paddingStart="20dp"
-    android:paddingTop="20dp"
-    android:paddingEnd="20dp"
-    android:paddingBottom="10dp">
+    android:layout_height="match_parent"
+    android:scrollbars="vertical"
+    android:fadeScrollbars="false"
+    app:layout_constraintBottom_toBottomOf="@id/search_divider"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintTop_toBottomOf="@id/toolbar">
 
-    <ImageView
-        android:id="@+id/info_button"
-        android:layout_width="24dp"
-        android:layout_height="24dp"
-        android:importantForAccessibility="no"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:srcCompat="@drawable/ic_info"
-        tools:tint="@color/contrast_text_private_theme" />
-
-    <TextView
-        android:id="@+id/title"
-        android:layout_width="0dp"
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="32dp"
-        android:paddingBottom="12dp"
-        android:textAppearance="?android:attr/textAppearanceListItem"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:text="@string/search_suggestions_onboarding_title"
-        tools:textAppearance="?android:attr/textAppearanceListItem" />
+        android:background="?attr/foundation"
+        android:paddingStart="20dp"
+        android:paddingTop="20dp"
+        android:paddingEnd="20dp"
+        android:paddingBottom="10dp">
 
-    <TextView
-        android:id="@+id/text"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:textAppearance="?android:attr/textAppearanceSmall"
-        app:layout_constraintBottom_toTopOf="@id/learn_more"
-        app:layout_constraintEnd_toEndOf="@id/title"
-        app:layout_constraintStart_toStartOf="@id/title"
-        app:layout_constraintTop_toBottomOf="@id/title"
-        tools:text="@string/search_suggestions_onboarding_text"
-        tools:textAppearance="?attr/textAppearanceListItemSmall" />
+        <ImageView
+            android:id="@+id/info_button"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:importantForAccessibility="no"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:srcCompat="@drawable/ic_info"
+            tools:tint="@color/contrast_text_private_theme" />
 
-    <org.mozilla.fenix.utils.LinkTextView
-        android:id="@+id/learn_more"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:minHeight="48dp"
-        android:text="@string/exceptions_empty_message_learn_more_link"
-        android:textAppearance="?android:attr/textAppearanceSmall"
-        android:textColor="?attr/accentHighContrast"
-        android:textStyle="bold"
-        app:layout_constraintBottom_toTopOf="@id/allow"
-        app:layout_constraintEnd_toStartOf="@id/dismiss"
-        app:layout_constraintStart_toStartOf="@id/title"
-        app:layout_constraintTop_toBottomOf="@id/text"
-        tools:textColor="@color/accent_high_contrast_private_theme" />
+        <TextView
+            android:id="@+id/title"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="32dp"
+            android:paddingBottom="12dp"
+            android:textAppearance="?android:attr/textAppearanceListItem"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="@string/search_suggestions_onboarding_title"
+            tools:textAppearance="?android:attr/textAppearanceListItem" />
 
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/allow"
-        style="@style/NeutralButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="20dp"
-        android:paddingHorizontal="12dp"
-        android:text="@string/search_suggestions_onboarding_allow_button"
-        app:layout_constraintEnd_toEndOf="@id/title"
-        app:layout_constraintTop_toBottomOf="@id/text" />
+        <TextView
+            android:id="@+id/text"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            app:layout_constraintBottom_toTopOf="@id/learn_more"
+            app:layout_constraintEnd_toEndOf="@id/title"
+            app:layout_constraintStart_toStartOf="@id/title"
+            app:layout_constraintTop_toBottomOf="@id/title"
+            tools:text="@string/search_suggestions_onboarding_text"
+            tools:textAppearance="?attr/textAppearanceListItemSmall" />
 
-    <TextView
-        android:id="@+id/dismiss"
-        android:layout_width="0dp"
-        android:layout_height="48dp"
-        android:fontFamily="@font/metropolis_semibold"
-        android:gravity="center_vertical"
-        android:letterSpacing="0"
-        android:paddingHorizontal="20dp"
-        android:text="@string/search_suggestions_onboarding_do_not_allow_button"
-        android:textColor="#ffffff"
-        android:textStyle="bold"
-        app:layout_constraintBottom_toBottomOf="@id/allow"
-        app:layout_constraintEnd_toStartOf="@id/allow"
-        app:layout_constraintTop_toTopOf="@id/allow" />
+        <org.mozilla.fenix.utils.LinkTextView
+            android:id="@+id/learn_more"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:minHeight="48dp"
+            android:text="@string/exceptions_empty_message_learn_more_link"
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            android:textColor="?attr/accentHighContrast"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toTopOf="@id/allow"
+            app:layout_constraintEnd_toStartOf="@id/dismiss"
+            app:layout_constraintStart_toStartOf="@id/title"
+            app:layout_constraintTop_toBottomOf="@id/text"
+            tools:textColor="@color/accent_high_contrast_private_theme" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/allow"
+            style="@style/NeutralButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:paddingHorizontal="12dp"
+            android:text="@string/search_suggestions_onboarding_allow_button"
+            app:layout_constraintEnd_toEndOf="@id/title"
+            app:layout_constraintTop_toBottomOf="@id/text" />
+
+        <TextView
+            android:id="@+id/dismiss"
+            android:layout_width="0dp"
+            android:layout_height="48dp"
+            android:fontFamily="@font/metropolis_semibold"
+            android:gravity="center_vertical"
+            android:letterSpacing="0"
+            android:paddingHorizontal="20dp"
+            android:text="@string/search_suggestions_onboarding_do_not_allow_button"
+            android:textColor="#ffffff"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="@id/allow"
+            app:layout_constraintEnd_toStartOf="@id/allow"
+            app:layout_constraintTop_toTopOf="@id/allow" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.core.widget.NestedScrollView>


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

**Landscape: Bottom and  Top Toolbar  with a scrollable hint:**
<img src = https://user-images.githubusercontent.com/48995920/105389486-91d07a00-5c20-11eb-97b3-0f3600aae612.png width = 45%> <img src =https://user-images.githubusercontent.com/48995920/105389497-95640100-5c20-11eb-8c8f-98839959dd03.png width = 45%>

**Portrait: Bottom and  Top Toolbar** 
<img src = https://user-images.githubusercontent.com/48995920/105389492-9432d400-5c20-11eb-905e-0a43be29647d.png width = 45%> <img src = https://user-images.githubusercontent.com/48995920/105389495-94cb6a80-5c20-11eb-9a31-2caf10b32ea0.png width = 45%>




### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
