### PR TITLE
For #17817 Change the feature prompt references to activity

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -538,7 +538,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
 
         promptsFeature.set(
             feature = PromptFeature(
-                fragment = this,
+                activity = activity,
                 store = store,
                 customTabId = customTabSessionId,
                 fragmentManager = parentFragmentManager,


### PR DESCRIPTION
When an input file is clicked, we delegate the file picking operation on the Android OS using an intent [[1]](https://github.com/mozilla-mobile/android-components/blob/4641e44c389501c0c9b9513009b18e3488a3750e/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/file/FilePicker.kt#L103) [[2]](https://github.com/mozilla-mobile/android-components/blob/4641e44c389501c0c9b9513009b18e3488a3750e/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/file/FilePicker.kt#L77) , internally feature prompts verifies the `requestCode` that comes back from [onActivityResult](https://github.com/mozilla-mobile/android-components/blob/4641e44c389501c0c9b9513009b18e3488a3750e/components/feature/prompts/src/main/java/mozilla/components/feature/prompts/file/FilePicker.kt#L119) it's the correct one, before this [patch](https://github.com/mozilla-mobile/fenix/commit/824f3fd82138b2e93dcfeddcf6310f7878e1de2d) it was getting the callback from `BaseBrowserFragment#onActivityResult`  now the callback is coming from [HomeActivity#onActivityResult](https://github.com/mozilla-mobile/fenix/commit/824f3fd82138b2e93dcfeddcf6310f7878e1de2d#diff-c05ae0c657bc8e08d523b61c5a6b7859d170b9fca19785593ea2ebeaefc72b66R1043), this causes the `requestCode` varies and as a result it breaks the feature, we have to adapt the reference of feature prompts to be the same as where it's going to get the `onActivityResult` callback.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
