### PR TITLE
Issue #17819: Update detekt to 1.17.1

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/perf/StartupTimelineStateMachine.kt
+++ b/app/src/main/java/org/mozilla/fenix/perf/StartupTimelineStateMachine.kt
@@ -25,8 +25,6 @@ object StartupTimelineStateMachine {
      * The states the application passes through during startup. We define these states to help us
      * better understand Android startup. Note that these states are not 100% correlated to the
      * cold/warm/hot states Google Play Vitals uses.
-     *
-     * TODO: link to extensive documentation on cold/warm/hot states when completed.
      */
     sealed class StartupState {
         /** The state when the application is starting up but is not in memory. */

--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ buildscript {
 }
 
 plugins {
-    id("io.gitlab.arturbosch.detekt").version("1.9.1")
+    id("io.gitlab.arturbosch.detekt").version("1.17.1")
 }
 
 allprojects {
@@ -146,12 +146,6 @@ allprojects {
                     // https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/
                     ////////////////////////////////////////////////////////////////////////////////
 
-                    // Used by detekt
-                    // Issue for publishing to maven central: https://github.com/Kotlin/kotlinx.html/issues/173
-                    // Related detekt issue: https://github.com/detekt/detekt/issues/3461
-                    includeVersion("org.jetbrains.kotlinx", "kotlinx-html-jvm", "0.7.1")
-                    includeVersion("org.jetbrains.kotlinx", "kotlinx-html-common", "0.7.1")
-
                     // Fastlane
                     // Doesn't seem to be available on Maven Central yet, and I couldn't find an issue for it
                     // https://github.com/fastlane/fastlane/issues/18174
@@ -178,7 +172,7 @@ tasks.register('clean', Delete) {
 
 detekt {
     // The version number is duplicated, please refer to plugins block for more details
-    version = "1.9.1"
+    version = "1.17.1"
     input = files("$projectDir/app/src")
     config = files("$projectDir/config/detekt.yml")
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -14,7 +14,7 @@ object Versions {
     const val sentry = "1.7.10"
     const val leakcanary = "2.4"
     const val osslicenses_plugin = "0.9.5"
-    const val detekt = "1.9.1"
+    const val detekt = "1.17.1"
     const val jna = "5.6.0"
 
     const val androidx_appcompat = "1.2.0"

--- a/mozilla-detekt-rules/src/main/java/org/mozilla/fenix/detektrules/CustomRulesetConsoleReport.kt
+++ b/mozilla-detekt-rules/src/main/java/org/mozilla/fenix/detektrules/CustomRulesetConsoleReport.kt
@@ -14,7 +14,7 @@ class CustomRulesetConsoleReport : ConsoleReport() {
     @Suppress("DEPRECATION") // locationAsString
     override fun render(detektion: Detektion): String? {
         return detektion.findings["mozilla-detekt-rules"]?.fold("") { accumulator, finding ->
-            accumulator + "${finding.id}:\n    ${finding.locationAsString}\n    ${finding.messageOrDescription()}\n\n"
+            accumulator + "${finding.id}:\n    ${finding.file}\n    ${finding.messageOrDescription()}\n\n"
             // This creates an extra newline at the very end but it's not worth fixing.
         }
     }

--- a/mozilla-detekt-rules/src/test/java/org/mozilla/fenix/detektrules/perf/MozillaBannedPropertyAccessTest.kt
+++ b/mozilla-detekt-rules/src/test/java/org/mozilla/fenix/detektrules/perf/MozillaBannedPropertyAccessTest.kt
@@ -7,8 +7,8 @@
 package org.mozilla.fenix.detektrules.perf
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.YamlConfig
 import io.gitlab.arturbosch.detekt.test.lint
+import io.gitlab.arturbosch.detekt.test.yamlConfig
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -26,7 +26,8 @@ internal class MozillaBannedPropertyAccessTest {
 
     @BeforeEach
     fun setup() {
-        config = YamlConfig.loadResource(this.javaClass.getResource("/config.yml"))
+        config = yamlConfig("/config.yml")
+
     }
 
     @Test


### PR DESCRIPTION
This version is on maven central and so we no longer need to pull it from JCenter. :)