### PR TITLE
For #9188: wait for page content to appear in Reader mode tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/ReaderViewTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/ReaderViewTest.kt
@@ -17,6 +17,7 @@ import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.ViewVisibilityIdlingResource
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
+import org.mozilla.fenix.ui.robots.browserScreen
 import org.mozilla.fenix.ui.robots.mDevice
 
 /**
@@ -32,6 +33,7 @@ import org.mozilla.fenix.ui.robots.mDevice
 class ReaderViewTest {
     private lateinit var mockWebServer: MockWebServer
     private var readerViewNotification: ViewVisibilityIdlingResource? = null
+    private val estimatedReadingTime = "1 - 2 minutes"
 
     @get:Rule
     val activityIntentTestRule = HomeActivityIntentTestRule()
@@ -120,6 +122,10 @@ class ReaderViewTest {
             verifyReaderViewDetected(true)
             toggleReaderView()
             mDevice.waitForIdle()
+        }
+
+        browserScreen {
+            verifyPageContent(estimatedReadingTime)
         }.openThreeDotMenu {
             verifyReaderViewAppearance(true)
         }.closeBrowserMenuToBrowser { }
@@ -153,6 +159,10 @@ class ReaderViewTest {
             verifyReaderViewDetected(true)
             toggleReaderView()
             mDevice.waitForIdle()
+        }
+
+        browserScreen {
+            verifyPageContent(estimatedReadingTime)
         }.openThreeDotMenu {
             verifyReaderViewAppearance(true)
         }.openReaderViewAppearance {
@@ -189,6 +199,10 @@ class ReaderViewTest {
             verifyReaderViewDetected(true)
             toggleReaderView()
             mDevice.waitForIdle()
+        }
+
+        browserScreen {
+            verifyPageContent(estimatedReadingTime)
         }.openThreeDotMenu {
             verifyReaderViewAppearance(true)
         }.openReaderViewAppearance {
@@ -231,6 +245,10 @@ class ReaderViewTest {
             verifyReaderViewDetected(true)
             toggleReaderView()
             mDevice.waitForIdle()
+        }
+
+        browserScreen {
+            verifyPageContent(estimatedReadingTime)
         }.openThreeDotMenu {
             verifyReaderViewAppearance(true)
         }.openReaderViewAppearance {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -1128,6 +1128,7 @@ class SmokeTest {
     fun verifyReaderViewAppearanceUI() {
         val readerViewPage =
             TestAssetHelper.getLoremIpsumAsset(mockWebServer)
+        val estimatedReadingTime = "1 - 2 minutes"
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(readerViewPage.url) {
@@ -1145,6 +1146,10 @@ class SmokeTest {
             verifyReaderViewDetected(true)
             toggleReaderView()
             mDevice.waitForIdle()
+        }
+
+        browserScreen {
+            verifyPageContent(estimatedReadingTime)
         }.openThreeDotMenu {
             verifyReaderViewAppearance(true)
         }.openReaderViewAppearance {


### PR DESCRIPTION
Follow-up for #17661 which didn't fix the problem entirely.
Ran the test with this change 70 times and all passed: https://github.com/mozilla-mobile/fenix/runs/1783288191