### PR TITLE
For #19590 - Enable credit card autofill in Debug and Nightly

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/SecretSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SecretSettingsFragment.kt
@@ -30,12 +30,6 @@ class SecretSettingsFragment : PreferenceFragmentCompat() {
             onPreferenceChangeListener = SharedPreferenceUpdater()
         }
 
-        requirePreference<SwitchPreference>(R.string.pref_key_show_credit_cards_feature).apply {
-            isVisible = FeatureFlags.creditCardsFeature
-            isChecked = context.settings().creditCardsFeature
-            onPreferenceChangeListener = SharedPreferenceUpdater()
-        }
-
         requirePreference<SwitchPreference>(R.string.pref_key_new_tabs_tray).apply {
             isVisible = FeatureFlags.tabsTrayRewrite
             isChecked = context.settings().tabsTrayRewrite

--- a/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
@@ -37,6 +37,7 @@ import mozilla.components.concept.sync.Profile
 import mozilla.components.support.ktx.android.view.showKeyboard
 import org.mozilla.fenix.BrowserDirection
 import org.mozilla.fenix.Config
+import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.metrics.Event
@@ -439,7 +440,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
         with(requireContext().settings()) {
             findPreference<Preference>(
                 getPreferenceKey(R.string.pref_key_credit_cards)
-            )?.isVisible = creditCardsFeature
+            )?.isVisible = FeatureFlags.creditCardsFeature
             findPreference<Preference>(
                 getPreferenceKey(R.string.pref_key_nimbus_experiments)
             )?.isVisible = showSecretDebugMenuThisSession

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -1042,12 +1042,6 @@ class Settings(private val appContext: Context) : PreferencesHolder {
         default = true
     )
 
-    var creditCardsFeature by featureFlagPreference(
-        appContext.getPreferenceKey(R.string.pref_key_show_credit_cards_feature),
-        default = false,
-        featureFlag = FeatureFlags.creditCardsFeature
-    )
-
     var addressFeature by featureFlagPreference(
         appContext.getPreferenceKey(R.string.pref_key_show_address_feature),
         default = false,

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -278,7 +278,6 @@
     <string name="pref_key_search_region_current" translatable="false">pref_key_search_region_current</string>
 
     <!-- Secret Settings -->
-    <string name="pref_key_show_credit_cards_feature" translatable="false">pref_key_show_credit_cards_feature</string>
     <string name="pref_key_show_address_feature" translatable="false">pref_key_show_address_feature</string>
     <string name="pref_key_nimbus_experiments" translatable="false">pref_key_nimbus_experiments</string>
 </resources>

--- a/app/src/main/res/values/static_strings.xml
+++ b/app/src/main/res/values/static_strings.xml
@@ -37,8 +37,6 @@
     <string name="preferences_debug_info" translatable="false">Secret Debug Info</string>
     <!-- Label for enabling Address Autofill -->
     <string name="preferences_debug_settings_enable_address_feature" translatable="false">Enable Address Autofill</string>
-    <!-- Label for enabling Credit Card Autofill -->
-    <string name="preferences_debug_settings_enable_credit_cards_feature" translatable="false">Enable Credit Card Autofill</string>
     <!-- Label for the new tabs tray preference -->
     <string name="preferences_debug_settings_tabs_tray_rewrite">Use new Tabs Tray</string>
     <!-- Label for a longer description of the new tabs tray preference -->

--- a/app/src/main/res/xml/secret_settings_preferences.xml
+++ b/app/src/main/res/xml/secret_settings_preferences.xml
@@ -11,11 +11,6 @@
         app:iconSpaceReserved="false" />
     <SwitchPreference
         android:defaultValue="false"
-        android:key="@string/pref_key_show_credit_cards_feature"
-        android:title="@string/preferences_debug_settings_enable_credit_cards_feature"
-        app:iconSpaceReserved="false" />
-    <SwitchPreference
-        android:defaultValue="false"
         android:key="@string/pref_key_new_tabs_tray"
         android:title="@string/preferences_debug_settings_tabs_tray_rewrite"
         android:summary="@string/preferences_debug_settings_tabs_tray_rewrite_summary"


### PR DESCRIPTION
No need to go to Secret Settings to enable this anymore.
The cool effect of the preference appearing after opening the Settings screen will still be there until https://github.com/mozilla-mobile/fenix/issues/19051.

https://user-images.githubusercontent.com/11428869/119150277-f8429900-ba56-11eb-9573-d3fa16d08ba8.mp4



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
