### PR TITLE
For #17724: Wait for tab to be fully created before showing ETP Onboarding if ETP is active

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionOverlay.kt
+++ b/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionOverlay.kt
@@ -62,9 +62,9 @@ class TrackingProtectionOverlay(
             }.ifChanged { tab ->
                 tab.content.loading
             }
-            .collect { tab ->
-                onLoadingStateChanged(tab)
-            }
+                .collect { tab ->
+                    onLoadingStateChanged(tab)
+                }
         }
     }
 
@@ -77,7 +77,10 @@ class TrackingProtectionOverlay(
 
     @VisibleForTesting
     internal fun onLoadingStateChanged(tab: SessionState) {
-        if (!tab.content.loading && shouldShowTrackingProtectionOnboarding(tab)) {
+        if (shouldShowTrackingProtectionOnboarding(tab) &&
+            tab.content.progress == FULL_PROGRESS &&
+            settings.shouldUseTrackingProtection
+        ) {
             showTrackingProtectionOnboarding()
         }
     }
@@ -85,7 +88,7 @@ class TrackingProtectionOverlay(
     private fun shouldShowTrackingProtectionOnboarding(tab: SessionState) =
         tab.trackingProtection.enabled &&
                 tab.trackingProtection.blockedTrackers.isNotEmpty() &&
-            settings.shouldShowTrackingProtectionCfr
+                settings.shouldShowTrackingProtectionCfr
 
     @Suppress("MagicNumber", "InflateParams")
     private fun showTrackingProtectionOnboarding() {
@@ -184,6 +187,7 @@ class TrackingProtectionOverlay(
     }
 
     private companion object {
+        private const val FULL_PROGRESS = 100
         private const val BUTTON_INCREASE_DPS = 12
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/trackingprotection/TrackingProtectionOverlayTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/trackingprotection/TrackingProtectionOverlayTest.kt
@@ -156,13 +156,29 @@ class TrackingProtectionOverlayTest {
     fun `show onboarding when trackers are blocked`() {
         every { toolbar.hasWindowFocus() } returns true
         every { settings.shouldShowTrackingProtectionCfr } returns true
+        every { session.content.progress } returns 100
         every { session.content.loading } returns false
+        every { settings.shouldUseTrackingProtection } returns true
         every { session.trackingProtection } returns TrackingProtectionState(
             enabled = true,
             blockedTrackers = listOf(mockk())
         )
         overlay.onLoadingStateChanged(session)
         verify { settings.incrementTrackingProtectionOnboardingCount() }
+    }
+
+    @Test
+    fun `no-op when trackers are blocked but not finished loading`() {
+        every { toolbar.hasWindowFocus() } returns true
+        every { settings.shouldShowTrackingProtectionCfr } returns true
+        every { session.content.progress } returns 50
+        every { session.content.loading } returns false
+        every { session.trackingProtection } returns TrackingProtectionState(
+            enabled = true,
+            blockedTrackers = listOf(mockk())
+        )
+        overlay.onLoadingStateChanged(session)
+        verify(exactly = 0) { settings.incrementTrackingProtectionOnboardingCount() }
     }
 
     @Test


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
