### PR TITLE
For #18667 - Migrated exitImmersiveModeIfNeeded to Fenix

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -80,7 +80,6 @@ import mozilla.components.service.sync.logins.DefaultLoginValidationDelegate
 import mozilla.components.support.base.feature.PermissionsFeature
 import mozilla.components.support.base.feature.UserInteractionHandler
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
-import mozilla.components.support.ktx.android.view.exitImmersiveModeIfNeeded
 import mozilla.components.support.ktx.android.view.hideKeyboard
 import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifAnyChanged
 import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
@@ -110,7 +109,6 @@ import org.mozilla.fenix.downloads.DynamicDownloadDialog
 import org.mozilla.fenix.ext.accessibilityManager
 import org.mozilla.fenix.ext.breadcrumb
 import org.mozilla.fenix.ext.components
-import org.mozilla.fenix.ext.enterToImmersiveMode
 import org.mozilla.fenix.ext.getPreferenceKey
 import org.mozilla.fenix.ext.hideToolbar
 import org.mozilla.fenix.ext.metrics
@@ -130,6 +128,8 @@ import mozilla.components.feature.session.behavior.EngineViewBrowserToolbarBehav
 import mozilla.components.feature.webauthn.WebAuthnFeature
 import mozilla.components.support.base.feature.ActivityResultHandler
 import org.mozilla.fenix.GleanMetrics.PerfStartup
+import org.mozilla.fenix.ext.enterToImmersiveMode
+import org.mozilla.fenix.ext.exitImmersiveModeIfNeeded
 import org.mozilla.fenix.ext.measureNoInline
 import mozilla.components.feature.session.behavior.ToolbarPosition as MozacToolbarPosition
 

--- a/app/src/main/java/org/mozilla/fenix/ext/Activity.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/Activity.kt
@@ -24,6 +24,19 @@ fun Activity.enterToImmersiveMode() {
             or View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY)
 }
 
+/**
+ * Attempts to come out from immersive mode using the View.
+ */
+fun Activity.exitImmersiveModeIfNeeded() {
+    if (WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON and window.attributes.flags == 0) {
+        // We left immersive mode already.
+        return
+    }
+
+    window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+    window.decorView.systemUiVisibility = View.SYSTEM_UI_FLAG_VISIBLE
+}
+
 fun Activity.breadcrumb(
     message: String,
     data: Map<String, String> = emptyMap()


### PR DESCRIPTION
For https://github.com/mozilla-mobile/fenix/issues/18667

⚠️ **This PR is a fix for the current v88.0.0-beta2 branch.** The issue specified in #18667 is not present in master or release branches.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes no tests as it is only a minor change, and mirrors current behavior.
- [x] **Screenshots**: This PR includes no screenshots as the code in this PR does not change the current behavior.
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

The bug stems from the fact that we're using a pair of methods ,`enterToImmersiveMode` and `exitImmersiveModeIfNeeded`, the former from Fenix, and the latter from AC. Moving the non-Android 11 compliant method to Fenix fixes the issue.