### PR TITLE
For #17804: Use enterToImmersiveMode from support-ktx component

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -110,7 +110,6 @@ import org.mozilla.fenix.downloads.DynamicDownloadDialog
 import org.mozilla.fenix.ext.accessibilityManager
 import org.mozilla.fenix.ext.breadcrumb
 import org.mozilla.fenix.ext.components
-import org.mozilla.fenix.ext.enterToImmersiveMode
 import org.mozilla.fenix.ext.getPreferenceKey
 import org.mozilla.fenix.ext.hideToolbar
 import org.mozilla.fenix.ext.metrics
@@ -129,6 +128,7 @@ import java.lang.ref.WeakReference
 import mozilla.components.feature.session.behavior.EngineViewBrowserToolbarBehavior
 import mozilla.components.feature.webauthn.WebAuthnFeature
 import mozilla.components.support.base.feature.ActivityResultHandler
+import mozilla.components.support.ktx.android.view.enterToImmersiveMode
 import mozilla.components.feature.session.behavior.ToolbarPosition as MozacToolbarPosition
 
 /**

--- a/app/src/main/java/org/mozilla/fenix/ext/Activity.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/Activity.kt
@@ -15,6 +15,13 @@ import mozilla.components.concept.base.crash.Breadcrumb
  * We don't use the equivalent function from Android Components because the stable flag messes
  * with the toolbar. See #1998 and #3272.
  */
+@Deprecated(
+    message = "Use the Android Component implementation instead.",
+    replaceWith = ReplaceWith(
+        "enterToImmersiveMode()",
+        "mozilla.components.support.ktx.android.view.enterToImmersiveMode"
+    )
+)
 fun Activity.enterToImmersiveMode() {
     window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
     // This will be addressed on https://github.com/mozilla-mobile/fenix/issues/17804

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "74.0.20210309143153"
+    const val VERSION = "74.0.20210309154120"
 }


### PR DESCRIPTION
This should land after the next AC nightly is out which adds Android 11 support for window insets.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
