### PR TITLE
Update Kotlin to 1.4.30 and Coroutines to 1.4.2.

### DIFF
--- a/app/src/test/java/org/mozilla/fenix/downloads/DynamicDownloadDialogBehaviorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/downloads/DynamicDownloadDialogBehaviorTest.kt
@@ -60,7 +60,7 @@ class DynamicDownloadDialogBehaviorTest {
     }
 
     @Test
-    fun `Behavior will snap the dialog up if it is more than 50% visible`() {
+    fun `Behavior will snap the dialog up if it is more than 50 percent visible`() {
         val behavior = spyk(DynamicDownloadDialogBehavior<View>(testContext, attrs = null,
         bottomToolbarHeight = 10f))
         every { behavior.shouldScroll } returns true

--- a/app/src/test/java/org/mozilla/fenix/share/ShareControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/share/ShareControllerTest.kt
@@ -361,12 +361,12 @@ class ShareControllerTest {
     }
 
     @Test
-    fun `getShareSubject will return "shareSubject" if that is non null`() {
+    fun `getShareSubject will return 'shareSubject' if that is non null`() {
         assertEquals(shareSubject, controller.getShareSubject())
     }
 
     @Test
-    fun `getShareSubject will return a concatenation of tab titles if "shareSubject" is null`() {
+    fun `getShareSubject will return a concatenation of tab titles if 'shareSubject' is null`() {
         val controller = DefaultShareController(
             context, null, shareData, sendTabUseCases, snackbar, navController,
             recentAppStorage, testCoroutineScope, testDispatcher, dismiss

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -3,8 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object Versions {
-    const val kotlin = "1.4.10"
-    const val coroutines = "1.3.9"
+    const val kotlin = "1.4.30"
+    const val coroutines = "1.4.2"
 
     // These versions are linked: lint should be X+23.Y.Z of gradle_plugin version, according to:
     // https://github.com/alexjlockwood/android-lint-checks-demo/blob/0245fc027463137b1b4afb97c5295d60dce998b6/dependencies.gradle#L3


### PR DESCRIPTION
I don't see any issues locally, I can build, test and run tools like ktlint/detekt.

AC is planning to update too:
https://github.com/mozilla-mobile/android-components/pull/9728