### PR TITLE
For #19492 - Provide the correct CreditCardNumber type to UpdatableCreditCardFields when updating a credit card

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/creditcards/view/CreditCardEditorView.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/creditcards/view/CreditCardEditorView.kt
@@ -17,6 +17,7 @@ import mozilla.components.support.ktx.android.view.hideKeyboard
 import mozilla.components.support.utils.creditCardIIN
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.toEditable
+import org.mozilla.fenix.settings.creditcards.CreditCardEditorFragment
 import org.mozilla.fenix.settings.creditcards.CreditCardEditorState
 import org.mozilla.fenix.settings.creditcards.interactor.CreditCardEditorInteractor
 import org.mozilla.fenix.settings.creditcards.last4Digits
@@ -64,8 +65,10 @@ class CreditCardEditorView(
     }
 
     /**
-     * Saves a new credit card or updates an existing one with data from user input.
-     * @param state The state for the CreditCardEditorFragment containing all credit card data.
+     * Saves a new credit card or updates an existing one with data from the user input.
+     *
+     * @param state The state of the [CreditCardEditorFragment] containing the edited credit card
+     * information.
      */
     internal fun saveCreditCard(state: CreditCardEditorState) {
         containerView.hideKeyboard()
@@ -76,7 +79,7 @@ class CreditCardEditorView(
             if (state.isEditing) {
                 val fields = UpdatableCreditCardFields(
                     billingName = name_on_card_input.text.toString(),
-                    cardNumber = CreditCardNumber.Encrypted(cardNumber),
+                    cardNumber = CreditCardNumber.Plaintext(cardNumber),
                     cardNumberLast4 = cardNumber.last4Digits(),
                     expiryMonth = (expiry_month_drop_down.selectedItemPosition + 1).toLong(),
                     expiryYear = expiry_year_drop_down.selectedItem.toString().toLong(),
@@ -99,6 +102,7 @@ class CreditCardEditorView(
 
     /**
      * Validates the credit card information entered by the user.
+     *
      * @return true if the credit card is valid, false otherwise.
      */
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)

--- a/app/src/test/java/org/mozilla/fenix/settings/creditcards/CreditCardEditorViewTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/creditcards/CreditCardEditorViewTest.kt
@@ -222,7 +222,7 @@ class CreditCardEditorViewTest {
                 guid = creditCard.guid,
                 creditCardFields = UpdatableCreditCardFields(
                     billingName = creditCard.billingName,
-                    cardNumber = creditCard.encryptedCardNumber,
+                    cardNumber = CreditCardNumber.Plaintext(cardNumber),
                     cardNumberLast4 = creditCard.cardNumberLast4,
                     expiryMonth = creditCard.expiryMonth,
                     expiryYear = creditCard.expiryYear,


### PR DESCRIPTION
Fixes #19492

We were crashing because we were specifying the wrong `CreditCardNumber` type when constructing the `UpdatableCreditCardFields`.
We only had the plaintext card number from the user input, but was placing it off as an encrypted card number, which resulted in the crash.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
