### PR TITLE
Bug 1692825 - Glean: Check for renamed reason

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/glean/BaselinePingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/glean/BaselinePingTest.kt
@@ -152,7 +152,7 @@ class BaselinePingTest {
             .click()
 
         // Validate the received data.
-        val baselinePing = waitForPingContent("baseline", "background")!!
+        val baselinePing = waitForPingContent("baseline", "inactive")!!
 
         val metrics = baselinePing.getJSONObject("metrics")
 

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "73.0.20210216143146"
+    const val VERSION = "73.0.20210216190306"
 }


### PR DESCRIPTION
Fixes the issues uncovered in #17977.
Requires relanding the Glean upgrade in A-C first.

I'm not sure how to properly coordinate that.
@csadilek for some help.
I would re-land the Glean upgrade in A-C, we wait for the PR here and tackle this change onto it too?

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
