### PR TITLE
UPLIFT: buildSrc: Use Maven Central instead of JCenter and use artifact cache.

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -7,5 +7,12 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    if (project.hasProperty("centralRepo")) {
+        maven {
+            name "MavenCentral"
+            url project.property("centralRepo")
+        }
+    } else {
+        mavenCentral()
+    }
 }


### PR DESCRIPTION
Uplifting patch from PR #18518 to `releases_v87.0.0`.