### PR TITLE
Uplift: For #17418 - Add event ping telemetry for the Google Top Site click (#17862) (Release)

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -3385,6 +3385,19 @@ top_sites:
     notification_emails:
       - fenix-core@mozilla.com
     expires: "2021-08-01"
+  open_google_search_attribution:
+    type: event
+    description: |
+      A user opened the google top site
+    bugs:
+      - https://github.com/mozilla-mobile/fenix/issues/17418
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/17637
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - fenix-core@mozilla.com
+    expires: "2021-08-01"
   open_frecency:
     type: event
     description: |

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/Event.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/Event.kt
@@ -122,6 +122,7 @@ sealed class Event {
     object NotificationMediaPlay : Event()
     object NotificationMediaPause : Event()
     object TopSiteOpenDefault : Event()
+    object TopSiteOpenGoogle : Event()
     object TopSiteOpenFrecent : Event()
     object TopSiteOpenPinned : Event()
     object TopSiteOpenInNewTab : Event()

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
@@ -513,6 +513,9 @@ private val Event.wrapper: EventWrapper<*>?
         is Event.TopSiteOpenDefault -> EventWrapper<NoExtraKeys>(
             { TopSites.openDefault.record(it) }
         )
+        is Event.TopSiteOpenGoogle -> EventWrapper<NoExtraKeys>(
+            { TopSites.openGoogleSearchAttribution.record(it) }
+        )
         is Event.TopSiteOpenFrecent -> EventWrapper<NoExtraKeys>(
             { TopSites.openFrecency.record(it) }
         )

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
@@ -371,6 +371,10 @@ class DefaultSessionControlController(
             TopSite.Type.PINNED -> metrics.track(Event.TopSiteOpenPinned)
         }
 
+        if (url == SupportUtils.GOOGLE_URL) {
+            metrics.track(Event.TopSiteOpenGoogle)
+        }
+
         if (url == SupportUtils.POCKET_TRENDING_URL) {
             metrics.track(Event.PocketTopSiteClicked)
         }

--- a/app/src/test/java/org/mozilla/fenix/home/DefaultSessionControlControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/DefaultSessionControlControllerTest.kt
@@ -349,6 +349,7 @@ class DefaultSessionControlControllerTest {
         controller.handleSelectTopSite(topSiteUrl, TopSite.Type.DEFAULT)
         verify { metrics.track(Event.TopSiteOpenInNewTab) }
         verify { metrics.track(Event.TopSiteOpenDefault) }
+        verify { metrics.track(Event.TopSiteOpenGoogle) }
         verify {
             tabsUseCases.addTab.invoke(
                 url = SupportUtils.GOOGLE_US_URL,
@@ -368,6 +369,7 @@ class DefaultSessionControlControllerTest {
         controller.handleSelectTopSite(topSiteUrl, TopSite.Type.DEFAULT)
         verify { metrics.track(Event.TopSiteOpenInNewTab) }
         verify { metrics.track(Event.TopSiteOpenDefault) }
+        verify { metrics.track(Event.TopSiteOpenGoogle) }
         verify {
             tabsUseCases.addTab.invoke(
                 SupportUtils.GOOGLE_XX_URL,
@@ -387,6 +389,7 @@ class DefaultSessionControlControllerTest {
         controller.handleSelectTopSite(topSiteUrl, TopSite.Type.PINNED)
         verify { metrics.track(Event.TopSiteOpenInNewTab) }
         verify { metrics.track(Event.TopSiteOpenPinned) }
+        verify { metrics.track(Event.TopSiteOpenGoogle) }
         verify {
             tabsUseCases.addTab.invoke(
                 SupportUtils.GOOGLE_US_URL,
@@ -406,6 +409,7 @@ class DefaultSessionControlControllerTest {
         controller.handleSelectTopSite(topSiteUrl, TopSite.Type.PINNED)
         verify { metrics.track(Event.TopSiteOpenInNewTab) }
         verify { metrics.track(Event.TopSiteOpenPinned) }
+        verify { metrics.track(Event.TopSiteOpenGoogle) }
         verify {
             tabsUseCases.addTab.invoke(
                 SupportUtils.GOOGLE_XX_URL,
@@ -425,6 +429,7 @@ class DefaultSessionControlControllerTest {
         controller.handleSelectTopSite(topSiteUrl, TopSite.Type.FRECENT)
         verify { metrics.track(Event.TopSiteOpenInNewTab) }
         verify { metrics.track(Event.TopSiteOpenFrecent) }
+        verify { metrics.track(Event.TopSiteOpenGoogle) }
         verify {
             tabsUseCases.addTab.invoke(
                 SupportUtils.GOOGLE_US_URL,
@@ -444,6 +449,7 @@ class DefaultSessionControlControllerTest {
         controller.handleSelectTopSite(topSiteUrl, TopSite.Type.FRECENT)
         verify { metrics.track(Event.TopSiteOpenInNewTab) }
         verify { metrics.track(Event.TopSiteOpenFrecent) }
+        verify { metrics.track(Event.TopSiteOpenGoogle) }
         verify {
             tabsUseCases.addTab.invoke(
                 SupportUtils.GOOGLE_XX_URL,

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -28,8 +28,8 @@ an hashed version of the Google Advertising ID.
 
 **Bugs related to this ping:**
 
-- 1538011
-- 1501822
+- <https://bugzilla.mozilla.com/1538011/>
+- <https://bugzilla.mozilla.com/1501822/>
 
 The following metrics are added to the ping:
 
@@ -212,6 +212,7 @@ The following metrics are added to the ping:
 | top_sites.long_press |[event](https://mozilla.github.io/glean/book/user/metrics/event.html) |A user long pressed on a top site  |[1](https://github.com/mozilla-mobile/fenix/pull/15136), [2](https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068)|<ul><li>type: The type of top site. Options are: "FRECENCY," "DEFAULT," or "PINNED." </li></ul>|2021-08-01 |2 |
 | top_sites.open_default |[event](https://mozilla.github.io/glean/book/user/metrics/event.html) |A user opened a default top site  |[1](https://github.com/mozilla-mobile/fenix/pull/10752), [2](https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068)||2021-08-01 |2 |
 | top_sites.open_frecency |[event](https://mozilla.github.io/glean/book/user/metrics/event.html) |A user opened a frecency top site  |[1](https://github.com/mozilla-mobile/fenix/pull/15136), [2](https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068)||2021-08-01 |2 |
+| top_sites.open_google_search_attribution |[event](https://mozilla.github.io/glean/book/user/metrics/event.html) |A user opened the google top site  |[1](https://github.com/mozilla-mobile/fenix/pull/17637)||2021-08-01 |2 |
 | top_sites.open_in_new_tab |[event](https://mozilla.github.io/glean/book/user/metrics/event.html) |A user opens a new tab based on a top site item  |[1](https://github.com/mozilla-mobile/fenix/pull/7523), [2](https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068)||2021-08-01 |2 |
 | top_sites.open_in_private_tab |[event](https://mozilla.github.io/glean/book/user/metrics/event.html) |A user opens a new private tab based on a top site item  |[1](https://github.com/mozilla-mobile/fenix/pull/7523), [2](https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068)||2021-08-01 |2 |
 | top_sites.open_pinned |[event](https://mozilla.github.io/glean/book/user/metrics/event.html) |A user opened a pinned top site  |[1](https://github.com/mozilla-mobile/fenix/pull/15136), [2](https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068)||2021-08-01 |2 |


### PR DESCRIPTION
Uplift for https://github.com/mozilla-mobile/fenix/pull/17862 to 85