### PR TITLE
AutofillConfiguration: Correctly specify autofill confirm activity.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/Components.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Components.kt
@@ -23,6 +23,7 @@ import org.mozilla.fenix.BuildConfig
 import org.mozilla.fenix.Config
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
+import org.mozilla.fenix.autofill.AutofillConfirmActivity
 import org.mozilla.fenix.autofill.AutofillUnlockActivity
 import org.mozilla.fenix.components.metrics.AppStartupTelemetry
 import org.mozilla.fenix.ext.components
@@ -169,7 +170,7 @@ class Components(private val context: Context) {
             storage = core.passwordsStorage,
             publicSuffixList = publicSuffixList,
             unlockActivity = AutofillUnlockActivity::class.java,
-            confirmActivity = AutofillConfiguration::class.java,
+            confirmActivity = AutofillConfirmActivity::class.java,
             applicationName = context.getString(R.string.app_name),
             httpClient = core.client
         )


### PR DESCRIPTION
Bug filed in A-C:
https://github.com/mozilla-mobile/android-components/issues/10300

This should have been `AutofillConfirmActivity` and not `AutofillConfiguration`.