### PR TITLE
For #19815 - Keeps tabTray FAB from obstructing last tab

### DIFF
--- a/app/src/main/res/layout/component_sync_tabs_tray_layout.xml
+++ b/app/src/main/res/layout/component_sync_tabs_tray_layout.xml
@@ -24,6 +24,8 @@
         android:id="@+id/synced_tabs_list"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:clipToPadding="false"
+        android:paddingBottom="@dimen/tab_tray_list_bottom_padding"
         tools:listitem="@layout/sync_tabs_list_item"/>
 
 </org.mozilla.fenix.tabstray.syncedtabs.SyncedTabsTrayLayout>

--- a/app/src/main/res/layout/component_tabstray2.xml
+++ b/app/src/main/res/layout/component_tabstray2.xml
@@ -151,8 +151,6 @@
         android:id="@+id/tabsTray"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:clipToPadding="false"
-        android:paddingBottom="140dp"
         android:scrollbarStyle="outsideOverlay"
         android:scrollbars="vertical"
         android:orientation="horizontal"

--- a/app/src/main/res/layout/normal_browser_tray_list.xml
+++ b/app/src/main/res/layout/normal_browser_tray_list.xml
@@ -7,6 +7,8 @@
         android:id="@+id/tray_list_item"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:clipToPadding="false"
+        android:paddingBottom="@dimen/tab_tray_list_bottom_padding"
         android:visibility="gone"/>
 
     <TextView

--- a/app/src/main/res/layout/private_browser_tray_list.xml
+++ b/app/src/main/res/layout/private_browser_tray_list.xml
@@ -7,6 +7,8 @@
         android:id="@+id/tray_list_item"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:clipToPadding="false"
+        android:paddingBottom="@dimen/tab_tray_list_bottom_padding"
         android:visibility="gone"/>
 
     <TextView

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -189,7 +189,7 @@
     <dimen name="tab_tray_multiselect_handle_top_margin">0dp</dimen>
     <dimen name="tab_tray_new_collection_padding_start">24dp</dimen>
     <dimen name="tab_tray_new_collection_drawable_padding">28dp</dimen>
-    <!--  Keeps FAB from covering last item in list  -->
+    <!--  Keeps FAB from covering last item in list. Fab 64dp, top & bottom margins 16dp each.  -->
     <dimen name="tab_tray_list_bottom_padding">96dp</dimen>
 
     <!-- Saved Logins Fragment -->

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -189,6 +189,8 @@
     <dimen name="tab_tray_multiselect_handle_top_margin">0dp</dimen>
     <dimen name="tab_tray_new_collection_padding_start">24dp</dimen>
     <dimen name="tab_tray_new_collection_drawable_padding">28dp</dimen>
+    <!--  Keeps FAB from covering last item in list  -->
+    <dimen name="tab_tray_list_bottom_padding">96dp</dimen>
 
     <!-- Saved Logins Fragment -->
     <dimen name="saved_logins_sort_menu_dropdown_chevron_icon_margin_start">24dp</dimen>


### PR DESCRIPTION
For https://github.com/mozilla-mobile/fenix/issues/19815
⚠️ **NOTE:** Requires https://github.com/mozilla-mobile/fenix/pull/19812 to me merged beforehand.
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR doesn't include tests as it is only a minor change
- [x] **Screenshots**: This PR includes screenshots or GIFs.
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

Recorded with https://github.com/mozilla-mobile/fenix/pull/19812 merged


https://user-images.githubusercontent.com/60002907/121176288-b4c49900-c864-11eb-904e-6b01a64866ec.mp4


