### PR TITLE
Close #19259: Pass CoroutineContext to nav interactor constructor

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabstray/NavigationInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/NavigationInteractor.kt
@@ -7,7 +7,6 @@ package org.mozilla.fenix.tabstray
 import android.content.Context
 import androidx.navigation.NavController
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import mozilla.components.browser.state.selector.getNormalOrPrivateTabs
@@ -25,6 +24,7 @@ import org.mozilla.fenix.components.metrics.MetricController
 import org.mozilla.fenix.ext.navigateBlockingForAsyncNavGraph
 import org.mozilla.fenix.home.HomeFragment
 import org.mozilla.fenix.tabstray.ext.getTabSessionState
+import kotlin.coroutines.CoroutineContext
 
 /**
  * An interactor that helps with navigating to different parts of the app from the tabs tray.
@@ -91,7 +91,8 @@ class DefaultNavigationInteractor(
     private val bookmarksUseCase: BookmarksUseCase,
     private val tabsTrayStore: TabsTrayStore,
     private val collectionStorage: TabCollectionStorage,
-    private val accountManager: FxaAccountManager
+    private val accountManager: FxaAccountManager,
+    private val ioDispatcher: CoroutineContext
 ) : NavigationInteractor {
 
     override fun onTabTrayDismissed() {
@@ -181,8 +182,9 @@ class DefaultNavigationInteractor(
     override fun onSaveToBookmarks(tabs: Collection<Tab>) {
         tabs.forEach { tab ->
             // We don't combine the context with lifecycleScope so that our jobs are not cancelled
-            // if we leave the fragment, i.e. we still want the bookmarks to be added.
-            CoroutineScope(Dispatchers.IO).launch {
+            // if we leave the fragment, i.e. we still want the bookmarks to be added if the
+            // tabs tray closes before the job is done.
+            CoroutineScope(ioDispatcher).launch {
                 bookmarksUseCase.addBookmark(tab.url, tab.title)
             }
         }

--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
@@ -119,7 +119,8 @@ class TabsTrayFragment : AppCompatDialogFragment(), TabsTrayInteractor {
                 dismissTabTrayAndNavigateHome = ::dismissTabsTrayAndNavigateHome,
                 bookmarksUseCase = requireComponents.useCases.bookmarksUseCases,
                 collectionStorage = requireComponents.core.tabCollectionStorage,
-                accountManager = requireComponents.backgroundServices.accountManager
+                accountManager = requireComponents.backgroundServices.accountManager,
+                ioDispatcher = Dispatchers.IO
             )
 
         tabsTrayController = DefaultTabsTrayController(


### PR DESCRIPTION
Pass the test dispatcher into the `NavigationInteractor` for tests.
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
