### PR TITLE
No issue: Enable the tabs tray refactor in nightly

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -42,7 +42,7 @@ object FeatureFlags {
     /**
      * Enables the tabs tray re-write with Synced Tabs.
      */
-    val tabsTrayRewrite = Config.channel.isDebug
+    val tabsTrayRewrite = Config.channel.isNightlyOrDebug
 
     /**
      * Enables the updated icon set look and feel.


### PR DESCRIPTION
We have our core functionality in now, so we can enable this on nightly for folks to test.

There are some known issues that we should fix before we let this ride the trains though.

<img width="539" alt="Screen Shot 2021-04-07 at 4 41 44 PM" src="https://user-images.githubusercontent.com/1370580/113931197-309c5980-97c0-11eb-9328-00329da73fcd.png">

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
