### PR TITLE
For #18608 made set a default browser functionality publicly available.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/ext/Activity.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/Activity.kt
@@ -8,6 +8,14 @@ import android.app.Activity
 import android.view.View
 import android.view.WindowManager
 import mozilla.components.concept.base.crash.Breadcrumb
+import android.app.role.RoleManager
+import android.content.Intent
+import android.os.Build
+import android.provider.Settings
+import androidx.core.os.bundleOf
+import org.mozilla.fenix.BrowserDirection
+import org.mozilla.fenix.HomeActivity
+import org.mozilla.fenix.settings.SupportUtils
 
 /**
  * Attempts to call immersive mode using the View to hide the status bar and navigation buttons.
@@ -48,3 +56,59 @@ fun Activity.breadcrumb(
         )
     )
 }
+
+/**
+ *  Opens Android's Manage Default Apps Settings if possible.
+ */
+fun Activity.openSetDefaultBrowserOption() {
+    when {
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q -> {
+            getSystemService(RoleManager::class.java).also {
+                if (it.isRoleAvailable(RoleManager.ROLE_BROWSER) && !it.isRoleHeld(
+                        RoleManager.ROLE_BROWSER
+                    )
+                ) {
+                    startActivityForResult(
+                        it.createRequestRoleIntent(RoleManager.ROLE_BROWSER),
+                        REQUEST_CODE_BROWSER_ROLE
+                    )
+                } else {
+                    navigateToDefaultBrowserAppsSettings()
+                }
+            }
+        }
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.N -> {
+            navigateToDefaultBrowserAppsSettings()
+        }
+        else -> {
+            (this as HomeActivity).openToBrowserAndLoad(
+                searchTermOrURL = SupportUtils.getSumoURLForTopic(
+                    this,
+                    SupportUtils.SumoTopic.SET_AS_DEFAULT_BROWSER
+                ),
+                newTab = true,
+                from = BrowserDirection.FromSettings
+            )
+        }
+    }
+}
+
+private fun Activity.navigateToDefaultBrowserAppsSettings() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+        val intent = Intent(Settings.ACTION_MANAGE_DEFAULT_APPS_SETTINGS)
+        intent.putExtra(
+            SETTINGS_SELECT_OPTION_KEY,
+            DEFAULT_BROWSER_APP_OPTION
+        )
+        intent.putExtra(
+            SETTINGS_SHOW_FRAGMENT_ARGS,
+            bundleOf(SETTINGS_SELECT_OPTION_KEY to DEFAULT_BROWSER_APP_OPTION)
+        )
+        startActivity(intent)
+    }
+}
+
+const val REQUEST_CODE_BROWSER_ROLE = 1
+const val SETTINGS_SELECT_OPTION_KEY = ":settings:fragment_args_key"
+const val SETTINGS_SHOW_FRAGMENT_ARGS = ":settings:show_fragment_args"
+const val DEFAULT_BROWSER_APP_OPTION = "default_browser"

--- a/app/src/main/java/org/mozilla/fenix/ext/Activity.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/Activity.kt
@@ -58,7 +58,7 @@ fun Activity.breadcrumb(
 }
 
 /**
- *  Opens Android's Manage Default Apps Settings if possible.
+ * Opens Android's Manage Default Apps Settings if possible.
  */
 fun Activity.openSetDefaultBrowserOption() {
     when {

--- a/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
@@ -6,7 +6,6 @@ package org.mozilla.fenix.settings
 
 import android.annotation.SuppressLint
 import android.app.Activity
-import android.app.role.RoleManager
 import android.content.ActivityNotFoundException
 import android.content.DialogInterface
 import android.content.Intent
@@ -19,7 +18,6 @@ import android.view.LayoutInflater
 import android.widget.Toast
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
-import androidx.core.os.bundleOf
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavDirections
 import androidx.navigation.findNavController
@@ -50,6 +48,8 @@ import org.mozilla.fenix.ext.metrics
 import org.mozilla.fenix.ext.navigateToNotificationsSettings
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.ext.REQUEST_CODE_BROWSER_ROLE
+import org.mozilla.fenix.ext.openSetDefaultBrowserOption
 import org.mozilla.fenix.ext.showToolbar
 import org.mozilla.fenix.settings.account.AccountUiView
 import org.mozilla.fenix.utils.Settings
@@ -455,44 +455,9 @@ class SettingsFragment : PreferenceFragmentCompat() {
      * For <N -> Open sumo page to show user how to change default app.
      */
     private fun getClickListenerForMakeDefaultBrowser(): Preference.OnPreferenceClickListener {
-        return when {
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q -> {
-                Preference.OnPreferenceClickListener {
-                    requireContext().getSystemService(RoleManager::class.java).also {
-                        if (it.isRoleAvailable(RoleManager.ROLE_BROWSER) && !it.isRoleHeld(
-                                RoleManager.ROLE_BROWSER
-                            )
-                        ) {
-                            startActivityForResult(
-                                it.createRequestRoleIntent(RoleManager.ROLE_BROWSER),
-                                REQUEST_CODE_BROWSER_ROLE
-                            )
-                        } else {
-                            navigateUserToDefaultAppsSettings()
-                        }
-                    }
-                    true
-                }
-            }
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.N -> {
-                Preference.OnPreferenceClickListener {
-                    navigateUserToDefaultAppsSettings()
-                    true
-                }
-            }
-            else -> {
-                Preference.OnPreferenceClickListener {
-                    (activity as HomeActivity).openToBrowserAndLoad(
-                        searchTermOrURL = SupportUtils.getSumoURLForTopic(
-                            requireContext(),
-                            SupportUtils.SumoTopic.SET_AS_DEFAULT_BROWSER
-                        ),
-                        newTab = true,
-                        from = BrowserDirection.FromSettings
-                    )
-                    true
-                }
-            }
+        return Preference.OnPreferenceClickListener {
+            activity?.openSetDefaultBrowserOption()
+            true
         }
     }
 
@@ -502,16 +467,6 @@ class SettingsFragment : PreferenceFragmentCompat() {
         // If the user made us the default browser, update the switch
         if (resultCode == Activity.RESULT_OK && requestCode == REQUEST_CODE_BROWSER_ROLE) {
             updateMakeDefaultBrowserPreference()
-        }
-    }
-
-    private fun navigateUserToDefaultAppsSettings() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            val intent = Intent(android.provider.Settings.ACTION_MANAGE_DEFAULT_APPS_SETTINGS)
-            intent.putExtra(SETTINGS_SELECT_OPTION_KEY, DEFAULT_BROWSER_APP_OPTION)
-            intent.putExtra(SETTINGS_SHOW_FRAGMENT_ARGS,
-                bundleOf(SETTINGS_SELECT_OPTION_KEY to DEFAULT_BROWSER_APP_OPTION))
-            startActivity(intent)
         }
     }
 
@@ -578,12 +533,8 @@ class SettingsFragment : PreferenceFragmentCompat() {
     }
 
     companion object {
-        private const val REQUEST_CODE_BROWSER_ROLE = 1
         private const val SCROLL_INDICATOR_DELAY = 10L
         private const val FXA_SYNC_OVERRIDE_EXIT_DELAY = 2000L
         private const val AMO_COLLECTION_OVERRIDE_EXIT_DELAY = 3000L
-        private const val SETTINGS_SELECT_OPTION_KEY = ":settings:fragment_args_key"
-        private const val SETTINGS_SHOW_FRAGMENT_ARGS = ":settings:show_fragment_args"
-        private const val DEFAULT_BROWSER_APP_OPTION = "default_browser"
     }
 }


### PR DESCRIPTION
For multiple experiments (https://github.com/mozilla-mobile/fenix/issues/18608 ,https://github.com/mozilla-mobile/fenix/issues/18376, https://github.com/mozilla-mobile/fenix/issues/18375)  we need a reusable behavior for setting a default browser, this PR make the functionality reusable. 
  
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
