### PR TITLE
No issue: when init profiling, remind to enable setting in app.

### DIFF
--- a/tools/setup-startup-profiling.py
+++ b/tools/setup-startup-profiling.py
@@ -41,7 +41,9 @@ def push(id, filename):
         print('Pushing {} to device.'.format(filename))
         run(['adb', 'push', config.name, os.path.join(PATH_PREFIX, filename)])
         run(['adb', 'shell', 'am', 'set-debug-app', '--persistent', id])
-        print('Startup profiling enabled on all future start ups, possibly even after reinstall. Call script with `deactivate` to disable it.')
+        print('\nStartup profiling enabled on all future start ups, possibly even after reinstall.')
+        print('Call script with `deactivate` to disable it.')
+        print('DON\'T FORGET TO ENABLE \'Remote debugging via USB\' IN THE APP SETTINGS!')
     finally:
         os.remove(config.name)
 


### PR DESCRIPTION
Small clean up to make the message more helpful.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
