### PR TITLE
Remove Session[Manager] references from Fennec intent processors

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/Components.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Components.kt
@@ -67,11 +67,10 @@ class Components(private val context: Context) {
             core.topSitesStorage
         )
     }
-    @Suppress("Deprecation")
+
     val intentProcessors by lazyMonitored {
         IntentProcessors(
             context,
-            core.sessionManager,
             core.store,
             useCases.sessionUseCases,
             useCases.tabsUseCases,

--- a/app/src/main/java/org/mozilla/fenix/components/IntentProcessors.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/IntentProcessors.kt
@@ -5,7 +5,6 @@
 package org.mozilla.fenix.components
 
 import android.content.Context
-import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.feature.customtabs.CustomTabIntentProcessor
 import mozilla.components.feature.customtabs.store.CustomTabsServiceStore
@@ -32,7 +31,6 @@ import org.mozilla.fenix.utils.Mockable
 @Suppress("LongParameterList")
 class IntentProcessors(
     private val context: Context,
-    private val sessionManager: SessionManager,
     private val store: BrowserStore,
     private val sessionUseCases: SessionUseCases,
     private val tabsUseCases: TabsUseCases,
@@ -74,12 +72,12 @@ class IntentProcessors(
                 store = customTabsStore
             ),
             WebAppIntentProcessor(store, tabsUseCases.addTab, sessionUseCases.loadUrl, manifestStorage),
-            FennecWebAppIntentProcessor(context, sessionManager, sessionUseCases.loadUrl, manifestStorage)
+            FennecWebAppIntentProcessor(context, tabsUseCases.addTab, manifestStorage)
         )
     }
 
     val fennecPageShortcutIntentProcessor by lazyMonitored {
-        FennecBookmarkShortcutsIntentProcessor(sessionManager, sessionUseCases.loadUrl)
+        FennecBookmarkShortcutsIntentProcessor(tabsUseCases.addTab)
     }
 
     val migrationIntentProcessor by lazyMonitored {

--- a/app/src/main/java/org/mozilla/fenix/home/intent/FennecBookmarkShortcutsIntentProcessor.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/intent/FennecBookmarkShortcutsIntentProcessor.kt
@@ -7,13 +7,11 @@ package org.mozilla.fenix.home.intent
 import android.content.Intent
 import android.content.Intent.ACTION_VIEW
 import androidx.annotation.VisibleForTesting
-import mozilla.components.browser.session.Session
-import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.state.state.SessionState
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.feature.intent.ext.putSessionId
 import mozilla.components.feature.intent.processing.IntentProcessor
-import mozilla.components.feature.session.SessionUseCases
+import mozilla.components.feature.tabs.TabsUseCases
 import mozilla.components.support.utils.toSafeIntent
 
 /**
@@ -21,8 +19,7 @@ import mozilla.components.support.utils.toSafeIntent
  * https://developer.android.com/guide/topics/ui/shortcuts/creating-shortcuts#pinned
  */
 class FennecBookmarkShortcutsIntentProcessor(
-    private val sessionManager: SessionManager,
-    private val loadUrlUseCase: SessionUseCases.DefaultLoadUrlUseCase
+    private val addNewTabUseCase: TabsUseCases.AddNewTabUseCase
 ) : IntentProcessor {
 
     /**
@@ -41,13 +38,15 @@ class FennecBookmarkShortcutsIntentProcessor(
         val url = safeIntent.dataString
 
         return if (!url.isNullOrEmpty() && matches(intent)) {
-            val session = Session(url, private = false, source = SessionState.Source.HOME_SCREEN)
-
-            sessionManager.add(session, selected = true)
-            loadUrlUseCase(url, session.id, EngineSession.LoadUrlFlags.external())
+            val sessionId = addNewTabUseCase(
+                url = url,
+                flags = EngineSession.LoadUrlFlags.external(),
+                source = SessionState.Source.HOME_SCREEN,
+                selectTab = true,
+                startLoading = true
+            )
             intent.action = ACTION_VIEW
-            intent.putSessionId(session.id)
-
+            intent.putSessionId(sessionId)
             true
         } else {
             false

--- a/app/src/test/java/org/mozilla/fenix/customtabs/FennecWebAppIntentProcessorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/customtabs/FennecWebAppIntentProcessorTest.kt
@@ -5,9 +5,8 @@
 package org.mozilla.fenix.customtabs
 
 import io.mockk.mockk
-import mozilla.components.browser.session.SessionManager
 import mozilla.components.feature.pwa.ManifestStorage
-import mozilla.components.feature.session.SessionUseCases
+import mozilla.components.feature.tabs.TabsUseCases
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -60,13 +59,11 @@ class FennecWebAppIntentProcessorTest {
 }
 
 private fun createFennecWebAppIntentProcessor(): FennecWebAppIntentProcessor {
-    val sessionManager = SessionManager(engine = mockk(relaxed = true))
-    val useCase: SessionUseCases.DefaultLoadUrlUseCase = mockk(relaxed = true)
+    val useCase: TabsUseCases.AddNewTabUseCase = mockk(relaxed = true)
     val storage: ManifestStorage = mockk(relaxed = true)
 
     return FennecWebAppIntentProcessor(
         testContext,
-        sessionManager,
         useCase,
         storage
     )

--- a/app/src/test/java/org/mozilla/fenix/home/intent/FennecBookmarkShortcutsIntentProcessorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/intent/FennecBookmarkShortcutsIntentProcessorTest.kt
@@ -9,33 +9,27 @@ import android.net.Uri
 import io.mockk.Called
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.mockkStatic
 import io.mockk.verify
-import io.mockk.verifyAll
 import kotlinx.coroutines.runBlocking
-import mozilla.components.browser.session.Session
-import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.state.state.SessionState
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.feature.intent.ext.getSessionId
-import mozilla.components.feature.session.SessionUseCases
+import mozilla.components.feature.tabs.TabsUseCases
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mozilla.fenix.home.intent.FennecBookmarkShortcutsIntentProcessor.Companion.ACTION_FENNEC_HOMESCREEN_SHORTCUT
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
-import java.util.UUID
+import org.mozilla.fenix.home.intent.FennecBookmarkShortcutsIntentProcessor.Companion.ACTION_FENNEC_HOMESCREEN_SHORTCUT
 
 @RunWith(FenixRobolectricTestRunner::class)
 class FennecBookmarkShortcutsIntentProcessorTest {
-    private val sessionManager = mockk<SessionManager>(relaxed = true)
-    private val loadUrlUseCase = mockk<SessionUseCases.DefaultLoadUrlUseCase>(relaxed = true)
+    private val addNewTabUseCase = mockk<TabsUseCases.AddNewTabUseCase>(relaxed = true)
 
     @Test
     fun `do not process blank Intents`() = runBlocking {
-        val processor = FennecBookmarkShortcutsIntentProcessor(sessionManager, loadUrlUseCase)
+        val processor = FennecBookmarkShortcutsIntentProcessor(addNewTabUseCase)
         val fennecShortcutsIntent = Intent(ACTION_FENNEC_HOMESCREEN_SHORTCUT)
         fennecShortcutsIntent.data = Uri.parse("http://mozilla.org")
 
@@ -43,30 +37,38 @@ class FennecBookmarkShortcutsIntentProcessorTest {
 
         assertFalse(wasEmptyIntentProcessed)
         verify {
-            sessionManager wasNot Called
-            loadUrlUseCase wasNot Called
+            addNewTabUseCase wasNot Called
         }
     }
 
     @Test
     fun `processing a Fennec shortcut Intent results in loading it's URL in a new Session`() = runBlocking {
-        mockkStatic(UUID::class)
-        // The Session constructor uses UUID.randomUUID().toString() as the default value for it's id field
-        every { UUID.randomUUID().toString() } returns "test"
-        val processor = FennecBookmarkShortcutsIntentProcessor(sessionManager, loadUrlUseCase)
+        val expectedSessionId = "test"
+        val processor = FennecBookmarkShortcutsIntentProcessor(addNewTabUseCase)
         val fennecShortcutsIntent = Intent(ACTION_FENNEC_HOMESCREEN_SHORTCUT)
         val testUrl = "http://mozilla.org"
         fennecShortcutsIntent.data = Uri.parse(testUrl)
-        val expectedSession = Session(testUrl, private = false, source = SessionState.Source.HOME_SCREEN)
+
+        every { addNewTabUseCase(
+            url = testUrl,
+            flags = EngineSession.LoadUrlFlags.external(),
+            source = SessionState.Source.HOME_SCREEN,
+            selectTab = true,
+            startLoading = true)
+        } returns expectedSessionId
 
         val wasIntentProcessed = processor.process(fennecShortcutsIntent)
-
         assertTrue(wasIntentProcessed)
         assertEquals(Intent.ACTION_VIEW, fennecShortcutsIntent.action)
-        assertEquals(expectedSession.id, fennecShortcutsIntent.getSessionId())
-        verifyAll {
-            sessionManager.add(expectedSession, true)
-            loadUrlUseCase(testUrl, expectedSession.id, EngineSession.LoadUrlFlags.external())
+        assertEquals(expectedSessionId, fennecShortcutsIntent.getSessionId())
+        verify {
+            addNewTabUseCase(
+                url = testUrl,
+                flags = EngineSession.LoadUrlFlags.external(),
+                source = SessionState.Source.HOME_SCREEN,
+                selectTab = true,
+                startLoading = true
+            )
         }
     }
 }


### PR DESCRIPTION
Switching to `TabsUseCases` to remove Session and SessionManager references from intent processors. This is the last direct usage of `SessionManager` in Fenix.