### PR TITLE
For #19738 - Secure mode enabled in private tabs tray

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabstray/SecureTabsTrayBinding.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/SecureTabsTrayBinding.kt
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabstray
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.map
+import mozilla.components.lib.state.helpers.AbstractBinding
+import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifAnyChanged
+import org.mozilla.fenix.ext.removeSecure
+import org.mozilla.fenix.ext.secure
+import org.mozilla.fenix.utils.Settings
+
+/**
+ * Sets TabsTrayFragment flags to secure when private tabs list is selected.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SecureTabsTrayBinding(
+    store: TabsTrayStore,
+    private val settings: Settings,
+    private val tabsTrayFragment: TabsTrayFragment
+) : AbstractBinding<TabsTrayState>(store) {
+
+    override suspend fun onState(flow: Flow<TabsTrayState>) {
+        flow.map { it }
+            .ifAnyChanged { state ->
+                arrayOf(
+                    state.selectedPage
+                )
+            }
+            .collect { state ->
+                if (state.selectedPage == Page.PrivateTabs) {
+                    tabsTrayFragment.secure()
+                } else if (!settings.lastKnownMode.isPrivate) {
+                    tabsTrayFragment.removeSecure()
+                }
+            }
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/tabstray/SecureTabsTrayBinding.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/SecureTabsTrayBinding.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.fenix.tabstray
 
+import androidx.fragment.app.Fragment
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
@@ -21,7 +22,7 @@ import org.mozilla.fenix.utils.Settings
 class SecureTabsTrayBinding(
     store: TabsTrayStore,
     private val settings: Settings,
-    private val tabsTrayFragment: TabsTrayFragment
+    private val fragment: Fragment
 ) : AbstractBinding<TabsTrayState>(store) {
 
     override suspend fun onState(flow: Flow<TabsTrayState>) {
@@ -33,9 +34,9 @@ class SecureTabsTrayBinding(
             }
             .collect { state ->
                 if (state.selectedPage == Page.PrivateTabs) {
-                    tabsTrayFragment.secure()
+                    fragment.secure()
                 } else if (!settings.lastKnownMode.isPrivate) {
-                    tabsTrayFragment.removeSecure()
+                    fragment.removeSecure()
                 }
             }
     }

--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
@@ -267,7 +267,7 @@ class TabsTrayFragment : AppCompatDialogFragment() {
             feature = SecureTabsTrayBinding(
                 store = tabsTrayStore,
                 settings = requireComponents.settings,
-                tabsTrayFragment = this
+                fragment = this
             ),
             owner = this,
             view = view

--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
@@ -67,6 +67,7 @@ class TabsTrayFragment : AppCompatDialogFragment() {
     private val selectionBannerBinding = ViewBoundFeatureWrapper<SelectionBannerBinding>()
     private val selectionHandleBinding = ViewBoundFeatureWrapper<SelectionHandleBinding>()
     private val tabsTrayCtaBinding = ViewBoundFeatureWrapper<TabsTrayInfoBannerBinding>()
+    private val secureTabsTrayBinding = ViewBoundFeatureWrapper<SecureTabsTrayBinding>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -257,6 +258,16 @@ class TabsTrayFragment : AppCompatDialogFragment() {
                 store = tabsTrayStore,
                 handle = handle,
                 containerLayout = tab_wrapper
+            ),
+            owner = this,
+            view = view
+        )
+
+        secureTabsTrayBinding.set(
+            feature = SecureTabsTrayBinding(
+                store = tabsTrayStore,
+                settings = requireComponents.settings,
+                tabsTrayFragment = this
             ),
             owner = this,
             view = view

--- a/app/src/test/java/org/mozilla/fenix/tabstray/SecureTabsTrayBindingTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/SecureTabsTrayBindingTest.kt
@@ -1,0 +1,92 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabstray
+
+import androidx.appcompat.content.res.AppCompatResources
+import androidx.fragment.app.Fragment
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import mozilla.components.support.test.libstate.ext.waitUntilIdle
+import mozilla.components.support.test.rule.MainCoroutineRule
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mozilla.fenix.ext.removeSecure
+import org.mozilla.fenix.ext.secure
+import org.mozilla.fenix.utils.Settings
+
+class SecureTabsTrayBindingTest {
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule(TestCoroutineDispatcher())
+
+    private val settings: Settings = mockk(relaxed = true)
+    private val fragment: Fragment = mockk(relaxed = true)
+
+    @Before
+    fun setup() {
+        mockkStatic(AppCompatResources::class)
+        every { AppCompatResources.getDrawable(any(), any()) } returns mockk(relaxed = true)
+        every { fragment.secure() } just Runs
+        every { fragment.removeSecure() } just Runs
+    }
+
+    @Test
+    fun `WHEN tab selected page switches to private THEN set fragment to secure`() {
+        val tabsTrayStore = TabsTrayStore(TabsTrayState())
+        val secureTabsTrayBinding = SecureTabsTrayBinding(
+            store = tabsTrayStore,
+            settings = settings,
+            fragment = fragment
+        )
+
+        secureTabsTrayBinding.start()
+        tabsTrayStore.dispatch(TabsTrayAction.PageSelected(Page.positionToPage(Page.PrivateTabs.ordinal)))
+        tabsTrayStore.waitUntilIdle()
+
+        verify { fragment.secure() }
+    }
+
+    @Test
+    fun `GIVEN not in private mode WHEN tab selected page switches to normal tabs from private THEN set fragment to un-secure`() {
+        every { settings.lastKnownMode.isPrivate } returns false
+        val tabsTrayStore = TabsTrayStore(TabsTrayState())
+        val secureTabsTrayBinding = SecureTabsTrayBinding(
+            store = tabsTrayStore,
+            settings = settings,
+            fragment = fragment
+        )
+
+        secureTabsTrayBinding.start()
+        tabsTrayStore.dispatch(TabsTrayAction.PageSelected(Page.positionToPage(Page.NormalTabs.ordinal)))
+        tabsTrayStore.waitUntilIdle()
+
+        verify { fragment.removeSecure() }
+    }
+
+    @Test
+    fun `GIVEN private mode WHEN tab selected page switches to normal tabs from private THEN do nothing`() {
+        every { settings.lastKnownMode.isPrivate } returns true
+        val tabsTrayStore = TabsTrayStore(TabsTrayState())
+        val secureTabsTrayBinding = SecureTabsTrayBinding(
+            store = tabsTrayStore,
+            settings = settings,
+            fragment = fragment
+        )
+
+        secureTabsTrayBinding.start()
+        tabsTrayStore.dispatch(TabsTrayAction.PageSelected(Page.positionToPage(Page.NormalTabs.ordinal)))
+        tabsTrayStore.waitUntilIdle()
+
+        verify(exactly = 0) { fragment.removeSecure() }
+    }
+}


### PR DESCRIPTION
 Prevents screenshots while tabs tray with private tabs page is open.

For https://github.com/mozilla-mobile/fenix/issues/19738

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests.
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made.
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture


https://user-images.githubusercontent.com/60002907/120822248-e4bb2600-c55e-11eb-91d5-cd446fe9bbf2.mp4

