### PR TITLE
Close #18973: Fix references to info banner

### DIFF
--- a/app/src/main/res/layout/component_tabstray2.xml
+++ b/app/src/main/res/layout/component_tabstray2.xml
@@ -47,7 +47,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/infoBanner" />
+        app:layout_constraintTop_toBottomOf="@id/info_banner" />
 
     <View
         android:id="@+id/topBar"
@@ -162,7 +162,7 @@
         android:background="@color/tab_tray_item_divider_normal_theme"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/infoBanner" />
+        app:layout_constraintTop_toBottomOf="@+id/info_banner" />
 
     <androidx.viewpager2.widget.ViewPager2
         android:id="@+id/tabsTray"


### PR DESCRIPTION
In https://github.com/mozilla-mobile/fenix/pull/18886, we changed the ID `infoBanner` -> `info_banner`.

This change needed to be made on other UI elements that reference that block too.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
