### PR TITLE
[RELENG-169] support staging release promotion projects

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -166,7 +166,7 @@ tasks:
                           routes:
                               $flattenDeep:
                                   - checks
-                                  - $if: 'level == "3"'
+                                  - $if: 'level == "3" || repoUrl == "https://github.com/mozilla-releng/staging-fenix"'
                                     then:
                                         - tc-treeherder.v2.${project}.${head_sha}
                                         # TODO Bug 1601928: Make this scope fork-friendly once ${project} is better defined. This will enable

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -17,7 +17,10 @@ treeherder:
         'Rap-P': 'Raptor power tests'
         'TL': 'Toolchain builds for Linux 64-bits'
 
-task-priority: highest
+task-priority:
+    by-project:
+        "fenix": highest
+        "staging-fenix": low
 
 taskgraph:
     register: fenix_taskgraph:register

--- a/taskcluster/fenix_taskgraph/release_promotion.py
+++ b/taskcluster/fenix_taskgraph/release_promotion.py
@@ -17,6 +17,7 @@ from taskgraph.util.taskgraph import find_decision_task, find_existing_tasks_fro
 
 RELEASE_PROMOTION_PROJECTS = (
     "https://github.com/mozilla-mobile/fenix",
+    "https://github.com/mozilla-releng/staging-fenix",
 )
 
 


### PR DESCRIPTION
Let's make mozilla-releng/staging-fenix the official staging repository.
By supporting it in the automation, we no longer need to maintain a
staging patchset to test things properly.