### PR TITLE
For #15083 - Add multi select in recently closed tabs

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/recentlyclosed/RecentlyClosedAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/recentlyclosed/RecentlyClosedAdapter.kt
@@ -9,21 +9,35 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import mozilla.components.browser.state.state.recover.RecoverableTab
+import org.mozilla.fenix.selection.SelectionHolder
 
 class RecentlyClosedAdapter(
     private val interactor: RecentlyClosedFragmentInteractor
-) : ListAdapter<RecoverableTab, RecentlyClosedItemViewHolder>(DiffCallback) {
+) : ListAdapter<RecoverableTab, RecentlyClosedItemViewHolder>(DiffCallback),
+    SelectionHolder<RecoverableTab> {
+
+    private var selectedTabs: Set<RecoverableTab> = emptySet()
+
     override fun onCreateViewHolder(
         parent: ViewGroup,
         viewType: Int
     ): RecentlyClosedItemViewHolder {
         val view = LayoutInflater.from(parent.context)
             .inflate(RecentlyClosedItemViewHolder.LAYOUT_ID, parent, false)
-        return RecentlyClosedItemViewHolder(view, interactor)
+        return RecentlyClosedItemViewHolder(view, interactor, this)
     }
 
     override fun onBindViewHolder(holder: RecentlyClosedItemViewHolder, position: Int) {
         holder.bind(getItem(position))
+    }
+
+    override val selectedItems: Set<RecoverableTab>
+        get() = selectedTabs
+
+    fun updateData(tabs: List<RecoverableTab>, selectedTabs: Set<RecoverableTab>) {
+        this.selectedTabs = selectedTabs
+        notifyItemRangeChanged(0, tabs.size)
+        submitList(tabs)
     }
 
     private object DiffCallback : DiffUtil.ItemCallback<RecoverableTab>() {
@@ -31,6 +45,6 @@ class RecentlyClosedAdapter(
             oldItem.id == newItem.id
 
         override fun areContentsTheSame(oldItem: RecoverableTab, newItem: RecoverableTab) =
-            oldItem.id == newItem.id
+            oldItem == newItem
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/library/recentlyclosed/RecentlyClosedController.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/recentlyclosed/RecentlyClosedController.kt
@@ -21,18 +21,27 @@ import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.ext.navigateBlockingForAsyncNavGraph
 
+@Suppress("TooManyFunctions")
 interface RecentlyClosedController {
-    fun handleOpen(item: RecoverableTab, mode: BrowsingMode? = null)
-    fun handleDeleteOne(tab: RecoverableTab)
+    fun handleOpen(tab: RecoverableTab, mode: BrowsingMode? = null)
+    fun handleOpen(tabs: Set<RecoverableTab>, mode: BrowsingMode? = null)
+    fun handleDelete(tab: RecoverableTab)
+    fun handleDelete(tabs: Set<RecoverableTab>)
     fun handleCopyUrl(item: RecoverableTab)
-    fun handleShare(item: RecoverableTab)
+    fun handleShare(tab: RecoverableTab)
+    fun handleShare(tabs: Set<RecoverableTab>)
     fun handleNavigateToHistory()
     fun handleRestore(item: RecoverableTab)
+    fun handleSelect(tab: RecoverableTab)
+    fun handleDeselect(tab: RecoverableTab)
+    fun handleBackPressed(): Boolean
 }
 
+@Suppress("TooManyFunctions")
 class DefaultRecentlyClosedController(
     private val navController: NavController,
-    private val store: BrowserStore,
+    private val browserStore: BrowserStore,
+    private val recentlyClosedStore: RecentlyClosedFragmentStore,
     private val tabsUseCases: TabsUseCases,
     private val resources: Resources,
     private val snackbar: FenixSnackbar,
@@ -40,12 +49,30 @@ class DefaultRecentlyClosedController(
     private val activity: HomeActivity,
     private val openToBrowser: (item: RecoverableTab, mode: BrowsingMode?) -> Unit
 ) : RecentlyClosedController {
-    override fun handleOpen(item: RecoverableTab, mode: BrowsingMode?) {
-        openToBrowser(item, mode)
+    override fun handleOpen(tab: RecoverableTab, mode: BrowsingMode?) {
+        openToBrowser(tab, mode)
     }
 
-    override fun handleDeleteOne(tab: RecoverableTab) {
-        store.dispatch(RecentlyClosedAction.RemoveClosedTabAction(tab))
+    override fun handleOpen(tabs: Set<RecoverableTab>, mode: BrowsingMode?) {
+        recentlyClosedStore.dispatch(RecentlyClosedFragmentAction.DeselectAll)
+        tabs.forEach { tab -> handleOpen(tab, mode) }
+    }
+
+    override fun handleSelect(tab: RecoverableTab) {
+        recentlyClosedStore.dispatch(RecentlyClosedFragmentAction.Select(tab))
+    }
+
+    override fun handleDeselect(tab: RecoverableTab) {
+        recentlyClosedStore.dispatch(RecentlyClosedFragmentAction.Deselect(tab))
+    }
+
+    override fun handleDelete(tab: RecoverableTab) {
+        browserStore.dispatch(RecentlyClosedAction.RemoveClosedTabAction(tab))
+    }
+
+    override fun handleDelete(tabs: Set<RecoverableTab>) {
+        recentlyClosedStore.dispatch(RecentlyClosedFragmentAction.DeselectAll)
+        tabs.forEach { tab -> handleDelete(tab) }
     }
 
     override fun handleNavigateToHistory() {
@@ -64,10 +91,13 @@ class DefaultRecentlyClosedController(
         }
     }
 
-    override fun handleShare(item: RecoverableTab) {
+    override fun handleShare(tab: RecoverableTab) = handleShare(setOf(tab))
+
+    override fun handleShare(tabs: Set<RecoverableTab>) {
+        val shareData = tabs.map { ShareData(url = it.url, title = it.title) }
         navController.navigateBlockingForAsyncNavGraph(
             RecentlyClosedFragmentDirections.actionGlobalShareFragment(
-                data = arrayOf(ShareData(url = item.url, title = item.title))
+                data = shareData.toTypedArray()
             )
         )
     }
@@ -75,12 +105,21 @@ class DefaultRecentlyClosedController(
     override fun handleRestore(item: RecoverableTab) {
         tabsUseCases.restore(item)
 
-        store.dispatch(
+        browserStore.dispatch(
             RecentlyClosedAction.RemoveClosedTabAction(item)
         )
 
         activity.openToBrowser(
             from = BrowserDirection.FromRecentlyClosed
         )
+    }
+
+    override fun handleBackPressed(): Boolean {
+        return if (recentlyClosedStore.state.selectedTabs.isNotEmpty()) {
+            recentlyClosedStore.dispatch(RecentlyClosedFragmentAction.DeselectAll)
+            true
+        } else {
+            false
+        }
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/library/recentlyclosed/RecentlyClosedFragmentInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/recentlyclosed/RecentlyClosedFragmentInteractor.kt
@@ -34,11 +34,23 @@ class RecentlyClosedFragmentInteractor(
         recentlyClosedController.handleOpen(item, BrowsingMode.Private)
     }
 
-    override fun onDeleteOne(tab: RecoverableTab) {
-        recentlyClosedController.handleDeleteOne(tab)
+    override fun onDelete(tab: RecoverableTab) {
+        recentlyClosedController.handleDelete(tab)
     }
 
     override fun onNavigateToHistory() {
         recentlyClosedController.handleNavigateToHistory()
+    }
+
+    override fun open(item: RecoverableTab) {
+        recentlyClosedController.handleRestore(item)
+    }
+
+    override fun select(item: RecoverableTab) {
+        recentlyClosedController.handleSelect(item)
+    }
+
+    override fun deselect(item: RecoverableTab) {
+        recentlyClosedController.handleDeselect(item)
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/library/recentlyclosed/RecentlyClosedFragmentStore.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/recentlyclosed/RecentlyClosedFragmentStore.kt
@@ -24,13 +24,19 @@ class RecentlyClosedFragmentStore(initialState: RecentlyClosedFragmentState) :
  */
 sealed class RecentlyClosedFragmentAction : Action {
     data class Change(val list: List<RecoverableTab>) : RecentlyClosedFragmentAction()
+    data class Select(val tab: RecoverableTab) : RecentlyClosedFragmentAction()
+    data class Deselect(val tab: RecoverableTab) : RecentlyClosedFragmentAction()
+    object DeselectAll : RecentlyClosedFragmentAction()
 }
 
 /**
  * The state for the Recently Closed Screen
  * @property items List of recently closed tabs to display
  */
-data class RecentlyClosedFragmentState(val items: List<RecoverableTab> = emptyList()) : State
+data class RecentlyClosedFragmentState(
+    val items: List<RecoverableTab> = emptyList(),
+    val selectedTabs: Set<RecoverableTab>
+) : State
 
 /**
  * The RecentlyClosedFragmentState Reducer.
@@ -41,5 +47,12 @@ private fun recentlyClosedStateReducer(
 ): RecentlyClosedFragmentState {
     return when (action) {
         is RecentlyClosedFragmentAction.Change -> state.copy(items = action.list)
+        is RecentlyClosedFragmentAction.Select -> {
+            state.copy(selectedTabs = state.selectedTabs + action.tab)
+        }
+        is RecentlyClosedFragmentAction.Deselect -> {
+            state.copy(selectedTabs = state.selectedTabs - action.tab)
+        }
+        RecentlyClosedFragmentAction.DeselectAll -> state.copy(selectedTabs = emptySet())
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/library/recentlyclosed/RecentlyClosedItemViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/recentlyclosed/RecentlyClosedItemViewHolder.kt
@@ -7,14 +7,19 @@ package org.mozilla.fenix.library.recentlyclosed
 import android.view.View
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.android.synthetic.main.history_list_item.view.*
+import kotlinx.android.synthetic.main.library_site_item.view.*
 import mozilla.components.browser.state.state.recover.RecoverableTab
 import org.mozilla.fenix.R
+import org.mozilla.fenix.ext.hideAndDisable
+import org.mozilla.fenix.ext.showAndEnable
+import org.mozilla.fenix.selection.SelectionHolder
 import org.mozilla.fenix.library.history.HistoryItemMenu
 import org.mozilla.fenix.utils.Do
 
 class RecentlyClosedItemViewHolder(
     view: View,
-    private val recentlyClosedFragmentInteractor: RecentlyClosedFragmentInteractor
+    private val recentlyClosedFragmentInteractor: RecentlyClosedFragmentInteractor,
+    private val selectionHolder: SelectionHolder<RecoverableTab>
 ) : RecyclerView.ViewHolder(view) {
 
     private var item: RecoverableTab? = null
@@ -30,12 +35,17 @@ class RecentlyClosedItemViewHolder(
             if (item.title.isNotEmpty()) item.title else item.url
         itemView.history_layout.urlView.text = item.url
 
+        itemView.history_layout.setSelectionInteractor(item, selectionHolder, recentlyClosedFragmentInteractor)
+        itemView.history_layout.changeSelected(item in selectionHolder.selectedItems)
+
         if (this.item?.url != item.url) {
             itemView.history_layout.loadFavicon(item.url)
         }
 
-        itemView.setOnClickListener {
-            recentlyClosedFragmentInteractor.restore(item)
+        if (selectionHolder.selectedItems.isEmpty()) {
+            itemView.overflow_menu.showAndEnable()
+        } else {
+            itemView.overflow_menu.hideAndDisable()
         }
 
         this.item = item
@@ -53,9 +63,7 @@ class RecentlyClosedItemViewHolder(
                 HistoryItemMenu.Item.OpenInPrivateTab -> recentlyClosedFragmentInteractor.onOpenInPrivateTab(
                     item
                 )
-                HistoryItemMenu.Item.Delete -> recentlyClosedFragmentInteractor.onDeleteOne(
-                    item
-                )
+                HistoryItemMenu.Item.Delete -> recentlyClosedFragmentInteractor.onDelete(item)
             }
         }
 

--- a/app/src/main/res/layout/component_recently_closed.xml
+++ b/app/src/main/res/layout/component_recently_closed.xml
@@ -18,7 +18,8 @@
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recently_closed_list"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintTop_toBottomOf="@id/view_more_history"
         tools:listitem="@layout/history_list_item" />
 

--- a/app/src/test/java/org/mozilla/fenix/library/recentlyclosed/RecentlyClosedFragmentInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/recentlyclosed/RecentlyClosedFragmentInteractorTest.kt
@@ -76,12 +76,12 @@ class RecentlyClosedFragmentInteractorTest {
     }
 
     @Test
-    fun onDeleteOne() {
+    fun onDelete() {
         val tab = RecoverableTab(id = "tab-id", title = "Mozilla", url = "mozilla.org", lastAccess = 1L)
-        interactor.onDeleteOne(tab)
+        interactor.onDelete(tab)
 
         verify {
-            defaultRecentlyClosedController.handleDeleteOne(tab)
+            defaultRecentlyClosedController.handleDelete(tab)
         }
     }
 


### PR DESCRIPTION
Fixes #15083

https://user-images.githubusercontent.com/14791787/113617821-bd270a80-964e-11eb-9ced-e3203829d71b.mp4


This also fixes a strange behavior in the animation when deleting items. Turns out that this was happening because the Recyclerview's layout_height was set to wrap_content. The bookmarks screen presents the same issue, I'll try to fix it in another PR.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
