### PR TITLE
No issue: Add full-junit-result in Flank config

### DIFF
--- a/automation/taskcluster/androidTest/flank-x86.yml
+++ b/automation/taskcluster/androidTest/flank-x86.yml
@@ -60,4 +60,6 @@ flank:
   ## which don't support ansi codes, to avoid corrupted output use single or verbose.
   ## The output style `compact` is used to produce less detailed output, it prints just Args, test and matrix count, weblinks, cost, and result reports.
   output-style: compact
-
+  ### Full Junit Result flag
+  ## Enable create additional local junit result on local storage with failure nodes on passed flaky tests.
+  full-junit-result: true


### PR DESCRIPTION
``JUnitReport.xml`` and ``FullJunitReport.xml`` are artifacts with differences. Full will include all tests results, including when tests failed and when passed on retry. This might expose more additional results for capturing as part of my Job/Push collection data on certain tasks. I think Junit report will contain one result per test. If a test fails, and then passes on retry, it will be recorded as a successful execution.