### PR TITLE
Resolves #18381: Explicitly set android:extractNativeLibs to true in ApplicationManifest.xml

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,6 +25,7 @@
     <application
         android:name=".FenixApplication"
         android:allowBackup="false"
+        android:extractNativeLibs="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"


### PR DESCRIPTION
Resolves #18381

The Android Gradle Plugin's default for android:extractNativeLibs changed from
true to false beginning with version 3.6.0. Based on GeckoView's needs, we
should ensure that this attribute is explicitly set to true


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: No tests, just a manifest attribute flip
- [N/A] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [N/A] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
