### PR TITLE
For #19180: Fix tab counter not entirely visible on RTL layout.

### DIFF
--- a/app/src/main/res/layout/tabs_tray_tab_counter2.xml
+++ b/app/src/main/res/layout/tabs_tray_tab_counter2.xml
@@ -5,7 +5,7 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:mozac="http://schemas.android.com/apk/res-auto"
     android:id="@+id/counter_root"
-    android:layout_width="wrap_content"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_centerHorizontal="true"
     android:layout_centerVertical="true">


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

LTR  / Real RTL / RTL dev options

<img src = https://user-images.githubusercontent.com/48995920/115719294-9f62e080-a384-11eb-8a7b-01d31d483bd1.png width = 32%> <img src = https://user-images.githubusercontent.com/48995920/115719276-9d008680-a384-11eb-931f-c77605c1764e.png width = 32%> <img src = https://user-images.githubusercontent.com/48995920/115719289-9eca4a00-a384-11eb-8c88-de3684a893bd.png width = 32%>

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
