### PR TITLE
Only run the build-contributor-pr workflow on forks

### DIFF
--- a/.github/workflows/build-contributor-pr.yml
+++ b/.github/workflows/build-contributor-pr.yml
@@ -3,7 +3,7 @@ on: [pull_request]
 jobs:
   run-build:
     runs-on: ubuntu-20.04
-    if: github.repository != 'mozilla-mobile/fenix'
+    if: github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -21,7 +21,7 @@ jobs:
 
   run-testDebugUnitTest:
     runs-on: ubuntu-20.04
-    if: github.repository != 'mozilla-mobile/fenix'
+    if: github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -39,7 +39,7 @@ jobs:
 
   run-detekt:
     runs-on: ubuntu-20.04
-    if: github.repository != 'mozilla-mobile/fenix'
+    if: github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -62,7 +62,7 @@ jobs:
 
   run-ktlint:
     runs-on: ubuntu-20.04
-    if: github.repository != 'mozilla-mobile/fenix'
+    if: github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -80,7 +80,7 @@ jobs:
 
   run-lintDebug:
     runs-on: ubuntu-20.04
-    if: github.repository != 'mozilla-mobile/fenix'
+    if: github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
This patch has a better check to see if the PR is running on a pull request that came from a fork. (The current workflow does not trigger at all.)

`if: github.event.pull_request.head.repo.full_name != github.repository`

The `github.repository` is always the original repo, in our case `mozilla-mobile/fenix` while `github.event.pull_request.head.repo` points to the repository where the PR is originating from, which for contributor PRs can never be `mozilla-mobile/*`.

Let's hope this works 🤞 
