### PR TITLE
For #17872, #18032: Remove disabled color for three dot menu icons and add report site issue

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
@@ -407,10 +407,10 @@ class DefaultToolbarMenu(
             onItemTapped.invoke(ToolbarMenu.Item.AddonsManager)
         }
 
-        val syncSignIn = BrowserMenuImageText(
-            context.getString(R.string.sync_sign_in),
-            R.drawable.ic_synced_tabs,
-            primaryTextColor()
+        val syncedTabs = BrowserMenuImageText(
+            label = context.getString(R.string.synced_tabs),
+            imageResource = R.drawable.ic_synced_tabs,
+            iconTintColorResource = primaryTextColor()
         ) {
             onItemTapped.invoke(ToolbarMenu.Item.SyncedTabs)
         }
@@ -439,19 +439,6 @@ class DefaultToolbarMenu(
             iconTintColorResource = primaryTextColor()
         ) {
             onItemTapped.invoke(ToolbarMenu.Item.CustomizeReaderView)
-        }
-
-        val openInApp = BrowserMenuHighlightableItem(
-            label = context.getString(R.string.browser_menu_open_app_link),
-            startImageResource = R.drawable.ic_open_in_app,
-            iconTintColorResource = primaryTextColor(),
-            highlight = BrowserMenuHighlight.LowPriority(
-                label = context.getString(R.string.browser_menu_open_app_link),
-                notificationTint = getColor(context, R.color.whats_new_notification_color)
-            ),
-            isHighlighted = { !context.settings().openInAppOpened }
-        ) {
-            onItemTapped.invoke(ToolbarMenu.Item.OpenInApp)
         }
 
         val reportSiteIssuePlaceholder = WebExtensionPlaceholderMenuItem(
@@ -508,12 +495,11 @@ class DefaultToolbarMenu(
                 historyItem,
                 downloadsItem,
                 extensionsItem,
-                syncSignIn,
+                syncedTabs,
                 BrowserMenuDivider(),
                 findInPageItem,
                 desktopSiteItem,
                 customizeReaderView.apply { visible = ::shouldShowReaderViewCustomization },
-                openInApp.apply { visible = ::shouldShowOpenInApp },
                 reportSiteIssuePlaceholder,
                 BrowserMenuDivider(),
                 addToHomeScreenItem.apply { visible = ::canAddToHomescreen },

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
@@ -454,6 +454,10 @@ class DefaultToolbarMenu(
             onItemTapped.invoke(ToolbarMenu.Item.OpenInApp)
         }
 
+        val reportSiteIssuePlaceholder = WebExtensionPlaceholderMenuItem(
+            id = WebCompatReporterFeature.WEBCOMPAT_REPORTER_EXTENSION_ID
+        )
+
         val addToHomeScreenItem = BrowserMenuImageText(
             label = context.getString(R.string.browser_menu_add_to_homescreen),
             imageResource = R.drawable.ic_add_to_homescreen,
@@ -510,6 +514,7 @@ class DefaultToolbarMenu(
                 desktopSiteItem,
                 customizeReaderView.apply { visible = ::shouldShowReaderViewCustomization },
                 openInApp.apply { visible = ::shouldShowOpenInApp },
+                reportSiteIssuePlaceholder,
                 BrowserMenuDivider(),
                 addToHomeScreenItem.apply { visible = ::canAddToHomescreen },
                 addToTopSitesItem,

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
@@ -22,7 +22,6 @@ import mozilla.components.browser.menu.item.BrowserMenuHighlightableItem
 import mozilla.components.browser.menu.item.BrowserMenuImageSwitch
 import mozilla.components.browser.menu.item.BrowserMenuImageText
 import mozilla.components.browser.menu.item.BrowserMenuItemToolbar
-import mozilla.components.browser.menu.item.SimpleBrowserMenuItem
 import mozilla.components.browser.menu.item.WebExtensionPlaceholderMenuItem
 import mozilla.components.browser.state.selector.findTab
 import mozilla.components.browser.state.selector.selectedTab
@@ -186,7 +185,7 @@ class DefaultToolbarMenu(
         appLink(session.content.url).hasExternalApp()
     } ?: false
 
-    private fun shouldShowReaderAppearance(): Boolean = selectedSession?.let {
+    private fun shouldShowReaderViewCustomization(): Boolean = selectedSession?.let {
         store.state.findTab(it.id)?.readerState?.active
     } ?: false
     // End of predicates //
@@ -355,7 +354,7 @@ class DefaultToolbarMenu(
             if (shouldShowSaveToCollection) saveToCollection else null,
             desktopMode,
             openInApp.apply { visible = ::shouldShowOpenInApp },
-            readerAppearance.apply { visible = ::shouldShowReaderAppearance },
+            readerAppearance.apply { visible = ::shouldShowReaderViewCustomization },
             BrowserMenuDivider(),
             menuToolbar
         )
@@ -370,8 +369,8 @@ class DefaultToolbarMenu(
     private val newCoreMenuItems by lazy {
         val newTabItem = BrowserMenuImageText(
             context.getString(R.string.library_new_tab),
-            R.drawable.ic_bookmark_filled,
-            disabledTextColor()
+            R.drawable.ic_new,
+            primaryTextColor()
         ) {
             onItemTapped.invoke(ToolbarMenu.Item.NewTab)
         }
@@ -379,7 +378,7 @@ class DefaultToolbarMenu(
         val bookmarksItem = BrowserMenuImageText(
             context.getString(R.string.library_bookmarks),
             R.drawable.ic_bookmark_filled,
-            disabledTextColor()
+            primaryTextColor()
         ) {
             onItemTapped.invoke(ToolbarMenu.Item.Bookmarks)
         }
@@ -387,7 +386,7 @@ class DefaultToolbarMenu(
         val historyItem = BrowserMenuImageText(
             context.getString(R.string.library_history),
             R.drawable.ic_history,
-            disabledTextColor()
+            primaryTextColor()
         ) {
             onItemTapped.invoke(ToolbarMenu.Item.History)
         }
@@ -395,7 +394,7 @@ class DefaultToolbarMenu(
         val downloadsItem = BrowserMenuImageText(
             context.getString(R.string.library_downloads),
             R.drawable.ic_download,
-            disabledTextColor()
+            primaryTextColor()
         ) {
             onItemTapped.invoke(ToolbarMenu.Item.Downloads)
         }
@@ -403,15 +402,15 @@ class DefaultToolbarMenu(
         val extensionsItem = BrowserMenuImageText(
             context.getString(R.string.browser_menu_extensions),
             R.drawable.ic_addons_extensions,
-            disabledTextColor()
+            primaryTextColor()
         ) {
             onItemTapped.invoke(ToolbarMenu.Item.AddonsManager)
         }
 
-        val syncedTabsItem = BrowserMenuImageText(
-            context.getString(R.string.library_synced_tabs),
+        val syncSignIn = BrowserMenuImageText(
+            context.getString(R.string.sync_sign_in),
             R.drawable.ic_synced_tabs,
-            disabledTextColor()
+            primaryTextColor()
         ) {
             onItemTapped.invoke(ToolbarMenu.Item.SyncedTabs)
         }
@@ -419,7 +418,7 @@ class DefaultToolbarMenu(
         val findInPageItem = BrowserMenuImageText(
             label = context.getString(R.string.browser_menu_find_in_page),
             imageResource = R.drawable.mozac_ic_search,
-            iconTintColorResource = disabledTextColor()
+            iconTintColorResource = primaryTextColor()
         ) {
             onItemTapped.invoke(ToolbarMenu.Item.FindInPage)
         }
@@ -434,17 +433,31 @@ class DefaultToolbarMenu(
             onItemTapped.invoke(ToolbarMenu.Item.RequestDesktop(checked))
         }
 
-        val customizeReaderView = SimpleBrowserMenuItem(
+        val customizeReaderView = BrowserMenuImageText(
             label = context.getString(R.string.browser_menu_customize_reader_view),
-            textColorResource = primaryTextColor()
+            imageResource = R.drawable.ic_readermode_appearance,
+            iconTintColorResource = primaryTextColor()
         ) {
             onItemTapped.invoke(ToolbarMenu.Item.CustomizeReaderView)
+        }
+
+        val openInApp = BrowserMenuHighlightableItem(
+            label = context.getString(R.string.browser_menu_open_app_link),
+            startImageResource = R.drawable.ic_open_in_app,
+            iconTintColorResource = primaryTextColor(),
+            highlight = BrowserMenuHighlight.LowPriority(
+                label = context.getString(R.string.browser_menu_open_app_link),
+                notificationTint = getColor(context, R.color.whats_new_notification_color)
+            ),
+            isHighlighted = { !context.settings().openInAppOpened }
+        ) {
+            onItemTapped.invoke(ToolbarMenu.Item.OpenInApp)
         }
 
         val addToHomeScreenItem = BrowserMenuImageText(
             label = context.getString(R.string.browser_menu_add_to_homescreen),
             imageResource = R.drawable.ic_add_to_homescreen,
-            iconTintColorResource = disabledTextColor()
+            iconTintColorResource = primaryTextColor()
         ) {
             onItemTapped.invoke(ToolbarMenu.Item.AddToHomeScreen)
         }
@@ -452,7 +465,7 @@ class DefaultToolbarMenu(
         val addToTopSitesItem = BrowserMenuImageText(
             label = context.getString(R.string.browser_menu_add_to_top_sites),
             imageResource = R.drawable.ic_top_sites,
-            iconTintColorResource = disabledTextColor()
+            iconTintColorResource = primaryTextColor()
         ) {
             onItemTapped.invoke(ToolbarMenu.Item.AddToTopSites)
         }
@@ -460,7 +473,7 @@ class DefaultToolbarMenu(
         val saveToCollectionItem = BrowserMenuImageText(
             label = context.getString(R.string.browser_menu_save_to_collection_2),
             imageResource = R.drawable.ic_tab_collection,
-            iconTintColorResource = disabledTextColor()
+            iconTintColorResource = primaryTextColor()
         ) {
             onItemTapped.invoke(ToolbarMenu.Item.SaveToCollection)
         }
@@ -468,7 +481,7 @@ class DefaultToolbarMenu(
         val settingsItem = BrowserMenuHighlightableItem(
             label = context.getString(R.string.browser_menu_settings),
             startImageResource = R.drawable.ic_settings,
-            iconTintColorResource = disabledTextColor(),
+            iconTintColorResource = primaryTextColor(),
             textColorResource = if (hasAccountProblem)
                 ThemeManager.resolveAttribute(R.attr.primaryText, context) else
                 primaryTextColor(),
@@ -491,11 +504,12 @@ class DefaultToolbarMenu(
                 historyItem,
                 downloadsItem,
                 extensionsItem,
-                syncedTabsItem,
+                syncSignIn,
                 BrowserMenuDivider(),
                 findInPageItem,
                 desktopSiteItem,
-                customizeReaderView.apply { visible = ::shouldShowReaderAppearance },
+                customizeReaderView.apply { visible = ::shouldShowReaderViewCustomization },
+                openInApp.apply { visible = ::shouldShowOpenInApp },
                 BrowserMenuDivider(),
                 addToHomeScreenItem.apply { visible = ::canAddToHomescreen },
                 addToTopSitesItem,
@@ -512,10 +526,6 @@ class DefaultToolbarMenu(
     @ColorRes
     @VisibleForTesting
     internal fun primaryTextColor() = ThemeManager.resolveAttribute(R.attr.primaryText, context)
-
-    @ColorRes
-    @VisibleForTesting
-    internal fun disabledTextColor() = R.color.toolbar_menu_transparent
 
     @VisibleForTesting
     internal fun registerForIsBookmarkedUpdates() {


### PR DESCRIPTION
For #17872 (icons), for #18032 (report site issue)

This makes the three dot menu icons visible again (per design decision). This also adds the "Report site issue" item in nightly/debug.

Confirmed colors in: 
- [x] light mode, normal browsing (see below)
- [x] light mode, private browsing (no screenshots)
- [x] dark mode, normal browsing (see below)
- [x] dark mode, private browsing (no screenshots)

### Screenshots

<img width="323" src="https://user-images.githubusercontent.com/43795363/110358030-8afb9c00-8001-11eb-9ae9-1650f3767672.png"> <img width="323" src="https://user-images.githubusercontent.com/43795363/110358038-8d5df600-8001-11eb-998e-8e5df834783f.png">

Open in app & reader view appearance: 
<img width="323" src="https://user-images.githubusercontent.com/43795363/110358316-e168da80-8001-11eb-8981-54bf67fc8301.png">

Report site issue: (FYI there's an open bug for making the lightbulb icon look better.. I'll link that here)
<img width="323" src="https://user-images.githubusercontent.com/43795363/110360604-8ab0d000-8004-11eb-9fa3-03481d561b4b.png">


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
