### PR TITLE
For issue #8605: Hiding the usernameview if the data item.username is blank.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/logins/view/LoginsListViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/view/LoginsListViewHolder.kt
@@ -5,6 +5,7 @@
 package org.mozilla.fenix.settings.logins.view
 
 import android.view.View
+import androidx.core.view.isVisible
 import kotlinx.android.synthetic.main.logins_item.*
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.loadIntoView
@@ -28,6 +29,7 @@ class LoginsListViewHolder(
             timeLastUsed = item.timeLastUsed
         )
         webAddressView.text = item.origin
+        usernameView.isVisible = item.username.isNotEmpty()
         usernameView.text = item.username
 
         updateFavIcon(item.origin)


### PR DESCRIPTION
resolves #8605 

The issue is if the 'userview' TextView is empty, then the other TextView is not consistent with other areas in the app as mentioned in the issue. The 'webAddressView' stays on the Top and does not center the parent view.

Issue screenshot:
![image](https://user-images.githubusercontent.com/10706659/106714375-9f86e780-65b0-11eb-89e6-d29d4c956564.png)

After resolving the issue screenshot:
![image](https://user-images.githubusercontent.com/10706659/106714879-4a97a100-65b1-11eb-8808-c685b7201eda.png)

Now the 'webAddressView' text view centers the parent view.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
