### PR TITLE
For issue #10428 Improve download dialog error message.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -474,13 +474,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
                     didFail = downloadJobStatus == DownloadState.Status.FAILED,
                     tryAgain = downloadFeature::tryAgain,
                     onCannotOpenFile = {
-                        FenixSnackbar.make(
-                            view = view.browserLayout,
-                            duration = Snackbar.LENGTH_SHORT,
-                            isDisplayedWithBrowserToolbar = true
-                        )
-                            .setText(context.getString(R.string.mozac_feature_downloads_could_not_open_file))
-                            .show()
+                        showCannotOpenFileError(view.browserLayout, context, it)
                     },
                     view = view.viewDynamicDownloadDialog,
                     toolbarHeight = toolbarHeight,
@@ -783,16 +777,6 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
             }
         }
 
-        val onCannotOpenFile = {
-            FenixSnackbar.make(
-                view = view.browserLayout,
-                duration = Snackbar.LENGTH_SHORT,
-                isDisplayedWithBrowserToolbar = true
-            )
-                .setText(context.getString(R.string.mozac_feature_downloads_could_not_open_file))
-                .show()
-        }
-
         val onDismiss: () -> Unit =
             { sharedViewModel.downloadDialogState.remove(sessionId) }
 
@@ -802,7 +786,9 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
             metrics = requireComponents.analytics.metrics,
             didFail = savedDownloadState.second,
             tryAgain = onTryAgain,
-            onCannotOpenFile = onCannotOpenFile,
+            onCannotOpenFile = {
+                showCannotOpenFileError(view.browserLayout, context, it)
+            },
             view = view.viewDynamicDownloadDialog,
             toolbarHeight = toolbarHeight,
             onDismiss = onDismiss
@@ -1283,6 +1269,19 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
         breadcrumb(
             message = "onDetach()"
         )
+    }
+
+    private fun showCannotOpenFileError(
+        view: View,
+        context: Context,
+        downloadState: DownloadState
+    ) {
+        FenixSnackbar.make(
+            view = view,
+            duration = Snackbar.LENGTH_SHORT,
+            isDisplayedWithBrowserToolbar = true
+        ).setText(DynamicDownloadDialog.getCannotOpenFileErrorMessage(context, downloadState))
+            .show()
     }
 
     companion object {

--- a/app/src/main/java/org/mozilla/fenix/downloads/DynamicDownloadDialog.kt
+++ b/app/src/main/java/org/mozilla/fenix/downloads/DynamicDownloadDialog.kt
@@ -4,8 +4,10 @@
 
 package org.mozilla.fenix.downloads
 
+import android.content.Context
 import android.view.View
 import android.view.ViewGroup
+import android.webkit.MimeTypeMap
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import kotlinx.android.extensions.LayoutContainer
 import kotlinx.android.synthetic.main.download_dialog_layout.view.*
@@ -30,7 +32,7 @@ class DynamicDownloadDialog(
     private val metrics: MetricController,
     private val didFail: Boolean,
     private val tryAgain: (String) -> Unit,
-    private val onCannotOpenFile: () -> Unit,
+    private val onCannotOpenFile: (DownloadState) -> Unit,
     private val view: View,
     private val toolbarHeight: Int,
     private val onDismiss: () -> Unit
@@ -110,7 +112,7 @@ class DynamicDownloadDialog(
                     )
 
                     if (!fileWasOpened) {
-                        onCannotOpenFile()
+                        onCannotOpenFile(downloadState)
                     }
 
                     context.metrics.track(Event.InAppNotificationDownloadOpen)
@@ -137,5 +139,16 @@ class DynamicDownloadDialog(
     private fun dismiss(view: View) {
         view.visibility = View.GONE
         onDismiss()
+    }
+
+    companion object {
+        fun getCannotOpenFileErrorMessage(context: Context, download: DownloadState): String {
+            val fileExt = MimeTypeMap.getFileExtensionFromUrl(
+                download.filePath
+            )
+            return context.getString(
+                R.string.mozac_feature_downloads_open_not_supported1, fileExt
+            )
+        }
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/downloads/DynamicDownloadDialogTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/downloads/DynamicDownloadDialogTest.kt
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.downloads
+
+import android.webkit.MimeTypeMap
+import mozilla.components.browser.state.state.content.DownloadState
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.fenix.R
+import org.mozilla.fenix.downloads.DynamicDownloadDialog.Companion.getCannotOpenFileErrorMessage
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+
+@RunWith(FenixRobolectricTestRunner::class)
+class DynamicDownloadDialogTest {
+
+    @Test
+    fun `WHEN calling getCannotOpenFileErrorMessage THEN should return the error message for the download file type`() {
+        val download = DownloadState(url = "", fileName = "image.gif")
+
+        shadowOf(MimeTypeMap.getSingleton()).apply {
+            addExtensionMimeTypMapping(".gif", "image/gif")
+        }
+
+        val expected = testContext.getString(
+            R.string.mozac_feature_downloads_open_not_supported1, "gif"
+        )
+
+        val result = getCannotOpenFileErrorMessage(testContext, download)
+        assertEquals(expected, result)
+    }
+}


### PR DESCRIPTION
Related to this comment https://github.com/mozilla-mobile/fenix/issues/10428#issuecomment-648014149, we want to improve the message shown to the users when we can't find any app for opening a recently downloaded file 

With this patch.
![no apps found](https://user-images.githubusercontent.com/773158/108562922-9f842880-72ce-11eb-8c3f-ff024939740a.gif)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
