### PR TITLE
 Issue #18535: Set the span count for grid view

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabLayoutMediator.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabLayoutMediator.kt
@@ -50,8 +50,19 @@ class TabLayoutMediator(
 internal class TabLayoutObserver(
     private val interactor: TabsTrayInteractor
 ) : TabLayout.OnTabSelectedListener {
+
+    private var initialScroll = true
+
     override fun onTabSelected(tab: TabLayout.Tab) {
-        interactor.setCurrentTrayPosition(tab.position)
+        // Do not animate the initial scroll when opening the tabs tray.
+        val animate = if (initialScroll) {
+            initialScroll = false
+            false
+        } else {
+            true
+        }
+
+        interactor.setCurrentTrayPosition(tab.position, animate)
     }
 
     override fun onTabUnselected(tab: TabLayout.Tab) = Unit

--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
@@ -98,8 +98,8 @@ class TabsTrayFragment : AppCompatDialogFragment(), TabsTrayInteractor {
         }
     }
 
-    override fun setCurrentTrayPosition(position: Int) {
-        tabsTray.currentItem = position
+    override fun setCurrentTrayPosition(position: Int, smoothScroll: Boolean) {
+        tabsTray.setCurrentItem(position, smoothScroll)
     }
 
     override fun navigateToBrowser() {

--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
@@ -74,7 +74,8 @@ class TabsTrayFragment : AppCompatDialogFragment(), TabsTrayInteractor {
         val browserTrayInteractor = DefaultBrowserTrayInteractor(
             this,
             selectTabUseCase,
-            removeUseCases
+            removeUseCases,
+            requireComponents.settings
         )
 
         val syncedTabsTrayInteractor = SyncedTabsInteractor(

--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayInteractor.kt
@@ -7,8 +7,11 @@ package org.mozilla.fenix.tabstray
 interface TabsTrayInteractor {
     /**
      * Set the current tray item to the clamped [position].
+     *
+     * @param position The position on the tray to focus.
+     * @param smoothScroll If true, animate the scrolling from the current tab to [position].
      */
-    fun setCurrentTrayPosition(position: Int)
+    fun setCurrentTrayPosition(position: Int, smoothScroll: Boolean)
 
     /**
      * Dismisses the tabs tray and navigates to the browser.

--- a/app/src/main/java/org/mozilla/fenix/tabstray/TrayPagerAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TrayPagerAdapter.kt
@@ -7,7 +7,6 @@ package org.mozilla.fenix.tabstray
 import android.content.Context
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import org.mozilla.fenix.tabstray.browser.BrowserTabsAdapter
 import org.mozilla.fenix.tabstray.browser.BrowserTrayInteractor
@@ -57,7 +56,7 @@ class TrayPagerAdapter(
             else -> throw IllegalStateException("View type does not exist.")
         }
 
-        viewHolder.bind(adapter, GridLayoutManager(context, 1))
+        viewHolder.bind(adapter, browserInteractor.getLayoutManagerForPosition(context, position))
     }
 
     override fun getItemViewType(position: Int): Int {

--- a/app/src/main/java/org/mozilla/fenix/tabstray/browser/BrowserTabsAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/browser/BrowserTabsAdapter.kt
@@ -16,8 +16,6 @@ import mozilla.components.support.base.observer.Observable
 import mozilla.components.support.base.observer.ObserverRegistry
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.settings
-import org.mozilla.fenix.tabstray.TabsTrayGridViewHolder
-import org.mozilla.fenix.tabstray.TabsTrayListViewHolder
 import org.mozilla.fenix.tabstray.TabsTrayViewHolder
 
 /**

--- a/app/src/main/java/org/mozilla/fenix/tabstray/browser/BrowserTrayInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/browser/BrowserTrayInteractor.kt
@@ -4,9 +4,15 @@
 
 package org.mozilla.fenix.tabstray.browser
 
+import android.content.Context
+import androidx.recyclerview.widget.GridLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import mozilla.components.concept.tabstray.Tab
 import mozilla.components.feature.tabs.TabsUseCases
 import org.mozilla.fenix.tabstray.TabsTrayInteractor
+import org.mozilla.fenix.tabstray.TrayPagerAdapter
+import org.mozilla.fenix.tabstray.ext.numberOfGridColumns
+import org.mozilla.fenix.utils.Settings
 
 /**
  * For interacting with UI that is specifically for [BaseBrowserTrayList] and other browser
@@ -28,6 +34,11 @@ interface BrowserTrayInteractor {
      * If multi-select mode is enabled or disabled.
      */
     fun isMultiSelectMode(): Boolean
+
+    /**
+     * Returns the appropriate [RecyclerView.LayoutManager] to be used at [position].
+     */
+    fun getLayoutManagerForPosition(context: Context, position: Int): RecyclerView.LayoutManager
 }
 
 /**
@@ -36,7 +47,8 @@ interface BrowserTrayInteractor {
 class DefaultBrowserTrayInteractor(
     private val trayInteractor: TabsTrayInteractor,
     private val selectTabUseCase: TabsUseCases.SelectTabUseCase,
-    private val removeUseCases: TabsUseCases.RemoveTabUseCase
+    private val removeUseCases: TabsUseCases.RemoveTabUseCase,
+    private val settings: Settings
 ) : BrowserTrayInteractor {
 
     /**
@@ -60,5 +72,24 @@ class DefaultBrowserTrayInteractor(
     override fun isMultiSelectMode(): Boolean {
         // Needs https://github.com/mozilla-mobile/fenix/issues/18513 to change this value
         return false
+    }
+
+    override fun getLayoutManagerForPosition(
+        context: Context,
+        position: Int
+    ): RecyclerView.LayoutManager {
+        if (position == TrayPagerAdapter.POSITION_SYNCED_TABS) {
+            // Lists are just Grids with one column :)
+            return GridLayoutManager(context, 1)
+        }
+
+        // Normal/Private tabs
+        val numberOfColumns = if (settings.gridTabView) {
+            context.numberOfGridColumns
+        } else {
+            1
+        }
+
+        return GridLayoutManager(context, numberOfColumns)
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/tabstray/browser/TabsTrayGridViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/browser/TabsTrayGridViewHolder.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.fenix.tabstray
+package org.mozilla.fenix.tabstray.browser
 
 import android.view.LayoutInflater
 import android.view.View
@@ -18,7 +18,7 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.increaseTapArea
 import kotlin.math.max
 import kotlinx.android.synthetic.main.tab_tray_grid_item.view.tab_tray_grid_item
-import org.mozilla.fenix.tabstray.browser.BrowserTrayInteractor
+import org.mozilla.fenix.tabstray.TabsTrayViewHolder
 
 /**
  * A RecyclerView ViewHolder implementation for "tab" items with grid layout.

--- a/app/src/main/java/org/mozilla/fenix/tabstray/browser/TabsTrayListViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/browser/TabsTrayListViewHolder.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.fenix.tabstray
+package org.mozilla.fenix.tabstray.browser
 
 import android.view.LayoutInflater
 import android.view.View
@@ -10,7 +10,7 @@ import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import mozilla.components.concept.base.images.ImageLoader
 import org.mozilla.fenix.R
-import org.mozilla.fenix.tabstray.browser.BrowserTrayInteractor
+import org.mozilla.fenix.tabstray.TabsTrayViewHolder
 import kotlin.math.max
 
 /**

--- a/app/src/main/java/org/mozilla/fenix/tabstray/ext/Context.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/ext/Context.kt
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabstray.ext
+
+import android.content.Context
+
+private const val MIN_COLUMN_WIDTH_DP = 180
+
+/**
+ * Returns the number of grid columns we can fit on the screen in the tabs tray.
+ */
+internal val Context.numberOfGridColumns: Int
+    get() {
+        val displayMetrics = resources.displayMetrics
+        val screenWidthDp = displayMetrics.widthPixels / displayMetrics.density
+        return (screenWidthDp / MIN_COLUMN_WIDTH_DP).toInt()
+    }

--- a/app/src/test/java/org/mozilla/fenix/tabstray/TabLayoutObserverTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/TabLayoutObserverTest.kt
@@ -21,6 +21,21 @@ class TabLayoutObserverTest {
 
         observer.onTabSelected(tab)
 
-        verify { interactor.setCurrentTrayPosition(1) }
+        verify { interactor.setCurrentTrayPosition(1, false) }
+    }
+
+    @Test
+    fun `WHEN observer is first started THEN do not smooth scroll`() {
+        val observer = TabLayoutObserver(interactor)
+        val tab = mockk<TabLayout.Tab>()
+        every { tab.position } returns 1
+
+        observer.onTabSelected(tab)
+
+        verify { interactor.setCurrentTrayPosition(1, false) }
+
+        observer.onTabSelected(tab)
+
+        verify { interactor.setCurrentTrayPosition(1, true) }
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/tabstray/browser/DefaultBrowserTrayInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/browser/DefaultBrowserTrayInteractorTest.kt
@@ -1,0 +1,79 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabstray.browser
+
+import android.content.Context
+import androidx.recyclerview.widget.GridLayoutManager
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.mozilla.fenix.tabstray.TrayPagerAdapter
+import org.mozilla.fenix.tabstray.ext.numberOfGridColumns
+import org.mozilla.fenix.utils.Settings
+
+class DefaultBrowserTrayInteractorTest {
+
+    @Before
+    fun setup() {
+        mockkStatic("org.mozilla.fenix.tabstray.ext.ContextKt")
+    }
+
+    @After
+    fun shutdown() {
+        unmockkStatic("org.mozilla.fenix.tabstray.ext.ContextKt")
+    }
+
+    @Test
+    fun `WHEN pager position is synced tabs THEN return a list layout manager`() {
+        val interactor = DefaultBrowserTrayInteractor(mockk(), mockk(), mockk(), mockk())
+
+        val result = interactor.getLayoutManagerForPosition(
+            mockk(),
+            TrayPagerAdapter.POSITION_SYNCED_TABS
+        )
+
+        assertEquals(1, (result as GridLayoutManager).spanCount)
+    }
+
+    @Test
+    fun `WHEN setting is grid view THEN return grid layout manager`() {
+        val context = mockk<Context>()
+        val settings = mockk<Settings>()
+        val interactor = DefaultBrowserTrayInteractor(mockk(), mockk(), mockk(), settings)
+
+        every { context.numberOfGridColumns }.answers { 4 }
+        every { settings.gridTabView }.answers { true }
+
+        val result = interactor.getLayoutManagerForPosition(
+            context,
+            TrayPagerAdapter.POSITION_NORMAL_TABS
+        )
+
+        assertEquals(4, (result as GridLayoutManager).spanCount)
+    }
+
+    @Test
+    fun `WHEN setting is list view THEN return list layout manager`() {
+        val context = mockk<Context>()
+        val settings = mockk<Settings>()
+        val interactor = DefaultBrowserTrayInteractor(mockk(), mockk(), mockk(), settings)
+
+        every { context.numberOfGridColumns }.answers { 4 }
+        every { settings.gridTabView }.answers { false }
+
+        val result = interactor.getLayoutManagerForPosition(
+            context,
+            TrayPagerAdapter.POSITION_NORMAL_TABS
+        )
+
+        // Should NOT be 4.
+        assertEquals(1, (result as GridLayoutManager).spanCount)
+    }
+}


### PR DESCRIPTION
There are three things in this PR:
 1. Moving the grid/list view holders from `tabstray` -> `tabstray.browser`.
 2. Correctly setting the span count available for a grid layout based on the screen metrics.
 3. Removing the animation when scrolling to the selected pager tray item - it was a pretty jarring animation when grid layout is enabled so I decided to bundle it with this as well.

<img src="https://user-images.githubusercontent.com/1370580/113068139-b3ebf880-918b-11eb-942f-c1be006bb5fc.png" width=320 />


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
