### PR TITLE
Stop depending on JCenter - Screengrab and Falcon

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -520,6 +520,8 @@ dependencies {
     androidTestImplementation Deps.uiautomator
 // Removed pending AndroidX fixes
     androidTestImplementation "tools.fastlane:screengrab:2.0.0"
+    // This Falcon version is added to maven central now required for Screengrab
+    implementation 'com.jraska:falcon:2.2.0'
 //    androidTestImplementation "br.com.concretesolutions:kappuccino:1.2.1"
 
     androidTestImplementation Deps.espresso_core, {

--- a/build.gradle
+++ b/build.gradle
@@ -153,11 +153,7 @@ allprojects {
                     includeVersion("org.jetbrains.kotlinx", "kotlinx-html-common", "0.7.1")
 
                     // Fastlane
-                    // Doesn't seem to be available on Maven Central yet, and I couldn't find an issue for it
-                    // https://github.com/fastlane/fastlane/issues/18174
-                    includeVersion("tools.fastlane", "screengrab", "2.0.0")
-                    // https://github.com/jraska/Falcon/issues/52
-                    includeVersion("com.jraska", "falcon", "2.1.1")
+                    // Both Screengrab and falcon are available on Maven Central
                 }
             }
         }


### PR DESCRIPTION
Fixes part of #17819 by removing the Fastlane dependencies on JCenter

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
