### PR TITLE
For #16317 UI tests: save long tap preference to restore it

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/HomeActivityTestRule.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/HomeActivityTestRule.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.fenix.helpers
 
+import android.view.ViewConfiguration.getLongPressTimeout
 import androidx.test.espresso.intent.rule.IntentsTestRule
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.ActivityTestRule
@@ -25,15 +26,17 @@ class HomeActivityTestRule(
     private val skipOnboarding: Boolean = false
 ) :
     ActivityTestRule<HomeActivity>(HomeActivity::class.java, initialTouchMode, launchActivity) {
+    private val longTapUserPreference = getLongPressTimeout()
+
     override fun beforeActivityLaunched() {
         super.beforeActivityLaunched()
-        setLongTapTimeout("3000")
+        setLongTapTimeout(3000)
         if (skipOnboarding) { skipOnboardingBeforeLaunch() }
     }
 
     override fun afterActivityFinished() {
         super.afterActivityFinished()
-        setLongTapTimeout("400")
+        setLongTapTimeout(longTapUserPreference)
     }
 }
 
@@ -51,20 +54,22 @@ class HomeActivityIntentTestRule(
     private val skipOnboarding: Boolean = false
 ) :
     IntentsTestRule<HomeActivity>(HomeActivity::class.java, initialTouchMode, launchActivity) {
+    private val longTapUserPreference = getLongPressTimeout()
+
     override fun beforeActivityLaunched() {
         super.beforeActivityLaunched()
-        setLongTapTimeout("3000")
+        setLongTapTimeout(3000)
         if (skipOnboarding) { skipOnboardingBeforeLaunch() }
     }
 
     override fun afterActivityFinished() {
         super.afterActivityFinished()
-        setLongTapTimeout("400")
+        setLongTapTimeout(longTapUserPreference)
     }
 }
 
 // changing the device preference for Touch and Hold delay, to avoid long-clicks instead of a single-click
-fun setLongTapTimeout(delay: String) {
+fun setLongTapTimeout(delay: Int) {
     val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
     mDevice.executeShellCommand("settings put secure long_press_timeout $delay")
 }


### PR DESCRIPTION
As requested in https://github.com/mozilla-mobile/fenix/issues/16317#issuecomment-781094691, saving the user's preference for the touch & hold delay to be able to restore it when the tests are finished.
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
