### PR TITLE
Bug 1694343 - Set `distributionId` right after initializing Glean

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -40,6 +40,7 @@ import mozilla.components.support.rustlog.RustLog
 import mozilla.components.support.utils.logElapsedTime
 import mozilla.components.support.webextensions.WebExtensionSupport
 import org.mozilla.fenix.GleanMetrics.GleanBuildInfo
+import org.mozilla.fenix.GleanMetrics.Metrics
 import org.mozilla.fenix.GleanMetrics.PerfStartup
 import org.mozilla.fenix.components.Components
 import org.mozilla.fenix.components.metrics.MetricServiceType
@@ -114,6 +115,14 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
                 )),
             uploadEnabled = telemetryEnabled,
             buildInfo = GleanBuildInfo.buildInfo
+        )
+
+        // Set this early to guarantee it's in every ping from here on.
+        Metrics.distributionId.set(
+            when (Config.channel.isMozillaOnline) {
+                true -> "MozillaOnline"
+                false -> "Mozilla"
+            }
         )
     }
 

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
@@ -12,7 +12,6 @@ import mozilla.components.service.fxa.manager.SyncEnginesStorage
 import mozilla.components.service.glean.Glean
 import mozilla.components.service.glean.private.NoExtraKeys
 import mozilla.components.support.base.log.logger.Logger
-import org.mozilla.fenix.Config
 import org.mozilla.fenix.GleanMetrics.AboutPage
 import org.mozilla.fenix.GleanMetrics.Addons
 import org.mozilla.fenix.GleanMetrics.AppTheme
@@ -847,13 +846,6 @@ class GleanMetricsService(
             mozillaProductDetector.getMozillaBrowserDefault(context)?.also {
                 defaultMozBrowser.set(it)
             }
-
-            distributionId.set(
-                when (Config.channel.isMozillaOnline) {
-                    true -> "MozillaOnline"
-                    false -> "Mozilla"
-                }
-            )
 
             mozillaProducts.set(mozillaProductDetector.getInstalledMozillaProducts(context))
 


### PR DESCRIPTION
Previously setting it might have been arbitrarily delayed, resulting in
this metrics missing from pings that get submitted earlier.
Setting it early should prevent that.
The performance impact is negligible, Glean dispatches recording that
data off-main-thread anyway.

---

This might help with too many pings missing that value. See [bug 1694343](https://bugzilla.mozilla.org/show_bug.cgi?id=1694343).


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
