### PR TITLE
For #17899 - Expand toolbar when returning from fullscreen video

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -1220,6 +1220,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
                 .setText(getString(R.string.full_screen_notification))
                 .show()
             activity?.enterToImmersiveMode()
+            browserToolbarView.collapse()
             browserToolbarView.view.isVisible = false
             val browserEngine = swipeRefresh.layoutParams as CoordinatorLayout.LayoutParams
             browserEngine.bottomMargin = 0
@@ -1227,7 +1228,6 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
             swipeRefresh.translationY = 0f
 
             engineView.setDynamicToolbarMaxHeight(0)
-            browserToolbarView.expand()
             // Without this, fullscreen has a margin at the top.
             engineView.setVerticalClipping(0)
 
@@ -1241,6 +1241,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
                 browserToolbarView.view.isVisible = true
                 val toolbarHeight = resources.getDimensionPixelSize(R.dimen.browser_toolbar_height)
                 initializeEngineView(toolbarHeight)
+                browserToolbarView.expand()
             }
         }
 

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarView.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarView.kt
@@ -215,6 +215,17 @@ class BrowserToolbarView(
         }
     }
 
+    fun collapse() {
+        // collapse only for normal tabs and custom tabs not for PWA or TWA. Mirror expand()
+        if (isPwaTabOrTwaTab) {
+            return
+        }
+
+        (view.layoutParams as? CoordinatorLayout.LayoutParams)?.apply {
+            (behavior as? BrowserToolbarBehavior)?.forceCollapse(view)
+        }
+    }
+
     fun dismissMenu() {
         view.dismissMenu()
     }

--- a/app/src/test/java/org/mozilla/fenix/components/toolbar/BrowserToolbarViewTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/toolbar/BrowserToolbarViewTest.kt
@@ -5,6 +5,7 @@
 package org.mozilla.fenix.components.toolbar
 
 import androidx.coordinatorlayout.widget.CoordinatorLayout
+import io.mockk.confirmVerified
 
 import io.mockk.every
 import io.mockk.mockk
@@ -192,5 +193,51 @@ class BrowserToolbarViewTest {
         toolbarViewSpy.setDynamicToolbarBehavior(MozacToolbarPosition.TOP)
 
         assertNotNull((toolbar.layoutParams as CoordinatorLayout.LayoutParams).behavior)
+    }
+
+    @Test
+    fun `expand should not do anything if isPwaTabOrTwaTab`() {
+        val toolbarViewSpy = spyk(toolbarView)
+        every { toolbarViewSpy.isPwaTabOrTwaTab } returns true
+
+        toolbarViewSpy.expand()
+
+        verify { toolbarViewSpy.expand() }
+        verify { toolbarViewSpy.isPwaTabOrTwaTab }
+        // verify that no other interactions than the expected ones took place
+        confirmVerified(toolbarViewSpy)
+    }
+
+    @Test
+    fun `expand should call forceExpand if not isPwaTabOrTwaTab`() {
+        val toolbarViewSpy = spyk(toolbarView)
+        every { toolbarViewSpy.isPwaTabOrTwaTab } returns false
+
+        toolbarViewSpy.expand()
+
+        verify { behavior.forceExpand(toolbar) }
+    }
+
+    @Test
+    fun `collapse should not do anything if isPwaTabOrTwaTab`() {
+        val toolbarViewSpy = spyk(toolbarView)
+        every { toolbarViewSpy.isPwaTabOrTwaTab } returns true
+
+        toolbarViewSpy.collapse()
+
+        verify { toolbarViewSpy.collapse() }
+        verify { toolbarViewSpy.isPwaTabOrTwaTab }
+        // verify that no other interactions than the expected ones took place
+        confirmVerified(toolbarViewSpy)
+    }
+
+    @Test
+    fun `collapse should call forceExpand if not isPwaTabOrTwaTab`() {
+        val toolbarViewSpy = spyk(toolbarView)
+        every { toolbarViewSpy.isPwaTabOrTwaTab } returns false
+
+        toolbarViewSpy.collapse()
+
+        verify { behavior.forceCollapse(toolbar) }
     }
 }


### PR DESCRIPTION
This was the previous behavior for both the top and bottom toolbars.
Regressed when changing to use a new custom behavior for the top toolbar.

When entering fullscreen we will now collapse and hide the toolbar, allow the
browser to expand to the entire screen estate and then, when exiting fullscreen
expand the toolbar.
Collapsing and then expanding the toolbar will trigger the
EngineViewBrowserToolbarBehavior to place the browser below the toolbar.

Needs https://github.com/mozilla-mobile/android-components/pull/9664

[video showing the result]

https://user-images.githubusercontent.com/11428869/107388511-98a32c00-6afe-11eb-80ff-8840196fb602.mp4



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
