### PR TITLE
For #19314: Move locale restoration on startup to the visual completeness queue to prevent perf impact

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -167,7 +167,6 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
                 initializeWebExtensionSupport()
                 restoreBrowserState()
                 restoreDownloads()
-                restoreLocale()
 
                 // Just to make sure it is impossible for any application-services pieces
                 // to invoke parts of itself that require complete megazord initialization
@@ -220,10 +219,6 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
         components.useCases.downloadUseCases.restoreDownloads()
     }
 
-    private fun restoreLocale() {
-        components.useCases.localeUseCases.restore()
-    }
-
     private fun initVisualCompletenessQueueAndQueueTasks() {
         val queue = components.performance.visualCompletenessQueue.queue
 
@@ -269,6 +264,14 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
             }
         }
 
+        fun queueRestoreLocale() {
+            components.performance.visualCompletenessQueue.queue.runIfReadyOrQueue {
+                GlobalScope.launch(Dispatchers.IO) {
+                    components.useCases.localeUseCases.restore()
+                }
+            }
+        }
+
         initQueue()
 
         // We init these items in the visual completeness queue to avoid them initing in the critical
@@ -276,6 +279,7 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
         queueInitStorageAndServices()
         queueMetrics()
         queueReviewPrompt()
+        queueRestoreLocale()
     }
 
     private fun startMetricsIfEnabled() {


### PR DESCRIPTION
For #19314 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
