### PR TITLE
Remove SessionManager references from UI tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/SessionLoadedIdlingResource.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/SessionLoadedIdlingResource.kt
@@ -5,6 +5,7 @@ package org.mozilla.fenix.helpers
 
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.IdlingResource
+import mozilla.components.browser.state.selector.selectedTab
 import org.mozilla.fenix.FenixApplication
 
 /**
@@ -21,13 +22,12 @@ class SessionLoadedIdlingResource : IdlingResource {
 
     override fun isIdleNow(): Boolean {
         val context = ApplicationProvider.getApplicationContext<FenixApplication>()
-        val sessionManager = context.components.core.sessionManager
-        val session = sessionManager.selectedSession
+        val selectedTab = context.components.core.store.state.selectedTab
 
-        return if (session?.loading == true) {
+        return if (selectedTab?.content?.loading == true) {
             false
         } else {
-            if (session?.progress == 100) {
+            if (selectedTab?.content?.progress == 100) {
                 invokeCallback()
                 true
             } else {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -32,6 +32,7 @@ import androidx.test.uiautomator.By.text
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
+import mozilla.components.browser.state.selector.selectedTab
 import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.Matchers.not
@@ -49,8 +50,8 @@ class BrowserRobot {
     private lateinit var sessionLoadedIdlingResource: SessionLoadedIdlingResource
 
     fun verifyCurrentPrivateSession(context: Context) {
-        val session = context.components.core.sessionManager.selectedSession
-        assertTrue("Current session is private", session?.private!!)
+        val selectedTab = context.components.core.store.state.selectedTab
+        assertTrue("Current session is private", selectedTab?.content?.private ?: false)
     }
 
     fun verifyUrl(url: String) {


### PR DESCRIPTION
Just switching to store so we can deprecate `SessionManager` soon.