### PR TITLE
Fix screenshots tests: showDefaultHomeScreen, bookmarksManagementTest

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/screenshots/DefaultHomeScreenTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/screenshots/DefaultHomeScreenTest.kt
@@ -31,8 +31,8 @@ class DefaultHomeScreenTest : ScreenshotTest() {
     @Test
     fun showDefaultHomeScreen() {
         homeScreen {
-            verifyAccountsSignInButton()
             swipeToBottom()
+            verifyAccountsSignInButton()
             Screengrab.screenshot("HomeScreenRobot_home-screen-scroll")
             TestAssetHelper.waitingTime
         }

--- a/app/src/androidTest/java/org/mozilla/fenix/screenshots/MenuScreenShotTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/screenshots/MenuScreenShotTest.kt
@@ -142,8 +142,8 @@ class MenuScreenShotTest : ScreenshotTest() {
         editBookmarkFolder()
         Screengrab.screenshot("ThreeDotMenuBookmarksRobot_edit-bookmark-folder-menu")
         // It may be needed to wait here to have the screenshot
-        mDevice.pressBack()
         bookmarksMenu {
+            navigateUp()
         }.openThreeDotMenu("test") {
             deleteBookmarkFolder()
             Screengrab.screenshot("ThreeDotMenuBookmarksRobot_delete-bookmark-folder-menu")


### PR DESCRIPTION
2 screenshot tests, showDefaultHomeScreen & bookmarksManagementTest, needed a small change due to the new onboarding cards order and the back press behavior on the edit bookmark screen.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
