### PR TITLE
Issue #17819: Add Maven Central repository and limit usage of JCenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ buildscript {
                 includeGroupByRegex RepoMatching.mozilla
             }
         }
+
         maven {
             name "Mozilla"
             url "https://maven.mozilla.org/maven2"
@@ -21,6 +22,7 @@ buildscript {
                 includeGroupByRegex RepoMatching.mozilla
             }
         }
+
         if (project.hasProperty("googleRepo")) {
             maven {
                 name "Google"
@@ -34,6 +36,24 @@ buildscript {
                     includeGroupByRegex RepoMatching.comGoogleAndroid
                     includeGroupByRegex RepoMatching.comGoogleFirebase
                     includeGroupByRegex RepoMatching.comAndroid
+                }
+            }
+        }
+
+        if (project.hasProperty("centralRepo")) {
+            maven {
+                name "MavenCentral"
+                url project.property("centralRepo")
+            }
+        } else {
+            mavenCentral() {
+                content {
+                    // Improve security: don't search deps with known repos.
+                    excludeGroupByRegex RepoMatching.mozilla
+                    excludeGroupByRegex RepoMatching.androidx
+                    excludeGroupByRegex RepoMatching.comGoogleAndroid
+                    excludeGroupByRegex RepoMatching.comGoogleFirebase
+                    excludeGroupByRegex RepoMatching.comAndroid
                 }
             }
         }
@@ -86,6 +106,7 @@ allprojects {
                 includeGroupByRegex RepoMatching.mozilla
             }
         }
+
         maven {
             name "Mozilla"
             url "https://maven.mozilla.org/maven2"
@@ -94,6 +115,7 @@ allprojects {
                 includeGroupByRegex RepoMatching.mozilla
             }
         }
+
         if (project.hasProperty("googleRepo")) {
             maven {
                 name "Google"
@@ -110,6 +132,25 @@ allprojects {
                 }
             }
         }
+
+        if (project.hasProperty("centralRepo")) {
+            maven {
+                name "MavenCentral"
+                url project.property("centralRepo")
+            }
+        } else {
+            mavenCentral() {
+                content {
+                    // Improve security: don't search deps with known repos.
+                    excludeGroupByRegex RepoMatching.mozilla
+                    excludeGroupByRegex RepoMatching.androidx
+                    excludeGroupByRegex RepoMatching.comGoogleAndroid
+                    excludeGroupByRegex RepoMatching.comGoogleFirebase
+                    excludeGroupByRegex RepoMatching.comAndroid
+                }
+            }
+        }
+
         if (project.hasProperty("jcenterRepo")) {
             maven {
                 name "BintrayJCenter"

--- a/build.gradle
+++ b/build.gradle
@@ -57,24 +57,6 @@ buildscript {
                 }
             }
         }
-
-        if (project.hasProperty("jcenterRepo")) {
-            maven {
-                name "BintrayJCenter"
-                url project.property("jcenterRepo")
-            }
-        } else {
-            jcenter() {
-                content {
-                    // Improve security: don't search deps with known repos.
-                    excludeGroupByRegex RepoMatching.mozilla
-                    excludeGroupByRegex RepoMatching.androidx
-                    excludeGroupByRegex RepoMatching.comGoogleAndroid
-                    excludeGroupByRegex RepoMatching.comGoogleFirebase
-                    excludeGroupByRegex RepoMatching.comAndroid
-                }
-            }
-        }
     }
 
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -141,12 +141,36 @@ allprojects {
         } else {
             jcenter() {
                 content {
-                    // Improve security: don't search deps with known repos.
-                    excludeGroupByRegex RepoMatching.mozilla
-                    excludeGroupByRegex RepoMatching.androidx
-                    excludeGroupByRegex RepoMatching.comGoogleAndroid
-                    excludeGroupByRegex RepoMatching.comGoogleFirebase
-                    excludeGroupByRegex RepoMatching.comAndroid
+                    ////////////////////////////////////////////////////////////////////////////////
+                    // JCenter is going away. Please do not add any new dependencies here.
+                    // https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/
+                    ////////////////////////////////////////////////////////////////////////////////
+
+                    // Leanplum
+                    // The docs mention a custom repository (repo.leanplum.com) that we may be able
+                    // to switch to.
+                    includeVersion("com.leanplum", "leanplum-core", "5.4.0")
+                    includeVersion("com.leanplum", "leanplum-push", "5.4.0")
+                    includeVersion("com.leanplum", "leanplum-fcm", "5.4.0")
+
+                    // Used by Android Gradle Plugin
+                    // Issue for publishing to maven central: https://youtrack.jetbrains.com/issue/IDEA-261387
+                    // Related plugin issue: https://issuetracker.google.com/issues/179291081
+                    // Other option: Update to Android Gradle Plugin 7+ (still in Alpha currently)
+                    includeVersion("org.jetbrains.trove4j", "trove4j", "20160824")
+
+                    // Used by detekt
+                    // Issue for publishing to maven central: https://github.com/Kotlin/kotlinx.html/issues/173
+                    // Related detekt issue: https://github.com/detekt/detekt/issues/3461
+                    includeVersion("org.jetbrains.kotlinx", "kotlinx-html-jvm", "0.7.1")
+                    includeVersion("org.jetbrains.kotlinx", "kotlinx-html-common", "0.7.1")
+
+                    // Fastlane
+                    // Doesn't seem to be available on Maven Central yet, and I couldn't find an issue for it
+                    // https://github.com/fastlane/fastlane
+                    includeVersion("tools.fastlane", "screengrab", "2.0.0")
+                    // https://github.com/jraska/Falcon/issues/52
+                    includeVersion("com.jraska", "falcon", "2.1.1")
                 }
             }
         }

--- a/taskcluster/scripts/toolchain/android-gradle-dependencies.sh
+++ b/taskcluster/scripts/toolchain/android-gradle-dependencies.sh
@@ -19,7 +19,7 @@ pushd $PROJECT_DIR
 . taskcluster/scripts/toolchain/android-gradle-dependencies/before.sh
 
 NEXUS_PREFIX='http://localhost:8081/nexus/content/repositories'
-GRADLE_ARGS="--parallel -PgoogleRepo=$NEXUS_PREFIX/google/ -PjcenterRepo=$NEXUS_PREFIX/jcenter/"
+GRADLE_ARGS="--parallel -PgoogleRepo=$NEXUS_PREFIX/google/ -PjcenterRepo=$NEXUS_PREFIX/jcenter/ -PcentralRepo=$NEXUS_PREFIX/central/"
 # We build everything to be sure to fetch all dependencies
 ./gradlew $GRADLE_ARGS assemble assembleAndroidTest testClasses ktlint detekt
 # Some tests may be flaky, although they still download dependencies. So we let the following

--- a/taskcluster/scripts/toolchain/android-gradle-dependencies/after.sh
+++ b/taskcluster/scripts/toolchain/android-gradle-dependencies/after.sh
@@ -22,6 +22,7 @@ mkdir -p android-gradle-dependencies /builds/worker/artifacts
 
 cp -R ${NEXUS_WORK}/storage/jcenter android-gradle-dependencies
 cp -R ${NEXUS_WORK}/storage/google android-gradle-dependencies
+cp -R ${NEXUS_WORK}/storage/central android-gradle-dependencies
 
 tar cf - android-gradle-dependencies | xz > /builds/worker/artifacts/android-gradle-dependencies.tar.xz
 


### PR DESCRIPTION
This adds Maven Central as a repository and adds it to our dependency caching mechanism. I'm not 100% sure if this is everything that is needed, but let's see what tasklcuster thinks. :)