### PR TITLE
Add UI tests nightly build

### DIFF
--- a/automation/taskcluster/androidTest/flank-x86-start-test.yml
+++ b/automation/taskcluster/androidTest/flank-x86-start-test.yml
@@ -42,6 +42,9 @@ gcloud:
 
 flank:
   project: GOOGLE_PROJECT
+  # test shards - the amount of groups to split the test suite into
+  # set to -1 to use one shard per test.
+  max-test-shards: 1
   # num-test-runs: the amount of times to run the tests.
   # 1 runs the tests once. 10 runs all the tests 10x
   num-test-runs: 1

--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -63,6 +63,15 @@ jobs:
         treeherder:
             symbol: beta(Bf)
 
+    nightly-firebase:
+        disable-optimization: true
+        run-on-tasks-for: [github-push] # We want this on push so that we detect problem before triggering a new nightly
+        run:
+            gradle-build-type: nightly
+            test-build-type: nightly
+        treeherder:
+            symbol: nightly(Bf)
+
     android-test-debug:
         attributes:
             code-review: true
@@ -85,13 +94,16 @@ jobs:
     android-test-nightly:
         attributes:
             nightly: true
-        run:
-            gradle-build-type: androidTest
         apk-artifact-template:
             # 2 differences here:
             #  * "androidTest/" is added
             #  * "{gradle_build_type}" is forced to "debug"
-            path: '/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/debug/{fileName}'
+            path: '/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/nightly/app-nightly-androidTest.apk'
+        disable-optimization: true
+        run:
+            gradle-build-type: androidTest
+            test-build-type: nightly
+        run-on-tasks-for: [github-push]
         treeherder:
             symbol: nightly(Bat)
 

--- a/taskcluster/ci/signing/kind.yml
+++ b/taskcluster/ci/signing/kind.yml
@@ -49,13 +49,14 @@ job-template:
             # No test job runs on push against this build type. Although we do want nightly-simulation
             # signed to use it in the gecko trees.
             # We want beta on push so that we detect problem before shipping it
-            (nightly-simulation|beta-firebase|android-test-beta): [github-push]
+            (nightly-simulation|beta-firebase|android-test-beta|nightly-firebase|android-test-nightly): [github-push]
             default: []
     treeherder:
         job-symbol:
             by-build-type:
                 android-test.+: Bats
                 beta-firebase: Bfs
+                nightly-firebase: Bfs
                 default: Bs
         kind: build
         platform: android-all/opt

--- a/taskcluster/ci/ui-test/kind.yml
+++ b/taskcluster/ci/ui-test/kind.yml
@@ -80,3 +80,17 @@ jobs:
                 - [automation/taskcluster/androidTest/ui-test.sh, x86-beta-tests, app.apk, android-test.apk, '50']
         treeherder:
             symbol: beta(ui-test-x86-beta)
+    x86-nightly:
+        attributes:
+            build-type: nightly-firebase
+        description: Test Fenix
+        run-on-tasks-for: [github-push]
+        dependencies:
+            signing: signing-nightly-firebase
+            signing-android-test: signing-android-test-nightly
+        run:
+            commands:
+                - [automation/taskcluster/androidTest/ui-test.sh, x86-start-test, app.apk, android-test.apk, '-1']
+        treeherder:
+            symbol: nightly(ui-test-x86-nightly)
+

--- a/try_task_config.json
+++ b/try_task_config.json
@@ -1,0 +1,7 @@
+{
+    "parameters": {
+        "optimize_target_tasks": true,
+        "tasks_for": "github-push"
+    },
+    "version": 2
+}

--- a/try_task_config.json
+++ b/try_task_config.json
@@ -1,7 +1,0 @@
-{
-    "parameters": {
-        "optimize_target_tasks": true,
-        "tasks_for": "github-push"
-    },
-    "version": 2
-}


### PR DESCRIPTION
Creating a new PR to continue the work and investigate the issue found in the decission task previously when trying to add a [test for Nightly](https://github.com/mozilla-mobile/fenix/pull/17513) builds, similar to the one added recently to [Beta builds](https://github.com/mozilla-mobile/fenix/pull/17496).

As commented in that PR: The idea is to run at least one test on the Nightly build in addition to the tests that run in the debug build so that if it fails we know something is not correct with the Nightly build that is used by the cron job to uplift it to the playstore. Currently there are only unit tests checking the Nightly build that is created by the cron job.


