### PR TITLE
Issue #17800: Cleanup and fix request desktop site from home

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -843,7 +843,7 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
         // has removed all of them, or we couldn't load any) we will pass searchTermOrURL to Gecko
         // and let it try to load whatever was entered.
         if ((!forceSearch && searchTermOrURL.isUrl()) || engine == null) {
-            if (newTab) {
+            val tabId = if (newTab) {
                 components.useCases.tabsUseCases.addTab(
                     url = searchTermOrURL.toNormalizedUrl(),
                     flags = flags,
@@ -854,10 +854,11 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
                     url = searchTermOrURL.toNormalizedUrl(),
                     flags = flags
                 )
+                components.core.store.state.selectedTabId
             }
 
-            if (requestDesktopMode) {
-                handleRequestDesktopMode()
+            if (requestDesktopMode && tabId != null) {
+                handleRequestDesktopMode(tabId)
             }
         } else {
             if (newTab) {
@@ -885,15 +886,10 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
         }
     }
 
-    internal fun handleRequestDesktopMode() {
-        val requestDesktopSiteUseCase =
-            components.useCases.sessionUseCases.requestDesktopSite
-        requestDesktopSiteUseCase.invoke(true)
-        components.core.store.dispatch(
-            ContentAction.UpdateDesktopModeAction(
-                components.core.store.state.selectedTabId.toString(), true
-            )
-        )
+    internal fun handleRequestDesktopMode(tabId: String) {
+        components.useCases.sessionUseCases.requestDesktopSite(true, tabId)
+        components.core.store.dispatch(ContentAction.UpdateDesktopModeAction(tabId, true))
+
         // Reset preference value after opening the tab in desktop mode
         settings().openNextTabInDesktopMode = false
     }

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -255,7 +255,6 @@ class HomeFragment : Fragment() {
                 restoreUseCase = components.useCases.tabsUseCases.restore,
                 reloadUrlUseCase = components.useCases.sessionUseCases.reload,
                 selectTabUseCase = components.useCases.tabsUseCases.selectTab,
-                requestDesktopSiteUseCase = components.useCases.sessionUseCases.requestDesktopSite,
                 fragmentStore = homeFragmentStore,
                 navController = findNavController(),
                 viewLifecycleScope = viewLifecycleOwner.lifecycleScope,

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
@@ -192,7 +192,6 @@ class DefaultSessionControlController(
     private val restoreUseCase: TabsUseCases.RestoreUseCase,
     private val reloadUrlUseCase: SessionUseCases.ReloadUrlUseCase,
     private val selectTabUseCase: TabsUseCases.SelectTabUseCase,
-    private val requestDesktopSiteUseCase: SessionUseCases.RequestDesktopSiteUseCase,
     private val fragmentStore: HomeFragmentStore,
     private val navController: NavController,
     private val viewLifecycleScope: CoroutineScope,
@@ -410,14 +409,14 @@ class DefaultSessionControlController(
             }
         event?.let { activity.metrics.track(it) }
 
-        addTabUseCase.invoke(
+        val tabId = addTabUseCase.invoke(
             url = appendSearchAttributionToUrlIfNeeded(url),
             selectTab = true,
             startLoading = true
         )
 
         if (settings.openNextTabInDesktopMode) {
-            activity.handleRequestDesktopMode()
+            activity.handleRequestDesktopMode(tabId)
         }
         activity.openToBrowser(BrowserDirection.FromHome)
     }

--- a/app/src/test/java/org/mozilla/fenix/home/DefaultSessionControlControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/DefaultSessionControlControllerTest.kt
@@ -145,7 +145,6 @@ class DefaultSessionControlControllerTest {
         every { analytics.metrics } returns metrics
 
         val restoreUseCase: TabsUseCases.RestoreUseCase = mockk(relaxed = true)
-        val requestDesktopSiteUseCase: SessionUseCases.RequestDesktopSiteUseCase = mockk(relaxed = true)
 
         controller = spyk(DefaultSessionControlController(
             activity = activity,
@@ -158,7 +157,6 @@ class DefaultSessionControlControllerTest {
             reloadUrlUseCase = reloadUrlUseCase.reload,
             selectTabUseCase = selectTabUseCase.selectTab,
             restoreUseCase = restoreUseCase,
-            requestDesktopSiteUseCase = requestDesktopSiteUseCase,
             fragmentStore = fragmentStore,
             navController = navController,
             viewLifecycleScope = scope,


### PR DESCRIPTION
Main change here it to explicitly specify the right tabId so it doesn't race with the store being updated i.e. this is currently broken in Nightly.

Other parts are just cleanup.