### PR TITLE
[SDK-218] Nimbus updates to provide app_name and channel

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/experiments/NimbusSetup.kt
+++ b/app/src/main/java/org/mozilla/fenix/experiments/NimbusSetup.kt
@@ -10,9 +10,11 @@ import android.os.StrictMode
 import io.sentry.Sentry
 import mozilla.components.service.nimbus.NimbusApi
 import mozilla.components.service.nimbus.Nimbus
+import mozilla.components.service.nimbus.NimbusAppInfo
 import mozilla.components.service.nimbus.NimbusDisabled
 import mozilla.components.service.nimbus.NimbusServerSettings
 import mozilla.components.support.base.log.logger.Logger
+import org.mozilla.fenix.Config
 import org.mozilla.fenix.components.isSentryEnabled
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.settings
@@ -37,7 +39,17 @@ fun createNimbus(context: Context, url: String?): NimbusApi =
                 context.settings().isExperimentationEnabled
             }
 
-        Nimbus(context, serverSettings).apply {
+        // The name "fenix" here corresponds to the app_name defined for the family of apps
+        // that encompasses all of the channels for the Fenix app.  This is defined upstream in
+        // the telemetry system. For more context on where the app_name come from see:
+        // https://probeinfo.telemetry.mozilla.org/v2/glean/app-listings
+        // and
+        // https://github.com/mozilla/probe-scraper/blob/master/repositories.yaml
+        val appInfo = NimbusAppInfo(
+            appName = "fenix",
+            channel = Config.channel.toString()
+        )
+        Nimbus(context, appInfo, serverSettings).apply {
             // This performs the minimal amount of work required to load branch and enrolment data
             // into memory. If `getExperimentBranch` is called from another thread between here
             // and the next nimbus disk write (setting `globalUserParticipation` or

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "74.0.20210318232824"
+    const val VERSION = "74.0.20210319190549"
 }


### PR DESCRIPTION
This patch provides the `app_name` and `channel` info to Nimbus.

Taken from https://github.com/mozilla-mobile/fenix/pull/18465


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
