### PR TITLE
For #16395 - Improve contrast ratio in Site Permissions caption

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsManagePhoneFeatureFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsManagePhoneFeatureFragment.kt
@@ -5,7 +5,6 @@
 package org.mozilla.fenix.settings.sitepermissions
 
 import android.content.Intent
-import android.graphics.Color
 import android.net.Uri
 import android.os.Bundle
 import android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS
@@ -19,6 +18,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.RadioButton
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.navArgs
 import mozilla.components.feature.sitepermissions.SitePermissionsRules
@@ -35,6 +35,7 @@ import org.mozilla.fenix.settings.PhoneFeature
 import org.mozilla.fenix.settings.PhoneFeature.AUTOPLAY_AUDIBLE
 import org.mozilla.fenix.settings.PhoneFeature.AUTOPLAY_INAUDIBLE
 import org.mozilla.fenix.settings.setStartCheckedIndicator
+import org.mozilla.fenix.theme.ThemeManager
 import org.mozilla.fenix.utils.Settings
 
 const val AUTOPLAY_BLOCK_ALL = 0
@@ -243,9 +244,13 @@ class SitePermissionsManagePhoneFeatureFragment : Fragment() {
         val subTextSize =
             resources.getDimensionPixelSize(R.dimen.phone_feature_label_recommended_text_size)
         val recommendedSpannable = SpannableString(subText)
+        val subTextColor = ContextCompat.getColor(
+            requireContext(),
+            ThemeManager.resolveAttribute(R.attr.secondaryText, requireContext())
+        )
 
         recommendedSpannable.setSpan(
-            ForegroundColorSpan(Color.GRAY),
+            ForegroundColorSpan(subTextColor),
             0,
             recommendedSpannable.length,
             SPAN_EXCLUSIVE_INCLUSIVE


### PR DESCRIPTION
Fixes #16395 

Right now, the subtext in SitePermissionsManagePhoneFeatureFragment always
displays as Color.gray (#888888).
    
Against the default light theme background (#F9F9FB), the contrast ratio
is ~3.37. For accessibility purposes, it would be preferable to use colors
that result in a contrast ratio greater than 4.50 for small text.
    
Let's resolve this issue by migrating to the following color schemes:
    
| Theme Name | Background Color | Foreground Color | Contrast Ratio |
|------------|------------------|------------------|----------------|
| Light      | #F9F9FB          | #5B5B66          |           6.37 |
| Dark       | #1C1B22          | #BFBFC9          |           9.36 |

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: Ran Firefox in light/dark mode in conjunction with Accessibility Scanner to ensure no warnings emitted. See screenshots below.
- [x] **Screenshots**:
<img width="267" alt="light_theme_scan" src="https://user-images.githubusercontent.com/50264607/120424233-f2dc2d00-c339-11eb-937a-455e89cf0481.png">
<img width="272" alt="dark_theme_scan" src="https://user-images.githubusercontent.com/50264607/120424237-f40d5a00-c339-11eb-9d2f-0beccc499795.png">

- [x] **Accessibility**: This fixes an accessibility bug and does not introduce new issues. See screenshots above.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
