### PR TITLE
For #17195 - Don't try setting an idle resource if the View is already off screen

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/ext/ViewInteraction.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/ext/ViewInteraction.kt
@@ -4,7 +4,14 @@
 
 package org.mozilla.fenix.helpers
 
+import android.view.InputDevice
+import android.view.MotionEvent
+import androidx.test.espresso.ViewAction
 import androidx.test.espresso.ViewInteraction
+import androidx.test.espresso.action.GeneralClickAction
+import androidx.test.espresso.action.GeneralLocation
+import androidx.test.espresso.action.Press
+import androidx.test.espresso.action.Tap
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.assertion.ViewAssertions.matches
 
@@ -21,3 +28,21 @@ fun ViewInteraction.assertIsChecked(isChecked: Boolean): ViewInteraction {
 fun ViewInteraction.assertIsSelected(isSelected: Boolean): ViewInteraction {
     return this.check(matches(isSelected(isSelected)))!!
 }
+
+/**
+ * Perform a click (simulate the finger touching the View) at a specific location in the View
+ * rather than the default middle of the View.
+ *
+ * Useful in situations where the View we want clicked contains other Views in it's x,y middle
+ * and we need to simulate the touch in some other free space of the View we want clicked.
+ */
+fun ViewInteraction.clickAtLocationInView(locationInView: GeneralLocation): ViewAction =
+    ViewActions.actionWithAssertions(
+        GeneralClickAction(
+            Tap.SINGLE,
+            locationInView,
+            Press.FINGER,
+            InputDevice.SOURCE_UNKNOWN,
+            MotionEvent.BUTTON_PRIMARY
+        )
+    )

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/TabDrawerRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/TabDrawerRobot.kt
@@ -7,6 +7,8 @@
 package org.mozilla.fenix.ui.robots
 
 import android.content.Context
+import android.view.InputDevice
+import android.view.MotionEvent
 import android.view.View
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.core.app.ApplicationProvider
@@ -15,7 +17,12 @@ import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.NoMatchingViewException
 import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
+import androidx.test.espresso.action.GeneralClickAction
+import androidx.test.espresso.action.GeneralLocation
+import androidx.test.espresso.action.Press
+import androidx.test.espresso.action.Tap
 import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.action.ViewActions.actionWithAssertions
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.replaceText
 import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
@@ -232,7 +239,19 @@ class TabDrawerRobot {
         }
 
         fun clickTopBar(interact: TabDrawerRobot.() -> Unit): Transition {
-            onView(withId(R.id.topBar)).click()
+            // The topBar contains other views.
+            // Don't do the default click in the middle, rather click in some free space - top right.
+            onView(withId(R.id.topBar)).perform(
+                actionWithAssertions(
+                    GeneralClickAction(
+                        Tap.SINGLE,
+                        GeneralLocation.TOP_RIGHT,
+                        Press.FINGER,
+                        InputDevice.SOURCE_UNKNOWN,
+                        MotionEvent.BUTTON_PRIMARY
+                    )
+                )
+            )
             TabDrawerRobot().interact()
             return Transition()
         }
@@ -257,8 +276,11 @@ class TabDrawerRobot {
         }
 
         fun waitForTabTrayBehaviorToIdle(interact: TabDrawerRobot.() -> Unit): Transition {
+            // Need to get the behavior of tab_wrapper and wait for that to idle.
             var behavior: BottomSheetBehavior<*>? = null
-            onView(withId(R.id.tab_wrapper)).perform(object : ViewAction {
+
+            // Null check here since it's possible that the view is already animated away from the screen.
+            onView(withId(R.id.tab_wrapper))?.perform(object : ViewAction {
                 override fun getDescription(): String {
                     return "Postpone actions to after the BottomSheetBehavior has settled"
                 }
@@ -271,9 +293,13 @@ class TabDrawerRobot {
                     behavior = BottomSheetBehavior.from(view!!)
                 }
             })
-            runWithIdleRes(BottomSheetBehaviorStateIdlingResource(behavior!!)) {
-                TabDrawerRobot().interact()
+
+            behavior?.let {
+                runWithIdleRes(BottomSheetBehaviorStateIdlingResource(it)) {
+                    TabDrawerRobot().interact()
+                }
             }
+
             return Transition()
         }
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/TabDrawerRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/TabDrawerRobot.kt
@@ -7,8 +7,6 @@
 package org.mozilla.fenix.ui.robots
 
 import android.content.Context
-import android.view.InputDevice
-import android.view.MotionEvent
 import android.view.View
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.core.app.ApplicationProvider
@@ -17,12 +15,8 @@ import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.NoMatchingViewException
 import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
-import androidx.test.espresso.action.GeneralClickAction
 import androidx.test.espresso.action.GeneralLocation
-import androidx.test.espresso.action.Press
-import androidx.test.espresso.action.Tap
 import androidx.test.espresso.action.ViewActions
-import androidx.test.espresso.action.ViewActions.actionWithAssertions
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.replaceText
 import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
@@ -51,6 +45,7 @@ import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.TestHelper.packageName
 import org.mozilla.fenix.helpers.click
+import org.mozilla.fenix.helpers.clickAtLocationInView
 import org.mozilla.fenix.helpers.ext.waitNotNull
 import org.mozilla.fenix.helpers.idlingresource.BottomSheetBehaviorStateIdlingResource
 import org.mozilla.fenix.helpers.matchers.BottomSheetBehaviorHalfExpandedMaxRatioMatcher
@@ -241,17 +236,7 @@ class TabDrawerRobot {
         fun clickTopBar(interact: TabDrawerRobot.() -> Unit): Transition {
             // The topBar contains other views.
             // Don't do the default click in the middle, rather click in some free space - top right.
-            onView(withId(R.id.topBar)).perform(
-                actionWithAssertions(
-                    GeneralClickAction(
-                        Tap.SINGLE,
-                        GeneralLocation.TOP_RIGHT,
-                        Press.FINGER,
-                        InputDevice.SOURCE_UNKNOWN,
-                        MotionEvent.BUTTON_PRIMARY
-                    )
-                )
-            )
+            onView(withId(R.id.topBar)).clickAtLocationInView(GeneralLocation.TOP_RIGHT)
             TabDrawerRobot().interact()
             return Transition()
         }

--- a/automation/taskcluster/androidTest/flank-x86.yml
+++ b/automation/taskcluster/androidTest/flank-x86.yml
@@ -38,8 +38,9 @@ gcloud:
   performance-metrics: true
 
   test-targets:
-   - package org.mozilla.fenix.ui
-   - package org.mozilla.fenix.glean
+    - package org.mozilla.fenix.ui.TabbedBrowsingTest#verifyTabTrayNotShowingStateHalfExpanded
+#   - package org.mozilla.fenix.ui
+#   - package org.mozilla.fenix.glean
 
   device:
    - model: Pixel2
@@ -52,5 +53,4 @@ flank:
   max-test-shards: 50 
   # num-test-runs: the amount of times to run the tests.
   # 1 runs the tests once. 10 runs all the tests 10x
-  num-test-runs: 1
-
+  num-test-runs: 50

--- a/automation/taskcluster/androidTest/flank-x86.yml
+++ b/automation/taskcluster/androidTest/flank-x86.yml
@@ -38,9 +38,8 @@ gcloud:
   performance-metrics: true
 
   test-targets:
-    - package org.mozilla.fenix.ui.TabbedBrowsingTest#verifyTabTrayNotShowingStateHalfExpanded
-#   - package org.mozilla.fenix.ui
-#   - package org.mozilla.fenix.glean
+   - package org.mozilla.fenix.ui
+   - package org.mozilla.fenix.glean
 
   device:
    - model: Pixel2
@@ -53,4 +52,5 @@ flank:
   max-test-shards: 50 
   # num-test-runs: the amount of times to run the tests.
   # 1 runs the tests once. 10 runs all the tests 10x
-  num-test-runs: 50
+  num-test-runs: 1
+


### PR DESCRIPTION
Speculative fix based on the Firebase logs which shows that on a second check
of R.id.tab_wrapper it is not found the screen.
It may be because after `advanceToHalfExpandedState` and before getting a
reference to it in `waitForTabTrayBehaviorToIdle` it was already animated off
the screen.
With this in mind I've added a null check for the view reference before trying
to register an idling resource on it's Behavior.

Also added and used a way to click at a specific location in a View, not just
in the default middle in the View.
It was observed from the Firebase videos that a "click" on the topBar actually
selected the private tabs section. This would leave us to believe that the
"click" was caught by that other View which was placed above the x,y middle of
the topBar.

In a previous test the `verifyTabTrayNotShowingStateHalfExpanded` ran 
successfully 50 times with these changes.
https://github.com/mozilla-mobile/fenix/pull/17961/checks?check_run_id=1878656103