### PR TITLE
Fix case of item extras in browser_menu_action event

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -205,11 +205,10 @@ events:
         description: |
           A string containing the name of the item the user tapped. These items
           include:
-
-            Settings, Help, Desktop Site toggle on/off, Find in Page,
-            New Tab, Private Tab, Share, Report Site Issue, Back/Forward button,
-            Reload Button, Quit, Reader Mode On, Reader Mode Off, Open In app,
-            Add To Top Sites, Add-ons Manager, Bookmarks, History
+          add_to_homescreen, add_to_top_sites, addons_manager, back, bookmark, bookmarks, desktop_view_off,
+          desktop_view_on, downloads, find_in_page, forward, help, history, library, new_private_tab, new_tab,
+          open_in_app, open_in_fenix, quit, reader_mode_appearance, reader_mode_off, reader_mode_on, reload,
+          save_to_collection, set_default_browser, settings, share, stop, sync_account, and sync_tabs.
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/1024
     data_reviews:


### PR DESCRIPTION
Update the event description to match the values observed in telemetry.

No tests: not a functional change
No screenshots: not user-visible
No accessibility impacts: not user-visible

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
