### PR TITLE
Close #19011: Always have a click listener in TabTrayViewHolder

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayViewHolder.kt
@@ -87,8 +87,10 @@ abstract class TabsTrayViewHolder(
         updateSelectedTabIndicator(isSelected)
         updateMediaState(tab)
 
-        selectionHolder?.let {
-            setSelectionInteractor(tab, it, browserTrayInteractor)
+        if (selectionHolder != null) {
+            setSelectionInteractor(tab, selectionHolder, browserTrayInteractor)
+        } else {
+            itemView.setOnClickListener { browserTrayInteractor.open(tab) }
         }
 
         if (tab.thumbnail != null) {

--- a/app/src/test/java/org/mozilla/fenix/tabstray/TabsTrayViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/TabsTrayViewHolderTest.kt
@@ -1,0 +1,102 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabstray
+
+import android.view.LayoutInflater
+import android.view.View
+import io.mockk.mockk
+import io.mockk.verify
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.concept.base.images.ImageLoader
+import mozilla.components.concept.tabstray.Tab
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.fenix.R
+import org.mozilla.fenix.components.metrics.MetricController
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+import org.mozilla.fenix.selection.SelectionHolder
+import org.mozilla.fenix.tabstray.browser.BrowserTrayInteractor
+import org.mozilla.fenix.tabstray.browser.createTab
+
+@RunWith(FenixRobolectricTestRunner::class)
+class TabsTrayViewHolderTest {
+    val store = TabsTrayStore()
+    val browserStore = BrowserStore()
+    val interactor = mockk<BrowserTrayInteractor>(relaxed = true)
+
+    @Test
+    fun `WHEN itemView is clicked THEN interactor invokes open`() {
+        val view = LayoutInflater.from(testContext).inflate(R.layout.tab_tray_item, null)
+        val holder = TestTabTrayViewHolder(
+            view,
+            mockk(relaxed = true),
+            store,
+            null,
+            browserStore,
+            mockk(relaxed = true),
+            interactor
+        )
+
+        holder.bind(createTab(), false, mockk(), mockk())
+
+        holder.itemView.performClick()
+
+        verify { interactor.open(any()) }
+    }
+
+    @Test
+    fun `WHEN itemView is clicked with a selection holder THEN the select holder is invoked`() {
+        val view = LayoutInflater.from(testContext).inflate(R.layout.tab_tray_item, null)
+        val selectionHolder = TestSelectionHolder(emptySet())
+        val holder = TestTabTrayViewHolder(
+            view,
+            mockk(relaxed = true),
+            store,
+            selectionHolder,
+            browserStore,
+            mockk(relaxed = true),
+            interactor
+        )
+
+        holder.bind(createTab(), false, mockk(), mockk())
+
+        holder.itemView.performClick()
+
+        verify { interactor.open(any()) }
+        assertTrue(selectionHolder.invoked)
+    }
+
+    @Suppress("LongParameterList")
+    class TestTabTrayViewHolder(
+        itemView: View,
+        imageLoader: ImageLoader,
+        trayStore: TabsTrayStore,
+        selectionHolder: SelectionHolder<Tab>?,
+        store: BrowserStore,
+        metrics: MetricController,
+        override val browserTrayInteractor: BrowserTrayInteractor
+    ) : TabsTrayViewHolder(itemView, imageLoader, trayStore, selectionHolder, store, metrics) {
+        override val thumbnailSize: Int
+            get() = 30
+
+        override fun updateSelectedTabIndicator(showAsSelected: Boolean) {
+            // do nothing
+        }
+    }
+
+    class TestSelectionHolder(
+        private val testItems: Set<Tab>
+    ) : SelectionHolder<Tab> {
+        override val selectedItems: Set<Tab>
+            get() {
+                invoked = true
+                return testItems
+            }
+
+        var invoked = false
+    }
+}


### PR DESCRIPTION
When we added multi-select, we delegated the onClickListener to the `SelectionInteractor` and [removed _our own_ click listeners](https://github.com/mozilla-mobile/fenix/commit/9078139e4024c14f55d4d283cccb8299e8423de6#diff-25e126b0322a3a843d7b554edae26d4002a0c077a0f82efc0a806fe882a6c04dL65-L67
).

This is fine for normal tabs which will have a `SelectionInteractor` set, but in private tabs, we do not. So we need to fallback to default handler in that case.

Caught by the UI tests. ❤️ 

Closes #19011.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
