### PR TITLE
For issue: mozilla-mobile#14716 Fix homescreen-increase touch target …

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/history/viewholders/HistoryListItemViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/viewholders/HistoryListItemViewHolder.kt
@@ -146,7 +146,7 @@ class HistoryListItemViewHolder(
     }
 
     companion object {
-        const val DELETE_BUTTON_DISABLED_ALPHA = 0.4f
+        const val DELETE_BUTTON_DISABLED_ALPHA = 0.7f
         const val LAYOUT_ID = R.layout.history_list_item
     }
 }


### PR DESCRIPTION
Hi! I made some little change.  

Screenshot: 

<img width="773" alt="Screen Shot 2021-01-23 at 17 28 13" src="https://user-images.githubusercontent.com/12996047/105588562-9ae95480-5da2-11eb-86fa-57911303ec1d.png">
