### PR TITLE
For #18034 - Don't animate the toolbar while the tab is loading

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarIntegration.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarIntegration.kt
@@ -19,6 +19,7 @@ import mozilla.components.concept.engine.Engine
 import mozilla.components.concept.storage.HistoryStorage
 import mozilla.components.feature.tabs.toolbar.TabCounterToolbarButton
 import mozilla.components.feature.toolbar.ToolbarAutocompleteFeature
+import mozilla.components.feature.toolbar.ToolbarBehaviorController
 import mozilla.components.feature.toolbar.ToolbarFeature
 import mozilla.components.feature.toolbar.ToolbarPresenter
 import mozilla.components.support.base.feature.LifecycleAwareFeature
@@ -53,6 +54,8 @@ abstract class ToolbarIntegration(
     private val menuPresenter =
         MenuPresenter(toolbar, context.components.core.store, sessionId)
 
+    private val toolbarController = ToolbarBehaviorController(toolbar, store, sessionId)
+
     init {
         toolbar.display.menuBuilder = toolbarMenu.menuBuilder
         toolbar.private = isPrivate
@@ -61,11 +64,13 @@ abstract class ToolbarIntegration(
     override fun start() {
         menuPresenter.start()
         toolbarPresenter.start()
+        toolbarController.start()
     }
 
     override fun stop() {
         menuPresenter.stop()
         toolbarPresenter.stop()
+        toolbarController.stop()
     }
 
     fun invalidateMenu() {


### PR DESCRIPTION
Use the new controller offered by AC to resolve some browser layout issues and
also offer an experience consistent with that of other browsers.

Needs https://github.com/mozilla-mobile/android-components/pull/9771

The toolbar is not animated while the tab loads but this does not fully fix the
original issue. Created https://bugzilla.mozilla.org/show_bug.cgi?id=1694730
for GV followup.
This patch should be though safe to land in preparation.

https://user-images.githubusercontent.com/11428869/109041564-d647ad80-76d7-11eb-8310-18b08f7e1b03.mp4

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: No tests. Small modification in a not yet tested component.
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
