### PR TITLE
For #19091 - Fix Undo of close multiple tabs

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabstray/ext/TabSessionState.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/ext/TabSessionState.kt
@@ -17,6 +17,6 @@ fun TabSessionState.filterFromConfig(configuration: Configuration): Boolean {
 
 fun TabSessionState.getTrayPosition(): Int =
     when (content.private) {
-        true -> Page.NormalTabs.ordinal
+        true -> Page.PrivateTabs.ordinal
         false -> Page.NormalTabs.ordinal
     }


### PR DESCRIPTION
 Fixes the issue where closing multiple selected tabs and then pressing Undo would only restore one of the tabs.


For https://github.com/mozilla-mobile/fenix/issues/19091
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes no tests as it is only a minor change.
- [x] **Screenshots**: This PR includes screenshots or GIFs.
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture


https://user-images.githubusercontent.com/60002907/117830835-ae023080-b27c-11eb-9b90-558c46ffdab5.mp4

