### PR TITLE
Remove TabsUseCases methods that take a Session object.

### DIFF
--- a/app/src/geckoRelease/java/org/mozilla/fenix/engine/GeckoProvider.kt
+++ b/app/src/geckoRelease/java/org/mozilla/fenix/engine/GeckoProvider.kt
@@ -13,6 +13,7 @@ import mozilla.components.lib.crash.handler.CrashHandlerService
 import mozilla.components.service.sync.logins.GeckoLoginStorageDelegate
 import org.mozilla.fenix.Config
 import org.mozilla.fenix.ext.components
+import org.mozilla.geckoview.ContentBlocking
 import org.mozilla.geckoview.GeckoRuntime
 import org.mozilla.geckoview.GeckoRuntimeSettings
 import org.mozilla.geckoview.ContentBlocking.SafeBrowsingProvider

--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -1070,7 +1070,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
         getSessionById()?.let { session ->
             return if (session.source == SessionState.Source.ACTION_VIEW) {
                 activity?.finish()
-                requireComponents.useCases.tabsUseCases.removeTab(session)
+                requireComponents.useCases.tabsUseCases.removeTab(session.id)
                 true
             } else {
                 if (session.hasParentSession) {

--- a/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarView.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarView.kt
@@ -10,7 +10,6 @@ import androidx.core.graphics.BlendModeCompat.SRC_IN
 import androidx.core.graphics.drawable.toBitmap
 import mozilla.components.browser.awesomebar.BrowserAwesomeBar
 import mozilla.components.browser.search.DefaultSearchEngineProvider
-import mozilla.components.browser.session.Session
 import mozilla.components.browser.state.search.SearchEngine
 import mozilla.components.concept.awesomebar.AwesomeBar
 import mozilla.components.concept.engine.EngineSession
@@ -86,10 +85,6 @@ class AwesomeBarView(
     }
 
     private val selectTabUseCase = object : TabsUseCases.SelectTabUseCase {
-        override fun invoke(session: Session) {
-            interactor.onExistingSessionSelected(session.id)
-        }
-
         override fun invoke(tabId: String) {
             interactor.onExistingSessionSelected(tabId)
         }

--- a/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayDialogFragment.kt
@@ -32,7 +32,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
 import mozilla.appservices.places.BookmarkRoot
-import mozilla.components.browser.session.Session
 import mozilla.components.browser.state.selector.findTab
 import mozilla.components.browser.state.selector.getNormalOrPrivateTabs
 import mozilla.components.browser.state.selector.normalTabs
@@ -105,12 +104,6 @@ class TabTrayDialogFragment : AppCompatDialogFragment(), UserInteractionHandler 
             requireComponents.useCases.tabsUseCases.selectTab(tabId)
             navigateToBrowser()
         }
-
-        override fun invoke(session: Session) {
-            requireContext().components.analytics.metrics.track(Event.OpenedExistingTab)
-            requireComponents.useCases.tabsUseCases.selectTab(session)
-            navigateToBrowser()
-        }
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
@@ -126,12 +119,6 @@ class TabTrayDialogFragment : AppCompatDialogFragment(), UserInteractionHandler 
             requireContext().components.analytics.metrics.track(Event.ClosedExistingTab)
             showUndoSnackbarForTab(sessionId)
             removeIfNotLastTab(sessionId)
-        }
-
-        override fun invoke(session: Session) {
-            requireContext().components.analytics.metrics.track(Event.ClosedExistingTab)
-            showUndoSnackbarForTab(session.id)
-            removeIfNotLastTab(session.id)
         }
     }
 

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "73.0.20210202194906"
+    const val VERSION = "73.0.20210203143122"
 }


### PR DESCRIPTION
This is the Fenix change for this breaking AC change (not landed yet): https://github.com/mozilla-mobile/android-components/pull/9592