### PR TITLE
For #18102: Implement TestLifecycleApplication interface.

### DIFF
--- a/app/src/test/java/org/mozilla/fenix/FenixApplicationTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/FenixApplicationTest.kt
@@ -13,9 +13,11 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.GleanMetrics.PerfStartup
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+import org.robolectric.TestLifecycleApplication
+import java.lang.reflect.Method
 
 @RunWith(FenixRobolectricTestRunner::class)
-class FenixApplicationTest {
+class FenixApplicationTest : TestLifecycleApplication {
 
     @get:Rule val gleanTestRule = GleanTestRule(ApplicationProvider.getApplicationContext())
 
@@ -31,5 +33,17 @@ class FenixApplicationTest {
         // application.onCreate is called before the test as part of test set up:
         // https://robolectric.blogspot.com/2013/04/the-test-lifecycle-in-20.html
         assertTrue(PerfStartup.applicationOnCreate.testHasValue())
+    }
+
+    override fun beforeTest(method: Method?) {
+        // no before test needed
+    }
+
+    override fun prepareTest(test: Any?) {
+        // no prepare test needed
+    }
+
+    override fun afterTest(method: Method?) {
+        // no after test needed
     }
 }


### PR DESCRIPTION
@mcomella 

I tried running the test in isolation, a single time and then multiple times. It appears that after the first run, `application.onCreate()` was not called for the following runs. Looking in the [link](https://robolectric.blogspot.com/2013/04/the-test-lifecycle-in-20.html) you provided in the comments I see that the steps are run **if** you implement `TestLifecycleApplication `. 
Maybe the intermittence of the test is determined by the order the test runs. I suspected that another test calls `application.onCreate()` and Robolectric does not call it again for our test. 

With this change of the test, I did not get any failures with multiple runs / random groups of tests ran before. Let's see if it passes on CI too. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
