### PR TITLE
For #18877 - Support updated PromptRequest AC APIs

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/share/ShareFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/share/ShareFragment.kt
@@ -135,10 +135,10 @@ class ShareFragment : AppCompatDialogFragment() {
         args.sessionId
             ?.let { sessionId -> browserStore.state.findTabOrCustomTab(sessionId) }
             ?.let { tab ->
-                val promptRequest = tab.content.promptRequest
+                val promptRequest = tab.content.promptRequests.lastOrNull { it is PromptRequest.Share }
                 if (promptRequest is PromptRequest.Share) {
                     consume(promptRequest)
-                    browserStore.dispatch(ContentAction.ConsumePromptRequestAction(tab.id))
+                    browserStore.dispatch(ContentAction.ConsumePromptRequestAction(tab.id, promptRequest))
                 }
             }
     }

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "91.0.20210601143118"
+    const val VERSION = "91.0.20210603145049"
 }


### PR DESCRIPTION
This issue stemming from a race condition is fully resolved in AC by adding
support for having multiple prompts at a time.
Fenix needs just a small change to support the AC refactoring from https://github.com/mozilla-mobile/android-components/pull/10273

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
