### PR TITLE
set tasks_for to action to use release signing in relpro

### DIFF
--- a/taskcluster/fenix_taskgraph/release_promotion.py
+++ b/taskcluster/fenix_taskgraph/release_promotion.py
@@ -159,6 +159,7 @@ def release_promotion_action(parameters, graph_config, input, task_group_id, tas
     else:
         raise ValueError("Unsupported version type: {}".format(version.version_type))
     parameters['release_type'] = release_type
+    parameters['tasks_for'] = "action"
 
     parameters['pull_request_number'] = None
 


### PR DESCRIPTION
I *think* this will fix beta signing.
We may need to uplift this fix to other branches, not sure.

This is the fenix equivalent to https://github.com/mozilla-mobile/android-components/blob/master/taskcluster/ac_taskgraph/release_promotion.py#L154 .