### PR TITLE
For #8984: Added color for "Share" menu's "Recently Used" in Dark theme

### DIFF
--- a/app/src/main/res/drawable/recent_apps_background.xml
+++ b/app/src/main/res/drawable/recent_apps_background.xml
@@ -3,6 +3,6 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
-    <solid android:color="?inset"/>
+    <solid android:color="?recentlyUsedShareMenu"/>
     <corners android:radius="@dimen/share_recent_apps_background_radius"/>
 </shape>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -54,6 +54,7 @@
     <color name="preference_section_header_normal_theme">@color/preference_section_header_dark_theme</color>
     <color name="notification_accent_color_normal_theme">@color/accent_high_contrast_dark_theme</color>
     <color name="menu_item_button_normal_theme">@color/accent_high_contrast_dark_theme</color>
+    <color name="recently_used_share_theme">@color/recently_used_share_menu_dark_theme</color>
 
     <color name="mozac_widget_favicon_background_normal_theme">@color/mozac_widget_favicon_background_dark_theme</color>
     <color name="mozac_widget_favicon_border_normal_theme">@color/mozac_widget_favicon_border_dark_theme</color>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -27,6 +27,7 @@
     <attr name="toolbarDivider" format="reference"/>
     <attr name="menuCategoryText" format="reference"/>
     <attr name="preferenceSectionHeader" format="reference"/>
+    <attr name="recentlyUsedShareMenu" format="reference" />
 
     <!-- Color used in DefaultToolbarMenu for buttons placed at the end of menu items -->
     <attr name="menuItemButtonTintColor" format="reference"/>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -82,7 +82,7 @@
     <color name="contrast_text_dark_theme">@color/primary_text_dark_theme</color>
     <color name="caption_text_dark_theme">@color/photonLightGrey70</color>
     <color name="foundation_dark_theme">#1C1B22</color>
-    <color name="inset_dark_theme">@color/photonDarkGrey10</color>
+    <color name="inset_dark_theme">#32313C</color>
     <color name="above_dark_theme">#32313C</color>
     <color name="accent_dark_theme">#9059FF</color>
     <color name="accent_bright_dark_theme">#592ACB</color>
@@ -123,6 +123,7 @@
     <color name="search_suggestion_indicator_icon_color_dark_theme">#2ac3a2</color>
     <color name="search_suggestion_indicator_icon_bookmark_color_dark_theme">#0090ed</color>
     <color name="preference_section_header_dark_theme">@color/accent_high_contrast_dark_theme</color>
+    <color name="recently_used_share_menu_dark_theme">@color/photonDarkGrey10</color>
 
     <color name="mozac_widget_favicon_background_dark_theme">@color/photonDarkGrey50</color>
     <color name="mozac_widget_favicon_border_dark_theme">@color/photonDarkGrey10</color>
@@ -251,6 +252,7 @@
     <color name="mozac_widget_favicon_border_normal_theme">@color/mozac_widget_favicon_border_light_theme</color>
     <color name="notification_accent_color_normal_theme">@color/accent_bright_light_theme</color>
     <color name="menu_item_button_normal_theme">@color/menu_item_button_light_theme</color>
+    <color name="recently_used_share_theme">@color/inset_light_theme</color>
 
     <!-- Tab tray -->
     <color name="tab_tray_item_text_normal_theme">@color/tab_tray_item_text_light_theme</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -82,7 +82,7 @@
     <color name="contrast_text_dark_theme">@color/primary_text_dark_theme</color>
     <color name="caption_text_dark_theme">@color/photonLightGrey70</color>
     <color name="foundation_dark_theme">#1C1B22</color>
-    <color name="inset_dark_theme">#32313C</color>
+    <color name="inset_dark_theme">#52525E</color>
     <color name="above_dark_theme">#32313C</color>
     <color name="accent_dark_theme">#9059FF</color>
     <color name="accent_bright_dark_theme">#592ACB</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -82,7 +82,7 @@
     <color name="contrast_text_dark_theme">@color/primary_text_dark_theme</color>
     <color name="caption_text_dark_theme">@color/photonLightGrey70</color>
     <color name="foundation_dark_theme">#1C1B22</color>
-    <color name="inset_dark_theme">#52525E</color>
+    <color name="inset_dark_theme">@color/photonDarkGrey10</color>
     <color name="above_dark_theme">#32313C</color>
     <color name="accent_dark_theme">#9059FF</color>
     <color name="accent_bright_dark_theme">#592ACB</color>
@@ -106,7 +106,7 @@
     <color name="toolbar_start_gradient_dark_theme">@color/foundation_dark_theme</color>
     <color name="toolbar_center_gradient_dark_theme">@color/foundation_dark_theme</color>
     <color name="toolbar_end_gradient_dark_theme">@color/foundation_dark_theme</color>
-    <color name="toolbar_divider_color_dark_theme">#52525E</color>
+    <color name="toolbar_divider_color_dark_theme">@color/photonDarkGrey10</color>
     <color name="fill_link_from_clipboard_dark_theme">@color/accent_on_dark_background_normal_theme</color>
     <color name="sync_disconnected_icon_fill_dark_theme">#FFF36E</color>
     <color name="sync_disconnected_background_dark_theme">#5B5846</color>
@@ -170,7 +170,7 @@
     <color name="toolbar_start_gradient_private_theme">#7529A7</color>
     <color name="toolbar_center_gradient_private_theme">#492E85</color>
     <color name="toolbar_end_gradient_private_theme">#383372</color>
-    <color name="toolbar_divider_color_private_theme">#52525E</color>
+    <color name="toolbar_divider_color_private_theme">@color/photonDarkGrey10</color>
     <color name="fill_link_from_clipboard_private_theme">@color/accent_on_dark_background_private_theme</color>
     <color name="menu_category_private_theme">@color/primary_text_private_theme</color>
     <color name="sync_disconnected_icon_fill_private_theme">#C45A27</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -83,6 +83,7 @@
         <item name="selectLoginHeaderTextColor">@color/select_login_header_normal_theme</item>
         <item name="preferenceSectionHeader">@color/preference_section_header_normal_theme</item>
         <item name="menuItemButtonTintColor">@color/menu_item_button_normal_theme</item>
+        <item name="recentlyUsedShareMenu">@color/recently_used_share_theme</item>
 
         <!-- Shared widget colors -->
         <item name="mozac_primary_text_color">@color/primary_text_normal_theme</item>


### PR DESCRIPTION
- Changed HEX code for `inset_dark_theme` to **#52525E** in `values/colors.xml` according to this discussion in the comments of linked issue: (https://github.com/mozilla-mobile/fenix/issues/8984#issuecomment-814177658)
- Fixes #8984



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

### Screenshots:
Before: 
![image](https://user-images.githubusercontent.com/67039214/113834643-b1e7f200-97a8-11eb-905d-a5feb7b12058.png)

After:
![image](https://user-images.githubusercontent.com/67039214/113834833-e78cdb00-97a8-11eb-8dc6-e93d0a8c8353.png)

**No** new accessibility related suggestions came up in Google Accessibility Scanner because of this change. 


