### PR TITLE
Close #18934: Remove adapter when deataching from window

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabstray/browser/BaseBrowserTrayList.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/browser/BaseBrowserTrayList.kt
@@ -88,6 +88,9 @@ abstract class BaseBrowserTrayList @JvmOverloads constructor(
         tabsFeature.stop()
         swipeToDelete.stop()
 
+        // Release the adapter so that `onDetachedFromRecyclerView` will be called in the adapter.
+        adapter = null
+
         touchHelper.attachToRecyclerView(null)
     }
 }


### PR DESCRIPTION
I tried to write a test for this, but it's rather complicated to get the `onDeatachedFromWindow` call to be invoked.

Maybe someone else knows how to create a test activity that can be used to add and remove a view for testing?

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
