### PR TITLE
For 17868: Removes listener to avoid leak

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/SavedLoginsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/SavedLoginsFragment.kt
@@ -150,6 +150,8 @@ class SavedLoginsFragment : Fragment() {
         toolbarChildContainer.visibility = View.GONE
         (activity as HomeActivity).getSupportActionBarAndInflateIfNecessary().setDisplayShowTitleEnabled(true)
         sortingStrategyMenu.menuController.dismiss()
+        sortLoginsMenuRoot.setOnClickListener(null)
+        setHasOptionsMenu(false)
 
         redirectToReAuth(listOf(R.id.loginDetailFragment), findNavController().currentDestination?.id)
         super.onPause()


### PR DESCRIPTION
## Tests:
Given this PR only adds a line to the onPause method I felt there was no need to add tests.

## Screenshots:
There are no screenshots due to the issue not being a visible feature neither a visible bug, the only feedback we get is from the LeakCanary

## Accessibility
There were no changes in the screen layout. I'm trying to change the language of the scanner because my results were in other language
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
