### PR TITLE
Issue #17819: buildSrc: Use Maven Central instead of JCenter and use artifact cache.

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -7,5 +7,12 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    if (project.hasProperty("centralRepo")) {
+        maven {
+            name "MavenCentral"
+            url project.property("centralRepo")
+        }
+    } else {
+        mavenCentral()
+    }
 }


### PR DESCRIPTION
`buildSrc` was still using JCenter. We can use Maven Central instead. In addition to that we never used our artifact cache here and always pulled everything from the network.