### PR TITLE
Refactor BrowserToolbarController to use browser store

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -281,14 +281,14 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
         )
         val browserToolbarController = DefaultBrowserToolbarController(
             store = store,
+            tabsUseCases = requireComponents.useCases.tabsUseCases,
             activity = activity,
             navController = findNavController(),
             metrics = requireComponents.analytics.metrics,
             readerModeController = readerMenuController,
-            sessionManager = requireComponents.core.sessionManager,
             engineView = engineView,
             homeViewModel = homeViewModel,
-            customTabSession = customTabSessionId?.let { sessionManager.findSessionById(it) },
+            customTabSessionId = customTabSessionId,
             onTabCounterClicked = {
                 thumbnailsFeature.get()?.requestScreenshot()
                 findNavController().nav(


### PR DESCRIPTION
First part of removing `SessionManager` from `BaseBrowserFragment`. We need some use case overrides for the rest so let's do that in a follow-up.