### PR TITLE
For #19116: refactor main three-dot menu

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/BackgroundServices.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/BackgroundServices.kt
@@ -38,6 +38,7 @@ import mozilla.components.support.utils.RunWhenReadyQueue
 import org.mozilla.fenix.Config
 import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.R
+import org.mozilla.fenix.components.accounts.FxaServer
 import org.mozilla.fenix.perf.StrictModeManager
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.components.metrics.MetricController

--- a/app/src/main/java/org/mozilla/fenix/components/Services.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Services.kt
@@ -13,6 +13,7 @@ import mozilla.components.feature.accounts.FirefoxAccountsAuthFeature
 import mozilla.components.feature.app.links.AppLinksInterceptor
 import mozilla.components.service.fxa.manager.FxaAccountManager
 import org.mozilla.fenix.R
+import org.mozilla.fenix.components.accounts.FxaServer
 import org.mozilla.fenix.ext.getPreferenceKey
 import org.mozilla.fenix.perf.lazyMonitored
 import org.mozilla.fenix.settings.SupportUtils

--- a/app/src/main/java/org/mozilla/fenix/components/accounts/FenixAccountManager.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/accounts/FenixAccountManager.kt
@@ -5,7 +5,6 @@
 package org.mozilla.fenix.components.accounts
 
 import android.content.Context
-import mozilla.components.service.fxa.manager.FxaAccountManager
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
@@ -25,6 +24,7 @@ class FenixAccountManager(
     private val context: Context,
     private val lifecycleOwner: LifecycleOwner
 ) {
+
     private val accountManager = context.components.backgroundServices.accountManager
 
     /**
@@ -51,7 +51,6 @@ class FenixAccountManager(
             }
         }
 
-
     /**
      * Check if the current account is signed in and authenticated.
      */
@@ -73,25 +72,29 @@ class FenixAccountManager(
             if (lifecycleOwner.lifecycle.currentState == Lifecycle.State.DESTROYED) {
                 return@runIfReadyOrQueue
             }
-            context.components.backgroundServices.accountManager.register(object : AccountObserver {
-                override fun onAuthenticationProblems() {
-                    lifecycleOwner.lifecycleScope.launch(Dispatchers.Main) {
-                        onMenuBuilderChanged(BrowserMenuBuilder(menuItems))
-                    }
-                }
 
-                override fun onAuthenticated(account: OAuthAccount, authType: AuthType) {
-                    lifecycleOwner.lifecycleScope.launch(Dispatchers.Main) {
-                        onMenuBuilderChanged(BrowserMenuBuilder(menuItems))
+            context.components.backgroundServices.accountManager.register(
+                object : AccountObserver {
+                    override fun onAuthenticationProblems() {
+                        lifecycleOwner.lifecycleScope.launch(Dispatchers.Main) {
+                            onMenuBuilderChanged(BrowserMenuBuilder(menuItems))
+                        }
                     }
-                }
 
-                override fun onLoggedOut() {
-                    lifecycleOwner.lifecycleScope.launch(Dispatchers.Main) {
-                        onMenuBuilderChanged(BrowserMenuBuilder(menuItems))
+                    override fun onAuthenticated(account: OAuthAccount, authType: AuthType) {
+                        lifecycleOwner.lifecycleScope.launch(Dispatchers.Main) {
+                            onMenuBuilderChanged(BrowserMenuBuilder(menuItems))
+                        }
                     }
-                }
-            }, lifecycleOwner)
+
+                    override fun onLoggedOut() {
+                        lifecycleOwner.lifecycleScope.launch(Dispatchers.Main) {
+                            onMenuBuilderChanged(BrowserMenuBuilder(menuItems))
+                        }
+                    }
+                },
+                lifecycleOwner
+            )
         }
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/components/accounts/FenixAccountManager.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/accounts/FenixAccountManager.kt
@@ -5,12 +5,26 @@
 package org.mozilla.fenix.components.accounts
 
 import android.content.Context
+import mozilla.components.service.fxa.manager.FxaAccountManager
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import mozilla.components.browser.menu.BrowserMenuBuilder
+import mozilla.components.browser.menu.BrowserMenuItem
+import mozilla.components.concept.sync.AccountObserver
+import mozilla.components.concept.sync.AuthType
+import mozilla.components.concept.sync.OAuthAccount
 import org.mozilla.fenix.ext.components
 
 /**
  * Contains helper methods for querying Firefox Account state and its properties.
  */
-class FenixAccountManager(context: Context) {
+class FenixAccountManager(
+    private val context: Context,
+    private val lifecycleOwner: LifecycleOwner
+) {
     private val accountManager = context.components.backgroundServices.accountManager
 
     /**
@@ -36,6 +50,50 @@ class FenixAccountManager(context: Context) {
                 AccountState.AUTHENTICATED
             }
         }
+
+
+    /**
+     * Check if the current account is signed in and authenticated.
+     */
+    fun signedInToFxa(): Boolean {
+        val account = accountManager.authenticatedAccount()
+        val needsReauth = accountManager.accountNeedsReauth()
+
+        return account != null && !needsReauth
+    }
+
+    /**
+     * Observe account state and updates menus.
+     */
+    fun observeAccountState(
+        menuItems: List<BrowserMenuItem>,
+        onMenuBuilderChanged: (BrowserMenuBuilder) -> Unit = {}
+    ) {
+        context.components.backgroundServices.accountManagerAvailableQueue.runIfReadyOrQueue {
+            if (lifecycleOwner.lifecycle.currentState == Lifecycle.State.DESTROYED) {
+                return@runIfReadyOrQueue
+            }
+            context.components.backgroundServices.accountManager.register(object : AccountObserver {
+                override fun onAuthenticationProblems() {
+                    lifecycleOwner.lifecycleScope.launch(Dispatchers.Main) {
+                        onMenuBuilderChanged(BrowserMenuBuilder(menuItems))
+                    }
+                }
+
+                override fun onAuthenticated(account: OAuthAccount, authType: AuthType) {
+                    lifecycleOwner.lifecycleScope.launch(Dispatchers.Main) {
+                        onMenuBuilderChanged(BrowserMenuBuilder(menuItems))
+                    }
+                }
+
+                override fun onLoggedOut() {
+                    lifecycleOwner.lifecycleScope.launch(Dispatchers.Main) {
+                        onMenuBuilderChanged(BrowserMenuBuilder(menuItems))
+                    }
+                }
+            }, lifecycleOwner)
+        }
+    }
 }
 
 /**

--- a/app/src/main/java/org/mozilla/fenix/components/accounts/FxaServer.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/accounts/FxaServer.kt
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-package org.mozilla.fenix.components
+package org.mozilla.fenix.components.accounts
 
 import android.content.Context
 import mozilla.components.service.fxa.ServerConfig

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarMenuController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarMenuController.kt
@@ -91,8 +91,6 @@ class DefaultBrowserToolbarMenuController(
         trackToolbarItemInteraction(item)
 
         Do exhaustive when (item) {
-            // TODO: These can be removed for https://github.com/mozilla-mobile/fenix/issues/17870
-            // todo === Start ===
             is ToolbarMenu.Item.InstallPwaToHomeScreen -> {
                 settings.installPwaOpened = true
                 MainScope().launch {
@@ -132,7 +130,6 @@ class DefaultBrowserToolbarMenuController(
                     activity.finishAndRemoveTask()
                 }
             }
-            // todo === End ===
             is ToolbarMenu.Item.OpenInApp -> {
                 settings.openInAppOpened = true
 
@@ -340,7 +337,6 @@ class DefaultBrowserToolbarMenuController(
                     BrowserFragmentDirections.actionGlobalHistoryFragment()
                 )
             }
-
             is ToolbarMenu.Item.Downloads -> browserAnimator.captureEngineViewAndDrawStatically {
                 navController.nav(
                     R.id.browserFragment,
@@ -374,7 +370,8 @@ class DefaultBrowserToolbarMenuController(
     private fun trackToolbarItemInteraction(item: ToolbarMenu.Item) {
         val eventItem = when (item) {
             is ToolbarMenu.Item.OpenInFenix -> Event.BrowserMenuItemTapped.Item.OPEN_IN_FENIX
-            is ToolbarMenu.Item.InstallPwaToHomeScreen -> Event.BrowserMenuItemTapped.Item.ADD_TO_HOMESCREEN
+            is ToolbarMenu.Item.InstallPwaToHomeScreen ->
+                Event.BrowserMenuItemTapped.Item.ADD_TO_HOMESCREEN
             is ToolbarMenu.Item.Quit -> Event.BrowserMenuItemTapped.Item.QUIT
             is ToolbarMenu.Item.OpenInApp -> Event.BrowserMenuItemTapped.Item.OPEN_IN_APP
             is ToolbarMenu.Item.CustomizeReaderView ->
@@ -397,12 +394,14 @@ class DefaultBrowserToolbarMenuController(
             is ToolbarMenu.Item.AddToHomeScreen -> Event.BrowserMenuItemTapped.Item.ADD_TO_HOMESCREEN
             is ToolbarMenu.Item.SyncAccount -> Event.BrowserMenuItemTapped.Item.SYNC_ACCOUNT
             is ToolbarMenu.Item.Bookmark -> Event.BrowserMenuItemTapped.Item.BOOKMARK
-            is ToolbarMenu.Item.AddonsManager -> Event.BrowserMenuItemTapped.Item.ADDONS_MANAGER
+            is ToolbarMenu.Item.AddonsManager ->
+                Event.BrowserMenuItemTapped.Item.ADDONS_MANAGER
             is ToolbarMenu.Item.Bookmarks -> Event.BrowserMenuItemTapped.Item.BOOKMARKS
             is ToolbarMenu.Item.History -> Event.BrowserMenuItemTapped.Item.HISTORY
             is ToolbarMenu.Item.Downloads -> Event.BrowserMenuItemTapped.Item.DOWNLOADS
             is ToolbarMenu.Item.NewTab -> Event.BrowserMenuItemTapped.Item.NEW_TAB
-            is ToolbarMenu.Item.SetDefaultBrowser -> Event.BrowserMenuItemTapped.Item.SET_DEFAULT_BROWSER
+            is ToolbarMenu.Item.SetDefaultBrowser ->
+                Event.BrowserMenuItemTapped.Item.SET_DEFAULT_BROWSER
         }
 
         metrics.track(Event.BrowserMenuItemTapped(eventItem))

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarView.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarView.kt
@@ -159,7 +159,10 @@ class BrowserToolbarView(
                     },
                     lifecycleOwner = lifecycleOwner,
                     bookmarksStorage = bookmarkStorage,
-                    isPinningSupported = isPinningSupported
+                    isPinningSupported = isPinningSupported,
+                    onMenuBuilderChanged = {
+                        view.display.menuBuilder = it
+                    }
                 )
                 view.display.setMenuDismissAction {
                     view.invalidateActions()

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
@@ -8,7 +8,6 @@ import android.content.Context
 import androidx.annotation.ColorRes
 import androidx.annotation.VisibleForTesting
 import androidx.annotation.VisibleForTesting.PRIVATE
-import androidx.core.content.ContextCompat.getColor
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -16,11 +15,9 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.launch
-import mozilla.components.browser.menu.BrowserMenuHighlight
+import mozilla.components.browser.menu.BrowserMenuBuilder
 import mozilla.components.browser.menu.WebExtensionBrowserMenuBuilder
 import mozilla.components.browser.menu.item.BrowserMenuDivider
-import mozilla.components.browser.menu.item.BrowserMenuHighlightableItem
-import mozilla.components.browser.menu.item.BrowserMenuImageSwitch
 import mozilla.components.browser.menu.item.BrowserMenuImageText
 import mozilla.components.browser.menu.item.BrowserMenuImageTextCheckboxButton
 import mozilla.components.browser.menu.item.BrowserMenuItemToolbar
@@ -32,12 +29,15 @@ import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.storage.BookmarksStorage
 import mozilla.components.feature.webcompat.reporter.WebCompatReporterFeature
 import mozilla.components.lib.state.ext.flowScoped
-import mozilla.components.support.ktx.android.content.getColorFromAttr
 import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifAnyChanged
+import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
+import org.mozilla.fenix.browser.browsingmode.BrowsingMode
+import org.mozilla.fenix.components.toolbar.ToolbarMenu.Item
 import org.mozilla.fenix.components.accounts.FenixAccountManager
 import org.mozilla.fenix.experiments.ExperimentBranch
 import org.mozilla.fenix.experiments.FeatureId
+import org.mozilla.fenix.ext.asActivity
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.withExperiment
@@ -46,23 +46,27 @@ import org.mozilla.fenix.utils.BrowsersCache
 
 /**
  * Builds the toolbar object used with the 3-dot menu in the browser fragment.
+ * @param context the [Context].
  * @param store reference to the application's [BrowserStore].
  * @param hasAccountProblem If true, there was a problem signing into the Firefox account.
  * @param shouldReverseItems If true, reverse the menu items.
  * @param onItemTapped Called when a menu item is tapped.
  * @param lifecycleOwner View lifecycle owner used to determine when to cancel UI jobs.
  * @param bookmarksStorage Used to check if a page is bookmarked.
+ * @param isPinningSupported Whether pinning is supported for install or add to homescreen.
+ * @param onMenuBuilderChanged Defines behavior when menu items have changed.
  */
-@Suppress("LargeClass", "LongParameterList", "TooManyFunctions")
+@Suppress("LongParameterList", "TooManyFunctions")
 @ExperimentalCoroutinesApi
 open class DefaultToolbarMenu(
     private val context: Context,
     private val store: BrowserStore,
     hasAccountProblem: Boolean = false,
-    private val onItemTapped: (ToolbarMenu.Item) -> Unit = {},
+    private val onItemTapped: (Item) -> Unit = {},
     private val lifecycleOwner: LifecycleOwner,
     private val bookmarksStorage: BookmarksStorage,
-    val isPinningSupported: Boolean
+    val isPinningSupported: Boolean,
+    onMenuBuilderChanged: (BrowserMenuBuilder) -> Unit = {},
 ) : ToolbarMenu {
 
     private var isCurrentUrlBookmarked = false
@@ -70,10 +74,27 @@ open class DefaultToolbarMenu(
 
     private val shouldDeleteDataOnQuit = context.settings().shouldDeleteBrowsingDataOnQuit
     private val shouldUseBottomToolbar = context.settings().shouldUseBottomToolbar
-    private val accountManager = FenixAccountManager(context)
+    private val accountManager = FenixAccountManager(context, lifecycleOwner)
 
     private val selectedSession: TabSessionState?
         get() = store.state.selectedTab
+
+    @ColorRes
+    internal val primaryTextColor = ThemeManager.resolveAttribute(R.attr.primaryText, context)
+
+    @ColorRes
+    internal val accentTextColor =
+        ThemeManager.resolveAttribute(R.attr.menuItemButtonTintColor, context)
+
+    internal val toolbarMenuItems = ToolbarMenuItems(
+        context,
+        store,
+        accountManager,
+        hasAccountProblem,
+        onItemTapped,
+        primaryTextColor,
+        accentTextColor
+    )
 
     override val menuBuilder by lazy {
         WebExtensionBrowserMenuBuilder(
@@ -81,73 +102,21 @@ open class DefaultToolbarMenu(
             endOfMenuAlwaysVisible = shouldUseBottomToolbar,
             store = store,
             style = WebExtensionBrowserMenuBuilder.Style(
-                webExtIconTintColorResource = primaryTextColor(),
+                webExtIconTintColorResource = primaryTextColor,
                 addonsManagerMenuItemDrawableRes = R.drawable.ic_addons_extensions
             ),
             onAddonsManagerTapped = {
-                onItemTapped.invoke(ToolbarMenu.Item.AddonsManager)
+                onItemTapped.invoke(Item.AddonsManager)
             },
             appendExtensionSubMenuAtStart = shouldUseBottomToolbar
         )
     }
 
-    override val menuToolbar by lazy {
-        val back = BrowserMenuItemToolbar.TwoStateButton(
-            primaryImageResource = mozilla.components.ui.icons.R.drawable.mozac_ic_back,
-            primaryContentDescription = context.getString(R.string.browser_menu_back),
-            primaryImageTintResource = primaryTextColor(),
-            isInPrimaryState = {
-                selectedSession?.content?.canGoBack ?: true
-            },
-            secondaryImageTintResource = ThemeManager.resolveAttribute(R.attr.disabled, context),
-            disableInSecondaryState = true,
-            longClickListener = { onItemTapped.invoke(ToolbarMenu.Item.Back(viewHistory = true)) }
-        ) {
-            onItemTapped.invoke(ToolbarMenu.Item.Back(viewHistory = false))
-        }
-
-        val forward = BrowserMenuItemToolbar.TwoStateButton(
-            primaryImageResource = mozilla.components.ui.icons.R.drawable.mozac_ic_forward,
-            primaryContentDescription = context.getString(R.string.browser_menu_forward),
-            primaryImageTintResource = primaryTextColor(),
-            isInPrimaryState = {
-                selectedSession?.content?.canGoForward ?: true
-            },
-            secondaryImageTintResource = ThemeManager.resolveAttribute(R.attr.disabled, context),
-            disableInSecondaryState = true,
-            longClickListener = { onItemTapped.invoke(ToolbarMenu.Item.Forward(viewHistory = true)) }
-        ) {
-            onItemTapped.invoke(ToolbarMenu.Item.Forward(viewHistory = false))
-        }
-
-        val refresh = BrowserMenuItemToolbar.TwoStateButton(
-            primaryImageResource = mozilla.components.ui.icons.R.drawable.mozac_ic_refresh,
-            primaryContentDescription = context.getString(R.string.browser_menu_refresh),
-            primaryImageTintResource = primaryTextColor(),
-            isInPrimaryState = {
-                selectedSession?.content?.loading == false
-            },
-            secondaryImageResource = mozilla.components.ui.icons.R.drawable.mozac_ic_stop,
-            secondaryContentDescription = context.getString(R.string.browser_menu_stop),
-            secondaryImageTintResource = primaryTextColor(),
-            disableInSecondaryState = false,
-            longClickListener = { onItemTapped.invoke(ToolbarMenu.Item.Reload(bypassCache = true)) }
-        ) {
-            if (selectedSession?.content?.loading == true) {
-                onItemTapped.invoke(ToolbarMenu.Item.Stop)
-            } else {
-                onItemTapped.invoke(ToolbarMenu.Item.Reload(bypassCache = false))
-            }
-        }
-
-        val share = BrowserMenuItemToolbar.Button(
-            imageResource = R.drawable.ic_share,
-            contentDescription = context.getString(R.string.browser_menu_share),
-            iconTintColorResource = primaryTextColor(),
-            listener = {
-                onItemTapped.invoke(ToolbarMenu.Item.Share)
-            }
-        )
+    override val menuToolbarNavigation by lazy {
+        val back = toolbarMenuItems.backNavButton
+        val forward = toolbarMenuItems.forwardNavButton
+        val refresh = toolbarMenuItems.refreshNavButton
+        val share = toolbarMenuItems.shareItem
 
         registerForIsBookmarkedUpdates()
 
@@ -177,147 +146,39 @@ open class DefaultToolbarMenu(
     } ?: false
     // End of predicates //
 
-    val installToHomescreen = BrowserMenuHighlightableItem(
-        label = context.getString(R.string.browser_menu_install_on_homescreen),
-        startImageResource = R.drawable.ic_add_to_homescreen,
-        iconTintColorResource = primaryTextColor(),
-        highlight = BrowserMenuHighlight.LowPriority(
-            label = context.getString(R.string.browser_menu_install_on_homescreen),
-            notificationTint = getColor(context, R.color.whats_new_notification_color)
-        ),
-        isHighlighted = {
-            !context.settings().installPwaOpened
-        }
-    ) {
-        onItemTapped.invoke(ToolbarMenu.Item.InstallPwaToHomeScreen)
-    }
+    internal val installPwaToHomescreen = toolbarMenuItems.installPwaToHomescreen
+    internal val newTabItem = toolbarMenuItems.newTabItem
+    internal val historyItem = toolbarMenuItems.historyItem
+    internal val downloadsItem = toolbarMenuItems.downloadsItem
+    internal var findInPageItem = toolbarMenuItems.findInPageItem
+    internal var desktopSiteItem = toolbarMenuItems.requestDesktopSiteItem
+    internal var customizeReaderView = toolbarMenuItems.customizeReaderView
+    internal var openInApp = toolbarMenuItems.openInAppItem
+    internal var addToHomeScreenItem = toolbarMenuItems.addToHomeScreenItem
+    internal var addToTopSitesItem = toolbarMenuItems.addToTopSitesItem
+    internal var saveToCollectionItem = toolbarMenuItems.saveToCollectionItem
+    internal var settingsItem = toolbarMenuItems.settingsItem
+    internal var deleteDataOnQuit = toolbarMenuItems.deleteDataOnQuitItem
+    internal var syncSignInItem = toolbarMenuItems.syncMenuItem
 
-    val newTabItem = BrowserMenuImageText(
-        context.getString(R.string.library_new_tab),
-        R.drawable.ic_new,
-        primaryTextColor()
-    ) {
-        onItemTapped.invoke(ToolbarMenu.Item.NewTab)
-    }
-
-    val historyItem = BrowserMenuImageText(
-        context.getString(R.string.library_history),
-        R.drawable.ic_history,
-        primaryTextColor()
-    ) {
-        onItemTapped.invoke(ToolbarMenu.Item.History)
-    }
-
-    val downloadsItem = BrowserMenuImageText(
-        context.getString(R.string.library_downloads),
-        R.drawable.ic_download,
-        primaryTextColor()
-    ) {
-        onItemTapped.invoke(ToolbarMenu.Item.Downloads)
-    }
-
-    val extensionsItem = WebExtensionPlaceholderMenuItem(
+    internal val extensionsItem = WebExtensionPlaceholderMenuItem(
         id = WebExtensionPlaceholderMenuItem.MAIN_EXTENSIONS_MENU_ID
     )
 
-    val findInPageItem = BrowserMenuImageText(
-        label = context.getString(R.string.browser_menu_find_in_page),
-        imageResource = R.drawable.mozac_ic_search,
-        iconTintColorResource = primaryTextColor()
-    ) {
-        onItemTapped.invoke(ToolbarMenu.Item.FindInPage)
-    }
-
-    val desktopSiteItem = BrowserMenuImageSwitch(
-        imageResource = R.drawable.ic_desktop,
-        label = context.getString(R.string.browser_menu_desktop_site),
-        initialState = {
-            selectedSession?.content?.desktopMode ?: false
-        }
-    ) { checked ->
-        onItemTapped.invoke(ToolbarMenu.Item.RequestDesktop(checked))
-    }
-
-    val customizeReaderView = BrowserMenuImageText(
-        label = context.getString(R.string.browser_menu_customize_reader_view),
-        imageResource = R.drawable.ic_readermode_appearance,
-        iconTintColorResource = primaryTextColor()
-    ) {
-        onItemTapped.invoke(ToolbarMenu.Item.CustomizeReaderView)
-    }
-
-    val openInApp = BrowserMenuHighlightableItem(
-        label = context.getString(R.string.browser_menu_open_app_link),
-        startImageResource = R.drawable.ic_open_in_app,
-        iconTintColorResource = primaryTextColor(),
-        highlight = BrowserMenuHighlight.LowPriority(
-            label = context.getString(R.string.browser_menu_open_app_link),
-            notificationTint = getColor(context, R.color.whats_new_notification_color)
-        ),
-        isHighlighted = { !context.settings().openInAppOpened }
-    ) {
-        onItemTapped.invoke(ToolbarMenu.Item.OpenInApp)
-    }
-
-    val reportSiteIssuePlaceholder = WebExtensionPlaceholderMenuItem(
-        id = WebCompatReporterFeature.WEBCOMPAT_REPORTER_EXTENSION_ID,
-        iconTintColorResource = primaryTextColor()
+    internal val reportSiteIssuePlaceholder = WebExtensionPlaceholderMenuItem(
+        id = WebCompatReporterFeature.WEBCOMPAT_REPORTER_EXTENSION_ID
     )
 
-    val addToHomeScreenItem = BrowserMenuImageText(
-        label = context.getString(R.string.browser_menu_add_to_homescreen),
-        imageResource = R.drawable.ic_add_to_homescreen,
-        iconTintColorResource = primaryTextColor(),
-        isCollapsingMenuLimit = true
-    ) {
-        onItemTapped.invoke(ToolbarMenu.Item.AddToHomeScreen)
-    }
-
-    val addToTopSitesItem = BrowserMenuImageText(
-        label = context.getString(R.string.browser_menu_add_to_top_sites),
-        imageResource = R.drawable.ic_top_sites,
-        iconTintColorResource = primaryTextColor()
-    ) {
-        onItemTapped.invoke(ToolbarMenu.Item.AddToTopSites)
-    }
-
-    val saveToCollectionItem = BrowserMenuImageText(
-        label = context.getString(R.string.browser_menu_save_to_collection_2),
-        imageResource = R.drawable.ic_tab_collection,
-        iconTintColorResource = primaryTextColor()
-    ) {
-        onItemTapped.invoke(ToolbarMenu.Item.SaveToCollection)
-    }
-
-    val settingsItem = BrowserMenuHighlightableItem(
-        label = context.getString(R.string.browser_menu_settings),
-        startImageResource = R.drawable.ic_settings,
-        iconTintColorResource = if (hasAccountProblem)
-            ThemeManager.resolveAttribute(R.attr.syncDisconnected, context) else
-            primaryTextColor(),
-        textColorResource = if (hasAccountProblem)
-            ThemeManager.resolveAttribute(R.attr.primaryText, context) else
-            primaryTextColor(),
-        highlight = BrowserMenuHighlight.HighPriority(
-            endImageResource = R.drawable.ic_sync_disconnected,
-            backgroundTint = context.getColorFromAttr(R.attr.syncDisconnectedBackground),
-            canPropagate = false
-        ),
-        isHighlighted = { hasAccountProblem }
-    ) {
-        onItemTapped.invoke(ToolbarMenu.Item.Settings)
-    }
-
-    val bookmarksItem = BrowserMenuImageTextCheckboxButton(
+    internal var addEditBookmarksItem = BrowserMenuImageTextCheckboxButton(
         imageResource = R.drawable.ic_bookmarks_menu,
-        iconTintColorResource = primaryTextColor(),
+        iconTintColorResource = primaryTextColor,
         label = context.getString(R.string.library_bookmarks),
         labelListener = {
-            onItemTapped.invoke(ToolbarMenu.Item.Bookmarks)
+            onItemTapped.invoke(Item.Bookmarks)
         },
         primaryStateIconResource = R.drawable.ic_bookmark_outline,
         secondaryStateIconResource = R.drawable.ic_bookmark_filled,
-        tintColorResource = menuItemButtonTintColor(),
+        tintColorResource = accentTextColor,
         primaryLabel = context.getString(R.string.browser_menu_add),
         secondaryLabel = context.getString(R.string.browser_menu_edit),
         isInPrimaryState = { !isCurrentUrlBookmarked }
@@ -325,39 +186,21 @@ open class DefaultToolbarMenu(
         handleBookmarkItemTapped()
     }
 
-    val deleteDataOnQuit = BrowserMenuImageText(
-        label = context.getString(R.string.delete_browsing_data_on_quit_action),
-        imageResource = R.drawable.ic_exit,
-        iconTintColorResource = primaryTextColor()
-    ) {
-        onItemTapped.invoke(ToolbarMenu.Item.Quit)
-    }
+    internal val coreMenuItems by lazy {
+        // Predicates that are called once, during screen init
+        val shouldShowSaveToCollection = (context.asActivity() as? HomeActivity)
+            ?.browsingModeManager?.mode == BrowsingMode.Normal
 
-    private fun getSyncItemTitle() =
-        accountManager.accountProfileEmail ?: context.getString(R.string.sync_menu_sign_in)
-
-    val syncMenuItem = BrowserMenuImageText(
-        getSyncItemTitle(),
-        R.drawable.ic_signed_out,
-        primaryTextColor()
-    ) {
-        onItemTapped.invoke(
-            ToolbarMenu.Item.SyncAccount(accountManager.accountState)
-        )
-    }
-
-    @VisibleForTesting(otherwise = PRIVATE)
-    val coreMenuItems by lazy {
         val menuItems =
             listOfNotNull(
-                if (shouldUseBottomToolbar) null else menuToolbar,
+                if (shouldUseBottomToolbar) null else menuToolbarNavigation,
                 newTabItem,
                 BrowserMenuDivider(),
-                bookmarksItem,
+                addEditBookmarksItem,
                 historyItem,
                 downloadsItem,
                 extensionsItem,
-                syncMenuItem,
+                syncSignInItem,
                 BrowserMenuDivider(),
                 getSetDefaultBrowserItem(),
                 getSetDefaultBrowserItem()?.let { BrowserMenuDivider() },
@@ -368,31 +211,32 @@ open class DefaultToolbarMenu(
                 reportSiteIssuePlaceholder,
                 BrowserMenuDivider(),
                 addToHomeScreenItem.apply { visible = ::canAddToHomescreen },
-                installToHomescreen.apply { visible = ::canInstall },
+                installPwaToHomescreen.apply { visible = ::canInstall },
                 addToTopSitesItem,
-                saveToCollectionItem,
+                if (shouldShowSaveToCollection) saveToCollectionItem else null,
                 BrowserMenuDivider(),
                 settingsItem,
                 if (shouldDeleteDataOnQuit) deleteDataOnQuit else null,
                 if (shouldUseBottomToolbar) BrowserMenuDivider() else null,
-                if (shouldUseBottomToolbar) menuToolbar else null
+                if (shouldUseBottomToolbar) menuToolbarNavigation else null
             )
 
         menuItems
     }
 
-    private fun handleBookmarkItemTapped() {
-        if (!isCurrentUrlBookmarked) isCurrentUrlBookmarked = true
-        onItemTapped.invoke(ToolbarMenu.Item.Bookmark)
+    init {
+        onMenuBuilderChanged(BrowserMenuBuilder(coreMenuItems))
+
+        accountManager.observeAccountState(
+            menuItems = coreMenuItems,
+            onMenuBuilderChanged = onMenuBuilderChanged
+        )
     }
 
-    @ColorRes
-    @VisibleForTesting
-    internal fun primaryTextColor() = ThemeManager.resolveAttribute(R.attr.primaryText, context)
-
-    @ColorRes
-    @VisibleForTesting
-    internal fun menuItemButtonTintColor() = ThemeManager.resolveAttribute(R.attr.menuItemButtonTintColor, context)
+    private fun handleBookmarkItemTapped() {
+        if (!isCurrentUrlBookmarked) isCurrentUrlBookmarked = true
+        onItemTapped.invoke(Item.Bookmark)
+    }
 
     @VisibleForTesting
     internal fun registerForIsBookmarkedUpdates() {
@@ -421,7 +265,7 @@ open class DefaultToolbarMenu(
         }
     }
 
-    private fun getSetDefaultBrowserItem(): BrowserMenuImageText? {
+    internal fun getSetDefaultBrowserItem(): BrowserMenuImageText? {
         val experiments = context.components.analytics.experiments
         val browsers = BrowsersCache.all(context)
 
@@ -433,7 +277,7 @@ open class DefaultToolbarMenu(
                     label = context.getString(R.string.preferences_set_as_default_browser),
                     imageResource = R.mipmap.ic_launcher
                 ) {
-                    onItemTapped.invoke(ToolbarMenu.Item.SetDefaultBrowser)
+                    onItemTapped.invoke(Item.SetDefaultBrowser)
                 }
             } else {
                 null

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarMenu.kt
@@ -28,14 +28,14 @@ interface ToolbarMenu {
         object Quit : Item()
         object OpenInApp : Item()
         object SetDefaultBrowser : Item()
-        object Bookmark : Item()
+        object Bookmark : Item() // handles adding bookmark on tap
         object CustomizeReaderView : Item()
-        object Bookmarks : Item()
+        object Bookmarks : Item() // add/edit bookmark button label and navigation
         object History : Item()
         object Downloads : Item()
         object NewTab : Item()
     }
 
     val menuBuilder: BrowserMenuBuilder
-    val menuToolbar: BrowserMenuItemToolbar
+    val menuToolbarNavigation: BrowserMenuItemToolbar
 }

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarMenuItems.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarMenuItems.kt
@@ -1,0 +1,252 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.components.toolbar
+
+import android.content.Context
+import androidx.annotation.ColorRes
+import androidx.core.content.ContextCompat.getColor
+import mozilla.components.browser.menu.BrowserMenuHighlight
+import mozilla.components.browser.menu.item.BrowserMenuHighlightableItem
+import mozilla.components.browser.menu.item.BrowserMenuImageSwitch
+import mozilla.components.browser.menu.item.BrowserMenuImageText
+import mozilla.components.browser.menu.item.BrowserMenuItemToolbar
+import mozilla.components.browser.state.selector.selectedTab
+import mozilla.components.browser.state.state.TabSessionState
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.support.ktx.android.content.getColorFromAttr
+import org.mozilla.fenix.R
+import org.mozilla.fenix.components.accounts.FenixAccountManager
+import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.theme.ThemeManager
+
+/**
+ * Defines commonly used items for use in the main toolbar menu.
+ *
+ * @param context The [Context].
+ * @param store Reference to the application's [BrowserStore].
+ * @param hasAccountProblem If true, there was a problem signing into the Firefox account.
+ * @param onItemTapped Called when a menu item is tapped.
+ * @param primaryTextColor The text color used for the items.
+ * @param accentTextColor The accent color used for the items.
+ */
+@Suppress("LargeClass", "LongParameterList")
+open class ToolbarMenuItems(
+    private val context: Context,
+    private val store: BrowserStore,
+    private val accountManager: FenixAccountManager,
+    hasAccountProblem: Boolean = false,
+    private val onItemTapped: (ToolbarMenu.Item) -> Unit = {},
+    @ColorRes val primaryTextColor: Int,
+    @ColorRes val accentTextColor: Int
+) {
+    private val selectedSession: TabSessionState?
+        get() = store.state.selectedTab
+
+    val backNavButton = BrowserMenuItemToolbar.TwoStateButton(
+        primaryImageResource = mozilla.components.ui.icons.R.drawable.mozac_ic_back,
+        primaryContentDescription = context.getString(R.string.browser_menu_back),
+        primaryImageTintResource = primaryTextColor,
+        isInPrimaryState = {
+            selectedSession?.content?.canGoBack ?: true
+        },
+        secondaryImageTintResource = ThemeManager.resolveAttribute(R.attr.disabled, context),
+        disableInSecondaryState = true,
+        longClickListener = { onItemTapped.invoke(ToolbarMenu.Item.Back(viewHistory = true)) }
+    ) {
+        onItemTapped.invoke(ToolbarMenu.Item.Back(viewHistory = false))
+    }
+
+    val forwardNavButton = BrowserMenuItemToolbar.TwoStateButton(
+        primaryImageResource = mozilla.components.ui.icons.R.drawable.mozac_ic_forward,
+        primaryContentDescription = context.getString(R.string.browser_menu_forward),
+        primaryImageTintResource = primaryTextColor,
+        isInPrimaryState = {
+            selectedSession?.content?.canGoForward ?: true
+        },
+        secondaryImageTintResource = ThemeManager.resolveAttribute(R.attr.disabled, context),
+        disableInSecondaryState = true,
+        longClickListener = {
+            onItemTapped.invoke(ToolbarMenu.Item.Forward(viewHistory = true))
+        }
+    ) {
+        onItemTapped.invoke(ToolbarMenu.Item.Forward(viewHistory = false))
+    }
+
+    val refreshNavButton = BrowserMenuItemToolbar.TwoStateButton(
+        primaryImageResource = mozilla.components.ui.icons.R.drawable.mozac_ic_refresh,
+        primaryContentDescription = context.getString(R.string.browser_menu_refresh),
+        primaryImageTintResource = primaryTextColor,
+        isInPrimaryState = {
+            selectedSession?.content?.loading == false
+        },
+        secondaryImageResource = mozilla.components.ui.icons.R.drawable.mozac_ic_stop,
+        secondaryContentDescription = context.getString(R.string.browser_menu_stop),
+        secondaryImageTintResource = primaryTextColor,
+        disableInSecondaryState = false,
+        longClickListener = { onItemTapped.invoke(ToolbarMenu.Item.Reload(bypassCache = true)) }
+    ) {
+        if (selectedSession?.content?.loading == true) {
+            onItemTapped.invoke(ToolbarMenu.Item.Stop)
+        } else {
+            onItemTapped.invoke(ToolbarMenu.Item.Reload(bypassCache = false))
+        }
+    }
+
+    val shareItem = BrowserMenuItemToolbar.Button(
+        imageResource = R.drawable.ic_share,
+        contentDescription = context.getString(R.string.browser_menu_share),
+        iconTintColorResource = primaryTextColor,
+        listener = {
+            onItemTapped.invoke(ToolbarMenu.Item.Share)
+        }
+    )
+
+    val installPwaToHomescreen = BrowserMenuHighlightableItem(
+            label = context.getString(R.string.browser_menu_install_on_homescreen),
+            startImageResource = R.drawable.ic_add_to_homescreen,
+            iconTintColorResource = primaryTextColor,
+            highlight = BrowserMenuHighlight.LowPriority(
+                label = context.getString(R.string.browser_menu_install_on_homescreen),
+                notificationTint = getColor(context, R.color.whats_new_notification_color)
+            ),
+            isHighlighted = {
+                !context.settings().installPwaOpened
+            }
+        )
+
+    val newTabItem = BrowserMenuImageText(
+        context.getString(R.string.library_new_tab),
+        R.drawable.ic_new,
+        primaryTextColor
+    ) {
+        onItemTapped.invoke(ToolbarMenu.Item.NewTab)
+    }
+
+    val historyItem = BrowserMenuImageText(
+        context.getString(R.string.library_history),
+        R.drawable.ic_history,
+        primaryTextColor
+    ) {
+        onItemTapped.invoke(ToolbarMenu.Item.History)
+    }
+
+    val downloadsItem = BrowserMenuImageText(
+        context.getString(R.string.library_downloads),
+        R.drawable.ic_download,
+        primaryTextColor
+    ) {
+        onItemTapped.invoke(ToolbarMenu.Item.Downloads)
+    }
+
+    private fun getSyncItemTitle(): String {
+        val authenticatedAccount = accountManager.authenticatedAccount
+        val email = accountManager.accountProfileEmail
+
+        return if (authenticatedAccount && !email.isNullOrEmpty()) {
+            email
+        } else {
+            context.getString(R.string.sync_menu_sign_in)
+        }
+    }
+
+    val syncMenuItem = BrowserMenuImageText(
+        getSyncItemTitle(),
+        R.drawable.ic_signed_out,
+        primaryTextColor
+    ) {
+        onItemTapped.invoke(ToolbarMenu.Item.SyncAccount(accountManager.signedInToFxa()))
+    }
+
+    val findInPageItem = BrowserMenuImageText(
+        label = context.getString(R.string.browser_menu_find_in_page),
+        imageResource = R.drawable.mozac_ic_search,
+        iconTintColorResource = primaryTextColor
+    ) {
+        onItemTapped.invoke(ToolbarMenu.Item.FindInPage)
+    }
+
+    val requestDesktopSiteItem = BrowserMenuImageSwitch(
+        imageResource = R.drawable.ic_desktop,
+        label = context.getString(R.string.browser_menu_desktop_site),
+        initialState = {
+            selectedSession?.content?.desktopMode ?: false
+        }
+    ) { checked ->
+        onItemTapped.invoke(ToolbarMenu.Item.RequestDesktop(checked))
+    }
+
+    var customizeReaderView = BrowserMenuImageText(
+        label = context.getString(R.string.browser_menu_customize_reader_view),
+        imageResource = R.drawable.ic_readermode_appearance,
+        iconTintColorResource = primaryTextColor
+    ) {
+        onItemTapped.invoke(ToolbarMenu.Item.CustomizeReaderView)
+    }
+
+    val openInAppItem = BrowserMenuHighlightableItem(
+        label = context.getString(R.string.browser_menu_open_app_link),
+        startImageResource = R.drawable.ic_open_in_app,
+        iconTintColorResource = primaryTextColor,
+        highlight = BrowserMenuHighlight.LowPriority(
+            label = context.getString(R.string.browser_menu_open_app_link),
+            notificationTint = getColor(context, R.color.whats_new_notification_color)
+        ),
+        isHighlighted = { !context.settings().openInAppOpened }
+    ) {
+        onItemTapped.invoke(ToolbarMenu.Item.OpenInApp)
+    }
+
+    val addToHomeScreenItem = BrowserMenuImageText(
+        label = context.getString(R.string.browser_menu_add_to_homescreen),
+        imageResource = R.drawable.ic_add_to_homescreen,
+        iconTintColorResource = primaryTextColor,
+        isCollapsingMenuLimit = true
+    ) {
+        onItemTapped.invoke(ToolbarMenu.Item.AddToHomeScreen)
+    }
+
+    val saveToCollectionItem = BrowserMenuImageText(
+        label = context.getString(R.string.browser_menu_save_to_collection_2),
+        imageResource = R.drawable.ic_tab_collection,
+        iconTintColorResource = primaryTextColor
+    ) {
+        onItemTapped.invoke(ToolbarMenu.Item.SaveToCollection)
+    }
+
+    val settingsItem = BrowserMenuHighlightableItem(
+        label = context.getString(R.string.browser_menu_settings),
+        startImageResource = R.drawable.ic_settings,
+        iconTintColorResource = if (hasAccountProblem)
+            ThemeManager.resolveAttribute(R.attr.syncDisconnected, context) else
+            primaryTextColor,
+        textColorResource = if (hasAccountProblem)
+            ThemeManager.resolveAttribute(R.attr.primaryText, context) else
+            primaryTextColor,
+        highlight = BrowserMenuHighlight.HighPriority(
+            endImageResource = R.drawable.ic_sync_disconnected,
+            backgroundTint = context.getColorFromAttr(R.attr.syncDisconnectedBackground),
+            canPropagate = false
+        ),
+        isHighlighted = { hasAccountProblem }
+    ) {
+        onItemTapped.invoke(ToolbarMenu.Item.Settings)
+    }
+
+    val addToTopSitesItem = BrowserMenuImageText(
+        label = context.getString(R.string.browser_menu_add_to_top_sites),
+        imageResource = R.drawable.ic_top_sites,
+        iconTintColorResource = primaryTextColor
+    ) {
+        onItemTapped.invoke(ToolbarMenu.Item.AddToTopSites)
+    }
+
+    val deleteDataOnQuitItem = BrowserMenuImageText(
+        label = context.getString(R.string.delete_browsing_data_on_quit_action),
+        imageResource = R.drawable.ic_exit,
+        iconTintColorResource = primaryTextColor
+    ) {
+        onItemTapped.invoke(ToolbarMenu.Item.Quit)
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarMenuItems.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarMenuItems.kt
@@ -104,17 +104,17 @@ open class ToolbarMenuItems(
     )
 
     val installPwaToHomescreen = BrowserMenuHighlightableItem(
+        label = context.getString(R.string.browser_menu_install_on_homescreen),
+        startImageResource = R.drawable.ic_add_to_homescreen,
+        iconTintColorResource = primaryTextColor,
+        highlight = BrowserMenuHighlight.LowPriority(
             label = context.getString(R.string.browser_menu_install_on_homescreen),
-            startImageResource = R.drawable.ic_add_to_homescreen,
-            iconTintColorResource = primaryTextColor,
-            highlight = BrowserMenuHighlight.LowPriority(
-                label = context.getString(R.string.browser_menu_install_on_homescreen),
-                notificationTint = getColor(context, R.color.whats_new_notification_color)
-            ),
-            isHighlighted = {
-                !context.settings().installPwaOpened
-            }
-        )
+            notificationTint = getColor(context, R.color.whats_new_notification_color)
+        ),
+        isHighlighted = {
+            !context.settings().installPwaOpened
+        }
+    )
 
     val newTabItem = BrowserMenuImageText(
         context.getString(R.string.library_new_tab),
@@ -141,7 +141,7 @@ open class ToolbarMenuItems(
     }
 
     private fun getSyncItemTitle(): String {
-        val authenticatedAccount = accountManager.authenticatedAccount
+        val authenticatedAccount = accountManager.signedInToFxa()
         val email = accountManager.accountProfileEmail
 
         return if (authenticatedAccount && !email.isNullOrEmpty()) {
@@ -156,7 +156,7 @@ open class ToolbarMenuItems(
         R.drawable.ic_signed_out,
         primaryTextColor
     ) {
-        onItemTapped.invoke(ToolbarMenu.Item.SyncAccount(accountManager.signedInToFxa()))
+        onItemTapped.invoke(ToolbarMenu.Item.SyncAccount(accountManager.accountState))
     }
 
     val findInPageItem = BrowserMenuImageText(

--- a/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabToolbarMenu.kt
@@ -51,7 +51,7 @@ class CustomTabToolbarMenu(
     internal val session: CustomTabSessionState? get() = sessionId?.let { store.state.findCustomTab(it) }
     private val appName = context.getString(R.string.app_name)
 
-    override val menuToolbar by lazy {
+    override val menuToolbarNavigation by lazy {
         val back = BrowserMenuItemToolbar.TwoStateButton(
             primaryImageResource = mozilla.components.ui.icons.R.drawable.mozac_ic_back,
             primaryContentDescription = context.getString(R.string.browser_menu_back),
@@ -123,7 +123,7 @@ class CustomTabToolbarMenu(
             openInApp.apply { visible = ::shouldShowOpenInApp },
             openInFenix,
             BrowserMenuDivider(),
-            menuToolbar
+            menuToolbarNavigation
         )
         if (shouldReverseItems) {
             menuItems.reversed()

--- a/app/src/main/java/org/mozilla/fenix/home/HomeMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeMenu.kt
@@ -62,7 +62,7 @@ class HomeMenu(
         context.getColorFromAttr(R.attr.syncDisconnectedBackground)
 
     private val shouldUseBottomToolbar = context.settings().shouldUseBottomToolbar
-    private val accountManager = FenixAccountManager(context)
+    private val accountManager = FenixAccountManager(context, lifecycleOwner)
 
     // 'Reconnect' and 'Quit' items aren't needed most of the time, so we'll only create the if necessary.
     private val reconnectToSyncItem by lazy {

--- a/app/src/test/java/org/mozilla/fenix/components/accounts/FenixAccountManagerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/accounts/FenixAccountManagerTest.kt
@@ -40,7 +40,7 @@ class FenixAccountManagerTest {
         every { accountManagerComponent.authenticatedAccount() } returns null
         every { accountManagerComponent.accountProfile() } returns null
         every { context.components.backgroundServices.accountManager } returns accountManagerComponent
-        fenixFxaManager = FenixAccountManager(context)
+        fenixFxaManager = FenixAccountManager(context, lifecycleOwner)
 
         val result = fenixFxaManager.accountProfileEmail
 
@@ -82,7 +82,7 @@ class FenixAccountManagerTest {
     fun `GIVEN no account exists WHEN accountState is called THEN it returns AccountState#NO_ACCOUNT`() {
         every { context.components.backgroundServices.accountManager } returns accountManagerComponent
         every { accountManagerComponent.authenticatedAccount() } returns null
-        fenixFxaManager = FenixAccountManager(context)
+        fenixFxaManager = FenixAccountManager(context, lifecycleOwner)
 
         assertSame(AccountState.NO_ACCOUNT, fenixFxaManager.accountState)
 
@@ -101,7 +101,7 @@ class FenixAccountManagerTest {
         every { accountManagerComponent.authenticatedAccount() } returns mockk()
         every { accountManagerComponent.accountNeedsReauth() } returns true
 
-        fenixFxaManager = FenixAccountManager(context)
+        fenixFxaManager = FenixAccountManager(context, lifecycleOwner)
 
         val result = fenixFxaManager.accountState
 

--- a/app/src/test/java/org/mozilla/fenix/components/accounts/FenixAccountManagerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/accounts/FenixAccountManagerTest.kt
@@ -5,6 +5,7 @@
 package org.mozilla.fenix.components.accounts
 
 import android.content.Context
+import androidx.lifecycle.LifecycleOwner
 import io.mockk.every
 import io.mockk.mockk
 import mozilla.components.concept.sync.OAuthAccount
@@ -23,12 +24,14 @@ class FenixAccountManagerTest {
     private lateinit var context: Context
     private lateinit var account: OAuthAccount
     private lateinit var profile: Profile
+    private lateinit var lifecycleOwner: LifecycleOwner
 
     @Before
     fun setUp() {
         context = mockk(relaxed = true)
         account = mockk(relaxed = true)
         profile = mockk(relaxed = true)
+        lifecycleOwner = mockk(relaxed = true)
         accountManagerComponent = mockk(relaxed = true)
     }
 
@@ -51,7 +54,8 @@ class FenixAccountManagerTest {
         every { accountManagerComponent.accountProfile()?.email } returns "firefoxIsFun@test.com"
         every { accountManagerComponent.accountNeedsReauth() } returns true
         every { context.components.backgroundServices.accountManager } returns accountManagerComponent
-        fenixFxaManager = FenixAccountManager(context)
+
+        fenixFxaManager = FenixAccountManager(context, lifecycleOwner)
 
         val result = fenixFxaManager.accountProfileEmail
 
@@ -66,7 +70,8 @@ class FenixAccountManagerTest {
         every { accountManagerComponent.accountProfile()?.email } returns accountEmail
         every { accountManagerComponent.accountNeedsReauth() } returns false
         every { context.components.backgroundServices.accountManager } returns accountManagerComponent
-        fenixFxaManager = FenixAccountManager(context)
+
+        fenixFxaManager = FenixAccountManager(context, lifecycleOwner)
 
         val result = fenixFxaManager.accountProfileEmail
 
@@ -95,6 +100,7 @@ class FenixAccountManagerTest {
         every { context.components.backgroundServices.accountManager } returns accountManagerComponent
         every { accountManagerComponent.authenticatedAccount() } returns mockk()
         every { accountManagerComponent.accountNeedsReauth() } returns true
+
         fenixFxaManager = FenixAccountManager(context)
 
         val result = fenixFxaManager.accountState
@@ -107,7 +113,8 @@ class FenixAccountManagerTest {
         every { context.components.backgroundServices.accountManager } returns accountManagerComponent
         every { accountManagerComponent.authenticatedAccount() } returns mockk()
         every { accountManagerComponent.accountNeedsReauth() } returns false
-        fenixFxaManager = FenixAccountManager(context)
+
+        fenixFxaManager = FenixAccountManager(context, lifecycleOwner)
 
         val result = fenixFxaManager.accountState
 

--- a/app/src/test/java/org/mozilla/fenix/toolbar/DefaultToolbarMenuTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/toolbar/DefaultToolbarMenuTest.kt
@@ -23,10 +23,11 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
+import org.mozilla.fenix.components.accounts.FenixAccountManager
 import org.mozilla.fenix.components.toolbar.DefaultToolbarMenu
+import org.mozilla.fenix.components.toolbar.ToolbarMenuItems
 import org.mozilla.fenix.ext.settings
 
 @ExperimentalCoroutinesApi
@@ -37,8 +38,12 @@ class DefaultToolbarMenuTest {
     private lateinit var toolbarMenu: DefaultToolbarMenu
     private lateinit var context: Context
     private lateinit var bookmarksStorage: BookmarksStorage
+    private lateinit var toolbarMenuItems: ToolbarMenuItems
+    private lateinit var accountManager: FenixAccountManager
 
     private val testDispatcher = TestCoroutineDispatcher()
+    private val primaryTextColor: Int = mockk(relaxed = true)
+    private val accentBrightTextColor: Int = mockk(relaxed = true)
 
     @get:Rule
     val coroutinesTestRule = MainCoroutineRule(testDispatcher)
@@ -62,6 +67,17 @@ class DefaultToolbarMenuTest {
                 ),
                 selectedTabId = "1"
             )
+        )
+        accountManager = mockk(relaxed = true)
+
+        toolbarMenuItems = ToolbarMenuItems(
+            context,
+            store,
+            accountManager,
+            hasAccountProblem = false,
+            onItemTapped = {},
+            primaryTextColor,
+            accentBrightTextColor
         )
     }
 
@@ -88,7 +104,6 @@ class DefaultToolbarMenuTest {
     }
 
     @Test
-    @Ignore("Intermittent test: https://github.com/mozilla-mobile/fenix/issues/18822")
     fun `WHEN the bottom toolbar is set THEN the first item in the list is not the navigation`() {
         every { context.settings().shouldUseBottomToolbar } returns true
         createMenu()
@@ -103,7 +118,6 @@ class DefaultToolbarMenuTest {
     }
 
     @Test
-    @Ignore("Intermittent test: https://github.com/mozilla-mobile/fenix/issues/18822")
     fun `WHEN the top toolbar is set THEN the first item in the list is the navigation`() {
         every { context.settings().shouldUseBottomToolbar } returns false
         createMenu()
@@ -112,13 +126,12 @@ class DefaultToolbarMenuTest {
         assertNotNull(menuItems)
 
         val firstItem = menuItems[0]
-        val navToolbar = toolbarMenu.menuToolbar
+        val navToolbar = toolbarMenu.menuToolbarNavigation
 
         assertEquals(navToolbar, firstItem)
     }
 
     @Test
-    @Ignore("Intermittent test: https://github.com/mozilla-mobile/fenix/issues/18822")
     fun `WHEN the bottom toolbar is set THEN the nav menu should be the last item`() {
         every { context.settings().shouldUseBottomToolbar } returns true
 
@@ -128,13 +141,12 @@ class DefaultToolbarMenuTest {
         assertNotNull(menuItems)
 
         val lastItem = menuItems[menuItems.size - 1]
-        val navToolbar = toolbarMenu.menuToolbar
+        val navToolbar = toolbarMenu.menuToolbarNavigation
 
         assertEquals(navToolbar, lastItem)
     }
 
     @Test
-    @Ignore("Intermittent test: https://github.com/mozilla-mobile/fenix/issues/18822")
     fun `WHEN the top toolbar is set THEN settings should be the last item`() {
         every { context.settings().shouldUseBottomToolbar } returns false
 


### PR DESCRIPTION
For #19116
Related to #19141 

**Default toolbar menu**
* `DefaultToolbarMenu.kt`
* Menu items: `ToolbarMenu.kt` (interface, impl by `DefaultToolbarMenu`)

**FxAccount manager**
* `FenixAccountManager.kt` 
* holds a reference to `context.components.backgroundServices.accountManager`
* handles `observeAccountState`, `getAuthAccountEmail` for menu items
* Put in a new package, `.accounts`, under `org.mozilla.fenix.components` and moved relevant account classes there too

**Tests**
- [x] DefaultBrowserToolbarMenuControllerTest
- [ ] DefaultToolbarMenuTest - intermittent tests #18822
- [ ] FenixAccountManagerTest
- [ ] UI tests


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
