### PR TITLE
Issue #19040 - Update marketing data setting description

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuDataCollectionRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuDataCollectionRobot.kt
@@ -77,7 +77,7 @@ private fun assertDataCollectionOptions() {
         .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
     val marketingDataText =
-        "Shares data about what features you use in Firefox Preview with Leanplum, our mobile marketing vendor."
+        "Shares basic usage data with Adjust, our mobile marketing vendor"
 
     onView(withText(marketingDataText))
         .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))

--- a/app/src/main/java/org/mozilla/fenix/settings/DataChoicesFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/DataChoicesFragment.kt
@@ -67,13 +67,6 @@ class DataChoicesFragment : PreferenceFragmentCompat() {
 
         requirePreference<SwitchPreference>(R.string.pref_key_marketing_telemetry).apply {
             isChecked = context.settings().isMarketingTelemetryEnabled
-
-            val appName = context.getString(R.string.app_name)
-            summary = String.format(
-                context.getString(R.string.preferences_marketing_data_description),
-                appName
-            )
-
             onPreferenceChangeListener = SharedPreferenceUpdater()
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -443,6 +443,8 @@
     <string name="preferences_marketing_data">Marketing data</string>
     <!-- Preference description for marketing data collection, parameter is the app name (e.g. Firefox) -->
     <string name="preferences_marketing_data_description">Shares data about what features you use in %1$s with Leanplum, our mobile marketing vendor.</string>
+    <!-- Preference description for marketing data collection -->
+    <string name="preferences_marketing_data_description2">Shares basic usage data with Adjust, our mobile marketing vendor</string>
     <!-- Title for studies preferences -->
     <string name="preference_experiments_2">Studies</string>
     <!-- Summary for studies preferences -->

--- a/app/src/main/res/xml/data_choices_preferences.xml
+++ b/app/src/main/res/xml/data_choices_preferences.xml
@@ -9,7 +9,7 @@
         android:title="@string/preference_usage_data" />
     <SwitchPreference
         android:key="@string/pref_key_marketing_telemetry"
-        android:summary="@string/preferences_marketing_data_description"
+        android:summary="@string/preferences_marketing_data_description2"
         android:title="@string/preferences_marketing_data" />
     <SwitchPreference
         android:key="@string/pref_key_experimentation"


### PR DESCRIPTION
Follow-up from #19186. This adds the new string for the settings description.