### PR TITLE
Issue #17819: Remove JCenter from buildscript repositories.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,24 +37,6 @@ buildscript {
                 }
             }
         }
-
-        if (project.hasProperty("jcenterRepo")) {
-            maven {
-                name "BintrayJCenter"
-                url project.property("jcenterRepo")
-            }
-        } else {
-            jcenter() {
-                content {
-                    // Improve security: don't search deps with known repos.
-                    excludeGroupByRegex RepoMatching.mozilla
-                    excludeGroupByRegex RepoMatching.androidx
-                    excludeGroupByRegex RepoMatching.comGoogleAndroid
-                    excludeGroupByRegex RepoMatching.comGoogleFirebase
-                    excludeGroupByRegex RepoMatching.comAndroid
-                }
-            }
-        }
     }
 
     dependencies {


### PR DESCRIPTION
Similar to https://github.com/mozilla-mobile/android-components/pull/9663, but here we do not limit the usage for project repositories yet. First we need to introduce Maven Central as a repository here.