### PR TITLE
For #19005: new tab three-dot menu sync sign in 

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -17,6 +17,7 @@ import org.junit.Before
 import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
+import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
@@ -227,11 +228,19 @@ class SmokeTest {
 
     @Test
     // Verifies the Synced tabs menu opens from a tab's 3 dot menu
-    fun openMainMenuSyncedTabsItemTest() {
-        homeScreen {
-        }.openThreeDotMenu {
-        }.openSyncedTabs {
-            verifySyncedTabsMenuHeader()
+    fun openMainMenuSyncItemTest() {
+        if (FeatureFlags.tabsTrayRewrite) {
+            homeScreen {
+            }.openThreeDotMenu {
+            }.openSyncSignIn {
+                verifyAccountSettingsMenuHeader()
+            }
+        } else {
+            homeScreen {
+            }.openThreeDotMenu {
+            }.openSyncedTabs {
+                verifySyncedTabsMenuHeader()
+            }
         }
     }
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/ThreeDotMenuMainTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/ThreeDotMenuMainTest.kt
@@ -9,6 +9,7 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.HomeActivityTestRule
 import org.mozilla.fenix.ui.robots.homeScreen
@@ -48,7 +49,11 @@ class ThreeDotMenuMainTest {
             verifyHistoryButton()
             verifyDownloadsButton()
             verifyAddOnsButton()
-            verifySyncedTabsButton()
+            if (FeatureFlags.tabsTrayRewrite) {
+                verifySyncSignInButton()
+            } else {
+                verifySyncedTabsButton()
+            }
             verifyDesktopSite()
             verifyWhatsNewButton()
             verifyHelpButton()

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SyncSignInRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SyncSignInRobot.kt
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.ui.robots
+
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
+import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.espresso.matcher.ViewMatchers.Visibility
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
+import org.hamcrest.CoreMatchers.allOf
+import org.mozilla.fenix.R
+import org.mozilla.fenix.helpers.click
+
+/**
+ * Implementation of Robot Pattern for Sync Sign In sub menu.
+ */
+class SyncSignInRobot {
+
+    fun verifyAccountSettingsMenuHeader() = assertAccountSettingsMenuHeader()
+
+    class Transition {
+        val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())!!
+
+        fun goBack(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
+            goBackButton().click()
+
+            BrowserRobot().interact()
+            return BrowserRobot.Transition()
+        }
+    }
+}
+
+private fun goBackButton() =
+    onView(allOf(withContentDescription("Navigate up")))
+
+private fun assertAccountSettingsMenuHeader() {
+    // Replaced with the new string here, the test is assuming we are NOT signed in
+    // Sync tests in SettingsSyncTest are still TO-DO, so I'm not sure that we have a test for signing into Sync
+    onView(withText(R.string.preferences_account_settings))
+        .check((matches(withEffectiveVisibility(Visibility.VISIBLE))))
+}

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuMainRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuMainRobot.kt
@@ -51,6 +51,7 @@ class ThreeDotMenuMainRobot {
     fun verifyHistoryButton() = assertHistoryButton()
     fun verifyBookmarksButton() = assertBookmarksButton()
     fun verifySyncedTabsButton() = assertSyncedTabsButton()
+    fun verifySyncSignInButton() = assertSyncSignInButton()
     fun verifyHelpButton() = assertHelpButton()
     fun verifyThreeDotMenuExists() = threeDotMenuRecyclerViewExists()
     fun verifyForwardButton() = assertForwardButton()
@@ -393,221 +394,226 @@ class ThreeDotMenuMainRobot {
         }
     }
 }
-private fun threeDotMenuRecyclerView() =
-    onView(withId(R.id.mozac_browser_menu_recyclerView))
 
-private fun threeDotMenuRecyclerViewExists() {
-    threeDotMenuRecyclerView().check(matches(isDisplayed()))
-}
+    private fun threeDotMenuRecyclerView() =
+        onView(withId(R.id.mozac_browser_menu_recyclerView))
 
-private fun settingsButton() = mDevice.findObject(UiSelector().text("Settings"))
-private fun assertSettingsButton() = assertTrue(settingsButton().waitForExists(waitingTime))
-
-private fun addOnsButton() = onView(allOf(withText("Add-ons")))
-private fun assertAddOnsButton() {
-    onView(withId(R.id.mozac_browser_menu_menuView)).perform(swipeDown())
-    addOnsButton().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-}
-
-private fun historyButton() = onView(allOf(withText(R.string.library_history)))
-private fun assertHistoryButton() = historyButton()
-    .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-
-private fun bookmarksButton() = onView(allOf(withText(R.string.library_bookmarks)))
-private fun assertBookmarksButton() = bookmarksButton()
-    .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-
-private fun syncedTabsButton() = onView(allOf(withText(R.string.library_synced_tabs)))
-private fun assertSyncedTabsButton() = syncedTabsButton()
-    .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-
-private fun signInToSyncButton() = onView(withText("Sign in to sync"))
-private fun assertSignInToSyncButton() = signInToSyncButton().check(matches(isDisplayed()))
-
-private fun helpButton() = onView(allOf(withText(R.string.browser_menu_help)))
-private fun assertHelpButton() = helpButton()
-    .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-
-private fun forwardButton() = mDevice.findObject(UiSelector().description("Forward"))
-private fun assertForwardButton() = assertTrue(forwardButton().waitForExists(waitingTime))
-
-private fun addBookmarkButton() = onView(allOf(withId(R.id.checkbox), withText("Add")))
-private fun assertAddBookmarkButton() {
-    onView(withId(R.id.mozac_browser_menu_menuView)).perform(swipeUp())
-    addBookmarkButton().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-}
-
-private fun editBookmarkButton() = onView(withText("Edit"))
-private fun assertEditBookmarkButton() = editBookmarkButton()
-    .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-
-private fun refreshButton() = mDevice.findObject(UiSelector().description("Refresh"))
-private fun assertRefreshButton() = assertTrue(refreshButton().waitForExists(waitingTime))
-
-private fun stopLoadingButton() = onView(ViewMatchers.withContentDescription("Stop"))
-
-private fun closeAllTabsButton() = onView(allOf(withText("Close all tabs"))).inRoot(RootMatchers.isPlatformPopup())
-private fun assertCloseAllTabsButton() = closeAllTabsButton()
-    .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-
-private fun shareTabButton() = onView(allOf(withText("Share all tabs"))).inRoot(RootMatchers.isPlatformPopup())
-private fun assertShareTabButton() = shareTabButton()
-    .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-
-private fun shareButton() = mDevice.findObject(UiSelector().description("Share"))
-private fun assertShareButton() = assertTrue(shareButton().waitForExists(waitingTime))
-
-private fun browserViewSaveCollectionButton() = onView(
-    allOf(
-        withText("Save to collection"),
-        withEffectiveVisibility(Visibility.VISIBLE)
-    )
-)
-
-private fun saveCollectionButton() = onView(allOf(withText("Save to collection"))).inRoot(RootMatchers.isPlatformPopup())
-private fun assertSaveCollectionButton() = saveCollectionButton()
-    .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-
-private fun selectTabsButton() = onView(allOf(withText("Select tabs"))).inRoot(RootMatchers.isPlatformPopup())
-private fun assertSelectTabsButton() = selectTabsButton()
-    .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-
-private fun addNewCollectionButton() = onView(allOf(withText("Add new collection")))
-private fun assertaddNewCollectionButton() = addNewCollectionButton()
-    .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-
-private fun collectionNameTextField() =
-    onView(allOf(withResourceName("name_collection_edittext")))
-
-private fun assertCollectionNameTextField() = collectionNameTextField()
-    .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-
-private fun reportSiteIssueButton() = onView(withText("Report Site Issue…"))
-private fun assertReportSiteIssueButton() = reportSiteIssueButton().check(matches(isDisplayed()))
-
-private fun findInPageButton() = onView(allOf(withText("Find in page")))
-
-private fun assertFindInPageButton() = findInPageButton()
-
-private fun shareScrim() = onView(withResourceName("closeSharingScrim"))
-
-private fun assertShareScrim() =
-    shareScrim().check(matches(ViewMatchers.withAlpha(ShareFragment.SHOW_PAGE_ALPHA)))
-
-private fun SendToDeviceTitle() =
-    onView(allOf(withText("SEND TO DEVICE"), withResourceName("accountHeaderText")))
-
-private fun assertSendToDeviceTitle() = SendToDeviceTitle()
-    .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-
-private fun shareALinkTitle() =
-    onView(allOf(withText("ALL ACTIONS"), withResourceName("apps_link_header")))
-
-private fun assertShareALinkTitle() = shareALinkTitle()
-
-private fun whatsNewButton() = onView(
-    allOf(
-        withText("What’s New"),
-        withEffectiveVisibility(Visibility.VISIBLE)
-    )
-)
-
-private fun assertWhatsNewButton() = whatsNewButton()
-    .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-
-private fun addToHomeScreenButton() = onView(withText("Add to Home screen"))
-
-private fun readerViewAppearanceToggle() =
-    mDevice.findObject(UiSelector().text("Customize reader view"))
-
-private fun assertReaderViewAppearanceButton(visible: Boolean) {
-    var maxSwipes = 3
-    if (visible) {
-        while (!readerViewAppearanceToggle().exists() && maxSwipes != 0) {
-            threeDotMenuRecyclerView().perform(swipeUp())
-            maxSwipes--
-        }
-        assertTrue(readerViewAppearanceToggle().exists())
-    } else {
-        while (!readerViewAppearanceToggle().exists() && maxSwipes != 0) {
-            threeDotMenuRecyclerView().perform(swipeUp())
-            maxSwipes--
-        }
-        assertFalse(readerViewAppearanceToggle().exists())
+    private fun threeDotMenuRecyclerViewExists() {
+        threeDotMenuRecyclerView().check(matches(isDisplayed()))
     }
-}
 
-private fun addToTopSitesButton() =
-    onView(allOf(withText(R.string.browser_menu_add_to_top_sites)))
+    private fun settingsButton() = mDevice.findObject(UiSelector().text("Settings"))
+    private fun assertSettingsButton() = assertTrue(settingsButton().waitForExists(waitingTime))
 
-private fun assertAddToTopSitesButton() {
-    onView(withId(R.id.mozac_browser_menu_recyclerView))
-        .perform(
-            RecyclerViewActions.scrollTo<RecyclerView.ViewHolder>(
-                hasDescendant(withText(R.string.browser_menu_add_to_top_sites))
-            )
-        ).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-}
+    private fun addOnsButton() = onView(allOf(withText("Add-ons")))
+    private fun assertAddOnsButton() {
+        onView(withId(R.id.mozac_browser_menu_menuView)).perform(swipeDown())
+        addOnsButton().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+    }
 
-private fun addToMobileHomeButton() =
-    onView(allOf(withText(R.string.browser_menu_add_to_homescreen)))
+    private fun historyButton() = onView(allOf(withText(R.string.library_history)))
+    private fun assertHistoryButton() = historyButton()
+        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
-private fun assertAddToMobileHome() {
-    onView(withId(R.id.mozac_browser_menu_recyclerView))
-        .perform(
-            RecyclerViewActions.scrollTo<RecyclerView.ViewHolder>(
-                hasDescendant(withText(R.string.browser_menu_add_to_homescreen))
-            )
-        ).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-}
+    private fun bookmarksButton() = onView(allOf(withText(R.string.library_bookmarks)))
+    private fun assertBookmarksButton() = bookmarksButton()
+        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
-private fun installPWAButton() = mDevice.findObject(UiSelector().text("Install"))
+    private fun syncedTabsButton() = onView(allOf(withText(R.string.library_synced_tabs)))
+    private fun assertSyncedTabsButton() = syncedTabsButton()
+        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
-private fun desktopSiteButton() =
-    onView(allOf(withText(R.string.browser_menu_desktop_site)))
-private fun assertDesktopSite() {
-    onView(withId(R.id.mozac_browser_menu_menuView)).perform(swipeUp())
-    desktopSiteButton().check(matches(isDisplayed()))
-}
+    private fun syncSignInButton() = onView(allOf(withText(R.string.sync_menu_sign_in)))
+    private fun assertSyncSignInButton() = syncSignInButton()
+        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
-private fun downloadsButton() = onView(withText(R.string.library_downloads))
-private fun assertDownloadsButton() {
-    onView(withId(R.id.mozac_browser_menu_menuView)).perform(swipeDown())
-    downloadsButton().check(matches(isDisplayed()))
-}
+    private fun signInToSyncButton() = onView(withText("Sign in to sync"))
+    private fun assertSignInToSyncButton() = signInToSyncButton().check(matches(isDisplayed()))
 
-private fun clickAddonsManagerButton() {
-    onView(withId(R.id.mozac_browser_menu_menuView)).perform(swipeDown())
-    addOnsButton().check(matches(isCompletelyDisplayed())).click()
-}
+    private fun helpButton() = onView(allOf(withText(R.string.browser_menu_help)))
+    private fun assertHelpButton() = helpButton()
+        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
-private fun exitSaveCollectionButton() = onView(withId(R.id.back_button)).check(matches(isDisplayed()))
+    private fun forwardButton() = mDevice.findObject(UiSelector().description("Forward"))
+    private fun assertForwardButton() = assertTrue(forwardButton().waitForExists(waitingTime))
 
-private fun tabSettingsButton() =
-    onView(allOf(withText("Tab settings"))).inRoot(RootMatchers.isPlatformPopup())
+    private fun addBookmarkButton() = onView(allOf(withId(R.id.checkbox), withText("Add")))
+    private fun assertAddBookmarkButton() {
+        onView(withId(R.id.mozac_browser_menu_menuView)).perform(swipeUp())
+        addBookmarkButton().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+    }
 
-private fun assertTabSettingsButton() {
-    tabSettingsButton()
-        .check(
-            matches(isDisplayed()))
-}
+    private fun editBookmarkButton() = onView(withText("Edit"))
+    private fun assertEditBookmarkButton() = editBookmarkButton()
+        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
-private fun recentlyClosedTabsButton() =
-    onView(allOf(withText("Recently closed tabs"))).inRoot(RootMatchers.isPlatformPopup())
+    private fun refreshButton() = mDevice.findObject(UiSelector().description("Refresh"))
+    private fun assertRefreshButton() = assertTrue(refreshButton().waitForExists(waitingTime))
 
-private fun assertRecentlyClosedTabsButton() {
-    recentlyClosedTabsButton()
-        .check(
-            matches(isDisplayed()))
-}
+    private fun stopLoadingButton() = onView(ViewMatchers.withContentDescription("Stop"))
 
-private fun shareAllTabsButton() =
-    onView(allOf(withText("Share all tabs"))).inRoot(RootMatchers.isPlatformPopup())
+    private fun closeAllTabsButton() = onView(allOf(withText("Close all tabs"))).inRoot(RootMatchers.isPlatformPopup())
+    private fun assertCloseAllTabsButton() = closeAllTabsButton()
+        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
-private fun assertShareAllTabsButton() {
-    shareAllTabsButton()
-        .check(
-            matches(isDisplayed()))
-}
+    private fun shareTabButton() = onView(allOf(withText("Share all tabs"))).inRoot(RootMatchers.isPlatformPopup())
+    private fun assertShareTabButton() = shareTabButton()
+        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
-private fun assertNewTabButton() = onView(withText("New tab")).check(matches(isDisplayed()))
+    private fun shareButton() = mDevice.findObject(UiSelector().description("Share"))
+    private fun assertShareButton() = assertTrue(shareButton().waitForExists(waitingTime))
+
+    private fun browserViewSaveCollectionButton() = onView(
+        allOf(
+            withText("Save to collection"),
+            withEffectiveVisibility(Visibility.VISIBLE)
+        )
+    )
+
+    private fun saveCollectionButton() = onView(allOf(withText("Save to collection"))).inRoot(RootMatchers.isPlatformPopup())
+    private fun assertSaveCollectionButton() = saveCollectionButton()
+        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+
+    private fun selectTabsButton() = onView(allOf(withText("Select tabs"))).inRoot(RootMatchers.isPlatformPopup())
+    private fun assertSelectTabsButton() = selectTabsButton()
+        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+
+    private fun addNewCollectionButton() = onView(allOf(withText("Add new collection")))
+    private fun assertaddNewCollectionButton() = addNewCollectionButton()
+        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+
+    private fun collectionNameTextField() =
+        onView(allOf(withResourceName("name_collection_edittext")))
+
+    private fun assertCollectionNameTextField() = collectionNameTextField()
+        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+
+    private fun reportSiteIssueButton() = onView(withText("Report Site Issue…"))
+    private fun assertReportSiteIssueButton() = reportSiteIssueButton().check(matches(isDisplayed()))
+
+    private fun findInPageButton() = onView(allOf(withText("Find in page")))
+
+    private fun assertFindInPageButton() = findInPageButton()
+
+    private fun shareScrim() = onView(withResourceName("closeSharingScrim"))
+
+    private fun assertShareScrim() =
+        shareScrim().check(matches(ViewMatchers.withAlpha(ShareFragment.SHOW_PAGE_ALPHA)))
+
+    private fun SendToDeviceTitle() =
+        onView(allOf(withText("SEND TO DEVICE"), withResourceName("accountHeaderText")))
+
+    private fun assertSendToDeviceTitle() = SendToDeviceTitle()
+        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+
+    private fun shareALinkTitle() =
+        onView(allOf(withText("ALL ACTIONS"), withResourceName("apps_link_header")))
+
+    private fun assertShareALinkTitle() = shareALinkTitle()
+
+    private fun whatsNewButton() = onView(
+        allOf(
+            withText("What’s New"),
+            withEffectiveVisibility(Visibility.VISIBLE)
+        )
+    )
+
+    private fun assertWhatsNewButton() = whatsNewButton()
+        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+
+    private fun addToHomeScreenButton() = onView(withText("Add to Home screen"))
+
+    private fun readerViewAppearanceToggle() =
+        mDevice.findObject(UiSelector().text("Customize reader view"))
+
+    private fun assertReaderViewAppearanceButton(visible: Boolean) {
+        var maxSwipes = 3
+        if (visible) {
+            while (!readerViewAppearanceToggle().exists() && maxSwipes != 0) {
+                threeDotMenuRecyclerView().perform(swipeUp())
+                maxSwipes--
+            }
+            assertTrue(readerViewAppearanceToggle().exists())
+        } else {
+            while (!readerViewAppearanceToggle().exists() && maxSwipes != 0) {
+                threeDotMenuRecyclerView().perform(swipeUp())
+                maxSwipes--
+            }
+            assertFalse(readerViewAppearanceToggle().exists())
+        }
+    }
+
+    private fun addToTopSitesButton() =
+        onView(allOf(withText(R.string.browser_menu_add_to_top_sites)))
+
+    private fun assertAddToTopSitesButton() {
+        onView(withId(R.id.mozac_browser_menu_recyclerView))
+            .perform(
+                RecyclerViewActions.scrollTo<RecyclerView.ViewHolder>(
+                    hasDescendant(withText(R.string.browser_menu_add_to_top_sites))
+                )
+            ).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+    }
+
+    private fun addToMobileHomeButton() =
+        onView(allOf(withText(R.string.browser_menu_add_to_homescreen)))
+
+    private fun assertAddToMobileHome() {
+        onView(withId(R.id.mozac_browser_menu_recyclerView))
+            .perform(
+                RecyclerViewActions.scrollTo<RecyclerView.ViewHolder>(
+                    hasDescendant(withText(R.string.browser_menu_add_to_homescreen))
+                )
+            ).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+    }
+
+    private fun installPWAButton() = mDevice.findObject(UiSelector().text("Install"))
+
+    private fun desktopSiteButton() =
+        onView(allOf(withText(R.string.browser_menu_desktop_site)))
+    private fun assertDesktopSite() {
+        onView(withId(R.id.mozac_browser_menu_menuView)).perform(swipeUp())
+        desktopSiteButton().check(matches(isDisplayed()))
+    }
+
+    private fun downloadsButton() = onView(withText(R.string.library_downloads))
+    private fun assertDownloadsButton() {
+        onView(withId(R.id.mozac_browser_menu_menuView)).perform(swipeDown())
+        downloadsButton().check(matches(isDisplayed()))
+    }
+
+    private fun clickAddonsManagerButton() {
+        onView(withId(R.id.mozac_browser_menu_menuView)).perform(swipeDown())
+        addOnsButton().check(matches(isCompletelyDisplayed())).click()
+    }
+
+    private fun exitSaveCollectionButton() = onView(withId(R.id.back_button)).check(matches(isDisplayed()))
+
+    private fun tabSettingsButton() =
+        onView(allOf(withText("Tab settings"))).inRoot(RootMatchers.isPlatformPopup())
+
+    private fun assertTabSettingsButton() {
+        tabSettingsButton()
+            .check(
+                matches(isDisplayed()))
+    }
+
+    private fun recentlyClosedTabsButton() =
+        onView(allOf(withText("Recently closed tabs"))).inRoot(RootMatchers.isPlatformPopup())
+
+    private fun assertRecentlyClosedTabsButton() {
+        recentlyClosedTabsButton()
+            .check(
+                matches(isDisplayed()))
+    }
+
+    private fun shareAllTabsButton() =
+        onView(allOf(withText("Share all tabs"))).inRoot(RootMatchers.isPlatformPopup())
+
+    private fun assertShareAllTabsButton() {
+        shareAllTabsButton()
+            .check(
+                matches(isDisplayed()))
+    }
+
+    private fun assertNewTabButton() = onView(withText("New tab")).check(matches(isDisplayed()))

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuMainRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuMainRobot.kt
@@ -51,7 +51,7 @@ class ThreeDotMenuMainRobot {
     fun verifyHistoryButton() = assertHistoryButton()
     fun verifyBookmarksButton() = assertBookmarksButton()
     fun verifySyncedTabsButton() = assertSyncedTabsButton()
-    fun verifySyncSignInButton() = assertSyncSignInButton()
+    fun verifySyncSignInButton() = assertSignInToSyncButton()
     fun verifyHelpButton() = assertHelpButton()
     fun verifyThreeDotMenuExists() = threeDotMenuRecyclerViewExists()
     fun verifyForwardButton() = assertForwardButton()
@@ -163,6 +163,15 @@ class ThreeDotMenuMainRobot {
 
             SyncedTabsRobot().interact()
             return SyncedTabsRobot.Transition()
+        }
+
+        fun openSyncSignIn(interact: SyncSignInRobot.() -> Unit): SyncSignInRobot.Transition {
+            onView(withId(R.id.mozac_browser_menu_recyclerView)).perform(swipeDown())
+            mDevice.waitNotNull(Until.findObject(By.text("Sign in to sync")), waitingTime)
+            signInToSyncButton().click()
+
+            SyncSignInRobot().interact()
+            return SyncSignInRobot.Transition()
         }
 
         fun openBookmarks(interact: BookmarksRobot.() -> Unit): BookmarksRobot.Transition {
@@ -394,226 +403,221 @@ class ThreeDotMenuMainRobot {
         }
     }
 }
+private fun threeDotMenuRecyclerView() =
+    onView(withId(R.id.mozac_browser_menu_recyclerView))
 
-    private fun threeDotMenuRecyclerView() =
-        onView(withId(R.id.mozac_browser_menu_recyclerView))
+private fun threeDotMenuRecyclerViewExists() {
+    threeDotMenuRecyclerView().check(matches(isDisplayed()))
+}
 
-    private fun threeDotMenuRecyclerViewExists() {
-        threeDotMenuRecyclerView().check(matches(isDisplayed()))
-    }
+private fun settingsButton() = mDevice.findObject(UiSelector().text("Settings"))
+private fun assertSettingsButton() = assertTrue(settingsButton().waitForExists(waitingTime))
 
-    private fun settingsButton() = mDevice.findObject(UiSelector().text("Settings"))
-    private fun assertSettingsButton() = assertTrue(settingsButton().waitForExists(waitingTime))
+private fun addOnsButton() = onView(allOf(withText("Add-ons")))
+private fun assertAddOnsButton() {
+    onView(withId(R.id.mozac_browser_menu_menuView)).perform(swipeDown())
+    addOnsButton().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+}
 
-    private fun addOnsButton() = onView(allOf(withText("Add-ons")))
-    private fun assertAddOnsButton() {
-        onView(withId(R.id.mozac_browser_menu_menuView)).perform(swipeDown())
-        addOnsButton().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-    }
+private fun historyButton() = onView(allOf(withText(R.string.library_history)))
+private fun assertHistoryButton() = historyButton()
+    .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
-    private fun historyButton() = onView(allOf(withText(R.string.library_history)))
-    private fun assertHistoryButton() = historyButton()
-        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+private fun bookmarksButton() = onView(allOf(withText(R.string.library_bookmarks)))
+private fun assertBookmarksButton() = bookmarksButton()
+    .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
-    private fun bookmarksButton() = onView(allOf(withText(R.string.library_bookmarks)))
-    private fun assertBookmarksButton() = bookmarksButton()
-        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+private fun syncedTabsButton() = onView(allOf(withText(R.string.library_synced_tabs)))
+private fun assertSyncedTabsButton() = syncedTabsButton()
+    .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
-    private fun syncedTabsButton() = onView(allOf(withText(R.string.library_synced_tabs)))
-    private fun assertSyncedTabsButton() = syncedTabsButton()
-        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+private fun signInToSyncButton() = onView(withText("Sign in to sync"))
+private fun assertSignInToSyncButton() = signInToSyncButton().check(matches(isDisplayed()))
 
-    private fun syncSignInButton() = onView(allOf(withText(R.string.sync_menu_sign_in)))
-    private fun assertSyncSignInButton() = syncSignInButton()
-        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+private fun helpButton() = onView(allOf(withText(R.string.browser_menu_help)))
+private fun assertHelpButton() = helpButton()
+    .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
-    private fun signInToSyncButton() = onView(withText("Sign in to sync"))
-    private fun assertSignInToSyncButton() = signInToSyncButton().check(matches(isDisplayed()))
+private fun forwardButton() = mDevice.findObject(UiSelector().description("Forward"))
+private fun assertForwardButton() = assertTrue(forwardButton().waitForExists(waitingTime))
 
-    private fun helpButton() = onView(allOf(withText(R.string.browser_menu_help)))
-    private fun assertHelpButton() = helpButton()
-        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+private fun addBookmarkButton() = onView(allOf(withId(R.id.checkbox), withText("Add")))
+private fun assertAddBookmarkButton() {
+    onView(withId(R.id.mozac_browser_menu_menuView)).perform(swipeUp())
+    addBookmarkButton().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+}
 
-    private fun forwardButton() = mDevice.findObject(UiSelector().description("Forward"))
-    private fun assertForwardButton() = assertTrue(forwardButton().waitForExists(waitingTime))
+private fun editBookmarkButton() = onView(withText("Edit"))
+private fun assertEditBookmarkButton() = editBookmarkButton()
+    .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
-    private fun addBookmarkButton() = onView(allOf(withId(R.id.checkbox), withText("Add")))
-    private fun assertAddBookmarkButton() {
-        onView(withId(R.id.mozac_browser_menu_menuView)).perform(swipeUp())
-        addBookmarkButton().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-    }
+private fun refreshButton() = mDevice.findObject(UiSelector().description("Refresh"))
+private fun assertRefreshButton() = assertTrue(refreshButton().waitForExists(waitingTime))
 
-    private fun editBookmarkButton() = onView(withText("Edit"))
-    private fun assertEditBookmarkButton() = editBookmarkButton()
-        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+private fun stopLoadingButton() = onView(ViewMatchers.withContentDescription("Stop"))
 
-    private fun refreshButton() = mDevice.findObject(UiSelector().description("Refresh"))
-    private fun assertRefreshButton() = assertTrue(refreshButton().waitForExists(waitingTime))
+private fun closeAllTabsButton() = onView(allOf(withText("Close all tabs"))).inRoot(RootMatchers.isPlatformPopup())
+private fun assertCloseAllTabsButton() = closeAllTabsButton()
+    .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
-    private fun stopLoadingButton() = onView(ViewMatchers.withContentDescription("Stop"))
+private fun shareTabButton() = onView(allOf(withText("Share all tabs"))).inRoot(RootMatchers.isPlatformPopup())
+private fun assertShareTabButton() = shareTabButton()
+    .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
-    private fun closeAllTabsButton() = onView(allOf(withText("Close all tabs"))).inRoot(RootMatchers.isPlatformPopup())
-    private fun assertCloseAllTabsButton() = closeAllTabsButton()
-        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+private fun shareButton() = mDevice.findObject(UiSelector().description("Share"))
+private fun assertShareButton() = assertTrue(shareButton().waitForExists(waitingTime))
 
-    private fun shareTabButton() = onView(allOf(withText("Share all tabs"))).inRoot(RootMatchers.isPlatformPopup())
-    private fun assertShareTabButton() = shareTabButton()
-        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-
-    private fun shareButton() = mDevice.findObject(UiSelector().description("Share"))
-    private fun assertShareButton() = assertTrue(shareButton().waitForExists(waitingTime))
-
-    private fun browserViewSaveCollectionButton() = onView(
-        allOf(
-            withText("Save to collection"),
-            withEffectiveVisibility(Visibility.VISIBLE)
-        )
+private fun browserViewSaveCollectionButton() = onView(
+    allOf(
+        withText("Save to collection"),
+        withEffectiveVisibility(Visibility.VISIBLE)
     )
+)
 
-    private fun saveCollectionButton() = onView(allOf(withText("Save to collection"))).inRoot(RootMatchers.isPlatformPopup())
-    private fun assertSaveCollectionButton() = saveCollectionButton()
-        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+private fun saveCollectionButton() = onView(allOf(withText("Save to collection"))).inRoot(RootMatchers.isPlatformPopup())
+private fun assertSaveCollectionButton() = saveCollectionButton()
+    .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
-    private fun selectTabsButton() = onView(allOf(withText("Select tabs"))).inRoot(RootMatchers.isPlatformPopup())
-    private fun assertSelectTabsButton() = selectTabsButton()
-        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+private fun selectTabsButton() = onView(allOf(withText("Select tabs"))).inRoot(RootMatchers.isPlatformPopup())
+private fun assertSelectTabsButton() = selectTabsButton()
+    .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
-    private fun addNewCollectionButton() = onView(allOf(withText("Add new collection")))
-    private fun assertaddNewCollectionButton() = addNewCollectionButton()
-        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+private fun addNewCollectionButton() = onView(allOf(withText("Add new collection")))
+private fun assertaddNewCollectionButton() = addNewCollectionButton()
+    .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
-    private fun collectionNameTextField() =
-        onView(allOf(withResourceName("name_collection_edittext")))
+private fun collectionNameTextField() =
+    onView(allOf(withResourceName("name_collection_edittext")))
 
-    private fun assertCollectionNameTextField() = collectionNameTextField()
-        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+private fun assertCollectionNameTextField() = collectionNameTextField()
+    .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
-    private fun reportSiteIssueButton() = onView(withText("Report Site Issue…"))
-    private fun assertReportSiteIssueButton() = reportSiteIssueButton().check(matches(isDisplayed()))
+private fun reportSiteIssueButton() = onView(withText("Report Site Issue…"))
+private fun assertReportSiteIssueButton() = reportSiteIssueButton().check(matches(isDisplayed()))
 
-    private fun findInPageButton() = onView(allOf(withText("Find in page")))
+private fun findInPageButton() = onView(allOf(withText("Find in page")))
 
-    private fun assertFindInPageButton() = findInPageButton()
+private fun assertFindInPageButton() = findInPageButton()
 
-    private fun shareScrim() = onView(withResourceName("closeSharingScrim"))
+private fun shareScrim() = onView(withResourceName("closeSharingScrim"))
 
-    private fun assertShareScrim() =
-        shareScrim().check(matches(ViewMatchers.withAlpha(ShareFragment.SHOW_PAGE_ALPHA)))
+private fun assertShareScrim() =
+    shareScrim().check(matches(ViewMatchers.withAlpha(ShareFragment.SHOW_PAGE_ALPHA)))
 
-    private fun SendToDeviceTitle() =
-        onView(allOf(withText("SEND TO DEVICE"), withResourceName("accountHeaderText")))
+private fun SendToDeviceTitle() =
+    onView(allOf(withText("SEND TO DEVICE"), withResourceName("accountHeaderText")))
 
-    private fun assertSendToDeviceTitle() = SendToDeviceTitle()
-        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+private fun assertSendToDeviceTitle() = SendToDeviceTitle()
+    .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
-    private fun shareALinkTitle() =
-        onView(allOf(withText("ALL ACTIONS"), withResourceName("apps_link_header")))
+private fun shareALinkTitle() =
+    onView(allOf(withText("ALL ACTIONS"), withResourceName("apps_link_header")))
 
-    private fun assertShareALinkTitle() = shareALinkTitle()
+private fun assertShareALinkTitle() = shareALinkTitle()
 
-    private fun whatsNewButton() = onView(
-        allOf(
-            withText("What’s New"),
-            withEffectiveVisibility(Visibility.VISIBLE)
-        )
+private fun whatsNewButton() = onView(
+    allOf(
+        withText("What’s New"),
+        withEffectiveVisibility(Visibility.VISIBLE)
     )
+)
 
-    private fun assertWhatsNewButton() = whatsNewButton()
-        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+private fun assertWhatsNewButton() = whatsNewButton()
+    .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
-    private fun addToHomeScreenButton() = onView(withText("Add to Home screen"))
+private fun addToHomeScreenButton() = onView(withText("Add to Home screen"))
 
-    private fun readerViewAppearanceToggle() =
-        mDevice.findObject(UiSelector().text("Customize reader view"))
+private fun readerViewAppearanceToggle() =
+    mDevice.findObject(UiSelector().text("Customize reader view"))
 
-    private fun assertReaderViewAppearanceButton(visible: Boolean) {
-        var maxSwipes = 3
-        if (visible) {
-            while (!readerViewAppearanceToggle().exists() && maxSwipes != 0) {
-                threeDotMenuRecyclerView().perform(swipeUp())
-                maxSwipes--
-            }
-            assertTrue(readerViewAppearanceToggle().exists())
-        } else {
-            while (!readerViewAppearanceToggle().exists() && maxSwipes != 0) {
-                threeDotMenuRecyclerView().perform(swipeUp())
-                maxSwipes--
-            }
-            assertFalse(readerViewAppearanceToggle().exists())
+private fun assertReaderViewAppearanceButton(visible: Boolean) {
+    var maxSwipes = 3
+    if (visible) {
+        while (!readerViewAppearanceToggle().exists() && maxSwipes != 0) {
+            threeDotMenuRecyclerView().perform(swipeUp())
+            maxSwipes--
         }
+        assertTrue(readerViewAppearanceToggle().exists())
+    } else {
+        while (!readerViewAppearanceToggle().exists() && maxSwipes != 0) {
+            threeDotMenuRecyclerView().perform(swipeUp())
+            maxSwipes--
+        }
+        assertFalse(readerViewAppearanceToggle().exists())
     }
+}
 
-    private fun addToTopSitesButton() =
-        onView(allOf(withText(R.string.browser_menu_add_to_top_sites)))
+private fun addToTopSitesButton() =
+    onView(allOf(withText(R.string.browser_menu_add_to_top_sites)))
 
-    private fun assertAddToTopSitesButton() {
-        onView(withId(R.id.mozac_browser_menu_recyclerView))
-            .perform(
-                RecyclerViewActions.scrollTo<RecyclerView.ViewHolder>(
-                    hasDescendant(withText(R.string.browser_menu_add_to_top_sites))
-                )
-            ).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-    }
+private fun assertAddToTopSitesButton() {
+    onView(withId(R.id.mozac_browser_menu_recyclerView))
+        .perform(
+            RecyclerViewActions.scrollTo<RecyclerView.ViewHolder>(
+                hasDescendant(withText(R.string.browser_menu_add_to_top_sites))
+            )
+        ).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+}
 
-    private fun addToMobileHomeButton() =
-        onView(allOf(withText(R.string.browser_menu_add_to_homescreen)))
+private fun addToMobileHomeButton() =
+    onView(allOf(withText(R.string.browser_menu_add_to_homescreen)))
 
-    private fun assertAddToMobileHome() {
-        onView(withId(R.id.mozac_browser_menu_recyclerView))
-            .perform(
-                RecyclerViewActions.scrollTo<RecyclerView.ViewHolder>(
-                    hasDescendant(withText(R.string.browser_menu_add_to_homescreen))
-                )
-            ).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-    }
+private fun assertAddToMobileHome() {
+    onView(withId(R.id.mozac_browser_menu_recyclerView))
+        .perform(
+            RecyclerViewActions.scrollTo<RecyclerView.ViewHolder>(
+                hasDescendant(withText(R.string.browser_menu_add_to_homescreen))
+            )
+        ).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+}
 
-    private fun installPWAButton() = mDevice.findObject(UiSelector().text("Install"))
+private fun installPWAButton() = mDevice.findObject(UiSelector().text("Install"))
 
-    private fun desktopSiteButton() =
-        onView(allOf(withText(R.string.browser_menu_desktop_site)))
-    private fun assertDesktopSite() {
-        onView(withId(R.id.mozac_browser_menu_menuView)).perform(swipeUp())
-        desktopSiteButton().check(matches(isDisplayed()))
-    }
+private fun desktopSiteButton() =
+    onView(allOf(withText(R.string.browser_menu_desktop_site)))
+private fun assertDesktopSite() {
+    onView(withId(R.id.mozac_browser_menu_menuView)).perform(swipeUp())
+    desktopSiteButton().check(matches(isDisplayed()))
+}
 
-    private fun downloadsButton() = onView(withText(R.string.library_downloads))
-    private fun assertDownloadsButton() {
-        onView(withId(R.id.mozac_browser_menu_menuView)).perform(swipeDown())
-        downloadsButton().check(matches(isDisplayed()))
-    }
+private fun downloadsButton() = onView(withText(R.string.library_downloads))
+private fun assertDownloadsButton() {
+    onView(withId(R.id.mozac_browser_menu_menuView)).perform(swipeDown())
+    downloadsButton().check(matches(isDisplayed()))
+}
 
-    private fun clickAddonsManagerButton() {
-        onView(withId(R.id.mozac_browser_menu_menuView)).perform(swipeDown())
-        addOnsButton().check(matches(isCompletelyDisplayed())).click()
-    }
+private fun clickAddonsManagerButton() {
+    onView(withId(R.id.mozac_browser_menu_menuView)).perform(swipeDown())
+    addOnsButton().check(matches(isCompletelyDisplayed())).click()
+}
 
-    private fun exitSaveCollectionButton() = onView(withId(R.id.back_button)).check(matches(isDisplayed()))
+private fun exitSaveCollectionButton() = onView(withId(R.id.back_button)).check(matches(isDisplayed()))
 
-    private fun tabSettingsButton() =
-        onView(allOf(withText("Tab settings"))).inRoot(RootMatchers.isPlatformPopup())
+private fun tabSettingsButton() =
+    onView(allOf(withText("Tab settings"))).inRoot(RootMatchers.isPlatformPopup())
 
-    private fun assertTabSettingsButton() {
-        tabSettingsButton()
-            .check(
-                matches(isDisplayed()))
-    }
+private fun assertTabSettingsButton() {
+    tabSettingsButton()
+        .check(
+            matches(isDisplayed()))
+}
 
-    private fun recentlyClosedTabsButton() =
-        onView(allOf(withText("Recently closed tabs"))).inRoot(RootMatchers.isPlatformPopup())
+private fun recentlyClosedTabsButton() =
+    onView(allOf(withText("Recently closed tabs"))).inRoot(RootMatchers.isPlatformPopup())
 
-    private fun assertRecentlyClosedTabsButton() {
-        recentlyClosedTabsButton()
-            .check(
-                matches(isDisplayed()))
-    }
+private fun assertRecentlyClosedTabsButton() {
+    recentlyClosedTabsButton()
+        .check(
+            matches(isDisplayed()))
+}
 
-    private fun shareAllTabsButton() =
-        onView(allOf(withText("Share all tabs"))).inRoot(RootMatchers.isPlatformPopup())
+private fun shareAllTabsButton() =
+    onView(allOf(withText("Share all tabs"))).inRoot(RootMatchers.isPlatformPopup())
 
-    private fun assertShareAllTabsButton() {
-        shareAllTabsButton()
-            .check(
-                matches(isDisplayed()))
-    }
+private fun assertShareAllTabsButton() {
+    shareAllTabsButton()
+        .check(
+            matches(isDisplayed()))
+}
 
-    private fun assertNewTabButton() = onView(withText("New tab")).check(matches(isDisplayed()))
+private fun assertNewTabButton() = onView(withText("New tab")).check(matches(isDisplayed()))

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -792,6 +792,13 @@ class HomeFragment : Fragment() {
                             HomeFragmentDirections.actionGlobalSyncedTabsFragment()
                         )
                     }
+                    HomeMenu.Item.SyncAccount -> {
+                        hideOnboardingIfNeeded()
+                        nav(
+                            R.id.homeFragment,
+                            HomeFragmentDirections.actionGlobalAccountSettingsFragment()
+                        )
+                    }
                     HomeMenu.Item.Bookmarks -> {
                         hideOnboardingIfNeeded()
                         nav(

--- a/app/src/main/java/org/mozilla/fenix/home/HomeMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeMenu.kt
@@ -48,6 +48,7 @@ class HomeMenu(
         object Downloads : Item()
         object Extensions : Item()
         object SyncTabs : Item()
+        object SyncAccount : Item()
         object WhatsNew : Item()
         object Help : Item()
         object Settings : Item()
@@ -313,12 +314,12 @@ class HomeMenu(
                 context.getString(R.string.sync_menu_sign_in)
             }
 
-        val syncMenuItem = BrowserMenuImageText(
+        val syncSignInMenuItem = BrowserMenuImageText(
             syncItemTitle,
             R.drawable.ic_synced_tabs,
             primaryTextColor
         ) {
-            onItemTapped.invoke(Item.SyncTabs)
+            onItemTapped.invoke(Item.SyncAccount)
         }
 
         val whatsNewItem = BrowserMenuHighlightableItem(
@@ -364,7 +365,7 @@ class HomeMenu(
             historyItem,
             downloadsItem,
             extensionsItem,
-            if (tabsTrayRewrite) syncMenuItem else syncedTabsItem,
+            if (tabsTrayRewrite) syncSignInMenuItem else syncedTabsItem,
             accountAuthItem,
             BrowserMenuDivider(),
             desktopItem,

--- a/app/src/main/java/org/mozilla/fenix/home/HomeMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeMenu.kt
@@ -57,17 +57,13 @@ class HomeMenu(
         data class DesktopMode(val checked: Boolean) : Item()
     }
 
-    private val primaryTextColor =
-        ThemeManager.resolveAttribute(R.attr.primaryText, context)
+    private val primaryTextColor = ThemeManager.resolveAttribute(R.attr.primaryText, context)
     private val syncDisconnectedColor =
         ThemeManager.resolveAttribute(R.attr.syncDisconnected, context)
     private val syncDisconnectedBackgroundColor =
         context.getColorFromAttr(R.attr.syncDisconnectedBackground)
 
     private val shouldUseBottomToolbar = context.settings().shouldUseBottomToolbar
-    private val accountManager = context.components.backgroundServices.accountManager
-
-    private var signedInToFxA = false
     private val accountManager = context.components.backgroundServices.accountManager
 
     // 'Reconnect' and 'Quit' items aren't needed most of the time, so we'll only create the if necessary.
@@ -94,17 +90,6 @@ class HomeMenu(
             primaryTextColor
         ) {
             onItemTapped.invoke(Item.Quit)
-        }
-    }
-
-    private fun getSyncItemTitle(): String {
-        val authenticatedAccount = accountManager.authenticatedAccount() != null
-        val email = accountManager.accountProfile()?.email
-
-        return if (authenticatedAccount && email != null) {
-            email
-        } else {
-            context.getString(R.string.sync_menu_sign_in)
         }
     }
 
@@ -241,6 +226,17 @@ class HomeMenu(
         onItemTapped.invoke(Item.DesktopMode(checked))
     }
 
+    private fun getSyncItemTitle(): String {
+        val authenticatedAccount = accountManager.authenticatedAccount() != null
+        val email = accountManager.accountProfile()?.email
+
+        return if (authenticatedAccount && email != null) {
+            email
+        } else {
+            context.getString(R.string.sync_menu_sign_in)
+        }
+    }
+
     @Suppress("ComplexMethod")
     private fun newCoreMenuItems(): List<BrowserMenuItem> {
         val experiments = context.components.analytics.experiments
@@ -306,16 +302,8 @@ class HomeMenu(
             onItemTapped.invoke(Item.SyncTabs)
         }
 
-        val syncItemTitle =
-            if (accountManager.accountProfile()?.email != null) {
-                signedInToFxA = true
-                accountManager.accountProfile()?.email!!
-            } else {
-                context.getString(R.string.sync_menu_sign_in)
-            }
-
         val syncSignInMenuItem = BrowserMenuImageText(
-            syncItemTitle,
+            getSyncItemTitle(),
             R.drawable.ic_synced_tabs,
             primaryTextColor
         ) {

--- a/app/src/main/java/org/mozilla/fenix/home/HomeMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeMenu.kt
@@ -24,6 +24,7 @@ import mozilla.components.concept.sync.AuthType
 import mozilla.components.concept.sync.OAuthAccount
 import mozilla.components.support.ktx.android.content.getColorFromAttr
 import org.mozilla.fenix.FeatureFlags
+import org.mozilla.fenix.FeatureFlags.tabsTrayRewrite
 import org.mozilla.fenix.R
 import org.mozilla.fenix.experiments.ExperimentBranch
 import org.mozilla.fenix.experiments.Experiments
@@ -63,6 +64,9 @@ class HomeMenu(
         context.getColorFromAttr(R.attr.syncDisconnectedBackground)
 
     private val shouldUseBottomToolbar = context.settings().shouldUseBottomToolbar
+    private val accountManager = context.components.backgroundServices.accountManager
+
+    private var signedInToFxA = false
     private val accountManager = context.components.backgroundServices.accountManager
 
     // 'Reconnect' and 'Quit' items aren't needed most of the time, so we'll only create the if necessary.
@@ -293,8 +297,24 @@ class HomeMenu(
             onItemTapped.invoke(Item.Extensions)
         }
 
-        val syncSignInItem = BrowserMenuImageText(
-            context.getString(R.string.library_synced_tabs),
+        val syncedTabsItem = BrowserMenuImageText(
+            context.getString(R.string.synced_tabs),
+            R.drawable.ic_synced_tabs,
+            primaryTextColor
+        ) {
+            onItemTapped.invoke(Item.SyncTabs)
+        }
+
+        val syncItemTitle =
+            if (accountManager.accountProfile()?.email != null) {
+                signedInToFxA = true
+                accountManager.accountProfile()?.email!!
+            } else {
+                context.getString(R.string.sync_menu_sign_in)
+            }
+
+        val syncMenuItem = BrowserMenuImageText(
+            syncItemTitle,
             R.drawable.ic_synced_tabs,
             primaryTextColor
         ) {
@@ -344,7 +364,7 @@ class HomeMenu(
             historyItem,
             downloadsItem,
             extensionsItem,
-            syncSignInItem,
+            if (tabsTrayRewrite) syncMenuItem else syncedTabsItem,
             accountAuthItem,
             BrowserMenuDivider(),
             desktopItem,


### PR DESCRIPTION
For #19005 

The sync item in the new tab three-dot menu should reflect the tabs tray rewrite. 
* If synced tabs are in the tabs tray, we show our new "sync sign in" item.
* Sync sign in clicks navigate to account settings

<img width="323" src="https://user-images.githubusercontent.com/43795363/114916217-27c40d00-9dea-11eb-95dd-bbdc52ae9fec.png">  <img width="323" alt="image" src="https://user-images.githubusercontent.com/43795363/114916959-0a437300-9deb-11eb-8878-27b35b9c8ddf.png">


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
