### PR TITLE
For #18461: add open in app to the main three dot menu

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
@@ -441,6 +441,19 @@ class DefaultToolbarMenu(
             onItemTapped.invoke(ToolbarMenu.Item.CustomizeReaderView)
         }
 
+        val openInApp = BrowserMenuHighlightableItem(
+            label = context.getString(R.string.browser_menu_open_app_link),
+            startImageResource = R.drawable.ic_open_in_app,
+            iconTintColorResource = primaryTextColor(),
+            highlight = BrowserMenuHighlight.LowPriority(
+                label = context.getString(R.string.browser_menu_open_app_link),
+                notificationTint = getColor(context, R.color.whats_new_notification_color)
+            ),
+            isHighlighted = { !context.settings().openInAppOpened }
+        ) {
+            onItemTapped.invoke(ToolbarMenu.Item.OpenInApp)
+        }
+
         val reportSiteIssuePlaceholder = WebExtensionPlaceholderMenuItem(
             id = WebCompatReporterFeature.WEBCOMPAT_REPORTER_EXTENSION_ID
         )
@@ -500,6 +513,7 @@ class DefaultToolbarMenu(
                 findInPageItem,
                 desktopSiteItem,
                 customizeReaderView.apply { visible = ::shouldShowReaderViewCustomization },
+                openInApp.apply { visible = ::shouldShowOpenInApp },
                 reportSiteIssuePlaceholder,
                 BrowserMenuDivider(),
                 addToHomeScreenItem.apply { visible = ::canAddToHomescreen },


### PR DESCRIPTION
For #18461

Base is https://github.com/mozilla-mobile/fenix/pull/18372, so that should be merged first. This PR just adds the last commit

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
