### PR TITLE
For #18325: dismiss GooglePlay ToS dialog after UI test

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAboutTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAboutTest.kt
@@ -6,6 +6,7 @@ package org.mozilla.fenix.ui
 
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
+import androidx.test.uiautomator.UiSelector
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.Rule
 import org.junit.Before
@@ -15,6 +16,7 @@ import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.ui.robots.clickRateButtonGooglePlay
 import org.mozilla.fenix.ui.robots.homeScreen
+import org.mozilla.fenix.ui.robots.mDevice
 
 /**
  *  Tests for verifying the main three dot menu options
@@ -65,8 +67,10 @@ class SettingsAboutTest {
         }.openSettings {
             clickRateButtonGooglePlay()
             verifyGooglePlayRedirect()
+            // press back to return to the app, or accept ToS if still visible
+            mDevice.pressBack()
+            dismissGooglePlayToS()
         }
-
     }
 
     @Test
@@ -77,5 +81,11 @@ class SettingsAboutTest {
         }.openAboutFirefoxPreview {
             verifyAboutFirefoxPreview()
         }
+    }
+}
+
+private fun dismissGooglePlayToS() {
+    if (mDevice.findObject(UiSelector().textContains("Terms of Service")).exists()) {
+        mDevice.findObject(UiSelector().textContains("ACCEPT")).click()
     }
 }


### PR DESCRIPTION
For #18325: The ToS dialog was blocking the app visibility for the next tests.
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
