### PR TITLE
For #18142: address bar freeze

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/utils/ClipboardHandler.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/ClipboardHandler.kt
@@ -10,7 +10,7 @@ import android.content.Context
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.getSystemService
 import mozilla.components.support.utils.SafeUrl
-import mozilla.components.support.utils.WebURLFinder
+import mozilla.components.support.utils.URLStringUtils
 
 private const val MIME_TYPE_TEXT_PLAIN = "text/plain"
 private const val MIME_TYPE_TEXT_HTML = "text/html"
@@ -38,8 +38,7 @@ class ClipboardHandler(val context: Context) {
     val url: String?
         get() {
             return text?.let {
-                val finder = WebURLFinder(it)
-                finder.bestWebURL()
+               if(URLStringUtils.isURLLike(it)) it else null
             }
         }
 

--- a/app/src/main/java/org/mozilla/fenix/utils/ClipboardHandler.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/ClipboardHandler.kt
@@ -38,7 +38,7 @@ class ClipboardHandler(val context: Context) {
     val url: String?
         get() {
             return text?.let {
-               if(URLStringUtils.isURLLike(it)) it else null
+                if(URLStringUtils.isURLLike(it)) it else null
             }
         }
 


### PR DESCRIPTION
For #18142

This fixes the jank created when a user has a super long string in their clipboard and tries to click on the URL bar. 

However, I have to point out that by calling `URLStringUtils`, there is one small change in behavior.

- Behavior before the changes:
If a user had the following string in their clipboard `abcdefg mozilla.com` the clipboard would offer to "FIll the link" with 
`mozilla.com`. Another example would be having `mozilla.com https://mozilla.com` would show the option to paste the link `https://mozilla.com`.

- Behavior with this patch:
If a user has the string `abcdefg mozilla.com`, nothing will be shown. However, if the user has  some sort of URL (ie: `c-c.com`, `about-mozilla:mozilla`, etc...) it will offer to paste the link from the clipboard.

The reason for the change is that to fix the problem in `WebURLFinder.kt`, we would need to fix the regex which is used in multiple different place ( one of them being `TabIntentProcessor.kt`). I didn't want to change the behavior of those classes by changing the regex. 
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
