### PR TITLE
Remove SessionManager dependency from CustomTabsIntegration.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabsIntegration.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabsIntegration.kt
@@ -6,7 +6,6 @@ package org.mozilla.fenix.customtabs
 
 import android.app.Activity
 import androidx.appcompat.content.res.AppCompatResources.getDrawable
-import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.browser.toolbar.display.DisplayToolbar
@@ -19,7 +18,6 @@ import org.mozilla.fenix.components.toolbar.ToolbarMenu
 import org.mozilla.fenix.ext.settings
 
 class CustomTabsIntegration(
-    sessionManager: SessionManager,
     store: BrowserStore,
     useCases: CustomTabsUseCases,
     toolbar: BrowserToolbar,
@@ -61,16 +59,6 @@ class CustomTabsIntegration(
         // If in private mode, override toolbar background to use private color
         // See #5334
         if (isPrivate) {
-            sessionManager.findSessionById(sessionId)?.apply {
-                val config = customTabConfig
-                customTabConfig = config?.copy(
-                    // Don't set toolbar background automatically
-                    toolbarColor = null,
-                    // Force tinting the action button
-                    actionButtonConfig = config.actionButtonConfig?.copy(tint = true)
-                )
-            }
-
             toolbar.background = getDrawable(activity, R.drawable.toolbar_background)
         }
     }
@@ -94,7 +82,9 @@ class CustomTabsIntegration(
         menuItemIndex = START_OF_MENU_ITEMS_INDEX,
         window = activity.window,
         shareListener = { onItemTapped.invoke(ToolbarMenu.Item.Share) },
-        closeListener = { activity.finishAndRemoveTask() }
+        closeListener = { activity.finishAndRemoveTask() },
+        updateToolbarBackground = !isPrivate,
+        forceActionButtonTinting = isPrivate
     )
 
     override fun start() = feature.start()

--- a/app/src/main/java/org/mozilla/fenix/customtabs/ExternalAppBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/ExternalAppBrowserFragment.kt
@@ -61,7 +61,6 @@ class ExternalAppBrowserFragment : BaseBrowserFragment(), UserInteractionHandler
 
         customTabsIntegration.set(
             feature = CustomTabsIntegration(
-                sessionManager = requireComponents.core.sessionManager,
                 store = requireComponents.core.store,
                 useCases = requireComponents.useCases.customTabsUseCases,
                 toolbar = toolbar,


### PR DESCRIPTION
Matching change in AC: https://github.com/mozilla-mobile/android-components/commit/d7f2692843445ed07db83324f48d55bfe0d30770

This patch removes the need for `SessionManager` by configuring CustomTabsToolbarFeature instead of manipulating `CustomTabConfig`.