### PR TITLE
Update build-contributor-pr.yml to trigger on pull_request_target

### DIFF
--- a/.github/workflows/build-contributor-pr.yml
+++ b/.github/workflows/build-contributor-pr.yml
@@ -1,5 +1,5 @@
 name: Android build PR
-on: [pull_request]
+on: [pull_request_target]
 jobs:
   run-build:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
This patch changes the trigger for the `build-contributor-pr.yml` workflow to `pull_request_target` which should allow it to run on forked repos.