### PR TITLE
For #19638 - Don't show extracted text UI for name when editing cards

### DIFF
--- a/app/src/main/res/layout/fragment_credit_card_editor.xml
+++ b/app/src/main/res/layout/fragment_credit_card_editor.xml
@@ -83,6 +83,7 @@
                 android:layout_height="wrap_content"
                 android:ellipsize="end"
                 android:fontFamily="sans-serif"
+                android:imeOptions="flagNoExtractUi"
                 android:letterSpacing="0.01"
                 android:lineSpacingExtra="8sp"
                 android:maxLines="1"


### PR DESCRIPTION
This comes to ensure consistency with the behavior for when editing the card
number.


https://user-images.githubusercontent.com/11428869/119676071-3d474080-be46-11eb-8829-56f4ff23e2f1.mp4



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
