### PR TITLE
For #17771: three-dot menu reorder

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/ReaderViewTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/ReaderViewTest.kt
@@ -12,7 +12,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.ui.robots.navigationToolbar
 import androidx.test.espresso.IdlingRegistry
-import org.mozilla.fenix.Config
 import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/ReaderViewTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/ReaderViewTest.kt
@@ -12,6 +12,8 @@ import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.ui.robots.navigationToolbar
 import androidx.test.espresso.IdlingRegistry
+import org.mozilla.fenix.Config
+import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.ViewVisibilityIdlingResource
@@ -103,39 +105,42 @@ class ReaderViewTest {
 
     @Test
     fun verifyReaderViewToggle() {
-        val readerViewPage =
-            TestAssetHelper.getLoremIpsumAsset(mockWebServer)
+        // New three-dot menu design does not have readerview
+        if (!FeatureFlags.toolbarMenuFeature) {
+            val readerViewPage =
+                TestAssetHelper.getLoremIpsumAsset(mockWebServer)
 
-        navigationToolbar {
-        }.enterURLAndEnterToBrowser(readerViewPage.url) {
-            mDevice.waitForIdle()
+            navigationToolbar {
+            }.enterURLAndEnterToBrowser(readerViewPage.url) {
+                mDevice.waitForIdle()
+            }
+
+            readerViewNotification = ViewVisibilityIdlingResource(
+                activityIntentTestRule.activity.findViewById(R.id.mozac_browser_toolbar_page_actions),
+                View.VISIBLE
+            )
+
+            IdlingRegistry.getInstance().register(readerViewNotification)
+
+            navigationToolbar {
+                verifyReaderViewDetected(true)
+                toggleReaderView()
+                mDevice.waitForIdle()
+            }
+
+            browserScreen {
+                verifyPageContent(estimatedReadingTime)
+            }.openThreeDotMenu {
+                verifyReaderViewAppearance(true)
+            }.closeBrowserMenuToBrowser { }
+
+            navigationToolbar {
+                toggleReaderView()
+                mDevice.waitForIdle()
+            }.openThreeDotMenu {
+                verifyReaderViewAppearance(false)
+            }.close { }
         }
-
-        readerViewNotification = ViewVisibilityIdlingResource(
-            activityIntentTestRule.activity.findViewById(R.id.mozac_browser_toolbar_page_actions),
-            View.VISIBLE
-        )
-
-        IdlingRegistry.getInstance().register(readerViewNotification)
-
-        navigationToolbar {
-            verifyReaderViewDetected(true)
-            toggleReaderView()
-            mDevice.waitForIdle()
-        }
-
-        browserScreen {
-            verifyPageContent(estimatedReadingTime)
-        }.openThreeDotMenu {
-            verifyReaderViewAppearance(true)
-        }.closeBrowserMenuToBrowser { }
-
-        navigationToolbar {
-            toggleReaderView()
-            mDevice.waitForIdle()
-        }.openThreeDotMenu {
-            verifyReaderViewAppearance(false)
-        }.close { }
     }
 
     @Test

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/ReaderViewTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/ReaderViewTest.kt
@@ -12,6 +12,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.ui.robots.navigationToolbar
 import androidx.test.espresso.IdlingRegistry
+import org.junit.Ignore
 import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
@@ -30,7 +31,7 @@ import org.mozilla.fenix.ui.robots.mDevice
  *
  */
 
-// @Ignore("Temp disable - reader view page detection issues: https://github.com/mozilla-mobile/fenix/issues/9688 ")
+@Ignore("Temp disable - reader view page detection issues: https://github.com/mozilla-mobile/fenix/issues/9688 ")
 class ReaderViewTest {
     private lateinit var mockWebServer: MockWebServer
     private var readerViewNotification: ViewVisibilityIdlingResource? = null

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAddonsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAddonsTest.kt
@@ -79,19 +79,23 @@ class SettingsAddonsTest {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
         val addonName = "uBlock Origin"
 
-        navigationToolbar {
-        }.openNewTabAndEnterToBrowser(defaultWebPage.url) {
-        }.openThreeDotMenu {
-        }.openAddonsManagerMenu {
-            addonsListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.add_ons_list), 1)
-            IdlingRegistry.getInstance().register(addonsListIdlingResource!!)
-            clickInstallAddon(addonName)
-            verifyAddonPrompt(addonName)
-            cancelInstallAddon()
-            clickInstallAddon(addonName)
-            acceptInstallAddon()
-            verifyDownloadAddonPrompt(addonName, activityTestRule)
+        navigationToolbar {}
+            .openNewTabAndEnterToBrowser(defaultWebPage.url) {}
+            .openThreeDotMenu {}
+            .openAddonsManagerMenu {
+                addonsListIdlingResource =
+                    RecyclerViewIdlingResource(
+                        activityTestRule.activity.findViewById(R.id.add_ons_list),
+                        1
+                    )
+                IdlingRegistry.getInstance().register(addonsListIdlingResource!!)
+                clickInstallAddon(addonName)
+                verifyAddonPrompt(addonName)
+                cancelInstallAddon()
+                clickInstallAddon(addonName)
+                acceptInstallAddon()
+
+                verifyDownloadAddonPrompt(addonName, activityTestRule)
         }
     }
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -14,6 +14,7 @@ import androidx.test.uiautomator.UiDevice
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.R
@@ -198,6 +199,7 @@ class SmokeTest {
 
     @Test
     // Verifies the list of items in a tab's 3 dot menu
+    @Ignore("To be re-implemented with the three dot menu changes https://github.com/mozilla-mobile/fenix/issues/17870")
     fun verifyPageMainMenuItemsTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
@@ -231,6 +233,7 @@ class SmokeTest {
     }
 
     @Test
+    @Ignore("To be re-implemented in https://github.com/mozilla-mobile/fenix/issues/17798")
     // Verifies the Synced tabs menu opens from a tab's 3 dot menu
     fun openMainMenuSyncedTabsItemTest() {
         homeScreen {
@@ -362,6 +365,7 @@ class SmokeTest {
 
     @Test
     // Turns ETP toggle off from Settings and verifies the ETP shield is not displayed in the nav bar
+    @Ignore("To be re-implemented with the three dot menu changes https://github.com/mozilla-mobile/fenix/issues/17870")
     fun verifyETPShieldNotDisplayedIfOFFGlobally() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
@@ -537,6 +541,7 @@ class SmokeTest {
 
     @Test
     // Saves a login, then changes it and verifies the update
+    @Ignore("To be re-implemented with the three dot menu changes https://github.com/mozilla-mobile/fenix/issues/17870")
     fun updateSavedLoginTest() {
         val saveLoginTest =
             TestAssetHelper.getSaveLoginAsset(mockWebServer)
@@ -600,6 +605,7 @@ class SmokeTest {
     }
 
     @Test
+    @Ignore("To be re-implemented in https://github.com/mozilla-mobile/fenix/issues/17799")
     // Installs uBlock add-on and checks that the app doesn't crash while loading pages with trackers
     fun noCrashWithAddonInstalledTest() {
         // setting ETP to Strict mode to test it works with add-ons
@@ -1107,6 +1113,7 @@ class SmokeTest {
     }
 
     @Test
+    @Ignore("To be re-implemented in https://github.com/mozilla-mobile/fenix/issues/17799")
     fun mainMenuInstallPWATest() {
         val pwaPage = "https://rpappalax.github.io/testapp/"
 
@@ -1123,6 +1130,7 @@ class SmokeTest {
     }
 
     @Test
+    @Ignore("To be re-implemented in https://github.com/mozilla-mobile/fenix/issues/17971")
     // Verifies that reader mode is detected and the custom appearance controls are displayed
     fun verifyReaderViewAppearanceUI() {
         val readerViewPage =

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/StrictEnhancedTrackingProtectionTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/StrictEnhancedTrackingProtectionTest.kt
@@ -8,6 +8,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.ext.settings
@@ -126,6 +127,7 @@ class StrictEnhancedTrackingProtectionTest {
     }
 
     @Test
+    @Ignore("To be re-implemented with the three dot menu changes https://github.com/mozilla-mobile/fenix/issues/17870")
     fun testStrictVisitDisable() {
         val trackingProtectionTest =
             TestAssetHelper.getEnhancedTrackingProtectionAsset(mockWebServer)

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
@@ -13,7 +13,6 @@ import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Rule
 import org.junit.Test
-import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.HomeActivityTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
@@ -13,6 +13,7 @@ import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Rule
 import org.junit.Test
+import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.HomeActivityTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/ThreeDotMenuMainTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/ThreeDotMenuMainTest.kt
@@ -58,14 +58,9 @@ class ThreeDotMenuMainTest {
         if (FeatureFlags.toolbarMenuFeature) {
             homeScreen {
             }.openThreeDotMenu {
-                verifySettingsButton()
-                verifyBookmarksButton()
-                verifyHistoryButton()
-            }.openSettings {
-                verifySettingsView()
-            }.goBack {
-            }.openThreeDotMenu {
-            }.goBack {}
+            }.openHistory {
+                verifyHistoryMenuView()
+            }.goBackToBrowser {}
 
             homeScreen {
             }.openThreeDotMenu {
@@ -75,9 +70,14 @@ class ThreeDotMenuMainTest {
 
             homeScreen {
             }.openThreeDotMenu {
-            }.openHistory {
-                verifyHistoryMenuView()
-            }
+                verifySettingsButton()
+                verifyBookmarksButton()
+                verifyHistoryButton()
+            }.openSettings {
+                verifySettingsView()
+            }.goBack {
+            }.openThreeDotMenu {
+            }.goBack {}
         } else {
             homeScreen {
             }.openThreeDotMenu {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/ThreeDotMenuMainTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/ThreeDotMenuMainTest.kt
@@ -12,6 +12,7 @@ import org.junit.Before
 import org.junit.BeforeClass
 import org.junit.Rule
 import org.junit.Test
+import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.HomeActivityTestRule
 import org.mozilla.fenix.ui.robots.homeScreen
@@ -54,42 +55,68 @@ class ThreeDotMenuMainTest {
 
     @Test
     fun threeDotMenuItemsTest() {
-        homeScreen {
-        }.openThreeDotMenu {
-            verifySettingsButton()
-            verifyBookmarksButton()
-            verifyHistoryButton()
-            verifyHelpButton()
-            verifyWhatsNewButton()
-        }.openSettings {
-            verifySettingsView()
-        }.goBack {
-        }.openThreeDotMenu {
-        }.openHelp {
-            verifyHelpUrl()
-        }.openTabDrawer {
-            closeTab()
+        if (FeatureFlags.toolbarMenuFeature) {
+            homeScreen {
+            }.openThreeDotMenu {
+                verifySettingsButton()
+                verifyBookmarksButton()
+                verifyHistoryButton()
+            }.openSettings {
+                verifySettingsView()
+            }.goBack {
+            }.openThreeDotMenu {
+            }.goBack {}
+
+            homeScreen {
+            }.openThreeDotMenu {
+            }.openBookmarks {
+                verifyBookmarksMenuView()
+            }.closeMenu {}
+
+            homeScreen {
+            }.openThreeDotMenu {
+            }.openHistory {
+                verifyHistoryMenuView()
+            }
+        } else {
+            homeScreen {
+            }.openThreeDotMenu {
+                verifySettingsButton()
+                verifyBookmarksButton()
+                verifyHistoryButton()
+                verifyHelpButton()
+                verifyWhatsNewButton()
+            }.openSettings {
+                verifySettingsView()
+            }.goBack {
+            }.openThreeDotMenu {
+            }.openHelp {
+                verifyHelpUrl()
+            }.openTabDrawer {
+                closeTab()
+            }
+
+            homeScreen {
+            }.openThreeDotMenu {
+            }.openWhatsNew {
+                verifyWhatsNewURL()
+            }.openTabDrawer {
+                closeTab()
+            }
+
+            homeScreen {
+            }.openThreeDotMenu {
+            }.openBookmarks {
+                verifyBookmarksMenuView()
+            }.closeMenu {
+            }
+
+            homeScreen {
+            }.openThreeDotMenu {
+            }.openHistory {
+                verifyHistoryMenuView()
+            }
         }
 
-        homeScreen {
-        }.openThreeDotMenu {
-        }.openWhatsNew {
-            verifyWhatsNewURL()
-        }.openTabDrawer {
-            closeTab()
-        }
-
-        homeScreen {
-        }.openThreeDotMenu {
-        }.openBookmarks {
-            verifyBookmarksMenuView()
-        }.closeMenu {
-        }
-
-        homeScreen {
-        }.openThreeDotMenu {
-        }.openHistory {
-            verifyHistoryMenuView()
-        }
     }
 }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuMainRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuMainRobot.kt
@@ -38,6 +38,7 @@ import androidx.test.uiautomator.Until
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers.allOf
 import org.junit.Assert.assertTrue
+import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.click
@@ -390,7 +391,8 @@ private fun assertSettingsButton() = settingsButton()
     .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
     .check(matches(isCompletelyDisplayed()))
 
-private fun addOnsButton() = onView(allOf(withText("Add-ons")))
+private val addOnsText = if (FeatureFlags.toolbarMenuFeature) "Extensions" else "Add-ons"
+private fun addOnsButton() = onView(allOf(withText(addOnsText)))
 private fun assertAddOnsButton() {
     onView(withId(R.id.mozac_browser_menu_menuView)).perform(swipeDown())
     addOnsButton().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuMainRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuMainRobot.kt
@@ -125,21 +125,33 @@ class ThreeDotMenuMainRobot {
     fun verifyShareTabsOverlay() = assertShareTabsOverlay()
 
     fun verifyThreeDotMainMenuItems() {
-        verifyAddOnsButton()
-        verifyDownloadsButton()
-        verifyHistoryButton()
-        verifyBookmarksButton()
-        verifySyncedTabsButton()
-        verifySettingsButton()
-        verifyFindInPageButton()
-        verifyAddFirefoxHome()
-        verifyAddToMobileHome()
-        verifyDesktopSite()
-        verifySaveCollection()
-        verifyAddBookmarkButton()
-        verifyShareButton()
-        verifyForwardButton()
-        verifyRefreshButton()
+        if (FeatureFlags.toolbarMenuFeature) {
+            verifyDownloadsButton()
+            verifyHistoryButton()
+            verifyBookmarksButton()
+            verifySettingsButton()
+            verifyDesktopSite()
+            verifySaveCollection()
+            verifyShareButton()
+            verifyForwardButton()
+            verifyRefreshButton()
+        } else {
+            verifyAddOnsButton()
+            verifyDownloadsButton()
+            verifyHistoryButton()
+            verifyBookmarksButton()
+            verifySyncedTabsButton()
+            verifySettingsButton()
+            verifyFindInPageButton()
+            verifyAddFirefoxHome()
+            verifyAddToMobileHome()
+            verifyDesktopSite()
+            verifySaveCollection()
+            verifyAddBookmarkButton()
+            verifyShareButton()
+            verifyForwardButton()
+            verifyRefreshButton()
+        }
     }
 
     private fun assertShareTabsOverlay() {

--- a/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -30,4 +30,9 @@ object FeatureFlags {
      * Enables WebAuthn support.
      */
     val webAuthFeature = Config.channel.isNightlyOrDebug
+
+    /**
+     * Shows new three-dot toolbar menu design.
+     */
+    val toolbarMenuFeature = Config.channel.isDebug
 }

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarMenuController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarMenuController.kt
@@ -51,7 +51,7 @@ interface BrowserToolbarMenuController {
     fun handleToolbarItemInteraction(item: ToolbarMenu.Item)
 }
 
-@Suppress("LargeClass")
+@Suppress("LargeClass", "ForbiddenComment")
 class DefaultBrowserToolbarMenuController(
     private val activity: HomeActivity,
     private val navController: NavController,

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarMenuController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarMenuController.kt
@@ -87,6 +87,76 @@ class DefaultBrowserToolbarMenuController(
         trackToolbarItemInteraction(item)
 
         Do exhaustive when (item) {
+            // TODO: These can be removed for https://github.com/mozilla-mobile/fenix/issues/17870
+            // todo === Start ===
+            is ToolbarMenu.Item.InstallToHomeScreen -> {
+                settings.installPwaOpened = true
+                MainScope().launch {
+                    with(activity.components.useCases.webAppUseCases) {
+                        if (isInstallable()) {
+                            addToHomescreen()
+                        } else {
+                            val directions =
+                                BrowserFragmentDirections.actionBrowserFragmentToCreateShortcutFragment()
+                            navController.navigateSafe(R.id.browserFragment, directions)
+                        }
+                    }
+                }
+            }
+            is ToolbarMenu.Item.OpenInFenix -> {
+                // Stop the SessionFeature from updating the EngineView and let it release the session
+                // from the EngineView so that it can immediately be rendered by a different view once
+                // we switch to the actual browser.
+                sessionFeature.get()?.release()
+
+                // Strip the CustomTabConfig to turn this Session into a regular tab and then select it
+                customTabSession!!.customTabConfig = null
+                sessionManager.select(customTabSession)
+
+                // Switch to the actual browser which should now display our new selected session
+                activity.startActivity(openInFenixIntent.apply {
+                    // We never want to launch the browser in the same task as the external app
+                    // activity. So we force a new task here. IntentReceiverActivity will do the
+                    // right thing and take care of routing to an already existing browser and avoid
+                    // cloning a new one.
+                    flags = flags or Intent.FLAG_ACTIVITY_NEW_TASK
+                })
+
+                // Close this activity (and the task) since it is no longer displaying any session
+                activity.finishAndRemoveTask()
+            }
+            is ToolbarMenu.Item.Quit -> {
+                // We need to show the snackbar while the browsing data is deleting (if "Delete
+                // browsing data on quit" is activated). After the deletion is over, the snackbar
+                // is dismissed.
+                val snackbar: FenixSnackbar? = activity.getRootView()?.let { v ->
+                    FenixSnackbar.make(
+                        view = v,
+                        duration = Snackbar.LENGTH_LONG,
+                        isDisplayedWithBrowserToolbar = true
+                    )
+                        .setText(v.context.getString(R.string.deleting_browsing_data_in_progress))
+                }
+
+                deleteAndQuit(activity, scope, snackbar)
+            }
+            is ToolbarMenu.Item.ReaderModeAppearance -> {
+                readerModeController.showControls()
+                metrics.track(Event.ReaderModeAppearanceOpened)
+            }
+            is ToolbarMenu.Item.OpenInApp -> {
+                settings.openInAppOpened = true
+
+                val appLinksUseCases = activity.components.useCases.appLinksUseCases
+                val getRedirect = appLinksUseCases.appLinkRedirect
+                currentSession?.let {
+                    val redirect = getRedirect.invoke(it.url)
+                    redirect.appIntent?.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                    appLinksUseCases.openAppLink.invoke(redirect.appIntent)
+                }
+            }
+            // todo === End ===
+
             is ToolbarMenu.Item.Back -> {
                 if (item.viewHistory) {
                     navController.navigate(
@@ -118,12 +188,24 @@ class DefaultBrowserToolbarMenuController(
 
                 sessionUseCases.reload.invoke(currentSession, flags = flags)
             }
-            ToolbarMenu.Item.Stop -> sessionUseCases.stopLoading.invoke(currentSession)
-            ToolbarMenu.Item.Settings -> browserAnimator.captureEngineViewAndDrawStatically {
+            is ToolbarMenu.Item.Stop -> sessionUseCases.stopLoading.invoke(currentSession)
+            is ToolbarMenu.Item.Share -> {
+                val directions = NavGraphDirections.actionGlobalShareFragment(
+                    data = arrayOf(
+                        ShareData(
+                            url = getProperUrl(currentSession),
+                            title = currentSession?.title
+                        )
+                    ),
+                    showPage = true
+                )
+                navController.navigate(directions)
+            }
+            is ToolbarMenu.Item.Settings -> browserAnimator.captureEngineViewAndDrawStatically {
                 val directions = BrowserFragmentDirections.actionBrowserFragmentToSettingsFragment()
                 navController.nav(R.id.browserFragment, directions)
             }
-            ToolbarMenu.Item.SyncedTabs -> browserAnimator.captureEngineViewAndDrawStatically {
+            is ToolbarMenu.Item.SyncedTabs -> browserAnimator.captureEngineViewAndDrawStatically {
                 navController.nav(
                     R.id.browserFragment,
                     BrowserFragmentDirections.actionBrowserFragmentToSyncedTabsFragment()
@@ -133,7 +215,7 @@ class DefaultBrowserToolbarMenuController(
                 item.isChecked,
                 currentSession
             )
-            ToolbarMenu.Item.AddToTopSites -> {
+            is ToolbarMenu.Item.AddToTopSites -> {
                 scope.launch {
                     val context = swipeRefresh.context
                     val numPinnedSites =
@@ -169,7 +251,7 @@ class DefaultBrowserToolbarMenuController(
                     }
                 }
             }
-            ToolbarMenu.Item.AddToHomeScreen, ToolbarMenu.Item.InstallToHomeScreen -> {
+            is ToolbarMenu.Item.AddToHomeScreen -> {
                 settings.installPwaOpened = true
                 MainScope().launch {
                     with(activity.components.useCases.webAppUseCases) {
@@ -183,31 +265,17 @@ class DefaultBrowserToolbarMenuController(
                     }
                 }
             }
-            ToolbarMenu.Item.Share -> {
-                val directions = NavGraphDirections.actionGlobalShareFragment(
-                    data = arrayOf(
-                        ShareData(
-                            url = getProperUrl(currentSession),
-                            title = currentSession?.title
-                        )
-                    ),
-                    showPage = true
-                )
-                navController.navigate(directions)
-            }
-
-            ToolbarMenu.Item.FindInPage -> {
+            is ToolbarMenu.Item.FindInPage -> {
                 findInPageLauncher()
                 metrics.track(Event.FindInPageOpened)
             }
-
-            ToolbarMenu.Item.AddonsManager -> browserAnimator.captureEngineViewAndDrawStatically {
+            is ToolbarMenu.Item.AddonsManager -> browserAnimator.captureEngineViewAndDrawStatically {
                 navController.nav(
                     R.id.browserFragment,
                     BrowserFragmentDirections.actionGlobalAddonsManagementFragment()
                 )
             }
-            ToolbarMenu.Item.SaveToCollection -> {
+            is ToolbarMenu.Item.SaveToCollection -> {
                 metrics
                     .track(Event.CollectionSaveButtonPressed(TELEMETRY_BROWSER_IDENTIFIER))
 
@@ -225,80 +293,33 @@ class DefaultBrowserToolbarMenuController(
                     navController.nav(R.id.browserFragment, directions)
                 }
             }
-            ToolbarMenu.Item.OpenInFenix -> {
-                // Stop the SessionFeature from updating the EngineView and let it release the session
-                // from the EngineView so that it can immediately be rendered by a different view once
-                // we switch to the actual browser.
-                sessionFeature.get()?.release()
-
-                // Strip the CustomTabConfig to turn this Session into a regular tab and then select it
-                customTabSession!!.customTabConfig = null
-                sessionManager.select(customTabSession)
-
-                // Switch to the actual browser which should now display our new selected session
-                activity.startActivity(openInFenixIntent.apply {
-                    // We never want to launch the browser in the same task as the external app
-                    // activity. So we force a new task here. IntentReceiverActivity will do the
-                    // right thing and take care of routing to an already existing browser and avoid
-                    // cloning a new one.
-                    flags = flags or Intent.FLAG_ACTIVITY_NEW_TASK
-                })
-
-                // Close this activity (and the task) since it is no longer displaying any session
-                activity.finishAndRemoveTask()
-            }
-            ToolbarMenu.Item.Quit -> {
-                // We need to show the snackbar while the browsing data is deleting (if "Delete
-                // browsing data on quit" is activated). After the deletion is over, the snackbar
-                // is dismissed.
-                val snackbar: FenixSnackbar? = activity.getRootView()?.let { v ->
-                    FenixSnackbar.make(
-                        view = v,
-                        duration = Snackbar.LENGTH_LONG,
-                        isDisplayedWithBrowserToolbar = true
-                    )
-                        .setText(v.context.getString(R.string.deleting_browsing_data_in_progress))
-                }
-
-                deleteAndQuit(activity, scope, snackbar)
-            }
-            ToolbarMenu.Item.ReaderModeAppearance -> {
-                readerModeController.showControls()
-                metrics.track(Event.ReaderModeAppearanceOpened)
-            }
-            ToolbarMenu.Item.OpenInApp -> {
-                settings.openInAppOpened = true
-
-                val appLinksUseCases = activity.components.useCases.appLinksUseCases
-                val getRedirect = appLinksUseCases.appLinkRedirect
-                currentSession?.let {
-                    val redirect = getRedirect.invoke(it.url)
-                    redirect.appIntent?.flags = Intent.FLAG_ACTIVITY_NEW_TASK
-                    appLinksUseCases.openAppLink.invoke(redirect.appIntent)
-                }
-            }
-            ToolbarMenu.Item.Bookmark -> {
+            is ToolbarMenu.Item.Bookmark -> {
                 sessionManager.selectedSession?.let {
                     getProperUrl(it)?.let { url -> bookmarkTapped(url, it.title) }
                 }
             }
-            ToolbarMenu.Item.Bookmarks -> browserAnimator.captureEngineViewAndDrawStatically {
+            is ToolbarMenu.Item.Bookmarks -> browserAnimator.captureEngineViewAndDrawStatically {
                 navController.nav(
                     R.id.browserFragment,
                     BrowserFragmentDirections.actionGlobalBookmarkFragment(BookmarkRoot.Mobile.id)
                 )
             }
-            ToolbarMenu.Item.History -> browserAnimator.captureEngineViewAndDrawStatically {
+            is ToolbarMenu.Item.History -> browserAnimator.captureEngineViewAndDrawStatically {
                 navController.nav(
                     R.id.browserFragment,
                     BrowserFragmentDirections.actionGlobalHistoryFragment()
                 )
             }
 
-            ToolbarMenu.Item.Downloads -> browserAnimator.captureEngineViewAndDrawStatically {
+            is ToolbarMenu.Item.Downloads -> browserAnimator.captureEngineViewAndDrawStatically {
                 navController.nav(
                     R.id.browserFragment,
                     BrowserFragmentDirections.actionGlobalDownloadsFragment()
+                )
+            }
+            is ToolbarMenu.Item.NewTab -> {
+                navController.navigate(
+                    BrowserFragmentDirections.actionGlobalHome(focusOnAddressBar = true)
                 )
             }
         }
@@ -318,35 +339,38 @@ class DefaultBrowserToolbarMenuController(
     @Suppress("ComplexMethod")
     private fun trackToolbarItemInteraction(item: ToolbarMenu.Item) {
         val eventItem = when (item) {
+            // TODO: These can be removed for https://github.com/mozilla-mobile/fenix/issues/17870
+            // todo === Start ===
+            is ToolbarMenu.Item.OpenInFenix -> Event.BrowserMenuItemTapped.Item.OPEN_IN_FENIX
+            is ToolbarMenu.Item.InstallToHomeScreen -> Event.BrowserMenuItemTapped.Item.ADD_TO_HOMESCREEN
+            is ToolbarMenu.Item.Quit -> Event.BrowserMenuItemTapped.Item.QUIT
+            is ToolbarMenu.Item.ReaderModeAppearance ->
+                Event.BrowserMenuItemTapped.Item.READER_MODE_APPEARANCE
+            is ToolbarMenu.Item.OpenInApp -> Event.BrowserMenuItemTapped.Item.OPEN_IN_APP
+            // todo === End ===
             is ToolbarMenu.Item.Back -> Event.BrowserMenuItemTapped.Item.BACK
             is ToolbarMenu.Item.Forward -> Event.BrowserMenuItemTapped.Item.FORWARD
             is ToolbarMenu.Item.Reload -> Event.BrowserMenuItemTapped.Item.RELOAD
-            ToolbarMenu.Item.Stop -> Event.BrowserMenuItemTapped.Item.STOP
-            ToolbarMenu.Item.Settings -> Event.BrowserMenuItemTapped.Item.SETTINGS
+            is ToolbarMenu.Item.Stop -> Event.BrowserMenuItemTapped.Item.STOP
+            is ToolbarMenu.Item.Share -> Event.BrowserMenuItemTapped.Item.SHARE
+            is ToolbarMenu.Item.Settings -> Event.BrowserMenuItemTapped.Item.SETTINGS
             is ToolbarMenu.Item.RequestDesktop ->
                 if (item.isChecked) {
                     Event.BrowserMenuItemTapped.Item.DESKTOP_VIEW_ON
                 } else {
                     Event.BrowserMenuItemTapped.Item.DESKTOP_VIEW_OFF
                 }
-
-            ToolbarMenu.Item.FindInPage -> Event.BrowserMenuItemTapped.Item.FIND_IN_PAGE
-            ToolbarMenu.Item.OpenInFenix -> Event.BrowserMenuItemTapped.Item.OPEN_IN_FENIX
-            ToolbarMenu.Item.Share -> Event.BrowserMenuItemTapped.Item.SHARE
-            ToolbarMenu.Item.SaveToCollection -> Event.BrowserMenuItemTapped.Item.SAVE_TO_COLLECTION
-            ToolbarMenu.Item.AddToTopSites -> Event.BrowserMenuItemTapped.Item.ADD_TO_TOP_SITES
-            ToolbarMenu.Item.AddToHomeScreen -> Event.BrowserMenuItemTapped.Item.ADD_TO_HOMESCREEN
-            ToolbarMenu.Item.SyncedTabs -> Event.BrowserMenuItemTapped.Item.SYNC_TABS
-            ToolbarMenu.Item.InstallToHomeScreen -> Event.BrowserMenuItemTapped.Item.ADD_TO_HOMESCREEN
-            ToolbarMenu.Item.Quit -> Event.BrowserMenuItemTapped.Item.QUIT
-            ToolbarMenu.Item.ReaderModeAppearance ->
-                Event.BrowserMenuItemTapped.Item.READER_MODE_APPEARANCE
-            ToolbarMenu.Item.OpenInApp -> Event.BrowserMenuItemTapped.Item.OPEN_IN_APP
-            ToolbarMenu.Item.Bookmark -> Event.BrowserMenuItemTapped.Item.BOOKMARK
-            ToolbarMenu.Item.AddonsManager -> Event.BrowserMenuItemTapped.Item.ADDONS_MANAGER
-            ToolbarMenu.Item.Bookmarks -> Event.BrowserMenuItemTapped.Item.BOOKMARKS
-            ToolbarMenu.Item.History -> Event.BrowserMenuItemTapped.Item.HISTORY
-            ToolbarMenu.Item.Downloads -> Event.BrowserMenuItemTapped.Item.DOWNLOADS
+            is ToolbarMenu.Item.FindInPage -> Event.BrowserMenuItemTapped.Item.FIND_IN_PAGE
+            is ToolbarMenu.Item.SaveToCollection -> Event.BrowserMenuItemTapped.Item.SAVE_TO_COLLECTION
+            is ToolbarMenu.Item.AddToTopSites -> Event.BrowserMenuItemTapped.Item.ADD_TO_TOP_SITES
+            is ToolbarMenu.Item.AddToHomeScreen -> Event.BrowserMenuItemTapped.Item.ADD_TO_HOMESCREEN
+            is ToolbarMenu.Item.SyncedTabs -> Event.BrowserMenuItemTapped.Item.SYNC_TABS
+            is ToolbarMenu.Item.Bookmark -> Event.BrowserMenuItemTapped.Item.BOOKMARK
+            is ToolbarMenu.Item.AddonsManager -> Event.BrowserMenuItemTapped.Item.ADDONS_MANAGER
+            is ToolbarMenu.Item.Bookmarks -> Event.BrowserMenuItemTapped.Item.BOOKMARKS
+            is ToolbarMenu.Item.History -> Event.BrowserMenuItemTapped.Item.HISTORY
+            is ToolbarMenu.Item.Downloads -> Event.BrowserMenuItemTapped.Item.DOWNLOADS
+            is ToolbarMenu.Item.NewTab -> Event.BrowserMenuItemTapped.Item.NEW_TAB
         }
 
         metrics.track(Event.BrowserMenuItemTapped(eventItem))

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
@@ -70,11 +70,12 @@ class DefaultToolbarMenu(
 
     override val menuBuilder by lazy {
         WebExtensionBrowserMenuBuilder(
-            if (FeatureFlags.toolbarMenuFeature) {
-                newCoreMenuItems
-            } else {
-                oldCoreMenuItems
-            },
+            items =
+                if (FeatureFlags.toolbarMenuFeature) {
+                    newCoreMenuItems
+                } else {
+                    oldCoreMenuItems
+                },
             endOfMenuAlwaysVisible = !shouldReverseItems,
             store = store,
             webExtIconTintColorResource = primaryTextColor(),
@@ -503,7 +504,7 @@ class DefaultToolbarMenu(
 
     @ColorRes
     @VisibleForTesting
-    internal fun disabledTextColor() = ThemeManager.resolveAttribute(R.attr.disabled, context)
+    internal fun disabledTextColor() = R.color.toolbar_menu_transparent
 
     @VisibleForTesting
     internal fun registerForIsBookmarkedUpdates() {

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
@@ -16,9 +16,7 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.launch
 import mozilla.components.browser.menu.BrowserMenuHighlight
-import mozilla.components.browser.menu.BrowserMenuItem
 import mozilla.components.browser.menu.WebExtensionBrowserMenuBuilder
-import mozilla.components.browser.menu.ext.getHighlight
 import mozilla.components.browser.menu.item.BrowserMenuDivider
 import mozilla.components.browser.menu.item.BrowserMenuHighlightableItem
 import mozilla.components.browser.menu.item.BrowserMenuImageSwitch
@@ -38,13 +36,9 @@ import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
-import org.mozilla.fenix.experiments.ExperimentBranch
-import org.mozilla.fenix.experiments.Experiments
 import org.mozilla.fenix.ext.asActivity
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.settings
-import org.mozilla.fenix.ext.withExperiment
-import org.mozilla.fenix.home.HomeMenu
 import org.mozilla.fenix.theme.ThemeManager
 
 /**
@@ -76,7 +70,11 @@ class DefaultToolbarMenu(
 
     override val menuBuilder by lazy {
         WebExtensionBrowserMenuBuilder(
-            if (FeatureFlags.toolbarMenuFeature) { newCoreMenuItems } else { oldCoreMenuItems },
+            if (FeatureFlags.toolbarMenuFeature) {
+                newCoreMenuItems
+            } else {
+                oldCoreMenuItems
+            },
             endOfMenuAlwaysVisible = !shouldReverseItems,
             store = store,
             webExtIconTintColorResource = primaryTextColor(),
@@ -365,11 +363,10 @@ class DefaultToolbarMenu(
     }
 
     private val newCoreMenuItems by lazy {
-
         val newTabItem = BrowserMenuImageText(
             context.getString(R.string.library_new_tab),
             R.drawable.ic_bookmark_filled,
-            primaryTextColor()
+            disabledTextColor()
         ) {
             onItemTapped.invoke(ToolbarMenu.Item.NewTab)
         }
@@ -377,7 +374,7 @@ class DefaultToolbarMenu(
         val bookmarksItem = BrowserMenuImageText(
             context.getString(R.string.library_bookmarks),
             R.drawable.ic_bookmark_filled,
-            primaryTextColor()
+            disabledTextColor()
         ) {
             onItemTapped.invoke(ToolbarMenu.Item.Bookmarks)
         }
@@ -385,7 +382,7 @@ class DefaultToolbarMenu(
         val historyItem = BrowserMenuImageText(
             context.getString(R.string.library_history),
             R.drawable.ic_history,
-            primaryTextColor()
+            disabledTextColor()
         ) {
             onItemTapped.invoke(ToolbarMenu.Item.History)
         }
@@ -393,7 +390,7 @@ class DefaultToolbarMenu(
         val downloadsItem = BrowserMenuImageText(
             context.getString(R.string.library_downloads),
             R.drawable.ic_download,
-            primaryTextColor()
+            disabledTextColor()
         ) {
             onItemTapped.invoke(ToolbarMenu.Item.Downloads)
         }
@@ -401,7 +398,7 @@ class DefaultToolbarMenu(
         val extensionsItem = BrowserMenuImageText(
             context.getString(R.string.browser_menu_extensions),
             R.drawable.ic_addons_extensions,
-            primaryTextColor()
+            disabledTextColor()
         ) {
             onItemTapped.invoke(ToolbarMenu.Item.AddonsManager)
         }
@@ -409,7 +406,7 @@ class DefaultToolbarMenu(
         val syncedTabsItem = BrowserMenuImageText(
             context.getString(R.string.library_synced_tabs),
             R.drawable.ic_synced_tabs,
-            primaryTextColor()
+            disabledTextColor()
         ) {
             onItemTapped.invoke(ToolbarMenu.Item.SyncedTabs)
         }
@@ -417,7 +414,7 @@ class DefaultToolbarMenu(
         val findInPageItem = BrowserMenuImageText(
             label = context.getString(R.string.browser_menu_find_in_page),
             imageResource = R.drawable.mozac_ic_search,
-            iconTintColorResource = primaryTextColor()
+            iconTintColorResource = disabledTextColor()
         ) {
             onItemTapped.invoke(ToolbarMenu.Item.FindInPage)
         }
@@ -435,7 +432,7 @@ class DefaultToolbarMenu(
         val addToHomeScreenItem = BrowserMenuImageText(
             label = context.getString(R.string.browser_menu_add_to_homescreen),
             imageResource = R.drawable.ic_add_to_homescreen,
-            iconTintColorResource = primaryTextColor()
+            iconTintColorResource = disabledTextColor()
         ) {
             onItemTapped.invoke(ToolbarMenu.Item.AddToHomeScreen)
         }
@@ -443,7 +440,7 @@ class DefaultToolbarMenu(
         val addToTopSitesItem = BrowserMenuImageText(
             label = context.getString(R.string.browser_menu_add_to_top_sites),
             imageResource = R.drawable.ic_top_sites,
-            iconTintColorResource = primaryTextColor()
+            iconTintColorResource = disabledTextColor()
         ) {
             onItemTapped.invoke(ToolbarMenu.Item.AddToTopSites)
         }
@@ -451,7 +448,7 @@ class DefaultToolbarMenu(
         val saveToCollectionItem = BrowserMenuImageText(
             label = context.getString(R.string.browser_menu_save_to_collection_2),
             imageResource = R.drawable.ic_tab_collection,
-            iconTintColorResource = primaryTextColor()
+            iconTintColorResource = disabledTextColor()
         ) {
             onItemTapped.invoke(ToolbarMenu.Item.SaveToCollection)
         }
@@ -459,9 +456,7 @@ class DefaultToolbarMenu(
         val settingsItem = BrowserMenuHighlightableItem(
             label = context.getString(R.string.browser_menu_settings),
             startImageResource = R.drawable.ic_settings,
-            iconTintColorResource = if (hasAccountProblem)
-                ThemeManager.resolveAttribute(R.attr.syncDisconnected, context) else
-                primaryTextColor(),
+            iconTintColorResource = disabledTextColor(),
             textColorResource = if (hasAccountProblem)
                 ThemeManager.resolveAttribute(R.attr.primaryText, context) else
                 primaryTextColor(),
@@ -473,14 +468,8 @@ class DefaultToolbarMenu(
             isHighlighted = { hasAccountProblem }
         ) {
             onItemTapped.invoke(ToolbarMenu.Item.Settings)
-
         }
 
-        // Predicates that are called once, during screen init
-        val shouldShowSaveToCollection = (context.asActivity() as? HomeActivity)
-            ?.browsingModeManager?.mode == BrowsingMode.Normal
-        val shouldDeleteDataOnQuit = context.components.settings
-            .shouldDeleteBrowsingDataOnQuit
         val syncedTabsInTabsTray = context.components.settings
             .syncedTabsInTabsTray
 
@@ -511,6 +500,10 @@ class DefaultToolbarMenu(
     @ColorRes
     @VisibleForTesting
     internal fun primaryTextColor() = ThemeManager.resolveAttribute(R.attr.primaryText, context)
+
+    @ColorRes
+    @VisibleForTesting
+    internal fun disabledTextColor() = ThemeManager.resolveAttribute(R.attr.disabled, context)
 
     @VisibleForTesting
     internal fun registerForIsBookmarkedUpdates() {

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
@@ -420,7 +420,7 @@ class DefaultToolbarMenu(
             onItemTapped.invoke(ToolbarMenu.Item.FindInPage)
         }
 
-        val desktopSiteItem =  BrowserMenuImageSwitch(
+        val desktopSiteItem = BrowserMenuImageSwitch(
             imageResource = R.drawable.ic_desktop,
             label = context.getString(R.string.browser_menu_desktop_site),
             initialState = {

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarMenu.kt
@@ -31,6 +31,7 @@ interface ToolbarMenu {
         object Bookmarks : Item()
         object History : Item()
         object Downloads : Item()
+        object NewTab : Item()
     }
 
     val menuBuilder: BrowserMenuBuilder

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -422,4 +422,7 @@
 
     <!-- App Spinners colors -->
     <color name="spinner_selected_item">#1415141A</color>
+
+    <!-- Toolbar menu icon colors -->
+    <color name="toolbar_menu_transparent">@android:color/transparent</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -128,6 +128,8 @@
     <string name="browser_menu_edit_bookmark">Edit bookmark</string>
     <!-- Browser menu button that opens the addon manager -->
     <string name="browser_menu_add_ons">Add-ons</string>
+    <!-- Browser menu button that opens the addon extensions manager -->
+    <string name="browser_menu_extensions">Extensions</string>
     <!-- Text displayed when there are no add-ons to be shown -->
     <string name="no_add_ons">No add-ons here</string>
     <!-- Browser menu button that sends a user to help articles -->
@@ -517,6 +519,10 @@
     <string name="library_desktop_bookmarks_unfiled">Other Bookmarks</string>
     <!-- Option in Library to open History page -->
     <string name="library_history">History</string>
+    <!-- Option in Library to open a new tab -->
+    <string name="library_new_tab">New tab</string>
+    <!-- Option in Library to find text in page -->
+    <string name="library_find_in_page">Find in page</string>
     <!-- Option in Library to open Synced Tabs page -->
     <string name="library_synced_tabs">Synced tabs</string>
     <!-- Option in Library to open Reading List -->

--- a/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarMenuControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarMenuControllerTest.kt
@@ -64,6 +64,7 @@ import org.mozilla.fenix.utils.Settings
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(FenixRobolectricTestRunner::class)
+@Suppress("ForbiddenComment")
 class DefaultBrowserToolbarMenuControllerTest {
 
     @get:Rule


### PR DESCRIPTION
Meta: #17796
For #17771 

Icons will be removed in #17872 (along with the erroneous add-ons menu that is added on the AC side in the `WebExtensionBrowserMenuBuilder`).
<img width="372" alt="image" src="https://user-images.githubusercontent.com/43795363/107092078-7fca0c00-67c8-11eb-8d36-495c263e8df9.png">

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
