### PR TITLE
Issue #10941: Align Nightly version with Gecko/A-C version.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -231,7 +231,7 @@ android.applicationVariants.all { variant ->
 
     def isDebug = variant.buildType.resValues['IS_DEBUG']?.value ?: false
     def useReleaseVersioning = variant.buildType.buildConfigFields['USE_RELEASE_VERSIONING']?.value ?: false
-    def versionName = Config.releaseVersionName(project)
+    def versionName = variant.buildType.name == 'nightly' ? Config.nightlyVersionName() : Config.releaseVersionName(project)
 
     println("----------------------------------------------")
     println("Variant name:      " + variant.name)
@@ -244,6 +244,8 @@ android.applicationVariants.all { variant ->
         // The Google Play Store does not allow multiple APKs for the same app that all have the
         // same version code. Therefore we need to have different version codes for our ARM and x86
         // builds.
+
+        println("versionName override: $versionName")
 
         variant.outputs.each { output ->
             def abi = output.getFilter(OutputFile.ABI)

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -37,6 +37,14 @@ object Config {
     }
 
     @JvmStatic
+    fun nightlyVersionName(): String {
+        // Nightly versions use the Gecko/A-C major version and append "0.a1", e.g. with A-C 90.0.20210426143115
+        // the Nightly version will be 90.0a1
+        val majorVersion = AndroidComponents.VERSION.split(".")[0]
+        return "$majorVersion.0a1"
+    }
+
+    @JvmStatic
     fun generateBuildDate(): String {
         val dateTime = LocalDateTime.now()
         val timeFormatter = DateTimeFormatter.ofPattern("h:mm a")

--- a/taskcluster/fenix_taskgraph/transforms/build.py
+++ b/taskcluster/fenix_taskgraph/transforms/build.py
@@ -95,14 +95,11 @@ def add_disable_optimization(config, tasks):
 
 @transforms.add
 def add_nightly_version(config, tasks):
-    push_date_string = config.params["moz_build_date"]
-    push_date_time = datetime.datetime.strptime(push_date_string, "%Y%m%d%H%M%S")
-    formated_date_time = 'Nightly {}'.format(push_date_time.strftime('%y%m%d %H:%M'))
-
     for task in tasks:
         if task.pop("include-nightly-version", False):
             task["run"]["gradlew"].extend([
-                '-PversionName={}'.format(formated_date_time),
+                # We only set the `official` flag here. The actual version name will be determined
+                # by Gradle (depending on the Gecko/A-C version being used)
                 '-Pofficial'
             ])
         yield task


### PR DESCRIPTION
Instead of using a timestamp this will synchronize the Nightly version with the version
of Gecko / A-C. So when using 90.0.20210426143115 then the Nightly version will be
90.0a1 - similar to what Firefox desktop uses.