### PR TITLE
Close #19064: Focus on tab page with the BrowsingModeManager

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabLayoutMediator.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabLayoutMediator.kt
@@ -6,9 +6,9 @@ package org.mozilla.fenix.tabstray
 
 import androidx.annotation.VisibleForTesting
 import com.google.android.material.tabs.TabLayout
-import mozilla.components.browser.state.selector.selectedTab
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.support.base.feature.LifecycleAwareFeature
+import org.mozilla.fenix.browser.browsingmode.BrowsingModeManager
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.components.metrics.MetricController
 import org.mozilla.fenix.tabstray.TrayPagerAdapter.Companion.POSITION_NORMAL_TABS
@@ -22,9 +22,9 @@ import org.mozilla.fenix.utils.Do
 class TabLayoutMediator(
     private val tabLayout: TabLayout,
     interactor: TabsTrayInteractor,
-    private val browserStore: BrowserStore,
+    private val browsingModeManager: BrowsingModeManager,
     private val tabsTrayStore: TabsTrayStore,
-    private val metrics: MetricController
+    metrics: MetricController
 ) : LifecycleAwareFeature {
 
     private val observer = TabLayoutObserver(interactor, metrics)
@@ -44,10 +44,8 @@ class TabLayoutMediator(
 
     @VisibleForTesting
     internal fun selectActivePage() {
-        val selectedTab = browserStore.state.selectedTab ?: return
-
         val selectedPagerPosition =
-            when (selectedTab.content.private) {
+            when (browsingModeManager.mode.isPrivate) {
                 true -> POSITION_PRIVATE_TABS
                 false -> POSITION_NORMAL_TABS
             }

--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
@@ -192,7 +192,7 @@ class TabsTrayFragment : AppCompatDialogFragment(), TabsTrayInteractor {
             feature = TabLayoutMediator(
                 tabLayout = tab_layout,
                 interactor = this,
-                browserStore = requireComponents.core.store,
+                browsingModeManager = activity.browsingModeManager,
                 tabsTrayStore = tabsTrayStore,
                 metrics = requireComponents.analytics.metrics
             ), owner = this,


### PR DESCRIPTION
Instead of using `BrowserStore` we use `BrowsingModeManager` to know which page on the tray should be selected in the `TabLayoutMediator`.


https://user-images.githubusercontent.com/1370580/115093258-b7031a80-9ee7-11eb-8b38-625ee4bac9c2.mp4


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
