### PR TITLE
For #17972: fix startup-timeline data in GLAM + split framework start metric

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -3859,14 +3859,21 @@ addons:
     expires: "2021-04-01"
 
 startup.timeline:
-  framework_start:
+  framework_primary:
     send_in_pings:
       - startup-timeline
     type: timespan
-    time_unit: nanosecond
+    time_unit: millisecond
     description: |
       The duration the Android framework takes to start before letting us run
-      code in `*Application.init`. This is calculated from `appInitTimestamp -
+      code in `*Application.init` when this device has `clock_ticks_per_second`
+      equal to 100: if it's not equal to 100, then this value is captured in
+      `framework_secondary`. We split this into two metrics to make it easier
+      to analyze in GLAM. We split on 100 because when we did our initial brief
+      analysis - https://sql.telemetry.mozilla.org/queries/75591 - the results
+      for clocks ticks were overwhelmingly 100.
+
+      The duration is calculated from `appInitTimestamp -
       processStartTimestamp`. `processStartTimestamp` is derived from the clock
       tick time unit, which is expected to be less granular than nanoseconds.
       Therefore, we convert and round our timestamps to clock ticks before
@@ -3876,9 +3883,30 @@ startup.timeline:
       devices, is also reported as a metric
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/8803
+      - https://github.com/mozilla-mobile/fenix/issues/17972
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/9788#pullrequestreview-394228626
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/18043#issue-575389284
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - perf-android-fe@mozilla.com
+      - mcomella@mozilla.com
+    expires: "2021-08-01"
+  framework_secondary:
+    send_in_pings:
+      - startup-timeline
+    type: timespan
+    time_unit: millisecond
+    description: |
+      The duration the Android framework takes to start before letting us run
+      code in `*Application.init` when this device has `clock_ticks_per_second`
+      not equal to 100. For more details on this metric, see `framework_primary`
+    bugs:
+      - https://github.com/mozilla-mobile/fenix/issues/17972
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/18043#issue-575389284
     data_sensitivity:
       - technical
     notification_emails:
@@ -3890,9 +3918,9 @@ startup.timeline:
       - startup-timeline
     type: boolean
     description: |
-      An error when attempting to record `framework_start` - the application
-      init timestamp returned a negative value - which is likely indicative of a
-      bug in the implementation.
+      An error when attempting to record `framework_primary/secondary` - the
+      application init timestamp returned a negative value - which is likely
+      indicative of a bug in the implementation.
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/8803
     data_reviews:

--- a/app/pings.yaml
+++ b/app/pings.yaml
@@ -35,14 +35,18 @@ startup-timeline:
   description: |
     This ping is intended to provide an understanding of startup performance.
 
-    The ping is intended to be captured by performance testing automation to
-    report results there, in addition to user telemetry. We place these metrics
-    into their own ping in order to isolate them and make this process easier.
-  include_client_id: false
+    In addition to being captured on real devices, the ping data was prematurely
+    optimized into this separate ping to be isolated from other metrics to be
+    more easily captured by performance testing automation but that hasn't
+    happened in practice. We would have removed it but implementation
+    details don't make that possible:
+    https://github.com/mozilla-mobile/fenix/issues/17972#issuecomment-781002987
+  include_client_id: true
   bugs:
     - https://github.com/mozilla-mobile/fenix/issues/8803
+    - https://github.com/mozilla-mobile/fenix/issues/17972
   data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/9788#pullrequestreview-394228626
   notification_emails:
     - perf-android-fe@mozilla.com
-    - esmyth@mozilla.com
+    - mcomella@mozilla.com

--- a/app/pings.yaml
+++ b/app/pings.yaml
@@ -47,6 +47,7 @@ startup-timeline:
     - https://github.com/mozilla-mobile/fenix/issues/17972
   data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/9788#pullrequestreview-394228626
+    - https://github.com/mozilla-mobile/fenix/pull/18043#issue-575389284
   notification_emails:
     - perf-android-fe@mozilla.com
     - mcomella@mozilla.com

--- a/app/src/test/java/org/mozilla/fenix/perf/StartupFrameworkStartMeasurementTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/perf/StartupFrameworkStartMeasurementTest.kt
@@ -17,7 +17,8 @@ import org.junit.Before
 import org.junit.Test
 import org.mozilla.fenix.GleanMetrics.StartupTimeline as Telemetry
 
-private const val CLOCK_TICKS_PER_SECOND = 100L
+private const val PRIMARY_TICKS = 100L
+private const val SECONDARY_TICKS = 50L
 
 class StartupFrameworkStartMeasurementTest {
 
@@ -27,9 +28,12 @@ class StartupFrameworkStartMeasurementTest {
     // We'd prefer to use the Glean test methods over these mocks but they require us to add
     // Robolectric and it's not worth the impact on test duration.
     @MockK private lateinit var telemetry: Telemetry
-    @MockK(relaxed = true) private lateinit var frameworkStart: TimespanMetricType
+    @MockK(relaxed = true) private lateinit var frameworkPrimary: TimespanMetricType
+    @MockK(relaxed = true) private lateinit var frameworkSecondary: TimespanMetricType
     @MockK(relaxed = true) private lateinit var frameworkStartError: BooleanMetricType
     @MockK(relaxed = true) private lateinit var clockTicksPerSecond: CounterMetricType
+
+    private var clockTicksPerSecondValue = -1L
 
     private var elapsedRealtimeNanos = -1L
     private var processStartTimeTicks = -1L
@@ -41,13 +45,17 @@ class StartupFrameworkStartMeasurementTest {
         elapsedRealtimeNanos = -1
         processStartTimeTicks = -1
 
+        // This value is hard-coded in the OS so we default to it as it's the expected value.
+        clockTicksPerSecondValue = PRIMARY_TICKS
+
         stat = spyk(object : Stat() {
-            override val clockTicksPerSecond: Long get() = CLOCK_TICKS_PER_SECOND
+            override val clockTicksPerSecond: Long get() = clockTicksPerSecondValue
         })
         every { stat.getProcessStartTimeTicks(any()) } answers { processStartTimeTicks }
         val getElapsedRealtimeNanos = { elapsedRealtimeNanos }
 
-        every { telemetry.frameworkStart } returns frameworkStart
+        every { telemetry.frameworkPrimary } returns frameworkPrimary
+        every { telemetry.frameworkSecondary } returns frameworkSecondary
         every { telemetry.frameworkStartError } returns frameworkStartError
         every { telemetry.clockTicksPerSecond } returns clockTicksPerSecond
 
@@ -67,13 +75,32 @@ class StartupFrameworkStartMeasurementTest {
     }
 
     @Test
-    fun `GIVEN app init is set to valid values WHEN metrics are set THEN frameworkStart is set with the correct value`() {
+    fun `GIVEN app init is set to valid values and clock ticks per second is 100 WHEN metrics are set THEN frameworkPrimary is set with the correct value`() {
+        clockTicksPerSecondValue = PRIMARY_TICKS
         setProcessAppInitAndMetrics(processStart = 166_636_813, appInit = 1_845_312_345_673_925)
-        verifyFrameworkStartSuccess(178_944_220_000_000) // calculated by hand.
+        verifyFrameworkStartSuccess(178_944_220_000_000, isPrimary = true) // calculated by hand.
+    }
+
+    @Test
+    fun `GIVEN app init is set to valid values and clock ticks per second is not 100 WHEN metrics are set THEN frameworkSecondary is set with the correct value`() {
+        clockTicksPerSecondValue = SECONDARY_TICKS
+        setProcessAppInitAndMetrics(processStart = 166_636_813, appInit = 1_845_312_345_673_925)
+        verifyFrameworkStartSuccess(178_944_220_000_000, isPrimary = false) // calculated by hand.
     }
 
     @Test // this overlaps with the success case test.
-    fun `GIVEN app init has valid values WHEN onAppInit is called twice and metrics are set THEN frameworkStart uses the first app init value`() {
+    fun `GIVEN app init has valid values and clock ticks per second is 100 WHEN onAppInit is called twice and metrics are set THEN frameworkPrimary uses the first app init value`() {
+        clockTicksPerSecondValue = PRIMARY_TICKS
+        testAppInitCalledTwice(isPrimary = true)
+    }
+
+    @Test // this overlaps with the success case test.
+    fun `GIVEN app init has valid values and clock ticks per second is not 100 WHEN onAppInit is called twice and metrics are set THEN frameworkSecondary uses the first app init value`() {
+        clockTicksPerSecondValue = SECONDARY_TICKS
+        testAppInitCalledTwice(isPrimary = false)
+    }
+
+    private fun testAppInitCalledTwice(isPrimary: Boolean) {
         processStartTimeTicks = 166_636_813
 
         elapsedRealtimeNanos = 1_845_312_345_673_925
@@ -82,14 +109,28 @@ class StartupFrameworkStartMeasurementTest {
         metrics.onApplicationInit()
 
         metrics.setExpensiveMetric()
-        verifyFrameworkStartSuccess(178_944_220_000_000) // calculated by hand.
+        verifyFrameworkStartSuccess(178_944_220_000_000, isPrimary) // calculated by hand.
     }
 
     @Test
-    fun `GIVEN app init have valid values WHEN metrics are set twice THEN frameworkStart is only set once`() {
+    fun `GIVEN app init have valid values and clock ticks per second is 100 WHEN metrics are set twice THEN frameworkPrimary is only set once`() {
+        clockTicksPerSecondValue = PRIMARY_TICKS
+        testMetricsSetTwice(isPrimary = true)
+    }
+
+    @Test
+    fun `GIVEN app init have valid values and clock ticks per second is not 100 WHEN metrics are set twice THEN frameworkSecondary is only set once`() {
+        clockTicksPerSecondValue = SECONDARY_TICKS
+        testMetricsSetTwice(isPrimary = false)
+    }
+
+    private fun testMetricsSetTwice(isPrimary: Boolean) {
         setProcessAppInitAndMetrics(10, 100)
         metrics.setExpensiveMetric()
-        verify(exactly = 1) { frameworkStart.setRawNanos(any()) }
+
+        val (setMetric, unsetMetric) = getSetAndUnsetMetric(isPrimary)
+        verify(exactly = 1) { setMetric.setRawNanos(any()) }
+        verify { unsetMetric wasNot Called }
         verify(exactly = 1) { clockTicksPerSecond.add(any()) }
         verify { frameworkStartError wasNot Called }
     }
@@ -103,15 +144,33 @@ class StartupFrameworkStartMeasurementTest {
         metrics.setExpensiveMetric()
     }
 
-    private fun verifyFrameworkStartSuccess(nanos: Long) {
-        verify { frameworkStart.setRawNanos(nanos) }
-        verify { clockTicksPerSecond.add(CLOCK_TICKS_PER_SECOND.toInt()) }
+    private fun verifyFrameworkStartSuccess(nanos: Long, isPrimary: Boolean) {
+        val (setMetric, unsetMetric) = getSetAndUnsetMetric(isPrimary)
+        verify { setMetric.setRawNanos(nanos) }
+        verify { unsetMetric wasNot Called }
+
+        val expectedClockTicksPerSecond = getExpectedClockTicksPerSecond(isPrimary)
+        verify { clockTicksPerSecond.add(expectedClockTicksPerSecond.toInt()) }
         verify { frameworkStartError wasNot Called }
     }
 
     private fun verifyFrameworkStartError() {
         verify { frameworkStartError.set(true) }
-        verify { frameworkStart wasNot Called }
+        verify { frameworkPrimary wasNot Called }
+        verify { frameworkSecondary wasNot Called }
         verify { clockTicksPerSecond wasNot Called }
     }
+
+    private fun getSetAndUnsetMetric(isPrimary: Boolean): Pair<TimespanMetricType, TimespanMetricType> {
+        return if (isPrimary) {
+            Pair(frameworkPrimary, frameworkSecondary)
+        } else {
+            Pair(frameworkSecondary, frameworkPrimary)
+        }
+    }
+
+    // This hard-codes some data that's passed into the test but I don't want to spend more time
+    // so I don't bother cleaning it up now.
+    private fun getExpectedClockTicksPerSecond(isPrimary: Boolean): Long =
+        if (isPrimary) PRIMARY_TICKS else SECONDARY_TICKS
 }

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -340,26 +340,34 @@ The following metrics are added to the ping:
 
 This ping is intended to provide an understanding of startup performance.
 
-The ping is intended to be captured by performance testing automation to
-report results there, in addition to user telemetry. We place these metrics
-into their own ping in order to isolate them and make this process easier.
+In addition to being captured on real devices, the ping data was prematurely
+optimized into this separate ping to be isolated from other metrics to be
+more easily captured by performance testing automation but that hasn't
+happened in practice. We would have removed it but implementation
+details don't make that possible:
+https://github.com/mozilla-mobile/fenix/issues/17972#issuecomment-781002987
 
+
+This ping includes the [client id](https://mozilla.github.io/glean/book/user/pings/index.html#the-client_info-section).
 
 **Data reviews for this ping:**
 
 - <https://github.com/mozilla-mobile/fenix/pull/9788#pullrequestreview-394228626>
+- <https://github.com/mozilla-mobile/fenix/pull/18043#issue-575389284>
 
 **Bugs related to this ping:**
 
 - <https://github.com/mozilla-mobile/fenix/issues/8803>
+- <https://github.com/mozilla-mobile/fenix/issues/17972>
 
 The following metrics are added to the ping:
 
 | Name | Type | Description | Data reviews | Extras | Expiration | [Data Sensitivity](https://wiki.mozilla.org/Firefox/Data_Collection) |
 | --- | --- | --- | --- | --- | --- | --- |
 | startup.timeline.clock_ticks_per_second |[counter](https://mozilla.github.io/glean/book/user/metrics/counter.html) |The number of clock tick time units that occur in one second on this particular device. This value is expected to be used in conjunction with the `framework_start` metric.  |[1](https://github.com/mozilla-mobile/fenix/pull/9788#pullrequestreview-394228626), [2](https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068)||2021-08-01 |1 |
-| startup.timeline.framework_start |[timespan](https://mozilla.github.io/glean/book/user/metrics/timespan.html) |The duration the Android framework takes to start before letting us run code in `*Application.init`. This is calculated from `appInitTimestamp - processStartTimestamp`. `processStartTimestamp` is derived from the clock tick time unit, which is expected to be less granular than nanoseconds. Therefore, we convert and round our timestamps to clock ticks before computing the difference and convert back to nanoseconds to report.  For debugging purposes, `clock_ticks_per_second`, which may vary between devices, is also reported as a metric  |[1](https://github.com/mozilla-mobile/fenix/pull/9788#pullrequestreview-394228626), [2](https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068)||2021-08-01 |1 |
-| startup.timeline.framework_start_error |[boolean](https://mozilla.github.io/glean/book/user/metrics/boolean.html) |An error when attempting to record `framework_start` - the application init timestamp returned a negative value - which is likely indicative of a bug in the implementation.  |[1](https://github.com/mozilla-mobile/fenix/pull/9788#pullrequestreview-394228626), [2](https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068)||2021-08-01 |1 |
+| startup.timeline.framework_primary |[timespan](https://mozilla.github.io/glean/book/user/metrics/timespan.html) |The duration the Android framework takes to start before letting us run code in `*Application.init` when this device has `clock_ticks_per_second` equal to 100: if it's not equal to 100, then this value is captured in `framework_secondary`. We split this into two metrics to make it easier to analyze in GLAM. We split on 100 because when we did our initial brief analysis - https://sql.telemetry.mozilla.org/queries/75591 - the results for clocks ticks were overwhelmingly 100.  The duration is calculated from `appInitTimestamp - processStartTimestamp`. `processStartTimestamp` is derived from the clock tick time unit, which is expected to be less granular than nanoseconds. Therefore, we convert and round our timestamps to clock ticks before computing the difference and convert back to nanoseconds to report.  For debugging purposes, `clock_ticks_per_second`, which may vary between devices, is also reported as a metric  |[1](https://github.com/mozilla-mobile/fenix/pull/9788#pullrequestreview-394228626), [2](https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068), [3](https://github.com/mozilla-mobile/fenix/pull/18043#issue-575389284)||2021-08-01 |1 |
+| startup.timeline.framework_secondary |[timespan](https://mozilla.github.io/glean/book/user/metrics/timespan.html) |The duration the Android framework takes to start before letting us run code in `*Application.init` when this device has `clock_ticks_per_second` not equal to 100. For more details on this metric, see `framework_primary`  |[1](https://github.com/mozilla-mobile/fenix/pull/18043#issue-575389284)||2021-08-01 |1 |
+| startup.timeline.framework_start_error |[boolean](https://mozilla.github.io/glean/book/user/metrics/boolean.html) |An error when attempting to record `framework_primary/secondary` - the application init timestamp returned a negative value - which is likely indicative of a bug in the implementation.  |[1](https://github.com/mozilla-mobile/fenix/pull/9788#pullrequestreview-394228626), [2](https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068)||2021-08-01 |1 |
 | startup.timeline.framework_start_read_error |[boolean](https://mozilla.github.io/glean/book/user/metrics/boolean.html) |An error when attempting to read stats from /proc pseudo-filesystem - privacy managers can block access to reading these files - the application will catch a file reading exception.  |[1](https://github.com/mozilla-mobile/fenix/pull/10481), [2](https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068)||2021-08-01 |1 |
 
 


### PR DESCRIPTION
@boek or @mmccorks for data review
@MarcLeclair for full review


# Request for data collection review form

**All questions are mandatory. You must receive review from a data steward peer on your responses to these questions before shipping new data collection.**

1) What questions will you answer with this data?

- How long does the framework take to start? Especially when the clock ticks per second is the expected value of 100

2) Why does Mozilla need to answer these questions?  Are there benefits for users? Do we need this information to address product or business requirements? Some example responses:

* Establish baselines or measure changes in product or platform quality or performance.
* Determine if we should invest effort in improving the time it takes the framework to start

3) What alternative methods did you consider to answer these questions? Why were they not sufficient?

We can measure locally but it's hard to know if the behavior we see locally is representative of actual user behavior.

4) Can current instrumentation answer these questions?

Yes but it's not set up to be easily analyzed. THe change makes it easy to analyze in glam.

5) List all proposed measurements and indicate the category of data collection for each measurement, using the [Firefox data collection categories](https://wiki.mozilla.org/Firefox/Data_Collection) found on the Mozilla wiki.   

**Note that the data steward reviewing your request will characterize your data collection based on the highest (and most sensitive) category.**

<table>
  <tr>
    <td>frameworkPrimary - duration from process start to appInit when clock ticks per second is 100</td>
    <td>Technical</td>
    <td>#17972</td>
  </tr>
  <tr>
    <td>frameworkSecondary - duration from process start to appInit when clock ticks per second is not 100</td>
    <td>Technical</td>
    <td>#17972</td>
  </tr>
</table>

6) Please provide a link to the documentation for this data collection which describes the ultimate data set in a public, complete, and accurate way.

https://github.com/mozilla-mobile/fenix/blob/master/docs/metrics.md

7) How long will this data be collected?  Choose one of the following:

* I want this data to be collected for 6 months initially (potentially renewable).

8) What populations will you measure?

* Which release channels?

All 

* Which countries?

All

* Which locales?

All

* Any other filters?  Please describe in detail below.

No

9) If this data collection is default on, what is the opt-out mechanism for users?

Telemetry settings toggle in app

10) Please provide a general description of how you will analyze this data.

Read durations, especially 95th percentile, to determine if there are perf issues with it.

11) Where do you intend to share the results of your analysis?

Internally: GLAM

12) Is there a third-party tool (i.e. not Telemetry) that you are proposing to use for this data collection? If so:

No.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
