### PR TITLE
Suppress deprecation warnings for now-deprecated Glean APIs 

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
@@ -99,10 +99,14 @@ private class EventWrapper<T : Enum<T>>(
             null
         }
 
+        @Suppress("DEPRECATION")
+        // FIXME(#19967): Migrate to non-deprecated API.
         this.recorder(extras)
     }
 }
 
+@Suppress("DEPRECATION")
+// FIXME(#19967): Migrate to non-deprecated API.
 private val Event.wrapper: EventWrapper<*>?
     get() = when (this) {
         is Event.OpenedApp -> EventWrapper(

--- a/app/src/main/java/org/mozilla/fenix/telemetry/TelemetryLifecycleObserver.kt
+++ b/app/src/main/java/org/mozilla/fenix/telemetry/TelemetryLifecycleObserver.kt
@@ -35,6 +35,8 @@ class TelemetryLifecycleObserver(
         val lastState = pausedState ?: return
         val currentState = createTabState()
 
+        @Suppress("DEPRECATION")
+        // FIXME(#19967): Migrate to non-deprecated API.
         EngineMetrics.foregroundMetrics.record(mapOf(
             MetricsKeys.backgroundActiveTabs to lastState.activeEngineTabs.toString(),
             MetricsKeys.backgroundCrashedTabs to lastState.crashedTabs.toString(),


### PR DESCRIPTION
This will be required when the Glean update lands in A-C and gets pulled in here.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
