### PR TITLE
Closes #18150: select tabs button not displayed

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -1056,6 +1056,33 @@ class SmokeTest {
     }
 
     @Test
+    fun selectTabsButtonVisibilityTest() {
+        homeScreen {
+        }.dismissOnboarding()
+
+        val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+        val secondWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 2)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(firstWebPage.url) {
+            mDevice.waitForIdle()
+        }.openTabDrawer {
+        }.openNewTab {
+        }.submitQuery(secondWebPage.url.toString()) {
+            mDevice.waitForIdle()
+        }.openTabDrawer {
+        }.toggleToPrivateTabs {
+        }.openNewTab {
+        }.dismissSearchBar {  }
+
+        homeScreen {  }
+            .openTabDrawer {
+            }.toggleToNormalTabs {
+                verifySelectTabsButton()
+            }
+    }
+
+    @Test
     fun privateTabsTrayWithOpenedTabTest() {
         val website = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -1075,11 +1075,11 @@ class SmokeTest {
         }.openNewTab {
         }.dismissSearchBar { }
 
-        homeScreen { }
-            .openTabDrawer {
-            }.toggleToNormalTabs {
-                verifySelectTabsButton()
-            }
+        homeScreen {
+        }.openTabDrawer {
+        }.toggleToNormalTabs {
+            verifySelectTabsButton()
+        }
     }
 
     @Test

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -1073,9 +1073,9 @@ class SmokeTest {
         }.openTabDrawer {
         }.toggleToPrivateTabs {
         }.openNewTab {
-        }.dismissSearchBar {  }
+        }.dismissSearchBar { }
 
-        homeScreen {  }
+        homeScreen { }
             .openTabDrawer {
             }.toggleToNormalTabs {
                 verifySelectTabsButton()

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/TabDrawerRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/TabDrawerRobot.kt
@@ -77,6 +77,7 @@ class TabDrawerRobot {
     fun verifyPrivateModeSelected() = assertPrivateModeSelected()
     fun verifyNormalModeSelected() = assertNormalModeSelected()
     fun verifyNewTabButton() = assertNewTabButton()
+    fun verifySelectTabsButton() = assertSelectTabsButton()
     fun verifyTabTrayOverflowMenu(visibility: Boolean) = assertTabTrayOverflowButton(visibility)
 
     fun verifyTabTrayIsClosed() = assertTabTrayDoesNotExist()
@@ -389,6 +390,10 @@ private fun assertNoTabsOpenedText() =
 
 private fun assertNewTabButton() =
     onView(withId(R.id.new_tab_button))
+        .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+
+private fun assertSelectTabsButton() =
+    onView(withText("Select tabs"))
         .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
 private fun assertNormalModeSelected() =

--- a/app/src/main/java/org/mozilla/fenix/tabtray/SaveToCollectionsButtonAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/SaveToCollectionsButtonAdapter.kt
@@ -23,15 +23,11 @@ import org.mozilla.fenix.tabtray.SaveToCollectionsButtonAdapter.ViewHolder
  */
 class SaveToCollectionsButtonAdapter(
     private val interactor: TabTrayInteractor,
-    private var isPrivate: Boolean = false
+    private val isPrivate: () -> Boolean = { false }
 ) : ListAdapter<Item, ViewHolder>(DiffCallback) {
 
     init {
         submitList(listOf(Item))
-    }
-
-    fun updatePrivateModeState(value: Boolean) {
-        isPrivate = value
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
@@ -70,7 +66,7 @@ class SaveToCollectionsButtonAdapter(
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        holder.itemView.isVisible = !isPrivate &&
+        holder.itemView.isVisible = !isPrivate() &&
                 interactor.onModeRequested() is TabTrayDialogFragmentState.Mode.Normal
     }
 

--- a/app/src/main/java/org/mozilla/fenix/tabtray/SaveToCollectionsButtonAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/SaveToCollectionsButtonAdapter.kt
@@ -23,11 +23,15 @@ import org.mozilla.fenix.tabtray.SaveToCollectionsButtonAdapter.ViewHolder
  */
 class SaveToCollectionsButtonAdapter(
     private val interactor: TabTrayInteractor,
-    private val isPrivate: Boolean = false
+    private var isPrivate: Boolean = false
 ) : ListAdapter<Item, ViewHolder>(DiffCallback) {
 
     init {
         submitList(listOf(Item))
+    }
+
+    fun updatePrivateModeState(value: Boolean) {
+        isPrivate = value
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {

--- a/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayView.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayView.kt
@@ -92,7 +92,8 @@ class TabTrayView(
     private var multiselectMenu: BrowserMenu? = null
 
     private var tabsTouchHelper: TabsTouchHelper
-    private val collectionsButtonAdapter = SaveToCollectionsButtonAdapter(interactor, isPrivate)
+    private val collectionsButtonAdapter =
+        SaveToCollectionsButtonAdapter(interactor) { isPrivateModeSelected }
 
     private var hasLoaded = false
 
@@ -365,7 +366,6 @@ class TabTrayView(
     }
 
     private fun toggleSaveToCollectionButton(isPrivate: Boolean) {
-        collectionsButtonAdapter.updatePrivateModeState(isPrivate)
         collectionsButtonAdapter.notifyItemChanged(
             0,
             if (isPrivate) TabChange.PRIVATE else TabChange.NORMAL

--- a/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayView.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayView.kt
@@ -365,6 +365,7 @@ class TabTrayView(
     }
 
     private fun toggleSaveToCollectionButton(isPrivate: Boolean) {
+        collectionsButtonAdapter.updatePrivateModeState(isPrivate)
         collectionsButtonAdapter.notifyItemChanged(
             0,
             if (isPrivate) TabChange.PRIVATE else TabChange.NORMAL


### PR DESCRIPTION
Fixes #18150

`NotifyItemChanged()` with `payload` has no effect for the first time as the whole view needs to be updated.
Added a method to update private mode state in `SaveToCollectionsButtonAdapter` to address the issue.
Added smoke test but not sure if such a test is needed.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
