### PR TITLE
For #16317: resets long press delay at the end of UI tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/HomeActivityTestRule.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/HomeActivityTestRule.kt
@@ -27,8 +27,13 @@ class HomeActivityTestRule(
     ActivityTestRule<HomeActivity>(HomeActivity::class.java, initialTouchMode, launchActivity) {
     override fun beforeActivityLaunched() {
         super.beforeActivityLaunched()
-        setLongTapTimeout()
+        setLongTapTimeout("3000")
         if (skipOnboarding) { skipOnboardingBeforeLaunch() }
+    }
+
+    override fun afterActivityFinished() {
+        super.afterActivityFinished()
+        setLongTapTimeout("400")
     }
 }
 
@@ -48,15 +53,20 @@ class HomeActivityIntentTestRule(
     IntentsTestRule<HomeActivity>(HomeActivity::class.java, initialTouchMode, launchActivity) {
     override fun beforeActivityLaunched() {
         super.beforeActivityLaunched()
-        setLongTapTimeout()
+        setLongTapTimeout("3000")
         if (skipOnboarding) { skipOnboardingBeforeLaunch() }
+    }
+
+    override fun afterActivityFinished() {
+        super.afterActivityFinished()
+        setLongTapTimeout("400")
     }
 }
 
 // changing the device preference for Touch and Hold delay, to avoid long-clicks instead of a single-click
-fun setLongTapTimeout() {
+fun setLongTapTimeout(delay: String) {
     val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-    mDevice.executeShellCommand("settings put secure long_press_timeout 3000")
+    mDevice.executeShellCommand("settings put secure long_press_timeout $delay")
 }
 
 private fun skipOnboardingBeforeLaunch() {


### PR DESCRIPTION
As requested in #16317, this resets the long tap delay set before launching the activity in UI tests.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
