### PR TITLE
No issue: add Android Emulator action for contributor PRs

### DIFF
--- a/.github/workflows/build-contributor-pr.yml
+++ b/.github/workflows/build-contributor-pr.yml
@@ -105,3 +105,30 @@ jobs:
           name: lintDebug report
           path: app/build/reports/lint-results-debug.html
 
+  run-ui:
+    runs-on: macos-latest
+    if: github.event.pull_request.head.repo.full_name != github.repository && github.actor != 'MickeyMoz'
+
+    timeout-minutes: 60
+    strategy:
+      matrix:
+        api-level: [28]
+        target: [google_apis]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Run subset of UI Tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          target: ${{ matrix.target }}
+          arch: x86_64
+          profile: pixel_3a
+          script:
+            "./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=\
+            org.mozilla.fenix.ui.NavigationToolbarTest#visitURLTest"
+      - name: Upload Test Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-report
+          path: app/build/reports


### PR DESCRIPTION
Adds a subset (those recently selected as fairly stable) to run via [android-emulator-runner](https://github.com/ReactiveCircus/android-emulator-runner) a HAXM enabled macOS VM. VM startup, AVD creation / boot time, and Gradle test-run for this small subset of tests (see below) takes a little less than 20 minutes. A full smoke-test run trying on personal repository took about 45 minutes. A full UI test-suite ran took just over 90 minutes. No parallelization or retries here compared to Firebase 😩 

Recommendation: continue with a small subset of UI tests to at least get something running for this scenario on contributor PR. 

Tests included in this draft (@sv-ohorvath selected these for beta execution recently):

- org.mozilla.fenix.ui.NavigationToolbarTest#visitURLTest
- org.mozilla.fenix.ui.HistoryTest#visitedUrlHistoryTest
- org.mozilla.fenix.ui.SmokeTest#openMainMenuSettingsItemTest
- org.mozilla.fenix.ui.SmokeTest#toggleSearchSuggestions
- org.mozilla.fenix.ui.SmokeTest#deleteCollectionTest
- org.mozilla.fenix.ui.SmokeTest#noHistoryInPrivateBrowsingTest
- org.mozilla.fenix.ui.NoNetworkAccessStartupTests#noNetworkConnectionStartupTest

Draft for feedback