### PR TITLE
For #18312: Do not update secure flag on pausing logins fragments.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/ext/Fragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/Fragment.kt
@@ -13,7 +13,6 @@ import androidx.navigation.NavOptions
 import androidx.navigation.fragment.NavHostFragment.findNavController
 import androidx.navigation.fragment.findNavController
 import mozilla.components.concept.base.crash.Breadcrumb
-import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.NavHostActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.Components
@@ -66,7 +65,6 @@ fun Fragment.hideToolbar() {
  *
  */
 fun Fragment.redirectToReAuth(destinations: List<Int>, currentDestination: Int?) {
-    (activity as? HomeActivity)?.updateSecureWindowFlags()
     if (currentDestination !in destinations) {
         findNavController().popBackStack(R.id.savedLoginsAuthFragment, false)
     }


### PR DESCRIPTION
The flags are already properly set for activity and thus for other fragments.

On testing this, after pausing fragments with logins list and login details/edit the screenshot rules are always respected.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
