### PR TITLE
For #17805 - Fix adjustResize deprecation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -73,8 +73,7 @@
             android:configChanges="keyboard|keyboardHidden|mcc|mnc|orientation|screenSize|layoutDirection|smallestScreenSize|screenLayout"
             android:launchMode="singleTask"
             android:resizeableActivity="true"
-            android:supportsPictureInPicture="true"
-            android:windowSoftInputMode="adjustResize">
+            android:supportsPictureInPicture="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.BROWSABLE" />
@@ -131,7 +130,7 @@
             android:taskAffinity=""
             android:resizeableActivity="true"
             android:supportsPictureInPicture="true"
-            android:windowSoftInputMode="adjustResize|stateAlwaysHidden" />
+            android:windowSoftInputMode="stateAlwaysHidden" />
 
         <activity
             android:name=".IntentReceiverActivity"
@@ -226,7 +225,7 @@
             android:configChanges="keyboard|keyboardHidden|mcc|mnc|orientation|screenSize|layoutDirection|smallestScreenSize|screenLayout"
             android:exported="false"
             android:taskAffinity=""
-            android:windowSoftInputMode="adjustResize|stateAlwaysHidden" />
+            android:windowSoftInputMode="stateAlwaysHidden" />
 
         <activity android:name=".settings.account.AuthIntentReceiverActivity"
             android:exported="false" />

--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -77,6 +77,7 @@ import org.mozilla.fenix.exceptions.trackingprotection.TrackingProtectionExcepti
 import org.mozilla.fenix.ext.alreadyOnDestination
 import org.mozilla.fenix.ext.breadcrumb
 import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.enableSystemInsetsHandling
 import org.mozilla.fenix.ext.metrics
 import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.settings
@@ -253,6 +254,8 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
         startupTelemetryOnCreateCalled(intent.toSafeIntent(), savedInstanceState != null)
 
         components.core.requestInterceptor.setNavigationController(navHost.navController)
+
+        enableSystemInsetsHandling()
 
         StartupTimeline.onActivityCreateEndHome(this) // DO NOT MOVE ANYTHING BELOW HERE.
     }

--- a/app/src/main/java/org/mozilla/fenix/customtabs/ExternalAppBrowserActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/ExternalAppBrowserActivity.kt
@@ -5,6 +5,8 @@
 package org.mozilla.fenix.customtabs
 
 import android.content.Intent
+import android.os.Bundle
+import android.os.PersistableBundle
 import androidx.annotation.VisibleForTesting
 import androidx.navigation.NavDestination
 import androidx.navigation.NavDirections
@@ -20,6 +22,7 @@ import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.NavGraphDirections
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.enableSystemInsetsHandling
 import java.security.InvalidParameterException
 
 /**
@@ -28,6 +31,12 @@ import java.security.InvalidParameterException
  */
 @Suppress("TooManyFunctions")
 open class ExternalAppBrowserActivity : HomeActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?, persistentState: PersistableBundle?) {
+        super.onCreate(savedInstanceState, persistentState)
+        enableSystemInsetsHandling()
+    }
+
     override fun onResume() {
         super.onResume()
 

--- a/app/src/main/java/org/mozilla/fenix/ext/Activity.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/Activity.kt
@@ -55,7 +55,7 @@ fun Activity.breadcrumb(
  * [Window.setDecorFitsSystemWindows] false tells the system that the app will handle all insets.
  * When a keyboard is opened [WindowInsets.getInsets] of [Type.ime] updates accordingly.
  *
- * See #17805.
+ * See https://github.com/mozilla-mobile/fenix/issues/17805.
  * */
 fun Activity.enableSystemInsetsHandling() {
     if (VERSION.SDK_INT >= VERSION_CODES.R) {

--- a/app/src/main/java/org/mozilla/fenix/ext/Activity.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/Activity.kt
@@ -5,7 +5,12 @@
 package org.mozilla.fenix.ext
 
 import android.app.Activity
+import android.os.Build.VERSION
+import android.os.Build.VERSION_CODES
 import android.view.View
+import android.view.Window
+import android.view.WindowInsets
+import android.view.WindowInsets.Type
 import android.view.WindowManager
 import mozilla.components.concept.base.crash.Breadcrumb
 
@@ -40,4 +45,44 @@ fun Activity.breadcrumb(
             level = Breadcrumb.Level.INFO
         )
     )
+}
+
+/**
+ * Handles inset changes for the whole activity.
+ *
+ * The deprecation of [WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE] in [VERSION_CODES.R]
+ * means inset changes have to be handled with a [View.OnApplyWindowInsetsListener].
+ * [Window.setDecorFitsSystemWindows] false tells the system that the app will handle all insets.
+ * When a keyboard is opened [WindowInsets.getInsets] of [Type.ime] updates accordingly.
+ *
+ * See #17805.
+ * */
+fun Activity.enableSystemInsetsHandling() {
+    if (VERSION.SDK_INT >= VERSION_CODES.R) {
+        val currentInsetTypes = mutableSetOf<Int>()
+
+        currentInsetTypes.add(Type.systemBars())
+        currentInsetTypes.add(Type.statusBars())
+        currentInsetTypes.add(Type.mandatorySystemGestures())
+        currentInsetTypes.add(Type.ime())
+
+        window.setDecorFitsSystemWindows(false)
+
+        window.decorView.setOnApplyWindowInsetsListener { v, _ ->
+            val currentInsetTypeMask = currentInsetTypes.fold(0) { accumulator, type ->
+                accumulator or type
+            }
+            val insets = window.decorView.rootWindowInsets.getInsets(currentInsetTypeMask)
+            v.setPadding(insets.left, insets.top, insets.right, insets.bottom)
+
+            WindowInsets.Builder()
+                .setInsets(currentInsetTypeMask, insets)
+                .build()
+        }
+    } else {
+        @Suppress("DEPRECATION")
+        window.setSoftInputMode(
+            WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE
+        )
+    }
 }

--- a/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt
@@ -13,7 +13,8 @@ import android.content.Intent
 import android.graphics.Color
 import android.graphics.Typeface
 import android.graphics.drawable.ColorDrawable
-import android.os.Build
+import android.os.Build.VERSION
+import android.os.Build.VERSION_CODES
 import android.os.Bundle
 import android.speech.RecognizerIntent
 import android.text.style.StyleSpan
@@ -89,7 +90,8 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
         // https://github.com/mozilla-mobile/fenix/issues/14279
         // To prevent GeckoView from resizing we're going to change the softInputMode to not adjust
         // the size of the window.
-        requireActivity().window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING)
+        if (VERSION.SDK_INT < VERSION_CODES.R)
+            requireActivity().window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING)
         // Refocus the toolbar editing and show keyboard if the QR fragment isn't showing
         if (childFragmentManager.findFragmentByTag(QR_FRAGMENT_TAG) == null) {
             toolbarView.view.edit.focus()
@@ -102,7 +104,8 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
         // Let's reset back to the default behavior after we're done searching
         // This will be addressed on https://github.com/mozilla-mobile/fenix/issues/17805
         @Suppress("DEPRECATION")
-        requireActivity().window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
+        if (VERSION.SDK_INT < VERSION_CODES.R)
+            requireActivity().window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -346,7 +349,7 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
 
     private fun updateAccessibilityTraversalOrder() {
         val searchWrapperId = search_wrapper.id
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
+        if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP_MR1) {
             qr_scan_button.accessibilityTraversalAfter = searchWrapperId
             search_engines_shortcut_button.accessibilityTraversalAfter = searchWrapperId
             fill_link_from_clipboard.accessibilityTraversalAfter = searchWrapperId

--- a/app/src/main/java/org/mozilla/fenix/settings/account/AuthCustomTabActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/account/AuthCustomTabActivity.kt
@@ -4,16 +4,24 @@
 
 package org.mozilla.fenix.settings.account
 
+import android.os.Bundle
+import android.os.PersistableBundle
 import mozilla.components.concept.sync.AccountObserver
 import mozilla.components.concept.sync.AuthType
 import mozilla.components.concept.sync.OAuthAccount
 import org.mozilla.fenix.customtabs.ExternalAppBrowserActivity
 import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.enableSystemInsetsHandling
 
 /**
  * A special custom tab for signing into a Firefox Account. The activity is closed once the user is signed in.
  */
 class AuthCustomTabActivity : ExternalAppBrowserActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?, persistentState: PersistableBundle?) {
+        super.onCreate(savedInstanceState, persistentState)
+        enableSystemInsetsHandling()
+    }
 
     private val accountStateObserver = object : AccountObserver {
         /**

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -342,7 +342,6 @@
         <item name="android:windowAnimationStyle">@style/Animation.Design.BottomSheetDialog</item>
         <item name="windowNoTitle">true</item>
         <item name="android:windowIsFloating">false</item>
-        <item name="android:windowSoftInputMode">adjustResize</item>
         <item name="windowActionBar">false</item>
         <item name="android:windowFullscreen">false</item>
         <item name="android:windowContentOverlay">@null</item>
@@ -619,7 +618,6 @@
         <item name="android:windowBackground">@android:color/transparent</item>
         <item name="windowNoTitle">true</item>
         <item name="android:windowIsFloating">false</item>
-        <item name="android:windowSoftInputMode">adjustResize</item>
         <item name="windowActionBar">false</item>
         <item name="android:windowFullscreen">false</item>
         <item name="android:windowContentOverlay">@null</item>


### PR DESCRIPTION
To handle the deprecation of `adjustResize` I've moved it from `styles.xml` and `AndroidManifest.xml` to `Activity.kt` as a fallback for devices with Android < 11. For Android 11 and up `setDecorFitsSystemWindows(false)` and `OnApplyWindowInsetsListener` will be used to handle app insets. Normal use activities should call `enableSystemInsetsHandling` in `onCreate` as to properly display system bars and for proper keyboard handling.


For https://github.com/mozilla-mobile/fenix/issues/17805
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR doesn't include any tests
- [x] **Screenshots**: This PR includes no screenshots as it shouldn't change anything visually.
- [x] **Accessibility**: The code in this PR should not change anything visually.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
