### PR TITLE
Issue #18819: Hide Credit Card pref by default (for settings w/o icons)

### DIFF
--- a/app/src/main/res/xml/preferences_without_icons.xml
+++ b/app/src/main/res/xml/preferences_without_icons.xml
@@ -73,7 +73,8 @@
         <androidx.preference.Preference
             app:iconSpaceReserved="false"
             android:key="@string/pref_key_credit_cards"
-            android:title="@string/preferences_credit_cards" />
+            android:title="@string/preferences_credit_cards"
+            app:isPreferenceVisible="false" />
 
         <androidx.preference.Preference
             android:key="@string/pref_key_accessibility"


### PR DESCRIPTION
Just saw the pref is still flashing briefly. We switched to a different preference file in the meantime / since the first fix.