### PR TITLE
Close #19094: Open sign-in flow if no account is created for tabs tray

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabstray/NavigationInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/NavigationInteractor.kt
@@ -15,6 +15,7 @@ import mozilla.components.browser.state.selector.normalTabs
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.prompt.ShareData
 import mozilla.components.concept.tabstray.Tab
+import mozilla.components.service.fxa.manager.FxaAccountManager
 import org.mozilla.fenix.collections.CollectionsDialog
 import org.mozilla.fenix.collections.show
 import org.mozilla.fenix.components.TabCollectionStorage
@@ -89,7 +90,8 @@ class DefaultNavigationInteractor(
     private val dismissTabTrayAndNavigateHome: (String) -> Unit,
     private val bookmarksUseCase: BookmarksUseCase,
     private val tabsTrayStore: TabsTrayStore,
-    private val collectionStorage: TabCollectionStorage
+    private val collectionStorage: TabCollectionStorage,
+    private val accountManager: FxaAccountManager
 ) : NavigationInteractor {
 
     override fun onTabTrayDismissed() {
@@ -97,18 +99,26 @@ class DefaultNavigationInteractor(
     }
 
     override fun onAccountSettingsClicked() {
-        navController.navigateBlockingForAsyncNavGraph(
-            TabsTrayFragmentDirections.actionGlobalAccountSettingsFragment())
+        val isSignedIn = accountManager.authenticatedAccount() != null
+
+        val direction = if (isSignedIn) {
+            TabsTrayFragmentDirections.actionGlobalAccountSettingsFragment()
+        } else {
+            TabsTrayFragmentDirections.actionGlobalTurnOnSync()
+        }
+        navController.navigateBlockingForAsyncNavGraph(direction)
     }
 
     override fun onTabSettingsClicked() {
         navController.navigateBlockingForAsyncNavGraph(
-            TabsTrayFragmentDirections.actionGlobalTabSettingsFragment())
+            TabsTrayFragmentDirections.actionGlobalTabSettingsFragment()
+        )
     }
 
     override fun onOpenRecentlyClosedClicked() {
         navController.navigateBlockingForAsyncNavGraph(
-            TabsTrayFragmentDirections.actionGlobalRecentlyClosed())
+            TabsTrayFragmentDirections.actionGlobalRecentlyClosed()
+        )
         metrics.track(Event.RecentlyClosedTabsOpened)
     }
 

--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
@@ -116,7 +116,8 @@ class TabsTrayFragment : AppCompatDialogFragment(), TabsTrayInteractor {
                 dismissTabTray = ::dismissTabsTray,
                 dismissTabTrayAndNavigateHome = ::dismissTabsTrayAndNavigateHome,
                 bookmarksUseCase = requireComponents.useCases.bookmarksUseCases,
-                collectionStorage = requireComponents.core.tabCollectionStorage
+                collectionStorage = requireComponents.core.tabCollectionStorage,
+                accountManager = requireComponents.backgroundServices.accountManager
             )
 
         tabsTrayController = DefaultTabsTrayController(


### PR DESCRIPTION
This isn't great that we have to do this check everywhere to show the right fragment, but it's what we currently follow and a larger change is a bit too late to add in at this moment.

https://user-images.githubusercontent.com/1370580/115286704-5bba6d80-a11d-11eb-8ae2-ae44c3bb0a31.mp4



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
