### PR TITLE
For #17484, #18003 UI tests: retry closing tab if it fails

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
@@ -10,7 +10,6 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
-import org.junit.BeforeClass
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
@@ -54,16 +53,6 @@ class TabbedBrowsingTest {
         }
     }
 
-    // changing the device preference for Touch and Hold delay, to avoid long-clicks instead of a single-click
-    companion object {
-        @BeforeClass
-        @JvmStatic
-        fun setDevicePreference() {
-            val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-            mDevice.executeShellCommand("settings put secure long_press_timeout 3000")
-        }
-    }
-
     @After
     fun tearDown() {
         mockWebServer.shutdown()
@@ -95,16 +84,9 @@ class TabbedBrowsingTest {
 
     @Test
     fun openNewPrivateTabTest() {
-        homeScreen { }.dismissOnboarding()
-
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
-        homeScreen { }.togglePrivateBrowsingMode()
-
-        homeScreen {
-            verifyPrivateSessionMessage()
-            verifyTabButton()
-        }
+        homeScreen {}.togglePrivateBrowsingMode()
 
         navigationToolbar {
         }.openNewTabAndEnterToBrowser(defaultWebPage.url) {
@@ -112,7 +94,7 @@ class TabbedBrowsingTest {
             verifyTabCounter("1")
         }.openTabDrawer {
             verifyExistingTabList()
-            verifyCloseTabsButton("Test_Page_1")
+            verifyPrivateModeSelected()
         }.toggleToNormalTabs {
             verifyNoTabsOpened()
         }.toggleToPrivateTabs {
@@ -160,7 +142,6 @@ class TabbedBrowsingTest {
         }.openNewTabAndEnterToBrowser(genericURL.url) {
         }.openTabDrawer {
             verifyExistingOpenTabs("Test_Page_1")
-            verifyCloseTabsButton("Test_Page_1")
             closeTabViaXButton("Test_Page_1")
             verifySnackBarText("Tab closed")
             snackBarButtonClick("UNDO")
@@ -191,8 +172,7 @@ class TabbedBrowsingTest {
         browserScreen {
         }.openTabDrawer {
             verifyExistingOpenTabs("Test_Page_1")
-        }.openNewTab {
-        }.dismissSearchBar { }
+        }.closeTabDrawer { }
     }
 
     @Test
@@ -283,8 +263,6 @@ class TabbedBrowsingTest {
 
     @Test
     fun verifyEmptyTabTray() {
-        homeScreen { }.dismissOnboarding()
-
         navigationToolbar {
         }.openTabTray {
             verifyNoTabsOpened()
@@ -299,8 +277,6 @@ class TabbedBrowsingTest {
 
     @Test
     fun verifyOpenTabDetails() {
-        homeScreen { }.dismissOnboarding()
-
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {
@@ -318,8 +294,6 @@ class TabbedBrowsingTest {
 
     @Test
     fun verifyContextMenuShortcuts() {
-        homeScreen { }.dismissOnboarding()
-
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/TabDrawerRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/TabDrawerRobot.kt
@@ -86,23 +86,46 @@ class TabDrawerRobot {
         mDevice.findObject(
             UiSelector().resourceId("org.mozilla.fenix.debug:id/mozac_browser_tabstray_close")
         ).waitForExists(waitingTime)
-        closeTabButton().click()
+
+        var retries = 0 // number of retries before failing, will stop at 2
+        do {
+            closeTabButton().click()
+            retries++
+        } while (mDevice.findObject(
+                UiSelector().resourceId("org.mozilla.fenix.debug:id/mozac_browser_tabstray_close")
+            ).exists() && retries < 3
+        )
     }
 
-    fun swipeTabRight(title: String) =
-        tab(title).perform(ViewActions.swipeRight())
+    fun swipeTabRight(title: String) {
+        var retries = 0 // number of retries before failing, will stop at 2
+        while (mDevice.findObject(UiSelector().text(title)).exists() && retries < 3) {
+            tab(title).perform(ViewActions.swipeRight())
+            retries++
+        }
+    }
 
-    fun swipeTabLeft(title: String) =
-        tab(title).perform(ViewActions.swipeLeft())
+    fun swipeTabLeft(title: String) {
+        var retries = 0 // number of retries before failing, will stop at 2
+        while (mDevice.findObject(UiSelector().text(title)).exists() && retries < 3) {
+            tab(title).perform(ViewActions.swipeLeft())
+            retries++
+        }
+    }
 
     fun closeTabViaXButton(title: String) {
-        val closeButton = onView(
-            allOf(
-                withId(R.id.mozac_browser_tabstray_close),
-                withContentDescription("Close tab $title")
+        mDevice.findObject(UiSelector().text(title)).waitForExists(waitingTime)
+        var retries = 0 // number of retries before failing, will stop at 2
+        do {
+            val closeButton = onView(
+                allOf(
+                    withId(R.id.mozac_browser_tabstray_close),
+                    withContentDescription("Close tab $title")
+                )
             )
-        )
-        closeButton.perform(click())
+            closeButton.perform(click())
+            retries++
+        } while (mDevice.findObject(UiSelector().text(title)).exists() && retries < 3)
     }
 
     fun verifySnackBarText(expectedText: String) {


### PR DESCRIPTION
Repeating a close or swipe tab action when it doesn't work the first time for some reason.
Ran the 2 tests on Firebase for 50 times and all passed, see runs: https://github.com/mozilla-mobile/fenix/runs/1904745164