### PR TITLE
For #19608 fix Intermittent UI test settingsPrivacyItemsTest

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsPrivacyTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsPrivacyTest.kt
@@ -147,6 +147,12 @@ class SettingsPrivacyTest {
             verifyDeleteBrowsingDataOnQuitSubMenuItems()
         }.goBack {
 
+            // NOTIFICATIONS
+            verifyNotificationsButton()
+        }.openSettingsSubMenuNotifications {
+            verifySystemNotificationsView()
+        }.goBack {
+
             // DATA COLLECTION
             verifyDataCollectionButton()
         }.openSettingsSubMenuDataCollection {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
@@ -9,10 +9,10 @@ package org.mozilla.fenix.ui.robots
 import android.content.pm.PackageManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.action.ViewActions
-import androidx.test.espresso.contrib.RecyclerViewActions
 import androidx.test.espresso.ViewInteraction
+import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.contrib.RecyclerViewActions
 import androidx.test.espresso.intent.Intents.intended
 import androidx.test.espresso.intent.matcher.IntentMatchers
 import androidx.test.espresso.intent.matcher.IntentMatchers.toPackage
@@ -70,6 +70,7 @@ class SettingsRobot {
     fun verifyDeleteBrowsingDataOnQuitButton() = assertDeleteBrowsingDataOnQuitButton()
     fun verifyDeleteBrowsingDataOnQuitValue(state: String) =
         assertDeleteBrowsingDataValue(state)
+    fun verifyNotificationsButton() = assertNotificationsButton()
     fun verifyDataCollectionButton() = assertDataCollectionButton()
     fun verifyOpenLinksInAppsButton() = assertOpenLinksInAppsButton()
     fun verifyOpenLinksInAppsSwitchDefault() = assertOpenLinksInAppsValue()
@@ -215,6 +216,15 @@ class SettingsRobot {
 
             SettingsSubMenuDeleteBrowsingDataOnQuitRobot().interact()
             return SettingsSubMenuDeleteBrowsingDataOnQuitRobot.Transition()
+        }
+
+        fun openSettingsSubMenuNotifications(interact: SystemSettingsRobot.() -> Unit): SystemSettingsRobot.Transition {
+            scrollToElementByText("Notifications")
+            fun notificationsButton() = mDevice.findObject(textContains("Notifications"))
+            notificationsButton().click()
+
+            SystemSettingsRobot().interact()
+            return SystemSettingsRobot.Transition()
         }
 
         fun openSettingsSubMenuDataCollection(interact: SettingsSubMenuDataCollectionRobot.() -> Unit): SettingsSubMenuDataCollectionRobot.Transition {
@@ -365,8 +375,17 @@ private fun assertDeleteBrowsingDataValue(state: String) {
     onView(withText(state)).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 }
 
-private fun assertDataCollectionButton() = onView(withText("Data collection"))
+private fun assertNotificationsButton() {
+    scrollToElementByText("Notifications")
+    onView(withText("Notifications"))
+        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+}
+
+private fun assertDataCollectionButton() {
+    scrollToElementByText("Data collection")
+    onView(withText("Data collection"))
     .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+}
 
 private fun openLinksInAppsButton() = onView(withText("Open links in apps"))
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SystemSettingsRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SystemSettingsRobot.kt
@@ -6,8 +6,12 @@ package org.mozilla.fenix.ui.robots
 
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
+import androidx.test.uiautomator.UiSelector
+import org.junit.Assert.assertTrue
+import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 
 class SystemSettingsRobot {
+    fun verifySystemNotificationsView() = assertSystemNotificationsView()
     fun verifyNotifications() {
         Intents.intended(hasAction("android.settings.APP_NOTIFICATION_SETTINGS"))
     }
@@ -18,10 +22,24 @@ class SystemSettingsRobot {
 
     class Transition {
         // Difficult to know where this will go
+        fun goBack(interact: SettingsRobot.() -> Unit): SettingsRobot.Transition {
+            mDevice.pressBack()
+
+            SettingsRobot().interact()
+            return SettingsRobot.Transition()
+        }
     }
 }
 
 fun systemSettings(interact: SystemSettingsRobot.() -> Unit): SystemSettingsRobot.Transition {
     SystemSettingsRobot().interact()
     return SystemSettingsRobot.Transition()
+}
+
+private fun assertSystemNotificationsView() {
+    mDevice.findObject(UiSelector().resourceId("com.android.settings:id/list"))
+        .waitForExists(waitingTime)
+    assertTrue(mDevice.findObject(UiSelector().textContains("Show notifications"))
+        .waitForExists(waitingTime)
+    )
 }


### PR DESCRIPTION
• Fix `settingsPrivacyItemsTest` scrolling issue to Data Collection subsection which caused the failure from #19608 .
• Added **Notifications** subsection check 
✔️ Successfully ran 30x on Firebase

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
