### PR TITLE
For #19797 - Go to problems page if account exists but not signed in

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/accounts/FenixAccountManager.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/accounts/FenixAccountManager.kt
@@ -5,18 +5,13 @@
 package org.mozilla.fenix.components.accounts
 
 import android.content.Context
-import mozilla.components.service.fxa.manager.FxaAccountManager
 import org.mozilla.fenix.ext.components
 
 /**
- * Component which holds a reference to [FxaAccountManager]. Manages account authentication,
- * profiles, and profile state observers.
+ * Contains helper methods for querying Firefox Account state and its properties.
  */
-open class FenixAccountManager(context: Context) {
-    val accountManager = context.components.backgroundServices.accountManager
-
-    val authenticatedAccount
-        get() = accountManager.authenticatedAccount() != null
+class FenixAccountManager(context: Context) {
+    private val accountManager = context.components.backgroundServices.accountManager
 
     /**
      * Returns the Firefox Account email if authenticated in the app, `null` otherwise.

--- a/app/src/main/java/org/mozilla/fenix/components/accounts/FenixAccountManager.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/accounts/FenixAccountManager.kt
@@ -18,8 +18,15 @@ open class FenixAccountManager(context: Context) {
     val authenticatedAccount
         get() = accountManager.authenticatedAccount() != null
 
-    val accountProfileEmail
-        get() = accountManager.accountProfile()?.email
+    /**
+     * Returns the Firefox Account email if authenticated in the app, `null` otherwise.
+     */
+    val accountProfileEmail: String?
+        get() = if (accountState == AccountState.AUTHENTICATED) {
+            accountManager.accountProfile()?.email
+        } else {
+            null
+        }
 
     /**
      * The current state of the Firefox Account. See [AccountState].

--- a/app/src/main/java/org/mozilla/fenix/components/accounts/FenixAccountManager.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/accounts/FenixAccountManager.kt
@@ -22,6 +22,20 @@ open class FenixAccountManager(context: Context) {
         get() = accountManager.accountProfile()?.email
 
     /**
+     * The current state of the Firefox Account. See [AccountState].
+     */
+    val accountState: AccountState
+        get() = if (accountManager.authenticatedAccount() == null) {
+            AccountState.NO_ACCOUNT
+        } else {
+            if (accountManager.accountNeedsReauth()) {
+                AccountState.NEEDS_REAUTHENTICATION
+            } else {
+                AccountState.AUTHENTICATED
+            }
+        }
+
+    /**
      * Check if the current account is signed in and authenticated.
      */
     fun signedInToFxa(): Boolean {
@@ -30,4 +44,24 @@ open class FenixAccountManager(context: Context) {
 
         return account != null && !needsReauth
     }
+}
+
+/**
+ * General states as an overview of the current Firefox Account.
+ */
+enum class AccountState {
+    /**
+     * There is no known Firefox Account.
+     */
+    NO_ACCOUNT,
+
+    /**
+     * A Firefox Account exists but needs to be re-authenticated.
+     */
+    NEEDS_REAUTHENTICATION,
+
+    /**
+     * A Firefox Account exists and the user is currently signed into it.
+     */
+    AUTHENTICATED,
 }

--- a/app/src/main/java/org/mozilla/fenix/components/accounts/FenixAccountManager.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/accounts/FenixAccountManager.kt
@@ -34,16 +34,6 @@ open class FenixAccountManager(context: Context) {
                 AccountState.AUTHENTICATED
             }
         }
-
-    /**
-     * Check if the current account is signed in and authenticated.
-     */
-    fun signedInToFxa(): Boolean {
-        val account = accountManager.authenticatedAccount()
-        val needsReauth = accountManager.accountNeedsReauth()
-
-        return account != null && !needsReauth
-    }
 }
 
 /**

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarMenuController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarMenuController.kt
@@ -35,6 +35,7 @@ import org.mozilla.fenix.browser.readermode.ReaderModeController
 import org.mozilla.fenix.collections.SaveCollectionStep
 import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.components.TabCollectionStorage
+import org.mozilla.fenix.components.accounts.AccountState
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.components.metrics.MetricController
 import org.mozilla.fenix.ext.components
@@ -220,10 +221,13 @@ class DefaultBrowserToolbarMenuController(
                 navController.nav(R.id.browserFragment, directions)
             }
             is ToolbarMenu.Item.SyncAccount -> {
-                val directions = if (item.signedIn) {
-                    BrowserFragmentDirections.actionGlobalAccountSettingsFragment()
-                } else {
-                    BrowserFragmentDirections.actionGlobalTurnOnSync()
+                val directions = when (item.accountState) {
+                    AccountState.AUTHENTICATED ->
+                        BrowserFragmentDirections.actionGlobalAccountSettingsFragment()
+                    AccountState.NEEDS_REAUTHENTICATION ->
+                        BrowserFragmentDirections.actionGlobalAccountProblemFragment()
+                    AccountState.NO_ACCOUNT ->
+                        BrowserFragmentDirections.actionGlobalTurnOnSync()
                 }
                 browserAnimator.captureEngineViewAndDrawStatically {
                     navController.nav(

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
@@ -348,7 +348,9 @@ open class DefaultToolbarMenu(
         R.drawable.ic_signed_out,
         primaryTextColor()
     ) {
-        onItemTapped.invoke(ToolbarMenu.Item.SyncAccount(accountManager.signedInToFxa()))
+        onItemTapped.invoke(
+            ToolbarMenu.Item.SyncAccount(accountManager.accountState)
+        )
     }
 
     @VisibleForTesting(otherwise = PRIVATE)

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
@@ -332,16 +332,8 @@ open class DefaultToolbarMenu(
         onItemTapped.invoke(ToolbarMenu.Item.Quit)
     }
 
-    private fun getSyncItemTitle(): String {
-        val authenticatedAccount = accountManager.authenticatedAccount
-        val email = accountManager.accountProfileEmail
-
-        return if (authenticatedAccount && !email.isNullOrEmpty()) {
-            email
-        } else {
-            context.getString(R.string.sync_menu_sign_in)
-        }
-    }
+    private fun getSyncItemTitle() =
+        accountManager.accountProfileEmail ?: context.getString(R.string.sync_menu_sign_in)
 
     val syncMenuItem = BrowserMenuImageText(
         getSyncItemTitle(),

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarMenu.kt
@@ -6,6 +6,7 @@ package org.mozilla.fenix.components.toolbar
 
 import mozilla.components.browser.menu.BrowserMenuBuilder
 import mozilla.components.browser.menu.item.BrowserMenuItemToolbar
+import org.mozilla.fenix.components.accounts.AccountState
 
 interface ToolbarMenu {
     sealed class Item {
@@ -22,7 +23,7 @@ interface ToolbarMenu {
         object AddToTopSites : Item()
         object InstallPwaToHomeScreen : Item()
         object AddToHomeScreen : Item()
-        data class SyncAccount(val signedIn: Boolean) : Item()
+        data class SyncAccount(val accountState: AccountState) : Item()
         object AddonsManager : Item()
         object Quit : Item()
         object OpenInApp : Item()

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -96,6 +96,7 @@ import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.components.PrivateShortcutCreateManager
 import org.mozilla.fenix.components.StoreProvider
 import org.mozilla.fenix.components.TabCollectionStorage
+import org.mozilla.fenix.components.accounts.AccountState
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.components.tips.FenixTipManager
 import org.mozilla.fenix.components.tips.Tip
@@ -809,10 +810,13 @@ class HomeFragment : Fragment() {
                     }
                     is HomeMenu.Item.SyncAccount -> {
                         hideOnboardingIfNeeded()
-                        val directions = if (it.signedIn) {
-                            BrowserFragmentDirections.actionGlobalAccountSettingsFragment()
-                        } else {
-                            BrowserFragmentDirections.actionGlobalTurnOnSync()
+                        val directions = when (it.accountState) {
+                            AccountState.AUTHENTICATED ->
+                                BrowserFragmentDirections.actionGlobalAccountSettingsFragment()
+                            AccountState.NEEDS_REAUTHENTICATION ->
+                                BrowserFragmentDirections.actionGlobalAccountProblemFragment()
+                            AccountState.NO_ACCOUNT ->
+                                BrowserFragmentDirections.actionGlobalTurnOnSync()
                         }
                         nav(
                             R.id.homeFragment,

--- a/app/src/main/java/org/mozilla/fenix/home/HomeMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeMenu.kt
@@ -91,16 +91,8 @@ class HomeMenu(
         }
     }
 
-    private fun getSyncItemTitle(): String {
-        val authenticatedAccount = accountManager.authenticatedAccount
-        val email = accountManager.accountProfileEmail
-
-        return if (authenticatedAccount && !email.isNullOrEmpty()) {
-            email
-        } else {
-            context.getString(R.string.sync_menu_sign_in)
-        }
-    }
+    private fun getSyncItemTitle(): String =
+        accountManager.accountProfileEmail ?: context.getString(R.string.sync_menu_sign_in)
 
     private val syncSignInMenuItem = BrowserMenuImageText(
         getSyncItemTitle(),

--- a/app/src/main/java/org/mozilla/fenix/home/HomeMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeMenu.kt
@@ -24,6 +24,7 @@ import mozilla.components.concept.sync.AuthType
 import mozilla.components.concept.sync.OAuthAccount
 import mozilla.components.support.ktx.android.content.getColorFromAttr
 import org.mozilla.fenix.R
+import org.mozilla.fenix.components.accounts.AccountState
 import org.mozilla.fenix.components.accounts.FenixAccountManager
 import org.mozilla.fenix.experiments.FeatureId
 import org.mozilla.fenix.ext.components
@@ -45,7 +46,7 @@ class HomeMenu(
         object History : Item()
         object Downloads : Item()
         object Extensions : Item()
-        data class SyncAccount(val signedIn: Boolean) : Item()
+        data class SyncAccount(val accountState: AccountState) : Item()
         object WhatsNew : Item()
         object Help : Item()
         object Settings : Item()
@@ -106,7 +107,7 @@ class HomeMenu(
         R.drawable.ic_synced_tabs,
         primaryTextColor
     ) {
-        onItemTapped.invoke(Item.SyncAccount(accountManager.signedInToFxa()))
+        onItemTapped.invoke(Item.SyncAccount(accountManager.accountState))
     }
 
     val desktopItem = BrowserMenuImageSwitch(

--- a/app/src/test/java/org/mozilla/fenix/components/accounts/FenixAccountManagerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/accounts/FenixAccountManagerTest.kt
@@ -11,9 +11,7 @@ import mozilla.components.concept.sync.OAuthAccount
 import mozilla.components.concept.sync.Profile
 import mozilla.components.service.fxa.manager.FxaAccountManager
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertSame
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -62,42 +60,6 @@ class FenixAccountManagerTest {
 
         val result = fenixFxaManager.accountProfileEmail
         assertEquals(null, result)
-    }
-
-    @Test
-    fun `GIVEN an account is signed in and authenticated THEN check returns true`() {
-        every { accountManagerComponent.authenticatedAccount() } returns account
-        every { accountManagerComponent.accountNeedsReauth() } returns false
-        every { context.components.backgroundServices.accountManager } returns accountManagerComponent
-
-        fenixFxaManager = FenixAccountManager(context)
-
-        val signedIn = fenixFxaManager.signedInToFxa()
-        assertTrue(signedIn)
-    }
-
-    @Test
-    fun `GIVEN an account is signed in and NOT authenticated THEN check returns false`() {
-        every { accountManagerComponent.authenticatedAccount() } returns account
-        every { accountManagerComponent.accountNeedsReauth() } returns true
-        every { context.components.backgroundServices.accountManager } returns accountManagerComponent
-
-        fenixFxaManager = FenixAccountManager(context)
-
-        val signedIn = fenixFxaManager.signedInToFxa()
-        assertFalse(signedIn)
-    }
-
-    @Test
-    fun `GIVEN an account is not signed in THEN check returns false`() {
-        every { accountManagerComponent.authenticatedAccount() } returns null
-        every { accountManagerComponent.accountNeedsReauth() } returns true
-        every { context.components.backgroundServices.accountManager } returns accountManagerComponent
-
-        fenixFxaManager = FenixAccountManager(context)
-
-        val signedIn = fenixFxaManager.signedInToFxa()
-        assertFalse(signedIn)
     }
 
     @Test

--- a/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarMenuControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarMenuControllerTest.kt
@@ -57,6 +57,7 @@ import org.mozilla.fenix.browser.readermode.ReaderModeController
 import org.mozilla.fenix.collections.SaveCollectionStep
 import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.components.TabCollectionStorage
+import org.mozilla.fenix.components.accounts.AccountState
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.components.metrics.MetricController
 import org.mozilla.fenix.ext.components
@@ -562,25 +563,36 @@ class DefaultBrowserToolbarMenuControllerTest {
     }
 
     @Test
-    fun `WHEN sync sign in menu item is pressed AND account is signed out THEN navigate to sync sign in`() = runBlockingTest {
-        val item = ToolbarMenu.Item.SyncAccount(false)
-        val directions = BrowserFragmentDirections.actionGlobalTurnOnSync()
-
+    fun `GIVEN account exists and the user is signed in WHEN sign in to sync menu item is pressed THEN navigate to account settings`() = runBlockingTest {
+        val item = ToolbarMenu.Item.SyncAccount(AccountState.AUTHENTICATED)
+        val accountSettingsDirections = BrowserFragmentDirections.actionGlobalAccountSettingsFragment()
         val controller = createController(scope = this, store = browserStore)
+
         controller.handleToolbarItemInteraction(item)
 
-        verify { navController.navigate(directions, null) }
+        verify { navController.navigate(accountSettingsDirections, null) }
     }
 
     @Test
-    fun `WHEN sync sign in menu item is pressed AND account is signed in THEN navigate to sync sign in`() = runBlockingTest {
-        val item = ToolbarMenu.Item.SyncAccount(true)
-        val directions = BrowserFragmentDirections.actionGlobalAccountSettingsFragment()
-
+    fun `GIVEN account exists and the user is not signed in WHEN sign in to sync menu item is pressed THEN navigate to account problem fragment`() = runBlockingTest {
+        val item = ToolbarMenu.Item.SyncAccount(AccountState.NEEDS_REAUTHENTICATION)
+        val accountProblemDirections = BrowserFragmentDirections.actionGlobalAccountProblemFragment()
         val controller = createController(scope = this, store = browserStore)
+
         controller.handleToolbarItemInteraction(item)
 
-        verify { navController.navigate(directions, null) }
+        verify { navController.navigate(accountProblemDirections, null) }
+    }
+
+    @Test
+    fun `GIVEN account doesn't exist WHEN sign in to sync menu item is pressed THEN navigate to sign in`() = runBlockingTest {
+        val item = ToolbarMenu.Item.SyncAccount(AccountState.NO_ACCOUNT)
+        val turnOnSyncDirections = BrowserFragmentDirections.actionGlobalTurnOnSync()
+        val controller = createController(scope = this, store = browserStore)
+
+        controller.handleToolbarItemInteraction(item)
+
+        verify { navController.navigate(turnOnSyncDirections, null) }
     }
 
     private fun createController(


### PR DESCRIPTION
Fixes #19797

Previously if an account existed but it wasn't signed in to we would open the fragment to allow the user to sign in to the Firefox account but then [exit early because an account was already existing](https://github.com/mozilla-mobile/fenix/blob/990bfa7e6dd5894d61473a41da6129e6947974e2/app/src/main/java/org/mozilla/fenix/settings/account/TurnOnSyncFragment.kt#L92-L98).


https://user-images.githubusercontent.com/11428869/120995966-942a0f80-c78e-11eb-89fc-ecf6e78baf56.mp4



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
