### PR TITLE
For #16959: verify page url not content in swipeToSwitchTabTest

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -531,9 +531,9 @@ class SmokeTest {
         }.openNewTab {
         }.submitQuery(secondWebPage.url.toString()) {
             swipeNavBarRight(secondWebPage.url.toString())
-            verifyPageContent(firstWebPage.content)
+            verifyUrl(firstWebPage.url.toString())
             swipeNavBarLeft(firstWebPage.url.toString())
-            verifyPageContent(secondWebPage.content)
+            verifyUrl(secondWebPage.url.toString())
         }
     }
 


### PR DESCRIPTION
For #16959. Ran the test on Firebase 50 times and all passed. See runs: https://github.com/mozilla-mobile/fenix/runs/1806799002. 