### PR TITLE
Closes #10300: Fix Baidu search telemetry

### DIFF
--- a/app/src/main/assets/extensions/ads/manifest.template.json
+++ b/app/src/main/assets/extensions/ads/manifest.template.json
@@ -13,6 +13,8 @@
       "include_globs": [
         "https://www.google.*/search*",
         "https://www.bing.com/search*",
+        "https://www.baidu.com/*",
+        "https://m.baidu.com/*",
         "https://duckduckgo.com/*"
       ],
       "js": ["ads.js"],

--- a/app/src/main/assets/extensions/cookies/manifest.template.json
+++ b/app/src/main/assets/extensions/cookies/manifest.template.json
@@ -12,8 +12,8 @@
       "matches": ["https://*/*"],
       "include_globs": [
         "https://www.google.*/search*",
-        "https://www.baidu.com/from=844b/s*",
-        "https://www.baidu.com/from=844b/baidu*",
+        "https://www.baidu.com/*",
+        "https://m.baidu.com/*",
         "https://*search.yahoo.com/search*",
         "https://www.bing.com/search*",
         "https://duckduckgo.com/*"

--- a/app/src/main/java/org/mozilla/fenix/search/telemetry/BaseSearchTelemetry.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/telemetry/BaseSearchTelemetry.kt
@@ -52,10 +52,10 @@ abstract class BaseSearchTelemetry {
         ),
         SearchProviderModel(
             name = "baidu",
-            regexp = "^https:\\/\\/www\\.baidu\\.com\\/from=844b\\/(?:s|baidu)",
-            queryParam = "wd",
-            codeParam = "tn",
-            codePrefixes = listOf("34046034_", "monline_"),
+            regexp = "^https:\\/\\/m\\.baidu\\.com(?:.*)\\/s",
+            queryParam = "word",
+            codeParam = "from",
+            codePrefixes = listOf("1000969a"),
             followOnParams = listOf("oq")
         ),
         SearchProviderModel(

--- a/app/src/test/java/org/mozilla/fenix/search/telemetry/incontent/InContentTelemetryTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/search/telemetry/incontent/InContentTelemetryTest.kt
@@ -84,11 +84,11 @@ class InContentTelemetryTest {
 
     @Test
     fun `track baidu sap metric`() {
-        val url = "https://www.baidu.com/from=844b/s?wd=aaa&tn=34046034_firefox"
+        val url = "https://m.baidu.com/s?from=1000969a&word=aaa"
 
         telemetry.trackPartnerUrlTypeMetric(url, listOf())
 
-        verify { metrics.track(Event.SearchInContent("baidu.in-content.sap.34046034_firefox")) }
+        verify { metrics.track(Event.SearchInContent("baidu.in-content.sap._1000969a")) }
     }
 
     @Test
@@ -120,11 +120,11 @@ class InContentTelemetryTest {
 
     @Test
     fun `track baidu sap-follow-on metric`() {
-        val url = "https://www.baidu.com/from=844b/s?wd=aaa&tn=34046034_firefox&oq=random"
+        val url = "https://m.baidu.com/s?from=1000969a&word=aaa&oq=random"
 
         telemetry.trackPartnerUrlTypeMetric(url, listOf())
 
-        verify { metrics.track(Event.SearchInContent("baidu.in-content.sap-follow-on.34046034_firefox")) }
+        verify { metrics.track(Event.SearchInContent("baidu.in-content.sap-follow-on._1000969a")) }
     }
 
     @Test
@@ -165,7 +165,7 @@ class InContentTelemetryTest {
 
     @Test
     fun `track baidu organic metric`() {
-        val url = "https://www.baidu.com/from=844b/s?wd=aaa"
+        val url = "https://m.baidu.com/s?word=aaa"
 
         telemetry.trackPartnerUrlTypeMetric(url, listOf())
 


### PR DESCRIPTION
Since there might be two types of urls from Baidu (https://m.baidu.com/s?from=... or https://m.baidu.com/from=*/s?), this patch handles baidu separately in Utils.kt

However, there is still a problem that the codes from Baidu are started with numbers (e.g. 844b/1000969a/...), which would be regarded as invalid characters by Glean.

Need more discussion about this, so leave it a draft.
