### PR TITLE
For #11819 - Show the mic in widget only if setting is enabled

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/search/SearchEngineFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/search/SearchEngineFragment.kt
@@ -5,6 +5,7 @@
 package org.mozilla.fenix.settings.search
 
 import android.os.Bundle
+import androidx.core.content.edit
 import androidx.navigation.fragment.findNavController
 import androidx.preference.CheckBoxPreference
 import androidx.preference.Preference
@@ -18,6 +19,7 @@ import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.showToolbar
 import org.mozilla.fenix.settings.SharedPreferenceUpdater
 import org.mozilla.fenix.settings.requirePreference
+import org.mozilla.gecko.search.SearchWidgetProvider
 
 class SearchEngineFragment : PreferenceFragmentCompat() {
 
@@ -83,7 +85,16 @@ class SearchEngineFragment : PreferenceFragmentCompat() {
         showSyncedTabsSuggestions.onPreferenceChangeListener = SharedPreferenceUpdater()
         showClipboardSuggestions.onPreferenceChangeListener = SharedPreferenceUpdater()
         searchSuggestionsInPrivatePreference.onPreferenceChangeListener = SharedPreferenceUpdater()
-        showVoiceSearchPreference.onPreferenceChangeListener = SharedPreferenceUpdater()
+        showVoiceSearchPreference.onPreferenceChangeListener = object : Preference.OnPreferenceChangeListener {
+            override fun onPreferenceChange(preference: Preference, newValue: Any?): Boolean {
+                val newBooleanValue = newValue as? Boolean ?: return false
+                requireContext().settings().preferences.edit {
+                    putBoolean(preference.key, newBooleanValue)
+                }
+                SearchWidgetProvider.updateAllWidgets(requireContext())
+                return true
+            }
+        }
         autocompleteURLsPreference.onPreferenceChangeListener = SharedPreferenceUpdater()
 
         searchSuggestionsPreference.setOnPreferenceClickListener {

--- a/app/src/test/java/org/mozilla/fenix/settings/search/SearchEngineFragmentTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/search/SearchEngineFragmentTest.kt
@@ -1,0 +1,102 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.settings.search
+
+import android.content.SharedPreferences
+import androidx.preference.CheckBoxPreference
+import androidx.preference.SwitchPreference
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.spyk
+import io.mockk.unmockkObject
+import io.mockk.verify
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.fenix.HomeActivity
+import org.mozilla.fenix.R
+import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+import org.mozilla.gecko.search.SearchWidgetProvider
+
+@RunWith(FenixRobolectricTestRunner::class)
+class SearchEngineFragmentTest {
+    @Test
+    fun `GIVEN pref_key_show_voice_search setting WHEN it is modified THEN the value is persisted and widgets updated`() {
+        try {
+            mockkObject(SearchWidgetProvider.Companion)
+
+            val preferences: SharedPreferences = mockk()
+            val preferencesEditor: SharedPreferences.Editor = mockk(relaxed = true)
+            every { testContext.settings().preferences } returns preferences
+            every { preferences.edit() } returns preferencesEditor
+            val fragment = spyk(SearchEngineFragment()) {
+                every { context } returns testContext
+                every { isAdded } returns true
+                every { activity } returns mockk<HomeActivity>(relaxed = true)
+            }
+            val voiceSearchPreferenceKey = testContext.getString(R.string.pref_key_show_voice_search)
+            val voiceSearchPreference = spyk(SwitchPreference(testContext)) {
+                every { key } returns voiceSearchPreferenceKey
+            }
+            // The type needed for "fragment.findPreference" / "fragment.requirePreference" is erased at compile time.
+            // Hence we need individual mocks, specific for each preference's type.
+            every {
+                fragment.findPreference<SwitchPreference>(testContext.getString(R.string.pref_key_show_search_suggestions))
+            } returns mockk(relaxed = true) {
+                every { context } returns testContext
+            }
+            every {
+                fragment.findPreference<SwitchPreference>(testContext.getString(R.string.pref_key_enable_autocomplete_urls))
+            } returns mockk(relaxed = true) {
+                every { context } returns testContext
+            }
+            every {
+                fragment.findPreference<CheckBoxPreference>(testContext.getString(R.string.pref_key_show_search_suggestions_in_private))
+            } returns mockk(relaxed = true) {
+                every { context } returns testContext
+            }
+            every {
+                fragment.findPreference<SwitchPreference>(testContext.getString(R.string.pref_key_show_search_engine_shortcuts))
+            } returns mockk(relaxed = true) {
+                every { context } returns testContext
+            }
+            every {
+                fragment.findPreference<SwitchPreference>(testContext.getString(R.string.pref_key_search_browsing_history))
+            } returns mockk(relaxed = true) {
+                every { context } returns testContext
+            }
+            every {
+                fragment.findPreference<SwitchPreference>(testContext.getString(R.string.pref_key_search_bookmarks))
+            } returns mockk(relaxed = true) {
+                every { context } returns testContext
+            }
+            every {
+                fragment.findPreference<SwitchPreference>(testContext.getString(R.string.pref_key_search_synced_tabs))
+            } returns mockk(relaxed = true) {
+                every { context } returns testContext
+            }
+            every {
+                fragment.findPreference<SwitchPreference>(testContext.getString(R.string.pref_key_show_clipboard_suggestions))
+            } returns mockk(relaxed = true) {
+                every { context } returns testContext
+            }
+            // This preference is the sole purpose of this test
+            every {
+                fragment.findPreference<SwitchPreference>(voiceSearchPreferenceKey)
+            } returns voiceSearchPreference
+
+            // Trigger the preferences setup.
+            fragment.onResume()
+            voiceSearchPreference.callChangeListener(true)
+
+            verify { preferencesEditor.putBoolean(voiceSearchPreferenceKey, true) }
+            verify { SearchWidgetProvider.updateAllWidgets(testContext) }
+        } finally {
+            unmockkObject(SearchWidgetProvider.Companion)
+        }
+    }
+}


### PR DESCRIPTION
If "Show voice search" is disabled under Settings, the mic icon should not be
shown in the search widget.

https://user-images.githubusercontent.com/11428869/116085033-13fc8e80-a6a7-11eb-9a1d-e73ad0398d56.mov


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
