### PR TITLE
Issue #19176: Exit select mode when removing tab

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabstray/NavigationInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/NavigationInteractor.kt
@@ -198,8 +198,6 @@ class DefaultNavigationInteractor(
             }
         }
 
-        tabsTrayStore.dispatch(TabsTrayAction.ExitSelectMode)
-
         // TODO show successful snackbar here (regardless of operation succes).
     }
 

--- a/app/src/main/java/org/mozilla/fenix/tabstray/browser/SelectionMenuIntegration.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/browser/SelectionMenuIntegration.kt
@@ -8,6 +8,7 @@ import android.content.Context
 import androidx.annotation.VisibleForTesting
 import mozilla.components.browser.menu.BrowserMenuBuilder
 import org.mozilla.fenix.tabstray.NavigationInteractor
+import org.mozilla.fenix.tabstray.TabsTrayAction
 import org.mozilla.fenix.tabstray.TabsTrayInteractor
 import org.mozilla.fenix.tabstray.TabsTrayStore
 import org.mozilla.fenix.utils.Do
@@ -30,12 +31,14 @@ class SelectionMenuIntegration(
     @VisibleForTesting
     internal fun handleMenuClicked(item: SelectionMenu.Item) {
         Do exhaustive when (item) {
-            is SelectionMenu.Item.BookmarkTabs -> navInteractor.onSaveToBookmarks(
-                store.state.mode.selectedTabs
-            )
-            is SelectionMenu.Item.DeleteTabs -> trayInteractor.onDeleteTabs(
-                store.state.mode.selectedTabs
-            )
+            is SelectionMenu.Item.BookmarkTabs -> {
+                navInteractor.onSaveToBookmarks(store.state.mode.selectedTabs)
+                store.dispatch(TabsTrayAction.ExitSelectMode)
+            }
+            is SelectionMenu.Item.DeleteTabs -> {
+                trayInteractor.onDeleteTabs(store.state.mode.selectedTabs)
+                store.dispatch(TabsTrayAction.ExitSelectMode)
+            }
         }
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/tabstray/browser/SelectionMenuIntegrationTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/browser/SelectionMenuIntegrationTest.kt
@@ -6,32 +6,45 @@ package org.mozilla.fenix.tabstray.browser
 
 import io.mockk.mockk
 import io.mockk.verify
+import mozilla.components.support.test.libstate.ext.waitUntilIdle
+import mozilla.components.support.test.middleware.CaptureActionsMiddleware
 import org.junit.Test
 import org.mozilla.fenix.tabstray.NavigationInteractor
+import org.mozilla.fenix.tabstray.TabsTrayAction
 import org.mozilla.fenix.tabstray.TabsTrayInteractor
+import org.mozilla.fenix.tabstray.TabsTrayState
 import org.mozilla.fenix.tabstray.TabsTrayStore
 
 class SelectionMenuIntegrationTest {
 
     private val navInteractor = mockk<NavigationInteractor>(relaxed = true)
     private val trayInteractor = mockk<TabsTrayInteractor>(relaxed = true)
-    private val store = TabsTrayStore()
+    private val capture = CaptureActionsMiddleware<TabsTrayState, TabsTrayAction>()
+    private val store = TabsTrayStore(middlewares = listOf(capture))
 
     @Test
-    fun `WHEN bookmark item is clicked THEN invoke interactor`() {
+    fun `WHEN bookmark item is clicked THEN invoke interactor and close tray`() {
         val menu = SelectionMenuIntegration(mockk(), store, navInteractor, trayInteractor)
 
         menu.handleMenuClicked(SelectionMenu.Item.BookmarkTabs)
 
+        store.waitUntilIdle()
+
         verify { navInteractor.onSaveToBookmarks(store.state.mode.selectedTabs) }
+
+        capture.findLastAction(TabsTrayAction.ExitSelectMode::class)
     }
 
     @Test
-    fun `WHEN delete tabs item is clicked THEN invoke interactor`() {
+    fun `WHEN delete tabs item is clicked THEN invoke interactor and close tray`() {
         val menu = SelectionMenuIntegration(mockk(), store, navInteractor, trayInteractor)
 
         menu.handleMenuClicked(SelectionMenu.Item.DeleteTabs)
 
+        store.waitUntilIdle()
+
         verify { trayInteractor.onDeleteTabs(store.state.mode.selectedTabs) }
+
+        capture.findLastAction(TabsTrayAction.ExitSelectMode::class)
     }
 }


### PR DESCRIPTION
@codrut-topliceanu put up a fix for this since it was bothering you. 😄 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture


https://user-images.githubusercontent.com/1370580/118039200-12d18f80-b33e-11eb-8eca-5e547c1d3efb.mp4

