### PR TITLE
Add first set of UI tests to Nightly

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
@@ -150,7 +150,7 @@ class HomeScreenRobot {
     fun confirmDeleteCollection() {
         onView(allOf(withText("DELETE"))).click()
         mDevice.waitNotNull(
-            findObject(By.res("org.mozilla.fenix.debug:id/no_collections_header")),
+            findObject(By.res("$packageName:id/no_collections_header")),
             waitingTime
         )
     }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/TabDrawerRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/TabDrawerRobot.kt
@@ -138,7 +138,7 @@ class TabDrawerRobot {
 
     fun snackBarButtonClick(expectedText: String) {
         mDevice.findObject(
-            UiSelector().resourceId("org.mozilla.fenix.debug:id/snackbar_btn")
+            UiSelector().resourceId("$packageName:id/snackbar_btn")
         ).waitForExists(waitingTime)
         onView(allOf(withId(R.id.snackbar_btn), withText(expectedText))).check(
             matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE))

--- a/automation/taskcluster/androidTest/flank-x86-start-test.yml
+++ b/automation/taskcluster/androidTest/flank-x86-start-test.yml
@@ -35,6 +35,12 @@ gcloud:
 
   test-targets:
    - class org.mozilla.fenix.ui.NavigationToolbarTest#visitURLTest
+   - class org.mozilla.fenix.ui.HistoryTest#visitedUrlHistoryTest
+   - class org.mozilla.fenix.ui.SmokeTest#openMainMenuSettingsItemTest
+   - class org.mozilla.fenix.ui.SmokeTest#toggleSearchSuggestions
+   - class org.mozilla.fenix.ui.SmokeTest#deleteCollectionTest
+   - class org.mozilla.fenix.ui.SmokeTest#noHistoryInPrivateBrowsingTest
+   - class org.mozilla.fenix.ui.NoNetworkAccessStartupTests#noNetworkConnectionStartupTest
 
   device:
    - model: Pixel2


### PR DESCRIPTION
For https://github.com/mozilla-mobile/mobile-test-eng/issues/289
Adding tests to run on the Nightly build.
 
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
