### PR TITLE
Remove autoplay indicator FeatureFlags

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -53,11 +53,6 @@ object FeatureFlags {
     val newMediaSessionApi = true
 
     /**
-     * Enabled showing site permission indicators in the toolbars.
-     */
-    val permissionIndicatorsToolbar = Config.channel.isNightlyOrDebug
-
-    /**
      * Enables experimental WebAuthn support. This implementation should never reach release!
      */
     val webAuthFeature = Config.channel.isNightlyOrDebug

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarIntegration.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarIntegration.kt
@@ -24,7 +24,6 @@ import mozilla.components.feature.toolbar.ToolbarPresenter
 import mozilla.components.lib.publicsuffixlist.PublicSuffixList
 import mozilla.components.support.base.feature.LifecycleAwareFeature
 import mozilla.components.support.ktx.android.view.hideKeyboard
-import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.settings
@@ -120,20 +119,16 @@ class DefaultToolbarIntegration(
                 listOf(
                     DisplayToolbar.Indicators.TRACKING_PROTECTION,
                     DisplayToolbar.Indicators.SECURITY,
-                    DisplayToolbar.Indicators.EMPTY
+                    DisplayToolbar.Indicators.EMPTY,
+                    DisplayToolbar.Indicators.HIGHLIGHT
                 )
             } else {
                 listOf(
                     DisplayToolbar.Indicators.SECURITY,
-                    DisplayToolbar.Indicators.EMPTY
+                    DisplayToolbar.Indicators.EMPTY,
+                    DisplayToolbar.Indicators.HIGHLIGHT
                 )
             }
-
-        if (FeatureFlags.permissionIndicatorsToolbar) {
-            toolbar.display.indicators += DisplayToolbar.Indicators.HIGHLIGHT
-        }
-
-        toolbar.display.displayIndicatorSeparator =
             context.settings().shouldUseTrackingProtection
 
         toolbar.display.icons = toolbar.display.icons.copy(


### PR DESCRIPTION
As the autoplay indicator https://github.com/mozilla-mobile/fenix/issues/17534 issue was verified by QA we can remove the feature flag.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
