### PR TITLE
For #16829: Increasing touch area for Scan and Search Engine buttons

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt
@@ -11,17 +11,14 @@ import android.content.Context
 import android.content.DialogInterface
 import android.content.Intent
 import android.graphics.Color
+import android.graphics.Rect
 import android.graphics.Typeface
 import android.graphics.drawable.ColorDrawable
 import android.os.Build
 import android.os.Bundle
 import android.speech.RecognizerIntent
 import android.text.style.StyleSpan
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
-import android.view.ViewStub
-import android.view.WindowManager
+import android.view.*
 import android.view.accessibility.AccessibilityEvent
 import android.view.inputmethod.InputMethodManager
 import androidx.appcompat.app.AlertDialog
@@ -68,6 +65,7 @@ import org.mozilla.fenix.search.awesomebar.AwesomeBarView
 import org.mozilla.fenix.search.toolbar.ToolbarView
 import org.mozilla.fenix.settings.SupportUtils
 import org.mozilla.fenix.widget.VoiceSearchActivity
+import kotlin.math.roundToInt
 
 typealias SearchDialogFragmentStore = SearchFragmentStore
 
@@ -269,6 +267,40 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
                 }
             }
             requireContext().settings().setCameraPermissionNeededState = false
+        }
+
+        // To increase touch area of the toggle buttons, without altering actual view bounds
+
+        fun Int.dpToPx() = (this * resources.displayMetrics.density).roundToInt()
+
+        search_engines_shortcut_layout.post {
+            val delegateArea = Rect()
+            search_engines_shortcut_button.apply { isEnabled = true }
+            search_engines_shortcut_layout.getHitRect(delegateArea)
+            delegateArea.top = search_engines_shortcut_button.top - 16.dpToPx()
+            delegateArea.bottom = search_engines_shortcut_button.bottom + 16.dpToPx()
+            delegateArea.left = search_engines_shortcut_button.left
+            delegateArea.right = search_engines_shortcut_button.right
+
+            (search_engines_shortcut_button.parent as? View)?.apply {
+                touchDelegate = TouchDelegate(delegateArea, search_engines_shortcut_button)
+            }
+
+        }
+
+        qr_scan_button_layout.post {
+            val delegateArea = Rect()
+            qr_scan_button.apply { isEnabled = true }
+            qr_scan_button_layout.getHitRect(delegateArea)
+            delegateArea.top = qr_scan_button.top - 16.dpToPx()
+            delegateArea.bottom = qr_scan_button.bottom + 16.dpToPx()
+            delegateArea.left = qr_scan_button.left
+            delegateArea.right = qr_scan_button.right
+
+            (qr_scan_button.parent as? View)?.apply {
+                touchDelegate = TouchDelegate(delegateArea, qr_scan_button)
+            }
+
         }
 
         fill_link_from_clipboard.setOnClickListener {

--- a/app/src/main/res/layout/fragment_search_dialog.xml
+++ b/app/src/main/res/layout/fragment_search_dialog.xml
@@ -172,25 +172,41 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
 
-    <ToggleButton
-        android:id="@+id/qr_scan_button"
-        style="@style/search_pill"
-        android:layout_marginEnd="@dimen/search_fragment_scan_button_margin_end"
-        android:textOff="@string/search_scan_button"
-        android:textOn="@string/search_scan_button"
-        app:drawableStartCompat="@drawable/ic_qr"
+    <RelativeLayout
+        android:id="@+id/qr_scan_button_layout"
+        android:layout_width="wrap_content"
+        android:layout_height="72dp"
         app:layout_constraintBottom_toBottomOf="@id/pill_wrapper"
-        app:layout_constraintEnd_toStartOf="@id/search_engines_shortcut_button"
+        app:layout_constraintEnd_toStartOf="@id/search_engines_shortcut_layout"
         app:layout_constraintStart_toStartOf="@id/pill_wrapper"
-        app:layout_constraintTop_toTopOf="@id/pill_wrapper" />
+        app:layout_constraintTop_toTopOf="@id/pill_wrapper">
 
-    <ToggleButton
-        android:id="@+id/search_engines_shortcut_button"
-        style="@style/search_pill"
-        android:textOff="@string/search_engine_button"
-        android:textOn="@string/search_engine_button"
-        app:drawableStartCompat="@drawable/ic_search"
+        <ToggleButton
+            android:id="@+id/qr_scan_button"
+            style="@style/search_pill"
+            android:layout_centerInParent="true"
+            android:layout_marginEnd="@dimen/search_fragment_scan_button_margin_end"
+            android:textOff="@string/search_scan_button"
+            android:textOn="@string/search_scan_button"
+            app:drawableStartCompat="@drawable/ic_qr" />
+
+    </RelativeLayout>
+
+    <RelativeLayout
+        android:id="@+id/search_engines_shortcut_layout"
+        android:layout_width="wrap_content"
+        android:layout_height="72dp"
         app:layout_constraintBottom_toBottomOf="@id/pill_wrapper"
-        app:layout_constraintStart_toEndOf="@id/qr_scan_button"
-        app:layout_constraintTop_toTopOf="@id/pill_wrapper" />
+        app:layout_constraintStart_toEndOf="@id/qr_scan_button_layout"
+        app:layout_constraintTop_toTopOf="@id/pill_wrapper">
+
+        <ToggleButton
+            android:id="@+id/search_engines_shortcut_button"
+            style="@style/search_pill"
+            android:layout_centerInParent="true"
+            android:textOff="@string/search_engine_button"
+            android:textOn="@string/search_engine_button"
+            app:drawableStartCompat="@drawable/ic_search" />
+
+    </RelativeLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
- TouchDelegate API has been used to increase touch area, and not actual view bounds
- Fixes #16829 
- Reasoning for some of the code: 
1. In `SearchDialogFragment.kt`, I took the increase in touch area as **16dp** and not 4 or 8dp. This is because on manual testing with 4/8dp increase, I couldn't observe a noticeable difference in ease of clicking. 
2. I tried using LinearLayout instead of RelativeLayout in `fragment_search_dialog.xml` but it was affecting the UI a bit, so used RelativeLayout.
3. **Separate RelativeLayout for each button** --> because TouchDelegate had to be used with an ancestor of the button and not just button itself. Also, as far as I could understand from available documentation - a View manages a single TouchDelegate i.e.  by default, one can’t have several ‘delegation areas’ for a single View.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

### Screenshot 

Google Accessibility Scanner does not display any message related to these 2 buttons anymore.

![image](https://user-images.githubusercontent.com/67039214/119705557-82836680-be76-11eb-91cc-714a022737b3.png)

