### PR TITLE
Issue #18885: Dismiss FAB icon when tabs tray is closed

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayController.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayController.kt
@@ -34,7 +34,7 @@ class DefaultTabsTrayController(
     private val browsingModeManager: BrowsingModeManager,
     private val navController: NavController,
     private val profiler: Profiler?,
-    private val dismissTabTray: () -> Unit,
+    private val navigationInteractor: NavigationInteractor,
     private val metrics: MetricController,
     private val ioScope: CoroutineScope,
     private val accountManager: FxaAccountManager
@@ -44,7 +44,7 @@ class DefaultTabsTrayController(
         val startTime = profiler?.getProfilerTime()
         browsingModeManager.mode = BrowsingMode.fromBoolean(isPrivate)
         navController.navigate(TabTrayDialogFragmentDirections.actionGlobalHome(focusOnAddressBar = true))
-        dismissTabTray()
+        navigationInteractor.onTabTrayDismissed()
         profiler?.addMarker(
             "DefaultTabTrayController.onNewTabTapped",
             startTime

--- a/app/src/main/java/org/mozilla/fenix/tabstray/TraySheetBehaviorCallback.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TraySheetBehaviorCallback.kt
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabstray
+
+import android.view.View
+import androidx.constraintlayout.widget.ConstraintLayout
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_HIDDEN
+import org.mozilla.fenix.components.metrics.Event
+import org.mozilla.fenix.components.metrics.MetricController
+
+class TraySheetBehaviorCallback(
+    private val behavior: BottomSheetBehavior<ConstraintLayout>,
+    private val trayInteractor: NavigationInteractor,
+    private val metrics: MetricController
+) : BottomSheetBehavior.BottomSheetCallback() {
+
+    override fun onStateChanged(bottomSheet: View, newState: Int) {
+        if (newState == STATE_HIDDEN) {
+            metrics.track(Event.TabsTrayClosed)
+            trayInteractor.onTabTrayDismissed()
+        } else if (newState == BottomSheetBehavior.STATE_HALF_EXPANDED) {
+            // We only support expanded and collapsed states.
+            // But why??
+            behavior.state = STATE_HIDDEN
+        }
+    }
+
+    override fun onSlide(bottomSheet: View, slideOffset: Float) = Unit
+}

--- a/app/src/test/java/org/mozilla/fenix/tabstray/TraySheetBehaviorCallbackTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/TraySheetBehaviorCallbackTest.kt
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabstray
+
+import androidx.constraintlayout.widget.ConstraintLayout
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_HALF_EXPANDED
+import com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_HIDDEN
+import com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_COLLAPSED
+import com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_DRAGGING
+import com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_SETTLING
+import com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_EXPANDED
+import io.mockk.Called
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Test
+import org.mozilla.fenix.components.metrics.Event
+import org.mozilla.fenix.components.metrics.MetricController
+
+class TraySheetBehaviorCallbackTest {
+
+    @Test
+    fun `WHEN state is hidden THEN invoke interactor`() {
+        val interactor = mockk<NavigationInteractor>(relaxed = true)
+        val metrics = mockk<MetricController>(relaxed = true)
+        val callback = TraySheetBehaviorCallback(mockk(), interactor, metrics)
+
+        callback.onStateChanged(mockk(), STATE_HIDDEN)
+
+        verify { interactor.onTabTrayDismissed() }
+        verify { metrics.track(Event.TabsTrayClosed) }
+    }
+
+    @Test
+    fun `WHEN state is half-expanded THEN close the tray`() {
+        val behavior = mockk<BottomSheetBehavior<ConstraintLayout>>(relaxed = true)
+        val callback = TraySheetBehaviorCallback(behavior, mockk(), mockk())
+
+        callback.onStateChanged(mockk(), STATE_HALF_EXPANDED)
+
+        verify { behavior.state = STATE_HIDDEN }
+    }
+
+    @Test
+    fun `WHEN other states are invoked THEN do nothing`() {
+        val behavior = mockk<BottomSheetBehavior<ConstraintLayout>>(relaxed = true)
+        val interactor = mockk<NavigationInteractor>(relaxed = true)
+        val metrics = mockk<MetricController>(relaxed = true)
+
+        val callback = TraySheetBehaviorCallback(behavior, interactor, metrics)
+
+        callback.onStateChanged(mockk(), STATE_COLLAPSED)
+        callback.onStateChanged(mockk(), STATE_DRAGGING)
+        callback.onStateChanged(mockk(), STATE_SETTLING)
+        callback.onStateChanged(mockk(), STATE_EXPANDED)
+
+        verify { behavior wasNot Called }
+        verify { interactor wasNot Called }
+        verify { metrics wasNot Called }
+    }
+}


### PR DESCRIPTION
Fixes the Add Tab/Sync Now button when dismissing the tabs tray which would stay on the screen until we pressed back one more time.

https://user-images.githubusercontent.com/1370580/114321983-cfd88e00-9aeb-11eb-979f-bfd620ac99c6.mp4


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
