### PR TITLE
For #19023 - Expands tabsTray when tabs over certain number

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabstray/TraySheetBehaviorCallback.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TraySheetBehaviorCallback.kt
@@ -26,3 +26,19 @@ class TraySheetBehaviorCallback(
 
     override fun onSlide(bottomSheet: View, slideOffset: Float) = Unit
 }
+
+fun BottomSheetBehavior<ConstraintLayout>.setUpTrayBehavior(
+    isLandscape: Boolean,
+    maxNumberOfTabs: Int,
+    numberForExpandingTray: Int,
+    navigationInteractor: DefaultNavigationInteractor
+) {
+    addBottomSheetCallback(
+        TraySheetBehaviorCallback(this, navigationInteractor)
+    )
+    state = if (isLandscape || maxNumberOfTabs >= numberForExpandingTray) {
+        BottomSheetBehavior.STATE_EXPANDED
+    } else {
+        BottomSheetBehavior.STATE_COLLAPSED
+    }
+}

--- a/app/src/test/java/org/mozilla/fenix/tabstray/TraySheetBehaviorCallbackTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/TraySheetBehaviorCallbackTest.kt
@@ -14,6 +14,7 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_SETTLIN
 import com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_EXPANDED
 import io.mockk.Called
 import io.mockk.mockk
+import io.mockk.spyk
 import io.mockk.verify
 import org.junit.Test
 
@@ -52,5 +53,41 @@ class TraySheetBehaviorCallbackTest {
 
         verify { behavior wasNot Called }
         verify { interactor wasNot Called }
+    }
+
+    @Test
+    fun `GIVEN portraitMode and 5 tabs WHEN setUpTrayBehavior THEN add TraySheetBehaviorCallback and STATE_COLLAPSED`() {
+        // given
+        val behavior = spyk(BottomSheetBehavior<ConstraintLayout>())
+        val interactor = mockk<DefaultNavigationInteractor>(relaxed = true)
+
+        // when
+        behavior.setUpTrayBehavior(
+            isLandscape = false,
+            maxNumberOfTabs = 5,
+            numberForExpandingTray = TabsTrayFragment.EXPAND_AT_LIST_SIZE,
+            navigationInteractor = interactor
+        )
+
+        // then
+        assert(behavior.state == STATE_EXPANDED)
+    }
+
+    @Test
+    fun `GIVEN portraitMode and 2 tabs WHEN setUpTrayBehavior THEN add TraySheetBehaviorCallback and STATE_COLLAPSED`() {
+        // given
+        val behavior = spyk(BottomSheetBehavior<ConstraintLayout>())
+        val interactor = mockk<DefaultNavigationInteractor>(relaxed = true)
+
+        // when
+        behavior.setUpTrayBehavior(
+            isLandscape = false,
+            maxNumberOfTabs = 2,
+            numberForExpandingTray = TabsTrayFragment.EXPAND_AT_LIST_SIZE,
+            navigationInteractor = interactor
+        )
+
+        // then
+        assert(behavior.state == STATE_COLLAPSED)
     }
 }


### PR DESCRIPTION
TabsTray should be collapsed when there are only a few tabs on screen, otherwise it should go straight to STATE_EXPANDED.

For https://github.com/mozilla-mobile/fenix/issues/19023
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests.
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made.
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture


https://user-images.githubusercontent.com/60002907/115030490-d130fe80-9ecf-11eb-8634-8333cf5e2ba0.mp4


