### PR TITLE
Uplift to 86: Closes #18006: DefaultSessionControlControllerTest: Correctly unmock SearchStateKt class.

### DIFF
--- a/app/src/test/java/org/mozilla/fenix/home/DefaultSessionControlControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/DefaultSessionControlControllerTest.kt
@@ -468,7 +468,7 @@ class DefaultSessionControlControllerTest {
                 )
             }
         } finally {
-            unmockkStatic(SearchState::class)
+            unmockkStatic("mozilla.components.browser.state.state.SearchStateKt")
         }
     }
 


### PR DESCRIPTION
Uplifting to 86 release branch to fix intermittent test failure.