### PR TITLE
Add new BuildConfig variables to support AMO non-production envs

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,7 +37,12 @@ android {
         testInstrumentationRunnerArguments clearPackageData: 'true'
         resValue "bool", "IS_DEBUG", "false"
         buildConfigField "boolean", "USE_RELEASE_VERSIONING", "false"
-        buildConfigField "String", "AMO_COLLECTION", "\"7dfae8669acc4312a65e8ba5553036\""
+        // This should be the "public" base URL of AMO.
+        buildConfigField "String", "AMO_BASE_URL", "\"https://addons.mozilla.org\""
+        buildConfigField "String", "AMO_COLLECTION_NAME", "\"7dfae8669acc4312a65e8ba5553036\""
+        buildConfigField "String", "AMO_COLLECTION_USER", "\"mozilla\""
+        // This should be the base URL used to call the AMO API.
+        buildConfigField "String", "AMO_SERVER_URL", "\"https://services.addons.mozilla.org\""
         def deepLinkSchemeValue = "fenix-dev"
         buildConfigField "String", "DEEP_LINK_SCHEME", "\"$deepLinkSchemeValue\""
         manifestPlaceholders = [

--- a/app/src/main/java/org/mozilla/fenix/AppRequestInterceptor.kt
+++ b/app/src/main/java/org/mozilla/fenix/AppRequestInterceptor.kt
@@ -12,6 +12,7 @@ import mozilla.components.browser.errorpages.ErrorPages
 import mozilla.components.browser.errorpages.ErrorType
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.engine.request.RequestInterceptor
+import org.mozilla.fenix.BuildConfig
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.isOnline
@@ -168,7 +169,7 @@ class AppRequestInterceptor(
     companion object {
         internal const val LOW_AND_MEDIUM_RISK_ERROR_PAGES = "low_and_medium_risk_error_pages.html"
         internal const val HIGH_RISK_ERROR_PAGES = "high_risk_error_pages.html"
-        internal const val AMO_BASE_URL = "https://addons.mozilla.org"
+        internal const val AMO_BASE_URL = BuildConfig.AMO_BASE_URL
         internal const val AMO_INSTALL_URL_REGEX = "$AMO_BASE_URL/android/downloads/file/([^\\s]+)/([^\\s]+\\.xpi)"
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/components/Components.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Components.kt
@@ -93,11 +93,15 @@ class Components(private val context: Context) {
             )
         }
         // Use build config otherwise
-        else if (!BuildConfig.AMO_COLLECTION.isNullOrEmpty()) {
+        else if (!BuildConfig.AMO_COLLECTION_USER.isNullOrEmpty() &&
+            !BuildConfig.AMO_COLLECTION_NAME.isNullOrEmpty()
+        ) {
             AddonCollectionProvider(
                 context,
                 core.client,
-                collectionName = BuildConfig.AMO_COLLECTION,
+                serverURL = BuildConfig.AMO_SERVER_URL,
+                collectionUser = BuildConfig.AMO_COLLECTION_USER,
+                collectionName = BuildConfig.AMO_COLLECTION_NAME,
                 maxCacheAgeInMinutes = DAY_IN_MINUTES
             )
         }


### PR DESCRIPTION
This patch adds some more configuration variables so that one can build the
project to target a specific AMO env (usually -dev or -stage) in order to test
specific features that require coordination between AMO and Fenix (e.g., the
install flow for recommended extensions).

I am not sure how to write new tests :/ I tried to look at existing tests but
could not see anything related to `BuildConfig`.