### PR TITLE
For #18768: Increased text contrast ratio of TextViews in 'Share tab'

### DIFF
--- a/app/src/main/res/layout/app_share_list_item.xml
+++ b/app/src/main/res/layout/app_share_list_item.xml
@@ -33,6 +33,7 @@
         android:gravity="center|top"
         android:lines="2"
         android:textAlignment="gravity"
+        android:textColor="@color/photonDarkGrey10"
         android:textSize="10sp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/share_tab_item.xml
+++ b/app/src/main/res/layout/share_tab_item.xml
@@ -42,7 +42,7 @@
         android:textSize="12sp"
         android:maxLines="1"
         android:ellipsize="end"
-        android:textColor="?secondaryText"
+        android:textColor="@color/photonLightGrey60"
         tools:text="https://www.mozilla.org/en-US/firefox/new/"
         app:layout_constraintStart_toStartOf="@id/share_tab_title"
         app:layout_constraintTop_toBottomOf="@id/share_tab_title"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -508,7 +508,7 @@
     <style name="ShareHeaderTextStyle">
         <item name="android:singleLine">true</item>
         <item name="android:textAllCaps">true</item>
-        <item name="android:textColor">?secondaryText</item>
+        <item name="android:textColor">@color/photonDarkGrey10</item>
         <item name="android:textSize">@dimen/share_header_text_size</item>
         <item name="android:textStyle">bold</item>
         <item name="fontFamily">@font/metropolis_semibold</item>


### PR DESCRIPTION
- Made changes according to discussion in comments of linked issue: https://github.com/mozilla-mobile/fenix/issues/18768#issuecomment-815278977
- Fixes #18768
- Changed `share_tab_url` color to `@color/photonLightGrey60` (`#AFAFBB`) (Used photonLightGrey60 instead of `secondary_text_dark_theme` as `secondary_text_dark_theme` corresponds to `#A7A2B7`)
- Changed `appName `and `recent_apps_link_header` color to `@color/photonDarkGrey10 (#52525E)`



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

### Screenshots:

After the changes, **no** accessibility suggestions appear. 

Light mode

![image](https://user-images.githubusercontent.com/67039214/114067949-fd8ac080-98ba-11eb-900e-8fe0af437e88.png)

Dark mode

![image](https://user-images.githubusercontent.com/67039214/114068042-198e6200-98bb-11eb-98cb-4a968e790e75.png)


