### PR TITLE
For #17870: Enable new three-dot menu redesign on nightly builds

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -37,7 +37,7 @@ object FeatureFlags {
     /**
      * Shows new three-dot toolbar menu design.
      */
-    val toolbarMenuFeature = Config.channel.isDebug
+    val toolbarMenuFeature = Config.channel.isNightlyOrDebug
 
     /**
      * Enables the tabs tray re-write with Synced Tabs.


### PR DESCRIPTION
For #17870 

The new redesign (meta: #17796) for the three-dot menu is currently only on debug builds. This will enable it on Nightly so we can start testing while we wait for the last few items to be completed.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
