### PR TITLE
No issue: Moved media UI tests to the SmokeTest class. Code cleanup on HomeScreenRobot.

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/MediaNotificationTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/MediaNotificationTest.kt
@@ -89,57 +89,6 @@ class MediaNotificationTest {
     }
 
     @Test
-    fun audioPlaybackSystemNotificationTest() {
-        val audioTestPage = TestAssetHelper.getAudioPageAsset(mockWebServer)
-
-        navigationToolbar {
-        }.enterURLAndEnterToBrowser(audioTestPage.url) {
-            mDevice.waitForIdle()
-            clickMediaPlayerPlayButton()
-            assertPlaybackState(browserStore, MediaSession.PlaybackState.PLAYING)
-        }.openNotificationShade {
-            verifySystemNotificationExists(audioTestPage.title)
-            clickMediaSystemNotificationControlButton("Pause")
-            verifyMediaSystemNotificationButtonState("Play")
-        }
-
-        mDevice.pressBack()
-
-        browserScreen {
-            assertPlaybackState(browserStore, MediaSession.PlaybackState.PAUSED)
-        }.openTabDrawer {
-            closeTab()
-        }
-
-        mDevice.openNotification()
-
-        notificationShade {
-            verifySystemNotificationGone(audioTestPage.title)
-        }
-
-        // close notification shade before the next test
-        mDevice.pressBack()
-    }
-
-    @Test
-    fun tabMediaControlButtonTest() {
-        val audioTestPage = TestAssetHelper.getAudioPageAsset(mockWebServer)
-
-        navigationToolbar {
-        }.enterURLAndEnterToBrowser(audioTestPage.url) {
-            mDevice.waitForIdle()
-            clickMediaPlayerPlayButton()
-            assertPlaybackState(browserStore, MediaSession.PlaybackState.PLAYING)
-        }.openTabDrawer {
-            verifyTabMediaControlButtonState("Pause")
-            clickTabMediaControlButton()
-            verifyTabMediaControlButtonState("Play")
-        }.openTab(audioTestPage.title) {
-            assertPlaybackState(browserStore, MediaSession.PlaybackState.PAUSED)
-        }
-    }
-
-    @Test
     fun mediaSystemNotificationInPrivateModeTest() {
         val audioTestPage = TestAssetHelper.getAudioPageAsset(mockWebServer)
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -32,6 +32,7 @@ import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.helpers.TestHelper
 import org.mozilla.fenix.helpers.TestHelper.createCustomTabIntent
 import org.mozilla.fenix.helpers.TestHelper.deleteDownloadFromStorage
+import org.mozilla.fenix.helpers.TestHelper.scrollToElementByText
 import org.mozilla.fenix.helpers.ViewVisibilityIdlingResource
 import org.mozilla.fenix.ui.robots.browserScreen
 import org.mozilla.fenix.ui.robots.clickTabCrashedRestoreButton
@@ -1076,34 +1077,6 @@ class SmokeTest {
         }.openTabsListThreeDotMenu {
             verifyTabSettingsButton()
             verifyRecentlyClosedTabsButton()
-        }
-    }
-
-    @Ignore("Feature is temporarily removed; disabling test. See https://github.com/mozilla-mobile/fenix/issues/18656")
-    @Test
-    fun selectTabsButtonVisibilityTest() {
-        homeScreen {
-        }.dismissOnboarding()
-
-        val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-        val secondWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 2)
-
-        navigationToolbar {
-        }.enterURLAndEnterToBrowser(firstWebPage.url) {
-            mDevice.waitForIdle()
-        }.openTabDrawer {
-        }.openNewTab {
-        }.submitQuery(secondWebPage.url.toString()) {
-            mDevice.waitForIdle()
-        }.openTabDrawer {
-        }.toggleToPrivateTabs {
-        }.openNewTab {
-        }.dismissSearchBar { }
-
-        homeScreen {
-        }.openTabDrawer {
-        }.toggleToNormalTabs {
-            verifySelectTabsButton()
         }
     }
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
@@ -23,7 +23,6 @@ import androidx.test.espresso.matcher.ViewMatchers.Visibility
 import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
 import androidx.test.espresso.matcher.ViewMatchers.hasSibling
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
-import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.espresso.matcher.ViewMatchers.withHint
 import androidx.test.espresso.matcher.ViewMatchers.withId
@@ -241,12 +240,6 @@ class HomeScreenRobot {
         }
     }
 
-    fun scrollToElementByText(text: String): UiScrollable {
-        val appView = UiScrollable(UiSelector().scrollable(true))
-        appView.scrollTextIntoView(text)
-        return appView
-    }
-
     fun togglePrivateBrowsingModeOnOff() {
         onView(ViewMatchers.withResourceName("privateBrowsingButton"))
             .perform(click())
@@ -256,12 +249,6 @@ class HomeScreenRobot {
 
     fun swipeToTop() =
         onView(withId(R.id.sessionControlRecyclerView)).perform(ViewActions.swipeDown())
-
-    fun swipeTabRight(title: String) =
-        tab(title).perform(ViewActions.swipeRight())
-
-    fun swipeTabLeft(title: String) =
-        tab(title).perform(ViewActions.swipeLeft())
 
     fun verifySnackBarText(expectedText: String) {
         val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
@@ -273,21 +260,6 @@ class HomeScreenRobot {
             matches(withEffectiveVisibility(Visibility.VISIBLE))
         ).perform(click())
     }
-
-    fun verifyTabMediaControlButtonState(action: String) {
-        mDevice.waitNotNull(
-            findObject(
-                By
-                    .res("org.mozilla.fenix.debug:id/play_pause_button")
-                    .desc(action)
-            ),
-            waitingTime
-        )
-
-        tabMediaControlButton().check(matches(withContentDescription(action)))
-    }
-
-    fun clickTabMediaControlButton() = tabMediaControlButton().click()
 
     class Transition {
         val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
@@ -361,22 +333,6 @@ class HomeScreenRobot {
 
         fun pressBack() {
             onView(ViewMatchers.isRoot()).perform(ViewActions.pressBack())
-        }
-
-        fun openTabsListThreeDotMenu(interact: ThreeDotMenuMainRobot.() -> Unit): ThreeDotMenuMainRobot.Transition {
-//            tabsListThreeDotButton().perform(click())
-
-            ThreeDotMenuMainRobot().interact()
-            return ThreeDotMenuMainRobot.Transition()
-        }
-
-        fun closeAllPrivateTabs(interact: HomeScreenRobot.() -> Unit): Transition {
-            onView(withId(R.id.close_tabs_button))
-                .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-                .perform(click())
-
-            HomeScreenRobot().interact()
-            return Transition()
         }
 
         fun openNavigationToolbar(interact: NavigationToolbarRobot.() -> Unit): NavigationToolbarRobot.Transition {
@@ -486,8 +442,6 @@ private fun assertKeyboardVisibility(isExpectedToBeVisible: Boolean) =
     )
 
 private fun navigationToolbar() = onView(withId(R.id.toolbar))
-
-private fun closeTabButton() = onView(withId(R.id.close_tab_button))
 
 private fun assertNavigationToolbar() =
     navigationToolbar().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
@@ -724,8 +678,6 @@ private fun assertShareTabsOverlay() {
 
 private fun privateBrowsingButton() = onView(withId(R.id.privateBrowsingButton))
 
-private fun tabMediaControlButton() = onView(withId(R.id.play_pause_button))
-
 private fun collectionItem(title: String) =
     onView(allOf(withId(R.id.label), withText(title)))
 
@@ -742,14 +694,6 @@ private fun removeTabFromCollectionButton(title: String) =
     )
 
 private fun tabsCounter() = onView(withId(R.id.tab_button))
-
-private fun tab(title: String) =
-    onView(
-        allOf(
-            withId(R.id.tab_title),
-            withText(title)
-        )
-    )
 
 private fun startBrowsingButton(): UiObject {
     val startBrowsingButton = mDevice.findObject(UiSelector().resourceId("$packageName:id/finish_button"))


### PR DESCRIPTION
Recently re-enabled media tests moved to the Smoke tests suite.
Code cleanup in HomeScreenRobot.kt of old tabs-related code.
Deleted SmokeTest#selectTabsButtonVisibilityTest, as the button was removed.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
