### PR TITLE
For #18027 - Also fix the bottom toolbar in place when a11y is enabled

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -822,12 +822,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
     internal fun initializeEngineView(toolbarHeight: Int) {
         val context = requireContext()
 
-        // If there is an a11y service enabled and the user hasn't explicitly set bottom toolbar
-        val isTopToolbarForced =
-            !context.settings().shouldUseBottomToolbar &&
-                context.settings().shouldUseFixedTopToolbar
-
-        if (!isTopToolbarForced && context.settings().isDynamicToolbarEnabled) {
+        if (!context.settings().shouldUseFixedTopToolbar && context.settings().isDynamicToolbarEnabled) {
             getEngineView().setDynamicToolbarMaxHeight(toolbarHeight)
 
             val toolbarPosition = if (context.settings().shouldUseBottomToolbar) {

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarView.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarView.kt
@@ -245,7 +245,7 @@ class BrowserToolbarView(
     fun setToolbarBehavior(shouldDisableScroll: Boolean = false) {
         when (settings.toolbarPosition) {
             ToolbarPosition.BOTTOM -> {
-                if (settings.isDynamicToolbarEnabled && !isPwaTabOrTwaTab) {
+                if (settings.isDynamicToolbarEnabled && !isPwaTabOrTwaTab && !settings.shouldUseFixedTopToolbar) {
                     setDynamicToolbarBehavior(MozacToolbarPosition.BOTTOM)
                 } else {
                     expandToolbarAndMakeItFixed()

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -468,6 +468,13 @@ class Settings(private val appContext: Context) : PreferencesHolder {
         true
     )
 
+    /**
+     * Prefer to use a fixed top toolbar when:
+     * - a talkback service is enabled or
+     * - switch access is enabled.
+     *
+     * This is automatically inferred based on the current system status. Not a setting in our app.
+     */
     val shouldUseFixedTopToolbar: Boolean
         get() {
             return touchExplorationIsEnabled || switchServiceIsEnabled

--- a/app/src/test/java/org/mozilla/fenix/browser/BaseBrowserFragmentTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/browser/BaseBrowserFragmentTest.kt
@@ -61,6 +61,16 @@ class BaseBrowserFragmentTest {
     }
 
     @Test
+    fun `initializeEngineView should setDynamicToolbarMaxHeight to 0 if bottom toolbar is forced for a11y`() {
+        every { testContext.settings().shouldUseBottomToolbar } returns true
+        every { testContext.settings().shouldUseFixedTopToolbar } returns true
+
+        fragment.initializeEngineView(13)
+
+        verify { engineView.setDynamicToolbarMaxHeight(0) }
+    }
+
+    @Test
     fun `initializeEngineView should setDynamicToolbarMaxHeight to toolbar height if dynamic toolbar is enabled`() {
         every { testContext.settings().shouldUseFixedTopToolbar } returns false
         every { testContext.settings().isDynamicToolbarEnabled } returns true
@@ -109,6 +119,16 @@ class BaseBrowserFragmentTest {
     @Test
     fun `initializeEngineView should set toolbar height as EngineView parent's bottom margin if top toolbar is forced for a11y`() {
         every { testContext.settings().shouldUseBottomToolbar } returns false
+        every { testContext.settings().shouldUseFixedTopToolbar } returns true
+
+        fragment.initializeEngineView(13)
+
+        verify { (swipeRefreshLayout.layoutParams as CoordinatorLayout.LayoutParams).bottomMargin = 13 }
+    }
+
+    @Test
+    fun `initializeEngineView should set toolbar height as EngineView parent's bottom margin if bottom toolbar is forced for a11y`() {
+        every { testContext.settings().shouldUseBottomToolbar } returns true
         every { testContext.settings().shouldUseFixedTopToolbar } returns true
 
         fragment.initializeEngineView(13)

--- a/app/src/test/java/org/mozilla/fenix/components/toolbar/BrowserToolbarViewTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/toolbar/BrowserToolbarViewTest.kt
@@ -50,11 +50,12 @@ class BrowserToolbarViewTest {
     }
 
     @Test
-    fun `setToolbarBehavior(false) should setDynamicToolbarBehavior if bottom toolbar is dynamic and the tab is not for a PWA or TWA`() {
+    fun `setToolbarBehavior(false) should setDynamicToolbarBehavior if no a11y, bottom toolbar is dynamic and the tab is not for a PWA or TWA`() {
         val toolbarViewSpy = spyk(toolbarView)
         every { testContext.settings().toolbarPosition } returns ToolbarPosition.BOTTOM
         every { testContext.settings().isDynamicToolbarEnabled } returns true
         every { toolbarViewSpy.isPwaTabOrTwaTab } returns false
+        every { testContext.settings().shouldUseFixedTopToolbar } returns false
 
         toolbarViewSpy.setToolbarBehavior(false)
 
@@ -66,6 +67,8 @@ class BrowserToolbarViewTest {
         val toolbarViewSpy = spyk(toolbarView)
         every { testContext.settings().toolbarPosition } returns ToolbarPosition.BOTTOM
         every { testContext.settings().isDynamicToolbarEnabled } returns false
+        every { toolbarViewSpy.isPwaTabOrTwaTab } returns false
+        every { testContext.settings().shouldUseFixedTopToolbar } returns false
 
         toolbarViewSpy.setToolbarBehavior(false)
 
@@ -78,6 +81,7 @@ class BrowserToolbarViewTest {
         every { testContext.settings().toolbarPosition } returns ToolbarPosition.BOTTOM
         every { testContext.settings().isDynamicToolbarEnabled } returns true
         every { toolbarViewSpy.isPwaTabOrTwaTab } returns true
+        every { testContext.settings().shouldUseFixedTopToolbar } returns false
 
         toolbarViewSpy.setToolbarBehavior(false)
 
@@ -85,11 +89,27 @@ class BrowserToolbarViewTest {
     }
 
     @Test
-    fun `setToolbarBehavior(true) should setDynamicToolbarBehavior if bottom toolbar is dynamic and the tab is not for a PWA or TWA`() {
+    fun `setToolbarBehavior(false) should expandToolbarAndMakeItFixed if bottom toolbar is dynamic tab is not for a PWA or TWA but a11y is enabled`() {
         val toolbarViewSpy = spyk(toolbarView)
         every { testContext.settings().toolbarPosition } returns ToolbarPosition.BOTTOM
         every { testContext.settings().isDynamicToolbarEnabled } returns true
         every { toolbarViewSpy.isPwaTabOrTwaTab } returns false
+        every { testContext.settings().shouldUseFixedTopToolbar } returns true
+
+        toolbarViewSpy.setToolbarBehavior(false)
+
+        verify { toolbarViewSpy.expandToolbarAndMakeItFixed() }
+    }
+
+    @Test
+    fun `setToolbarBehavior(true) should expandToolbarAndMakeItFixed bottom toolbar is dynamic, the tab is not for a PWA or TWA and a11y is disabled`() {
+        // All intrinsic checks are met but the method was called with `shouldDisableScroll` = true
+
+        val toolbarViewSpy = spyk(toolbarView)
+        every { testContext.settings().toolbarPosition } returns ToolbarPosition.BOTTOM
+        every { testContext.settings().isDynamicToolbarEnabled } returns true
+        every { toolbarViewSpy.isPwaTabOrTwaTab } returns false
+        every { testContext.settings().shouldUseFixedTopToolbar } returns false
 
         toolbarViewSpy.setToolbarBehavior(false)
 
@@ -101,6 +121,8 @@ class BrowserToolbarViewTest {
         val toolbarViewSpy = spyk(toolbarView)
         every { testContext.settings().toolbarPosition } returns ToolbarPosition.BOTTOM
         every { testContext.settings().isDynamicToolbarEnabled } returns false
+        every { toolbarViewSpy.isPwaTabOrTwaTab } returns false
+        every { testContext.settings().shouldUseFixedTopToolbar } returns false
 
         toolbarViewSpy.setToolbarBehavior(false)
 
@@ -113,6 +135,20 @@ class BrowserToolbarViewTest {
         every { testContext.settings().toolbarPosition } returns ToolbarPosition.BOTTOM
         every { testContext.settings().isDynamicToolbarEnabled } returns true
         every { toolbarViewSpy.isPwaTabOrTwaTab } returns true
+        every { testContext.settings().shouldUseFixedTopToolbar } returns false
+
+        toolbarViewSpy.setToolbarBehavior(false)
+
+        verify { toolbarViewSpy.expandToolbarAndMakeItFixed() }
+    }
+
+    @Test
+    fun `setToolbarBehavior(true) should expandToolbarAndMakeItFixed if bottom toolbar is dynamic, the tab is for a PWA or TWA and a11 is enabled`() {
+        val toolbarViewSpy = spyk(toolbarView)
+        every { testContext.settings().toolbarPosition } returns ToolbarPosition.BOTTOM
+        every { testContext.settings().isDynamicToolbarEnabled } returns true
+        every { toolbarViewSpy.isPwaTabOrTwaTab } returns false
+        every { testContext.settings().shouldUseFixedTopToolbar } returns true
 
         toolbarViewSpy.setToolbarBehavior(false)
 


### PR DESCRIPTION
We previously only set the top toolbar as fixed if an a11y service was running.


https://user-images.githubusercontent.com/11428869/108527151-9dc06200-72da-11eb-8fa5-5f8f0af4111b.mp4



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. I

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
