### PR TITLE
For #19620 - Have MenuScreenShotTest screenshot DefaultBrowser setting again

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/screenshots/MenuScreenShotTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/screenshots/MenuScreenShotTest.kt
@@ -68,47 +68,38 @@ class MenuScreenShotTest : ScreenshotTest() {
         }.openThreeDotMenu {
         }.openSettings {
             Screengrab.screenshot("SettingsRobot_settings-menu")
-            settingsAccountPreferences()
+        }.openTurnOnSyncMenu {
             Screengrab.screenshot("AccountSettingsRobot_settings-account")
-            mDevice.pressBack()
-
-            settingsSearch()
+        }.goBack {
+        }.openSearchSubMenu {
             Screengrab.screenshot("SettingsSubMenuSearchRobot_settings-search")
-            mDevice.pressBack()
-
-            settingsTheme()
+        }.goBack {
+        }.openCustomizeSubMenu {
             Screengrab.screenshot("SettingsSubMenuThemeRobot_settings-theme")
-            mDevice.pressBack()
-
-            settingsAccessibility()
+        }.goBack {
+        }.openAccessibilitySubMenu {
             Screengrab.screenshot("SettingsSubMenuAccessibilityRobot_settings-accessibility")
-            mDevice.pressBack()
-
-            settingsLanguage()
+        }.goBack {
+        }.openLanguageSubMenu {
             Screengrab.screenshot("SettingsSubMenuAccessibilityRobot_settings-language")
-            mDevice.pressBack()
-
-            settingDefaultBrowser()
+        }.goBack {
+        // From about here we need to scroll up to ensure all settings options are visible.
+        }.openSetDefaultBrowserSubMenu {
             Screengrab.screenshot("SettingsSubMenuDefaultBrowserRobot_settings-default-browser")
-            mDevice.pressBack()
-
-            // Disabled for Pixel 2
-            // settingsTP()
-            // Screengrab.screenshot("settings-enhanced-tp")
-            // mDevice.pressBack()
-
-            loginsAndPassword()
+        }.goBack {
+        // Disabled for Pixel 2
+        // }.openEnhancedTrackingProtectionSubMenu {
+        //     Screengrab.screenshot("settings-enhanced-tp")
+        // }.goBack {
+        }.openLoginsAndPasswordSubMenu {
             Screengrab.screenshot("SettingsSubMenuLoginsAndPasswords-settings-logins-passwords")
-            mDevice.pressBack()
-
+        }.goBack {
             swipeToBottom()
             Screengrab.screenshot("SettingsRobot_settings-scroll-to-bottom")
-
-            settingsTelemetry()
+        }.openSettingsSubMenuDataCollection {
             Screengrab.screenshot("settings-telemetry")
-            mDevice.pressBack()
-
-            addOns()
+        }.goBack {
+        }.openAddonsManagerMenu {
             Screengrab.screenshot("settings-addons")
         }
     }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
@@ -154,6 +154,24 @@ class SettingsRobot {
             return SettingsSubMenuAccessibilityRobot.Transition()
         }
 
+        fun openLanguageSubMenu(interact: SettingsSubMenuLanguageRobot.() -> Unit): SettingsSubMenuLanguageRobot.Transition {
+
+            fun languageButton() = onView(withText("Language"))
+            languageButton().click()
+
+            SettingsSubMenuLanguageRobot().interact()
+            return SettingsSubMenuLanguageRobot.Transition()
+        }
+
+        fun openSetDefaultBrowserSubMenu(interact: SettingsSubMenuSetDefaultBrowserRobot.() -> Unit): SettingsSubMenuSetDefaultBrowserRobot.Transition {
+            scrollToElementByText("Set as default browser")
+            fun setDefaultBrowserButton() = onView(withText("Set as default browser"))
+            setDefaultBrowserButton().click()
+
+            SettingsSubMenuSetDefaultBrowserRobot().interact()
+            return SettingsSubMenuSetDefaultBrowserRobot.Transition()
+        }
+
         fun openEnhancedTrackingProtectionSubMenu(interact: SettingsSubMenuEnhancedTrackingProtectionRobot.() -> Unit): SettingsSubMenuEnhancedTrackingProtectionRobot.Transition {
             scrollToElementByText("Enhanced Tracking Protection")
             fun enhancedTrackingProtectionButton() =

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuLanguageRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuLanguageRobot.kt
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.ui.robots
+
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
+import org.hamcrest.CoreMatchers
+
+class SettingsSubMenuLanguageRobot {
+    class Transition {
+        val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+
+        fun goBack(interact: SettingsRobot.() -> Unit): SettingsRobot.Transition {
+            mDevice.waitForIdle()
+            goBackButton().perform(ViewActions.click())
+
+            SettingsRobot().interact()
+            return SettingsRobot.Transition()
+        }
+    }
+}
+
+private fun goBackButton() =
+    onView(CoreMatchers.allOf(ViewMatchers.withContentDescription("Navigate up")))

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuSetDefaultBrowserRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuSetDefaultBrowserRobot.kt
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.ui.robots
+
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
+
+class SettingsSubMenuSetDefaultBrowserRobot {
+    class Transition {
+        val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+
+        fun goBack(interact: SettingsRobot.() -> Unit): SettingsRobot.Transition {
+            mDevice.waitForIdle()
+
+            // We are now in system settings / showing a default browser dialog.
+            // Really want to go back to the app. Not interested in up navigation like in other robots.
+            mDevice.pressBack()
+
+            SettingsRobot().interact()
+            return SettingsRobot.Transition()
+        }
+    }
+}

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsTurnOnSyncRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsTurnOnSyncRobot.kt
@@ -36,11 +36,11 @@ class SettingsTurnOnSyncRobot {
     class Transition {
         val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
 
-        fun goBack(interact: SettingsSubMenuLoginsAndPasswordRobot.() -> Unit): SettingsSubMenuLoginsAndPasswordRobot.Transition {
+        fun goBack(interact: SettingsSubMenuLoginsAndPasswordRobot.() -> Unit): SettingsRobot.Transition {
             goBackButton().perform(ViewActions.click())
 
             SettingsSubMenuLoginsAndPasswordRobot().interact()
-            return SettingsSubMenuLoginsAndPasswordRobot.Transition()
+            return SettingsRobot.Transition()
         }
     }
 }


### PR DESCRIPTION
As a regression from #19590 which added a new setting above the existing
"Set as default browser" setting the settingsTest() needed to be updated to
allow clicking and screenshot of what happens after clicking on the
"Set as default browser" setting which can now be pushed offscreen.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
