### PR TITLE
For #18270 - Adds ellipses+last 4 digits to CC display

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/creditcards/CreditCardsManagementFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/creditcards/CreditCardsManagementFragment.kt
@@ -14,7 +14,6 @@ import kotlinx.android.synthetic.main.fragment_saved_cards.view.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
-import mozilla.components.concept.storage.CreditCard
 import mozilla.components.lib.state.ext.consumeFrom
 import org.mozilla.fenix.R
 import org.mozilla.fenix.SecureFragment
@@ -82,36 +81,11 @@ class CreditCardsManagementFragment : SecureFragment() {
      */
     private fun loadCreditCards() {
         lifecycleScope.launch(Dispatchers.IO) {
-            val creditCards =
-                addEllipses(requireContext().components.core.autofillStorage.getAllCreditCards())
+            val creditCards = requireContext().components.core.autofillStorage.getAllCreditCards()
 
             lifecycleScope.launch(Dispatchers.Main) {
                 creditCardsStore.dispatch(CreditCardsAction.UpdateCreditCards(creditCards))
             }
         }
-    }
-
-    private fun addEllipses(creditCards: List<CreditCard>): List<CreditCard> {
-        val result: MutableList<CreditCard> = mutableListOf()
-        creditCards.forEach {
-            result.add(
-                it.copy(
-                    cardNumberLast4 =
-                    CC_ELLIPSES + CC_ELLIPSIS + CC_ELLIPSIS + CC_ELLIPSIS + CC_ELLIPSIS +
-                            it.cardNumberLast4 + CC_ELLIPSES_END
-                )
-            )
-        }
-        return result
-    }
-
-    companion object {
-
-        // Left-To-Right Embedding (LTE) mark
-        const val CC_ELLIPSES: String = "\u202A"
-        // Dot ellipsis
-        const val CC_ELLIPSIS: String = "\u2022\u2060\u2006\u2060"
-        // Pop Directional Formatting (PDF) mark
-        const val CC_ELLIPSES_END: String = "\u202C"
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/settings/creditcards/CreditCardsManagementFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/creditcards/CreditCardsManagementFragment.kt
@@ -14,6 +14,7 @@ import kotlinx.android.synthetic.main.fragment_saved_cards.view.*
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
+import mozilla.components.concept.storage.CreditCard
 import mozilla.components.lib.state.ext.consumeFrom
 import org.mozilla.fenix.R
 import org.mozilla.fenix.SecureFragment
@@ -81,11 +82,36 @@ class CreditCardsManagementFragment : SecureFragment() {
      */
     private fun loadCreditCards() {
         lifecycleScope.launch(Dispatchers.IO) {
-            val creditCards = requireContext().components.core.autofillStorage.getAllCreditCards()
+            val creditCards =
+                addEllipses(requireContext().components.core.autofillStorage.getAllCreditCards())
 
             lifecycleScope.launch(Dispatchers.Main) {
                 creditCardsStore.dispatch(CreditCardsAction.UpdateCreditCards(creditCards))
             }
         }
+    }
+
+    private fun addEllipses(creditCards: List<CreditCard>): List<CreditCard> {
+        val result: MutableList<CreditCard> = mutableListOf()
+        creditCards.forEach {
+            result.add(
+                it.copy(
+                    cardNumberLast4 =
+                    CC_ELLIPSES + CC_ELLIPSIS + CC_ELLIPSIS + CC_ELLIPSIS + CC_ELLIPSIS +
+                            it.cardNumberLast4 + CC_ELLIPSES_END
+                )
+            )
+        }
+        return result
+    }
+
+    companion object {
+
+        // Left-To-Right Embedding (LTE) mark
+        const val CC_ELLIPSES: String = "\u202A"
+        // Dot ellipsis
+        const val CC_ELLIPSIS: String = "\u2022\u2060\u2006\u2060"
+        // Pop Directional Formatting (PDF) mark
+        const val CC_ELLIPSES_END: String = "\u202C"
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/settings/creditcards/view/CreditCardItemViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/creditcards/view/CreditCardItemViewHolder.kt
@@ -7,6 +7,7 @@ package org.mozilla.fenix.settings.creditcards.view
 import android.view.View
 import kotlinx.android.synthetic.main.credit_card_list_item.*
 import mozilla.components.concept.storage.CreditCard
+import mozilla.components.support.ktx.kotlin.addEllipsesToCreditCardNumber
 import org.mozilla.fenix.R
 import org.mozilla.fenix.settings.creditcards.interactor.CreditCardsManagementInteractor
 import org.mozilla.fenix.utils.view.ViewHolder
@@ -23,7 +24,7 @@ class CreditCardItemViewHolder(
 ) : ViewHolder(view) {
 
     fun bind(creditCard: CreditCard) {
-        credit_card_number.text = creditCard.cardNumberLast4
+        credit_card_number.text = creditCard.cardNumberLast4.addEllipsesToCreditCardNumber()
 
         bindCreditCardExpiryDate(creditCard)
 

--- a/app/src/main/java/org/mozilla/fenix/settings/creditcards/view/CreditCardItemViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/creditcards/view/CreditCardItemViewHolder.kt
@@ -23,7 +23,7 @@ class CreditCardItemViewHolder(
 ) : ViewHolder(view) {
 
     fun bind(creditCard: CreditCard) {
-        credit_card_number.text = creditCard.ellipsizedNumber
+        credit_card_number.text = creditCard.obfuscatedCardNumber
 
         bindCreditCardExpiryDate(creditCard)
 

--- a/app/src/main/java/org/mozilla/fenix/settings/creditcards/view/CreditCardItemViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/creditcards/view/CreditCardItemViewHolder.kt
@@ -23,8 +23,6 @@ class CreditCardItemViewHolder(
 ) : ViewHolder(view) {
 
     fun bind(creditCard: CreditCard) {
-        // TODO this should be last4 instead...
-        //  and option to explicitly decrypt if necessary to show full number
         credit_card_number.text = creditCard.cardNumberLast4
 
         bindCreditCardExpiryDate(creditCard)

--- a/app/src/main/java/org/mozilla/fenix/settings/creditcards/view/CreditCardItemViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/creditcards/view/CreditCardItemViewHolder.kt
@@ -25,7 +25,7 @@ class CreditCardItemViewHolder(
     fun bind(creditCard: CreditCard) {
         // TODO this should be last4 instead...
         //  and option to explicitly decrypt if necessary to show full number
-        credit_card_number.text = creditCard.encryptedCardNumber.number
+        credit_card_number.text = creditCard.cardNumberLast4
 
         bindCreditCardExpiryDate(creditCard)
 

--- a/app/src/main/java/org/mozilla/fenix/settings/creditcards/view/CreditCardItemViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/creditcards/view/CreditCardItemViewHolder.kt
@@ -7,7 +7,6 @@ package org.mozilla.fenix.settings.creditcards.view
 import android.view.View
 import kotlinx.android.synthetic.main.credit_card_list_item.*
 import mozilla.components.concept.storage.CreditCard
-import mozilla.components.support.ktx.kotlin.addEllipsesToCreditCardNumber
 import org.mozilla.fenix.R
 import org.mozilla.fenix.settings.creditcards.interactor.CreditCardsManagementInteractor
 import org.mozilla.fenix.utils.view.ViewHolder
@@ -24,7 +23,7 @@ class CreditCardItemViewHolder(
 ) : ViewHolder(view) {
 
     fun bind(creditCard: CreditCard) {
-        credit_card_number.text = creditCard.cardNumberLast4.addEllipsesToCreditCardNumber()
+        credit_card_number.text = creditCard.ellipsizedNumber
 
         bindCreditCardExpiryDate(creditCard)
 

--- a/app/src/test/java/org/mozilla/fenix/settings/creditcards/CreditCardItemViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/creditcards/CreditCardItemViewHolderTest.kt
@@ -11,6 +11,7 @@ import io.mockk.verify
 import kotlinx.android.synthetic.main.credit_card_list_item.view.*
 import mozilla.components.concept.storage.CreditCard
 import mozilla.components.concept.storage.CreditCardNumber
+import mozilla.components.support.ktx.kotlin.addEllipsesToCreditCardNumber
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -50,7 +51,7 @@ class CreditCardItemViewHolderTest {
     fun `GIVEN a new credit card item on bind THEN set the card number and expiry date text`() {
         CreditCardItemViewHolder(view, interactor).bind(creditCard)
 
-        assertEquals(creditCard.cardNumberLast4, view.credit_card_number.text)
+        assertEquals(creditCard.cardNumberLast4.addEllipsesToCreditCardNumber(), view.credit_card_number.text)
         assertEquals("0${creditCard.expiryMonth}/${creditCard.expiryYear}", view.expiry_date.text)
     }
 

--- a/app/src/test/java/org/mozilla/fenix/settings/creditcards/CreditCardItemViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/creditcards/CreditCardItemViewHolderTest.kt
@@ -11,7 +11,6 @@ import io.mockk.verify
 import kotlinx.android.synthetic.main.credit_card_list_item.view.*
 import mozilla.components.concept.storage.CreditCard
 import mozilla.components.concept.storage.CreditCardNumber
-import mozilla.components.support.ktx.kotlin.addEllipsesToCreditCardNumber
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -51,7 +50,7 @@ class CreditCardItemViewHolderTest {
     fun `GIVEN a new credit card item on bind THEN set the card number and expiry date text`() {
         CreditCardItemViewHolder(view, interactor).bind(creditCard)
 
-        assertEquals(creditCard.cardNumberLast4.addEllipsesToCreditCardNumber(), view.credit_card_number.text)
+        assertEquals(creditCard.obfuscatedCardNumber, view.credit_card_number.text)
         assertEquals("0${creditCard.expiryMonth}/${creditCard.expiryYear}", view.expiry_date.text)
     }
 

--- a/app/src/test/java/org/mozilla/fenix/settings/creditcards/CreditCardItemViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/creditcards/CreditCardItemViewHolderTest.kt
@@ -50,7 +50,7 @@ class CreditCardItemViewHolderTest {
     fun `GIVEN a new credit card item on bind THEN set the card number and expiry date text`() {
         CreditCardItemViewHolder(view, interactor).bind(creditCard)
 
-        assertEquals(creditCard.encryptedCardNumber.number, view.credit_card_number.text)
+        assertEquals(creditCard.cardNumberLast4, view.credit_card_number.text)
         assertEquals("0${creditCard.expiryMonth}/${creditCard.expiryYear}", view.expiry_date.text)
     }
 


### PR DESCRIPTION
For https://github.com/mozilla-mobile/fenix/issues/18270


**Needs https://github.com/mozilla-mobile/android-components/pull/10256** 
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests.
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture


![image](https://user-images.githubusercontent.com/60002907/117461215-fa383280-af55-11eb-8b6f-287910496a2b.png)

More info on unicode for LTR/RTL text https://www.w3.org/International/questions/qa-bidi-unicode-controls