### PR TITLE
For #17537: Add preferences for syncing credit cards and addresses

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/account/AccountSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/account/AccountSettingsFragment.kt
@@ -192,14 +192,14 @@ class AccountSettingsFragment : PreferenceFragmentCompat() {
         // 'Passwords' and 'Credit card' listeners are special, since we also display a pin protection warning.
         requirePreference<CheckBoxPreference>(SyncEngine.Passwords.prefId()).apply {
             setOnPreferenceChangeListener { _, newValue ->
-                updateSyncEngineStateWithPinWarning(newValue as Boolean)
+                updateSyncEngineStateWithPinWarning(SyncEngine.Passwords, newValue as Boolean)
                 true
             }
         }
 
         requirePreference<CheckBoxPreference>(SyncEngine.CreditCards.prefId()).apply {
             setOnPreferenceChangeListener { _, newValue ->
-                updateSyncEngineStateWithPinWarning(newValue as Boolean)
+                updateSyncEngineStateWithPinWarning(SyncEngine.CreditCards, newValue as Boolean)
                 true
             }
         }
@@ -223,18 +223,22 @@ class AccountSettingsFragment : PreferenceFragmentCompat() {
      *
      * Currently used for logins and credit cards.
      *
+     * @param engine the sync engine whose preference has changed.
      * @param newValue the value denoting whether or not to sync the specified preference.
      */
-    private fun CheckBoxPreference.updateSyncEngineStateWithPinWarning(newValue: Boolean) {
-        val manager =
-            activity?.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
+    private fun CheckBoxPreference.updateSyncEngineStateWithPinWarning(
+        syncEngine: SyncEngine,
+        newValue: Boolean
+    ) {
+        val manager = activity?.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
+
         if (manager.isKeyguardSecure ||
             !newValue ||
             !requireContext().settings().shouldShowSecurityPinWarningSync
         ) {
-            updateSyncEngineState(context, SyncEngine.CreditCards, newValue)
+            updateSyncEngineState(context, syncEngine, newValue)
         } else {
-            showPinDialogWarning(SyncEngine.CreditCards, newValue)
+            showPinDialogWarning(syncEngine, newValue)
         }
     }
 

--- a/app/src/main/java/org/mozilla/fenix/settings/account/AccountSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/account/AccountSettingsFragment.kt
@@ -278,6 +278,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat() {
             isChecked = syncEnginesStatus.getOrElse(SyncEngine.Bookmarks) { true }
         }
         requirePreference<CheckBoxPreference>(R.string.pref_key_sync_credit_cards).apply {
+            isVisible = FeatureFlags.creditCardsFeature
             isEnabled = syncEnginesStatus.containsKey(SyncEngine.CreditCards)
             isChecked = syncEnginesStatus.getOrElse(SyncEngine.CreditCards) { true }
         }
@@ -293,11 +294,10 @@ class AccountSettingsFragment : PreferenceFragmentCompat() {
             isEnabled = syncEnginesStatus.containsKey(SyncEngine.Tabs)
             isChecked = syncEnginesStatus.getOrElse(SyncEngine.Tabs) { true }
         }
-        if (FeatureFlags.addressesFeature) {
-            requirePreference<CheckBoxPreference>(R.string.pref_key_sync_address).apply {
-                isEnabled = syncEnginesStatus.containsKey(SyncEngine.Addresses)
-                isChecked = syncEnginesStatus.getOrElse(SyncEngine.Addresses) { true }
-            }
+        requirePreference<CheckBoxPreference>(R.string.pref_key_sync_address).apply {
+            isVisible = FeatureFlags.addressesFeature
+            isEnabled = syncEnginesStatus.containsKey(SyncEngine.Addresses)
+            isChecked = syncEnginesStatus.getOrElse(SyncEngine.Addresses) { true }
         }
     }
 
@@ -443,6 +443,5 @@ class AccountSettingsFragment : PreferenceFragmentCompat() {
 
     companion object {
         private const val DEVICE_NAME_MAX_LENGTH = 128
-        private const val DEVICE_NAME_EDIT_TEXT_MIN_HEIGHT_DP = 48
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/settings/creditcards/CreditCardsSettingFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/creditcards/CreditCardsSettingFragment.kt
@@ -98,7 +98,6 @@ class CreditCardsSettingFragment : PreferenceFragmentCompat() {
         )
     }
 
-    @Suppress("MaxLineLength")
     override fun onPreferenceTreeClick(preference: Preference): Boolean {
         when (preference.key) {
             getPreferenceKey(R.string.pref_key_credit_cards_add_credit_card) -> {

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -91,6 +91,10 @@
     <string name="pref_key_fxa_has_synced_items" translatable="false">pref_key_fxa_has_synced_items</string>
     <string name="pref_key_search_widget_installed" translatable="false">pref_key_search_widget_installed</string>
     <string name="pref_key_saved_logins_sorting_strategy" translatable="false">pref_key_saved_logins_sorting_strategy</string>
+    <!-- Key for credit cards sync preference in the account settings fragment -->
+    <string name="pref_key_sync_credit_cards" translatable="false">pref_key_sync_credit_cards</string>
+    <!-- Key for Address sync preference in the account settings fragment -->
+    <string name="pref_key_sync_address" translatable="false">pref_key_sync_address</string>
 
     <!-- Search Settings -->
     <string name="pref_key_search_engine_list" translatable="false">pref_key_search_engine_list</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1556,7 +1556,6 @@
     <!-- Error message for credit card number validation -->
     <string name="credit_cards_number_validation_error_message">Please enter a valid credit card number</string>
 
-
     <!-- Title of the Add search engine screen -->
     <string name="search_engine_add_custom_search_engine_title">Add search engine</string>
     <!-- Title of the Edit search engine screen -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -402,6 +402,10 @@
         The first parameter is the application name, the second is the device manufacturer name
         and the third is the device model. -->
     <string name="default_device_name_2">%1$s on %2$s %3$s</string>
+    <!-- Preference for syncing credit cards -->
+    <string name="preferences_sync_credit_cards">Credit cards</string>
+    <!-- Preference for syncing addresses -->
+    <string name="preferences_sync_address">Addresses</string>
 
     <!-- Send Tab -->
     <!-- Name of the "receive tabs" notification channel. Displayed in the "App notifications" system settings for the app -->
@@ -1551,6 +1555,7 @@
     <string name="credit_cards_saved_cards">Saved cards</string>
     <!-- Error message for credit card number validation -->
     <string name="credit_cards_number_validation_error_message">Please enter a valid credit card number</string>
+
 
     <!-- Title of the Add search engine screen -->
     <string name="search_engine_add_custom_search_engine_title">Add search engine</string>

--- a/app/src/main/res/xml/account_settings_preferences.xml
+++ b/app/src/main/res/xml/account_settings_preferences.xml
@@ -31,6 +31,7 @@
 
         <CheckBoxPreference
             android:defaultValue="false"
+            android:visible="false"
             android:key="@string/pref_key_sync_credit_cards"
             android:layout="@layout/checkbox_left_preference"
             android:title="@string/preferences_sync_credit_cards" />
@@ -55,6 +56,7 @@
 
         <CheckBoxPreference
             android:defaultValue="false"
+            android:visible="false"
             android:key="@string/pref_key_sync_address"
             android:layout="@layout/checkbox_left_preference"
             android:title="@string/preferences_sync_address" />

--- a/app/src/main/res/xml/account_settings_preferences.xml
+++ b/app/src/main/res/xml/account_settings_preferences.xml
@@ -30,7 +30,7 @@
             android:title="@string/preferences_sync_bookmarks" />
 
         <CheckBoxPreference
-            android:defaultValue="true"
+            android:defaultValue="false"
             android:key="@string/pref_key_sync_credit_cards"
             android:layout="@layout/checkbox_left_preference"
             android:title="@string/preferences_sync_credit_cards" />

--- a/app/src/main/res/xml/account_settings_preferences.xml
+++ b/app/src/main/res/xml/account_settings_preferences.xml
@@ -31,6 +31,12 @@
 
         <CheckBoxPreference
             android:defaultValue="true"
+            android:key="@string/pref_key_sync_credit_cards"
+            android:layout="@layout/checkbox_left_preference"
+            android:title="@string/preferences_sync_credit_cards" />
+
+        <CheckBoxPreference
+            android:defaultValue="true"
             android:key="@string/pref_key_sync_history"
             android:layout="@layout/checkbox_left_preference"
             android:title="@string/preferences_sync_history" />
@@ -47,5 +53,10 @@
             android:layout="@layout/checkbox_left_preference"
             android:title="@string/preferences_sync_tabs_2"/>
 
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="@string/pref_key_sync_address"
+            android:layout="@layout/checkbox_left_preference"
+            android:title="@string/preferences_sync_address" />
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
For #17537 

* Visibility for CC and addresses based on respective Feature Flags
* Device pin needed to enable CC syncing using same logic as Logins (new copy TBD)
* Default values and visibility for CC and address preferences are `false`

## Old version
<img width="323" src="https://user-images.githubusercontent.com/43795363/117885256-40053b80-b273-11eb-8636-3b8b8dc4cbe1.png">

## New version -- addresses visible based on feature flag
<img width="323" src="https://user-images.githubusercontent.com/43795363/117885309-514e4800-b273-11eb-94ee-a86f7d1703f0.png">  <img width="323" src="https://user-images.githubusercontent.com/43795363/117885315-53b0a200-b273-11eb-8931-074e40a78bee.png">


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
