### PR TITLE
Closes #18816: Disable TabsTray FAB on accessibility enabled

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
@@ -12,6 +12,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatDialogFragment
 import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
@@ -68,6 +69,7 @@ class TabsTrayFragment : AppCompatDialogFragment(), TabsTrayInteractor {
     private val tabLayoutMediator = ViewBoundFeatureWrapper<TabLayoutMediator>()
     private val tabCounterBinding = ViewBoundFeatureWrapper<TabCounterBinding>()
     private val floatingActionButtonBinding = ViewBoundFeatureWrapper<FloatingActionButtonBinding>()
+    private val newTabButtonBinding = ViewBoundFeatureWrapper<AccessibleNewTabButtonBinding>()
     private val selectionBannerBinding = ViewBoundFeatureWrapper<SelectionBannerBinding>()
     private val selectionHandleBinding = ViewBoundFeatureWrapper<SelectionHandleBinding>()
     private val tabsTrayCtaBinding = ViewBoundFeatureWrapper<TabsTrayInfoBannerBinding>()
@@ -211,7 +213,20 @@ class TabsTrayFragment : AppCompatDialogFragment(), TabsTrayInteractor {
         floatingActionButtonBinding.set(
             feature = FloatingActionButtonBinding(
                 store = tabsTrayStore,
+                settings = requireComponents.settings,
                 actionButton = new_tab_button,
+                browserTrayInteractor = browserTrayInteractor,
+                syncedTabsInteractor = syncedTabsTrayInteractor
+            ),
+            owner = this,
+            view = view
+        )
+
+        newTabButtonBinding.set(
+            feature = AccessibleNewTabButtonBinding(
+                store = tabsTrayStore,
+                settings = requireComponents.settings,
+                newTabButton = tab_tray_new_tab,
                 browserTrayInteractor = browserTrayInteractor,
                 syncedTabsInteractor = syncedTabsTrayInteractor
             ),
@@ -312,7 +327,7 @@ class TabsTrayFragment : AppCompatDialogFragment(), TabsTrayInteractor {
             },
             operation = { },
             elevation = ELEVATION,
-            anchorView = new_tab_button
+            anchorView = if (new_tab_button.isVisible) new_tab_button else null
         )
     }
 

--- a/app/src/main/res/layout/component_tabstray_fab.xml
+++ b/app/src/main/res/layout/component_tabstray_fab.xml
@@ -17,6 +17,7 @@
     android:elevation="99dp"
     android:text="@string/tab_drawer_fab_content"
     android:textColor="@color/photonWhite"
+    android:visibility="gone"
     app:elevation="99dp"
     app:borderWidth="0dp"
     app:icon="@drawable/ic_new"

--- a/app/src/test/java/org/mozilla/fenix/tabstray/AccessibleNewTabButtonBindingTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/AccessibleNewTabButtonBindingTest.kt
@@ -1,0 +1,140 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabstray
+
+import android.view.View
+import android.widget.ImageButton
+import androidx.appcompat.content.res.AppCompatResources
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import mozilla.components.support.test.libstate.ext.waitUntilIdle
+import mozilla.components.support.test.rule.MainCoroutineRule
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mozilla.fenix.R
+import org.mozilla.fenix.tabstray.browser.BrowserTrayInteractor
+import org.mozilla.fenix.tabstray.syncedtabs.SyncedTabsInteractor
+import org.mozilla.fenix.utils.Settings
+
+class AccessibleNewTabButtonBindingTest {
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule(TestCoroutineDispatcher())
+
+    private val settings: Settings = mockk(relaxed = true)
+    private val newTabButton: ImageButton = mockk(relaxed = true)
+    private val browserTrayInteractor: BrowserTrayInteractor = mockk(relaxed = true)
+    private val syncedTabsInteractor: SyncedTabsInteractor = mockk(relaxed = true)
+
+    @Before
+    fun setup() {
+        mockkStatic(AppCompatResources::class)
+        every { AppCompatResources.getDrawable(any(), any()) } returns mockk(relaxed = true)
+    }
+
+    @Test
+    fun `WHEN tab selected page is normal tab THEN new tab button is visible`() {
+        val tabsTrayStore = TabsTrayStore(TabsTrayState(selectedPage = Page.NormalTabs))
+        val newTabButtonBinding = AccessibleNewTabButtonBinding(
+            tabsTrayStore, settings, newTabButton, browserTrayInteractor, syncedTabsInteractor
+        )
+        every { settings.accessibilityServicesEnabled } returns true
+
+        newTabButtonBinding.start()
+
+        verify(exactly = 1) { newTabButton.visibility = View.VISIBLE }
+    }
+
+    @Test
+    fun `WHEN tab selected page is private tab THEN new tab button is visible`() {
+        val tabsTrayStore = TabsTrayStore(TabsTrayState(selectedPage = Page.PrivateTabs))
+        val newTabButtonBinding = AccessibleNewTabButtonBinding(
+            tabsTrayStore, settings, newTabButton, browserTrayInteractor, syncedTabsInteractor
+        )
+        every { settings.accessibilityServicesEnabled } returns true
+
+        newTabButtonBinding.start()
+
+        verify(exactly = 1) { newTabButton.visibility = View.VISIBLE }
+    }
+
+    @Test
+    fun `WHEN tab selected page is sync tab THEN new tab button is visible`() {
+        val tabsTrayStore = TabsTrayStore(TabsTrayState(selectedPage = Page.SyncedTabs))
+        val newTabButtonBinding = AccessibleNewTabButtonBinding(
+            tabsTrayStore, settings, newTabButton, browserTrayInteractor, syncedTabsInteractor
+        )
+        every { settings.accessibilityServicesEnabled } returns true
+
+        newTabButtonBinding.start()
+
+        verify(exactly = 1) { newTabButton.visibility = View.VISIBLE }
+    }
+
+    @Test
+    fun `WHEN accessibility is disabled THEN new tab button is not visible`() {
+        var tabsTrayStore = TabsTrayStore(TabsTrayState(selectedPage = Page.NormalTabs))
+        var newTabButtonBinding = AccessibleNewTabButtonBinding(
+            tabsTrayStore, settings, newTabButton, browserTrayInteractor, syncedTabsInteractor
+        )
+        every { settings.accessibilityServicesEnabled } returns false
+
+        newTabButtonBinding.start()
+
+        verify(exactly = 1) { newTabButton.visibility = View.GONE }
+
+        tabsTrayStore = TabsTrayStore(TabsTrayState(selectedPage = Page.PrivateTabs))
+        newTabButtonBinding = AccessibleNewTabButtonBinding(
+            tabsTrayStore, settings, newTabButton, browserTrayInteractor, syncedTabsInteractor
+        )
+
+        newTabButtonBinding.start()
+
+        verify(exactly = 2) { newTabButton.visibility = View.GONE }
+
+        tabsTrayStore = TabsTrayStore(TabsTrayState(selectedPage = Page.SyncedTabs))
+        newTabButtonBinding = AccessibleNewTabButtonBinding(
+            tabsTrayStore, settings, newTabButton, browserTrayInteractor, syncedTabsInteractor
+        )
+
+        newTabButtonBinding.start()
+
+        verify(exactly = 3) { newTabButton.visibility = View.GONE }
+    }
+
+    @Test
+    fun `WHEN selected page is updated THEN button is updated`() {
+        val tabsTrayStore = TabsTrayStore(TabsTrayState(selectedPage = Page.NormalTabs))
+        val newTabButtonBinding = AccessibleNewTabButtonBinding(
+            tabsTrayStore, settings, newTabButton, browserTrayInteractor, syncedTabsInteractor
+        )
+        every { settings.accessibilityServicesEnabled } returns true
+
+        newTabButtonBinding.start()
+
+        verify(exactly = 1) { newTabButton.setImageResource(R.drawable.ic_new) }
+
+        tabsTrayStore.dispatch(TabsTrayAction.PageSelected(Page.positionToPage(Page.PrivateTabs.ordinal)))
+        tabsTrayStore.waitUntilIdle()
+
+        verify(exactly = 2) { newTabButton.setImageResource(R.drawable.ic_new) }
+
+        tabsTrayStore.dispatch(TabsTrayAction.PageSelected(Page.positionToPage(Page.SyncedTabs.ordinal)))
+        tabsTrayStore.waitUntilIdle()
+
+        verify(exactly = 1) { newTabButton.setImageResource(R.drawable.ic_fab_sync) }
+
+        tabsTrayStore.dispatch(TabsTrayAction.SyncNow)
+        tabsTrayStore.waitUntilIdle()
+
+        verify(exactly = 1) { newTabButton.visibility = View.GONE }
+    }
+}

--- a/app/src/test/java/org/mozilla/fenix/tabstray/FloatingActionButtonBindingTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/FloatingActionButtonBindingTest.kt
@@ -1,0 +1,170 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabstray
+
+import androidx.appcompat.content.res.AppCompatResources
+import com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import mozilla.components.support.test.libstate.ext.waitUntilIdle
+import mozilla.components.support.test.rule.MainCoroutineRule
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mozilla.fenix.R
+import org.mozilla.fenix.tabstray.browser.BrowserTrayInteractor
+import org.mozilla.fenix.tabstray.syncedtabs.SyncedTabsInteractor
+import org.mozilla.fenix.utils.Settings
+
+class FloatingActionButtonBindingTest {
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule(TestCoroutineDispatcher())
+
+    private val settings: Settings = mockk(relaxed = true)
+    private val actionButton: ExtendedFloatingActionButton = mockk(relaxed = true)
+    private val browserTrayInteractor: BrowserTrayInteractor = mockk(relaxed = true)
+    private val syncedTabsInteractor: SyncedTabsInteractor = mockk(relaxed = true)
+
+    @Before
+    fun setup() {
+        mockkStatic(AppCompatResources::class)
+        every { AppCompatResources.getDrawable(any(), any()) } returns mockk(relaxed = true)
+    }
+
+    @Test
+    fun `WHEN tab selected page is normal tab THEN shrink and show is called`() {
+        val tabsTrayStore = TabsTrayStore(TabsTrayState(selectedPage = Page.NormalTabs))
+        val fabBinding = FloatingActionButtonBinding(
+            tabsTrayStore, settings, actionButton, browserTrayInteractor, syncedTabsInteractor
+        )
+        every { settings.accessibilityServicesEnabled } returns false
+
+        fabBinding.start()
+
+        verify(exactly = 1) { actionButton.shrink() }
+        verify(exactly = 1) { actionButton.show() }
+        verify(exactly = 0) { actionButton.extend() }
+        verify(exactly = 0) { actionButton.hide() }
+    }
+
+    @Test
+    fun `WHEN tab selected page is private tab THEN extend and show is called`() {
+        val tabsTrayStore = TabsTrayStore(TabsTrayState(selectedPage = Page.PrivateTabs))
+        val fabBinding = FloatingActionButtonBinding(
+            tabsTrayStore, settings, actionButton, browserTrayInteractor, syncedTabsInteractor
+        )
+        every { settings.accessibilityServicesEnabled } returns false
+
+        fabBinding.start()
+
+        verify(exactly = 1) { actionButton.extend() }
+        verify(exactly = 1) { actionButton.show() }
+        verify(exactly = 0) { actionButton.shrink() }
+        verify(exactly = 0) { actionButton.hide() }
+    }
+
+    @Test
+    fun `WHEN tab selected page is sync tab THEN extend and show is called`() {
+        val tabsTrayStore = TabsTrayStore(TabsTrayState(selectedPage = Page.SyncedTabs))
+        val fabBinding = FloatingActionButtonBinding(
+            tabsTrayStore, settings, actionButton, browserTrayInteractor, syncedTabsInteractor
+        )
+        every { settings.accessibilityServicesEnabled } returns false
+
+        fabBinding.start()
+
+        verify(exactly = 1) { actionButton.extend() }
+        verify(exactly = 1) { actionButton.show() }
+        verify(exactly = 0) { actionButton.shrink() }
+        verify(exactly = 0) { actionButton.hide() }
+    }
+
+    @Test
+    fun `WHEN accessibility is enabled THEN show is not called`() {
+        var tabsTrayStore = TabsTrayStore(TabsTrayState(selectedPage = Page.NormalTabs))
+        var fabBinding = FloatingActionButtonBinding(
+            tabsTrayStore, settings, actionButton, browserTrayInteractor, syncedTabsInteractor
+        )
+        every { settings.accessibilityServicesEnabled } returns true
+
+        fabBinding.start()
+
+        verify(exactly = 0) { actionButton.show() }
+        verify(exactly = 1) { actionButton.hide() }
+
+        tabsTrayStore = TabsTrayStore(TabsTrayState(selectedPage = Page.PrivateTabs))
+        fabBinding = FloatingActionButtonBinding(
+            tabsTrayStore, settings, actionButton, browserTrayInteractor, syncedTabsInteractor
+        )
+
+        fabBinding.start()
+
+        verify(exactly = 0) { actionButton.show() }
+        verify(exactly = 2) { actionButton.hide() }
+
+        tabsTrayStore = TabsTrayStore(TabsTrayState(selectedPage = Page.SyncedTabs))
+        fabBinding = FloatingActionButtonBinding(
+            tabsTrayStore, settings, actionButton, browserTrayInteractor, syncedTabsInteractor
+        )
+
+        fabBinding.start()
+
+        verify(exactly = 0) { actionButton.show() }
+        verify(exactly = 3) { actionButton.hide() }
+    }
+
+    @Test
+    fun `WHEN selected page is updated THEN button is updated`() {
+        val tabsTrayStore = TabsTrayStore(TabsTrayState(selectedPage = Page.NormalTabs))
+        val fabBinding = FloatingActionButtonBinding(
+            tabsTrayStore, settings, actionButton, browserTrayInteractor, syncedTabsInteractor
+        )
+        every { settings.accessibilityServicesEnabled } returns false
+
+        fabBinding.start()
+
+        verify(exactly = 1) { actionButton.shrink() }
+        verify(exactly = 1) { actionButton.show() }
+        verify(exactly = 0) { actionButton.extend() }
+        verify(exactly = 0) { actionButton.hide() }
+        verify(exactly = 1) { actionButton.setIconResource(R.drawable.ic_new) }
+
+        tabsTrayStore.dispatch(TabsTrayAction.PageSelected(Page.positionToPage(Page.PrivateTabs.ordinal)))
+        tabsTrayStore.waitUntilIdle()
+
+        verify(exactly = 1) { actionButton.shrink() }
+        verify(exactly = 2) { actionButton.show() }
+        verify(exactly = 1) { actionButton.extend() }
+        verify(exactly = 0) { actionButton.hide() }
+        verify(exactly = 1) { actionButton.setText(R.string.tab_drawer_fab_content) }
+        verify(exactly = 2) { actionButton.setIconResource(R.drawable.ic_new) }
+
+        tabsTrayStore.dispatch(TabsTrayAction.PageSelected(Page.positionToPage(Page.SyncedTabs.ordinal)))
+        tabsTrayStore.waitUntilIdle()
+
+        verify(exactly = 1) { actionButton.shrink() }
+        verify(exactly = 3) { actionButton.show() }
+        verify(exactly = 2) { actionButton.extend() }
+        verify(exactly = 0) { actionButton.hide() }
+        verify(exactly = 1) { actionButton.setText(R.string.tab_drawer_fab_sync) }
+        verify(exactly = 1) { actionButton.setIconResource(R.drawable.ic_fab_sync) }
+
+        tabsTrayStore.dispatch(TabsTrayAction.SyncNow)
+        tabsTrayStore.waitUntilIdle()
+
+        verify(exactly = 1) { actionButton.shrink() }
+        verify(exactly = 4) { actionButton.show() }
+        verify(exactly = 3) { actionButton.extend() }
+        verify(exactly = 0) { actionButton.hide() }
+        verify(exactly = 1) { actionButton.setText(R.string.sync_syncing_in_progress) }
+        verify(exactly = 2) { actionButton.setIconResource(R.drawable.ic_fab_sync) }
+    }
+}


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
