### PR TITLE
Properly quote descriptions in ad metric definitions

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -3949,7 +3949,7 @@ browser.search:
     type: labeled_counter
     description: |
       Records counts of SERP pages with adverts displayed.
-      The key format is ‘<provider-name>’.
+      The key format is `<provider-name>`.
     send_in_pings:
       - metrics
     bugs:
@@ -3966,7 +3966,7 @@ browser.search:
     type: labeled_counter
     description: |
       Records clicks of adverts on SERP pages.
-      The key format is ‘<provider-name>’.
+      The key format is `<provider-name>`.
     send_in_pings:
       - metrics
     bugs:


### PR DESCRIPTION
This is pedantic, but strictly something called `<provider-name>` is considered an HTML tag
unless it's in a code block (backticks). This can cause problems with downstream consumers like the glean dictionary unless we work around it there:

![image](https://user-images.githubusercontent.com/20569/116107311-eac90780-a680-11eb-9a3b-4750d45b6f03.png)

See mozilla/glean-dictionary#549 and mozilla/glean-dictionary#497. I'm working around this downstream in the glean dictionary now (I suspect this is going to crop up again and don't want to go around fixing this everywhere) but figured I might as well file a PR here while I was at it.

FWIW you can view this metric here: https://dictionary.protosaur.dev/apps/fenix/metrics/browser_search_ad_clicks

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
