### PR TITLE
Disable failing UI Tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/NavigationToolbarTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/NavigationToolbarTest.kt
@@ -66,6 +66,7 @@ class NavigationToolbarTest {
         }
     }
 
+    @Ignore("Test failures: https://github.com/mozilla-mobile/fenix/issues/18720")
     @Test
     fun goForwardTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
@@ -94,6 +95,7 @@ class NavigationToolbarTest {
         }
     }
 
+    @Ignore("Test failures: https://github.com/mozilla-mobile/fenix/issues/18720")
     @Test
     fun refreshPageTest() {
         val refreshWebPage = TestAssetHelper.getRefreshAsset(mockWebServer)

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/NoNetworkAccessStartupTests.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/NoNetworkAccessStartupTests.kt
@@ -6,6 +6,7 @@ package org.mozilla.fenix.ui
 
 import androidx.core.net.toUri
 import org.junit.After
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.R
@@ -65,6 +66,7 @@ class NoNetworkAccessStartupTests {
         }
     }
 
+    @Ignore("Test failures: https://github.com/mozilla-mobile/fenix/issues/18720")
     @Test
     fun testPageReloadAfterNetworkInterrupted() {
         val url = "example.com"

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/ShareButtonTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/ShareButtonTest.kt
@@ -9,6 +9,7 @@ import androidx.test.uiautomator.UiDevice
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
@@ -43,6 +44,7 @@ class ShareButtonTest {
         mockWebServer.shutdown()
     }
 
+    @Ignore("Test failures: https://github.com/mozilla-mobile/fenix/issues/18720")
     @Test
     fun ShareButtonAppearanceTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -328,6 +328,7 @@ class SmokeTest {
         }
     }
 
+    @Ignore("Test failures: https://github.com/mozilla-mobile/fenix/issues/18720")
     @Test
     // Verifies the Share button in a tab's 3 dot menu
     fun mainMenuShareButtonTest() {
@@ -341,6 +342,7 @@ class SmokeTest {
         }
     }
 
+    @Ignore("Test failures: https://github.com/mozilla-mobile/fenix/issues/18720")
     @Test
     // Verifies the refresh button in a tab's 3 dot menu
     fun mainMenuRefreshButtonTest() {


### PR DESCRIPTION
Due to intermittent test failures in #18619 the following tests will be disabled:
<NavigationToolbarTest.goForwardTest>
<NavigationToolbarTest.refreshPageTest>
<NoNetworkAccessStartupTests.testPageReloadAfterNetworkInterrupted>
<SmokeTest.mainMenuShareButtonTest>
<SmokeTest.mainMenuRefreshButtonTest>
<ShareButtonTest.ShareButtonAppearanceTest>

Filled #18720

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
