### PR TITLE
Closes #17889: Wrong tab selected/reloaded when restored from collection

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
@@ -215,10 +215,8 @@ class DefaultSessionControlController(
             tab,
             onTabRestored = {
                 activity.openToBrowser(BrowserDirection.FromHome)
-                store.state.selectedTabId?.let {
-                    selectTabUseCase.invoke(it)
-                    reloadUrlUseCase.invoke(it)
-                }
+                selectTabUseCase.invoke(it)
+                reloadUrlUseCase.invoke(it)
             },
             onFailure = {
                 activity.openToBrowserAndLoad(


### PR DESCRIPTION
This is a regression from https://github.com/mozilla-mobile/fenix/pull/17631. A-C now passes the restored tab ID to the lambda which we can use to select and reload the correct one. We don't have to rely on `SessionManager` this way (under the hood or directly).

STR:
- Open a tab
- Then open another tab from a collection

Without the fix the first tab is being selected and reloaded. Let's also uplift this to beta. Release is not affected. Added a test to cover this.
