### PR TITLE
Fix OpenSpecificTabIntentProcessorTest to remove AbstractMediaService

### DIFF
--- a/app/src/test/java/org/mozilla/fenix/home/intent/OpenSpecificTabIntentProcessorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/intent/OpenSpecificTabIntentProcessorTest.kt
@@ -14,7 +14,6 @@ import io.mockk.verifyOrder
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.createTab
 import mozilla.components.browser.state.store.BrowserStore
-import mozilla.components.feature.media.service.AbstractMediaService
 import mozilla.components.feature.media.service.AbstractMediaSessionService
 import mozilla.components.feature.tabs.TabsUseCases
 import org.junit.Assert.assertFalse
@@ -67,8 +66,13 @@ class OpenSpecificTabIntentProcessorTest {
     @Test
     fun `GIVEN an intent with null extra string WHEN it is processed THEN openToBrowser should not be called`() {
         val intent = Intent().apply {
-            action = AbstractMediaService.Companion.ACTION_SWITCH_TAB
+            action = AbstractMediaSessionService.Companion.ACTION_SWITCH_TAB
         }
+
+        val store = BrowserStore(BrowserState(tabs = listOf(createTab(id = TEST_SESSION_ID, url = "https:mozilla.org"))))
+        val tabUseCases: TabsUseCases = mockk(relaxed = true)
+        every { activity.components.core.store } returns store
+        every { activity.components.useCases.tabsUseCases } returns tabUseCases
 
         assertFalse(processor.process(intent, navController, out))
 


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
