### PR TITLE
Close #19459: Use Store.waitUntilIdle in intermittent failing test

### DIFF
--- a/app/src/test/java/org/mozilla/fenix/nimbus/NimbusBranchesControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/nimbus/NimbusBranchesControllerTest.kt
@@ -7,7 +7,8 @@ package org.mozilla.fenix.nimbus
 import io.mockk.mockk
 import io.mockk.verify
 import mozilla.components.service.nimbus.NimbusApi
-import mozilla.components.support.test.mock
+import mozilla.components.support.test.libstate.ext.waitUntilIdle
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.mozilla.experiments.nimbus.Branch
@@ -24,7 +25,7 @@ class NimbusBranchesControllerTest {
 
     @Before
     fun setup() {
-        nimbusBranchesStore = mock()
+        nimbusBranchesStore = NimbusBranchesStore(NimbusBranchesState(emptyList()))
         controller = NimbusBranchesController(nimbusBranchesStore, experiments, experimentId)
     }
 
@@ -41,9 +42,12 @@ class NimbusBranchesControllerTest {
 
         controller.onBranchItemClicked(branch)
 
+        nimbusBranchesStore.waitUntilIdle()
+
         verify {
             experiments.optInWithBranch(experimentId, branch.slug)
-            nimbusBranchesStore.dispatch(NimbusBranchesAction.UpdateSelectedBranch(branch.slug))
         }
+
+        assertEquals(branch.slug, nimbusBranchesStore.state.selectedBranch)
     }
 }


### PR DESCRIPTION
Close #19459

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
