### PR TITLE
Related to #18822: Add ignores for intermittent toolbar tests

### DIFF
--- a/app/src/test/java/org/mozilla/fenix/toolbar/DefaultToolbarMenuTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/toolbar/DefaultToolbarMenuTest.kt
@@ -23,6 +23,7 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.FeatureFlags
@@ -85,6 +86,7 @@ class DefaultToolbarMenuTest {
     }
 
     @Test
+    @Ignore("Intermittent test: https://github.com/mozilla-mobile/fenix/issues/18822")
     fun `WHEN the bottom toolbar is set THEN the first item in the list is not the navigation`() {
         if (FeatureFlags.toolbarMenuFeature) {
             every { context.settings().shouldUseBottomToolbar } returns true
@@ -101,6 +103,7 @@ class DefaultToolbarMenuTest {
     }
 
     @Test
+    @Ignore("Intermittent test: https://github.com/mozilla-mobile/fenix/issues/18822")
     fun `WHEN the top toolbar is set THEN the first item in the list is the navigation`() {
         if (FeatureFlags.toolbarMenuFeature) {
             every { context.settings().shouldUseBottomToolbar } returns false
@@ -117,6 +120,7 @@ class DefaultToolbarMenuTest {
     }
 
     @Test
+    @Ignore("Intermittent test: https://github.com/mozilla-mobile/fenix/issues/18822")
     fun `WHEN the bottom toolbar is set THEN the nav menu should be the last item`() {
         if (FeatureFlags.toolbarMenuFeature) {
             every { context.settings().shouldUseBottomToolbar } returns true
@@ -134,6 +138,7 @@ class DefaultToolbarMenuTest {
     }
 
     @Test
+    @Ignore("Intermittent test: https://github.com/mozilla-mobile/fenix/issues/18822")
     fun `WHEN the top toolbar is set THEN settings should be the last item`() {
         if (FeatureFlags.toolbarMenuFeature) {
             every { context.settings().shouldUseBottomToolbar } returns false


### PR DESCRIPTION
Related to #18822 

Temporary solution for these intermittent tests. They are currently breaking master 😢 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
