### PR TITLE
Re-instate catch-all to withExperiment

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/ext/Nimbus.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/Nimbus.kt
@@ -29,6 +29,7 @@ fun <T> NimbusApi.withExperiment(featureId: FeatureId, transform: (String?) -> T
  *
  * Short-hand for ` org.mozilla.experiments.nimbus.NimbusApi.getExperimentBranch`.
  */
+@Suppress("TooGenericExceptionCaught")
 fun NimbusApi.withExperiment(featureId: FeatureId) =
     try {
         getExperimentBranch(featureId.jsonName)

--- a/app/src/main/java/org/mozilla/fenix/ext/Nimbus.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/Nimbus.kt
@@ -5,6 +5,7 @@
 package org.mozilla.fenix.ext
 
 import mozilla.components.service.nimbus.NimbusApi
+import mozilla.components.support.base.log.logger.Logger
 import org.mozilla.experiments.nimbus.Variables
 import org.mozilla.fenix.experiments.FeatureId
 
@@ -20,7 +21,7 @@ import org.mozilla.fenix.experiments.FeatureId
  * is passed a `null`.
  */
 fun <T> NimbusApi.withExperiment(featureId: FeatureId, transform: (String?) -> T): T {
-    return transform(getExperimentBranch(featureId.jsonName))
+    return transform(withExperiment(featureId))
 }
 
 /**
@@ -29,7 +30,12 @@ fun <T> NimbusApi.withExperiment(featureId: FeatureId, transform: (String?) -> T
  * Short-hand for ` org.mozilla.experiments.nimbus.NimbusApi.getExperimentBranch`.
  */
 fun NimbusApi.withExperiment(featureId: FeatureId) =
-    getExperimentBranch(featureId.jsonName)
+    try {
+        getExperimentBranch(featureId.jsonName)
+    } catch (e: Throwable) {
+        Logger.error("Failed to getExperimentBranch(${featureId.jsonName})", e)
+        null
+    }
 
 /**
  * Get the variables needed to configure the feature given by `featureId`.


### PR DESCRIPTION
Fixes #19837

This catch-all should go away once:

1. Application Services `Nimbus` wraps `getExperimentBranch` in a catchAll. We should keep track of `DatabaseNotReadyExceptions`.
2. Once experiments move away from `getExperimentBranch()` to `getVariables`.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture