### PR TITLE
For #19569 - Increases CC expiry date spinners

### DIFF
--- a/app/src/main/res/layout/fragment_credit_card_editor.xml
+++ b/app/src/main/res/layout/fragment_credit_card_editor.xml
@@ -116,7 +116,7 @@
             <LinearLayout
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginEnd="24dp"
+                android:layout_marginEnd="4dp"
                 android:layout_weight="1"
                 android:orientation="vertical">
 

--- a/app/src/main/res/layout/fragment_credit_card_editor.xml
+++ b/app/src/main/res/layout/fragment_credit_card_editor.xml
@@ -116,7 +116,7 @@
             <LinearLayout
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginEnd="4dp"
+                android:layout_marginEnd="24dp"
                 android:layout_weight="1"
                 android:orientation="vertical">
 
@@ -136,7 +136,7 @@
             <LinearLayout
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
+                android:layout_weight="0.8"
                 android:orientation="vertical">
 
                 <androidx.appcompat.widget.AppCompatSpinner


### PR DESCRIPTION
Fixes #19569

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR doesn't include any tests as it is only a minor change.
- [x] **Screenshots**: This PR includes screenshots.
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

To test this I set font size to largest on a Pixel 4(android11). 
The fix was just to reduce the margin on the expiry month spinner, but please note that with a low enough DPI device and with a high enough font setting the issue might still occur. 

Other solutions would be to increase the month spinner size and reduce the year spinner size, but I think that would just look bad. Or maybe to have it occupy 2 rows.

I could really use some UX feedback on this. @violasong ?
Please see attached screenshots:

**With fix (margin of month set to 4)**
_Largest font size:_
![image](https://user-images.githubusercontent.com/60002907/118969765-1edcd300-b976-11eb-98f0-ae424fe98283.png)
_Small font size:_
![image](https://user-images.githubusercontent.com/60002907/118969853-3f0c9200-b976-11eb-8bdb-d0afcfbf403e.png)
_Default font size:_
![image](https://user-images.githubusercontent.com/60002907/118969928-53508f00-b976-11eb-8326-ba8af237751b.png)


**Without fix (margin of month set to 24)**
_Largest font size:_
![image](https://user-images.githubusercontent.com/60002907/118970446-e8538800-b976-11eb-8c0a-ca673fc54cec.png)
_Small font size:_
![image](https://user-images.githubusercontent.com/60002907/118970490-f86b6780-b976-11eb-9f73-7db45416c339.png)
_Default font size:_
![image](https://user-images.githubusercontent.com/60002907/118970537-0620ed00-b977-11eb-9b80-4ded3a96c5b0.png)


