### PR TITLE
Revert "Minor account settings cleanup & enable addresses sync for nightly/debug channels"

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/BackgroundServices.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/BackgroundServices.kt
@@ -36,7 +36,6 @@ import mozilla.components.service.sync.autofill.AutofillCreditCardsAddressesStor
 import mozilla.components.service.sync.logins.SyncableLoginsStorage
 import mozilla.components.support.utils.RunWhenReadyQueue
 import org.mozilla.fenix.Config
-import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.R
 import org.mozilla.fenix.perf.StrictModeManager
 import org.mozilla.fenix.components.metrics.Event
@@ -94,13 +93,12 @@ class BackgroundServices(
 
     @VisibleForTesting
     val supportedEngines =
-        setOfNotNull(
+        setOf(
             SyncEngine.History,
             SyncEngine.Bookmarks,
             SyncEngine.Passwords,
             SyncEngine.Tabs,
-            SyncEngine.CreditCards,
-            if (FeatureFlags.addressesFeature) SyncEngine.Addresses else null
+            SyncEngine.CreditCards
         )
     private val syncConfig =
         SyncConfig(supportedEngines, PeriodicSyncConfig(periodMinutes = 240)) // four hours
@@ -118,9 +116,6 @@ class BackgroundServices(
             storePair = SyncEngine.CreditCards to creditCardsStorage,
             keyProvider = lazy { creditCardKeyProvider }
         )
-        if (FeatureFlags.addressesFeature) {
-            GlobalSyncableStoreProvider.configureStore(SyncEngine.Addresses to creditCardsStorage)
-        }
     }
 
     private val telemetryAccountObserver = TelemetryAccountObserver(

--- a/app/src/main/res/xml/account_settings_preferences.xml
+++ b/app/src/main/res/xml/account_settings_preferences.xml
@@ -30,7 +30,8 @@
             android:title="@string/preferences_sync_bookmarks" />
 
         <CheckBoxPreference
-            android:defaultValue="true"
+            android:defaultValue="false"
+            android:visible="false"
             android:key="@string/pref_key_sync_credit_cards"
             android:layout="@layout/checkbox_left_preference"
             android:title="@string/preferences_sync_credit_cards" />
@@ -48,14 +49,13 @@
             android:title="@string/preferences_sync_logins" />
 
         <CheckBoxPreference
-            android:defaultValue="true"
+            android:defaultValue="false"
             android:key="@string/pref_key_sync_tabs"
             android:layout="@layout/checkbox_left_preference"
             android:title="@string/preferences_sync_tabs_2"/>
 
-        <!-- The default visibility is 'false' because we don't display this on most channels. -->
         <CheckBoxPreference
-            android:defaultValue="true"
+            android:defaultValue="false"
             android:visible="false"
             android:key="@string/pref_key_sync_address"
             android:layout="@layout/checkbox_left_preference"


### PR DESCRIPTION
Let's revert this to help with the A-S team with investigation of https://github.com/mozilla/application-services/issues/4035.

We want to confirm if the spike is triggered by problems with the new addresses sync.
