### PR TITLE
Workflow to sync strings

### DIFF
--- a/.github/workflows/sync-strings.yml
+++ b/.github/workflows/sync-strings.yml
@@ -6,7 +6,7 @@ name: "Sync Strings"
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 */4 * * *'
 
 jobs:
   main:

--- a/.github/workflows/sync-strings.yml
+++ b/.github/workflows/sync-strings.yml
@@ -1,0 +1,43 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+name: "Sync Strings"
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  main:
+    name: "Sync Strings"
+    runs-on: ubuntu-20.04
+    steps:
+      - name: "Discover Fenix Beta Version"
+        id: fenix-beta-version
+        uses: mozilla-mobile/fenix-beta-version@1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: "Checkout Master Branch"
+        uses: actions/checkout@v2
+        with:
+          path: main
+          ref: master
+      - name: "Checkout Beta Branch"
+        uses: actions/checkout@v2
+        with:
+          path: beta
+          ref: "releases_v${{ steps.fenix-beta-version.outputs.fenix-beta-version }}.0.0"
+      - name: "Sync Strings"
+        uses: mozilla-mobile/sync-strings-action@1.0.0
+        with:
+          src: main
+          dst: beta
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: beta
+          branch: automation/sync-strings-${{ steps.fenix-beta-version.outputs.major-beta-version }}
+          title: "Sync Strings from master to releases_${{steps.fenix-beta-version.outputs.fenix-beta-version}}.0"
+          body: "This (automated) PR syncs strings from `master` to `releases_${{steps.fenix-beta-version.outputs.fenix-beta-version}}.0.0`"


### PR DESCRIPTION
(Similar to https://github.com/mozilla-mobile/android-components/pull/10075)

This patch introduces a `sync-strings.yml` _GitHub Actions Workflow_ that will periodically copy strings from `master` to the Fenix Beta branch.

 - It is configured to run daily at midnight UTC.
 - It will only create Pull Requests, but not land them. I'd like to start with manually reviewing these string sync PRs for a while and if we feel they are good to auto-land we can introduce a Mergify rule for that.
 - It will create PRs names `automation/string-sync-$RELEASE` and it will re-use the PR if new string changes need to be integrated and a previous PR has not been merged yet.

The _GitHub Actions_ used in this workflow are either from Mozilla or GItHUb, except for the [peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request) one. I've read through the code and I think it is trustworthy. (Good version number, well maintained, high number of users, officially on the GitHub Marketplace - but let's have a discussion if we have doubts)

The string sync logic is in https://github.com/mozilla-mobile/sync-strings-action

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
