### PR TITLE
Incrementalify updateExtensionVersion

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -733,22 +733,31 @@ if (gradle.hasProperty('localProperties.autoPublish.application-services.dir')) 
 // https://github.com/mozilla-mobile/android-components/issues/7249
 ext.updateExtensionVersion = { task, extDir ->
     configure(task) {
-        from extDir
-        include 'manifest.template.json'
-        rename { 'manifest.json' }
-        into extDir
+        final MANIFEST_FILE = 'manifest.json'
+        final MANIFEST_TEMPLATE = 'manifest.template.json'
 
-        def values = ['version': AndroidComponents.VERSION + "." + new Date().format('MMddHHmmss')]
-        inputs.properties(values)
-        expand(values)
+        inputs.dir project.fileTree(dir: extDir, exclude: MANIFEST_FILE)
+        outputs.file MANIFEST_FILE
+
+        doLast {
+            copy {
+                from extDir
+                include MANIFEST_TEMPLATE
+                rename { MANIFEST_FILE }
+                into extDir
+
+                def values = ['version': AndroidComponents.VERSION + "." + new Date().format('MMddHHmmss')]
+                expand(values)
+            }
+        }
     }
 }
 
-tasks.register("updateAdsExtensionVersion", Copy) { task ->
+tasks.register("updateAdsExtensionVersion") { task ->
     updateExtensionVersion(task, 'src/main/assets/extensions/ads')
 }
 
-tasks.register("updateCookiesExtensionVersion", Copy) { task ->
+tasks.register("updateCookiesExtensionVersion") { task ->
     updateExtensionVersion(task, 'src/main/assets/extensions/cookies')
 }
 


### PR DESCRIPTION
Before this PR extension version was updated on every build, causing merge assets task to be run on every build.

With this PR extension version is only updated if a file changed except the target `manifest.json`, resulting in faster incremental builds.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
