### PR TITLE
Closes #18164: on pre-push, check for uncommitted glean docs.

### DIFF
--- a/config/pre-push-recommended.sh
+++ b/config/pre-push-recommended.sh
@@ -14,6 +14,25 @@
 # Descriptions for each gradle task below can be found in the
 # output of `./gradlew tasks`.
 
+# Prevent push if generated glean docs are not committed.
+# A better implementation would make sure these doc updates
+# only came from this commit.
+./gradlew -q \
+        gleanGenerateMetricsDocsForDebug \
+        gleanGenerateMetricsSourceForDebug
+if git status --porcelain=v1 | grep -q "docs/metrics.md"; then
+  echo "
+FAIL pre-push hook: generated glean file, docs/metrics.md, has uncommitted changes.
+Please commit these files and try again.
+
+This check tries to prevent these generated files from being uncommitted on master.
+However, it may fail unintuitively if we're in that state. If this happens often
+and is disruptive to your workflow, please notify mcomella so we can improve this
+check." >&2
+  exit 1
+fi
+
+# Run core checks.
 ./gradlew -q \
         ktlint \
         detekt \


### PR DESCRIPTION
This can blow up in our face in a few ways:
- people may not re-run the pre-push hook when they push for the data review update (which is probably what causes this problem)
- people may start skipping the pre-push hook if they don't want to commit the docs/metrics.md already on master for some reason

If either of these happen, we may need to change the implementation

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
