### PR TITLE
For #19132 - Fix navigation on disconnect started from tabsTray

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/account/SignOutFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/account/SignOutFragment.kt
@@ -66,9 +66,10 @@ class SignOutFragment : AppCompatDialogFragment() {
                 accountManager.logout()
             }.invokeOnCompletion {
                 runIfFragmentIsAttached {
-                    if (!findNavController().popBackStack(R.id.settingsFragment, false)) {
+                    if (this.isVisible) {
                         dismiss()
                     }
+                    findNavController().popBackStack()
                 }
             }
         }


### PR DESCRIPTION
 - Added checks to popBackStack from the Disconnect Logged-in User Dialog, either back to settings, browserFragment or homeFragment.


For https://github.com/mozilla-mobile/fenix/issues/19132
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes no tests as it is only a minor change.
- [x] **Screenshots**: This PR includes video of the changes made.
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture


https://user-images.githubusercontent.com/60002907/116385095-24387900-a821-11eb-8de5-3b33b05a4378.mp4

