### PR TITLE
Update the sync-strings workflow

### DIFF
--- a/.github/workflows/sync-strings.yml
+++ b/.github/workflows/sync-strings.yml
@@ -15,9 +15,7 @@ jobs:
     steps:
       - name: "Discover Fenix Beta Version"
         id: fenix-beta-version
-        uses: mozilla-mobile/fenix-beta-version@1.0.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: mozilla-mobile/fenix-beta-version@1.1.0
       - name: "Checkout Master Branch"
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
This patch updates the `fenix-beta-version` action in the `sync-strings.yml` workflow to use `v1.1.0`. This version does not require the `GITHUB_TOKEN` input anymore.