### PR TITLE
For #17636: Ability to edit top site URLs

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/TopSitesTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/TopSitesTest.kt
@@ -142,9 +142,43 @@ class TopSitesTest {
             verifyExistingTopSitesTabs(defaultWebPageTitle)
         }.openContextMenuOnTopSitesWithTitle(defaultWebPageTitle) {
             verifyTopSiteContextMenuItems()
+        }.clickEdit {
+            verifyEditTopSiteValues(defaultWebPageTitle, defaultWebPage.url.toString())
         }.renameTopSite(defaultWebPageTitleNew) {
             verifyExistingTopSitesList()
             verifyExistingTopSitesTabs(defaultWebPageTitleNew)
+        }
+    }
+
+    @Test
+    fun verifyEditTopSiteUrl() {
+        val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+        val defaultWebPageTitle = "Test_Page_1"
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(defaultWebPage.url) {
+        }.openThreeDotMenu {
+            verifyAddFirefoxHome()
+        }.addToFirefoxHome {
+            verifySnackBarText("Added to top sites!")
+        }.openTabDrawer {
+        }.openNewTab {
+        }.dismissSearchBar {
+            verifyExistingTopSitesList()
+            verifyExistingTopSitesTabs(defaultWebPageTitle)
+        }.openContextMenuOnTopSitesWithTitle(defaultWebPageTitle) {
+            verifyTopSiteContextMenuItems()
+        }.clickEdit {
+            verifyEditTopSiteValues(defaultWebPageTitle, defaultWebPage.url.toString())
+        }.editTopSiteUrl("") {
+            verifyEditTopSiteUrlInvalid()
+        }.editTopSiteUrl("not-a-url") {
+            verifyEditTopSiteUrlInvalid()
+        }.editTopSiteUrl(" barely-valid:url ") {
+            verifyExistingTopSitesList()
+            verifyExistingTopSitesTabs(defaultWebPageTitle)
+        }.openTopSiteTabWithTitle(title = defaultWebPageTitle) {
+            verifyUrl("barely-valid:url")
         }
     }
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
@@ -115,6 +115,8 @@ class HomeScreenRobot {
     fun verifyNotExistingTopSitesList(title: String) = assertNotExistingTopSitesList(title)
     fun verifyExistingTopSitesTabs(title: String) = assertExistingTopSitesTabs(title)
     fun verifyTopSiteContextMenuItems() = assertTopSiteContextMenuItems()
+    fun verifyEditTopSiteValues(title: String, url: String) = assertEditTopSiteValues(title, url)
+    fun verifyEditTopSiteUrlInvalid() = assertEditTopSiteUrlInvalid()
 
     // Collections elements
     fun verifyCollectionIsDisplayed(title: String, collectionExists: Boolean = true) {
@@ -262,12 +264,27 @@ class HomeScreenRobot {
             return BrowserRobot.Transition()
         }
 
-        fun renameTopSite(title: String, interact: HomeScreenRobot.() -> Unit): Transition {
-            onView(withText("Rename"))
+        fun clickEdit(interact: HomeScreenRobot.() -> Unit): Transition {
+            onView(withText("Edit"))
                 .check((matches(withEffectiveVisibility(Visibility.VISIBLE))))
                 .perform(click())
+
+            HomeScreenRobot().interact()
+            return Transition()
+        }
+
+        fun renameTopSite(title: String, interact: HomeScreenRobot.() -> Unit): Transition {
             onView(Matchers.allOf(withId(R.id.top_site_title), instanceOf(EditText::class.java)))
                 .perform(ViewActions.replaceText(title))
+            onView(withId(android.R.id.button1)).perform((click()))
+
+            HomeScreenRobot().interact()
+            return Transition()
+        }
+
+        fun editTopSiteUrl(url: String, interact: HomeScreenRobot.() -> Unit): Transition {
+            onView(Matchers.allOf(withId(R.id.top_site_url), instanceOf(EditText::class.java)))
+                    .perform(ViewActions.replaceText(url))
             onView(withId(android.R.id.button1)).perform((click()))
 
             HomeScreenRobot().interact()
@@ -565,9 +582,25 @@ private fun assertTopSiteContextMenuItems() {
         waitingTime
     )
     mDevice.waitNotNull(
+        findObject(By.text("Edit")),
+        waitingTime
+    )
+    mDevice.waitNotNull(
         findObject(By.text("Remove")),
         waitingTime
     )
+}
+
+private fun assertEditTopSiteValues(title: String, url: String) {
+    onView(allOf(withId(R.id.top_site_title), instanceOf(EditText::class.java)))
+        .check(matches(withText(title)))
+    onView(allOf(withId(R.id.top_site_url), instanceOf(EditText::class.java)))
+        .check(matches(withText(url)))
+}
+
+private fun assertEditTopSiteUrlInvalid() {
+    onView(withId(R.id.top_site_url_layout))
+        .check(matches(hasDescendant(withText("Invalid URL"))))
 }
 
 private fun assertShareTabsOverlay() {

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlInteractor.kt
@@ -176,7 +176,7 @@ interface TopSiteInteractor {
      *
      * @param topSite The top site that will be renamed.
      */
-    fun onRenameTopSiteClicked(topSite: TopSite)
+    fun onEditTopSiteClicked(topSite: TopSite)
 
     /**
      * Removes the given top site. Called when an user clicks on the "Remove" top site menu item.
@@ -261,8 +261,8 @@ class SessionControlInteractor(
         controller.handleOpenInPrivateTabClicked(topSite)
     }
 
-    override fun onRenameTopSiteClicked(topSite: TopSite) {
-        controller.handleRenameTopSiteClicked(topSite)
+    override fun onEditTopSiteClicked(topSite: TopSite) {
+        controller.handleEditTopSiteClicked(topSite)
     }
 
     override fun onRemoveTopSiteClicked(topSite: TopSite) {

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/topsites/TopSiteItemViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/topsites/TopSiteItemViewHolder.kt
@@ -23,6 +23,7 @@ import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.loadIntoView
 import org.mozilla.fenix.home.sessioncontrol.TopSiteInteractor
 import org.mozilla.fenix.settings.SupportUtils
+import org.mozilla.fenix.theme.ThemeManager
 import org.mozilla.fenix.utils.view.ViewHolder
 
 class TopSiteItemViewHolder(
@@ -46,7 +47,7 @@ class TopSiteItemViewHolder(
                     is TopSiteItemMenu.Item.OpenInPrivateTab -> interactor.onOpenInPrivateTabClicked(
                         topSite
                     )
-                    is TopSiteItemMenu.Item.RenameTopSite -> interactor.onRenameTopSiteClicked(
+                    is TopSiteItemMenu.Item.EditTopSite -> interactor.onEditTopSiteClicked(
                         topSite
                     )
                     is TopSiteItemMenu.Item.RemoveTopSite -> interactor.onRemoveTopSiteClicked(
@@ -116,7 +117,7 @@ class TopSiteItemMenu(
 ) {
     sealed class Item {
         object OpenInPrivateTab : Item()
-        object RenameTopSite : Item()
+        object EditTopSite : Item()
         object RemoveTopSite : Item()
     }
 
@@ -130,16 +131,17 @@ class TopSiteItemMenu(
                 onItemTapped.invoke(Item.OpenInPrivateTab)
             },
             if (isPinnedSite) SimpleBrowserMenuItem(
-                context.getString(R.string.rename_top_site)
+                context.getString(R.string.edit_top_site)
             ) {
-                onItemTapped.invoke(Item.RenameTopSite)
+                onItemTapped.invoke(Item.EditTopSite)
             } else null,
             SimpleBrowserMenuItem(
                 if (isPinnedSite) {
                     context.getString(R.string.remove_top_site)
                 } else {
                     context.getString(R.string.delete_from_history)
-                }
+                },
+                textColorResource = ThemeManager.resolveAttribute(R.attr.destructive, context)
             ) {
                 onItemTapped.invoke(Item.RemoveTopSite)
             }

--- a/app/src/main/res/layout/top_sites_edit_dialog.xml
+++ b/app/src/main/res/layout/top_sites_edit_dialog.xml
@@ -3,6 +3,7 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical">
@@ -31,4 +32,33 @@
         android:inputType="textCapSentences"
         android:singleLine="true"
         android:textAlignment="viewStart" />
+
+    <TextView
+        android:id="@+id/url_header"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="26dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="24dp"
+        android:text="@string/top_sites_rename_dialog_url"
+        android:textAllCaps="true"
+        android:textAppearance="@style/Body16TextStyle"
+        android:textColor="?secondaryText" />
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/top_site_url_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="24dp"
+        android:layout_marginEnd="24dp">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/top_site_url"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:autofillHints="false"
+            android:backgroundTint="?neutral"
+            android:inputType="textUri" />
+
+    </com.google.android.material.textfield.TextInputLayout>
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -731,7 +731,7 @@
     <!-- Hint for adding name of a collection -->
     <string name="collection_name_hint">Collection name</string>
 	<!-- Text for the menu button to rename a top site -->
-	<string name="rename_top_site">Rename</string>
+	<string name="edit_top_site">Edit</string>
 	<!-- Text for the menu button to remove a top site -->
 	<string name="remove_top_site">Remove</string>
     <!-- Text for the menu button to delete a top site from history -->
@@ -1825,13 +1825,17 @@
     <string name="top_sites_toggle_top_frecent_sites_2">Show most visited top sites</string>
     <!-- Label for the show most visited sites preference -->
     <string name="top_sites_toggle_top_frecent_sites" moz:removedIn="93" tools:ignore="UnusedResources">Show most visited sites</string>
-	<!-- Title text displayed in the rename top site dialog. -->
+	<!-- Label for the title in the edit top site dialog. -->
 	<string name="top_sites_rename_dialog_title">Name</string>
 	<!-- Hint for renaming title of a top site -->
 	<string name="top_site_name_hint">Top site name</string>
-	<!-- Button caption to confirm the renaming of the top site. -->
+	<!-- Label for the URL in the edit top site dialog. -->
+	<string name="top_sites_rename_dialog_url">URL</string>
+	<!-- Error message when the user entered an invalid top site URL -->
+	<string name="top_site_url_invalid">Invalid URL</string>
+	<!-- Button caption to confirm the editing of the top site. -->
 	<string name="top_sites_rename_dialog_ok">OK</string>
-	<!-- Dialog button text for canceling the rename top site prompt. -->
+	<!-- Dialog button text for canceling the edit top site prompt. -->
 	<string name="top_sites_rename_dialog_cancel">Cancel</string>
 
     <!-- In-activate tabs in the tabs tray -->


### PR DESCRIPTION
This PR adds the ability to edit top site URLs for issue #17636.

- In the context menu for top sites: replace "Rename" with "Edit"
- Also in the context menu for top sites: make "Remove" red, which as far as I can tell it should be
- In the dialog for editing top sites (formerly renaming top sites):
  - Add user input for URL
  - Add (lenient) URL validation
  - Add validation message
  - Normalize the URL (removing leading/trailing whitespace etc.) before saving it
- Add UI test for this interaction

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

### Screenshots
![Screenshots](https://user-images.githubusercontent.com/823248/109432646-6ce3d980-7a0c-11eb-988f-9d2ae0ce55e7.png)
