### PR TITLE
For #18743 - Change the top sites label colour and text size

### DIFF
--- a/app/src/main/res/layout/top_site_item.xml
+++ b/app/src/main/res/layout/top_site_item.xml
@@ -30,7 +30,7 @@
         android:gravity="center"
         android:singleLine="true"
         android:textColor="@color/top_site_title_text"
-        android:textSize="10sp"
+        android:textSize="12sp"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toBottomOf="@id/favicon_image"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -11,6 +11,8 @@
     <color name="violet_50_32a">#529059FF</color>
     <color name="violet_50_48a">#7A9059FF</color>
     <color name="violet_70_12a">#1F592ACB</color>
+    <color name="dark_grey_90">#15141A</color>
+    <color name="violet_05">#E7DFFF</color>
 
     <!-- Light theme color palette -->
     <color name="primary_text_light_theme">#20123A</color>
@@ -35,7 +37,7 @@
     <color name="dark_grey_90_gradient_start">#FF15141A</color>
     <color name="dark_grey_90_gradient_end">#0015141A</color>
     <color name="synced_tabs_separator_light_theme">@color/photonLightGrey30</color>
-    <color name="top_site_title_text_light_theme">@color/photonDarkGrey10</color>
+    <color name="top_site_title_text_light_theme">@color/dark_grey_90</color>
     <color name="collection_icon_color_violet_light_theme">#7542E5</color>
     <color name="collection_icon_color_blue_light_theme">#0250BB</color>
     <color name="collection_icon_color_pink_light_theme">#E31587</color>
@@ -105,7 +107,7 @@
     <color name="scrimStart_dark_theme">#F520123A</color>
     <color name="scrimEnd_dark_theme">#F515141A</color>
     <color name="synced_tabs_separator_dark_theme">@color/photonDarkGrey10</color>
-    <color name="top_site_title_text_dark_theme">@color/photonLightGrey60</color>
+    <color name="top_site_title_text_dark_theme">@color/photonLightGrey05</color>
     <color name="collection_icon_color_violet_dark_theme">#AB71FF</color>
     <color name="collection_icon_color_blue_dark_theme">#00B3F4</color>
     <color name="collection_icon_color_pink_dark_theme">#FF6BBA</color>
@@ -358,10 +360,8 @@
     <color name="suggestion_highlight_color">#5C592ACB</color>
     <color name="private_browsing_button_accent_color">@color/foundation_private_theme</color>
     <color name="white_color">#FBFBFE</color>
-    <color name="dark_grey_90">#15141A</color>
     <color name="neutral_text">@color/white_color</color>
     <color name="disabled_text">#cccccc</color>
-    <color name="violet_05">#E7DFFF</color>
     <color name="text_scale_example_text_color">#232749</color>
     <color name="sync_error_background_color">#FFF36E</color>
     <color name="sync_error_text_color">#960E18</color>


### PR DESCRIPTION
This changes the top sites label colour and text size according to the spec defined in #18743.

Fixes #18743

<img width="441" alt="Screen Shot 2021-04-01 at 12 35 13 PM" src="https://user-images.githubusercontent.com/1190888/113325682-bfa00200-92e6-11eb-8d03-fd5479eacd05.png">
<img width="441" alt="Screen Shot 2021-04-01 at 12 35 00 PM" src="https://user-images.githubusercontent.com/1190888/113325692-c2025c00-92e6-11eb-90eb-04456205ae98.png">


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
