### PR TITLE
Issue #18453

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/intent/DeepLinkIntentProcessor.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/intent/DeepLinkIntentProcessor.kt
@@ -36,8 +36,7 @@ class DeepLinkIntentProcessor(
     private val logger = Logger("DeepLinkIntentProcessor")
 
     override fun process(intent: Intent, navController: NavController, out: Intent): Boolean {
-        val scheme =
-            intent.scheme?.equals(BuildConfig.DEEP_LINK_SCHEME, ignoreCase = true) ?: return false
+        val scheme = intent.scheme?.equals(BuildConfig.DEEP_LINK_SCHEME, ignoreCase = true) ?: return false
         return if (scheme) {
             intent.data?.let { handleDeepLink(it, navController) }
             true

--- a/app/src/main/java/org/mozilla/fenix/home/intent/DeepLinkIntentProcessor.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/intent/DeepLinkIntentProcessor.kt
@@ -21,6 +21,8 @@ import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.components.SearchWidgetCreator
 import org.mozilla.fenix.ext.alreadyOnDestination
+import org.mozilla.fenix.home.intent.DeepLinkIntentProcessor.DeepLinkVerifier
+import org.mozilla.fenix.settings.SupportUtils
 
 /**
  * Deep links in the form of `fenix://host` open different parts of the app.
@@ -34,7 +36,8 @@ class DeepLinkIntentProcessor(
     private val logger = Logger("DeepLinkIntentProcessor")
 
     override fun process(intent: Intent, navController: NavController, out: Intent): Boolean {
-        val scheme = intent.scheme?.equals(BuildConfig.DEEP_LINK_SCHEME, ignoreCase = true) ?: return false
+        val scheme =
+            intent.scheme?.equals(BuildConfig.DEEP_LINK_SCHEME, ignoreCase = true) ?: return false
         return if (scheme) {
             intent.data?.let { handleDeepLink(it, navController) }
             true
@@ -93,6 +96,16 @@ class DeepLinkIntentProcessor(
                     settingsIntent.putExtra(SETTINGS_SHOW_FRAGMENT_ARGS,
                         bundleOf(SETTINGS_SELECT_OPTION_KEY to DEFAULT_BROWSER_APP_OPTION))
                     activity.startActivity(settingsIntent)
+                } else {
+                    activity.openToBrowserAndLoad(
+                        searchTermOrURL = SupportUtils.getSumoURLForTopic(
+                            activity,
+                            SupportUtils.SumoTopic.SET_AS_DEFAULT_BROWSER
+                        ),
+                        newTab = true,
+                        from = BrowserDirection.FromGlobal,
+                        flags = EngineSession.LoadUrlFlags.external()
+                    )
                 }
             }
             "open" -> {

--- a/app/src/test/java/org/mozilla/fenix/home/intent/DeepLinkIntentProcessorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/intent/DeepLinkIntentProcessorTest.kt
@@ -8,6 +8,7 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Build.VERSION_CODES.M
 import android.os.Build.VERSION_CODES.N
+import android.os.Build.VERSION_CODES.P
 import androidx.core.net.toUri
 import androidx.navigation.NavController
 import io.mockk.Called

--- a/app/src/test/java/org/mozilla/fenix/home/intent/DeepLinkIntentProcessorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/intent/DeepLinkIntentProcessorTest.kt
@@ -248,7 +248,7 @@ class DeepLinkIntentProcessorTest {
     }
 
     @Test
-    @Config(minSdk = N)
+    @Config(minSdk = N, maxSdk = P)
     fun `process make_default_browser deep link for above API 23`() {
         assertTrue(processor.process(testIntent("make_default_browser"), navController, out))
 

--- a/app/src/test/java/org/mozilla/fenix/home/intent/DeepLinkIntentProcessorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/intent/DeepLinkIntentProcessorTest.kt
@@ -249,7 +249,7 @@ class DeepLinkIntentProcessorTest {
     }
 
     @Test
-    @Config(minSdk = N, maxSdk = P)
+    @Config(minSdk = N)
     fun `process make_default_browser deep link for above API 23`() {
         assertTrue(processor.process(testIntent("make_default_browser"), navController, out))
 

--- a/app/src/test/java/org/mozilla/fenix/home/intent/DeepLinkIntentProcessorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/intent/DeepLinkIntentProcessorTest.kt
@@ -8,7 +8,6 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Build.VERSION_CODES.M
 import android.os.Build.VERSION_CODES.N
-import android.os.Build.VERSION_CODES.P
 import androidx.core.net.toUri
 import androidx.navigation.NavController
 import io.mockk.Called

--- a/docs/mma.md
+++ b/docs/mma.md
@@ -357,7 +357,7 @@ Here is the list of current deep links available, which can be found here in the
   </tr>
   <tr>
     <td>`fenix://make_default_browser`</td>
-    <td>Opens to the Android default apps settings screen. **Only works on Android API >=24**</td>
+    <td>Opens to the Android default apps settings screen. If Android API <= 23 opens tab to support page defined in SupportUtils.SumoTopic.SET_AS_DEFAULT_BROWSER</td>
   </tr>
   <tr>
     <td>`fenix://settings_notifications`</td>


### PR DESCRIPTION
Open to this support page when URI to make_default_browser (eg.  `adb shell am start -a android.intent.action.VIEW -d fenix-nightly://make_default_browser\`) is open on Android SDK 23 and below: 
![fenix_set_default_browser_support_page](https://user-images.githubusercontent.com/6177662/112208654-7ed22a00-8c10-11eb-980d-ddc820bcf4f2.png)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
