### PR TITLE
For #7924: Added an undo snackbar when a pinned site is removed

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/TopSitesTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/TopSitesTest.kt
@@ -20,6 +20,7 @@ import org.mozilla.fenix.helpers.RetryTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper.getGenericAsset
 import org.mozilla.fenix.helpers.TestHelper.generateRandomString
 import org.mozilla.fenix.helpers.TestHelper.getStringResource
+import org.mozilla.fenix.helpers.TestHelper.waitUntilSnackbarGone
 import org.mozilla.fenix.ui.robots.browserScreen
 import org.mozilla.fenix.ui.robots.homeScreen
 import org.mozilla.fenix.ui.robots.navigationToolbar
@@ -228,6 +229,8 @@ class TopSitesTest {
             verifyExistingTopSitesTabs(defaultWebPage.title)
         }.openContextMenuOnTopSitesWithTitle(defaultWebPage.title) {
         }.deleteTopSiteFromHistory {
+            verifySnackBarText(getStringResource(R.string.snackbar_top_site_removed))
+            waitUntilSnackbarGone()
         }.openThreeDotMenu {
         }.openHistory {
             verifyEmptyHistoryView()

--- a/app/src/main/java/org/mozilla/fenix/home/topsites/TopSiteItemViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/topsites/TopSiteItemViewHolder.kt
@@ -31,6 +31,7 @@ import org.mozilla.fenix.GleanMetrics.Pings
 import org.mozilla.fenix.GleanMetrics.TopSites
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.AppStore
+import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.databinding.TopSiteItemBinding
 import org.mozilla.fenix.ext.bitmapForUrl
 import org.mozilla.fenix.ext.components
@@ -67,9 +68,22 @@ class TopSiteItemViewHolder(
                     is TopSiteItemMenu.Item.RenameTopSite -> interactor.onRenameTopSiteClicked(
                         topSite,
                     )
-                    is TopSiteItemMenu.Item.RemoveTopSite -> interactor.onRemoveTopSiteClicked(
-                        topSite,
-                    )
+                    is TopSiteItemMenu.Item.RemoveTopSite -> {
+                        interactor.onRemoveTopSiteClicked(topSite)
+                        FenixSnackbar.make(
+                            view = it,
+                            duration = FenixSnackbar.LENGTH_LONG,
+                            isDisplayedWithBrowserToolbar = false,
+                        )
+                            .setText(it.context.getString(R.string.snackbar_top_site_removed))
+                            .setAction(it.context.getString(R.string.snackbar_deleted_undo)) {
+                                it.context.components.useCases.topSitesUseCase.addPinnedSites(
+                                    topSite.title.toString(),
+                                    topSite.url,
+                                )
+                            }
+                            .show()
+                    }
                     is TopSiteItemMenu.Item.Settings -> interactor.onSettingsClicked()
                     is TopSiteItemMenu.Item.SponsorPrivacy -> interactor.onSponsorPrivacyClicked()
                 }


### PR DESCRIPTION
fixes: #7924
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture



![WhatsApp Image 2021-04-08 at 11 03 09 PM](https://user-images.githubusercontent.com/56197993/114071491-ce764e00-98be-11eb-9b94-3a17a675d080.jpeg)


Fixes #7924
Fixes #7924
Fixes #7924
Fixes #7924