### PR TITLE
For #18729 - Use consistent string naming for generic strings

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
@@ -504,8 +504,8 @@ open class DefaultToolbarMenu(
         primaryStateIconResource = R.drawable.ic_bookmark_outline,
         secondaryStateIconResource = R.drawable.ic_bookmark_filled,
         tintColorResource = accentBrightTextColor(),
-        primaryLabel = context.getString(R.string.add_label),
-        secondaryLabel = context.getString(R.string.edit_label),
+        primaryLabel = context.getString(R.string.add),
+        secondaryLabel = context.getString(R.string.edit),
         isInPrimaryState = { !isCurrentUrlBookmarked }
     ) {
         handleBookmarkItemTapped()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,9 +8,9 @@
     <!-- A 'Save' string to be used for labeling UI elements. -->
     <string name="save">Save</string>
     <!-- An 'Add' string to be used for labeling UI elements. -->
-    <string name="add_label">Add</string>
-    <!-- A 'Edit' string to be used for labeling UI elements. -->
-    <string name="edit_label">Edit</string>
+    <string name="add">Add</string>
+    <!-- An 'Edit' string to be used for labeling UI elements. -->
+    <string name="edit">Edit</string>
 
     <!-- App name for private browsing mode. The first parameter is the name of the app defined in app_name (for example: Fenix)-->
     <string name="app_name_private_5">Private %s</string>
@@ -1644,8 +1644,6 @@
     <string name="save_changes_to_login">Save changes to login.</string>
     <!--  The button description to discard changes to an edited login. -->
     <string name="discard_changes">Discard changes</string>
-    <!--  The page title for editing a saved login. -->
-    <string name="edit">Edit</string>
     <!--  The error message in edit login view when password field is blank. -->
     <string name="saved_login_password_required">Password required</string>
     <!-- Voice search button content description  -->


### PR DESCRIPTION
Fixes #18729 

We don't use `R.string.edit` anywhere except in a nav_graph label and snackbar test. https://github.com/mozilla-mobile/fenix/search?q=R.string.edit. So, I am moving that up to where we have our generic strings. I think this is sufficiently generic that we don't need to create a new `edit_label` string as done in https://github.com/mozilla-mobile/fenix/pull/18555#discussion_r604996058.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
