### PR TITLE
For #18041: startup smoke tests for unsuccesfull server requests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/MockWebServer.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/MockWebServer.kt
@@ -48,6 +48,25 @@ object MockWebServerHelper {
             this.dispatcher = dispatcher
         }
     }
+
+    /**
+     * Create a mock webserver that accepts all requests and replies with an error message.
+     * @return a [MockWebServer] instance
+     */
+    fun createErrorResponseMockWebServer(code: Int, body: String = "", header: Pair<String, String> = Pair("", "")): MockWebServer {
+        return MockWebServer().apply {
+            val dispatcher = object : Dispatcher() {
+                @Throws(InterruptedException::class)
+                override fun dispatch(request: RecordedRequest): MockResponse {
+                    return MockResponse()
+                        .setResponseCode(code)
+                        .setHeader(header.first, header.second)
+                        .setBody(body)
+                }
+            }
+            this.dispatcher = dispatcher
+        }
+    }
 }
 
 /**

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/BadServerResponseTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/BadServerResponseTest.kt
@@ -1,0 +1,88 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.ui
+
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Test
+import org.mozilla.fenix.helpers.HomeActivityTestRule
+import org.mozilla.fenix.helpers.MockWebServerHelper
+import org.mozilla.fenix.ui.robots.homeScreen
+
+class BadServerResponseTest {
+    private val activityTestRule = HomeActivityTestRule()
+    private var mockWebServer = MockWebServer()
+
+    @After
+    fun tearDown() {
+        mockWebServer.shutdown()
+    }
+
+    @Test
+    fun serverResponse400StartupTest() {
+        mockWebServer = MockWebServerHelper.createErrorResponseMockWebServer(400)
+        mockWebServer.start()
+
+        activityTestRule.launchActivity(null)
+
+        homeScreen {
+        }.dismissOnboarding()
+
+        homeScreen {
+        }.openSearch {
+        }.openBrowser {}
+    }
+
+    @Test
+    fun serverResponse500StartupTest() {
+        mockWebServer = MockWebServerHelper.createErrorResponseMockWebServer(500)
+        mockWebServer.start()
+
+        activityTestRule.launchActivity(null)
+
+        homeScreen {
+        }.dismissOnboarding()
+
+        homeScreen {
+        }.openSearch {
+        }.openBrowser {}
+    }
+
+    @Test
+    fun badJSONResponseStartupTest() {
+        val body = "{badJsonResponse}"
+        val header = Pair("Content-Type", "application/json; charset=utf-8")
+
+        mockWebServer = MockWebServerHelper.createErrorResponseMockWebServer(200, body, header)
+        mockWebServer.start()
+
+        activityTestRule.launchActivity(null)
+
+        homeScreen {
+        }.dismissOnboarding()
+
+        homeScreen {
+        }.openSearch {
+        }.openBrowser {}
+    }
+
+    @Test
+    fun badHeaderResponseStartupTest() {
+        val body = "{badResponse}"
+        val header = Pair("badName", "badValue")
+
+        mockWebServer = MockWebServerHelper.createErrorResponseMockWebServer(200, body, header)
+        mockWebServer.start()
+
+        activityTestRule.launchActivity(null)
+
+        homeScreen {
+        }.dismissOnboarding()
+
+        homeScreen {
+        }.openSearch {
+        }.openBrowser {}
+    }
+}


### PR DESCRIPTION
Ran the tests on Firebase for 15 times and all passed: https://github.com/mozilla-mobile/fenix/runs/1970732410

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
