### PR TITLE
Run the sync-strings workflow daily at 2am

### DIFF
--- a/.github/workflows/sync-strings.yml
+++ b/.github/workflows/sync-strings.yml
@@ -6,7 +6,7 @@ name: "Sync Strings"
 
 on:
   schedule:
-    - cron: '0 */4 * * *'
+    - cron: '0 2 * * *'
 
 jobs:
   main:


### PR DESCRIPTION
This patch changes the schedule for the `sync-strings.yml` workflow from _every four hours_ to _daily at 2am_. There is no need to run the workflow more frequently than once a day.

If my timezone skillz are correct, this runs after the job that imports strings from the l10n repository.