### PR TITLE
No issue: Add matrix outcome details to parse-ui-test.py

### DIFF
--- a/automation/taskcluster/androidTest/parse-ui-test.py
+++ b/automation/taskcluster/androidTest/parse-ui-test.py
@@ -52,10 +52,10 @@ def main():
     print(yaml.safe_dump(android_args["gcloud"]["device"]))
 
     print("# Results\n")
-    print("| matrix | result | logs |\n")
-    print("| --- | --- | --- |\n")
+    print("| matrix | result | logs | details \n")
+    print("| --- | --- | --- | --- |\n")
     for matrix, matrix_result in matrix_ids.items():
-        print("| {matrixId} | {outcome} | [logs]({webLink}) |\n".format(**matrix_result))
+        print("| {matrixId} | {outcome} | [logs]({webLink}) | {testAxises[0][details]}\n".format(**matrix_result))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This adds matrix outcome details to the markdown in test results

E.g,
```Json
"testAxises": [
      {
        "device": "Pixel2-28-en-portrait",
        "outcome": "success",
        "details": "145 test cases passed"
      }
```

"145 test cases passed", or "151 test cases passed, 1 flaky"

ex: https://github.com/mozilla-mobile/fenix/pull/19900/checks?check_run_id=2777846522