### PR TITLE
For #18776: PWA install to homescreen is available in main menu

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
@@ -199,6 +199,21 @@ open class DefaultToolbarMenu(
     } ?: false
     // End of predicates //
 
+    val installToHomescreen = BrowserMenuHighlightableItem(
+        label = context.getString(R.string.browser_menu_install_on_homescreen),
+        startImageResource = R.drawable.ic_add_to_homescreen,
+        iconTintColorResource = primaryTextColor,
+        highlight = BrowserMenuHighlight.LowPriority(
+            label = context.getString(R.string.browser_menu_install_on_homescreen),
+            notificationTint = getColor(context, R.color.whats_new_notification_color)
+        ),
+        isHighlighted = {
+            !context.settings().installPwaOpened
+        }
+    ) {
+        onItemTapped.invoke(ToolbarMenu.Item.InstallToHomeScreen)
+    }
+
     private val oldCoreMenuItems by lazy {
         val settings = BrowserMenuHighlightableItem(
             label = context.getString(R.string.browser_menu_settings),
@@ -251,21 +266,6 @@ open class DefaultToolbarMenu(
             iconTintColorResource = primaryTextColor
         ) {
             onItemTapped.invoke(ToolbarMenu.Item.SyncedTabs)
-        }
-
-        val installToHomescreen = BrowserMenuHighlightableItem(
-            label = context.getString(R.string.browser_menu_install_on_homescreen),
-            startImageResource = R.drawable.ic_add_to_homescreen,
-            iconTintColorResource = primaryTextColor,
-            highlight = BrowserMenuHighlight.LowPriority(
-                label = context.getString(R.string.browser_menu_install_on_homescreen),
-                notificationTint = getColor(context, R.color.whats_new_notification_color)
-            ),
-            isHighlighted = {
-                !context.settings().installPwaOpened
-            }
-        ) {
-            onItemTapped.invoke(ToolbarMenu.Item.InstallToHomeScreen)
         }
 
         val findInPage = BrowserMenuImageText(
@@ -541,6 +541,7 @@ open class DefaultToolbarMenu(
                 reportSiteIssuePlaceholder,
                 BrowserMenuDivider(),
                 addToHomeScreenItem.apply { visible = ::canAddToHomescreen },
+                installToHomescreen.apply { visible = ::canInstall },
                 addToTopSitesItem,
                 saveToCollectionItem,
                 BrowserMenuDivider(),


### PR DESCRIPTION
For #18776 

This was missed in the original designs. See issue for STR

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
