### PR TITLE
For #19221, Use ISO-8601 format build date in About Firefox

### DIFF
--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -44,12 +44,12 @@ object Config {
         return "$majorVersion.0a1"
     }
 
+    /**
+     * Generate a build date that follows the ISO-8601 format
+     */
     @JvmStatic
     fun generateBuildDate(): String {
-        val dateTime = LocalDateTime.now()
-        val timeFormatter = DateTimeFormatter.ofPattern("h:mm a")
-
-        return "${dateTime.dayOfWeek.toString().toLowerCase().capitalize()} ${dateTime.monthValue}/${dateTime.dayOfMonth} @ ${timeFormatter.format(dateTime)}"
+        return LocalDateTime.now().toString()
     }
 
     private val fennecBaseVersionCode by lazy {


### PR DESCRIPTION
## Changes

This PR change the build date format to ISO-8601 in the Firefox About. This prevents the unnecessary confusion caused by the MM/DD or DD/MM formatting by adopting an international standard. (close #19221)

## Tests

- This PR does not introduce a new feature. No test is included.

## Screenshots

### Before

![Screenshot_1620888755](https://user-images.githubusercontent.com/23636124/118090718-2de9e100-b3ca-11eb-9265-8ab8ecc74ee2.png)

### After

![Screenshot_1620889238](https://user-images.githubusercontent.com/23636124/118090765-3b9f6680-b3ca-11eb-8bab-d375a9d8079b.png)



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
