### PR TITLE
Update Kotlin to 1.5.10 (and Coroutines to 1.5.0).

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -579,6 +579,10 @@ if (project.hasProperty("coverage")) {
         jacoco.includeNoLocationClasses = true
     }
 
+    jacoco {
+        toolVersion = "0.8.7"
+    }
+
     android.applicationVariants.all { variant ->
         tasks.register("jacoco${variant.name.capitalize()}TestReport", JacocoReport) {
             dependsOn "test${variant.name.capitalize()}UnitTest"

--- a/app/src/androidTest/java/org/mozilla/fenix/glean/BaselinePingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/glean/BaselinePingTest.kt
@@ -11,6 +11,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.ActivityTestRule
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiSelector
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
@@ -76,6 +77,7 @@ class BaselinePingTest {
     companion object {
         @BeforeClass
         @JvmStatic
+        @OptIn(DelicateCoroutinesApi::class) // GlobalScope usage
         fun setupOnce() {
             val httpClient = ConceptFetchHttpUploader(lazy {
                 GeckoViewFetchClient(ApplicationProvider.getApplicationContext())

--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/ext/String.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/ext/String.kt
@@ -16,10 +16,10 @@ import java.net.URISyntaxException
  */
 fun String.removePrefixesIgnoreCase(vararg prefixes: String): String {
     var value = this
-    var lower = this.toLowerCase()
+    var lower = this.lowercase()
 
     prefixes.forEach {
-        if (lower.startsWith(it.toLowerCase())) {
+        if (lower.startsWith(it.lowercase())) {
             value = value.substring(it.length)
             lower = lower.substring(it.length)
         }

--- a/app/src/androidTest/java/org/mozilla/fenix/perf/StartupExcessiveResourceUseTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/perf/StartupExcessiveResourceUseTest.kt
@@ -134,7 +134,7 @@ private fun countRecyclerViewConstraintLayoutChildren(view: View, parent: View?)
     return if (view !is ViewGroup) {
         viewValue
     } else {
-        viewValue + view.children.sumBy { countRecyclerViewConstraintLayoutChildren(it, view) }
+        viewValue + view.children.sumOf { countRecyclerViewConstraintLayoutChildren(it, view) }
     }
 }
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SearchRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SearchRobot.kt
@@ -222,10 +222,10 @@ private fun searchWrapper() = onView(withId(R.id.search_wrapper))
 
 private fun assertSearchEngineURL(searchEngineName: String) {
     mDevice.waitNotNull(
-        Until.findObject(By.textContains("${searchEngineName.toLowerCase()}.com/?q=mozilla")),
+        Until.findObject(By.textContains("${searchEngineName.lowercase()}.com/?q=mozilla")),
         TestAssetHelper.waitingTime
     )
-    onView(allOf(withText(startsWith("${searchEngineName.toLowerCase()}.com"))))
+    onView(allOf(withText(startsWith("${searchEngineName.lowercase()}.com"))))
         .check(matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 }
 

--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -17,6 +17,7 @@ import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.work.Configuration.Builder
 import androidx.work.Configuration.Provider
 import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
@@ -125,6 +126,7 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
         PerfStartup.applicationOnCreate.stopAndAccumulate(completeMethodDurationTimerId)
     }
 
+    @OptIn(DelicateCoroutinesApi::class) // GlobalScope usage
     protected open fun initializeGlean() {
         val telemetryEnabled = settings().isTelemetryEnabled
 
@@ -208,6 +210,7 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
         }
     }
 
+    @OptIn(DelicateCoroutinesApi::class) // GlobalScope usage
     private fun restoreBrowserState() = GlobalScope.launch(Dispatchers.Main) {
         val store = components.core.store
         val sessionStorage = components.core.sessionStorage
@@ -233,6 +236,7 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
             registerActivityLifecycleCallbacks(PerformanceActivityLifecycleCallbacks(queue))
         }
 
+        @OptIn(DelicateCoroutinesApi::class) // GlobalScope usage
         fun queueInitStorageAndServices() {
             components.performance.visualCompletenessQueue.queue.runIfReadyOrQueue {
                 GlobalScope.launch(Dispatchers.IO) {
@@ -266,12 +270,14 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
             }
         }
 
+        @OptIn(DelicateCoroutinesApi::class) // GlobalScope usage
         fun queueReviewPrompt() {
             GlobalScope.launch(Dispatchers.IO) {
                 components.reviewPromptController.trackApplicationLaunch()
             }
         }
 
+        @OptIn(DelicateCoroutinesApi::class) // GlobalScope usage
         fun queueRestoreLocale() {
             components.performance.visualCompletenessQueue.queue.runIfReadyOrQueue {
                 GlobalScope.launch(Dispatchers.IO) {
@@ -304,6 +310,8 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
     // To re-enable this, we need to do so in a way that won't interfere with any startup operations
     // which acquire reserved+ sqlite lock. Currently, Fennec migrations need to write to storage
     // on startup, and since they run in a background service we can't simply order these operations.
+
+    @OptIn(DelicateCoroutinesApi::class) // GlobalScope usage
     private fun runStorageMaintenance() {
         GlobalScope.launch(Dispatchers.IO) {
             // Bookmarks and history storage sit on top of the same db file so we only need to
@@ -358,6 +366,7 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
      * - https://github.com/mozilla/application-services/blob/master/docs/design/megazords.md
      * - https://mozilla.github.io/application-services/docs/applications/consuming-megazord-libraries.html
      */
+    @OptIn(DelicateCoroutinesApi::class) // GlobalScope usage
     private fun setupMegazord(): Deferred<Unit> {
         // Note: Megazord.init() must be called as soon as possible ...
         Megazord.init()
@@ -439,6 +448,7 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
         }
     }
 
+    @OptIn(DelicateCoroutinesApi::class) // GlobalScope usage
     private fun warmBrowsersCache() {
         // We avoid blocking the main thread for BrowsersCache on startup by loading it on
         // background thread.

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/Event.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/Event.kt
@@ -495,7 +495,7 @@ sealed class Event {
                 }
 
             val countLabel: String
-                get() = "${engineSource.identifier.toLowerCase(Locale.getDefault())}.$label"
+                get() = "${engineSource.identifier.lowercase(Locale.getDefault())}.$label"
 
             val sourceLabel: String
                 get() = "${engineSource.descriptor}.$label"
@@ -576,7 +576,7 @@ sealed class Event {
         }
 
         override val extras: Map<Events.browserMenuActionKeys, String>?
-            get() = mapOf(Events.browserMenuActionKeys.item to item.toString().toLowerCase(Locale.ROOT))
+            get() = mapOf(Events.browserMenuActionKeys.item to item.toString().lowercase(Locale.ROOT))
     }
 
     data class TabCounterMenuItemTapped(val item: Item) : Event() {
@@ -585,7 +585,7 @@ sealed class Event {
         }
 
         override val extras: Map<Events.tabCounterMenuActionKeys, String>?
-            get() = mapOf(Events.tabCounterMenuActionKeys.item to item.toString().toLowerCase(Locale.ROOT))
+            get() = mapOf(Events.tabCounterMenuActionKeys.item to item.toString().lowercase(Locale.ROOT))
     }
 
     object AutoPlaySettingVisited : Event()
@@ -596,7 +596,7 @@ sealed class Event {
         }
 
         override val extras: Map<Autoplay.settingChangedKeys, String>?
-            get() = mapOf(Autoplay.settingChangedKeys.autoplaySetting to setting.toString().toLowerCase(Locale.ROOT))
+            get() = mapOf(Autoplay.settingChangedKeys.autoplaySetting to setting.toString().lowercase(Locale.ROOT))
     }
 
     sealed class Search

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
@@ -83,7 +83,7 @@ private class EventWrapper<T : Enum<T>>(
             if (index == 0) {
                 builder.append(part)
             } else {
-                builder.append(part[0].toUpperCase())
+                builder.append(part[0].uppercase())
                 builder.append(part.substring(1))
             }
         }

--- a/app/src/main/java/org/mozilla/fenix/crashes/CrashReporterController.kt
+++ b/app/src/main/java/org/mozilla/fenix/crashes/CrashReporterController.kt
@@ -5,6 +5,7 @@
 package org.mozilla.fenix.crashes
 
 import androidx.navigation.NavController
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
@@ -69,6 +70,7 @@ class CrashReporterController(
      * @param sendCrash If true, submit a crash report.
      * @return Job if report is submitted through an IO thread, null otherwise
      */
+    @OptIn(DelicateCoroutinesApi::class) // GlobalScope usage
     private fun submitReportIfNecessary(sendCrash: Boolean): Job? {
         var job: Job? = null
         val didSubmitReport = if (sendCrash && settings.isCrashReportingEnabled) {

--- a/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/CustomTabToolbarMenu.kt
@@ -170,7 +170,7 @@ class CustomTabToolbarMenu(
 
     private val poweredBy = BrowserMenuCategory(
         label = context.getStringWithArgSafe(R.string.browser_menu_powered_by, appName)
-            .toUpperCase(Locale.getDefault()),
+            .uppercase(Locale.getDefault()),
         textSize = CAPTION_TEXT_SIZE,
         textColorResource = primaryTextColor(),
         textStyle = Typeface.NORMAL

--- a/app/src/main/java/org/mozilla/fenix/ext/String.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/String.kt
@@ -75,7 +75,7 @@ fun String.toShortUrl(publicSuffixList: PublicSuffixList): String {
 
     return inputString
         .stripUserInfo()
-        .toLowerCase(Locale.getDefault())
+        .lowercase(Locale.getDefault())
         .stripPrefixes()
         .toUnicode()
 }

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragment.kt
@@ -294,7 +294,7 @@ class BookmarkFragment : LibraryPageFragment<BookmarkNode>(), UserInteractionHan
     }
 
     private fun deleteMulti(selected: Set<BookmarkNode>, eventType: Event = Event.RemoveBookmarks) {
-        selected.forEach { if (it.type == BookmarkNodeType.FOLDER) {
+        selected.iterator().forEach { if (it.type == BookmarkNodeType.FOLDER) {
             showRemoveFolderDialog(selected)
             return
         } }

--- a/app/src/main/java/org/mozilla/fenix/perf/StartupTimeline.kt
+++ b/app/src/main/java/org/mozilla/fenix/perf/StartupTimeline.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.OnLifecycleEvent
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import mozilla.components.service.glean.private.NoReasonCodes
@@ -74,6 +75,7 @@ object StartupTimeline {
 /**
  * A [LifecycleObserver] for [HomeActivity] focused on startup performance measurement.
  */
+@OptIn(DelicateCoroutinesApi::class) // GlobalScope usage
 internal class StartupHomeActivityLifecycleObserver(
     private val frameworkStartMeasurement: StartupFrameworkStartMeasurement,
     private val startupTimeline: PingType<NoReasonCodes> = Pings.startupTimeline,

--- a/app/src/main/java/org/mozilla/fenix/perf/StorageStatsMetrics.kt
+++ b/app/src/main/java/org/mozilla/fenix/perf/StorageStatsMetrics.kt
@@ -13,6 +13,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.annotation.VisibleForTesting.PRIVATE
 import androidx.annotation.WorkerThread
 import androidx.core.content.getSystemService
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
@@ -28,6 +29,7 @@ import org.mozilla.fenix.GleanMetrics.StorageStats as Metrics
 @RequiresApi(Build.VERSION_CODES.O) // StorageStatsManager
 object StorageStatsMetrics {
 
+    @OptIn(DelicateCoroutinesApi::class) // GlobalScope usage
     fun report(context: Context) {
         GlobalScope.launch(Dispatchers.IO) {
             reportSync(context)

--- a/app/src/main/java/org/mozilla/fenix/settings/about/AboutLibrariesFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/about/AboutLibrariesFragment.kt
@@ -85,7 +85,7 @@ class AboutLibrariesFragment : Fragment(R.layout.fragment_about_libraries) {
             val licenseData = licensesData.sliceArray(startOffset until startOffset + length)
             val licenseText = licenseData.toString(Charset.forName("UTF-8"))
             LibraryItem(name, licenseText)
-        }.sortedBy { item -> item.name.toLowerCase(Locale.ROOT) }
+        }.sortedBy { item -> item.name.lowercase(Locale.ROOT) }
     }
 
     private fun showLicenseDialog(libraryItem: LibraryItem) {

--- a/app/src/main/java/org/mozilla/fenix/settings/advanced/LocaleViewHolders.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/advanced/LocaleViewHolders.kt
@@ -311,7 +311,7 @@ abstract class BaseLocaleViewHolder(
  * Similar to Kotlin's capitalize with locale parameter, but that method is currently experimental
  */
 private fun String.capitalize(locale: Locale): String {
-    return substring(0, 1).toUpperCase(locale) + substring(1)
+    return substring(0, 1).uppercase(locale) + substring(1)
 }
 
 /**

--- a/app/src/main/java/org/mozilla/fenix/settings/deletebrowsingdata/DeleteBrowsingDataFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/deletebrowsingdata/DeleteBrowsingDataFragment.kt
@@ -55,14 +55,14 @@ class DeleteBrowsingDataFragment : Fragment(R.layout.fragment_delete_browsing_da
         )
         settings = requireContext().settings()
 
-        getCheckboxes().forEach {
+        getCheckboxes().iterator().forEach {
             it.onCheckListener = { _ ->
                 updateDeleteButton()
                 updatePreference(it)
             }
         }
 
-        getCheckboxes().forEach {
+        getCheckboxes().iterator().forEach {
             it.isChecked = when (it.id) {
                 R.id.open_tabs_item -> settings.deleteOpenTabs
                 R.id.browsing_data_item -> settings.deleteBrowsingHistory

--- a/app/src/main/java/org/mozilla/fenix/share/ShareController.kt
+++ b/app/src/main/java/org/mozilla/fenix/share/ShareController.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import mozilla.components.concept.engine.prompt.ShareData
@@ -141,6 +142,7 @@ class DefaultShareController(
         dismiss(ShareController.Result.DISMISSED)
     }
 
+    @OptIn(DelicateCoroutinesApi::class) // GlobalScope usage
     private fun shareToDevicesWithRetry(shareOperation: () -> Deferred<Boolean>) {
         // Use GlobalScope to allow the continuation of this method even if the share fragment is closed.
         GlobalScope.launch(Dispatchers.Main) {

--- a/app/src/test/java/org/mozilla/fenix/settings/deletebrowsingdata/DefaultDeleteBrowsingDataControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/deletebrowsingdata/DefaultDeleteBrowsingDataControllerTest.kt
@@ -8,6 +8,7 @@ import io.mockk.coVerify
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.GlobalScope.coroutineContext
 import kotlinx.coroutines.test.TestCoroutineDispatcher
@@ -45,6 +46,7 @@ class DefaultDeleteBrowsingDataControllerTest {
     private lateinit var controller: DefaultDeleteBrowsingDataController
 
     @Before
+    @OptIn(DelicateCoroutinesApi::class) // coroutineContext usage
     fun setup() {
         controller = DefaultDeleteBrowsingDataController(
             removeAllTabs = removeAllTabs,

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ buildscript {
                     includeGroupByRegex RepoMatching.androidx
                     includeGroupByRegex RepoMatching.comGoogleAndroid
                     includeGroupByRegex RepoMatching.comGoogleFirebase
+                    includeGroupByRegex RepoMatching.comGoogleTesting
                     includeGroupByRegex RepoMatching.comAndroid
                 }
             }

--- a/build.gradle
+++ b/build.gradle
@@ -138,7 +138,8 @@ allprojects {
         kotlinOptions.jvmTarget = "1.8"
         kotlinOptions.allWarningsAsErrors = true
         kotlinOptions.freeCompilerArgs += [
-            "-Xuse-experimental=kotlin.Experimental"
+            "-Xuse-experimental=kotlin.Experimental",
+            "-Xopt-in=kotlin.RequiresOptIn"
         ]
     }
 }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -3,12 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object Versions {
-    const val kotlin = "1.5.10"
+    const val kotlin = "1.5.20"
     const val coroutines = "1.5.0"
 
     // These versions are linked: lint should be X+23.Y.Z of gradle_plugin version, according to:
     // https://github.com/alexjlockwood/android-lint-checks-demo/blob/0245fc027463137b1b4afb97c5295d60dce998b6/dependencies.gradle#L3
-    const val android_gradle_plugin = "4.0.1"
+    const val android_gradle_plugin = "4.2.2"
     const val android_lint_api = "27.0.1"
 
     const val sentry = "1.7.10"
@@ -243,6 +243,7 @@ object RepoMatching {
     const val androidx = "androidx\\..*"
     const val comAndroid = "com\\.android.*"
     const val comGoogleFirebase = "com\\.google\\.firebase"
+    const val comGoogleTesting = "com\\.google\\.testing\\..*"
 
     /**
      * A matcher for com.google.android.* with one exception: the espresso-contrib dependency includes the

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -3,8 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object Versions {
-    const val kotlin = "1.4.30"
-    const val coroutines = "1.4.2"
+    const val kotlin = "1.5.10"
+    const val coroutines = "1.5.0"
 
     // These versions are linked: lint should be X+23.Y.Z of gradle_plugin version, according to:
     // https://github.com/alexjlockwood/android-lint-checks-demo/blob/0245fc027463137b1b4afb97c5295d60dce998b6/dependencies.gradle#L3

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Matching A-C upgrade: https://github.com/mozilla-mobile/android-components/pull/10453

Similar to the patch in A-C, I added `@OptIn(DelicateCoroutinesApi::class)` to all existing `GlobalScope` usages. However I think we may want to review them and see if there are better options.