### PR TITLE
Enable new tabs tray only for debug builds

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -42,7 +42,7 @@ object FeatureFlags {
     /**
      * Enables the tabs tray re-write with Synced Tabs.
      */
-    val tabsTrayRewrite = Config.channel.isNightlyOrDebug
+    val tabsTrayRewrite = Config.channel.isDebug
 
     /**
      * Enables the updated icon set look and feel.


### PR DESCRIPTION
To avoid bug reports like https://github.com/mozilla-mobile/fenix/issues/18533 let's enable this only for debug builds.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
