### PR TITLE
No issue: Observe only normal tabs when updating counter

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabCounterBinding.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabCounterBinding.kt
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabstray
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.map
+import mozilla.components.browser.state.selector.normalTabs
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.lib.state.ext.flowScoped
+import mozilla.components.support.base.feature.LifecycleAwareFeature
+import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
+import mozilla.components.ui.tabcounter.TabCounter
+
+/**
+ * Updates the tab counter to the size of [BrowserState.normalTabs].
+ */
+class TabCounterBinding(
+    private val store: BrowserStore,
+    private val counter: TabCounter
+) : LifecycleAwareFeature {
+
+    private var scope: CoroutineScope? = null
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    override fun start() {
+        scope = store.flowScoped { flow ->
+            flow.map { it.normalTabs }
+                .ifChanged()
+                .collect {
+                    counter.setCount(it.size)
+                }
+        }
+    }
+
+    override fun stop() {
+        scope?.cancel()
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
@@ -19,16 +19,14 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.tabs.TabLayout
 import kotlinx.android.synthetic.main.component_tabstray2.*
 import kotlinx.android.synthetic.main.component_tabstray2.view.*
+import kotlinx.android.synthetic.main.tabs_tray_tab_counter2.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import mozilla.components.browser.state.selector.normalTabs
-import mozilla.components.lib.state.ext.consumeFrom
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
-import mozilla.components.ui.tabcounter.TabCounter
+import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.NavGraphDirections
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.components
-import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.components.StoreProvider
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.home.HomeScreenViewModel
@@ -52,6 +50,7 @@ class TabsTrayFragment : AppCompatDialogFragment(), TabsTrayInteractor {
     private lateinit var behavior: BottomSheetBehavior<ConstraintLayout>
 
     private val tabLayoutMediator = ViewBoundFeatureWrapper<TabLayoutMediator>()
+    private val tabCounterBinding = ViewBoundFeatureWrapper<TabCounterBinding>()
 
     private val selectTabUseCase by lazy {
         SelectTabUseCaseWrapper(
@@ -140,11 +139,14 @@ class TabsTrayFragment : AppCompatDialogFragment(), TabsTrayInteractor {
             view = view
         )
 
-        consumeFrom(requireComponents.core.store) {
-            view.findViewById<TabCounter>(R.id.tab_counter)?.apply {
-                setCount(requireComponents.core.store.state.normalTabs.size)
-            }
-        }
+        tabCounterBinding.set(
+            feature = TabCounterBinding(
+                store = requireComponents.core.store,
+                counter = tab_counter
+            ),
+            owner = this,
+            view = view
+        )
     }
 
     override fun setCurrentTrayPosition(position: Int, smoothScroll: Boolean) {

--- a/app/src/test/java/org/mozilla/fenix/tabstray/NavigationInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/NavigationInteractorTest.kt
@@ -5,6 +5,7 @@
 package org.mozilla.fenix.tabstray
 
 import androidx.navigation.NavController
+import androidx.navigation.NavDirections
 import io.mockk.mockk
 import io.mockk.verify
 import mozilla.components.browser.state.state.BrowserState
@@ -81,26 +82,32 @@ class NavigationInteractorTest {
     }
 
     @Test
-    fun `onTabTrayDismissed calls dismissTabTray on DefaultNaviationInteractor`() {
+    fun `onTabTrayDismissed calls dismissTabTray on DefaultNavigationInteractor`() {
         navigationInteractor.onTabTrayDismissed()
         verify(exactly = 1) { dismissTabTray() }
     }
 
     @Test
-    fun `onTabSettingsClicked calls navigation on DefaultNaviationInteractor`() {
+    fun `onTabSettingsClicked calls navigation on DefaultNavigationInteractor`() {
         navigationInteractor.onTabSettingsClicked()
         verify(exactly = 1) { navController.navigate(TabsTrayFragmentDirections.actionGlobalTabSettingsFragment()) }
     }
 
     @Test
-    fun `onOpenRecentlyClosedClicked calls navigation on DefaultNaviationInteractor`() {
+    fun `onOpenRecentlyClosedClicked calls navigation on DefaultNavigationInteractor`() {
         navigationInteractor.onOpenRecentlyClosedClicked()
         verify(exactly = 1) { navController.navigate(TabsTrayFragmentDirections.actionGlobalRecentlyClosed()) }
     }
 
     @Test
-    fun `onCloseAllTabsClicked calls navigation on DefaultNaviationInteractor`() {
+    fun `onCloseAllTabsClicked calls navigation on DefaultNavigationInteractor`() {
         navigationInteractor.onCloseAllTabsClicked(false)
         verify(exactly = 1) { dismissTabTrayAndNavigateHome(any()) }
+    }
+
+    @Test
+    fun `onShareTabsOfType calls navigation on DefaultNavigationInteractor`() {
+        navigationInteractor.onShareTabsOfTypeClicked(false)
+        verify(exactly = 1) { navController.navigate(any<NavDirections>()) }
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/tabstray/TabCounterBindingTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/TabCounterBindingTest.kt
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabstray
+
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import mozilla.components.browser.state.action.TabListAction
+import mozilla.components.browser.state.state.createTab
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.support.test.libstate.ext.waitUntilIdle
+import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.ui.tabcounter.TabCounter
+import org.junit.Rule
+import org.junit.Test
+
+class TabCounterBindingTest {
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule(TestCoroutineDispatcher())
+
+    @Test
+    fun `WHEN normalTabs changes THEN update counter`() {
+        val store = BrowserStore()
+        val counter = mockk<TabCounter>(relaxed = true)
+        val binding = TabCounterBinding(store, counter)
+
+        binding.start()
+
+        store.dispatch(TabListAction.AddTabAction(createTab("https://mozilla.org")))
+
+        store.waitUntilIdle()
+
+        verify { counter.setCount(1) }
+    }
+
+    @Test
+    fun `WHEN feature starts THEN update counter`() {
+        val store = BrowserStore()
+        val counter = mockk<TabCounter>(relaxed = true)
+        val binding = TabCounterBinding(store, counter)
+
+        binding.start()
+
+        store.waitUntilIdle()
+
+        verify { counter.setCount(0) }
+    }
+}


### PR DESCRIPTION
Spoke offline with @rocketsroger about this change. We're moving the tabs counter updates to a separate flow observer (also includes tests 😉 ).

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
