### PR TITLE
Integrate Android Autofill support into Nightly and debug builds.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -466,6 +466,7 @@ dependencies {
 
     implementation Deps.mozilla_feature_accounts
     implementation Deps.mozilla_feature_app_links
+    implementation Deps.mozilla_feature_autofill
     implementation Deps.mozilla_feature_awesomebar
     implementation Deps.mozilla_feature_contextmenu
     implementation Deps.mozilla_feature_customtabs

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -18,6 +18,25 @@
 
     <application
             tools:replace="android:name"
-            android:name="org.mozilla.fenix.DebugFenixApplication" />
+            android:name="org.mozilla.fenix.DebugFenixApplication">
+
+        <activity android:name=".autofill.AutofillUnlockActivity"
+            android:exported="false"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar" />
+
+        <activity android:name=".autofill.AutofillConfirmActivity"
+            android:exported="false"
+            android:theme="@style/Theme.AppCompat.Translucent" />
+
+        <service
+            android:name=".autofill.AutofillService"
+            android:label="@string/app_name"
+            android:permission="android.permission.BIND_AUTOFILL_SERVICE">
+            <intent-filter>
+                <action android:name="android.service.autofill.AutofillService"/>
+            </intent-filter>
+        </service>
+
+    </application>
 
 </manifest>

--- a/app/src/main/java/org/mozilla/fenix/autofill/AutofillConfirmActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/autofill/AutofillConfirmActivity.kt
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.autofill
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import mozilla.components.feature.autofill.AutofillConfiguration
+import mozilla.components.feature.autofill.ui.AbstractAutofillConfirmActivity
+import org.mozilla.fenix.ext.components
+
+/**
+ * Activity responsible for asking the user to confirm before auto-filling a third-party app.
+ */
+@RequiresApi(Build.VERSION_CODES.O)
+class AutofillConfirmActivity : AbstractAutofillConfirmActivity() {
+    override val configuration: AutofillConfiguration by lazy { components.autofillConfiguration }
+}

--- a/app/src/main/java/org/mozilla/fenix/autofill/AutofillService.kt
+++ b/app/src/main/java/org/mozilla/fenix/autofill/AutofillService.kt
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.autofill
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import mozilla.components.feature.autofill.AbstractAutofillService
+import mozilla.components.feature.autofill.AutofillConfiguration
+import org.mozilla.fenix.ext.components
+
+/**
+ * Service responsible for implementing Android's Autofill framework.
+ */
+@RequiresApi(Build.VERSION_CODES.O)
+class AutofillService : AbstractAutofillService() {
+    override val configuration: AutofillConfiguration by lazy { components.autofillConfiguration }
+}

--- a/app/src/main/java/org/mozilla/fenix/autofill/AutofillUnlockActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/autofill/AutofillUnlockActivity.kt
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.autofill
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import mozilla.components.feature.autofill.AutofillConfiguration
+import mozilla.components.feature.autofill.ui.AbstractAutofillUnlockActivity
+import org.mozilla.fenix.ext.components
+
+/**
+ * Activity responsible for unlocking the autofill service by asking the user to verify.
+ */
+@RequiresApi(Build.VERSION_CODES.O)
+class AutofillUnlockActivity : AbstractAutofillUnlockActivity() {
+    override val configuration: AutofillConfiguration by lazy { components.autofillConfiguration }
+}

--- a/app/src/main/java/org/mozilla/fenix/components/Components.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Components.kt
@@ -14,12 +14,15 @@ import mozilla.components.feature.addons.migration.DefaultSupportedAddonsChecker
 import mozilla.components.feature.addons.migration.SupportedAddonsChecker
 import mozilla.components.feature.addons.update.AddonUpdater
 import mozilla.components.feature.addons.update.DefaultAddonUpdater
+import mozilla.components.feature.autofill.AutofillConfiguration
 import mozilla.components.feature.sitepermissions.SitePermissionsStorage
 import mozilla.components.lib.publicsuffixlist.PublicSuffixList
 import mozilla.components.support.migration.state.MigrationStore
 import org.mozilla.fenix.BuildConfig
 import org.mozilla.fenix.Config
 import org.mozilla.fenix.HomeActivity
+import org.mozilla.fenix.R
+import org.mozilla.fenix.autofill.AutofillUnlockActivity
 import org.mozilla.fenix.perf.StrictModeManager
 import org.mozilla.fenix.components.metrics.AppStartupTelemetry
 import org.mozilla.fenix.ext.components
@@ -153,6 +156,17 @@ class Components(private val context: Context) {
         ReviewPromptController(
             context,
             FenixReviewSettings(settings)
+        )
+    }
+
+    val autofillConfiguration by lazyMonitored {
+        AutofillConfiguration(
+            storage = core.passwordsStorage,
+            publicSuffixList = publicSuffixList,
+            unlockActivity = AutofillUnlockActivity::class.java,
+            confirmActivity = AutofillConfiguration::class.java,
+            applicationName = context.getString(R.string.app_name),
+            httpClient = core.client
         )
     }
 }

--- a/app/src/nightly/AndroidManifest.xml
+++ b/app/src/nightly/AndroidManifest.xml
@@ -4,6 +4,24 @@
 
     <application>
 
+        <activity android:name=".autofill.AutofillUnlockActivity"
+            android:exported="false"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar" />
+
+        <activity android:name=".autofill.AutofillConfirmActivity"
+            android:exported="false"
+            android:theme="@style/Theme.AppCompat.Translucent" />
+
+        <service
+            android:name=".autofill.AutofillService"
+            android:label="@string/app_name"
+            android:permission="android.permission.BIND_AUTOFILL_SERVICE">
+            <intent-filter>
+                <action android:name="android.service.autofill.AutofillService"/>
+            </intent-filter>
+        </service>
+
+
         <service android:name=".customtabs.CustomTabsService">
             <!-- Trusted Web Activities are currently only supported in nightly. -->
             <intent-filter tools:node="removeAll" />

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -98,6 +98,7 @@ object Deps {
 
     const val mozilla_feature_accounts = "org.mozilla.components:feature-accounts:${Versions.mozilla_android_components}"
     const val mozilla_feature_app_links = "org.mozilla.components:feature-app-links:${Versions.mozilla_android_components}"
+    const val mozilla_feature_autofill = "org.mozilla.components:feature-autofill:${Versions.mozilla_android_components}"
     const val mozilla_feature_awesomebar = "org.mozilla.components:feature-awesomebar:${Versions.mozilla_android_components}"
     const val mozilla_feature_contextmenu = "org.mozilla.components:feature-contextmenu:${Versions.mozilla_android_components}"
     const val mozilla_feature_customtabs = "org.mozilla.components:feature-customtabs:${Versions.mozilla_android_components}"


### PR DESCRIPTION
Only in Nightly and debug for testing and collecting feedback.