### PR TITLE
bug 1696457 - restrict signing index

### DIFF
--- a/taskcluster/ci/signing/kind.yml
+++ b/taskcluster/ci/signing/kind.yml
@@ -40,9 +40,12 @@ job-template:
                 default: dep-signing
     signing-format: autograph_apk
     index:
-        by-build-type:
-            (nightly|debug|nightly-simulation|beta|release):
-                type: signing
+        by-tasks-for:
+            (action|cron|github-release):
+                by-build-type:
+                    (nightly|debug|nightly-simulation|beta|release):
+                        type: signing
+                    default: {}
             default: {}
     run-on-tasks-for:
         by-build-type:

--- a/taskcluster/fenix_taskgraph/transforms/signing.py
+++ b/taskcluster/fenix_taskgraph/transforms/signing.py
@@ -26,6 +26,7 @@ def resolve_keys(config, tasks):
                 **{
                     'build-type': task["attributes"]["build-type"],
                     'level': config.params["level"],
+                    'tasks-for': config.params["tasks_for"],
                 }
             )
         yield task


### PR DESCRIPTION
I'm not 100% sure whether this is tuned perfectly, but this should reduce the number of bogus nightly-simulation indexes to just the nightly graphs, per https://bugzilla.mozilla.org/show_bug.cgi?id=1696457 .