### PR TITLE
Bug 1701764 - Remove --no-conditioned-profile from Raptor tests

### DIFF
--- a/taskcluster/ci/browsertime/kind.yml
+++ b/taskcluster/ci/browsertime/kind.yml
@@ -85,7 +85,6 @@ job-defaults:
             - '--cfg=mozharness/configs/raptor/android_hw_config.py'
             - '--app=fenix'
             - '--browsertime'
-            - '--no-conditioned-profile'
             - '--binary=org.mozilla.fenix'
             - '--activity=org.mozilla.fenix.IntentReceiverActivity'
             - '--download-symbols=ondemand'


### PR DESCRIPTION
Conditioned profiles are now disabled by default. This pull request doesn't contain tests as it is a test-only change to the command lines passed to the performance tests and does not impact users of the app.

@gmierz I'm not familiar with how to test this. Without this patch I would expect Fenix performance tests to fail due to the now unexpected command line option of `--no-conditioned-profile`.