### PR TITLE
For #18616 #18122 - Fix find in bar pagebar layout issues

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -371,8 +371,12 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
                 store = store,
                 sessionId = customTabSessionId,
                 stub = view.stubFindInPage,
-                engineView = view.engineView,
-                toolbar = browserToolbarView.view
+                engineView = engineView,
+                toolbarInfo = FindInPageIntegration.ToolbarInfo(
+                    browserToolbarView.view,
+                    !context.settings().shouldUseFixedTopToolbar && context.settings().isDynamicToolbarEnabled,
+                    !context.settings().shouldUseBottomToolbar
+                )
             ),
             owner = this,
             view = view

--- a/app/src/main/java/org/mozilla/fenix/components/FindInPageIntegration.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/FindInPageIntegration.kt
@@ -67,6 +67,10 @@ class FindInPageIntegration(
             } else {
                 engineViewParent.translationY = 0f
             }
+        } else {
+            if (toolbarInfo.isToolbarDynamic) {
+                engineViewParentParams.bottomMargin = 0
+            }
         }
     }
 
@@ -86,6 +90,10 @@ class FindInPageIntegration(
                 // With a fixed toolbar the EngineView is anchored below the toolbar with 0 Y translation.
                 engineViewParent.translationY = -toolbarInfo.toolbar.height.toFloat()
             }
+        } else {
+            // With a bottom toolbar the EngineView is already anchored to the top of the screen.
+            // Need just to ensure space for the find in page bar under the engineView.
+            engineViewParentParams.bottomMargin = toolbarInfo.toolbar.height
         }
     }
 

--- a/app/src/test/java/org/mozilla/fenix/components/FindInPageIntegrationTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/FindInPageIntegrationTest.kt
@@ -1,0 +1,255 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.components
+
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.core.view.isVisible
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
+import mozilla.components.browser.engine.gecko.GeckoEngineView
+import mozilla.components.browser.toolbar.BrowserToolbar
+import mozilla.components.concept.engine.EngineView
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+class FindInPageIntegrationTest {
+    // For ease of tests naming "find in page bar" is referred to as FIPB.
+
+    @Test
+    fun `GIVEN FIPB not shown WHEN prepareLayoutForFindBar is called for a dynamic top toolbar THEN toolbar is hidden and browser translated up`() {
+        val toolbar: BrowserToolbar = mockk(relaxed = true) {
+            every { height } returns 123
+        }
+        val engineViewParent: FrameLayout = mockk(relaxed = true)
+        val engineViewParentParams = ViewGroup.MarginLayoutParams(100, 100)
+        val toolbarInfo = FindInPageIntegration.ToolbarInfo(
+            toolbar = toolbar,
+            isToolbarDynamic = true,
+            isToolbarPlacedAtTop = true
+        )
+        val feature = spyk(FindInPageIntegration(mockk(), null, mockk(), mockk(), toolbarInfo)) {
+            every { getEngineViewsParentLayoutParams() } returns engineViewParentParams
+            every { getEngineViewParent() } returns engineViewParent
+        }
+
+        feature.prepareLayoutForFindBar()
+
+        verify { toolbar.isVisible = false }
+        verify { engineViewParent.translationY = 0f }
+        // MockKException: Missing calls inside verify { ... } block if verifying the bottomMargin setter on a mockk
+        // So I used a real instance and assert on the value actually set.
+        assertEquals(123, engineViewParentParams.bottomMargin)
+    }
+
+    @Test
+    fun `GIVEN FIPB not shown WHEN prepareLayoutForFindBar is called for a fixed top toolbar THEN toolbar is hidden and browser translated up`() {
+        val toolbar: BrowserToolbar = mockk(relaxed = true) {
+            every { height } returns 123
+        }
+        val engineViewParent: FrameLayout = mockk(relaxed = true)
+        val engineViewParentParams = ViewGroup.MarginLayoutParams(100, 100)
+        val toolbarInfo = FindInPageIntegration.ToolbarInfo(
+            toolbar = toolbar,
+            isToolbarDynamic = false,
+            isToolbarPlacedAtTop = true
+        )
+        val feature = spyk(FindInPageIntegration(mockk(), null, mockk(), mockk(), toolbarInfo)) {
+            every { getEngineViewsParentLayoutParams() } returns engineViewParentParams
+            every { getEngineViewParent() } returns engineViewParent
+        }
+
+        feature.prepareLayoutForFindBar()
+
+        verify { toolbar.isVisible = false }
+        verify { engineViewParent.translationY = -123f }
+        // MockKException: Missing calls inside verify { ... } block if verifying the bottomMargin setter on a mockk
+        // So a real instance is used to then assert on the value actually set.
+        assertEquals(0, engineViewParentParams.bottomMargin)
+    }
+
+    @Test
+    fun `GIVEN FIPB shown WHEN restorePreviousLayout is called for a dynamic top toolbar THEN toolbar is shown and browser translated down`() {
+        val toolbar: BrowserToolbar = mockk(relaxed = true) {
+            every { height } returns 123
+        }
+        val engineViewParent: FrameLayout = mockk(relaxed = true)
+        val engineViewParentParams = ViewGroup.MarginLayoutParams(100, 100)
+        val toolbarInfo = FindInPageIntegration.ToolbarInfo(
+            toolbar = toolbar,
+            isToolbarDynamic = true,
+            isToolbarPlacedAtTop = true
+        )
+        val feature = spyk(FindInPageIntegration(mockk(), null, mockk(), mockk(), toolbarInfo)) {
+            every { getEngineViewsParentLayoutParams() } returns engineViewParentParams
+            every { getEngineViewParent() } returns engineViewParent
+        }
+
+        feature.restorePreviousLayout()
+
+        verify { toolbar.isVisible = true }
+        verify { engineViewParent.translationY = 123f }
+        // MockKException: Missing calls inside verify { ... } block if verifying the bottomMargin setter on a mockk
+        // So I used a real instance and assert on the value actually set.
+        assertEquals(0, engineViewParentParams.bottomMargin)
+    }
+
+    @Test
+    fun `GIVEN FIPB shown WHEN restorePreviousLayout is called for a fixed top toolbar THEN toolbar is shown and browser translated down`() {
+        val toolbar: BrowserToolbar = mockk(relaxed = true) {
+            every { height } returns 123
+        }
+        val engineViewParent: FrameLayout = mockk(relaxed = true)
+        val engineViewParentParams = ViewGroup.MarginLayoutParams(100, 100)
+        val toolbarInfo = FindInPageIntegration.ToolbarInfo(
+            toolbar = toolbar,
+            isToolbarDynamic = false,
+            isToolbarPlacedAtTop = true
+        )
+        val feature = spyk(FindInPageIntegration(mockk(), null, mockk(), mockk(), toolbarInfo)) {
+            every { getEngineViewsParentLayoutParams() } returns engineViewParentParams
+            every { getEngineViewParent() } returns engineViewParent
+        }
+
+        feature.restorePreviousLayout()
+
+        verify { toolbar.isVisible = true }
+        verify { engineViewParent.translationY = 0f }
+        // MockKException: Missing calls inside verify { ... } block if verifying the bottomMargin setter on a mockk
+        // So I used a real instance and assert on the value actually set.
+        assertEquals(0, engineViewParentParams.bottomMargin)
+    }
+
+    @Test
+    fun `GIVEN FIPB not shown WHEN prepareLayoutForFindBar is called for a dynamic bottom toolbar THEN toolbar is hidden and browser is made smaller`() {
+        val toolbar: BrowserToolbar = mockk(relaxed = true) {
+            every { height } returns 123
+        }
+        val engineViewParent: FrameLayout = mockk(relaxed = true)
+        val engineViewParentParams = ViewGroup.MarginLayoutParams(100, 100)
+        val toolbarInfo = FindInPageIntegration.ToolbarInfo(
+            toolbar = toolbar,
+            isToolbarDynamic = true,
+            isToolbarPlacedAtTop = false
+        )
+        val feature = spyk(FindInPageIntegration(mockk(), null, mockk(), mockk(), toolbarInfo)) {
+            every { getEngineViewsParentLayoutParams() } returns engineViewParentParams
+            every { getEngineViewParent() } returns engineViewParent
+        }
+
+        feature.prepareLayoutForFindBar()
+
+        verify { toolbar.isVisible = false }
+        verify(exactly = 0) { engineViewParent.translationY = any() }
+        // MockKException: Missing calls inside verify { ... } block if verifying the bottomMargin setter on a mockk
+        // So I used a real instance and assert on the value actually set.
+        assertEquals(123, engineViewParentParams.bottomMargin)
+    }
+
+    @Test
+    fun `GIVEN FIPB not shown WHEN prepareLayoutForFindBar is called for a fixed bottom toolbar THEN toolbar is hidden and browser remains the same`() {
+        val toolbar: BrowserToolbar = mockk(relaxed = true) {
+            every { height } returns 123
+        }
+        val engineViewParent: FrameLayout = mockk(relaxed = true)
+        val engineViewParentParams = ViewGroup.MarginLayoutParams(100, 100)
+        val toolbarInfo = FindInPageIntegration.ToolbarInfo(
+            toolbar = toolbar,
+            isToolbarDynamic = false,
+            isToolbarPlacedAtTop = false
+        )
+        val feature = spyk(FindInPageIntegration(mockk(), null, mockk(), mockk(), toolbarInfo)) {
+            every { getEngineViewsParentLayoutParams() } returns engineViewParentParams
+            every { getEngineViewParent() } returns engineViewParent
+        }
+
+        feature.prepareLayoutForFindBar()
+
+        verify { toolbar.isVisible = false }
+        verify(exactly = 0) { engineViewParent.translationY = any() }
+        // MockKException: Missing calls inside verify { ... } block if verifying the bottomMargin setter on a mockk
+        // So I used a real instance and assert on the value actually set.
+        assertEquals(123, engineViewParentParams.bottomMargin)
+    }
+
+    @Test
+    fun `GIVEN FIPB shown WHEN restorePreviousLayout is called for a dynamic bottom toolbar THEN toolbar is shown and browser is made bigger`() {
+        val toolbar: BrowserToolbar = mockk(relaxed = true) {
+            every { height } returns 123
+        }
+        val engineViewParent: FrameLayout = mockk(relaxed = true)
+        val engineViewParentParams = ViewGroup.MarginLayoutParams(100, 100)
+        val toolbarInfo = FindInPageIntegration.ToolbarInfo(
+            toolbar = toolbar,
+            isToolbarDynamic = true,
+            isToolbarPlacedAtTop = false
+        )
+        val feature = spyk(FindInPageIntegration(mockk(), null, mockk(), mockk(), toolbarInfo)) {
+            every { getEngineViewsParentLayoutParams() } returns engineViewParentParams
+            every { getEngineViewParent() } returns engineViewParent
+        }
+
+        feature.restorePreviousLayout()
+
+        verify { toolbar.isVisible = true }
+        verify(exactly = 0) { engineViewParent.translationY = any() }
+        // MockKException: Missing calls inside verify { ... } block if verifying the bottomMargin setter on a mockk
+        // So I used a real instance and assert on the value actually set.
+        assertEquals(0, engineViewParentParams.bottomMargin)
+    }
+
+    @Test
+    fun `GIVEN FIPB shown WHEN restorePreviousLayout is called for a fixed bottom toolbar THEN toolbar is shown and browser remains the same`() {
+        val toolbar: BrowserToolbar = mockk(relaxed = true) {
+            every { height } returns 123
+        }
+        val engineViewParent: FrameLayout = mockk(relaxed = true)
+        val engineViewParentParams = ViewGroup.MarginLayoutParams(100, 100)
+        val toolbarInfo = FindInPageIntegration.ToolbarInfo(
+            toolbar = toolbar,
+            isToolbarDynamic = true,
+            isToolbarPlacedAtTop = false
+        )
+        val feature = spyk(FindInPageIntegration(mockk(), null, mockk(), mockk(), toolbarInfo)) {
+            every { getEngineViewsParentLayoutParams() } returns engineViewParentParams
+            every { getEngineViewParent() } returns engineViewParent
+        }
+
+        feature.restorePreviousLayout()
+
+        verify { toolbar.isVisible = true }
+        verify(exactly = 0) { engineViewParent.translationY = any() }
+        // MockKException: Missing calls inside verify { ... } block if verifying the bottomMargin setter on a mockk
+        // So I used a real instance and assert on the value actually set.
+        assertEquals(0, engineViewParentParams.bottomMargin)
+    }
+
+    @Test
+    fun `GIVEN FindInPageIntegration WHEN getEngineViewParent is called THEN it returns EngineView's layout parent`() {
+        val parent: FrameLayout = mockk()
+        val engineView: GeckoEngineView = mockk(relaxed = true)
+        every { (engineView as EngineView).asView().parent } returns parent
+
+        val feature = FindInPageIntegration(mockk(), null, mockk(), engineView, mockk())
+
+        assertSame(parent as View, feature.getEngineViewParent())
+    }
+
+    @Test
+    fun `GIVEN FindInPageIntegration WHEN getEngineViewsParentLayoutParams is called THEN it returns EngineView's layout parent MarginLayoutParams`() {
+        val parent: FrameLayout = mockk(relaxed = true) {
+            every { layoutParams } returns mockk<ViewGroup.MarginLayoutParams>(relaxed = true)
+        }
+        val engineView: GeckoEngineView = mockk(relaxed = true)
+        val feature = spyk(FindInPageIntegration(mockk(), null, mockk(), engineView, mockk()))
+        every { feature.getEngineViewParent() } returns parent
+
+        assertSame(parent.layoutParams, feature.getEngineViewsParentLayoutParams())
+    }
+}


### PR DESCRIPTION
There are certain issues with the find in page bar appearing at the bottom of the screen and the toolbar disappearing.
The EngineView needs also to be updated in the BrowserFragment layout.
After this changes when the find in page bar is shown the EngineView will extend to the top of the screen and be placed at the top of the find in par page.

Moving the EngineView up the find in bar page when that shown and to the bottom of the screen when that is hidden can be seen as an issue and for more investigations and a possible fix I've opened https://github.com/mozilla-mobile/fenix/issues/18696

Recording showing the entire browser content shown

https://user-images.githubusercontent.com/11428869/112974075-b84bed80-915a-11eb-9b72-725354f5e25a.mp4



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
