### PR TITLE
For #19820: Add labels for month and year spinners.

### DIFF
--- a/app/src/main/res/layout/fragment_credit_card_editor.xml
+++ b/app/src/main/res/layout/fragment_credit_card_editor.xml
@@ -123,6 +123,12 @@
                 android:layout_weight="1"
                 android:orientation="vertical">
 
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="0dp"
+                    android:labelFor="@id/expiry_month_drop_down"
+                    android:text="@string/credit_cards_expiration_date_month" />
+
                 <androidx.appcompat.widget.AppCompatSpinner
                     android:id="@+id/expiry_month_drop_down"
                     android:layout_width="match_parent"
@@ -141,6 +147,12 @@
                 android:layout_height="wrap_content"
                 android:layout_weight="0.8"
                 android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="0dp"
+                    android:labelFor="@id/expiry_year_drop_down"
+                    android:text="@string/credit_cards_expiration_date_year" />
 
                 <androidx.appcompat.widget.AppCompatSpinner
                     android:id="@+id/expiry_year_drop_down"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1528,6 +1528,10 @@
     <string name="credit_cards_card_number">Card Number</string>
     <!-- The header for the expiration date of a credit card -->
     <string name="credit_cards_expiration_date">Expiration Date</string>
+    <!-- The label for the expiration date month of a credit card -->
+    <string name="credit_cards_expiration_date_month">Expiration Date Month</string>
+    <!-- The label for the expiration date year of a credit card -->
+    <string name="credit_cards_expiration_date_year">Expiration Date Year</string>
     <!-- The header for the name on the credit card -->
     <string name="credit_cards_name_on_card">Name on Card</string>
     <!-- The header for the nickname for a credit card -->


### PR DESCRIPTION
Fixes #19820

This follows the guidelines described in
developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/listbox_role

Note: As spinners do not have a label or a hint property, the only viable solution that follows UX design is to provide labels that are not visible (have 0 height and 0 width)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not: 
       No relevant unit tests for Talkback announcements.
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
       No visual changes.
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
