### PR TITLE
For 17808: Resolve deprecated methods in ThemeManager

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,8 +46,7 @@ android {
         def deepLinkSchemeValue = "fenix-dev"
         buildConfigField "String", "DEEP_LINK_SCHEME", "\"$deepLinkSchemeValue\""
         manifestPlaceholders = [
-                "deepLinkScheme": deepLinkSchemeValue,
-                "requestLegacyExternalStorage": true
+                "deepLinkScheme": deepLinkSchemeValue
         ]
 
         // Build flag for "Mozilla Online" variants. See `Config.isMozillaOnline`.
@@ -82,19 +81,13 @@ android {
             applicationIdSuffix ".fenix.debug"
             resValue "bool", "IS_DEBUG", "true"
             pseudoLocalesEnabled true
-            def deepLinkSchemeValue = "fenix-dev"
-            buildConfigField "String", "DEEP_LINK_SCHEME", "\"$deepLinkSchemeValue\""
-            manifestPlaceholders = [
-                    "deepLinkScheme": deepLinkSchemeValue,
-                    "requestLegacyExternalStorage": false
-            ]
         }
         nightly releaseTemplate >> {
             applicationIdSuffix ".fenix"
             buildConfigField "boolean", "USE_RELEASE_VERSIONING", "true"
             def deepLinkSchemeValue = "fenix-nightly"
             buildConfigField "String", "DEEP_LINK_SCHEME", "\"$deepLinkSchemeValue\""
-            manifestPlaceholders = ["deepLinkScheme": deepLinkSchemeValue, "requestLegacyExternalStorage": false]
+            manifestPlaceholders = ["deepLinkScheme": deepLinkSchemeValue]
         }
         beta releaseTemplate >> {
             buildConfigField "boolean", "USE_RELEASE_VERSIONING", "true"
@@ -110,8 +103,7 @@ android {
                     //  - https://issuetracker.google.com/issues/36924841
                     //  - https://issuetracker.google.com/issues/36905922
                     "sharedUserId": "org.mozilla.firefox.sharedID",
-                    "deepLinkScheme": deepLinkSchemeValue,
-                    "requestLegacyExternalStorage": true
+                    "deepLinkScheme": deepLinkSchemeValue
             ]
         }
         release releaseTemplate >> {
@@ -128,8 +120,7 @@ android {
                     //  - https://issuetracker.google.com/issues/36924841
                     //  - https://issuetracker.google.com/issues/36905922
                     "sharedUserId": "org.mozilla.firefox.sharedID",
-                    "deepLinkScheme": deepLinkSchemeValue,
-                    "requestLegacyExternalStorage": true
+                    "deepLinkScheme": deepLinkSchemeValue
             ]
         }
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,7 +23,6 @@
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
-        android:requestLegacyExternalStorage="${requestLegacyExternalStorage}"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/NormalTheme"

--- a/app/src/main/java/org/mozilla/fenix/collections/CollectionCreationView.kt
+++ b/app/src/main/java/org/mozilla/fenix/collections/CollectionCreationView.kt
@@ -168,6 +168,8 @@ class CollectionCreationView(
             text = context.getString(R.string.create_collection_name_collection)
             setOnClickListener {
                 name_collection_edittext.hideKeyboard()
+                // This will be addressed on https://github.com/mozilla-mobile/fenix/issues/17803
+                @Suppress("DEPRECATION")
                 val handler = Handler()
                 handler.postDelayed({
                     interactor.onBackPressed(SaveCollectionStep.NameCollection)
@@ -214,6 +216,8 @@ class CollectionCreationView(
             text = context.getString(R.string.collection_rename)
             setOnClickListener {
                 name_collection_edittext.hideKeyboard()
+                // Will be addressed on https://github.com/mozilla-mobile/fenix/issues/17803
+                @Suppress("DEPRECATION")
                 val handler = Handler()
                 handler.postDelayed({
                     interactor.onBackPressed(SaveCollectionStep.RenameCollection)

--- a/app/src/main/java/org/mozilla/fenix/ext/Activity.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/Activity.kt
@@ -17,6 +17,8 @@ import mozilla.components.concept.base.crash.Breadcrumb
  */
 fun Activity.enterToImmersiveMode() {
     window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+    // This will be addressed on https://github.com/mozilla-mobile/fenix/issues/17804
+    @Suppress("DEPRECATION")
     window.decorView.systemUiVisibility = (View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
             or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
             or View.SYSTEM_UI_FLAG_HIDE_NAVIGATION

--- a/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt
@@ -100,6 +100,8 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
         super.onStop()
         // https://github.com/mozilla-mobile/fenix/issues/14279
         // Let's reset back to the default behavior after we're done searching
+        // This will be addressed on https://github.com/mozilla-mobile/fenix/issues/17805
+        @Suppress("DEPRECATION")
         requireActivity().window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
     }
 

--- a/app/src/main/java/org/mozilla/fenix/session/PerformanceActivityLifecycleCallbacks.kt
+++ b/app/src/main/java/org/mozilla/fenix/session/PerformanceActivityLifecycleCallbacks.kt
@@ -59,12 +59,12 @@ class PerformanceActivityLifecycleCallbacks(
         }
     }
 
-    override fun onActivityStarted(activity: Activity?) {}
-    override fun onActivityStopped(activity: Activity?) {}
-    override fun onActivityResumed(activity: Activity?) {}
-    override fun onActivityPaused(activity: Activity?) {}
-    override fun onActivitySaveInstanceState(activity: Activity?, bundle: Bundle?) {}
-    override fun onActivityDestroyed(activity: Activity?) {}
+    override fun onActivityStarted(activity: Activity) {}
+    override fun onActivityStopped(activity: Activity) {}
+    override fun onActivityResumed(activity: Activity) {}
+    override fun onActivityPaused(activity: Activity) {}
+    override fun onActivitySaveInstanceState(activity: Activity, bundle: Bundle) {}
+    override fun onActivityDestroyed(activity: Activity) {}
 
     companion object {
         /**

--- a/app/src/main/java/org/mozilla/fenix/session/VisibilityLifecycleCallback.kt
+++ b/app/src/main/java/org/mozilla/fenix/session/VisibilityLifecycleCallback.kt
@@ -44,23 +44,23 @@ class VisibilityLifecycleCallback(private val activityManager: ActivityManager?)
         return false
     }
 
-    override fun onActivityStarted(activity: Activity?) {
+    override fun onActivityStarted(activity: Activity) {
         activitiesInStartedState++
     }
 
-    override fun onActivityStopped(activity: Activity?) {
+    override fun onActivityStopped(activity: Activity) {
         activitiesInStartedState--
     }
 
-    override fun onActivityResumed(activity: Activity?) {}
+    override fun onActivityResumed(activity: Activity) {}
 
-    override fun onActivityPaused(activity: Activity?) {}
+    override fun onActivityPaused(activity: Activity) {}
 
-    override fun onActivityCreated(activity: Activity?, bundle: Bundle?) {}
+    override fun onActivityCreated(activity: Activity, bundle: Bundle?) {}
 
-    override fun onActivitySaveInstanceState(activity: Activity?, bundle: Bundle?) {}
+    override fun onActivitySaveInstanceState(activity: Activity, bundle: Bundle) {}
 
-    override fun onActivityDestroyed(activity: Activity?) {}
+    override fun onActivityDestroyed(activity: Activity) {}
 
     companion object {
         /**

--- a/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
@@ -335,6 +335,8 @@ class SettingsFragment : PreferenceFragmentCompat() {
                             Toast.LENGTH_LONG
                         ).show()
 
+                        // This will be addressed on https://github.com/mozilla-mobile/fenix/issues/17806
+                        @Suppress("DEPRECATION")
                         Handler().postDelayed({
                             exitProcess(0)
                         }, AMO_COLLECTION_OVERRIDE_EXIT_DELAY)
@@ -406,6 +408,8 @@ class SettingsFragment : PreferenceFragmentCompat() {
                         getString(R.string.toast_override_fxa_sync_server_done),
                         Toast.LENGTH_LONG
                     ).show()
+                    // This will be addressed on https://github.com/mozilla-mobile/fenix/issues/17806
+                    @Suppress("DEPRECATION")
                     Handler().postDelayed({
                         exitProcess(0)
                     }, FXA_SYNC_OVERRIDE_EXIT_DELAY)

--- a/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsDetailsExceptionsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsDetailsExceptionsFragment.kt
@@ -130,11 +130,11 @@ class SitePermissionsDetailsExceptionsFragment : PreferenceFragmentCompat() {
             AlertDialog.Builder(requireContext()).apply {
                 setMessage(R.string.confirm_clear_permissions_site)
                 setTitle(R.string.clear_permissions)
-                setPositiveButton(android.R.string.yes) { dialog: DialogInterface, _ ->
+                setPositiveButton(android.R.string.ok) { dialog: DialogInterface, _ ->
                     clearSitePermissions()
                     dialog.dismiss()
                 }
-                setNegativeButton(android.R.string.no) { dialog: DialogInterface, _ ->
+                setNegativeButton(android.R.string.cancel) { dialog: DialogInterface, _ ->
                     dialog.cancel()
                 }
             }.show()

--- a/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsExceptionsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsExceptionsFragment.kt
@@ -95,11 +95,11 @@ class SitePermissionsExceptionsFragment :
             AlertDialog.Builder(requireContext()).apply {
                 setMessage(R.string.confirm_clear_permissions_on_all_sites)
                 setTitle(R.string.clear_permissions)
-                setPositiveButton(android.R.string.yes) { dialog: DialogInterface, _ ->
+                setPositiveButton(android.R.string.ok) { dialog: DialogInterface, _ ->
                     deleteAllSitePermissions()
                     dialog.dismiss()
                 }
-                setNegativeButton(android.R.string.no) { dialog: DialogInterface, _ ->
+                setNegativeButton(android.R.string.cancel) { dialog: DialogInterface, _ ->
                     dialog.cancel()
                 }
             }.show()

--- a/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsManageExceptionsPhoneFeatureFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsManageExceptionsPhoneFeatureFragment.kt
@@ -159,11 +159,11 @@ class SitePermissionsManageExceptionsPhoneFeatureFragment : Fragment() {
             AlertDialog.Builder(requireContext()).apply {
                 setMessage(R.string.confirm_clear_permission_site)
                 setTitle(R.string.clear_permission)
-                setPositiveButton(android.R.string.yes) { dialog: DialogInterface, _ ->
+                setPositiveButton(android.R.string.ok) { dialog: DialogInterface, _ ->
                     clearPermissions()
                     dialog.dismiss()
                 }
-                setNegativeButton(android.R.string.no) { dialog: DialogInterface, _ ->
+                setNegativeButton(android.R.string.cancel) { dialog: DialogInterface, _ ->
                     dialog.cancel()
                 }
             }.show()

--- a/app/src/main/java/org/mozilla/fenix/share/ShareViewModel.kt
+++ b/app/src/main/java/org/mozilla/fenix/share/ShareViewModel.kt
@@ -47,8 +47,8 @@ class ShareViewModel(application: Application) : AndroidViewModel(application) {
 
     @VisibleForTesting
     internal val networkCallback = object : ConnectivityManager.NetworkCallback() {
-        override fun onLost(network: Network?) = reloadDevices(network)
-        override fun onAvailable(network: Network?) = reloadDevices(network)
+        override fun onLost(network: Network) = reloadDevices(network)
+        override fun onAvailable(network: Network) = reloadDevices(network)
 
         private fun reloadDevices(network: Network?) {
             viewModelScope.launch(ioDispatcher) {

--- a/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayDialogFragment.kt
@@ -243,12 +243,16 @@ class TabTrayDialogFragment : AppCompatDialogFragment(), UserInteractionHandler 
         }
 
         view.tabLayout.setOnApplyWindowInsetsListener { v, insets ->
+            // This will be addressed on https://github.com/mozilla-mobile/fenix/issues/17807
+            @Suppress("DEPRECATION")
             v.updatePadding(
                 left = insets.systemWindowInsetLeft,
                 right = insets.systemWindowInsetRight,
                 bottom = insets.systemWindowInsetBottom
             )
 
+            // This will be addressed on https://github.com/mozilla-mobile/fenix/issues/17807
+            @Suppress("DEPRECATION")
             tabTrayView.view.tab_wrapper.updatePadding(
                 bottom = insets.systemWindowInsetBottom
             )

--- a/app/src/main/java/org/mozilla/fenix/theme/ThemeManager.kt
+++ b/app/src/main/java/org/mozilla/fenix/theme/ThemeManager.kt
@@ -76,7 +76,8 @@ abstract class ThemeManager {
         private fun updateLightSystemBars(window: Window, context: Context) {
             if (SDK_INT >= Build.VERSION_CODES.M) {
                 window.statusBarColor = context.getColorFromAttr(android.R.attr.statusBarColor)
-
+                // This will be addressed on https://github.com/mozilla-mobile/fenix/issues/17808
+                @Suppress("DEPRECATION")
                 window.decorView.systemUiVisibility =
                     window.decorView.systemUiVisibility or SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
             } else {
@@ -85,6 +86,8 @@ abstract class ThemeManager {
 
             if (SDK_INT >= Build.VERSION_CODES.O) {
                 // API level can display handle light navigation bar color
+                // This will be addressed on https://github.com/mozilla-mobile/fenix/issues/17808
+                @Suppress("DEPRECATION")
                 window.decorView.systemUiVisibility =
                     window.decorView.systemUiVisibility or SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR
                 updateNavigationBar(window, context)
@@ -93,12 +96,16 @@ abstract class ThemeManager {
 
         private fun clearLightSystemBars(window: Window) {
             if (SDK_INT >= Build.VERSION_CODES.M) {
+                // This will be addressed on https://github.com/mozilla-mobile/fenix/issues/17808
+                @Suppress("DEPRECATION")
                 window.decorView.systemUiVisibility = window.decorView.systemUiVisibility and
                     SYSTEM_UI_FLAG_LIGHT_STATUS_BAR.inv()
             }
 
             if (SDK_INT >= Build.VERSION_CODES.O) {
                 // API level can display handle light navigation bar color
+                // This will be addressed on https://github.com/mozilla-mobile/fenix/issues/17808
+                @Suppress("DEPRECATION")
                 window.decorView.systemUiVisibility = window.decorView.systemUiVisibility and
                     SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR.inv()
             }

--- a/app/src/main/java/org/mozilla/fenix/theme/ThemeManager.kt
+++ b/app/src/main/java/org/mozilla/fenix/theme/ThemeManager.kt
@@ -15,6 +15,8 @@ import android.util.TypedValue
 import android.view.View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR
 import android.view.View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
 import android.view.Window
+import android.view.WindowInsetsController.APPEARANCE_LIGHT_NAVIGATION_BARS
+import androidx.annotation.RequiresApi
 import androidx.annotation.StyleRes
 import mozilla.components.support.ktx.android.content.getColorFromAttr
 import org.mozilla.fenix.HomeActivity
@@ -76,38 +78,54 @@ abstract class ThemeManager {
         private fun updateLightSystemBars(window: Window, context: Context) {
             if (SDK_INT >= Build.VERSION_CODES.M) {
                 window.statusBarColor = context.getColorFromAttr(android.R.attr.statusBarColor)
-                // This will be addressed on https://github.com/mozilla-mobile/fenix/issues/17808
-                @Suppress("DEPRECATION")
-                window.decorView.systemUiVisibility =
-                    window.decorView.systemUiVisibility or SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
+                updateLightSystemBarsType(window, context)
             } else {
                 window.statusBarColor = Color.BLACK
             }
+        }
 
-            if (SDK_INT >= Build.VERSION_CODES.O) {
-                // API level can display handle light navigation bar color
-                // This will be addressed on https://github.com/mozilla-mobile/fenix/issues/17808
-                @Suppress("DEPRECATION")
-                window.decorView.systemUiVisibility =
-                    window.decorView.systemUiVisibility or SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR
-                updateNavigationBar(window, context)
+        @RequiresApi(Build.VERSION_CODES.M)
+        @Suppress("DEPRECATION")
+        private fun updateLightSystemBarsType(window: Window, context: Context) {
+            when {
+                SDK_INT >= Build.VERSION_CODES.R -> {
+                    window.insetsController?.apply {
+                        setSystemBarsAppearance(APPEARANCE_LIGHT_NAVIGATION_BARS, APPEARANCE_LIGHT_NAVIGATION_BARS)
+                    }
+                }
+                SDK_INT >= Build.VERSION_CODES.O -> {
+                    // API level can display handle light navigation bar color
+                    window.decorView.systemUiVisibility =
+                            window.decorView.systemUiVisibility or SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR
+                    updateNavigationBar(window, context)
+                }
+                else -> {
+                    //API Level is at least 23
+                    window.decorView.systemUiVisibility =
+                            window.decorView.systemUiVisibility or SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
+                }
             }
         }
 
+        @Suppress("DEPRECATION")
         private fun clearLightSystemBars(window: Window) {
-            if (SDK_INT >= Build.VERSION_CODES.M) {
-                // This will be addressed on https://github.com/mozilla-mobile/fenix/issues/17808
-                @Suppress("DEPRECATION")
-                window.decorView.systemUiVisibility = window.decorView.systemUiVisibility and
-                    SYSTEM_UI_FLAG_LIGHT_STATUS_BAR.inv()
-            }
-
-            if (SDK_INT >= Build.VERSION_CODES.O) {
-                // API level can display handle light navigation bar color
-                // This will be addressed on https://github.com/mozilla-mobile/fenix/issues/17808
-                @Suppress("DEPRECATION")
-                window.decorView.systemUiVisibility = window.decorView.systemUiVisibility and
-                    SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR.inv()
+            when {
+                SDK_INT >= Build.VERSION_CODES.R -> {
+                    window.insetsController?.apply {
+                        setSystemBarsAppearance(0, APPEARANCE_LIGHT_NAVIGATION_BARS)
+                    }
+                }
+                SDK_INT >= Build.VERSION_CODES.O -> {
+                    // API level can display handle light navigation bar color
+                    // This will be addressed on https://github.com/mozilla-mobile/fenix/issues/17808
+                    window.decorView.systemUiVisibility = window.decorView.systemUiVisibility and
+                            SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR.inv()
+                }
+                SDK_INT >= Build.VERSION_CODES.M -> {
+                    // This will be addressed on https://github.com/mozilla-mobile/fenix/issues/17808
+                    window.decorView.systemUiVisibility = window.decorView.systemUiVisibility and
+                            SYSTEM_UI_FLAG_LIGHT_STATUS_BAR.inv()
+                }
             }
         }
 

--- a/app/src/main/java/org/mozilla/fenix/wifi/WifiConnectionMonitor.kt
+++ b/app/src/main/java/org/mozilla/fenix/wifi/WifiConnectionMonitor.kt
@@ -34,12 +34,12 @@ class WifiConnectionMonitor(app: Application) {
     private var isRegistered = false
 
     private val frameworkListener = object : ConnectivityManager.NetworkCallback() {
-        override fun onLost(network: Network?) {
+        override fun onLost(network: Network) {
             notifyListeners(false)
             lastKnownStateWasAvailable = false
         }
 
-        override fun onAvailable(network: Network?) {
+        override fun onAvailable(network: Network) {
             notifyListeners(true)
             lastKnownStateWasAvailable = true
         }

--- a/app/src/test/java/org/mozilla/fenix/ext/ActivityTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/ext/ActivityTest.kt
@@ -18,6 +18,8 @@ import org.robolectric.Shadows.shadowOf
 @RunWith(FenixRobolectricTestRunner::class)
 class ActivityTest {
 
+    // This will be addressed on https://github.com/mozilla-mobile/fenix/issues/17804
+    @Suppress("DEPRECATION")
     @Test
     fun testEnterImmersiveMode() {
         val activity = Robolectric.buildActivity(Activity::class.java).create().get()

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -13,9 +13,9 @@ import java.util.Locale
 
 object Config {
     // Synchronized build configuration for all modules
-    const val compileSdkVersion = 29
+    const val compileSdkVersion = 30
     const val minSdkVersion = 21
-    const val targetSdkVersion = 29
+    const val targetSdkVersion = 30
 
     @JvmStatic
     private fun generateDebugVersionName(): String {


### PR DESCRIPTION
## Description
This PR adds method calls on the ThemeManager to avoid deprecated calls if possible, for now, we cannot use the CompatLibrary due to it being available only on ktx-core beta, however, I can make changes to the code when the CompatLibrary is released.
This branch was created based on the PR: https://github.com/mozilla-mobile/fenix/pull/17809, we shouldn't merge this before merging it first

## **Tests**
There are no **tests** of the Theme Manager.

## **Screenshots**
It is not a visual change so there are no screenshots.

## **Accessibility**
This PR does not include any user-facing features.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
