### PR TITLE
Uplift: Closes #17889: Wrong tab selected/reloaded when restored from collection

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
@@ -215,10 +215,8 @@ class DefaultSessionControlController(
             tab,
             onTabRestored = {
                 activity.openToBrowser(BrowserDirection.FromHome)
-                store.state.selectedTabId?.let {
-                    selectTabUseCase.invoke(it)
-                    reloadUrlUseCase.invoke(it)
-                }
+                selectTabUseCase.invoke(it)
+                reloadUrlUseCase.invoke(it)
             },
             onFailure = {
                 activity.openToBrowserAndLoad(


### PR DESCRIPTION
See https://github.com/mozilla-mobile/fenix/pull/17940.