### PR TITLE
For #18603: Fix and re-enable startBrowsingButtonTest

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -155,7 +155,6 @@ class SmokeTest {
     }
 
     @Test
-    @Ignore("https://github.com/mozilla-mobile/fenix/issues/18603")
     // Verifies the functionality of the onboarding Start Browsing button
     fun startBrowsingButtonTest() {
         homeScreen {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
@@ -11,7 +11,6 @@ import android.widget.EditText
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.NoMatchingViewException
-import androidx.test.espresso.ViewInteraction
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.swipeLeft
@@ -33,10 +32,12 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.By.text
 import androidx.test.uiautomator.UiDevice
+import androidx.test.uiautomator.UiObject
 import androidx.test.uiautomator.UiScrollable
 import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
 import androidx.test.uiautomator.Until.findObject
+import junit.framework.TestCase.assertTrue
 import mozilla.components.browser.state.state.searchEngines
 import mozilla.components.support.ktx.android.content.appName
 import org.hamcrest.CoreMatchers.allOf
@@ -327,7 +328,6 @@ class HomeScreenRobot {
         }
 
         fun clickStartBrowsingButton(interact: SearchRobot.() -> Unit): SearchRobot.Transition {
-            scrollToElementByText("Start browsing")
             startBrowsingButton().click()
 
             SearchRobot().interact()
@@ -465,6 +465,13 @@ fun homeScreen(interact: HomeScreenRobot.() -> Unit): HomeScreenRobot.Transition
 
 val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
 val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+
+private fun homeScreenList() =
+    UiScrollable(
+        UiSelector()
+            .resourceId("$packageName:id/sessionControlRecyclerView")
+            .scrollable(true)
+    ).setAsVerticalList()
 
 private fun assertKeyboardVisibility(isExpectedToBeVisible: Boolean) =
     Assert.assertEquals(
@@ -646,9 +653,7 @@ private fun assertPrivacyNoticeButton() {
 }
 
 private fun assertStartBrowsingButton() {
-    scrollToElementByText("Start browsing")
-    onView(withId(R.id.finish_button))
-        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+    assertTrue(startBrowsingButton().waitForExists(waitingTime))
 }
 
 // Pick your toolbar placement
@@ -740,7 +745,11 @@ private fun tab(title: String) =
         )
     )
 
-private fun startBrowsingButton(): ViewInteraction {
-    scrollToElementByText("Start browsing")
-    return onView(allOf(withText("Start browsing")))
+private fun startBrowsingButton(): UiObject {
+    val startBrowsingButton = mDevice.findObject(UiSelector().resourceId("$packageName:id/finish_button"))
+    homeScreenList()
+        .scrollIntoView(startBrowsingButton)
+    homeScreenList()
+        .ensureFullyVisible(startBrowsingButton)
+    return startBrowsingButton
 }


### PR DESCRIPTION
For #18603 Ran on Firebase 50x and all passed.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
