### PR TITLE
Close #19731: Track metrics before we dismiss the tabs tray

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabstray/NavigationInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/NavigationInteractor.kt
@@ -105,6 +105,7 @@ class DefaultNavigationInteractor(
 ) : NavigationInteractor {
 
     override fun onTabTrayDismissed() {
+        metrics.track(Event.TabsTrayClosed)
         dismissTabTray()
     }
 

--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
@@ -365,8 +365,9 @@ class TabsTrayFragment : AppCompatDialogFragment() {
 
     @VisibleForTesting
     internal fun dismissTabsTray() {
+        // This should always be the last thing we do because nothing (e.g. telemetry)
+        // is guaranteed after that.
         dismissAllowingStateLoss()
-        requireComponents.analytics.metrics.track(Event.TabsTrayClosed)
     }
 
     companion object {

--- a/app/src/test/java/org/mozilla/fenix/tabstray/NavigationInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/NavigationInteractorTest.kt
@@ -167,7 +167,12 @@ class NavigationInteractorTest {
     @Test
     fun `onTabTrayDismissed calls dismissTabTray on DefaultNavigationInteractor`() {
         navigationInteractor.onTabTrayDismissed()
-        verify(exactly = 1) { dismissTabTray() }
+
+        // We care about the order here; anything after `dismissTabTray` is not guaranteed.
+        verifyOrder {
+            metrics.track(Event.TabsTrayClosed)
+            dismissTabTray()
+        }
     }
 
     @Test

--- a/app/src/test/java/org/mozilla/fenix/tabstray/TabsTrayFragmentTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/TabsTrayFragmentTest.kt
@@ -335,7 +335,7 @@ class TabsTrayFragmentTest {
     }
 
     @Test
-    fun `WHEN dismissTabsTray is called THEN it dismisses the tray and record this event`() {
+    fun `WHEN dismissTabsTray is called THEN it dismisses the tray`() {
         every { fragment.dismissAllowingStateLoss() } just Runs
         val metrics: MetricController = mockk(relaxed = true)
         every { context.components.analytics.metrics } returns metrics
@@ -343,6 +343,5 @@ class TabsTrayFragmentTest {
         fragment.dismissTabsTray()
 
         verify { fragment.dismissAllowingStateLoss() }
-        verify { metrics.track(Event.TabsTrayClosed) }
     }
 }


### PR DESCRIPTION
Having the track event happen after calling `dismiss` to the tabs tray, would mean that we need to make sure our track events are done before we lose the context of that fragment. This is obviously a race that we can avoid by correcting the order of events.

Also, from my [comment](https://github.com/mozilla-mobile/fenix/issues/19731#issuecomment-851567672) in the issue..

> Thinking about it more, I think it would make sense to call the track event in [the navigation interactor](https://github.com/mozilla-mobile/fenix/blob/master/app/src/main/java/org/mozilla/fenix/tabstray/NavigationInteractor.kt#L108) since that's really the real case where we want to track the user event. The other places are side-effects to other interactions (like clicking a synced tab).
> 
> This would also make that method a bit more testable without mocking the world for the `TabsTrayFragment`.

Fixes #19731 which is covered by a test and don't require QA.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
