### PR TITLE
Fixes #17833 - increment A/A experiment id

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/experiments/Experiments.kt
+++ b/app/src/main/java/org/mozilla/fenix/experiments/Experiments.kt
@@ -6,7 +6,7 @@ package org.mozilla.fenix.experiments
 
 class Experiments {
     companion object {
-        const val A_A_NIMBUS_VALIDATION = "fenix-nimbus-validation-v2"
+        const val A_A_NIMBUS_VALIDATION = "fenix-nimbus-validation-v3"
         const val BOOKMARK_ICON = "fenix-bookmark-list-icon"
     }
 }


### PR DESCRIPTION
This PR increments the experiment id of the A/A nimbus validation experiment.

N.B. For local build/testing purposes you can set the `nimbus.remote-settings.url` property in `local.properties`; this is usually supplied by the CI.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture