### PR TITLE
Closes #17819: Remove JCenter from build files.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -132,25 +132,6 @@ allprojects {
                 }
             }
         }
-
-        if (project.hasProperty("jcenterRepo")) {
-            maven {
-                name "BintrayJCenter"
-                url project.property("jcenterRepo")
-            }
-        } else {
-            jcenter() {
-                content {
-                    ////////////////////////////////////////////////////////////////////////////////
-                    // JCenter is going away. Please do not add any new dependencies here.
-                    // https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/
-                    ////////////////////////////////////////////////////////////////////////////////
-
-                    // Fastlane
-                    // Both Screengrab and falcon are available on Maven Central
-                }
-            }
-        }
     }
 
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -248,8 +248,8 @@ object RepoMatching {
     /**
      * A matcher for com.google.android.* with one exception: the espresso-contrib dependency includes the
      * accessibility-test-framework dependency, which is not available in the google repo. As such, we must
-     * explicitly exclude it from this regex so it can be found on jcenter. Note that the transitive dependency
-     * com.google.guava is also not available on google's repo.
+     * explicitly exclude it from this regex so it can be found on Maven Central. Note that the transitive
+     * dependency com.google.guava is also not available on google's repo.
      */
     const val comGoogleAndroid = "com\\.google\\.android\\.(?!apps\\.common\\.testing\\.accessibility\\.framework).*"
 }

--- a/taskcluster/fenix_taskgraph/job.py
+++ b/taskcluster/fenix_taskgraph/job.py
@@ -99,7 +99,7 @@ def _extract_gradlew_command(run, fetches_dir):
         "-P{repo_name}Repo=file://{dir}/{repo_name}".format(
             dir=maven_dependencies_dir, repo_name=repo_name
         )
-        for repo_name in ("google", "jcenter")
+        for repo_name in ("google", "central")
     ]
     gradle_command = ["./gradlew"] + gradle_repos_args + ["listRepositories"] + run.pop("gradlew")
     post_gradle_commands = run.pop("post-gradlew", [])

--- a/taskcluster/scripts/toolchain/android-gradle-dependencies.sh
+++ b/taskcluster/scripts/toolchain/android-gradle-dependencies.sh
@@ -19,7 +19,7 @@ pushd $PROJECT_DIR
 . taskcluster/scripts/toolchain/android-gradle-dependencies/before.sh
 
 NEXUS_PREFIX='http://localhost:8081/nexus/content/repositories'
-GRADLE_ARGS="--parallel -PgoogleRepo=$NEXUS_PREFIX/google/ -PjcenterRepo=$NEXUS_PREFIX/jcenter/ -PcentralRepo=$NEXUS_PREFIX/central/"
+GRADLE_ARGS="--parallel -PgoogleRepo=$NEXUS_PREFIX/google/ -PcentralRepo=$NEXUS_PREFIX/central/"
 # We build everything to be sure to fetch all dependencies
 ./gradlew $GRADLE_ARGS assemble assembleAndroidTest testClasses ktlint detekt
 # Some tests may be flaky, although they still download dependencies. So we let the following

--- a/taskcluster/scripts/toolchain/android-gradle-dependencies/after.sh
+++ b/taskcluster/scripts/toolchain/android-gradle-dependencies/after.sh
@@ -20,7 +20,6 @@ set -v
 pushd $WORKSPACE
 mkdir -p android-gradle-dependencies /builds/worker/artifacts
 
-cp -R ${NEXUS_WORK}/storage/jcenter android-gradle-dependencies
 cp -R ${NEXUS_WORK}/storage/google android-gradle-dependencies
 cp -R ${NEXUS_WORK}/storage/central android-gradle-dependencies
 

--- a/taskcluster/scripts/toolchain/android-gradle-dependencies/nexus.xml
+++ b/taskcluster/scripts/toolchain/android-gradle-dependencies/nexus.xml
@@ -24,37 +24,6 @@
   </routing>
   <repositories>
     <repository>
-      <id>jcenter</id>
-      <name>jcenter</name>
-      <providerRole>org.sonatype.nexus.proxy.repository.Repository</providerRole>
-      <providerHint>maven2</providerHint>
-      <localStatus>IN_SERVICE</localStatus>
-      <notFoundCacheActive>true</notFoundCacheActive>
-      <notFoundCacheTTL>1440</notFoundCacheTTL>
-      <userManaged>true</userManaged>
-      <exposed>true</exposed>
-      <browseable>true</browseable>
-      <writePolicy>READ_ONLY</writePolicy>
-      <indexable>true</indexable>
-      <searchable>true</searchable>
-      <localStorage>
-        <provider>file</provider>
-      </localStorage>
-      <remoteStorage>
-        <url>https://jcenter.bintray.com/</url>
-      </remoteStorage>
-      <externalConfiguration>
-        <repositoryPolicy>RELEASE</repositoryPolicy>
-        <checksumPolicy>STRICT</checksumPolicy>
-        <fileTypeValidation>true</fileTypeValidation>
-        <downloadRemoteIndex>false</downloadRemoteIndex>
-        <artifactMaxAge>-1</artifactMaxAge>
-        <metadataMaxAge>1440</metadataMaxAge>
-        <itemMaxAge>1440</itemMaxAge>
-        <autoBlockActive>true</autoBlockActive>
-      </externalConfiguration>
-    </repository>
-    <repository>
       <id>gradle-plugins</id>
       <name>Gradle Plugins</name>
       <providerRole>org.sonatype.nexus.proxy.repository.Repository</providerRole>


### PR DESCRIPTION
All dependencies have been migrated and we can finally remove JCenter. :)