### PR TITLE
For #18770: Correct addons position in three dot menu based on toolbar position

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
@@ -83,13 +83,13 @@ open class DefaultToolbarMenu(
                 } else {
                     oldCoreMenuItems
                 },
-            endOfMenuAlwaysVisible = !shouldUseBottomToolbar,
+            endOfMenuAlwaysVisible = shouldUseBottomToolbar,
             store = store,
             webExtIconTintColorResource = primaryTextColor,
             onAddonsManagerTapped = {
                 onItemTapped.invoke(ToolbarMenu.Item.AddonsManager)
             },
-            appendExtensionSubMenuAtStart = !shouldUseBottomToolbar
+            appendExtensionSubMenuAtStart = shouldUseBottomToolbar
         )
     }
 
@@ -374,6 +374,7 @@ open class DefaultToolbarMenu(
             menuItems.reversed()
         }
     }
+
     val newTabItem = BrowserMenuImageText(
         context.getString(R.string.library_new_tab),
         R.drawable.ic_new,
@@ -402,21 +403,21 @@ open class DefaultToolbarMenu(
         id = WebExtensionPlaceholderMenuItem.MAIN_EXTENSIONS_MENU_ID
     )
 
-        val accountManager = context.components.backgroundServices.accountManager
-        val account = accountManager.authenticatedAccount()
-        val syncItemTitle = if (account != null && accountManager.accountProfile()?.email != null) {
-            context.getString(R.string.sync_signed_as, accountManager.accountProfile()?.email)
-        } else {
-            context.getString(R.string.sync_menu_sign_in)
-        }
+    val accountManager = context.components.backgroundServices.accountManager
+    val account = accountManager.authenticatedAccount()
+    val syncItemTitle = if (account != null && accountManager.accountProfile()?.email != null) {
+        context.getString(R.string.sync_signed_as, accountManager.accountProfile()?.email)
+    } else {
+        context.getString(R.string.sync_menu_sign_in)
+    }
 
-        val syncedTabs = BrowserMenuImageText(
-            syncItemTitle,
-            R.drawable.ic_synced_tabs,
-            primaryTextColor()
-        ) {
-            onItemTapped.invoke(ToolbarMenu.Item.SyncedTabs)
-        }
+    val syncedTabs = BrowserMenuImageText(
+        syncItemTitle,
+        R.drawable.ic_synced_tabs,
+        primaryTextColor()
+    ) {
+        onItemTapped.invoke(ToolbarMenu.Item.SyncedTabs)
+    }
 
     val findInPageItem = BrowserMenuImageText(
         label = context.getString(R.string.browser_menu_find_in_page),


### PR DESCRIPTION
For #18770 
Bug caused by https://github.com/mozilla-mobile/fenix/pull/18427/files: changed a boolean from

```kotlin
private val isTopToolbarSelected = shouldReverseItems
```

to this

```kotlin
private val shouldUseBottomToolbar = context.settings().shouldUseBottomToolbar
```

and forgot to remove the `!` when evaluating for addons item.

**Bottom toolbar & top toolbar**
<img width="324" alt="image" src="https://user-images.githubusercontent.com/43795363/113764760-02941800-96e1-11eb-9cb0-f70e90954b05.png">  <img width="326" alt="image" src="https://user-images.githubusercontent.com/43795363/113764856-25263100-96e1-11eb-9dba-5be885125709.png">


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
