### PR TITLE
Bug 1699639 - Run browsertime tests in python3.

### DIFF
--- a/taskcluster/ci/browsertime/kind.yml
+++ b/taskcluster/ci/browsertime/kind.yml
@@ -37,7 +37,7 @@ job-defaults:
                     subject: '[{product_name}] Raptor-Browsertime job "{task_name}" failed'
                     to-addresses: [perftest-alerts@mozilla.com]
             default: {}
-    run-on-tasks-for: []
+    run-on-tasks-for: [github-pull-request]
     treeherder:
         kind: test
         tier: 2

--- a/taskcluster/ci/browsertime/kind.yml
+++ b/taskcluster/ci/browsertime/kind.yml
@@ -137,7 +137,6 @@ jobs:
             - allrecipes
 
     youtube-playback-av1-sfr:
-        run-on-tasks-for: [github-pull-request]
         description: "Raptor YouTube Playback AV1 SFR on Fenix"
         test-name: youtube-playback-av1-sfr
         run-visual-metrics: False

--- a/taskcluster/ci/browsertime/kind.yml
+++ b/taskcluster/ci/browsertime/kind.yml
@@ -37,7 +37,7 @@ job-defaults:
                     subject: '[{product_name}] Raptor-Browsertime job "{task_name}" failed'
                     to-addresses: [perftest-alerts@mozilla.com]
             default: {}
-    run-on-tasks-for: [github-pull-request]
+    run-on-tasks-for: []
     treeherder:
         kind: test
         tier: 2
@@ -63,6 +63,7 @@ job-defaults:
             NO_FAIL_ON_TEST_ERRORS: "1"
             XPCOM_DEBUG_BREAK: "warn"
             PYTHON: "python3"
+            LANG: "en_US.UTF-8"
         artifacts:
             - name: public/logs/
               path: workspace/logs
@@ -136,6 +137,7 @@ jobs:
             - allrecipes
 
     youtube-playback-av1-sfr:
+        run-on-tasks-for: [github-pull-request]
         description: "Raptor YouTube Playback AV1 SFR on Fenix"
         test-name: youtube-playback-av1-sfr
         run-visual-metrics: False

--- a/taskcluster/ci/browsertime/kind.yml
+++ b/taskcluster/ci/browsertime/kind.yml
@@ -62,6 +62,7 @@ job-defaults:
             NEED_XVFB: "false"
             NO_FAIL_ON_TEST_ERRORS: "1"
             XPCOM_DEBUG_BREAK: "warn"
+            PYTHON: "python3"
         artifacts:
             - name: public/logs/
               path: workspace/logs


### PR DESCRIPTION
Currently, the fenix browsertime tests are failing as they are running in python2.7 but we've upgraded the code to use python3. This patch attempts to fix this issue. See the following bug for more details: https://bugzilla.mozilla.org/show_bug.cgi?id=1699639 