### PR TITLE
Issue #17819: Pull trove4j from Maven Central instead of JCenter.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -146,12 +146,6 @@ allprojects {
                     // https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/
                     ////////////////////////////////////////////////////////////////////////////////
 
-                    // Used by Android Gradle Plugin
-                    // Issue for publishing to maven central: https://youtrack.jetbrains.com/issue/IDEA-261387
-                    // Related plugin issue: https://issuetracker.google.com/issues/179291081
-                    // Other option: Update to Android Gradle Plugin 7+ (still in Alpha currently)
-                    includeVersion("org.jetbrains.trove4j", "trove4j", "20160824")
-
                     // Used by detekt
                     // Issue for publishing to maven central: https://github.com/Kotlin/kotlinx.html/issues/173
                     // Related detekt issue: https://github.com/detekt/detekt/issues/3461
@@ -160,7 +154,7 @@ allprojects {
 
                     // Fastlane
                     // Doesn't seem to be available on Maven Central yet, and I couldn't find an issue for it
-                    // https://github.com/fastlane/fastlane
+                    // https://github.com/fastlane/fastlane/issues/18174
                     includeVersion("tools.fastlane", "screengrab", "2.0.0")
                     // https://github.com/jraska/Falcon/issues/52
                     includeVersion("com.jraska", "falcon", "2.1.1")


### PR DESCRIPTION
One more gone. :)