### PR TITLE
Bug 1670902 - Use WebRender platforms for Raptor performance tests

### DIFF
--- a/taskcluster/ci/browsertime/kind.yml
+++ b/taskcluster/ci/browsertime/kind.yml
@@ -43,8 +43,8 @@ job-defaults:
         tier: 2
         platform:
             by-abi:
-                arm64-v8a: android-hw-p2-8-0-android-aarch64-shippable/opt
-                armeabi-v7a: android-hw-g5-7-0-arm7-api-16-shippable/opt
+                arm64-v8a: android-hw-p2-8-0-android-aarch64-shippable-qr/opt
+                armeabi-v7a: android-hw-g5-7-0-arm7-api-16-shippable-qr/opt
     worker-type:
         by-abi:
             armeabi-v7a: t-bitbar-gw-perf-g5

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -4,7 +4,6 @@ treeherder:
     group-names:
         'beta': 'Beta-related tasks with same APK configuration as Fennec'
         'Btime': 'Raptor-Browsertime tests'
-        'Btime-wr': 'Raptor-Browsertime tests with webrender enabled'
         'bump': 'Bump dependencies'
         'debug': 'Builds made for testing'
         'Fetch': 'Fetch and store content'


### PR DESCRIPTION
This is an attempt to use the WebRender (-qr) platforms for the Raptor performance tests instead of augmenting the command line and job group/symbols. This is a test-only change.

@gmierz could you help with testing this?
