### PR TITLE
For issue: #16394 Fix UI for consider increasing some elements from ETP-Exceptions page

### DIFF
--- a/app/src/main/res/layout/component_exceptions.xml
+++ b/app/src/main/res/layout/component_exceptions.xml
@@ -30,7 +30,7 @@
         <org.mozilla.fenix.utils.LinkTextView
             android:id="@+id/exceptions_learn_more"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="@dimen/component_exceptions_learn_more_height"
             android:padding="4dp"
             android:text="@string/exceptions_empty_message_learn_more_link"
             android:textAlignment="viewStart"

--- a/app/src/main/res/layout/exception_item.xml
+++ b/app/src/main/res/layout/exception_item.xml
@@ -48,8 +48,8 @@
 
     <ImageButton
         android:id="@+id/delete_exception"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="@dimen/component_tp_exceptions_icon_size"
+        android:layout_height="@dimen/component_tp_exceptions_icon_size"
         android:layout_marginStart="8dp"
         android:layout_marginEnd="16dp"
         android:background="?android:attr/selectableItemBackgroundBorderless"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -37,6 +37,8 @@
     <dimen name="site_permissions_exceptions_item_height">56dp</dimen>
     <dimen name="component_collection_creation_list_margin">16dp</dimen>
     <dimen name="exceptions_description_margin">12dp</dimen>
+    <dimen name="component_exceptions_learn_more_height">48dp</dimen>
+    <dimen name="component_tp_exceptions_icon_size">48dp</dimen>
     <dimen name="preference_seek_bar_padding">16dp</dimen>
     <dimen name="custom_checkbox_alignment_margin">68dp</dimen>
     <!--The assumed minimum height of the keyboard on Lollipop.-->


### PR DESCRIPTION


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
