### PR TITLE
Closes #18816: Disable TabsTray FAB on accessibility enabled

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabstray/FloatingActionButtonBinding.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/FloatingActionButtonBinding.kt
@@ -17,9 +17,11 @@ import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifAnyChanged
 import org.mozilla.fenix.R
 import org.mozilla.fenix.tabstray.browser.BrowserTrayInteractor
 import org.mozilla.fenix.tabstray.syncedtabs.SyncedTabsInteractor
+import org.mozilla.fenix.utils.Settings
 
 class FloatingActionButtonBinding(
     private val store: TabsTrayStore,
+    private val settings: Settings,
     private val actionButton: ExtendedFloatingActionButton,
     private val browserTrayInteractor: BrowserTrayInteractor,
     private val syncedTabsInteractor: SyncedTabsInteractor
@@ -29,7 +31,6 @@ class FloatingActionButtonBinding(
 
     @OptIn(ExperimentalCoroutinesApi::class)
     override fun start() {
-        setFab(store.state.selectedPage, store.state.syncing)
         scope = store.flowScoped { flow ->
             flow.map { it }
                 .ifAnyChanged { state ->
@@ -49,6 +50,12 @@ class FloatingActionButtonBinding(
     }
 
     private fun setFab(selectedPage: Page, syncing: Boolean) {
+        /* Do not show fab when accessibility service is enabled */
+        if (settings.accessibilityServicesEnabled) {
+            actionButton.hide()
+            return
+        }
+
         when (selectedPage) {
             Page.NormalTabs -> {
                 actionButton.apply {

--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
@@ -12,6 +12,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatDialogFragment
 import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
@@ -210,6 +211,7 @@ class TabsTrayFragment : AppCompatDialogFragment(), TabsTrayInteractor {
         floatingActionButtonBinding.set(
             feature = FloatingActionButtonBinding(
                 store = tabsTrayStore,
+                settings = requireComponents.settings,
                 actionButton = new_tab_button,
                 browserTrayInteractor = browserTrayInteractor,
                 syncedTabsInteractor = syncedTabsTrayInteractor
@@ -311,7 +313,7 @@ class TabsTrayFragment : AppCompatDialogFragment(), TabsTrayInteractor {
             },
             operation = { },
             elevation = ELEVATION,
-            anchorView = new_tab_button
+            anchorView = if (new_tab_button.isVisible) new_tab_button else null
         )
     }
 

--- a/app/src/main/res/layout/component_tabstray_fab.xml
+++ b/app/src/main/res/layout/component_tabstray_fab.xml
@@ -17,6 +17,7 @@
     android:elevation="99dp"
     android:text="@string/tab_drawer_fab_content"
     android:textColor="@color/photonWhite"
+    android:visibility="gone"
     app:elevation="99dp"
     app:borderWidth="0dp"
     app:icon="@drawable/ic_new"

--- a/app/src/test/java/org/mozilla/fenix/tabstray/FloatingActionButtonBindingTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/FloatingActionButtonBindingTest.kt
@@ -1,0 +1,154 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabstray
+
+import androidx.appcompat.content.res.AppCompatResources
+import com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import mozilla.components.support.test.libstate.ext.waitUntilIdle
+import mozilla.components.support.test.rule.MainCoroutineRule
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mozilla.fenix.tabstray.browser.BrowserTrayInteractor
+import org.mozilla.fenix.tabstray.syncedtabs.SyncedTabsInteractor
+import org.mozilla.fenix.utils.Settings
+
+class FloatingActionButtonBindingTest {
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule(TestCoroutineDispatcher())
+
+    private val settings: Settings = mockk(relaxed = true)
+    private val actionButton: ExtendedFloatingActionButton = mockk(relaxed = true)
+    private val browserTrayInteractor: BrowserTrayInteractor = mockk(relaxed = true)
+    private val syncedTabsInteractor: SyncedTabsInteractor = mockk(relaxed = true)
+
+    @Before
+    fun setup() {
+        mockkStatic(AppCompatResources::class)
+        every { AppCompatResources.getDrawable(any(), any()) } returns mockk(relaxed = true)
+    }
+
+    @Test
+    fun `WHEN tab selected page is normal tab THEN shrink and show is called`() {
+        val tabsTrayStore = TabsTrayStore(TabsTrayState(selectedPage = Page.NormalTabs))
+        val fabBinding = FloatingActionButtonBinding(
+            tabsTrayStore, settings, actionButton, browserTrayInteractor, syncedTabsInteractor
+        )
+        every { settings.accessibilityServicesEnabled } returns false
+
+        fabBinding.start()
+
+        verify(exactly = 1) { actionButton.shrink() }
+        verify(exactly = 1) { actionButton.show() }
+        verify(exactly = 0) { actionButton.extend() }
+        verify(exactly = 0) { actionButton.hide() }
+    }
+
+    @Test
+    fun `WHEN tab selected page is private tab THEN extend and show is called`() {
+        val tabsTrayStore = TabsTrayStore(TabsTrayState(selectedPage = Page.PrivateTabs))
+        val fabBinding = FloatingActionButtonBinding(
+            tabsTrayStore, settings, actionButton, browserTrayInteractor, syncedTabsInteractor
+        )
+        every { settings.accessibilityServicesEnabled } returns false
+
+        fabBinding.start()
+
+        verify(exactly = 1) { actionButton.extend() }
+        verify(exactly = 1) { actionButton.show() }
+        verify(exactly = 0) { actionButton.shrink() }
+        verify(exactly = 0) { actionButton.hide() }
+    }
+
+    @Test
+    fun `WHEN tab selected page is sync tab THEN extend and show is called`() {
+        val tabsTrayStore = TabsTrayStore(TabsTrayState(selectedPage = Page.SyncedTabs))
+        val fabBinding = FloatingActionButtonBinding(
+            tabsTrayStore, settings, actionButton, browserTrayInteractor, syncedTabsInteractor
+        )
+        every { settings.accessibilityServicesEnabled } returns false
+
+        fabBinding.start()
+
+        verify(exactly = 1) { actionButton.extend() }
+        verify(exactly = 1) { actionButton.show() }
+        verify(exactly = 0) { actionButton.shrink() }
+        verify(exactly = 0) { actionButton.hide() }
+    }
+
+    @Test
+    fun `WHEN accessibility is enabled THEN show is not called`() {
+        var tabsTrayStore = TabsTrayStore(TabsTrayState(selectedPage = Page.NormalTabs))
+        var fabBinding = FloatingActionButtonBinding(
+            tabsTrayStore, settings, actionButton, browserTrayInteractor, syncedTabsInteractor
+        )
+        every { settings.accessibilityServicesEnabled } returns true
+
+        fabBinding.start()
+
+        verify(exactly = 0) { actionButton.show() }
+        verify(exactly = 1) { actionButton.hide() }
+
+        tabsTrayStore = TabsTrayStore(TabsTrayState(selectedPage = Page.PrivateTabs))
+        fabBinding = FloatingActionButtonBinding(
+            tabsTrayStore, settings, actionButton, browserTrayInteractor, syncedTabsInteractor
+        )
+
+        fabBinding.start()
+
+        verify(exactly = 0) { actionButton.show() }
+        verify(exactly = 2) { actionButton.hide() }
+
+        tabsTrayStore = TabsTrayStore(TabsTrayState(selectedPage = Page.SyncedTabs))
+        fabBinding = FloatingActionButtonBinding(
+            tabsTrayStore, settings, actionButton, browserTrayInteractor, syncedTabsInteractor
+        )
+
+        fabBinding.start()
+
+        verify(exactly = 0) { actionButton.show() }
+        verify(exactly = 3) { actionButton.hide() }
+    }
+
+    @Test
+    fun `WHEN selected page is updated THEN button is updated`() {
+        val tabsTrayStore = TabsTrayStore(TabsTrayState(selectedPage = Page.NormalTabs))
+        val fabBinding = FloatingActionButtonBinding(
+            tabsTrayStore, settings, actionButton, browserTrayInteractor, syncedTabsInteractor
+        )
+        every { settings.accessibilityServicesEnabled } returns false
+
+        fabBinding.start()
+
+        verify(exactly = 1) { actionButton.shrink() }
+        verify(exactly = 1) { actionButton.show() }
+        verify(exactly = 0) { actionButton.extend() }
+        verify(exactly = 0) { actionButton.hide() }
+
+        tabsTrayStore.dispatch(TabsTrayAction.PageSelected(Page.positionToPage(Page.PrivateTabs.ordinal)))
+        tabsTrayStore.waitUntilIdle()
+
+        verify(exactly = 1) { actionButton.shrink() }
+        verify(exactly = 2) { actionButton.show() }
+        verify(exactly = 1) { actionButton.extend() }
+        verify(exactly = 0) { actionButton.hide() }
+
+        tabsTrayStore.dispatch(TabsTrayAction.PageSelected(Page.positionToPage(Page.SyncedTabs.ordinal)))
+        tabsTrayStore.waitUntilIdle()
+
+        verify(exactly = 1) { actionButton.shrink() }
+        verify(exactly = 3) { actionButton.show() }
+        verify(exactly = 2) { actionButton.extend() }
+        verify(exactly = 0) { actionButton.hide() }
+    }
+}


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
