### PR TITLE
For #18395: Text selection menu is not dismissed after activating reader mode

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -167,6 +167,9 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
 
     private lateinit var navigationToolbar: Toolbar
 
+    // Tracker for contextual menu (Copy|Search|Select all|etc...)
+    private var actionMode: ActionMode? = null
+
     final override fun onCreate(savedInstanceState: Bundle?): Unit = PerfStartup.homeActivityOnCreate.measureNoInline {
         // DO NOT MOVE ANYTHING ABOVE THIS addMarker CALL.
         components.core.engine.profiler?.addMarker("Activity.onCreate", "HomeActivity")
@@ -522,8 +525,6 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
         }.asView()
         else -> super.onCreateView(parent, name, context, attrs)
     }
-
-    private var actionMode: ActionMode? = null
 
     override fun onActionModeStarted(mode: ActionMode?) {
         actionMode = mode

--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -16,6 +16,7 @@ import android.util.AttributeSet
 import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.View
+import android.view.ActionMode
 import android.view.ViewConfiguration
 import android.view.WindowManager.LayoutParams.FLAG_SECURE
 import androidx.annotation.CallSuper
@@ -520,6 +521,22 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
             )
         }.asView()
         else -> super.onCreateView(parent, name, context, attrs)
+    }
+
+    private var actionMode: ActionMode? = null
+
+    override fun onActionModeStarted(mode: ActionMode?) {
+        actionMode = mode
+        super.onActionModeStarted(mode)
+    }
+
+    override fun onActionModeFinished(mode: ActionMode?) {
+        actionMode = null
+        super.onActionModeFinished(mode)
+    }
+
+    fun finishActionMode() {
+        actionMode?.finish().also { actionMode = null }
     }
 
     @Suppress("MagicNumber")

--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -282,7 +282,8 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
         val readerMenuController = DefaultReaderModeController(
             readerViewFeature,
             view.readerViewControlsBar,
-            isPrivate = activity.browsingModeManager.mode.isPrivate
+            isPrivate = activity.browsingModeManager.mode.isPrivate,
+            onReaderModeChanged = { activity.finishActionMode() }
         )
         val browserToolbarController = DefaultBrowserToolbarController(
             store = store,

--- a/app/src/main/java/org/mozilla/fenix/browser/readermode/ReaderModeController.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/readermode/ReaderModeController.kt
@@ -24,9 +24,11 @@ interface ReaderModeController {
 class DefaultReaderModeController(
     private val readerViewFeature: ViewBoundFeatureWrapper<ReaderViewFeature>,
     private val readerViewControlsBar: View,
-    private val isPrivate: Boolean = false
+    private val isPrivate: Boolean = false,
+    private val onReaderModeChanged: () -> Unit = {}
 ) : ReaderModeController {
     override fun hideReaderView() {
+        onReaderModeChanged()
         readerViewFeature.withFeature {
             it.hideReaderView()
             it.hideControls()
@@ -34,6 +36,7 @@ class DefaultReaderModeController(
     }
 
     override fun showReaderView() {
+        onReaderModeChanged()
         readerViewFeature.withFeature { it.showReaderView() }
     }
 

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt
@@ -99,6 +99,7 @@ class DefaultBrowserToolbarController(
     }
 
     override fun handleReaderModePressed(enabled: Boolean) {
+        activity.finishActionMode()
         if (enabled) {
             readerModeController.showReaderView()
             metrics.track(Event.ReaderModeOpened)

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt
@@ -99,7 +99,6 @@ class DefaultBrowserToolbarController(
     }
 
     override fun handleReaderModePressed(enabled: Boolean) {
-        activity.finishActionMode()
         if (enabled) {
             readerModeController.showReaderView()
             metrics.track(Event.ReaderModeOpened)

--- a/app/src/test/java/org/mozilla/fenix/browser/readermode/DefaultReaderModeControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/browser/readermode/DefaultReaderModeControllerTest.kt
@@ -32,6 +32,7 @@ class DefaultReaderModeControllerTest {
     private lateinit var readerViewFeature: ReaderViewFeature
     private lateinit var featureWrapper: ViewBoundFeatureWrapper<ReaderViewFeature>
     private lateinit var readerViewControlsBar: View
+    private lateinit var onReaderModeChanged: () -> Unit
 
     @Before
     fun setup() {
@@ -50,6 +51,7 @@ class DefaultReaderModeControllerTest {
             view = mockk(relaxed = true)
         )
         readerViewControlsBar = mockk(relaxed = true)
+        onReaderModeChanged = mockk(relaxed = true)
 
         every { readerViewFeature.hideReaderView() } returns Unit
         every { readerViewFeature.showReaderView() } returns Unit
@@ -59,17 +61,27 @@ class DefaultReaderModeControllerTest {
 
     @Test
     fun testHideReaderView() {
-        val controller = DefaultReaderModeController(featureWrapper, readerViewControlsBar)
+        val controller = DefaultReaderModeController(
+            featureWrapper,
+            readerViewControlsBar,
+            onReaderModeChanged = onReaderModeChanged
+        )
         controller.hideReaderView()
         verify { readerViewFeature.hideReaderView() }
         verify { readerViewFeature.hideControls() }
+        verify { onReaderModeChanged.invoke() }
     }
 
     @Test
     fun testShowReaderView() {
-        val controller = DefaultReaderModeController(featureWrapper, readerViewControlsBar)
+        val controller = DefaultReaderModeController(
+            featureWrapper,
+            readerViewControlsBar,
+            onReaderModeChanged = onReaderModeChanged
+        )
         controller.showReaderView()
         verify { readerViewFeature.showReaderView() }
+        verify { onReaderModeChanged.invoke() }
     }
 
     @Test


### PR DESCRIPTION
Fixes #18395 

Added a variable `actionMode` to track the state of contextual text selection menu and a method `finishActionMode()` to dismiss it before switching to reader mode.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
