### PR TITLE
[SDK-246] Change Nimbus `channel` input to use the same method as Gle…

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/experiments/NimbusSetup.kt
+++ b/app/src/main/java/org/mozilla/fenix/experiments/NimbusSetup.kt
@@ -14,7 +14,7 @@ import mozilla.components.service.nimbus.NimbusAppInfo
 import mozilla.components.service.nimbus.NimbusDisabled
 import mozilla.components.service.nimbus.NimbusServerSettings
 import mozilla.components.support.base.log.logger.Logger
-import org.mozilla.fenix.Config
+import org.mozilla.fenix.BuildConfig
 import org.mozilla.fenix.components.isSentryEnabled
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.settings
@@ -47,7 +47,10 @@ fun createNimbus(context: Context, url: String?): NimbusApi =
         // https://github.com/mozilla/probe-scraper/blob/master/repositories.yaml
         val appInfo = NimbusAppInfo(
             appName = "fenix",
-            channel = Config.channel.toString()
+            // Note: Using BuildConfig.BUILD_TYPE is important here so that it matches the value
+            // passed into Glean. `Config.channel.toString()` turned out to be non-deterministic
+            // and would mostly produce the value `Beta` and rarely would produce `beta`.
+            channel = BuildConfig.BUILD_TYPE
         )
         Nimbus(context, appInfo, serverSettings).apply {
             // This performs the minimal amount of work required to load branch and enrolment data


### PR DESCRIPTION
Uplift request for:  [SDK-246] Change Nimbus `channel` input to use the same method as Glean (#18766)

* [SDK-246] Change Nimbus `channel` input to use the same method as Glean

* Update app/src/main/java/org/mozilla/fenix/experiments/NimbusSetup.kt

Authored-by: Travis Long @travis79 
Co-authored-by: Gabriel Luong <gabriel.luong@gmail.com>


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
