### PR TITLE
For #19191 - Fixes missing multi-select checkmarks

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabstray/browser/BrowserTrayList.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/browser/BrowserTrayList.kt
@@ -73,6 +73,8 @@ class BrowserTrayList @JvmOverloads constructor(
         tabsFeature.start()
         swipeToDelete.start()
 
+        adapter?.onAttachedToRecyclerView(this)
+
         touchHelper.attachToRecyclerView(this)
     }
 


### PR DESCRIPTION
For https://github.com/mozilla-mobile/fenix/issues/19191
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR doesn't include any tests as it is only a minor change.
- [x] **Screenshots**: This PR includes screenshots or GIFs.
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture




https://user-images.githubusercontent.com/60002907/120786092-82e6c600-c536-11eb-96c8-c697d60f58d0.mp4

### Notes:
The problem arises from the fact that when changing the page of the tabs tray to either Sync or Private `onDetachedFromWindow` (`BrowserTrayList.kt`) is called on the Normal adapter, triggering `adapter?.onDetachedFromRecyclerView` ->`selectedItemAdapterBinding.stop()`. 
But when returning to the Normal Tabs Page -> `onAttachedToWindow()` is executed but we would not run `adapter?.onAttachedToRecyclerView` so the `selectedItemAdapterBinding` would not restart.

An alternative solution would be to configure the `tabsTray` pager in `TabsTrayFragment.kt` to `offscreenPageLimit=2` thus keeping all tab page adapters running at the same time and bypassing the `onDetachedFromWindow` call altogether. That would make switching between the pages faster but at the cost of memory.


PS: Thank you @Mugurell for all the help <3

