### PR TITLE
Closes #17473: Intermittent failues of PwaOnboardingObserver

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/shortcut/PwaOnboardingObserver.kt
+++ b/app/src/main/java/org/mozilla/fenix/shortcut/PwaOnboardingObserver.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.fenix.shortcut
 
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.LifecycleOwner
 import androidx.navigation.NavController
 import kotlinx.coroutines.CoroutineScope
@@ -47,9 +48,7 @@ class PwaOnboardingObserver(
                 if (webAppUseCases.isInstallable() && !settings.userKnowsAboutPwas) {
                     settings.incrementVisitedInstallableCount()
                     if (settings.shouldShowPwaCfr) {
-                        val directions =
-                            BrowserFragmentDirections.actionBrowserFragmentToPwaOnboardingDialogFragment()
-                        navController.nav(R.id.browserFragment, directions)
+                        navigateToPwaOnboarding()
                         settings.lastCfrShownTimeInMillis = System.currentTimeMillis()
                         settings.userKnowsAboutPwas = true
                     }
@@ -60,5 +59,13 @@ class PwaOnboardingObserver(
 
     fun stop() {
         scope?.cancel()
+    }
+
+    @VisibleForTesting
+    internal fun navigateToPwaOnboarding() {
+        navController.nav(
+            R.id.browserFragment,
+            BrowserFragmentDirections.actionBrowserFragmentToPwaOnboardingDialogFragment()
+        )
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/shortcut/PwaOnboardingObserverTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/shortcut/PwaOnboardingObserverTest.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.LifecycleRegistry
 import androidx.navigation.NavController
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.spyk
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineDispatcher
@@ -24,9 +25,6 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.mozilla.fenix.R
-import org.mozilla.fenix.browser.BrowserFragmentDirections
-import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.utils.Settings
 
 @ExperimentalCoroutinesApi
@@ -54,17 +52,19 @@ class PwaOnboardingObserverTest {
             )
         )
         lifecycleOwner = MockedLifecycleOwner(Lifecycle.State.STARTED)
+
         navigationController = mockk(relaxed = true)
         settings = mockk(relaxed = true)
         webAppUseCases = mockk(relaxed = true)
 
-        pwaOnboardingObserver = PwaOnboardingObserver(
+        pwaOnboardingObserver = spyk(PwaOnboardingObserver(
             store = store,
             lifecycleOwner = lifecycleOwner,
             navController = navigationController,
             settings = settings,
             webAppUseCases = webAppUseCases
-        )
+        ))
+        every { pwaOnboardingObserver.navigateToPwaOnboarding() } returns Unit
     }
 
     @After
@@ -81,10 +81,7 @@ class PwaOnboardingObserverTest {
 
         store.dispatch(ContentAction.UpdateWebAppManifestAction("1", mockk())).joinBlocking()
         verify { settings.incrementVisitedInstallableCount() }
-        verify(exactly = 0) { navigationController.nav(
-            R.id.browserFragment,
-            BrowserFragmentDirections.actionBrowserFragmentToPwaOnboardingDialogFragment())
-        }
+        verify(exactly = 0) { pwaOnboardingObserver.navigateToPwaOnboarding() }
     }
 
     @Test
@@ -96,10 +93,7 @@ class PwaOnboardingObserverTest {
 
         store.dispatch(ContentAction.UpdateWebAppManifestAction("1", mockk())).joinBlocking()
         verify { settings.incrementVisitedInstallableCount() }
-        verify { navigationController.nav(
-            R.id.browserFragment,
-            BrowserFragmentDirections.actionBrowserFragmentToPwaOnboardingDialogFragment())
-        }
+        verify { pwaOnboardingObserver.navigateToPwaOnboarding() }
     }
 
     @Test
@@ -111,10 +105,7 @@ class PwaOnboardingObserverTest {
 
         store.dispatch(ContentAction.UpdateWebAppManifestAction("1", mockk())).joinBlocking()
         verify(exactly = 0) { settings.incrementVisitedInstallableCount() }
-        verify(exactly = 0) { navigationController.nav(
-            R.id.browserFragment,
-            BrowserFragmentDirections.actionBrowserFragmentToPwaOnboardingDialogFragment())
-        }
+        verify(exactly = 0) { pwaOnboardingObserver.navigateToPwaOnboarding() }
     }
 
     internal class MockedLifecycleOwner(initialState: Lifecycle.State) : LifecycleOwner {


### PR DESCRIPTION
Instead of verifying calls to the `nav` extension function which has complex dependencies including various static calls we verify a local mocked call. If this still keeps failing we should also get a clearer stacktrace. The stacktrace we're getting indicated a failed call verification for a call we don't even verify (a static call which is a dependency of `nav`).