### PR TITLE
Close #15979: Add MOZILLA_OFFICIAL flag for release builds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -360,6 +360,16 @@ android.applicationVariants.all { variant ->
         buildConfigField 'String', 'NIMBUS_ENDPOINT', 'null'
         println("--")
     }
+
+// -------------------------------------------------------------------------------------------------
+// BuildConfig: Set flag for official builds; similar to MOZILLA_OFFICIAL in mozilla-central.
+// -------------------------------------------------------------------------------------------------
+
+    if (project.hasProperty("official") || gradle.hasProperty("localProperties.official")) {
+        buildConfigField 'Boolean', 'MOZILLA_OFFICIAL', 'true'
+    } else {
+        buildConfigField 'Boolean', 'MOZILLA_OFFICIAL', 'false'
+    }
 }
 
 androidExtensions {

--- a/taskcluster/fenix_taskgraph/transforms/build.py
+++ b/taskcluster/fenix_taskgraph/transforms/build.py
@@ -104,7 +104,10 @@ def add_nightly_version(config, tasks):
 
     for task in tasks:
         if task.pop("include-nightly-version", False):
-            task["run"]["gradlew"].append('-PversionName={}'.format(formated_date_time))
+            task["run"]["gradlew"].extend([
+                '-PversionName={}'.format(formated_date_time),
+                '-Pofficial'
+            ])
         yield task
 
 
@@ -112,9 +115,10 @@ def add_nightly_version(config, tasks):
 def add_release_version(config, tasks):
     for task in tasks:
         if task.pop("include-release-version", False):
-            task["run"]["gradlew"].append(
-                '-PversionName={}'.format(config.params["version"])
-            )
+            task["run"]["gradlew"].extend([
+                '-PversionName={}'.format(config.params["version"]),
+                '-Pofficial'
+            ])
         yield task
 
 


### PR DESCRIPTION
When we build release APKs on Mozilla infrastructure, we want a way to
know this in code for features that would only work on them.

---

A bit outside my knowledge, so please review with extreme scrutiny. 😄 I've tried to follow the original pattern, but I wasn't sure if it made any sense to have a separate transform for appending a flag to the gradlew task.

@pocmo would you be interested in reviewing this as well? 

Fixes #15979 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
