### PR TITLE
No issue: test one shard per UI test on FTL

### DIFF
--- a/automation/taskcluster/androidTest/flank-x86.yml
+++ b/automation/taskcluster/androidTest/flank-x86.yml
@@ -48,9 +48,16 @@ gcloud:
 flank:
   project: GOOGLE_PROJECT
   # test shards - the amount of groups to split the test suite into
-  # set to -1 to use one shard per test.
-  max-test-shards: 50 
+  # set to -1 to use one shard per test. default: 1
+  max-test-shards: -1
   # num-test-runs: the amount of times to run the tests.
   # 1 runs the tests once. 10 runs all the tests 10x
   num-test-runs: 1
+  ### Output Style flag
+  ## Output style of execution status. May be one of [verbose, multi, single, compact].
+  ## For runs with only one test execution the default value is 'verbose', in other cases
+  ## 'multi' is used as the default. The output style 'multi' is not displayed correctly on consoles
+  ## which don't support ansi codes, to avoid corrupted output use single or verbose.
+  ## The output style `compact` is used to produce less detailed output, it prints just Args, test and matrix count, weblinks, cost, and result reports.
+  output-style: compact
 

--- a/taskcluster/ci/ui-test/kind.yml
+++ b/taskcluster/ci/ui-test/kind.yml
@@ -52,7 +52,7 @@ jobs:
         run-on-git-branches: ["^((?!releases[_/]).+)$"]
         run:
             commands:
-                - [automation/taskcluster/androidTest/ui-test.sh, x86, app.apk, android-test.apk, '50']
+                - [automation/taskcluster/androidTest/ui-test.sh, x86, app.apk, android-test.apk, '-1']
         treeherder:
             symbol: debug(ui-test-x86)
     screenshots-x86:


### PR DESCRIPTION
Testing the speed of test execution on FTL by using one shard per UI test.