### PR TITLE
For #16615 & #11191: re-enabled ReaderViewTest and added a UI smoke test

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/ReaderViewTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/ReaderViewTest.kt
@@ -8,11 +8,9 @@ import android.view.View
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.ui.robots.navigationToolbar
-import org.mozilla.fenix.ui.robots.readerViewRobot
 import androidx.test.espresso.IdlingRegistry
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
@@ -30,10 +28,10 @@ import org.mozilla.fenix.ui.robots.mDevice
  *
  */
 
-@Ignore("Temp disable - reader view page detection issues: https://github.com/mozilla-mobile/fenix/issues/9688 ")
+// @Ignore("Temp disable - reader view page detection issues: https://github.com/mozilla-mobile/fenix/issues/9688 ")
 class ReaderViewTest {
     private lateinit var mockWebServer: MockWebServer
-    private var readerViewNotificationDot: ViewVisibilityIdlingResource? = null
+    private var readerViewNotification: ViewVisibilityIdlingResource? = null
 
     @get:Rule
     val activityIntentTestRule = HomeActivityIntentTestRule()
@@ -44,24 +42,18 @@ class ReaderViewTest {
             dispatcher = AndroidAssetDispatcher()
             start()
         }
-
-        readerViewNotificationDot = ViewVisibilityIdlingResource(
-            activityIntentTestRule.activity.findViewById(R.id.notification_dot),
-            View.VISIBLE
-        )
     }
 
     @After
     fun tearDown() {
         mockWebServer.shutdown()
-        IdlingRegistry.getInstance().unregister(readerViewNotificationDot)
+        IdlingRegistry.getInstance().unregister(readerViewNotification)
     }
 
     /**
      *  Verify that Reader View capable pages
      *
-     *   - Show blue notification in the three dot menu
-     *   - Show the toggle button in the three dot menu
+     *   - Show the toggle button in the navigation bar
      *
      */
     @Test
@@ -74,23 +66,22 @@ class ReaderViewTest {
             mDevice.waitForIdle()
         }
 
-        IdlingRegistry.getInstance().register(readerViewNotificationDot)
+        readerViewNotification = ViewVisibilityIdlingResource(
+            activityIntentTestRule.activity.findViewById(R.id.mozac_browser_toolbar_page_actions),
+            View.VISIBLE
+        )
 
-        readerViewRobot {
-            verifyReaderViewDetected(true)
-        }
+        IdlingRegistry.getInstance().register(readerViewNotification)
 
         navigationToolbar {
-        }.openThreeDotMenu {
-            verifyReaderViewToggle(true)
-        }.closeBrowserMenuToBrowser { }
+            verifyReaderViewDetected(true)
+        }
     }
 
     /**
      *  Verify that non Reader View capable pages
      *
-     *   - Do not show a blue notification in the three dot menu
-     *   - Reader View toggle should not be visible in the three dot menu
+     *   - Reader View toggle should not be visible in the navigation toolbar
      *
      */
     @Test
@@ -103,15 +94,9 @@ class ReaderViewTest {
             mDevice.waitForIdle()
         }
 
-        readerViewRobot {
+        navigationToolbar {
             verifyReaderViewDetected(false)
         }
-
-        navigationToolbar {
-        }.openThreeDotMenu {
-            verifyReaderViewToggle(false)
-            verifyReaderViewAppearance(false)
-        }.closeBrowserMenuToBrowser { }
     }
 
     @Test
@@ -124,61 +109,25 @@ class ReaderViewTest {
             mDevice.waitForIdle()
         }
 
-        IdlingRegistry.getInstance().register(readerViewNotificationDot)
+        readerViewNotification = ViewVisibilityIdlingResource(
+            activityIntentTestRule.activity.findViewById(R.id.mozac_browser_toolbar_page_actions),
+            View.VISIBLE
+        )
 
-        readerViewRobot {
-            verifyReaderViewDetected(true)
-        }
+        IdlingRegistry.getInstance().register(readerViewNotification)
 
         navigationToolbar {
-        }.openThreeDotMenu {
-            verifyReaderViewToggle(true)
-        }.toggleReaderView {
+            verifyReaderViewDetected(true)
+            toggleReaderView()
         }.openThreeDotMenu {
             verifyReaderViewAppearance(true)
-        }.toggleReaderView {
+        }.closeBrowserMenuToBrowser { }
+
+        navigationToolbar {
+            toggleReaderView()
         }.openThreeDotMenu {
             verifyReaderViewAppearance(false)
         }.close { }
-
-        readerViewRobot {
-            verifyReaderViewDetected(false)
-        }
-    }
-
-    @Test
-    fun verifyReaderViewAppearanceUI() {
-        val readerViewPage =
-            TestAssetHelper.getLoremIpsumAsset(mockWebServer)
-
-        navigationToolbar {
-        }.enterURLAndEnterToBrowser(readerViewPage.url) {
-            mDevice.waitForIdle()
-        }
-
-        IdlingRegistry.getInstance().register(readerViewNotificationDot)
-
-        readerViewRobot {
-            verifyReaderViewDetected(true)
-        }
-
-        navigationToolbar {
-        }.openThreeDotMenu {
-            verifyReaderViewToggle(true)
-        }.toggleReaderView {
-        }.openThreeDotMenu {
-            verifyReaderViewAppearance(true)
-        }.openReaderViewAppearance {
-            verifyAppearanceFontGroup(true)
-            verifyAppearanceFontSansSerif(true)
-            verifyAppearanceFontSerif(true)
-            verifyAppearanceFontIncrease(true)
-            verifyAppearanceFontDecrease(true)
-            verifyAppearanceColorGroup(true)
-            verifyAppearanceColorDark(true)
-            verifyAppearanceColorLight(true)
-            verifyAppearanceColorSepia(true)
-        }
     }
 
     @Test
@@ -191,16 +140,16 @@ class ReaderViewTest {
             mDevice.waitForIdle()
         }
 
-        IdlingRegistry.getInstance().register(readerViewNotificationDot)
+        readerViewNotification = ViewVisibilityIdlingResource(
+            activityIntentTestRule.activity.findViewById(R.id.mozac_browser_toolbar_page_actions),
+            View.VISIBLE
+        )
 
-        readerViewRobot {
-            verifyReaderViewDetected(true)
-        }
+        IdlingRegistry.getInstance().register(readerViewNotification)
 
         navigationToolbar {
-        }.openThreeDotMenu {
-            verifyReaderViewToggle(true)
-        }.toggleReaderView {
+            verifyReaderViewDetected(true)
+            toggleReaderView()
         }.openThreeDotMenu {
             verifyReaderViewAppearance(true)
         }.openReaderViewAppearance {
@@ -226,16 +175,16 @@ class ReaderViewTest {
             mDevice.waitForIdle()
         }
 
-        IdlingRegistry.getInstance().register(readerViewNotificationDot)
+        readerViewNotification = ViewVisibilityIdlingResource(
+            activityIntentTestRule.activity.findViewById(R.id.mozac_browser_toolbar_page_actions),
+            View.VISIBLE
+        )
 
-        readerViewRobot {
-            verifyReaderViewDetected(true)
-        }
+        IdlingRegistry.getInstance().register(readerViewNotification)
 
         navigationToolbar {
-        }.openThreeDotMenu {
-            verifyReaderViewToggle(true)
-        }.toggleReaderView {
+            verifyReaderViewDetected(true)
+            toggleReaderView()
         }.openThreeDotMenu {
             verifyReaderViewAppearance(true)
         }.openReaderViewAppearance {
@@ -267,16 +216,16 @@ class ReaderViewTest {
             mDevice.waitForIdle()
         }
 
-        IdlingRegistry.getInstance().register(readerViewNotificationDot)
+        readerViewNotification = ViewVisibilityIdlingResource(
+            activityIntentTestRule.activity.findViewById(R.id.mozac_browser_toolbar_page_actions),
+            View.VISIBLE
+        )
 
-        readerViewRobot {
-            verifyReaderViewDetected(true)
-        }
+        IdlingRegistry.getInstance().register(readerViewNotification)
 
         navigationToolbar {
-        }.openThreeDotMenu {
-            verifyReaderViewToggle(true)
-        }.toggleReaderView {
+            verifyReaderViewDetected(true)
+            toggleReaderView()
         }.openThreeDotMenu {
             verifyReaderViewAppearance(true)
         }.openReaderViewAppearance {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -45,6 +45,7 @@ class SmokeTest {
     private var searchSuggestionsIdlingResource: RecyclerViewIdlingResource? = null
     private var addonsListIdlingResource: RecyclerViewIdlingResource? = null
     private var recentlyClosedTabsListIdlingResource: RecyclerViewIdlingResource? = null
+    private var readerViewNotification: ViewVisibilityIdlingResource? = null
     private val downloadFileName = "Globe.svg"
     private val searchEngine = object {
         var title = "Ecosia"
@@ -103,6 +104,10 @@ class SmokeTest {
 
         if (bookmarksListIdlingResource != null) {
             IdlingRegistry.getInstance().unregister(bookmarksListIdlingResource!!)
+        }
+
+        if (readerViewNotification != null) {
+            IdlingRegistry.getInstance().unregister(readerViewNotification)
         }
     }
 
@@ -1115,6 +1120,42 @@ class SmokeTest {
         }.openHomeScreenShortcut("yay app") {
             mDevice.waitForIdle()
             verifyNavURLBarHidden()
+        }
+    }
+
+    @Test
+    // Verifies that reader mode is detected and the custom appearance controls are displayed
+    fun verifyReaderViewAppearanceUI() {
+        val readerViewPage =
+            TestAssetHelper.getLoremIpsumAsset(mockWebServer)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(readerViewPage.url) {
+            org.mozilla.fenix.ui.robots.mDevice.waitForIdle()
+        }
+
+        readerViewNotification = ViewVisibilityIdlingResource(
+            activityTestRule.activity.findViewById(R.id.mozac_browser_toolbar_page_actions),
+            View.VISIBLE
+        )
+
+        IdlingRegistry.getInstance().register(readerViewNotification)
+
+        navigationToolbar {
+            verifyReaderViewDetected(true)
+            toggleReaderView()
+        }.openThreeDotMenu {
+            verifyReaderViewAppearance(true)
+        }.openReaderViewAppearance {
+            verifyAppearanceFontGroup(true)
+            verifyAppearanceFontSansSerif(true)
+            verifyAppearanceFontSerif(true)
+            verifyAppearanceFontIncrease(true)
+            verifyAppearanceFontDecrease(true)
+            verifyAppearanceColorGroup(true)
+            verifyAppearanceColorDark(true)
+            verifyAppearanceColorLight(true)
+            verifyAppearanceColorSepia(true)
         }
     }
 }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NavigationToolbarRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NavigationToolbarRobot.kt
@@ -11,22 +11,27 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.IdlingRegistry
 import androidx.test.espresso.IdlingResource
+import androidx.test.espresso.ViewInteraction
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.action.ViewActions.pressImeActionButton
 import androidx.test.espresso.action.ViewActions.replaceText
 import androidx.test.espresso.action.ViewActions.typeText
+import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
+import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withParent
 import androidx.test.espresso.matcher.ViewMatchers.withResourceName
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.Until
+import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.CoreMatchers.anyOf
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.CoreMatchers.not
@@ -54,7 +59,12 @@ class NavigationToolbarRobot {
 
     fun verifyTabButtonShortcutMenuItems() = assertTabButtonShortcutMenuItems()
 
+    fun verifyReaderViewDetected(visible: Boolean = false): ViewInteraction =
+        assertReaderViewDetected(visible)
+
     fun typeSearchTerm(searchTerm: String) = awesomeBar().perform(typeText(searchTerm))
+
+    fun toggleReaderView() = readerViewToggle().click()
 
     class Transition {
 
@@ -274,6 +284,20 @@ private fun tabTrayButton() = onView(withId(R.id.tab_button))
 private fun fillLinkButton() = onView(withId(R.id.fill_link_from_clipboard))
 private fun clearAddressBar() = onView(withId(R.id.mozac_browser_toolbar_clear_view))
 private fun goBackButton() = mDevice.pressBack()
+private fun readerViewToggle() =
+    onView(withParent(withId(R.id.mozac_browser_toolbar_page_actions)))
+
+private fun assertReaderViewDetected(visible: Boolean) =
+    onView(
+        allOf(
+            withParent(withId(R.id.mozac_browser_toolbar_page_actions)),
+            withContentDescription("Reader view")
+        )
+    ).check(
+        if (visible) matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE))
+        else ViewAssertions.doesNotExist()
+    )
+
 inline fun runWithIdleRes(ir: IdlingResource?, pendingCheck: () -> Unit) {
     try {
         IdlingRegistry.getInstance().register(ir)

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ReaderViewRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ReaderViewRobot.kt
@@ -17,15 +17,11 @@ import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.Assert.assertEquals
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.click
-import org.mozilla.fenix.helpers.nthChildOf
 
 /**
  * Implementation of Robot Pattern for Reader View UI.
  */
 class ReaderViewRobot {
-
-    fun verifyReaderViewDetected(visible: Boolean = false): ViewInteraction =
-        assertReaderViewDetected(visible)
 
     fun verifyAppearanceFontGroup(visible: Boolean = false): ViewInteraction =
         assertAppearanceFontGroup(visible)
@@ -183,18 +179,6 @@ fun readerViewRobot(interact: ReaderViewRobot.() -> Unit): ReaderViewRobot.Trans
     ReaderViewRobot().interact()
     return ReaderViewRobot.Transition()
 }
-
-/**
- * Detects for the blue notification dot in the three dot menu
- */
-private fun assertReaderViewDetected(visible: Boolean) =
-    onView(
-        nthChildOf(
-            withId(R.id.mozac_browser_toolbar_menu), 2
-        )
-    ).check(
-        matches(withEffectiveVisibility(visibleOrGone(visible)))
-    )
 
 private fun assertAppearanceFontGroup(visible: Boolean) =
     onView(

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuMainRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuMainRobot.kt
@@ -65,8 +65,8 @@ class ThreeDotMenuMainRobot {
     fun verifyRefreshButton() = assertRefreshButton()
     fun verifyCloseAllTabsButton() = assertCloseAllTabsButton()
     fun verifyShareButton() = assertShareButton()
-    fun verifyReaderViewToggle(visible: Boolean) = assertReaderViewToggle(visible)
     fun verifyReaderViewAppearance(visible: Boolean) = assertReaderViewAppearanceButton(visible)
+
     fun clickShareButton() {
         shareButton().click()
         mDevice.waitNotNull(Until.findObject(By.text("ALL ACTIONS")), waitingTime)
@@ -318,13 +318,6 @@ class ThreeDotMenuMainRobot {
             return BrowserRobot.Transition()
         }
 
-        fun toggleReaderView(interact: NavigationToolbarRobot.() -> Unit): NavigationToolbarRobot.Transition {
-            readerViewToggle().click()
-
-            NavigationToolbarRobot().interact()
-            return NavigationToolbarRobot.Transition()
-        }
-
         fun openReaderViewAppearance(interact: ReaderViewRobot.() -> Unit): ReaderViewRobot.Transition {
             readerViewAppearanceToggle().click()
 
@@ -505,12 +498,6 @@ private fun assertWhatsNewButton() = whatsNewButton()
     .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
 private fun addToHomeScreenButton() = onView(withText("Add to Home screen"))
-
-private fun readerViewToggle() = onView(allOf(withText(R.string.browser_menu_read)))
-private fun assertReaderViewToggle(visible: Boolean) = readerViewToggle()
-    .check(
-        if (visible) matches(withEffectiveVisibility(Visibility.VISIBLE)) else ViewAssertions.doesNotExist()
-    )
 
 private fun readerViewAppearanceToggle() =
     onView(allOf(withText(R.string.browser_menu_read_appearance)))


### PR DESCRIPTION
> Just a heads-up that the tests will need some updates as the UI has changed a while ago. Reader mode button is now in the toolbar directly.
https://github.com/mozilla-mobile/fenix/issues/11191#issuecomment-736097268

Refactored and re-enabled the readerView tests, moved one to the SmokeTests class.
Ran on Firebase for 20 times and all passed: [runs](https://github.com/mozilla-mobile/fenix/runs/1749471331)