### PR TITLE
Issue #19647: Navigate to browser from home via Synced Tabs page

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/BrowserDirection.kt
+++ b/app/src/main/java/org/mozilla/fenix/BrowserDirection.kt
@@ -31,6 +31,7 @@ enum class BrowserDirection(@IdRes val fragmentId: Int) {
     FromAddonDetailsFragment(R.id.addonDetailsFragment),
     FromAddonPermissionsDetailsFragment(R.id.addonPermissionsDetailFragment),
     FromLoginDetailFragment(R.id.loginDetailFragment),
-    FromTabTray(R.id.tabTrayDialogFragment),
+    FromTabTrayDialog(R.id.tabTrayDialogFragment),
+    FromTabTray(R.id.tabsTrayFragment),
     FromRecentlyClosed(R.id.recentlyClosedFragment)
 }

--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -112,6 +112,7 @@ import org.mozilla.fenix.settings.search.AddSearchEngineFragmentDirections
 import org.mozilla.fenix.settings.search.EditCustomSearchEngineFragmentDirections
 import org.mozilla.fenix.share.AddNewDeviceFragmentDirections
 import org.mozilla.fenix.sync.SyncedTabsFragmentDirections
+import org.mozilla.fenix.tabstray.TabsTrayFragmentDirections
 import org.mozilla.fenix.tabtray.TabTrayDialogFragment
 import org.mozilla.fenix.tabtray.TabTrayDialogFragmentDirections
 import org.mozilla.fenix.theme.DefaultThemeManager
@@ -812,8 +813,10 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
             AddonPermissionsDetailsFragmentDirections.actionGlobalBrowser(customTabSessionId)
         BrowserDirection.FromLoginDetailFragment ->
             LoginDetailFragmentDirections.actionGlobalBrowser(customTabSessionId)
-        BrowserDirection.FromTabTray ->
+        BrowserDirection.FromTabTrayDialog ->
             TabTrayDialogFragmentDirections.actionGlobalBrowser(customTabSessionId)
+        BrowserDirection.FromTabTray ->
+            TabsTrayFragmentDirections.actionGlobalBrowser(customTabSessionId)
         BrowserDirection.FromRecentlyClosed ->
             RecentlyClosedFragmentDirections.actionGlobalBrowser(customTabSessionId)
     }

--- a/app/src/main/java/org/mozilla/fenix/tabstray/NavigationInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/NavigationInteractor.kt
@@ -198,11 +198,13 @@ class DefaultNavigationInteractor(
             }
         }
 
-        // TODO show successful snackbar here (regardless of operation succes).
+        // TODO show successful snackbar here (regardless of operation success).
     }
 
     override fun onSyncedTabClicked(tab: SyncTab) {
         metrics.track(Event.SyncedTabOpened)
+
+        dismissTabTray()
         activity.openToBrowserAndLoad(
             searchTermOrURL = tab.active().url,
             newTab = true,

--- a/app/src/test/java/org/mozilla/fenix/tabstray/NavigationInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/NavigationInteractorTest.kt
@@ -13,6 +13,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
+import io.mockk.verifyOrder
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlinx.coroutines.test.runBlockingTest
@@ -258,8 +259,10 @@ class NavigationInteractorTest {
 
         navigationInteractor.onSyncedTabClicked(tab)
 
-        verify { metrics.track(Event.SyncedTabOpened) }
-        verify {
+        verifyOrder {
+            metrics.track(Event.SyncedTabOpened)
+
+            dismissTabTray()
             activity.openToBrowserAndLoad(
                 searchTermOrURL = "https://mozilla.org",
                 newTab = true,


### PR DESCRIPTION
> Figured out the issue: the nav graph was still referencing the old tab tray dialog as the "from" address and this affected our transition from home to browser view.
> 
> Adding a separate entry for the new tray until we remove the old code in #19112.

https://user-images.githubusercontent.com/1370580/119716590-411d9780-be33-11eb-9c21-c0c545306c0a.mp4


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
