### PR TITLE
For #19876 - Add a Home screen button to the browser toolbar

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -28,4 +28,9 @@ object FeatureFlags {
      * Enables WebAuthn support.
      */
     val webAuthFeature = Config.channel.isNightlyOrDebug
+
+    /**
+     * Enables the Home button in the browser toolbar to navigate back to the home screen.
+     */
+    val showHomeButtonFeature = Config.channel.isNightlyOrDebug
 }

--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -105,9 +105,7 @@ import org.mozilla.fenix.components.StoreProvider
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.components.toolbar.BrowserFragmentState
 import org.mozilla.fenix.components.toolbar.BrowserFragmentStore
-import org.mozilla.fenix.components.toolbar.BrowserInteractor
 import org.mozilla.fenix.components.toolbar.BrowserToolbarView
-import org.mozilla.fenix.components.toolbar.BrowserToolbarViewInteractor
 import org.mozilla.fenix.components.toolbar.DefaultBrowserToolbarController
 import org.mozilla.fenix.components.toolbar.DefaultBrowserToolbarMenuController
 import org.mozilla.fenix.components.toolbar.ToolbarIntegration
@@ -137,6 +135,8 @@ import mozilla.components.support.base.feature.ActivityResultHandler
 import org.mozilla.fenix.ext.navigateBlockingForAsyncNavGraph
 import mozilla.components.support.ktx.android.view.enterToImmersiveMode
 import org.mozilla.fenix.GleanMetrics.PerfStartup
+import org.mozilla.fenix.components.toolbar.interactor.BrowserToolbarInteractor
+import org.mozilla.fenix.components.toolbar.interactor.DefaultBrowserToolbarInteractor
 import org.mozilla.fenix.ext.measureNoInline
 import org.mozilla.fenix.ext.secure
 import org.mozilla.fenix.settings.biometric.BiometricPromptFeature
@@ -155,9 +155,9 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
     private lateinit var browserFragmentStore: BrowserFragmentStore
     private lateinit var browserAnimator: BrowserAnimator
 
-    private var _browserInteractor: BrowserToolbarViewInteractor? = null
-    protected val browserInteractor: BrowserToolbarViewInteractor
-        get() = _browserInteractor!!
+    private var _browserToolbarInteractor: BrowserToolbarInteractor? = null
+    protected val browserToolbarInteractor: BrowserToolbarInteractor
+        get() = _browserToolbarInteractor!!
 
     @VisibleForTesting
     @Suppress("VariableNaming")
@@ -357,7 +357,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
             browserStore = store
         )
 
-        _browserInteractor = BrowserInteractor(
+        _browserToolbarInteractor = DefaultBrowserToolbarInteractor(
             browserToolbarController,
             browserToolbarMenuController
         )
@@ -365,7 +365,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
         _browserToolbarView = BrowserToolbarView(
             container = view.browserLayout,
             toolbarPosition = context.settings().toolbarPosition,
-            interactor = browserInteractor,
+            interactor = browserToolbarInteractor,
             customTabSession = customTabSessionId?.let { store.state.findCustomTab(it) },
             lifecycleOwner = viewLifecycleOwner
         )
@@ -1343,7 +1343,7 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
 
         requireContext().accessibilityManager.removeAccessibilityStateChangeListener(this)
         _browserToolbarView = null
-        _browserInteractor = null
+        _browserToolbarInteractor = null
     }
 
     override fun onAttach(context: Context) {

--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -76,6 +76,14 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
             )
         }
 
+        val homeAction = BrowserToolbar.Button(
+            imageDrawable = AppCompatResources.getDrawable(requireContext(), R.drawable.ic_home)!!,
+            contentDescription = requireContext().getString(R.string.browser_toolbar_home),
+            listener = browserToolbarInteractor::onHomeButtonClicked
+        )
+
+        browserToolbarView.view.addNavigationAction(homeAction)
+
         val readerModeAction =
             BrowserToolbar.ToggleButton(
                 image = AppCompatResources.getDrawable(requireContext(), R.drawable.ic_readermode)!!,

--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -89,7 +89,7 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
                 selected = getCurrentTab()?.let {
                         activity?.components?.core?.store?.state?.findTab(it.id)?.readerState?.active
                     } ?: false,
-                listener = browserInteractor::onReaderModePressed
+                listener = browserToolbarInteractor::onReaderModePressed
             )
 
         browserToolbarView.view.addPageAction(readerModeAction)

--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -17,8 +17,8 @@ import kotlinx.android.synthetic.main.fragment_browser.*
 import kotlinx.android.synthetic.main.fragment_browser.view.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.components.browser.state.selector.findTab
-import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.state.state.SessionState
+import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.thumbnails.BrowserThumbnails
 import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.feature.app.links.AppLinksUseCases
@@ -29,13 +29,14 @@ import mozilla.components.feature.tab.collections.TabCollection
 import mozilla.components.feature.tabs.WindowFeature
 import mozilla.components.support.base.feature.UserInteractionHandler
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
+import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.components.TabCollectionStorage
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.components
-import org.mozilla.fenix.ext.navigateBlockingForAsyncNavGraph
 import org.mozilla.fenix.ext.nav
+import org.mozilla.fenix.ext.navigateBlockingForAsyncNavGraph
 import org.mozilla.fenix.ext.navigateSafe
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.settings
@@ -51,7 +52,8 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
 
     private val windowFeature = ViewBoundFeatureWrapper<WindowFeature>()
     private val openInAppOnboardingObserver = ViewBoundFeatureWrapper<OpenInAppOnboardingObserver>()
-    private val trackingProtectionOverlayObserver = ViewBoundFeatureWrapper<TrackingProtectionOverlay>()
+    private val trackingProtectionOverlayObserver =
+        ViewBoundFeatureWrapper<TrackingProtectionOverlay>()
 
     private var readerModeAvailable = false
     private var pwaOnboardingObserver: PwaOnboardingObserver? = null
@@ -76,27 +78,38 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
             )
         }
 
-        val homeAction = BrowserToolbar.Button(
-            imageDrawable = AppCompatResources.getDrawable(requireContext(), R.drawable.ic_home)!!,
-            contentDescription = requireContext().getString(R.string.browser_toolbar_home),
-            listener = browserToolbarInteractor::onHomeButtonClicked
-        )
+        if (FeatureFlags.showHomeButtonFeature) {
+            val homeAction = BrowserToolbar.Button(
+                imageDrawable = AppCompatResources.getDrawable(
+                    requireContext(),
+                    R.drawable.ic_home
+                )!!,
+                contentDescription = requireContext().getString(R.string.browser_toolbar_home),
+                listener = browserToolbarInteractor::onHomeButtonClicked
+            )
 
-        browserToolbarView.view.addNavigationAction(homeAction)
+            browserToolbarView.view.addNavigationAction(homeAction)
+        }
 
         val readerModeAction =
             BrowserToolbar.ToggleButton(
-                image = AppCompatResources.getDrawable(requireContext(), R.drawable.ic_readermode)!!,
+                image = AppCompatResources.getDrawable(
+                    requireContext(),
+                    R.drawable.ic_readermode
+                )!!,
                 imageSelected =
-                    AppCompatResources.getDrawable(requireContext(), R.drawable.ic_readermode_selected)!!,
+                AppCompatResources.getDrawable(
+                    requireContext(),
+                    R.drawable.ic_readermode_selected
+                )!!,
                 contentDescription = requireContext().getString(R.string.browser_menu_read),
                 contentDescriptionSelected = requireContext().getString(R.string.browser_menu_read_close),
                 visible = {
                     readerModeAvailable
                 },
                 selected = getCurrentTab()?.let {
-                        activity?.components?.core?.store?.state?.findTab(it.id)?.readerState?.active
-                    } ?: false,
+                    activity?.components?.core?.store?.state?.findTab(it.id)?.readerState?.active
+                } ?: false,
                 listener = browserToolbarInteractor::onReaderModePressed
             )
 
@@ -246,7 +259,11 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
     }
 
     private val collectionStorageObserver = object : TabCollectionStorage.Observer {
-        override fun onCollectionCreated(title: String, sessions: List<TabSessionState>, id: Long?) {
+        override fun onCollectionCreated(
+            title: String,
+            sessions: List<TabSessionState>,
+            id: Long?
+        ) {
             showTabSavedToCollectionSnackbar(sessions.size, true)
         }
 
@@ -254,7 +271,10 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
             showTabSavedToCollectionSnackbar(sessions.size)
         }
 
-        private fun showTabSavedToCollectionSnackbar(tabSize: Int, isNewCollection: Boolean = false) {
+        private fun showTabSavedToCollectionSnackbar(
+            tabSize: Int,
+            isNewCollection: Boolean = false
+        ) {
             view?.let { view ->
                 val messageStringRes = when {
                     isNewCollection -> {
@@ -298,8 +318,10 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
             context.components.useCases.contextMenuUseCases,
             view,
             FenixSnackbarDelegate(view)
-        ) + ContextMenuCandidate.createOpenInExternalAppCandidate(requireContext(),
-            contextMenuCandidateAppLinksUseCases)
+        ) + ContextMenuCandidate.createOpenInExternalAppCandidate(
+            requireContext(),
+            contextMenuCandidateAppLinksUseCases
+        )
     }
 
     /**

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt
@@ -23,6 +23,7 @@ import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.browser.readermode.ReaderModeController
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.components.metrics.MetricController
+import org.mozilla.fenix.components.toolbar.interactor.BrowserToolbarInteractor
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.navigateBlockingForAsyncNavGraph
 import org.mozilla.fenix.ext.nav
@@ -40,6 +41,11 @@ interface BrowserToolbarController {
     fun handleTabCounterClick()
     fun handleTabCounterItemInteraction(item: TabCounterMenu.Item)
     fun handleReaderModePressed(enabled: Boolean)
+
+    /**
+     * @see [BrowserToolbarInteractor.onHomeButtonClicked]
+     */
+    fun handleHomeButtonClick()
 }
 
 class DefaultBrowserToolbarController(
@@ -155,6 +161,12 @@ class DefaultBrowserToolbarController(
         if (activity.settings().isDynamicToolbarEnabled) {
             engineView.setVerticalClipping(offset)
         }
+    }
+
+    override fun handleHomeButtonClick() {
+        navController.navigateBlockingForAsyncNavGraph(
+            BrowserFragmentDirections.actionGlobalHome()
+        )
     }
 
     companion object {

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarView.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarView.kt
@@ -23,8 +23,8 @@ import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.browser.toolbar.behavior.BrowserToolbarBehavior
 import mozilla.components.browser.toolbar.display.DisplayToolbar
 import mozilla.components.support.utils.URLStringUtils
-import mozilla.components.ui.tabcounter.TabCounterMenu
 import org.mozilla.fenix.R
+import org.mozilla.fenix.components.toolbar.interactor.BrowserToolbarInteractor
 import org.mozilla.fenix.customtabs.CustomTabToolbarIntegration
 import org.mozilla.fenix.customtabs.CustomTabToolbarMenu
 import org.mozilla.fenix.ext.bookmarkStorage
@@ -35,23 +35,12 @@ import org.mozilla.fenix.utils.ToolbarPopupWindow
 import java.lang.ref.WeakReference
 import mozilla.components.browser.toolbar.behavior.ToolbarPosition as MozacToolbarPosition
 
-interface BrowserToolbarViewInteractor {
-    fun onBrowserToolbarPaste(text: String)
-    fun onBrowserToolbarPasteAndGo(text: String)
-    fun onBrowserToolbarClicked()
-    fun onBrowserToolbarMenuItemTapped(item: ToolbarMenu.Item)
-    fun onTabCounterClicked()
-    fun onTabCounterMenuItemTapped(item: TabCounterMenu.Item)
-    fun onScrolled(offset: Int)
-    fun onReaderModePressed(enabled: Boolean)
-}
-
 @ExperimentalCoroutinesApi
 @SuppressWarnings("LargeClass")
 class BrowserToolbarView(
     private val container: ViewGroup,
     private val toolbarPosition: ToolbarPosition,
-    private val interactor: BrowserToolbarViewInteractor,
+    private val interactor: BrowserToolbarInteractor,
     private val customTabSession: CustomTabSessionState?,
     private val lifecycleOwner: LifecycleOwner
 ) : LayoutContainer {

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarIntegration.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/ToolbarIntegration.kt
@@ -25,6 +25,7 @@ import mozilla.components.feature.toolbar.ToolbarPresenter
 import mozilla.components.support.base.feature.LifecycleAwareFeature
 import mozilla.components.support.ktx.android.view.hideKeyboard
 import org.mozilla.fenix.R
+import org.mozilla.fenix.components.toolbar.interactor.BrowserToolbarInteractor
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.theme.ThemeManager
@@ -88,7 +89,7 @@ class DefaultToolbarIntegration(
     lifecycleOwner: LifecycleOwner,
     sessionId: String? = null,
     isPrivate: Boolean,
-    interactor: BrowserToolbarViewInteractor,
+    interactor: BrowserToolbarInteractor,
     engine: Engine
 ) : ToolbarIntegration(
     context = context,

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/interactor/BrowserToolbarInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/interactor/BrowserToolbarInteractor.kt
@@ -2,14 +2,40 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.fenix.components.toolbar
+package org.mozilla.fenix.components.toolbar.interactor
 
 import mozilla.components.ui.tabcounter.TabCounterMenu
+import org.mozilla.fenix.components.toolbar.BrowserToolbarController
+import org.mozilla.fenix.components.toolbar.BrowserToolbarMenuController
+import org.mozilla.fenix.components.toolbar.ToolbarMenu
 
-open class BrowserInteractor(
+/**
+ * Interface for the browser toolbar interactor. This interface is implemented by objects that
+ * want to respond to user interaction on the browser toolbar.
+ */
+interface BrowserToolbarInteractor {
+    fun onBrowserToolbarPaste(text: String)
+    fun onBrowserToolbarPasteAndGo(text: String)
+    fun onBrowserToolbarClicked()
+    fun onBrowserToolbarMenuItemTapped(item: ToolbarMenu.Item)
+    fun onTabCounterClicked()
+    fun onTabCounterMenuItemTapped(item: TabCounterMenu.Item)
+    fun onScrolled(offset: Int)
+    fun onReaderModePressed(enabled: Boolean)
+}
+
+/**
+ * The default implementation of [BrowserToolbarInteractor].
+ *
+ * @property browserToolbarController [BrowserToolbarController] to which user actions can be
+ * delegated for all interactions on the browser toolbar.
+ * @property menuController [BrowserToolbarMenuController] to which user actions can be delegated
+ * for all interactions on the the browser toolbar menu.
+ */
+class DefaultBrowserToolbarInteractor(
     private val browserToolbarController: BrowserToolbarController,
     private val menuController: BrowserToolbarMenuController
-) : BrowserToolbarViewInteractor {
+) : BrowserToolbarInteractor {
 
     override fun onTabCounterClicked() {
         browserToolbarController.handleTabCounterClick()

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/interactor/BrowserToolbarInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/interactor/BrowserToolbarInteractor.kt
@@ -22,6 +22,11 @@ interface BrowserToolbarInteractor {
     fun onTabCounterMenuItemTapped(item: TabCounterMenu.Item)
     fun onScrolled(offset: Int)
     fun onReaderModePressed(enabled: Boolean)
+
+    /**
+     * Navigates to the Home screen. Called when a user taps on the Home button.
+     */
+    fun onHomeButtonClicked()
 }
 
 /**
@@ -67,5 +72,9 @@ class DefaultBrowserToolbarInteractor(
 
     override fun onReaderModePressed(enabled: Boolean) {
         browserToolbarController.handleReaderModePressed(enabled)
+    }
+
+    override fun onHomeButtonClicked() {
+        browserToolbarController.handleHomeButtonClick()
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/customtabs/ExternalAppBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/ExternalAppBrowserFragment.kt
@@ -66,7 +66,7 @@ class ExternalAppBrowserFragment : BaseBrowserFragment(), UserInteractionHandler
                 toolbar = toolbar,
                 sessionId = customTabSessionId,
                 activity = activity,
-                onItemTapped = { browserInteractor.onBrowserToolbarMenuItemTapped(it) },
+                onItemTapped = { browserToolbarInteractor.onBrowserToolbarMenuItemTapped(it) },
                 isPrivate = tab.content.private,
                 shouldReverseItems = !activity.settings().shouldUseBottomToolbar
             ),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -173,6 +173,10 @@
     <!-- Browser menu label for editing a bookmark -->
     <string name="browser_menu_edit">Edit</string>
 
+    <!-- Browser Toolbar -->
+    <!-- Content description for the Home screen button on the browser toolbar -->
+    <string name="browser_toolbar_home">Home screen</string>
+
     <!-- Error message to show when the user tries to access a scheme not
         handled by the app (Ex: blob, tel etc) -->
     <string name="unknown_scheme_error_message">Unable to connect. Unrecognizable URL scheme.</string>

--- a/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarControllerTest.kt
@@ -312,6 +312,14 @@ class DefaultBrowserToolbarControllerTest {
         verify(exactly = 0) { engineView.setVerticalClipping(10) }
     }
 
+    @Test
+    fun handleHomeButtonClick() {
+        val controller = createController()
+        controller.handleHomeButtonClick()
+
+        verify { navController.navigate(BrowserFragmentDirections.actionGlobalHome()) }
+    }
+
     private fun createController(
         activity: HomeActivity = this.activity,
         customTabSessionId: String? = null

--- a/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarInteractorTest.kt
@@ -68,4 +68,11 @@ class DefaultBrowserToolbarInteractorTest {
 
         verify { browserToolbarMenuController.handleToolbarItemInteraction(item) }
     }
+
+    @Test
+    fun onHomeButtonClicked() {
+        interactor.onHomeButtonClicked()
+
+        verify { browserToolbarController.handleHomeButtonClick() }
+    }
 }

--- a/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarInteractorTest.kt
@@ -7,17 +7,18 @@ import io.mockk.verify
 import mozilla.components.ui.tabcounter.TabCounterMenu
 import org.junit.Before
 import org.junit.Test
+import org.mozilla.fenix.components.toolbar.interactor.DefaultBrowserToolbarInteractor
 
-class BrowserInteractorTest {
+class DefaultBrowserToolbarInteractorTest {
 
     @RelaxedMockK lateinit var browserToolbarController: BrowserToolbarController
     @RelaxedMockK lateinit var browserToolbarMenuController: BrowserToolbarMenuController
-    lateinit var interactor: BrowserInteractor
+    lateinit var interactor: DefaultBrowserToolbarInteractor
 
     @Before
     fun setup() {
         MockKAnnotations.init(this)
-        interactor = BrowserInteractor(
+        interactor = DefaultBrowserToolbarInteractor(
             browserToolbarController,
             browserToolbarMenuController
         )


### PR DESCRIPTION
Fixes #19876. Probably best to review the commits individually.

For #19876 - Part 1: Refactor BrowserToolbarInteractor
- Renames `BrowserInteractor` to `DefaultBrowserTolbarInteractor`
- Renames `BrowserTooolbarViewInteractor` to `BrowserToolbarInteractor`
- Refactors `BrowserToolbarViewInteractor` interface from `BrowserToolbarView.kt` to  `BrowserToolbarInteractor` as `BrowserToolbarInteractor`

The motivation for this was that `BrowserInteractor` doesn't quite fit when it's really only acting on the browser toolbar. So, I refactored it to use the same language within our current architecture.

For #19876 - Part 2: Add a Home screen button to the browser toolbar

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
