### PR TITLE
Issue #17822: Create a tabs tray layout and fragment

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -294,7 +294,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
                 thumbnailsFeature.get()?.requestScreenshot()
                 findNavController().nav(
                     R.id.browserFragment,
-                    BrowserFragmentDirections.actionGlobalTabTrayDialogFragment()
+                    getTrayDirection(context)
                 )
             },
             onCloseTab = { closedSession ->
@@ -1277,6 +1277,17 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
             isDisplayedWithBrowserToolbar = true
         ).setText(DynamicDownloadDialog.getCannotOpenFileErrorMessage(context, downloadState))
             .show()
+    }
+
+    /**
+     * Retrieves the correct tray direction while using a feature flag.
+     *
+     * Remove this when [FeatureFlags.tabsTrayRewrite] is removed.
+     */
+    private fun getTrayDirection(context: Context) = if (context.settings().tabsTrayRewrite) {
+        BrowserFragmentDirections.actionGlobalTabsTrayFragment()
+    } else {
+        BrowserFragmentDirections.actionGlobalTabTrayDialogFragment()
     }
 
     companion object {

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -1013,9 +1013,14 @@ class HomeFragment : Fragment() {
     }
 
     private fun openTabTray() {
+        val direction = if (requireContext().settings().tabsTrayRewrite) {
+            HomeFragmentDirections.actionGlobalTabsTrayFragment()
+        } else {
+            HomeFragmentDirections.actionGlobalTabTrayDialogFragment()
+        }
         findNavController().nav(
             R.id.homeFragment,
-            HomeFragmentDirections.actionGlobalTabTrayDialogFragment()
+            direction
         )
     }
 

--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
@@ -1,0 +1,96 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabstray
+
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.appcompat.app.AppCompatDialogFragment
+import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.navigation.fragment.findNavController
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.tabs.TabLayout
+import kotlinx.android.synthetic.main.component_tabstray2.*
+import kotlinx.android.synthetic.main.component_tabstray2.view.*
+import org.mozilla.fenix.R
+
+class TabsTrayFragment : AppCompatDialogFragment(), TabsTrayInteractor {
+
+    lateinit var behavior: BottomSheetBehavior<ConstraintLayout>
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setStyle(STYLE_NO_TITLE, R.style.TabTrayDialogStyle)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        val containerView = inflater.inflate(R.layout.fragment_tab_tray_dialog, container, false)
+        val view: View = LayoutInflater.from(containerView.context)
+            .inflate(R.layout.component_tabstray2, containerView as ViewGroup, true)
+
+        behavior = BottomSheetBehavior.from(view.tab_wrapper)
+
+        return containerView
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        setupPager(view.context, this)
+    }
+
+    override fun setCurrentTrayPosition(position: Int) {
+        tabsTray.currentItem = position
+    }
+
+    override fun navigateToBrowser() {
+        dismissAllowingStateLoss()
+
+        val navController = findNavController()
+
+        if (navController.currentDestination?.id == R.id.browserFragment) {
+            return
+        }
+
+        if (!navController.popBackStack(R.id.browserFragment, false)) {
+            navController.navigate(R.id.browserFragment)
+        }
+    }
+
+    override fun tabRemoved(sessionId: String) {
+        // TODO re-implement these methods
+        // showUndoSnackbarForTab(sessionId)
+        // removeIfNotLastTab(sessionId)
+    }
+
+    private fun setupPager(context: Context, interactor: TabsTrayInteractor) {
+        tabsTray.apply {
+            adapter = TrayPagerAdapter(context, interactor)
+            isUserInputEnabled = false
+        }
+
+        tab_layout.addOnTabSelectedListener(TabLayoutObserver(interactor))
+    }
+}
+
+/**
+ * An observer for the [TabLayout] used for the Tabs Tray.
+ */
+internal class TabLayoutObserver(
+    private val interactor: TabsTrayInteractor
+) : TabLayout.OnTabSelectedListener {
+    override fun onTabSelected(tab: TabLayout.Tab) {
+        interactor.setCurrentTrayPosition(tab.position)
+    }
+
+    override fun onTabUnselected(tab: TabLayout.Tab) = Unit
+    override fun onTabReselected(tab: TabLayout.Tab) = Unit
+}

--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayInteractor.kt
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabstray
+
+interface TabsTrayInteractor {
+    /**
+     * Set the current tray item to the clamped [position].
+     */
+    fun setCurrentTrayPosition(position: Int)
+
+    /**
+     * Dismisses the tabs tray and navigates to the browser.
+     */
+    fun navigateToBrowser()
+
+    /**
+     * Invoked when a tab is removed from the tabs tray with the given [sessionId].
+     */
+    fun tabRemoved(sessionId: String)
+}

--- a/app/src/main/java/org/mozilla/fenix/tabstray/TrayItem.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TrayItem.kt
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabstray
+
+import android.view.View
+import android.view.ViewGroup
+
+/**
+ * A [View] or [ViewGroup] that can be add in the Tabs Tray.
+ */
+interface TrayItem

--- a/app/src/main/java/org/mozilla/fenix/tabstray/TrayPagerAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TrayPagerAdapter.kt
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabstray
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import org.mozilla.fenix.tabstray.BrowserTabViewHolder.Companion.LAYOUT_ID_NORMAL_TAB
+import org.mozilla.fenix.tabstray.BrowserTabViewHolder.Companion.LAYOUT_ID_PRIVATE_TAB
+import org.mozilla.fenix.tabtray.FenixTabsAdapter
+
+class TrayPagerAdapter(
+    context: Context,
+    val interactor: TabsTrayInteractor
+) : RecyclerView.Adapter<TrayViewHolder>() {
+
+    private val normalAdapter by lazy { FenixTabsAdapter(context) }
+    private val privateAdapter by lazy { FenixTabsAdapter(context) }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TrayViewHolder {
+        val itemView = LayoutInflater.from(parent.context).inflate(viewType, parent, false)
+
+        return when (viewType) {
+            LAYOUT_ID_NORMAL_TAB -> BrowserTabViewHolder(itemView, interactor)
+            LAYOUT_ID_PRIVATE_TAB -> BrowserTabViewHolder(itemView, interactor)
+            else -> throw IllegalStateException("Unknown viewType.")
+        }
+    }
+
+    override fun onBindViewHolder(viewHolder: TrayViewHolder, position: Int) {
+        val adapter = when (position) {
+            POSITION_NORMAL_TABS -> normalAdapter
+            POSITION_PRIVATE_TABS -> privateAdapter
+            else -> throw IllegalStateException("View type does not exist.")
+        }
+
+        viewHolder.bind(adapter)
+    }
+
+    override fun getItemViewType(position: Int): Int {
+        return when (position) {
+            POSITION_NORMAL_TABS -> LAYOUT_ID_NORMAL_TAB
+            POSITION_PRIVATE_TABS -> LAYOUT_ID_PRIVATE_TAB
+            else -> throw IllegalStateException("Unknown position.")
+        }
+    }
+
+    override fun getItemCount(): Int = TRAY_TABS_COUNT
+
+    companion object {
+        const val TRAY_TABS_COUNT = 2
+
+        const val POSITION_NORMAL_TABS = 0
+        const val POSITION_PRIVATE_TABS = 1
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/tabstray/TrayViewHolders.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TrayViewHolders.kt
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabstray
+
+import android.view.View
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import kotlinx.android.extensions.LayoutContainer
+import org.mozilla.fenix.R
+import org.mozilla.fenix.tabstray.browser.BaseBrowserTrayList
+
+sealed class TrayViewHolder constructor(
+    override val containerView: View
+) : RecyclerView.ViewHolder(containerView), LayoutContainer {
+
+    abstract fun bind(adapter: RecyclerView.Adapter<out RecyclerView.ViewHolder>)
+}
+
+class BrowserTabViewHolder(
+    containerView: View,
+    interactor: TabsTrayInteractor
+) : TrayViewHolder(containerView) {
+
+    private val trayList: BaseBrowserTrayList = itemView.findViewById(R.id.tray_list_item)
+
+    init {
+        trayList.interactor = interactor
+    }
+
+    override fun bind(adapter: RecyclerView.Adapter<out RecyclerView.ViewHolder>) {
+        trayList.layoutManager = LinearLayoutManager(itemView.context)
+        trayList.adapter = adapter
+    }
+
+    companion object {
+        const val LAYOUT_ID_NORMAL_TAB = R.layout.normal_browser_tray_list
+        const val LAYOUT_ID_PRIVATE_TAB = R.layout.private_browser_tray_list
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/tabstray/browser/BaseBrowserTrayList.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/browser/BaseBrowserTrayList.kt
@@ -1,0 +1,95 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabstray.browser
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.recyclerview.widget.RecyclerView
+import mozilla.components.browser.tabstray.TabsAdapter
+import mozilla.components.feature.tabs.TabsUseCases
+import mozilla.components.feature.tabs.tabstray.TabsFeature
+import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
+import org.mozilla.fenix.components.metrics.Event
+import org.mozilla.fenix.components.metrics.MetricController
+import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.tabstray.TabsTrayInteractor
+import org.mozilla.fenix.tabstray.TrayItem
+import org.mozilla.fenix.tabstray.ext.filterFromConfig
+import org.mozilla.fenix.utils.view.LifecycleViewProvider
+
+abstract class BaseBrowserTrayList @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : RecyclerView(context, attrs, defStyleAttr), TrayItem {
+
+    enum class BrowserTabType { NORMAL, PRIVATE }
+    data class Configuration(val browserTabType: BrowserTabType)
+
+    abstract val configuration: Configuration
+
+    var interactor: TabsTrayInteractor? = null
+
+    private val lifecycleProvider = LifecycleViewProvider(this)
+
+    private val selectTabUseCase = SelectTabUseCaseWrapper(
+        context.components.analytics.metrics,
+        context.components.useCases.tabsUseCases.selectTab
+    ) {
+        interactor?.navigateToBrowser()
+    }
+
+    private val removeTabUseCase = RemoveTabUseCaseWrapper(
+        context.components.analytics.metrics
+    ) { sessionId ->
+        interactor?.tabRemoved(sessionId)
+    }
+
+    private val tabsFeature by lazy {
+        ViewBoundFeatureWrapper(
+            feature = TabsFeature(
+                adapter as TabsAdapter,
+                context.components.core.store,
+                selectTabUseCase,
+                removeTabUseCase,
+                { it.filterFromConfig(configuration) },
+                { }
+            ),
+            owner = lifecycleProvider,
+            view = this
+        )
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+
+        // This is weird, but I don't have a better solution right now: We need to keep a
+        // lazy reference to the feature/adapter so that we do not re-create
+        // it every time it's attached. This reference is our way to init.
+        tabsFeature
+    }
+}
+
+internal class SelectTabUseCaseWrapper(
+    private val metrics: MetricController,
+    private val selectTab: TabsUseCases.SelectTabUseCase,
+    private val onSelect: (String) -> Unit
+) : TabsUseCases.SelectTabUseCase {
+    override fun invoke(tabId: String) {
+        metrics.track(Event.OpenedExistingTab)
+        selectTab(tabId)
+        onSelect(tabId)
+    }
+}
+
+internal class RemoveTabUseCaseWrapper(
+    private val metrics: MetricController,
+    private val onRemove: (String) -> Unit
+) : TabsUseCases.RemoveTabUseCase {
+    override fun invoke(sessionId: String) {
+        metrics.track(Event.ClosedExistingTab)
+        onRemove(sessionId)
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/tabstray/browser/NormalBrowserTrayList.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/browser/NormalBrowserTrayList.kt
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabstray.browser
+
+import android.content.Context
+import android.util.AttributeSet
+
+/**
+ * A browser tabs list that displays normal tabs.
+ */
+class NormalBrowserTrayList @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : BaseBrowserTrayList(context, attrs, defStyleAttr) {
+    override val configuration: Configuration = Configuration(BrowserTabType.NORMAL)
+}

--- a/app/src/main/java/org/mozilla/fenix/tabstray/browser/PrivateBrowserTrayList.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/browser/PrivateBrowserTrayList.kt
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabstray.browser
+
+import android.content.Context
+import android.util.AttributeSet
+
+/**
+ * A browser tabs list that displays private tabs.
+ */
+class PrivateBrowserTrayList @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : BaseBrowserTrayList(context, attrs, defStyleAttr) {
+    override val configuration: Configuration = Configuration(BrowserTabType.PRIVATE)
+}

--- a/app/src/main/java/org/mozilla/fenix/tabstray/ext/TabSessionState.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/ext/TabSessionState.kt
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabstray.ext
+
+import mozilla.components.browser.state.state.TabSessionState
+import org.mozilla.fenix.tabstray.browser.BaseBrowserTrayList.BrowserTabType.PRIVATE
+import org.mozilla.fenix.tabstray.browser.BaseBrowserTrayList.Configuration
+
+fun TabSessionState.filterFromConfig(configuration: Configuration): Boolean {
+    val isPrivate = configuration.browserTabType == PRIVATE
+
+    return content.private == isPrivate
+}

--- a/app/src/main/java/org/mozilla/fenix/tabtray/FenixTabsAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/FenixTabsAdapter.kt
@@ -15,6 +15,7 @@ import kotlinx.android.synthetic.main.tab_tray_item.view.*
 import mozilla.components.browser.state.selector.findTab
 import mozilla.components.browser.tabstray.TabViewHolder
 import mozilla.components.browser.tabstray.TabsAdapter
+import mozilla.components.browser.thumbnails.loader.ThumbnailLoader
 import mozilla.components.concept.base.images.ImageLoader
 import mozilla.components.concept.tabstray.Tab
 import mozilla.components.concept.tabstray.Tabs
@@ -27,7 +28,7 @@ import org.mozilla.fenix.ext.updateAccessibilityCollectionItemInfo
 
 class FenixTabsAdapter(
     private val context: Context,
-    imageLoader: ImageLoader
+    imageLoader: ImageLoader = ThumbnailLoader(context.components.core.thumbnailStorage)
 ) : TabsAdapter(
     viewHolderProvider = { parentView ->
         TabTrayViewHolder(

--- a/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayView.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabtray/TabTrayView.kt
@@ -701,7 +701,6 @@ class TabTrayView(
     fun scrollToSelectedBrowserTab(selectedTabId: String? = null) {
         view.tabsTray.apply {
             val recyclerViewIndex = getSelectedBrowserTabViewIndex(selectedTabId)
-
             layoutManager?.scrollToPosition(recyclerViewIndex)
             smoothScrollBy(
                 0,

--- a/app/src/main/java/org/mozilla/fenix/utils/view/LifecycleViewProvider.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/view/LifecycleViewProvider.kt
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.utils.view
+
+import android.view.View
+import androidx.annotation.VisibleForTesting
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.Lifecycle.State
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+
+/**
+ * Provides a [LifecycleOwner] on a given [View] for features that function on lifecycle events.
+ *
+ * When the [View] is attached to the window, observers will receive the [Lifecycle.Event.ON_START] event.
+ * When the [View] is detached to the window, observers will receive the [Lifecycle.Event.ON_STOP] event.
+ *
+ * @param view The [View] that will be observed.
+ */
+class LifecycleViewProvider(view: View) : LifecycleOwner {
+    private val registry = LifecycleRegistry(this)
+
+    init {
+        registry.currentState = State.INITIALIZED
+
+        view.addOnAttachStateChangeListener(ViewBinding(registry))
+    }
+
+    override fun getLifecycle(): Lifecycle = registry
+}
+
+@VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+internal class ViewBinding(
+    private val registry: LifecycleRegistry
+) : View.OnAttachStateChangeListener {
+    override fun onViewAttachedToWindow(v: View?) {
+        registry.currentState = State.STARTED
+    }
+
+    override fun onViewDetachedFromWindow(v: View?) {
+        registry.currentState = State.DESTROYED
+    }
+}

--- a/app/src/main/res/layout/component_tabstray2.xml
+++ b/app/src/main/res/layout/component_tabstray2.xml
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/tab_wrapper"
+    style="@style/BottomSheetModal"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:backgroundTint="@color/foundation_normal_theme"
+    app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"
+    tools:ignore="MozMultipleConstraintLayouts">
+
+    <View
+        android:id="@+id/handle"
+        android:layout_width="0dp"
+        android:layout_height="@dimen/bottom_sheet_handle_height"
+        android:layout_marginTop="@dimen/bottom_sheet_handle_top_margin"
+        android:background="@color/secondary_text_normal_theme"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintWidth_percent="0.1" />
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/infoBanner"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/foundation_normal_theme"
+        android:visibility="gone"
+        app:layout_constraintTop_toBottomOf="@+id/topBar" />
+
+    <TextView
+        android:id="@+id/tab_tray_empty_view"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:focusable="true"
+        android:focusableInTouchMode="true"
+        android:gravity="center_horizontal"
+        android:paddingTop="80dp"
+        android:text="@string/no_open_tabs_description"
+        android:textColor="?secondaryText"
+        android:textSize="16sp"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/infoBanner" />
+
+    <View
+        android:id="@+id/topBar"
+        android:layout_width="match_parent"
+        android:layout_height="80dp"
+        android:background="@color/foundation_normal_theme"
+        android:importantForAccessibility="no"
+        app:layout_constraintTop_toBottomOf="@+id/handle" />
+
+    <ImageButton
+        android:id="@+id/exit_multi_select"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_marginStart="0dp"
+        android:background="?android:attr/selectableItemBackgroundBorderless"
+        android:contentDescription="@string/tab_tray_close_multiselect_content_description"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="@+id/multiselect_title"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/multiselect_title"
+        app:srcCompat="@drawable/ic_close"
+        app:tint="@color/contrast_text_normal_theme" />
+
+    <TextView
+        android:id="@+id/multiselect_title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="12dp"
+        android:focusableInTouchMode="true"
+        android:textColor="@color/contrast_text_normal_theme"
+        android:textSize="20sp"
+        app:fontFamily="@font/metropolis_semibold"
+        app:layout_constraintBottom_toBottomOf="@id/topBar"
+        app:layout_constraintEnd_toStartOf="@id/collect_multi_select"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintHorizontal_chainStyle="packed"
+        app:layout_constraintStart_toEndOf="@+id/exit_multi_select"
+        app:layout_constraintTop_toTopOf="@id/topBar"
+        tools:text="3 selected" />
+
+    <include layout="@layout/tabstray_multiselect_items" />
+
+    <com.google.android.material.tabs.TabLayout
+        android:id="@+id/tab_layout"
+        android:layout_width="0dp"
+        android:layout_height="80dp"
+        android:background="@color/foundation_normal_theme"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/handle"
+        app:layout_constraintWidth_percent="0.5"
+        app:tabGravity="fill"
+        app:tabIconTint="@color/tab_icon"
+        app:tabIndicatorColor="@color/accent_normal_theme"
+        app:tabMaxWidth="0dp"
+        app:tabRippleColor="@android:color/transparent">
+
+        <com.google.android.material.tabs.TabItem
+            android:id="@+id/default_tab_item"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:contentDescription="@string/tab_header_label"
+            android:layout="@layout/tabs_tray_tab_counter"
+            app:tabIconTint="@color/tab_icon" />
+
+        <com.google.android.material.tabs.TabItem
+            android:id="@+id/private_tab_item"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:contentDescription="@string/tabs_header_private_tabs_title"
+            android:icon="@drawable/ic_private_browsing" />
+
+    </com.google.android.material.tabs.TabLayout>
+
+    <ImageButton
+        android:id="@+id/tab_tray_new_tab"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:background="?android:attr/selectableItemBackgroundBorderless"
+        android:contentDescription="@string/add_tab"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="@id/tab_layout"
+        app:layout_constraintEnd_toStartOf="@id/tab_tray_overflow"
+        app:layout_constraintTop_toTopOf="@id/tab_layout"
+        app:srcCompat="@drawable/ic_new"
+        app:tint="@color/primary_text_normal_theme" />
+
+    <ImageButton
+        android:id="@+id/tab_tray_overflow"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_marginEnd="0dp"
+        android:background="?android:attr/selectableItemBackgroundBorderless"
+        android:contentDescription="@string/open_tabs_menu"
+        android:visibility="visible"
+        app:layout_constraintBottom_toBottomOf="@id/tab_layout"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@id/tab_layout"
+        app:srcCompat="@drawable/ic_menu"
+        app:tint="@color/tab_tray_heading_icon_menu_normal_theme" />
+
+    <View
+        android:id="@+id/divider"
+        android:layout_width="0dp"
+        android:layout_height="1dp"
+        android:background="@color/tab_tray_item_divider_normal_theme"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/infoBanner" />
+
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/tabsTray"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:clipToPadding="false"
+        android:paddingBottom="140dp"
+        android:scrollbarStyle="outsideOverlay"
+        android:scrollbars="vertical"
+        android:orientation="horizontal"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/divider" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/normal_browser_tray_list.xml
+++ b/app/src/main/res/layout/normal_browser_tray_list.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<org.mozilla.fenix.tabstray.browser.NormalBrowserTrayList
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/tray_list_item"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"/>

--- a/app/src/main/res/layout/private_browser_tray_list.xml
+++ b/app/src/main/res/layout/private_browser_tray_list.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<org.mozilla.fenix.tabstray.browser.PrivateBrowserTrayList
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/tray_list_item"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"/>

--- a/app/src/main/res/layout/synced_tabs_tray_list.xml
+++ b/app/src/main/res/layout/synced_tabs_tray_list.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.recyclerview.widget.RecyclerView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/synced_tabs_tray_list_item"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"/>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -119,6 +119,11 @@
         app:popUpTo="@id/tabTrayDialogFragment"
         app:popUpToInclusive="true"/>
     <action
+        android:id="@+id/action_global_tabsTrayFragment"
+        app:destination="@id/tabsTrayFragment"
+        app:popUpTo="@id/tabsTrayFragment"
+        app:popUpToInclusive="true" />
+    <action
         android:id="@+id/action_global_savedLoginsAuthFragment"
         app:destination="@id/savedLoginsAuthFragment" />
     <action
@@ -127,6 +132,15 @@
     <action
         android:id="@+id/action_global_tabSettingsFragment"
         app:destination="@id/tabsSettingsFragment" />
+
+    <dialog
+        android:id="@+id/tabsTrayFragment"
+        android:name="org.mozilla.fenix.tabstray.TabsTrayFragment">
+        <argument
+            android:name="enterMultiselect"
+            android:defaultValue="false"
+            app:argType="boolean" />
+    </dialog>
 
     <dialog
         android:id="@+id/tabTrayDialogFragment"

--- a/app/src/test/java/org/mozilla/fenix/tabstray/TabLayoutObserverTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/TabLayoutObserverTest.kt
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabstray
+
+import com.google.android.material.tabs.TabLayout
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Test
+
+class TabLayoutObserverTest {
+    private val interactor = mockk<TabsTrayInteractor>(relaxed = true)
+
+    @Test
+    fun `WHEN tab is selected THEN notify the interactor`() {
+        val observer = TabLayoutObserver(interactor)
+        val tab = mockk<TabLayout.Tab>()
+        every { tab.position } returns 1
+
+        observer.onTabSelected(tab)
+
+        verify { interactor.setCurrentTrayPosition(1) }
+    }
+}

--- a/app/src/test/java/org/mozilla/fenix/tabstray/browser/RemoveTabUseCaseWrapperTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/browser/RemoveTabUseCaseWrapperTest.kt
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabstray.browser
+
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Test
+import org.mozilla.fenix.components.metrics.Event
+import org.mozilla.fenix.components.metrics.MetricController
+
+class RemoveTabUseCaseWrapperTest {
+
+    val metricController = mockk<MetricController>(relaxed = true)
+
+    @Test
+    fun `WHEN invoked THEN metrics, use case and callback are triggered`() {
+        val onRemove: (String) -> Unit = mockk(relaxed = true)
+        val wrapper = RemoveTabUseCaseWrapper(metricController, onRemove)
+
+        wrapper("123")
+
+        verify { metricController.track(Event.ClosedExistingTab) }
+        verify { onRemove("123") }
+    }
+}

--- a/app/src/test/java/org/mozilla/fenix/tabstray/browser/SelectTabUseCaseWrapperTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/browser/SelectTabUseCaseWrapperTest.kt
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabstray.browser
+
+import io.mockk.mockk
+import io.mockk.verify
+import mozilla.components.feature.tabs.TabsUseCases
+import org.junit.Test
+import org.mozilla.fenix.components.metrics.Event
+import org.mozilla.fenix.components.metrics.MetricController
+
+class SelectTabUseCaseWrapperTest {
+
+    val metricController = mockk<MetricController>(relaxed = true)
+    val selectUseCase: TabsUseCases.SelectTabUseCase = mockk(relaxed = true)
+
+    @Test
+    fun `WHEN invoked THEN metrics, use case and callback are triggered`() {
+        val onSelect: (String) -> Unit = mockk(relaxed = true)
+        val wrapper = SelectTabUseCaseWrapper(metricController, selectUseCase, onSelect)
+
+        wrapper("123")
+
+        verify { metricController.track(Event.OpenedExistingTab) }
+        verify { selectUseCase("123") }
+        verify { onSelect("123") }
+    }
+}

--- a/app/src/test/java/org/mozilla/fenix/tabstray/ext/TabSessionStateKtTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/ext/TabSessionStateKtTest.kt
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabstray.ext
+
+import io.mockk.every
+import io.mockk.mockk
+import mozilla.components.browser.state.state.ContentState
+import mozilla.components.browser.state.state.TabSessionState
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mozilla.fenix.tabstray.browser.BaseBrowserTrayList.BrowserTabType.NORMAL
+import org.mozilla.fenix.tabstray.browser.BaseBrowserTrayList.BrowserTabType.PRIVATE
+import org.mozilla.fenix.tabstray.browser.BaseBrowserTrayList.Configuration
+
+class TabSessionStateKtTest {
+
+    @Test
+    fun `WHEN configuration is private THEN return true`() {
+        val contentState = mockk<ContentState>()
+        val state = TabSessionState(content = contentState)
+        val config = Configuration(PRIVATE)
+
+        every { contentState.private } returns true
+
+        assertTrue(state.filterFromConfig(config))
+    }
+
+    @Test
+    fun `WHEN configuration is normal THEN return false`() {
+        val contentState = mockk<ContentState>()
+        val state = TabSessionState(content = contentState)
+        val config = Configuration(NORMAL)
+
+        every { contentState.private } returns false
+
+        assertTrue(state.filterFromConfig(config))
+    }
+
+    @Test
+    fun `WHEN configuration does not match THEN return false`() {
+        val contentState = mockk<ContentState>()
+        val state = TabSessionState(content = contentState)
+        val config = Configuration(NORMAL)
+
+        every { contentState.private } returns true
+
+        assertFalse(state.filterFromConfig(config))
+
+        val config2 = Configuration(PRIVATE)
+
+        every { contentState.private } returns false
+
+        assertFalse(state.filterFromConfig(config2))
+    }
+}


### PR DESCRIPTION
The tray should look the same with less function while we refactor for now. 🙃 

You can enabled the refactored tray in Secret Settings.

https://user-images.githubusercontent.com/1370580/110819069-d4472800-825b-11eb-869c-b4839aabb8ff.mp4

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
