### PR TITLE
Fixes #19773 - Add a needs:review label to the automatic String Sync PRs

### DIFF
--- a/.github/workflows/sync-strings.yml
+++ b/.github/workflows/sync-strings.yml
@@ -39,3 +39,4 @@ jobs:
           branch: automation/sync-strings-${{ steps.fenix-beta-version.outputs.major-beta-version }}
           title: "Sync Strings from master to releases_${{steps.fenix-beta-version.outputs.fenix-beta-version}}.0"
           body: "This (automated) PR syncs strings from `master` to `releases_${{steps.fenix-beta-version.outputs.fenix-beta-version}}.0.0`"
+          labels: needs:review


### PR DESCRIPTION
This PR is a small update to the `sync-strings.yml` workflow that asks the `create-pull-request` action to set the `needs:review` label to the generated PRs.