### PR TITLE
For #19495 - Add validation for the name on card

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/creditcards/view/CreditCardEditorView.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/creditcards/view/CreditCardEditorView.kt
@@ -73,7 +73,7 @@ class CreditCardEditorView(
     internal fun saveCreditCard(state: CreditCardEditorState) {
         containerView.hideKeyboard()
 
-        if (validateCreditCard()) {
+        if (validateForm()) {
             val cardNumber = card_number_input.text.toString().toCreditCardNumber()
 
             if (state.isEditing) {
@@ -103,20 +103,32 @@ class CreditCardEditorView(
     /**
      * Validates the credit card information entered by the user.
      *
-     * @return true if the credit card is valid, false otherwise.
+     * @return true if the credit card information is valid, false otherwise.
      */
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    internal fun validateCreditCard(): Boolean {
+    internal fun validateForm(): Boolean {
         var isValid = true
 
         if (card_number_input.text.toString().validateCreditCardNumber()) {
             card_number_layout.error = null
             card_number_title.setTextColor(containerView.context.getColorFromAttr(R.attr.primaryText))
         } else {
+            isValid = false
+
             card_number_layout.error =
                 containerView.context.getString(R.string.credit_cards_number_validation_error_message)
             card_number_title.setTextColor(containerView.context.getColorFromAttr(R.attr.destructive))
+        }
+
+        if (name_on_card_input.text.toString().isNotBlank()) {
+            name_on_card_layout.error = null
+            name_on_card_title.setTextColor(containerView.context.getColorFromAttr(R.attr.primaryText))
+        } else {
             isValid = false
+
+            name_on_card_layout.error =
+                containerView.context.getString(R.string.credit_cards_name_on_card_validation_error_message)
+            name_on_card_title.setTextColor(containerView.context.getColorFromAttr(R.attr.destructive))
         }
 
         return isValid

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1553,6 +1553,8 @@
     <string name="credit_cards_saved_cards">Saved cards</string>
     <!-- Error message for credit card number validation -->
     <string name="credit_cards_number_validation_error_message">Please enter a valid credit card number</string>
+    <!-- Error message for credit card name on card validation -->
+    <string name="credit_cards_name_on_card_validation_error_message">Please fill out this field</string>
     <!-- Message displayed in biometric prompt displayed for authentication before allowing users to view their saved credit cards -->
     <string name="credit_cards_biometric_prompt_message">Unlock to view your saved cards</string>
     <!-- Title of warning dialog if users have no device authentication set up -->

--- a/app/src/test/java/org/mozilla/fenix/settings/creditcards/CreditCardEditorViewTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/creditcards/CreditCardEditorViewTest.kt
@@ -143,7 +143,7 @@ class CreditCardEditorViewTest {
 
         val calendar = Calendar.getInstance()
 
-        val billingName = "Banana Apple"
+        var billingName = "Banana Apple"
         val cardNumber = "2221000000000000"
         val expiryMonth = 5
         val expiryYear = calendar.get(Calendar.YEAR)
@@ -155,10 +155,67 @@ class CreditCardEditorViewTest {
         view.save_button.performClick()
 
         verify {
-            creditCardEditorView.validateCreditCard()
+            creditCardEditorView.validateForm()
         }
 
-        assertFalse(creditCardEditorView.validateCreditCard())
+        assertFalse(creditCardEditorView.validateForm())
+
+        verify(exactly = 0) {
+            interactor.onSaveCreditCard(
+                NewCreditCardFields(
+                    billingName = billingName,
+                    plaintextCardNumber = CreditCardNumber.Plaintext(cardNumber),
+                    cardNumberLast4 = "0000",
+                    expiryMonth = expiryMonth.toLong(),
+                    expiryYear = expiryYear.toLong(),
+                    cardType = CreditCardNetworkType.MASTERCARD.cardName
+                )
+            )
+        }
+
+        billingName = ""
+        view.name_on_card_input.text = billingName.toEditable()
+
+        view.save_button.performClick()
+
+        assertFalse(creditCardEditorView.validateForm())
+
+        verify(exactly = 0) {
+            interactor.onSaveCreditCard(
+                NewCreditCardFields(
+                    billingName = billingName,
+                    plaintextCardNumber = CreditCardNumber.Plaintext(cardNumber),
+                    cardNumberLast4 = "0000",
+                    expiryMonth = expiryMonth.toLong(),
+                    expiryYear = expiryYear.toLong(),
+                    cardType = CreditCardNetworkType.MASTERCARD.cardName
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `GIVEN invalid name on card WHEN the save button is clicked THEN interactor is not called`() {
+        creditCardEditorView.bind(getInitialCreditCardEditorState())
+
+        val calendar = Calendar.getInstance()
+
+        val billingName = "       "
+        val cardNumber = "2221000000000000"
+        val expiryMonth = 5
+        val expiryYear = calendar.get(Calendar.YEAR)
+
+        view.card_number_input.text = cardNumber.toEditable()
+        view.name_on_card_input.text = billingName.toEditable()
+        view.expiry_month_drop_down.setSelection(expiryMonth - 1)
+
+        view.save_button.performClick()
+
+        verify {
+            creditCardEditorView.validateForm()
+        }
+
+        assertFalse(creditCardEditorView.validateForm())
 
         verify(exactly = 0) {
             interactor.onSaveCreditCard(
@@ -192,10 +249,10 @@ class CreditCardEditorViewTest {
         view.save_button.performClick()
 
         verify {
-            creditCardEditorView.validateCreditCard()
+            creditCardEditorView.validateForm()
         }
 
-        assertTrue(creditCardEditorView.validateCreditCard())
+        assertTrue(creditCardEditorView.validateForm())
 
         verify {
             interactor.onSaveCreditCard(


### PR DESCRIPTION
Fixes #19495

- We want to ensure that name on card in the credit card is not empty when submitted. Display an appropriate error when the field is invalid.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
