### PR TITLE
For issue #18049 Download complete dialog is not showing in custom tab.

### DIFF
--- a/app/src/test/java/org/mozilla/fenix/browser/BaseBrowserFragmentTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/browser/BaseBrowserFragmentTest.kt
@@ -12,8 +12,12 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.spyk
 import io.mockk.verify
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.components.browser.state.state.SessionState
+import mozilla.components.browser.state.state.content.DownloadState
+import mozilla.components.browser.state.state.createTab
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.feature.contextmenu.ContextMenuCandidate
 import mozilla.components.feature.session.behavior.EngineViewBrowserToolbarBehavior
@@ -110,6 +114,66 @@ class BaseBrowserFragmentTest {
         fragment.initializeEngineView(13)
 
         verify { (swipeRefreshLayout.layoutParams as CoordinatorLayout.LayoutParams).bottomMargin = 13 }
+    }
+
+    @Test
+    fun `WHEN status is equals to FAILED or COMPLETED and it is the same tab then shouldShowCompletedDownloadDialog will be true`() {
+        every { fragment.getCurrentTab() } returns createTab(id = "1", url = "")
+
+        val download = DownloadState(
+            url = "",
+            sessionId = "1"
+        )
+
+        val status = DownloadState.Status.values()
+            .filter { it == DownloadState.Status.COMPLETED && it == DownloadState.Status.FAILED }
+
+        status.forEach {
+            val result =
+                fragment.shouldShowCompletedDownloadDialog(download, it)
+
+            assertTrue(result)
+        }
+    }
+
+    @Test
+    fun `WHEN status is different from FAILED or COMPLETED then shouldShowCompletedDownloadDialog will be false`() {
+        every { fragment.getCurrentTab() } returns createTab(id = "1", url = "")
+
+        val download = DownloadState(
+            url = "",
+            sessionId = "1"
+        )
+
+        val status = DownloadState.Status.values()
+            .filter { it != DownloadState.Status.COMPLETED && it != DownloadState.Status.FAILED }
+
+        status.forEach {
+            val result =
+                fragment.shouldShowCompletedDownloadDialog(download, it)
+
+            assertFalse(result)
+        }
+    }
+
+    @Test
+    fun `WHEN the tab is different from the initial one then shouldShowCompletedDownloadDialog will be false`() {
+        every { fragment.getCurrentTab() } returns createTab(id = "1", url = "")
+
+        val download = DownloadState(
+            url = "",
+            sessionId = "2"
+        )
+
+        val status = DownloadState.Status.values()
+            .filter { it != DownloadState.Status.COMPLETED && it != DownloadState.Status.FAILED }
+
+        status.forEach {
+            val result =
+                fragment.shouldShowCompletedDownloadDialog(download, it)
+
+            assertFalse(result)
+        }
     }
 }
 


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
