### PR TITLE
For #15214: Don't display separators in the bookmarks list views

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/ext/BookmarkNode.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/BookmarkNode.kt
@@ -15,6 +15,6 @@ val Context.bookmarkStorage: PlacesBookmarksStorage
  * Removes [children] from [BookmarkNode.children] and returns the new modified [BookmarkNode].
  */
 operator fun BookmarkNode.minus(children: Set<BookmarkNode>): BookmarkNode {
-    val removedChildrenGuids = children.map { it.guid }.toSet()
+    val removedChildrenGuids = children.map { it.guid }
     return this.copy(children = this.children?.filterNot { removedChildrenGuids.contains(it.guid) })
 }

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkAdapter.kt
@@ -21,23 +21,25 @@ import org.mozilla.fenix.library.bookmarks.viewholders.BookmarkSeparatorViewHold
 class BookmarkAdapter(private val emptyView: View, private val interactor: BookmarkViewInteractor) :
     RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
-    private var tree: List<BookmarkNode> = listOf()
+    @VisibleForTesting var tree: List<BookmarkNode> = listOf()
     private var mode: BookmarkFragmentState.Mode = BookmarkFragmentState.Mode.Normal()
     private var isFirstRun = true
 
     fun updateData(tree: BookmarkNode?, mode: BookmarkFragmentState.Mode) {
-        // Display folders above all other bookmarks.
         val allNodes = tree?.children.orEmpty()
         val folders: MutableList<BookmarkNode> = mutableListOf()
         val notFolders: MutableList<BookmarkNode> = mutableListOf()
+        val separators: MutableList<BookmarkNode> = mutableListOf()
         allNodes.forEach {
-            if (it.type == BookmarkNodeType.FOLDER) {
-                folders.add(it)
-            } else {
-                notFolders.add(it)
+            when (it.type) {
+                BookmarkNodeType.SEPARATOR -> separators.add(it)
+                BookmarkNodeType.FOLDER -> folders.add(it)
+                else -> notFolders.add(it)
             }
         }
-        val newTree = folders + notFolders
+        // Display folders above all other bookmarks. Exclude separators.
+        // For separator removal, see discussion in https://github.com/mozilla-mobile/fenix/issues/15214
+        val newTree = folders + notFolders - separators
 
         val diffUtil = DiffUtil.calculateDiff(
             BookmarkDiffUtil(

--- a/app/src/test/java/org/mozilla/fenix/ext/BookmarkNodeTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/ext/BookmarkNodeTest.kt
@@ -5,22 +5,21 @@
 package org.mozilla.fenix.ext
 
 import mozilla.components.concept.storage.BookmarkNode
-import mozilla.components.concept.storage.BookmarkNodeType
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import org.mozilla.fenix.library.bookmarks.testBookmarkItem
+import org.mozilla.fenix.library.bookmarks.testFolder
 
 class BookmarkNodeTest {
 
-    private val bookmarkChild1 = newBookmarkNode("Child 1", 1, null)
-    private val bookmarkChild2 = newBookmarkNode("Child 2", 2, null)
-    private val bookmarkChild3 = newBookmarkNode("Child 3", 3, null)
+    private val bookmarkChild1 = testBookmarkItem("someFolder", "http://www.mockurl.com/1", "Child 1")
+    private val bookmarkChild2 = testBookmarkItem("someFolder", "http://www.mockurl.com/2", "Child 2")
+    private val bookmarkChild3 = testBookmarkItem("someFolder", "http://www.mockurl.com/3", "Child 3")
     private val allChildren = listOf(bookmarkChild1, bookmarkChild2)
-
-    private var uniqueId = 0
 
     @Test
     fun `GIVEN a bookmark node with children WHEN minusing a sub set of children THEN the children subset is removed and rest remains`() {
-        val bookmarkNode = newBookmarkNode("Parent 1", 0, allChildren)
+        val bookmarkNode = testFolder("parent1", "root", allChildren)
         val subsetToSubtract = setOf(bookmarkChild1)
         val expectedRemainingSubset = listOf(bookmarkChild2)
         val bookmarkNodeSubsetRemoved = bookmarkNode.minus(subsetToSubtract)
@@ -29,7 +28,7 @@ class BookmarkNodeTest {
 
     @Test
     fun `GIVEN a bookmark node with children WHEN minusing a set of all children THEN all children are removed and empty list remains`() {
-        val bookmarkNode = newBookmarkNode("Parent 1", 0, allChildren)
+        val bookmarkNode = testFolder("parent1", "root", allChildren)
         val setofAllChildren = setOf(bookmarkChild1, bookmarkChild2)
         val bookmarkNodeAllChildrenRemoved = bookmarkNode.minus(setofAllChildren)
         assertEquals(emptyList<BookmarkNode>(), bookmarkNodeAllChildrenRemoved.children)
@@ -38,21 +37,21 @@ class BookmarkNodeTest {
     @Test
     fun `GIVEN a bookmark node with children WHEN minusing a set of non-children THEN no children are removed`() {
         val setofNonChildren = setOf(bookmarkChild3)
-        val bookmarkNode = newBookmarkNode("Parent 1", 0, allChildren)
+        val bookmarkNode = testFolder("parent1", "root", allChildren)
         val bookmarkNodeNonChildrenRemoved = bookmarkNode.minus(setofNonChildren)
         assertEquals(allChildren, bookmarkNodeNonChildrenRemoved.children)
     }
 
     @Test
     fun `GIVEN a bookmark node with children WHEN minusing an empty set THEN no children are removed`() {
-        val bookmarkNode = newBookmarkNode("Parent 1", 0, allChildren)
+        val bookmarkNode = testFolder("parent1", "root", allChildren)
         val bookmarkNodeEmptySetRemoved = bookmarkNode.minus(emptySet())
         assertEquals(allChildren, bookmarkNodeEmptySetRemoved.children)
     }
 
     @Test
     fun `GIVEN a bookmark node with an empty list as children WHEN minusing a set of non-children from an empty parent THEN an empty list remains`() {
-        val parentWithEmptyList = newBookmarkNode("Parent 1", 0, emptyList<BookmarkNode>())
+        val parentWithEmptyList = testFolder("parent1", "root", emptyList())
         val setofAllChildren = setOf(bookmarkChild1, bookmarkChild2)
         val parentWithEmptyListNonChildRemoved = parentWithEmptyList.minus(setofAllChildren)
         assertEquals(emptyList<BookmarkNode>(), parentWithEmptyListNonChildRemoved.children)
@@ -60,14 +59,14 @@ class BookmarkNodeTest {
 
     @Test
     fun `GIVEN a bookmark node with null as children WHEN minusing a set of non-children from a parent with null children THEN null remains`() {
-        val parentWithNullList = newBookmarkNode("Parent 1", 0, null)
+        val parentWithNullList = testFolder("parent1", "root", null)
         val parentWithNullListNonChildRemoved = parentWithNullList.minus(allChildren.toSet())
         assertEquals(null, parentWithNullListNonChildRemoved.children)
     }
 
     @Test
     fun `GIVEN a bookmark node with children WHEN minusing a sub-set of children THEN the rest of the parents object should remain the same`() {
-        val bookmarkNode = newBookmarkNode("Parent 1", 0, allChildren)
+        val bookmarkNode = testFolder("parent1", "root", allChildren)
         val subsetToSubtract = setOf(bookmarkChild1)
         val expectedRemainingSubset = listOf(bookmarkChild2)
         val resultBookmarkNode = bookmarkNode.minus(subsetToSubtract)
@@ -77,14 +76,4 @@ class BookmarkNodeTest {
         val restofOriginal = bookmarkNode.copy(children = expectedRemainingSubset)
         assertEquals(restOfResult, restofOriginal)
     }
-
-    private fun newBookmarkNode(title: String, position: Int, children: List<BookmarkNode>?) = BookmarkNode(
-            type = BookmarkNodeType.ITEM,
-            guid = uniqueId++.toString(),
-            parentGuid = "12",
-            position = position,
-            title = title,
-            url = "www.mockurl.com",
-            children = children
-    )
 }

--- a/app/src/test/java/org/mozilla/fenix/library/bookmarks/UtilsKtTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/bookmarks/UtilsKtTest.kt
@@ -16,7 +16,7 @@ import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 class UtilsKtTest {
     @Test
     fun `friendly root titles`() {
-        val url = testBookmarkItem("folder","http://mozilla.org", "Mozilla")
+        val url = testBookmarkItem("folder", "http://mozilla.org", "Mozilla")
         assertEquals("Mozilla", friendlyRootTitle(testContext, url))
 
         val folder = testFolder("456", "folder", null, "Folder")
@@ -50,7 +50,7 @@ class UtilsKtTest {
     @Test
     fun `flatNodeList various cases`() {
         val url = testBookmarkItem("folder", "http://mozilla.org")
-        val url2 = testBookmarkItem( "folder2", "http://mozilla.org")
+        val url2 = testBookmarkItem("folder2", "http://mozilla.org")
         assertEquals(emptyList<BookmarkNodeWithDepth>(), url.flatNodeList(null))
 
         val root = testFolder("root", null, null)
@@ -98,4 +98,8 @@ internal fun testFolder(guid: String, parentGuid: String?, children: List<Bookma
     title,
     null,
     children
+)
+
+internal fun testSeparator(parentGuid: String) = BookmarkNode(
+    BookmarkNodeType.SEPARATOR, "guid#${Math.random() * 1000}", parentGuid, null, null, null, null
 )

--- a/app/src/test/java/org/mozilla/fenix/library/bookmarks/UtilsKtTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/bookmarks/UtilsKtTest.kt
@@ -16,26 +16,10 @@ import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 class UtilsKtTest {
     @Test
     fun `friendly root titles`() {
-        val url = BookmarkNode(
-            BookmarkNodeType.ITEM,
-            "456",
-            "folder",
-            0,
-            "Mozilla",
-            "http://mozilla.org",
-            null
-        )
+        val url = testBookmarkItem("folder","http://mozilla.org", "Mozilla")
         assertEquals("Mozilla", friendlyRootTitle(testContext, url))
 
-        val folder = BookmarkNode(
-            BookmarkNodeType.FOLDER,
-            "456",
-            "folder",
-            0,
-            "Folder",
-            null,
-            null
-        )
+        val folder = testFolder("456", "folder", null, "Folder")
         assertEquals("Folder", friendlyRootTitle(testContext, folder))
 
         val root = folder.copy(guid = "root________", title = "root")
@@ -65,67 +49,17 @@ class UtilsKtTest {
 
     @Test
     fun `flatNodeList various cases`() {
-        val url = BookmarkNode(
-            BookmarkNodeType.ITEM,
-            "456",
-            "folder",
-            0,
-            "Mozilla",
-            "http://mozilla.org",
-            null
-        )
-        val url2 = BookmarkNode(
-            BookmarkNodeType.ITEM,
-            "8674",
-            "folder2",
-            0,
-            "Mozilla",
-            "http://mozilla.org",
-            null
-        )
+        val url = testBookmarkItem("folder", "http://mozilla.org")
+        val url2 = testBookmarkItem( "folder2", "http://mozilla.org")
         assertEquals(emptyList<BookmarkNodeWithDepth>(), url.flatNodeList(null))
 
-        val root = BookmarkNode(
-            BookmarkNodeType.FOLDER,
-            "root",
-            null,
-            0,
-            "root",
-            null,
-            null
-        )
+        val root = testFolder("root", null, null)
         assertEquals(listOf(BookmarkNodeWithDepth(0, root, null)), root.flatNodeList(null))
         assertEquals(emptyList<BookmarkNodeWithDepth>(), root.flatNodeList("root"))
 
-        val folder = BookmarkNode(
-            BookmarkNodeType.FOLDER,
-            "folder",
-            root.guid,
-            0,
-            "folder",
-            null,
-            listOf(url)
-        )
-
-        val folder3 = BookmarkNode(
-            BookmarkNodeType.FOLDER,
-            "folder3",
-            "folder2",
-            0,
-            "folder3",
-            null,
-            null
-        )
-
-        val folder2 = BookmarkNode(
-            BookmarkNodeType.FOLDER,
-            "folder2",
-            root.guid,
-            0,
-            "folder2",
-            null,
-            listOf(folder3, url2)
-        )
+        val folder = testFolder("folder", root.guid, listOf(url))
+        val folder3 = testFolder("folder3", "folder2", null)
+        val folder2 = testFolder("folder2", root.guid, listOf(folder3, url2))
 
         val rootWithChildren = root.copy(children = listOf(folder, folder2))
         assertEquals(
@@ -145,3 +79,23 @@ class UtilsKtTest {
         )
     }
 }
+
+internal fun testBookmarkItem(parentGuid: String, url: String, title: String = "Item for $url") = BookmarkNode(
+    BookmarkNodeType.ITEM,
+    "guid#${Math.random() * 1000}",
+    parentGuid,
+    0,
+    title,
+    url,
+    null
+)
+
+internal fun testFolder(guid: String, parentGuid: String?, children: List<BookmarkNode>?, title: String = "Folder: $guid") = BookmarkNode(
+    BookmarkNodeType.FOLDER,
+    guid,
+    parentGuid,
+    0,
+    title,
+    null,
+    children
+)


### PR DESCRIPTION
This simply excludes separators in the adapter. Also adds/cleans up a few adjacent tests.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
