### PR TITLE
For #19564: Explicitly update switch state for a11y event announcements.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/SyncPreference.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SyncPreference.kt
@@ -32,6 +32,13 @@ class SyncPreference @JvmOverloads constructor(
         widgetLayoutResource = R.layout.preference_sync
     }
 
+    /**
+     * Updates the switch state.
+     * */
+    internal fun setSwitchCheckedState(isChecked: Boolean) {
+        switchView?.isChecked = isChecked
+    }
+
     override fun onBindViewHolder(holder: PreferenceViewHolder) {
         super.onBindViewHolder(holder)
 

--- a/app/src/main/java/org/mozilla/fenix/settings/SyncPreferenceView.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SyncPreferenceView.kt
@@ -83,6 +83,7 @@ class SyncPreferenceView(
 
             setOnPreferenceChangeListener { _, newValue ->
                 SyncEnginesStorage(context).setStatus(syncEngine, newValue as Boolean)
+                setSwitchCheckedState(newValue)
                 true
             }
         }

--- a/app/src/test/java/org/mozilla/fenix/settings/logins/SyncPreferenceViewTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/logins/SyncPreferenceViewTest.kt
@@ -137,6 +137,7 @@ class SyncPreferenceViewTest {
             SyncEngine.Passwords to true
         )
         every { anyConstructed<SyncEnginesStorage>().setStatus(any(), any()) } just Runs
+        every { syncPreference.setSwitchCheckedState(any()) } just Runs
 
         createView()
 
@@ -155,6 +156,7 @@ class SyncPreferenceViewTest {
             SyncEngine.Passwords to false
         )
         every { anyConstructed<SyncEnginesStorage>().setStatus(any(), any()) } just Runs
+        every { syncPreference.setSwitchCheckedState(any()) } just Runs
 
         createView()
 


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
         - adding tests for talkback announcements not feasible. 
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
         - PR does not contain UI changes. 
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
