### PR TITLE
Fixes #18995 - Upgrade the sync-strings action to v1.0.1

### DIFF
--- a/.github/workflows/sync-strings.yml
+++ b/.github/workflows/sync-strings.yml
@@ -29,7 +29,7 @@ jobs:
           path: beta
           ref: "releases_v${{ steps.fenix-beta-version.outputs.fenix-beta-version }}.0.0"
       - name: "Sync Strings"
-        uses: mozilla-mobile/sync-strings-action@1.0.0
+        uses: mozilla-mobile/sync-strings-action@1.0.1
         with:
           src: main
           dst: beta


### PR DESCRIPTION
This patch upgrades the sync-strings action in the `sync-strings` workflow to v1.0.1