### PR TITLE
Close #19045: Dismiss tabstray when last tab in a page is closed 

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabstray/CloseOnLastTabBinding.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/CloseOnLastTabBinding.kt
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabstray
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.map
+import mozilla.components.browser.state.selector.normalTabs
+import mozilla.components.browser.state.selector.privateTabs
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
+import org.mozilla.fenix.components.AbstractBinding
+
+/**
+ * A binding that closes the tabs tray when the last tab is closed.
+ */
+class CloseOnLastTabBinding(
+    browserStore: BrowserStore,
+    private val tabsTrayStore: TabsTrayStore,
+    private val navigationInteractor: NavigationInteractor
+) : AbstractBinding<BrowserState>(browserStore) {
+    override suspend fun onState(flow: Flow<BrowserState>) {
+        flow.map { it }
+            // Ignore the initial state; we don't want to close immediately.
+            .drop(1)
+            .ifChanged { it.tabs }
+            .collect { state ->
+                val selectedPage = tabsTrayStore.state.selectedPage
+                val tabs = when (selectedPage) {
+                    Page.NormalTabs -> {
+                        state.normalTabs
+                    }
+                    Page.PrivateTabs -> {
+                        state.privateTabs
+                    }
+                    else -> {
+                        // Do nothing if we're on any other non-browser page.
+                        null
+                    }
+                }
+                if (tabs?.isEmpty() == true) {
+                    navigationInteractor.onCloseAllTabsClicked(selectedPage == Page.PrivateTabs)
+                }
+            }
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
@@ -21,6 +21,7 @@ import kotlinx.android.synthetic.main.component_tabstray2.view.*
 import kotlinx.android.synthetic.main.component_tabstray2.view.tab_tray_overflow
 import kotlinx.android.synthetic.main.component_tabstray2.view.tab_wrapper
 import kotlinx.android.synthetic.main.component_tabstray_fab.*
+import kotlinx.android.synthetic.main.fragment_tab_tray_dialog.*
 import kotlinx.android.synthetic.main.tabs_tray_tab_counter2.*
 import kotlinx.android.synthetic.main.tabstray_multiselect_items.*
 import kotlinx.android.synthetic.main.tabstray_multiselect_items.view.*
@@ -143,6 +144,11 @@ class TabsTrayFragment : AppCompatDialogFragment(), TabsTrayInteractor {
             browserTrayInteractor,
             syncedTabsTrayInteractor
         )
+
+        setupBackgroundDismissalListener {
+            requireComponents.analytics.metrics.track(Event.TabsTrayClosed)
+            dismissAllowingStateLoss()
+        }
 
         behavior.addBottomSheetCallback(
             TraySheetBehaviorCallback(
@@ -309,6 +315,11 @@ class TabsTrayFragment : AppCompatDialogFragment(), TabsTrayInteractor {
 
             menu.showWithTheme(anchor)
         }
+    }
+
+    private fun setupBackgroundDismissalListener(block: (View) -> Unit) {
+        tabLayout.setOnClickListener(block)
+        handle.setOnClickListener(block)
     }
 
     private val homeViewModel: HomeScreenViewModel by activityViewModels()

--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
@@ -59,6 +59,7 @@ class TabsTrayFragment : AppCompatDialogFragment(), TabsTrayInteractor {
     private val selectionBannerBinding = ViewBoundFeatureWrapper<SelectionBannerBinding>()
     private val selectionHandleBinding = ViewBoundFeatureWrapper<SelectionHandleBinding>()
     private val tabsTrayCtaBinding = ViewBoundFeatureWrapper<TabsTrayInfoBannerBinding>()
+    private val closeOnLastTabBinding = ViewBoundFeatureWrapper<CloseOnLastTabBinding>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -224,6 +225,16 @@ class TabsTrayFragment : AppCompatDialogFragment(), TabsTrayInteractor {
                 store = tabsTrayStore,
                 handle = handle,
                 containerLayout = tab_wrapper
+            ),
+            owner = this,
+            view = view
+        )
+
+        closeOnLastTabBinding.set(
+            feature = CloseOnLastTabBinding(
+                browserStore = requireComponents.core.store,
+                tabsTrayStore = tabsTrayStore,
+                navigationInteractor = navigationInteractor
             ),
             owner = this,
             view = view

--- a/app/src/test/java/org/mozilla/fenix/tabstray/CloseOnLastTabBindingTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/CloseOnLastTabBindingTest.kt
@@ -1,0 +1,115 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabstray
+
+import io.mockk.Called
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import mozilla.components.browser.state.action.TabListAction
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.state.createTab
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.support.test.libstate.ext.waitUntilIdle
+import mozilla.components.support.test.rule.MainCoroutineRule
+import org.junit.Rule
+import org.junit.Test
+
+class CloseOnLastTabBindingTest {
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule(TestCoroutineDispatcher())
+
+    @Test
+    fun `WHEN the binding starts THEN do nothing`() {
+        val browserStore = BrowserStore()
+        val tabsTrayStore = TabsTrayStore()
+        val interactor = mockk<NavigationInteractor>(relaxed = true)
+        val binding = CloseOnLastTabBinding(browserStore, tabsTrayStore, interactor)
+
+        binding.start()
+
+        verify { interactor wasNot Called }
+    }
+
+    @Test
+    fun `WHEN a tab is closed THEN invoke the interactor`() {
+        val browserStore = BrowserStore(
+            BrowserState(
+                tabs = listOf(
+                    createTab(
+                        "https://mozilla.org",
+                        id = "tab1"
+                    )
+                )
+            )
+        )
+        val tabsTrayStore = TabsTrayStore()
+        val interactor = mockk<NavigationInteractor>(relaxed = true)
+        val binding = CloseOnLastTabBinding(browserStore, tabsTrayStore, interactor)
+
+        binding.start()
+
+        browserStore.dispatch(TabListAction.RemoveTabAction("tab1"))
+
+        browserStore.waitUntilIdle()
+
+        verify { interactor.onCloseAllTabsClicked(false) }
+    }
+
+    @Test
+    fun `WHEN a private tab is closed THEN invoke the interactor`() {
+        val browserStore = BrowserStore(
+            BrowserState(
+                tabs = listOf(
+                    createTab(
+                        "https://mozilla.org",
+                        id = "tab1",
+                        private = true
+                    )
+                )
+            )
+        )
+        val tabsTrayStore = TabsTrayStore(TabsTrayState(selectedPage = Page.PrivateTabs))
+        val interactor = mockk<NavigationInteractor>(relaxed = true)
+        val binding = CloseOnLastTabBinding(browserStore, tabsTrayStore, interactor)
+
+        binding.start()
+
+        browserStore.dispatch(TabListAction.RemoveTabAction("tab1"))
+
+        browserStore.waitUntilIdle()
+
+        verify { interactor.onCloseAllTabsClicked(true) }
+    }
+
+    @Test
+    fun `WHEN on the synced tabs page THEN nothing is invoked`() {
+        val browserStore = BrowserStore(
+            BrowserState(
+                tabs = listOf(
+                    createTab(
+                        "https://mozilla.org",
+                        id = "tab1",
+                        private = true
+                    )
+                )
+            )
+        )
+        val tabsTrayStore = TabsTrayStore(TabsTrayState(selectedPage = Page.SyncedTabs))
+        val interactor = mockk<NavigationInteractor>(relaxed = true)
+        val binding = CloseOnLastTabBinding(browserStore, tabsTrayStore, interactor)
+
+        binding.start()
+
+        browserStore.dispatch(TabListAction.RemoveAllTabsAction)
+
+        browserStore.waitUntilIdle()
+
+        verify { interactor wasNot Called }
+    }
+}


### PR DESCRIPTION
Fixes one the regressions caught by the UI test when running https://github.com/mozilla-mobile/fenix/pull/19001.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
