### PR TITLE
metrics.yaml: Update data review link of engine_tab.kill_foreground_age metric.

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -4515,7 +4515,7 @@ engine_tab:
     bugs:
       - https://github.com/mozilla-mobile/android-components/issues/9366
     data_reviews:
-      - TBD
+      - https://github.com/mozilla-mobile/fenix/pull/17864
     data_sensitivity:
       - technical
     notification_emails:


### PR DESCRIPTION
I forgot to add the data review link to one of the probes.