### PR TITLE
For issue #18132 remove icons from settings page

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -43,4 +43,9 @@ object FeatureFlags {
      * Enables the tabs tray re-write with Synced Tabs.
      */
     val tabsTrayRewrite = Config.channel.isNightlyOrDebug
+
+    /**
+     * Enables the updated icon set look and feel.
+     */
+    val newIconSet = Config.channel.isNightlyOrDebug
 }

--- a/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
@@ -40,6 +40,7 @@ import org.mozilla.fenix.BrowserDirection
 import org.mozilla.fenix.Config
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
+import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.application
 import org.mozilla.fenix.ext.components
@@ -132,7 +133,12 @@ class SettingsFragment : PreferenceFragmentCompat() {
     }
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
-        setPreferencesFromResource(R.xml.preferences, rootKey)
+        val preferencesId = if (FeatureFlags.newIconSet) {
+            R.xml.preferences_without_icons
+        } else {
+            R.xml.preferences
+        }
+        setPreferencesFromResource(preferencesId, rootKey)
         updateMakeDefaultBrowserPreference()
     }
 
@@ -368,8 +374,10 @@ class SettingsFragment : PreferenceFragmentCompat() {
         val preferenceOpenLinksInExternalApp =
             findPreference<Preference>(getPreferenceKey(R.string.pref_key_open_links_in_external_app))
 
-        preferencePrivateBrowsing.icon.mutate().apply {
-            setTint(requireContext().getColorFromAttr(R.attr.primaryText))
+        if (!FeatureFlags.newIconSet) {
+            preferencePrivateBrowsing.icon.mutate().apply {
+                setTint(requireContext().getColorFromAttr(R.attr.primaryText))
+            }
         }
 
         if (!Config.channel.isReleased) {

--- a/app/src/main/res/layout/preference_category_no_icon_style.xml
+++ b/app/src/main/res/layout/preference_category_no_icon_style.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@android:id/title"
+    style="@style/PreferenceSectionHeader"
+    android:layout_width="match_parent"
+    android:layout_height="@dimen/section_header_height"
+    android:layout_marginStart="@dimen/top_bar_no_icon_alignment_margin_start"
+    android:gravity="start|center_vertical"
+    app:allowDividerAbove="true" />

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -58,6 +58,7 @@
     <dimen name="checkbox_preference_padding_vertical">12dp</dimen>
     <dimen name="radiobutton_preference_margin_start">8dp</dimen>
     <dimen name="top_bar_alignment_margin_start">72dp</dimen>
+    <dimen name="top_bar_no_icon_alignment_margin_start">16dp</dimen>
     <dimen name="section_header_height">48dp</dimen>
 
     <!--Quick Settings-->

--- a/app/src/main/res/xml/preferences_without_icons.xml
+++ b/app/src/main/res/xml/preferences_without_icons.xml
@@ -1,0 +1,191 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<androidx.preference.PreferenceScreen
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <androidx.preference.Preference
+        android:key="@string/pref_key_sign_in"
+        android:layout="@layout/sign_in_preference"
+        android:summary="@string/preferences_sign_in_description"
+        android:title="@string/preferences_sync"
+        app:allowDividerBelow="false"/>
+
+    <androidx.preference.PreferenceCategory
+        android:key="@string/pref_key_account_category"
+        android:title="@string/preferences_category_account"
+        app:isPreferenceVisible="false"
+        android:layout="@layout/preference_category_no_icon_style" >
+
+        <org.mozilla.fenix.settings.account.AccountPreference
+            android:icon="@drawable/ic_account"
+            android:key="@string/pref_key_account" />
+
+        <org.mozilla.fenix.settings.account.AccountAuthErrorPreference
+            android:icon="@drawable/ic_account_warning"
+            android:key="@string/pref_key_account_auth_error"/>
+    </androidx.preference.PreferenceCategory>
+
+    <androidx.preference.EditTextPreference
+        android:key="@string/pref_key_override_fxa_server"
+        android:title="@string/preferences_override_fxa_server"
+        android:inputType="textUri"
+        app:iconSpaceReserved="false"
+        app:isPreferenceVisible="false"/>
+
+    <androidx.preference.EditTextPreference
+        android:key="@string/pref_key_override_sync_tokenserver"
+        android:title="@string/preferences_override_sync_tokenserver"
+        android:inputType="textUri"
+        app:iconSpaceReserved="false"
+        app:isPreferenceVisible="false"/>
+
+    <androidx.preference.PreferenceCategory
+        android:title="@string/preferences_category_general"
+        android:layout="@layout/preference_category_no_icon_style">
+        <androidx.preference.Preference
+            app:iconSpaceReserved="false"
+            android:key="@string/pref_key_search_settings"
+            android:title="@string/preferences_search" />
+
+        <androidx.preference.Preference
+            app:iconSpaceReserved="false"
+            android:key="@string/pref_key_tabs"
+            android:title="@string/preferences_tabs" />
+
+        <androidx.preference.Preference
+            android:key="@string/pref_key_customize"
+            app:iconSpaceReserved="false"
+            android:title="@string/preferences_customize" />
+
+        <androidx.preference.Preference
+            android:key="@string/pref_key_passwords"
+            app:iconSpaceReserved="false"
+            android:title="@string/preferences_passwords_logins_and_passwords" />
+
+        <androidx.preference.Preference
+            android:key="@string/pref_key_accessibility"
+            app:iconSpaceReserved="false"
+            android:title="@string/preferences_accessibility" />
+
+        <androidx.preference.Preference
+            android:key="@string/pref_key_language"
+            app:iconSpaceReserved="false"
+            android:title="@string/preferences_language" />
+
+        <org.mozilla.fenix.settings.DefaultBrowserPreference
+            android:key="@string/pref_key_make_default_browser"
+            app:iconSpaceReserved="false"
+            android:title="@string/preferences_set_as_default_browser" />
+    </androidx.preference.PreferenceCategory>
+
+    <androidx.preference.PreferenceCategory
+        android:title="@string/preferences_category_privacy_security"
+        android:layout="@layout/preference_category_no_icon_style">
+
+        <androidx.preference.Preference
+            android:key="@string/pref_key_private_browsing"
+            app:iconSpaceReserved="false"
+            android:title="@string/preferences_private_browsing_options"/>
+
+        <androidx.preference.Preference
+            android:key="@string/pref_key_tracking_protection_settings"
+            app:iconSpaceReserved="false"
+            android:title="@string/preference_enhanced_tracking_protection" />
+
+        <androidx.preference.Preference
+            android:key="@string/pref_key_site_permissions"
+            app:iconSpaceReserved="false"
+            android:title="@string/preferences_site_permissions" />
+
+        <androidx.preference.Preference
+            android:key="@string/pref_key_delete_browsing_data"
+            app:iconSpaceReserved="false"
+            android:title="@string/preferences_delete_browsing_data" />
+
+        <androidx.preference.Preference
+            android:key="@string/pref_key_delete_browsing_data_on_quit_preference"
+            app:iconSpaceReserved="false"
+            android:title="@string/preferences_delete_browsing_data_on_quit" />
+
+        <androidx.preference.Preference
+            android:key="@string/pref_key_notifications"
+            app:iconSpaceReserved="false"
+            android:title="@string/preferences_notifications" />
+
+        <androidx.preference.Preference
+            android:key="@string/pref_key_data_choices"
+            app:iconSpaceReserved="false"
+            android:title="@string/preferences_data_collection" />
+
+    </androidx.preference.PreferenceCategory>
+
+    <PreferenceCategory
+        android:title="@string/preferences_category_advanced"
+        android:key="@string/pref_key_advanced"
+        android:layout="@layout/preference_category_no_icon_style">
+        <androidx.preference.Preference
+            android:key="@string/pref_key_addons"
+            app:iconSpaceReserved="false"
+            android:title="@string/preferences_addons" />
+
+        <androidx.preference.Preference
+            android:key="@string/pref_key_override_amo_collection"
+            app:iconSpaceReserved="false"
+            android:title="@string/preferences_customize_amo_collection"/>
+
+        <androidx.preference.SwitchPreference
+            android:defaultValue="false"
+            android:key="@string/pref_key_open_links_in_external_app"
+            app:iconSpaceReserved="false"
+            android:title="@string/preferences_open_links_in_apps" />
+
+        <androidx.preference.SwitchPreference
+            android:defaultValue="false"
+            android:key="@string/pref_key_external_download_manager"
+            app:iconSpaceReserved="false"
+            android:title="@string/preferences_external_download_manager"/>
+
+        <androidx.preference.SwitchPreference
+            android:defaultValue="true"
+            android:key="@string/pref_key_leakcanary"
+            android:title="@string/preference_leakcanary"
+            app:iconSpaceReserved="false"
+            app:isPreferenceVisible="@bool/IS_DEBUG" />
+
+        <androidx.preference.SwitchPreference
+            android:key="@string/pref_key_remote_debugging"
+            android:title="@string/preferences_remote_debugging"
+            app:iconSpaceReserved="false"
+            android:defaultValue="false" />
+    </PreferenceCategory>
+
+    <androidx.preference.PreferenceCategory
+        android:title="@string/preferences_category_about"
+        app:iconSpaceReserved="false"
+        android:layout="@layout/preference_category_no_icon_style">
+        <androidx.preference.Preference
+            android:key="@string/pref_key_rate"
+            app:iconSpaceReserved="false"
+            android:title="@string/preferences_rate" />
+
+        <androidx.preference.Preference
+            android:key="@string/pref_key_about"
+            app:iconSpaceReserved="false"
+            android:title="@string/preferences_about" />
+
+        <androidx.preference.Preference
+            android:key="@string/pref_key_debug_settings"
+            app:iconSpaceReserved="false"
+            android:title="@string/preferences_debug_settings"
+            app:isPreferenceVisible="false" />
+        <androidx.preference.Preference
+            android:key="@string/pref_key_secret_debug_info"
+            app:iconSpaceReserved="false"
+            android:title="@string/preferences_debug_info"
+            app:isPreferenceVisible="false" />
+    </androidx.preference.PreferenceCategory>
+</androidx.preference.PreferenceScreen>


### PR DESCRIPTION
This PR removes the icons from the setting page and put it behind a feature flag only active in debug and nightly. Below a view of the end result.



https://user-images.githubusercontent.com/773158/110135493-969a5900-7d9c-11eb-830d-ebba5c2ad3bd.mp4

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
