### PR TITLE
Bug 1706913 - Fix node archive name change caused by bug 1611513.

### DIFF
--- a/taskcluster/ci/browsertime/kind.yml
+++ b/taskcluster/ci/browsertime/kind.yml
@@ -126,7 +126,6 @@ jobs:
 
     tp6m-hv:
         web-render-only: False
-        run-on-tasks-for: [github-pull-request]
         page-load-tests:
             - google
             - [amazon-search, amazon-s]

--- a/taskcluster/ci/browsertime/kind.yml
+++ b/taskcluster/ci/browsertime/kind.yml
@@ -126,6 +126,7 @@ jobs:
 
     tp6m-hv:
         web-render-only: False
+        run-on-tasks-for: [github-pull-request]
         page-load-tests:
             - google
             - [amazon-search, amazon-s]

--- a/taskcluster/ci/toolchain/gecko-derived.yml
+++ b/taskcluster/ci/toolchain/gecko-derived.yml
@@ -43,7 +43,7 @@ linux64-minidump-stackwalk:
 
 linux64-node:
     attributes:
-        toolchain-artifact: public/build/node.tar.xz
+        toolchain-artifact: public/build/node.tar.zst
     description: "Node.js toolchain"
     run:
         index-search:


### PR DESCRIPTION
See the following bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1706913

This patch fixes the permafailure.