### PR TITLE
Issue #18934: Do not nullify adapter on window detached

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabstray/browser/BaseBrowserTrayList.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/browser/BaseBrowserTrayList.kt
@@ -6,6 +6,7 @@ package org.mozilla.fenix.tabstray.browser
 
 import android.content.Context
 import android.util.AttributeSet
+import androidx.annotation.VisibleForTesting
 import androidx.recyclerview.widget.RecyclerView
 import mozilla.components.feature.tabs.tabstray.TabsFeature
 import org.mozilla.fenix.ext.components
@@ -82,14 +83,15 @@ abstract class BaseBrowserTrayList @JvmOverloads constructor(
         touchHelper.attachToRecyclerView(this)
     }
 
-    override fun onDetachedFromWindow() {
+    @VisibleForTesting
+    public override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
 
         tabsFeature.stop()
         swipeToDelete.stop()
 
-        // Release the adapter so that `onDetachedFromRecyclerView` will be called in the adapter.
-        adapter = null
+        // Notify the adapter that it is released from the view preemptively.
+        adapter?.onDetachedFromRecyclerView(this)
 
         touchHelper.attachToRecyclerView(null)
     }

--- a/app/src/test/java/org/mozilla/fenix/tabstray/browser/BaseBrowserTrayListTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/browser/BaseBrowserTrayListTest.kt
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabstray.browser
+
+import android.content.Context
+import io.mockk.mockk
+import io.mockk.verify
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+import org.mozilla.fenix.tabstray.TabsTrayStore
+
+@RunWith(FenixRobolectricTestRunner::class)
+class BaseBrowserTrayListTest {
+
+    @Test
+    fun `WHEN recyclerview detaches from window THEN notify adapter`() {
+        val trayList = TestBaseBrowserTrayList(testContext)
+        val adapter = mockk<BrowserTabsAdapter>(relaxed = true)
+
+        trayList.adapter = adapter
+        trayList.tabsTrayStore = TabsTrayStore()
+
+        trayList.onDetachedFromWindow()
+
+        verify { adapter.onDetachedFromRecyclerView(trayList) }
+    }
+
+    class TestBaseBrowserTrayList(context: Context) : BaseBrowserTrayList(context) {
+        override val configuration = Configuration(BrowserTabType.PRIVATE)
+    }
+}


### PR DESCRIPTION
Previously, to fix a memory leak, we were removing the adapter reference
entirely in order to have the `onDetachedFromRecyclerView` callback
invoked. This causes a side-effect where we can no longer reference the
adapter any more when we re-attach.

The simpler solution is to just invoke the needed callback directly
instead.

What the bug looks like in the tray:

https://user-images.githubusercontent.com/1370580/114648987-b41ce580-9cad-11eb-905b-7a3a5d21a33a.mp4


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
