### PR TITLE
Remove browser-search references.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -442,7 +442,6 @@ dependencies {
     implementation Deps.mozilla_browser_icons
     implementation Deps.mozilla_browser_menu
     implementation Deps.mozilla_browser_menu2
-    implementation Deps.mozilla_browser_search
     implementation Deps.mozilla_browser_session
     implementation Deps.mozilla_browser_session_storage
     implementation Deps.mozilla_browser_state

--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -52,7 +52,6 @@ import mozilla.components.concept.storage.BookmarkNodeType
 import mozilla.components.feature.contextmenu.DefaultSelectionActionDelegate
 import mozilla.components.feature.privatemode.notification.PrivateNotificationFeature
 import mozilla.components.feature.search.BrowserStoreSearchAdapter
-import mozilla.components.feature.search.ext.legacy
 import mozilla.components.service.fxa.sync.SyncReason
 import mozilla.components.support.base.feature.ActivityResultHandler
 import mozilla.components.support.base.feature.UserInteractionHandler
@@ -855,10 +854,10 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
                         SessionState.Source.USER_ENTERED,
                         true,
                         mode.isPrivate,
-                        searchEngine = engine.legacy()
+                        searchEngine = engine
                     )
             } else {
-                components.useCases.searchUseCases.defaultSearch.invoke(searchTermOrURL, engine.legacy())
+                components.useCases.searchUseCases.defaultSearch.invoke(searchTermOrURL, engine)
             }
         }
 

--- a/app/src/main/java/org/mozilla/fenix/components/UseCases.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/UseCases.kt
@@ -15,7 +15,6 @@ import mozilla.components.feature.downloads.DownloadsUseCases
 import mozilla.components.feature.pwa.WebAppShortcutManager
 import mozilla.components.feature.pwa.WebAppUseCases
 import mozilla.components.feature.search.SearchUseCases
-import mozilla.components.feature.search.ext.toDefaultSearchEngineProvider
 import mozilla.components.feature.session.SessionUseCases
 import mozilla.components.feature.session.SettingsUseCases
 import mozilla.components.feature.session.TrackingProtectionUseCases
@@ -66,7 +65,6 @@ class UseCases(
     val searchUseCases by lazyMonitored {
         SearchUseCases(
             store,
-            store.toDefaultSearchEngineProvider(),
             tabsUseCases
         )
     }

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
@@ -6,7 +6,7 @@ package org.mozilla.fenix.components.metrics
 
 import android.content.Context
 import mozilla.components.browser.state.store.BrowserStore
-import mozilla.components.feature.search.ext.legacy
+import mozilla.components.feature.search.ext.buildSearchUrl
 import mozilla.components.feature.search.ext.waitForSelectedOrDefaultSearchEngine
 import mozilla.components.service.fxa.manager.SyncEnginesStorage
 import mozilla.components.service.glean.Glean
@@ -971,7 +971,7 @@ class GleanMetricsService(
                 SearchDefaultEngine.apply {
                     code.set(searchEngine.id)
                     name.set(searchEngine.name)
-                    submissionUrl.set(searchEngine.legacy().buildSearchUrl(""))
+                    submissionUrl.set(searchEngine.buildSearchUrl(""))
                 }
             }
 

--- a/app/src/main/java/org/mozilla/fenix/components/search/SearchMigration.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/search/SearchMigration.kt
@@ -6,9 +6,8 @@ package org.mozilla.fenix.components.search
 
 import android.content.Context
 import android.content.SharedPreferences
-import mozilla.components.browser.search.SearchEngineParser
 import mozilla.components.browser.state.search.SearchEngine
-import mozilla.components.feature.search.ext.migrate
+import mozilla.components.feature.search.ext.parseLegacySearchEngine
 import mozilla.components.feature.search.middleware.SearchMiddleware
 import org.mozilla.fenix.ext.components
 import org.xmlpull.v1.XmlPullParserException
@@ -50,18 +49,17 @@ internal class SearchMigration(
     ): List<SearchEngine> {
         val ids = preferences.getStringSet(PREF_KEY_CUSTOM_SEARCH_ENGINES, emptySet()) ?: emptySet()
 
-        val parser = SearchEngineParser()
-
         return ids.mapNotNull { id ->
             val xml = preferences.getString(id, null)
-            parser.loadSafely(id, xml?.byteInputStream()?.buffered())
+            loadSafely(id, xml?.byteInputStream()?.buffered())
         }
     }
 }
 
-private fun SearchEngineParser.loadSafely(id: String, stream: BufferedInputStream?): SearchEngine? {
+@Suppress("DEPRECATION")
+private fun loadSafely(id: String, stream: BufferedInputStream?): SearchEngine? {
     return try {
-        stream?.let { load(id, it).migrate() }
+        stream?.let { parseLegacySearchEngine(id, it) }
     } catch (e: IOException) {
         null
     } catch (e: XmlPullParserException) {

--- a/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarView.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarView.kt
@@ -9,7 +9,6 @@ import androidx.core.graphics.BlendModeColorFilterCompat.createBlendModeColorFil
 import androidx.core.graphics.BlendModeCompat.SRC_IN
 import androidx.core.graphics.drawable.toBitmap
 import mozilla.components.browser.awesomebar.BrowserAwesomeBar
-import mozilla.components.browser.search.DefaultSearchEngineProvider
 import mozilla.components.browser.state.search.SearchEngine
 import mozilla.components.browser.state.state.searchEngines
 import mozilla.components.concept.awesomebar.AwesomeBar
@@ -21,8 +20,6 @@ import mozilla.components.feature.awesomebar.provider.SearchEngineSuggestionProv
 import mozilla.components.feature.awesomebar.provider.SearchSuggestionProvider
 import mozilla.components.feature.awesomebar.provider.SessionSuggestionProvider
 import mozilla.components.feature.search.SearchUseCases
-import mozilla.components.feature.search.ext.legacy
-import mozilla.components.feature.search.ext.toDefaultSearchEngineProvider
 import mozilla.components.feature.session.SessionUseCases
 import mozilla.components.feature.syncedtabs.DeviceIndicators
 import mozilla.components.feature.syncedtabs.SyncedTabsStorageSuggestionProvider
@@ -34,7 +31,6 @@ import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.search.SearchEngineSource
 import org.mozilla.fenix.search.SearchFragmentState
-import mozilla.components.browser.search.SearchEngine as LegacySearchEngine
 
 /**
  * View that contains and configures the BrowserAwesomeBar
@@ -70,7 +66,7 @@ class AwesomeBarView(
     private val searchUseCase = object : SearchUseCases.SearchUseCase {
         override fun invoke(
             searchTerms: String,
-            searchEngine: mozilla.components.browser.search.SearchEngine?,
+            searchEngine: SearchEngine?,
             parentSessionId: String?
         ) {
             interactor.onSearchTermsTapped(searchTerms)
@@ -80,7 +76,7 @@ class AwesomeBarView(
     private val shortcutSearchUseCase = object : SearchUseCases.SearchUseCase {
         override fun invoke(
             searchTerms: String,
-            searchEngine: mozilla.components.browser.search.SearchEngine?,
+            searchEngine: SearchEngine?,
             parentSessionId: String?
         ) {
             interactor.onSearchTermsTapped(searchTerms)
@@ -151,7 +147,7 @@ class AwesomeBarView(
         defaultSearchSuggestionProvider =
             SearchSuggestionProvider(
                 context = activity,
-                defaultSearchEngineProvider = components.core.store.toDefaultSearchEngineProvider(),
+                store = components.core.store,
                 searchUseCase = searchUseCase,
                 fetchClient = components.core.client,
                 mode = SearchSuggestionProvider.Mode.MULTIPLE_SUGGESTIONS,
@@ -164,7 +160,7 @@ class AwesomeBarView(
 
         defaultSearchActionProvider =
             SearchActionProvider(
-                defaultSearchEngineProvider = components.core.store.toDefaultSearchEngineProvider(),
+                store = components.core.store,
                 searchUseCase = searchUseCase,
                 icon = searchBitmap,
                 showDescription = false
@@ -326,17 +322,13 @@ class AwesomeBarView(
 
             listOf(
                 SearchActionProvider(
-                    defaultSearchEngineProvider = object : DefaultSearchEngineProvider {
-                        override fun getDefaultSearchEngine(): LegacySearchEngine? =
-                            engine.legacy()
-                        override suspend fun retrieveDefaultSearchEngine(): LegacySearchEngine? =
-                            engine.legacy()
-                    },
+                    searchEngine = engine,
+                    store = components.core.store,
                     searchUseCase = shortcutSearchUseCase,
                     icon = searchBitmap
                 ),
                 SearchSuggestionProvider(
-                    engine.legacy(),
+                    engine,
                     shortcutSearchUseCase,
                     components.core.client,
                     limit = 3,

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "90.0.20210420185510"
+    const val VERSION = "90.0.20210421164305"
 }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -79,7 +79,6 @@ object Deps {
     const val mozilla_browser_engine_gecko = "org.mozilla.components:browser-engine-gecko:${Versions.mozilla_android_components}"
     const val mozilla_browser_domains = "org.mozilla.components:browser-domains:${Versions.mozilla_android_components}"
     const val mozilla_browser_icons = "org.mozilla.components:browser-icons:${Versions.mozilla_android_components}"
-    const val mozilla_browser_search = "org.mozilla.components:browser-search:${Versions.mozilla_android_components}"
     const val mozilla_browser_session = "org.mozilla.components:browser-session:${Versions.mozilla_android_components}"
     const val mozilla_browser_session_storage = "org.mozilla.components:browser-session-storage:${Versions.mozilla_android_components}"
     const val mozilla_browser_state = "org.mozilla.components:browser-state:${Versions.mozilla_android_components}"


### PR DESCRIPTION
Over in A-C we remove `browser-search` because all functionality is now provided by `feature-search` and all apps have been migrated. ([PR #10045](https://github.com/mozilla-mobile/android-components/pull/10045)).

This patch removes `browser-search` from the dependencies and makes the necessary API changes.

Needs an A-C Nightly with the changes applied before this passes here. :)