### PR TITLE
For #19468 and #19478 Fix openRecentlyClosedTabsInNewTabTest and toggleSearchSuggestions

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
@@ -314,9 +314,9 @@ class HomeScreenRobot {
         }
 
         fun openSearch(interact: SearchRobot.() -> Unit): SearchRobot.Transition {
-            navigationToolbar().perform(click())
-            mDevice.findObject(UiSelector().resourceId("$packageName:id/search_wrapper"))
+            mDevice.findObject(UiSelector().resourceId("$packageName:id/toolbar"))
                 .waitForExists(waitingTime)
+            navigationToolbar().perform(click())
 
             SearchRobot().interact()
             return SearchRobot.Transition()
@@ -376,7 +376,9 @@ class HomeScreenRobot {
         }
 
         fun openNavigationToolbar(interact: NavigationToolbarRobot.() -> Unit): NavigationToolbarRobot.Transition {
-            assertNavigationToolbar().perform(click())
+            mDevice.findObject(UiSelector().resourceId("$packageName:id/toolbar"))
+                .waitForExists(waitingTime)
+            navigationToolbar().perform(click())
 
             NavigationToolbarRobot().interact()
             return NavigationToolbarRobot.Transition()
@@ -472,8 +474,7 @@ private fun assertKeyboardVisibility(isExpectedToBeVisible: Boolean) =
             .contains("mInputShown=true")
     )
 
-private fun navigationToolbar() =
-    onView(withId(R.id.toolbar_wrapper))
+private fun navigationToolbar() = onView(withId(R.id.toolbar))
 
 private fun closeTabButton() = onView(withId(R.id.close_tab_button))
 


### PR DESCRIPTION
Fixes #19468 and #19478

► `openRecentlyClosedTabsInNewTabTest`
✔️ Successfully ran 50x on Firebase

► `toggleSearchSuggestions `
✔️ Successfully ran 50x on Firebase

Modified the `openSearch` transition for consistency

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
