### PR TITLE
For #19600: Set manage cards preference visible by default.

### DIFF
--- a/app/src/main/res/xml/credit_cards_preferences.xml
+++ b/app/src/main/res/xml/credit_cards_preferences.xml
@@ -17,6 +17,5 @@
     <Preference
         android:key="@string/pref_key_credit_cards_manage_cards"
         android:title="@string/preferences_credit_cards_manage_saved_cards"
-        app:isPreferenceVisible="false"
         app:allowDividerAbove="true" />
 </PreferenceScreen>


### PR DESCRIPTION
The preference should be visible by default, no need to update the visibility programmatically.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
