### PR TITLE
Bug 1693532 - Pass auto-generated build info (version code and name) to Glean

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/glean/BaselinePingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/glean/BaselinePingTest.kt
@@ -27,6 +27,7 @@ import org.junit.BeforeClass
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mozilla.fenix.GleanMetrics.GleanBuildInfo
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.HomeActivityTestRule
@@ -85,9 +86,10 @@ class BaselinePingTest {
             // we need to do this on the main thread, as the Glean SDK requires it.
             GlobalScope.launch(Dispatchers.Main.immediate) {
                 Glean.initialize(
-                    ApplicationProvider.getApplicationContext(),
-                    true,
-                    Configuration(httpClient = httpClient)
+                    applicationContext = ApplicationProvider.getApplicationContext(),
+                    uploadEnabled = true,
+                    configuration = Configuration(httpClient = httpClient),
+                    buildInfo = GleanBuildInfo.buildInfo
                 )
             }
         }

--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -39,6 +39,7 @@ import mozilla.components.support.rusthttp.RustHttpConfig
 import mozilla.components.support.rustlog.RustLog
 import mozilla.components.support.utils.logElapsedTime
 import mozilla.components.support.webextensions.WebExtensionSupport
+import org.mozilla.fenix.GleanMetrics.GleanBuildInfo
 import org.mozilla.fenix.GleanMetrics.PerfStartup
 import org.mozilla.fenix.components.Components
 import org.mozilla.fenix.components.metrics.MetricServiceType
@@ -111,7 +112,8 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
                 httpClient = ConceptFetchHttpUploader(
                     lazy(LazyThreadSafetyMode.NONE) { components.core.client }
                 )),
-            uploadEnabled = telemetryEnabled
+            uploadEnabled = telemetryEnabled,
+            buildInfo = GleanBuildInfo.buildInfo
         )
     }
 


### PR DESCRIPTION
This also re-generated the Glean docs due to an update of the bundled glean-parser.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
