### PR TITLE
Fix breaking changes introduced by credit card encryption APIs

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/BackgroundServices.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/BackgroundServices.kt
@@ -95,8 +95,8 @@ class BackgroundServices(
     private val syncConfig = SyncConfig(supportedEngines, PeriodicSyncConfig(periodMinutes = 240)) // four hours
 
     init {
-        /* Make the "history", "bookmark", "passwords", and "tabs" stores accessible to workers
-           spawned by the sync manager. */
+        // Make the "history", "bookmark", "passwords", "tabs" stores
+        // accessible to workers spawned by the sync manager.
         GlobalSyncableStoreProvider.configureStore(SyncEngine.History to historyStorage)
         GlobalSyncableStoreProvider.configureStore(SyncEngine.Bookmarks to bookmarkStorage)
         GlobalSyncableStoreProvider.configureStore(SyncEngine.Passwords to passwordsStorage)

--- a/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -291,7 +291,7 @@ class Core(
     val lazyHistoryStorage = lazyMonitored { PlacesHistoryStorage(context, crashReporter) }
     val lazyBookmarksStorage = lazyMonitored { PlacesBookmarksStorage(context) }
     val lazyPasswordsStorage = lazyMonitored { SyncableLoginsStorage(context, passwordsEncryptionKey) }
-    val lazyAutofillStorage = lazyMonitored { AutofillCreditCardsAddressesStorage(context) }
+    private val lazyAutofillStorage = lazyMonitored { AutofillCreditCardsAddressesStorage(context, lazySecurePrefs) }
 
     /**
      * The storage component to sync and persist tabs in a Firefox Sync account.
@@ -390,6 +390,7 @@ class Core(
      * Shared Preferences that encrypt/decrypt using Android KeyStore and lib-dataprotect for 23+
      * only on Nightly/Debug for now, otherwise simply stored.
      * See https://github.com/mozilla-mobile/fenix/issues/8324
+     * Also, this needs revision. See https://github.com/mozilla-mobile/fenix/issues/19155
      */
     private fun getSecureAbove22Preferences() =
         SecureAbove22Preferences(
@@ -397,6 +398,9 @@ class Core(
             name = KEY_STORAGE_NAME,
             forceInsecure = !Config.channel.isNightlyOrDebug
         )
+
+    // Temporary. See https://github.com/mozilla-mobile/fenix/issues/19155
+    private val lazySecurePrefs = lazyMonitored { getSecureAbove22Preferences() }
 
     private val passwordsEncryptionKey by lazyMonitored {
         getSecureAbove22Preferences().getString(PASSWORDS_KEY)

--- a/app/src/main/java/org/mozilla/fenix/settings/creditcards/CreditCardEditorState.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/creditcards/CreditCardEditorState.kt
@@ -37,7 +37,8 @@ fun CreditCard.toCreditCardEditorState(): CreditCardEditorState {
     return CreditCardEditorState(
         guid = guid,
         billingName = billingName,
-        cardNumber = cardNumber,
+        // TODO - need to represented a full CreditCardNumber object here, along with last4
+        cardNumber = encryptedCardNumber.number,
         expiryMonth = expiryMonth.toInt(),
         expiryYears = Pair(startYear, endYear),
         isEditing = true

--- a/app/src/main/java/org/mozilla/fenix/settings/creditcards/controller/CreditCardEditorController.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/creditcards/controller/CreditCardEditorController.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import mozilla.components.concept.storage.NewCreditCardFields
 import mozilla.components.concept.storage.UpdatableCreditCardFields
 import mozilla.components.service.sync.autofill.AutofillCreditCardsAddressesStorage
 import org.mozilla.fenix.settings.creditcards.CreditCardEditorFragment
@@ -33,7 +34,7 @@ interface CreditCardEditorController {
     /**
      * @see [CreditCardEditorInteractor.onSaveCreditCard]
      */
-    fun handleSaveCreditCard(creditCardFields: UpdatableCreditCardFields)
+    fun handleSaveCreditCard(creditCardFields: NewCreditCardFields)
 
     /**
      * @see [CreditCardEditorInteractor.onUpdateCreditCard]
@@ -71,7 +72,7 @@ class DefaultCreditCardEditorController(
         }
     }
 
-    override fun handleSaveCreditCard(creditCardFields: UpdatableCreditCardFields) {
+    override fun handleSaveCreditCard(creditCardFields: NewCreditCardFields) {
         lifecycleScope.launch(ioDispatcher) {
             storage.addCreditCard(creditCardFields)
 

--- a/app/src/main/java/org/mozilla/fenix/settings/creditcards/interactor/CreditCardEditorInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/creditcards/interactor/CreditCardEditorInteractor.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.fenix.settings.creditcards.interactor
 
+import mozilla.components.concept.storage.NewCreditCardFields
 import mozilla.components.concept.storage.UpdatableCreditCardFields
 import org.mozilla.fenix.settings.creditcards.controller.CreditCardEditorController
 
@@ -30,9 +31,9 @@ interface CreditCardEditorInteractor {
      * Saves the provided credit card field into the credit card storage. Called when a user
      * taps on the save menu item or "Save" button.
      *
-     * @param creditCardFields A [UpdatableCreditCardFields] record to add.
+     * @param creditCardFields A [NewCreditCardFields] record to add.
      */
-    fun onSaveCreditCard(creditCardFields: UpdatableCreditCardFields)
+    fun onSaveCreditCard(creditCardFields: NewCreditCardFields)
 
     /**
      * Updates the provided credit card with the new credit card fields. Called when a user
@@ -62,7 +63,7 @@ class DefaultCreditCardEditorInteractor(
         controller.handleDeleteCreditCard(guid)
     }
 
-    override fun onSaveCreditCard(creditCardFields: UpdatableCreditCardFields) {
+    override fun onSaveCreditCard(creditCardFields: NewCreditCardFields) {
         controller.handleSaveCreditCard(creditCardFields)
     }
 

--- a/app/src/main/java/org/mozilla/fenix/settings/creditcards/view/CreditCardEditorView.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/creditcards/view/CreditCardEditorView.kt
@@ -9,6 +9,8 @@ import android.view.View
 import android.widget.ArrayAdapter
 import kotlinx.android.extensions.LayoutContainer
 import kotlinx.android.synthetic.main.fragment_credit_card_editor.*
+import mozilla.components.concept.storage.CreditCardNumber
+import mozilla.components.concept.storage.NewCreditCardFields
 import mozilla.components.concept.storage.UpdatableCreditCardFields
 import mozilla.components.support.ktx.android.view.hideKeyboard
 import org.mozilla.fenix.ext.toEditable
@@ -30,6 +32,7 @@ class CreditCardEditorView(
     /**
      * Binds the given [CreditCardEditorState] in the [CreditCardEditorFragment].
      */
+    @Suppress("MagicNumber")
     fun bind(state: CreditCardEditorState) {
         if (state.isEditing) {
             delete_button.apply {
@@ -48,18 +51,29 @@ class CreditCardEditorView(
         save_button.setOnClickListener {
             containerView.hideKeyboard()
 
-            val creditCardFields = UpdatableCreditCardFields(
-                billingName = name_on_card_input.text.toString(),
-                cardNumber = card_number_input.text.toString(),
-                expiryMonth = (expiry_month_drop_down.selectedItemPosition + 1).toLong(),
-                expiryYear = expiry_year_drop_down.selectedItem.toString().toLong(),
-                cardType = CARD_TYPE_PLACEHOLDER
-            )
-
+            // TODO same as in the corresponding fragment, plaintext number if it's being updated or
+            //  round-tripped otherwise. Also, why is there so much duplication?
+            val cardNumber = card_number_input.text.toString()
             if (state.isEditing) {
-                interactor.onUpdateCreditCard(state.guid, creditCardFields)
+                val fields = UpdatableCreditCardFields(
+                    billingName = name_on_card_input.text.toString(),
+                    cardNumber = CreditCardNumber.Plaintext(cardNumber),
+                    cardNumberLast4 = cardNumber.substring(cardNumber.length - 5, cardNumber.length - 1),
+                    expiryMonth = (expiry_month_drop_down.selectedItemPosition + 1).toLong(),
+                    expiryYear = expiry_year_drop_down.selectedItem.toString().toLong(),
+                    cardType = CARD_TYPE_PLACEHOLDER
+                )
+                interactor.onUpdateCreditCard(state.guid, fields)
             } else {
-                interactor.onSaveCreditCard(creditCardFields)
+                val fields = NewCreditCardFields(
+                    billingName = name_on_card_input.text.toString(),
+                    plaintextCardNumber = CreditCardNumber.Plaintext(cardNumber),
+                    cardNumberLast4 = cardNumber.substring(cardNumber.length - 5, cardNumber.length - 1),
+                    expiryMonth = (expiry_month_drop_down.selectedItemPosition + 1).toLong(),
+                    expiryYear = expiry_year_drop_down.selectedItem.toString().toLong(),
+                    cardType = CARD_TYPE_PLACEHOLDER
+                )
+                interactor.onSaveCreditCard(fields)
             }
         }
 

--- a/app/src/main/java/org/mozilla/fenix/settings/creditcards/view/CreditCardItemViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/creditcards/view/CreditCardItemViewHolder.kt
@@ -23,7 +23,9 @@ class CreditCardItemViewHolder(
 ) : ViewHolder(view) {
 
     fun bind(creditCard: CreditCard) {
-        credit_card_number.text = creditCard.cardNumber
+        // TODO this should be last4 instead...
+        //  and option to explicitly decrypt if necessary to show full number
+        credit_card_number.text = creditCard.encryptedCardNumber.number
 
         bindCreditCardExpiryDate(creditCard)
 


### PR DESCRIPTION
A side-kick of https://github.com/mozilla-mobile/android-components/pull/10054

This kind-of breaks the hidden credit cards UI, so needs a quick follow-up. As part of taking the https://github.com/mozilla-mobile/android-components/pull/10054 update, currently stored cc data will be wiped. cc @gabrielluong 
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
