### PR TITLE
For #9188: wait for page load in Reader mode

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/ReaderViewTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/ReaderViewTest.kt
@@ -119,12 +119,14 @@ class ReaderViewTest {
         navigationToolbar {
             verifyReaderViewDetected(true)
             toggleReaderView()
+            mDevice.waitForIdle()
         }.openThreeDotMenu {
             verifyReaderViewAppearance(true)
         }.closeBrowserMenuToBrowser { }
 
         navigationToolbar {
             toggleReaderView()
+            mDevice.waitForIdle()
         }.openThreeDotMenu {
             verifyReaderViewAppearance(false)
         }.close { }
@@ -150,6 +152,7 @@ class ReaderViewTest {
         navigationToolbar {
             verifyReaderViewDetected(true)
             toggleReaderView()
+            mDevice.waitForIdle()
         }.openThreeDotMenu {
             verifyReaderViewAppearance(true)
         }.openReaderViewAppearance {
@@ -185,6 +188,7 @@ class ReaderViewTest {
         navigationToolbar {
             verifyReaderViewDetected(true)
             toggleReaderView()
+            mDevice.waitForIdle()
         }.openThreeDotMenu {
             verifyReaderViewAppearance(true)
         }.openReaderViewAppearance {
@@ -226,6 +230,7 @@ class ReaderViewTest {
         navigationToolbar {
             verifyReaderViewDetected(true)
             toggleReaderView()
+            mDevice.waitForIdle()
         }.openThreeDotMenu {
             verifyReaderViewAppearance(true)
         }.openReaderViewAppearance {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -1144,6 +1144,7 @@ class SmokeTest {
         navigationToolbar {
             verifyReaderViewDetected(true)
             toggleReaderView()
+            mDevice.waitForIdle()
         }.openThreeDotMenu {
             verifyReaderViewAppearance(true)
         }.openReaderViewAppearance {


### PR DESCRIPTION
For #9188: Reader View tests needed to wait for the page to finish loading in reader mode before the Appearance button is visible.
