### PR TITLE
For #14716: Increased height of Learn more link TextView in button_tip_item.xml

### DIFF
--- a/app/src/main/res/layout/button_tip_item.xml
+++ b/app/src/main/res/layout/button_tip_item.xml
@@ -57,7 +57,8 @@
     <TextView
         android:id="@+id/tip_learn_more"
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
+        android:layout_height="48dp"
+        android:layout_marginTop="8dp"
         android:text="@string/search_suggestions_onboarding_learn_more_link"
         android:textAppearance="?android:attr/textAppearanceSmall"
         android:textColor="@color/primary_text_dark_theme"


### PR DESCRIPTION
Touch target size of **Learn more link** increased, as per Google Accessibility Scanner's suggestion.
Fixes issue #14716



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

### Screenshot:
Besides increasing height to 48dp (which resolves Google Accessibility Scanner's issue), have also added a top margin of 8dp, to properly space out the Learn more link with respect to above tip description.   

![image](https://user-images.githubusercontent.com/67039214/113127387-5365c580-9236-11eb-945d-d9095c396dce.png)

