### PR TITLE
Closes #12565: Clean up use of Context within ReviewPromptController.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/Components.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Components.kt
@@ -8,6 +8,7 @@ import android.app.Application
 import android.content.Context
 import android.content.Intent
 import androidx.core.net.toUri
+import com.google.android.play.core.review.ReviewManagerFactory
 import mozilla.components.feature.addons.AddonManager
 import mozilla.components.feature.addons.amo.AddonCollectionProvider
 import mozilla.components.feature.addons.migration.DefaultSupportedAddonsChecker
@@ -154,8 +155,8 @@ class Components(private val context: Context) {
 
     val reviewPromptController by lazyMonitored {
         ReviewPromptController(
-            context,
-            FenixReviewSettings(settings)
+            manager = ReviewManagerFactory.create(context),
+            reviewSettings = FenixReviewSettings(settings)
         )
     }
 

--- a/app/src/main/java/org/mozilla/fenix/components/ReviewPromptController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/ReviewPromptController.kt
@@ -5,9 +5,8 @@
 package org.mozilla.fenix.components
 
 import android.app.Activity
-import android.content.Context
 import androidx.annotation.VisibleForTesting
-import com.google.android.play.core.review.ReviewManagerFactory
+import com.google.android.play.core.review.ReviewManager
 import kotlinx.coroutines.Dispatchers.Main
 import kotlinx.coroutines.withContext
 import org.mozilla.fenix.utils.Settings
@@ -41,11 +40,10 @@ class FenixReviewSettings(
  * Controls the Review Prompt behavior.
  */
 class ReviewPromptController(
-    private val context: Context,
+    private val manager: ReviewManager,
     private val reviewSettings: ReviewSettings,
     private val timeNowInMillis: () -> Long = { System.currentTimeMillis() },
     private val tryPromptReview: suspend (Activity) -> Unit = { activity ->
-        val manager = ReviewManagerFactory.create(context)
         val flow = manager.requestReviewFlow()
 
         withContext(Main) {

--- a/app/src/test/java/org/mozilla/fenix/components/ReviewPromptControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/ReviewPromptControllerTest.kt
@@ -4,6 +4,8 @@
 
 package org.mozilla.fenix.components
 
+import com.google.android.play.core.review.ReviewManager
+import com.google.android.play.core.review.ReviewManagerFactory
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
 import mozilla.components.support.test.robolectric.testContext
@@ -11,6 +13,7 @@ import org.junit.Test
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertFalse
+import org.junit.Before
 import org.junit.runner.RunWith
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
@@ -27,6 +30,14 @@ class TestReviewSettings(
 @ExperimentalCoroutinesApi
 @RunWith(FenixRobolectricTestRunner::class)
 class ReviewPromptControllerTest {
+
+    private lateinit var reviewManager: ReviewManager
+
+    @Before
+    fun setUp() {
+        reviewManager = ReviewManagerFactory.create(testContext)
+    }
+
     @Test
     fun promptReviewDoesNotSetMillis() = runBlockingTest {
         var promptWasCalled = false
@@ -37,7 +48,7 @@ class ReviewPromptControllerTest {
         )
 
         val controller = ReviewPromptController(
-            testContext,
+            reviewManager,
             settings,
             { 100L },
             { promptWasCalled = true }
@@ -60,7 +71,7 @@ class ReviewPromptControllerTest {
         )
 
         val controller = ReviewPromptController(
-            testContext,
+            reviewManager,
             settings,
             { 100L },
             { promptWasCalled = true }
@@ -82,7 +93,7 @@ class ReviewPromptControllerTest {
         )
 
         val controller = ReviewPromptController(
-            testContext,
+            reviewManager,
             settings,
             { 100L },
             { promptWasCalled = true }
@@ -102,7 +113,7 @@ class ReviewPromptControllerTest {
         )
 
         val controller = ReviewPromptController(
-            testContext,
+            reviewManager,
             settings,
             { 100L },
             { promptWasCalled = true }
@@ -126,7 +137,7 @@ class ReviewPromptControllerTest {
         )
 
         val controller = ReviewPromptController(
-            testContext,
+            reviewManager,
             settings,
             { 0L }
         )
@@ -149,7 +160,7 @@ class ReviewPromptControllerTest {
         )
 
         val controller = ReviewPromptController(
-            testContext,
+            reviewManager,
             settings,
             { TEST_TIME_NOW }
         )


### PR DESCRIPTION
The rest of the controllers in Fenix that have context as constructor param use it to retrieve resources, so I rather keep them as they are. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
