### PR TITLE
Bug 1609191 - Disable hardware acceleration on devices affected by Adreno shader compilation crash

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,6 +32,7 @@
         android:supportsRtl="true"
         android:theme="@style/NormalTheme"
         android:usesCleartextTraffic="true"
+        android:hardwareAccelerated="false"
         tools:ignore="UnusedAttribute">
 
         <!--

--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -57,6 +57,7 @@ import org.mozilla.fenix.perf.StorageStatsMetrics
 import org.mozilla.fenix.perf.runBlockingIncrement
 import org.mozilla.fenix.push.PushFxaIntegration
 import org.mozilla.fenix.push.WebPushEngineIntegration
+import org.mozilla.fenix.session.HardwareAccelerationLifecycleCallbacks
 import org.mozilla.fenix.session.PerformanceActivityLifecycleCallbacks
 import org.mozilla.fenix.session.VisibilityLifecycleCallback
 import org.mozilla.fenix.utils.BrowsersCache
@@ -77,6 +78,9 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
     open val components by lazy { Components(this) }
 
     var visibilityLifecycleCallback: VisibilityLifecycleCallback? = null
+        private set
+
+    var hardwareAccelerationLifecycleCallbacks: HardwareAccelerationLifecycleCallbacks? = null
         private set
 
     override fun onCreate() {
@@ -183,6 +187,9 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
 
             visibilityLifecycleCallback = VisibilityLifecycleCallback(getSystemService())
             registerActivityLifecycleCallbacks(visibilityLifecycleCallback)
+
+            hardwareAccelerationLifecycleCallbacks = HardwareAccelerationLifecycleCallbacks()
+            registerActivityLifecycleCallbacks(hardwareAccelerationLifecycleCallbacks)
 
             // Storage maintenance disabled, for now, as it was interfering with background migrations.
             // See https://github.com/mozilla-mobile/fenix/issues/7227 for context.

--- a/app/src/main/java/org/mozilla/fenix/session/HardwareAccelerationLifecycleCallbacks.kt
+++ b/app/src/main/java/org/mozilla/fenix/session/HardwareAccelerationLifecycleCallbacks.kt
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.session
+
+import android.app.Activity
+import android.app.Application
+import android.os.Build
+import android.os.Bundle
+import android.view.WindowManager.LayoutParams.FLAG_HARDWARE_ACCELERATED
+
+/**
+ * This ActivityLifecycleCallbacks implementation ensures that hardware acceleration is enabled for
+ * a Window when an Activity is created. On some devices we cannot enable UI hardware acceleration
+ * due to graphics driver issues. So we must globally disable hardware acceleration in
+ * AndroidManifest.xml, then enable it where possible on a per-window basis.
+ * See https://bugzilla.mozilla.org/show_bug.cgi?id=1609191
+ */
+@SuppressWarnings("EmptyFunctionBlock")
+class HardwareAccelerationLifecycleCallbacks : Application.ActivityLifecycleCallbacks {
+    val supportsHardwareAcceleration by lazy {
+        // List of boards on which we should keep hardware acceleration disabled.
+        // These were the boards with the highest number of crashes caused by hardware acceleration being enabled.
+        // There will be some affected devices with different boards which therefore may still crash,
+        // however the numbers should be low enough and the crashes infrequent enough for that to be okay.
+        val buggyBoards = listOf("msm8953", "msm8976", "msm8937", "msm8996", "sdm450_mh4x")
+
+        Build.BOARD !in buggyBoards
+    }
+
+    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
+        if (supportsHardwareAcceleration) {
+            activity.window.setFlags(FLAG_HARDWARE_ACCELERATED, FLAG_HARDWARE_ACCELERATED)
+        }
+    }
+
+    override fun onActivityStarted(activity: Activity) {}
+
+    override fun onActivityResumed(activity: Activity) {}
+
+    override fun onActivityPaused(activity: Activity) {}
+
+    override fun onActivityStopped(activity: Activity) {}
+
+    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {}
+
+    override fun onActivityDestroyed(activity: Activity) {}
+}


### PR DESCRIPTION
On various Adreno devices we have experienced crashes in glLinkProgram
due to a suspected driver bug. There appears to be a race condition
between the gecko renderer thread compiling shaders used to render web
content, and the Android UI render thread compiling shaders used to
render the Fenix UI. Disabling hardware acceleration avoids this crash
as shader compilation will only occur on the gecko renderer thread.

Hardware acceleration must be disabled globally in
AndroidManifest.xml.  We can then opt in to hardware acceleration at
runtime on a per-window basis on suitable devices. We do this by
creating an ActivityLifecycleCallbacks which enables hardware
acceleration for the window whenever an activity is created.

We use a hardcoded list of known-buggy device boards, and only enable
hardware acceleration if the device is not in that list. The list was
chosen by selecting the most common boards that this crash occurs
on (covering >90% of crashes in the past month). Some crashes may
still occur on boards not in this list, however the numbers will be
low and crashes infrequent enough that this should not matter.
Likewise, some devices with these boards may be running driver
versions unaffected by this bug, but it should not matter if hardware
acceleration is disabled anyway.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
