### PR TITLE
Refactor WebAppSiteControlsBuilder to use browser store

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/customtabs/ExternalAppBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/ExternalAppBrowserFragment.kt
@@ -138,7 +138,7 @@ class ExternalAppBrowserFragment : BaseBrowserFragment(), UserInteractionHandler
                     customTabSessionId,
                     manifest,
                     WebAppSiteControlsBuilder(
-                        requireComponents.core.sessionManager,
+                        requireComponents.core.store,
                         requireComponents.useCases.sessionUseCases.reload,
                         customTabSessionId,
                         manifest

--- a/app/src/main/java/org/mozilla/fenix/customtabs/WebAppSiteControlsBuilder.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/WebAppSiteControlsBuilder.kt
@@ -7,15 +7,16 @@ package org.mozilla.fenix.customtabs
 import android.app.Notification
 import android.content.Context
 import android.content.Intent
-import mozilla.components.browser.session.SessionManager
+import mozilla.components.browser.state.selector.findCustomTab
 import mozilla.components.browser.state.state.CustomTabSessionState
+import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.manifest.WebAppManifest
 import mozilla.components.feature.pwa.feature.SiteControlsBuilder
 import mozilla.components.feature.session.SessionUseCases
 import org.mozilla.fenix.R
 
 class WebAppSiteControlsBuilder(
-    private val sessionManager: SessionManager,
+    private val store: BrowserStore,
     reloadUrlUseCase: SessionUseCases.ReloadUrlUseCase,
     private val sessionId: String,
     private val manifest: WebAppManifest
@@ -26,9 +27,9 @@ class WebAppSiteControlsBuilder(
     override fun buildNotification(context: Context, builder: Notification.Builder) {
         inner.buildNotification(context, builder)
 
-        val isPrivateSession = sessionManager.findSessionById(sessionId)?.private ?: false
-
-        if (!isPrivateSession) { return }
+        if (store.state.findCustomTab(sessionId)?.content?.private != true) {
+            return
+        }
 
         builder.setSmallIcon(R.drawable.ic_private_browsing)
         builder.setContentTitle(context.getString(R.string.pwa_site_controls_title_private, manifest.name))


### PR DESCRIPTION
Another step to remove `SessionManager` usage.