### PR TITLE
No issue: Enable tabs tray re-write by default in nightly

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -1049,6 +1049,7 @@ class SmokeTest {
         }
     }
 
+    @Ignore("Feature is temporarily removed; disabling test. See https://github.com/mozilla-mobile/fenix/issues/18656")
     @Test
     fun selectTabsButtonVisibilityTest() {
         homeScreen {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -886,6 +886,7 @@ class SmokeTest {
         }
     }
 
+    @Ignore("Disabling until re-implemented by #19090")
     @Test
     fun verifyExpandedCollectionItemsTest() {
         val webPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
@@ -935,6 +936,7 @@ class SmokeTest {
         }
     }
 
+    @Ignore("Disabling until re-implemented by #19090")
     @Test
     fun shareCollectionTest() {
         val webPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
@@ -952,6 +954,7 @@ class SmokeTest {
         }
     }
 
+    @Ignore("Disabling until re-implemented by #19090")
     @Test
     fun deleteCollectionTest() {
         val webPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NavigationToolbarRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NavigationToolbarRobot.kt
@@ -185,10 +185,10 @@ class NavigationToolbarRobot {
         }
 
         fun openTabTray(interact: TabDrawerRobot.() -> Unit): TabDrawerRobot.Transition {
-            onView(withId(R.id.tab_button))
-                .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
-
+            mDevice.waitForIdle(waitingTime)
             tabTrayButton().click()
+            mDevice.waitNotNull(Until.findObject(By.res("$packageName:id/tab_layout")),
+                waitingTime)
 
             TabDrawerRobot().interact()
             return TabDrawerRobot.Transition()

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/TabDrawerRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/TabDrawerRobot.kt
@@ -174,7 +174,15 @@ class TabDrawerRobot {
 
     fun clickAddNewCollection() = addNewCollectionButton().click()
 
-    fun selectTab(title: String) = tab(title).click()
+    fun selectTab(title: String) {
+        mDevice.waitNotNull(
+            findObject(text(title)),
+            waitingTime
+        )
+
+        val tab = mDevice.findObject(text(title))
+        tab.click()
+    }
 
     fun clickSaveCollection() = saveTabsToCollectionButton().click()
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/TabDrawerRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/TabDrawerRobot.kt
@@ -160,7 +160,10 @@ class TabDrawerRobot {
 
     fun clickTabMediaControlButton() = tabMediaControlButton().click()
 
-    fun clickSelectTabs() = onView(withText("Select tabs")).click()
+    fun clickSelectTabs() {
+        threeDotMenu().click()
+        onView(withText("Select tabs")).click()
+    }
 
     fun clickAddNewCollection() = addNewCollectionButton().click()
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/TabDrawerRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/TabDrawerRobot.kt
@@ -208,15 +208,10 @@ class TabDrawerRobot {
         }
 
         fun openTabDrawer(interact: TabDrawerRobot.() -> Unit): TabDrawerRobot.Transition {
-            mDevice.findObject(UiSelector().resourceId("$packageName:id/tab_button"))
-                .waitForExists(waitingTime)
-
+            mDevice.waitForIdle(waitingTime)
             tabsCounter().click()
-
-            org.mozilla.fenix.ui.robots.mDevice.waitNotNull(
-                Until.findObject(By.res("$packageName:id/tab_layout")),
-                waitingTime
-            )
+            mDevice.waitNotNull(Until.findObject(By.res("$packageName:id/tab_layout")),
+                waitingTime)
 
             TabDrawerRobot().interact()
             return TabDrawerRobot.Transition()

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/TabDrawerRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/TabDrawerRobot.kt
@@ -162,7 +162,14 @@ class TabDrawerRobot {
 
     fun clickSelectTabs() {
         threeDotMenu().click()
-        onView(withText("Select tabs")).click()
+
+        mDevice.waitNotNull(
+            Until.findObject(text("Select tabs")),
+            waitingTime
+        )
+
+        val selectTabsButton = mDevice.findObject(text("Select tabs"))
+        selectTabsButton.click()
     }
 
     fun clickAddNewCollection() = addNewCollectionButton().click()
@@ -201,13 +208,13 @@ class TabDrawerRobot {
         }
 
         fun openTabDrawer(interact: TabDrawerRobot.() -> Unit): TabDrawerRobot.Transition {
-            mDevice.findObject(UiSelector().resourceId("org.mozilla.fenix.debug:id/tab_button"))
+            mDevice.findObject(UiSelector().resourceId("$packageName:id/tab_button"))
                 .waitForExists(waitingTime)
 
             tabsCounter().click()
 
             org.mozilla.fenix.ui.robots.mDevice.waitNotNull(
-                Until.findObject(By.res("org.mozilla.fenix.debug:id/tab_layout")),
+                Until.findObject(By.res("$packageName:id/tab_layout")),
                 waitingTime
             )
 

--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
@@ -352,7 +352,7 @@ class TabsTrayFragment : AppCompatDialogFragment(), TabsTrayInteractor {
             val menu = MenuIntegration(
                 context = requireContext(),
                 browserStore = requireComponents.core.store,
-                tabsTrayStore = TabsTrayStore(),
+                tabsTrayStore = tabsTrayStore,
                 tabLayout = tab_layout,
                 navigationInteractor = navigationInteractor
             ).build()

--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
@@ -71,7 +71,6 @@ class TabsTrayFragment : AppCompatDialogFragment(), TabsTrayInteractor {
     private val selectionBannerBinding = ViewBoundFeatureWrapper<SelectionBannerBinding>()
     private val selectionHandleBinding = ViewBoundFeatureWrapper<SelectionHandleBinding>()
     private val tabsTrayCtaBinding = ViewBoundFeatureWrapper<TabsTrayInfoBannerBinding>()
-    private val closeOnLastTabBinding = ViewBoundFeatureWrapper<CloseOnLastTabBinding>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -253,16 +252,6 @@ class TabsTrayFragment : AppCompatDialogFragment(), TabsTrayInteractor {
             owner = this,
             view = view
         )
-
-        closeOnLastTabBinding.set(
-            feature = CloseOnLastTabBinding(
-                browserStore = requireComponents.core.store,
-                tabsTrayStore = tabsTrayStore,
-                navigationInteractor = navigationInteractor
-            ),
-            owner = this,
-            view = view
-        )
     }
 
     override fun setCurrentTrayPosition(position: Int, smoothScroll: Boolean) {
@@ -290,9 +279,11 @@ class TabsTrayFragment : AppCompatDialogFragment(), TabsTrayInteractor {
         val tab = browserStore.state.findTab(tabId)
 
         tab?.let {
-            requireComponents.useCases.tabsUseCases.removeTab(tabId)
-            if (browserStore.state.getNormalOrPrivateTabs(it.content.private).isNotEmpty()) {
+            if (browserStore.state.getNormalOrPrivateTabs(it.content.private).size != 1) {
+                requireComponents.useCases.tabsUseCases.removeTab(tabId)
                 showUndoSnackbarForTab(it)
+            } else {
+                dismissTabsTrayAndNavigateHome(tabId)
             }
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayViewHolder.kt
@@ -38,6 +38,7 @@ import org.mozilla.fenix.ext.toShortUrl
 import org.mozilla.fenix.selection.SelectionHolder
 import org.mozilla.fenix.selection.SelectionInteractor
 import org.mozilla.fenix.tabstray.browser.BrowserTrayInteractor
+import org.mozilla.fenix.tabstray.ext.isSelect
 
 /**
  * A RecyclerView ViewHolder implementation for "tab" items.
@@ -206,7 +207,7 @@ abstract class TabsTrayViewHolder(
         itemView.setOnClickListener {
             val selected = holder.selectedItems
             when {
-                selected.isEmpty() -> interactor.open(item)
+                selected.isEmpty() && trayStore.state.mode.isSelect().not() -> interactor.open(item)
                 item in selected -> interactor.deselect(item)
                 else -> interactor.select(item)
             }

--- a/app/src/main/java/org/mozilla/fenix/tabstray/ext/TabsTrayState.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/ext/TabsTrayState.kt
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabstray.ext
+
+import org.mozilla.fenix.tabstray.TabsTrayState.Mode
+
+/**
+ * A helper to check if we're in [Mode.Select] mode.
+ */
+fun Mode.isSelect() = this is Mode.Select

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -353,7 +353,7 @@ class Settings(private val appContext: Context) : PreferencesHolder {
 
     var tabsTrayRewrite by featureFlagPreference(
         appContext.getPreferenceKey(R.string.pref_key_new_tabs_tray),
-        default = false,
+        default = true,
         featureFlag = FeatureFlags.tabsTrayRewrite
     )
 


### PR DESCRIPTION
With https://github.com/mozilla-mobile/fenix/pull/18999 in review, all our existing functionality has complete code paths. So it we can flip the flag for nightly only users to get some feedback from our users. 🎉 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
