### PR TITLE
For #19307: Increased contrast ratio of chevron symbol in Collections (For Dark theme)

### DIFF
--- a/app/src/main/res/layout/collection_home_list_row.xml
+++ b/app/src/main/res/layout/collection_home_list_row.xml
@@ -51,7 +51,7 @@
         android:layout_width="24dp"
         android:layout_height="24dp"
         android:layout_marginEnd="16dp"
-        android:background="@drawable/ic_chevron"
+        android:src="@drawable/ic_chevron"
         android:contentDescription="@string/tab_menu"
         app:layout_constraintBottom_toBottomOf="@id/collection_icon"
         app:layout_constraintEnd_toStartOf="@+id/collection_share_button"

--- a/app/src/main/res/layout/collection_home_list_row.xml
+++ b/app/src/main/res/layout/collection_home_list_row.xml
@@ -51,7 +51,7 @@
         android:layout_width="24dp"
         android:layout_height="24dp"
         android:layout_marginEnd="16dp"
-        android:src="@drawable/ic_chevron"
+        app:srcCompat="@drawable/ic_chevron"
         android:contentDescription="@string/tab_menu"
         app:layout_constraintBottom_toBottomOf="@id/collection_icon"
         app:layout_constraintEnd_toStartOf="@+id/collection_share_button"


### PR DESCRIPTION
- Fixes #19307
- The colors assigned to `ic_chevron_up.xml` and `ic_chevron_down.xml` through `android:fillColor="?primaryText"` were **already correct**, i.e., in Dark mode, the chevron symbol was already defined to have `#FBFBFE` as its color (as mentioned here: https://github.com/mozilla-mobile/fenix/issues/19307#issuecomment-831505418). Inspite of that, in Dark mode, the color of the chevron symbol being displayed was not `#FBFBFE`.
- However, changing the `android:background` attribute to `android:src` for the `chevron` TextView in the file `collection_home_list_row.xml` fixes this problem. It does **not** affect the chevron symbol's behavior in Light Theme and fixes the Accessibility issues raised by Google Accessibility Scanner. 



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture  

### Screenshots

1. Before and After the Code changes (for Light Theme) - Remains the same (unchanged) 

![image](https://user-images.githubusercontent.com/67039214/117009332-3e82c300-ad09-11eb-8598-59462e633749.png)

2. Before vs After (for Dark theme) - Contrast ratio issue has been fixed 

![image](https://user-images.githubusercontent.com/67039214/117009495-72f67f00-ad09-11eb-86d4-8c754a110814.png)  
 
![image](https://user-images.githubusercontent.com/67039214/117009620-93263e00-ad09-11eb-859b-ef0da1a5b121.png)


