### PR TITLE
For #19131 - Fixes top sites refresh and interactability

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlAdapter.kt
@@ -47,6 +47,10 @@ sealed class AdapterItem(@LayoutRes val viewType: Int) {
         ButtonTipViewHolder.LAYOUT_ID
     )
 
+    /**
+     * Contains a set of [Pair]s where [Pair.first] is the index of the changed [TopSite] and
+     * [Pair.second] is the new [TopSite].
+     */
     data class TopSitePagerPayload(
         val changed: Set<Pair<Int, TopSite>>
     )

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/TopSitePagerViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/TopSitePagerViewHolder.kt
@@ -53,9 +53,9 @@ class TopSitePagerViewHolder(
     }
 
     fun update(payload: AdapterItem.TopSitePagerPayload) {
-        for (item in payload.changed) {
-            topSitesPagerAdapter.notifyItemChanged(currentPage, payload)
-        }
+        // Due to offscreenPageLimit = 1 we need to update both pages manually here
+        topSitesPagerAdapter.notifyItemChanged(0, payload)
+        topSitesPagerAdapter.notifyItemChanged(1, payload)
     }
 
     fun bind(topSites: List<TopSite>) {

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/topsites/TopSiteItemViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/topsites/TopSiteItemViewHolder.kt
@@ -11,7 +11,6 @@ import android.view.View
 import android.widget.PopupWindow
 import androidx.appcompat.content.res.AppCompatResources.getDrawable
 import kotlinx.android.synthetic.main.top_site_item.*
-import kotlinx.android.synthetic.main.top_site_item.view.*
 import mozilla.components.browser.menu.BrowserMenuBuilder
 import mozilla.components.browser.menu.item.SimpleBrowserMenuItem
 import mozilla.components.feature.top.sites.TopSite
@@ -91,11 +90,6 @@ class TopSiteItemViewHolder(
         }
 
         this.topSite = topSite
-    }
-
-    fun bind(topSitePayload: TopSitesAdapter.TopSitePayload) {
-        itemView.top_site_title.text = topSitePayload.newTitle
-        topSite = topSite.copy(title = topSitePayload.newTitle)
     }
 
     private fun onTouchEvent(

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/topsites/TopSitesAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/topsites/TopSitesAdapter.kt
@@ -8,7 +8,6 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
-import kotlinx.android.synthetic.main.top_site_item.view.*
 import mozilla.components.feature.top.sites.TopSite
 import org.mozilla.fenix.home.sessioncontrol.TopSiteInteractor
 import org.mozilla.fenix.perf.StartupTimeline
@@ -39,16 +38,9 @@ class TopSitesAdapter(
                 is TopSite -> {
                     holder.bind((payloads[0] as TopSite))
                 }
-                is TopSitePayload -> {
-                    holder.bind(payloads[0] as TopSitePayload)
-                }
             }
         }
     }
-
-    data class TopSitePayload(
-        val newTitle: String?
-    )
 
     internal object TopSitesDiffCallback : DiffUtil.ItemCallback<TopSite>() {
         override fun areItemsTheSame(oldItem: TopSite, newItem: TopSite) = oldItem.id == newItem.id
@@ -58,7 +50,7 @@ class TopSitesAdapter(
 
         override fun getChangePayload(oldItem: TopSite, newItem: TopSite): Any? {
             return if (oldItem.id == newItem.id && oldItem.url == newItem.url && oldItem.title != newItem.title) {
-                TopSitePayload(newItem.title)
+                newItem
             } else null
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/topsites/TopSitesPagerAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/topsites/TopSitesPagerAdapter.kt
@@ -10,7 +10,7 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import kotlinx.android.synthetic.main.component_top_sites.view.*
 import mozilla.components.feature.top.sites.TopSite
-import org.mozilla.fenix.home.sessioncontrol.AdapterItem
+import org.mozilla.fenix.home.sessioncontrol.AdapterItem.TopSitePagerPayload
 import org.mozilla.fenix.home.sessioncontrol.TopSiteInteractor
 import org.mozilla.fenix.home.sessioncontrol.viewholders.TopSitePagerViewHolder.Companion.TOP_SITES_PER_PAGE
 import org.mozilla.fenix.home.sessioncontrol.viewholders.TopSiteViewHolder
@@ -33,15 +33,26 @@ class TopSitesPagerAdapter(
         if (payloads.isNullOrEmpty()) {
             onBindViewHolder(holder, position)
         } else {
-            if (payloads[0] is AdapterItem.TopSitePagerPayload) {
+            if (payloads[0] is TopSitePagerPayload) {
                 val adapter = holder.itemView.top_sites_list.adapter as TopSitesAdapter
-                val payload = payloads[0] as AdapterItem.TopSitePagerPayload
-                for (item in payload.changed) {
-                    adapter.notifyItemChanged(
-                        item.first % TOP_SITES_PER_PAGE,
-                        TopSitesAdapter.TopSitePayload(item.second.title)
-                    )
-                }
+                val payload = payloads[0] as TopSitePagerPayload
+
+                update(payload, position, adapter)
+            }
+        }
+    }
+
+    private fun update(
+        payload: TopSitePagerPayload,
+        position: Int,
+        adapter: TopSitesAdapter
+    ) {
+        // Only currently selected page items need to be updated.
+        for (item in payload.changed) {
+            if (item.first < TOP_SITES_PER_PAGE && position == 0) {
+                adapter.notifyItemChanged(item.first, item.second)
+            } else if (item.first >= TOP_SITES_PER_PAGE && position == 1) {
+                adapter.notifyItemChanged(item.first - TOP_SITES_PER_PAGE, item.second)
             }
         }
     }
@@ -67,7 +78,7 @@ class TopSitesPagerAdapter(
                     changed.add(Pair(index, item))
                 }
             }
-            return if (changed.isNotEmpty()) AdapterItem.TopSitePagerPayload(changed) else null
+            return if (changed.isNotEmpty()) TopSitePagerPayload(changed) else null
         }
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/viewholders/topsites/TopSitesAdapterTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/viewholders/topsites/TopSitesAdapterTest.kt
@@ -29,7 +29,7 @@ class TopSitesAdapterTest {
 
         assertEquals(
             TopSitesAdapter.TopSitesDiffCallback.getChangePayload(topSite, topSite2),
-            TopSitesAdapter.TopSitePayload("Title2")
+            topSite.copy(title = "Title2")
         )
 
         val topSite3 = TopSite(


### PR DESCRIPTION
For https://github.com/mozilla-mobile/fenix/issues/19131

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes no new tests as it is only a bug fix of previous behavior.
- [x] **Screenshots**: This PR includes screenshots or GIFs.
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

Video of the fix:


https://user-images.githubusercontent.com/60002907/121899989-99a6cd00-cd2d-11eb-8265-be4f0fce0f9e.mp4




### Notes: 
- The issue was caused by a combination of several factors including the behavior change of using `offscreenPageLimit = 1` in `TopSitePagerViewHolder`(which is needed to keep the height of the topSites accurate)
- There fix reveals a new issue, however: when the items for the topSites list are fewer than 16, the efficient `getChangePayload` isn't triggered in `SessionControlAdapter` and thus all the topSites are refreshed. I will log a separate issue for this and link it here. I think this should be fixed sooner rather than later as it seems very jarring. Below you can see the problem in action:


https://user-images.githubusercontent.com/60002907/121891974-d4583780-cd24-11eb-8d42-629271f9704f.mp4




