### PR TITLE
For #20007: Prevent multiselect title being selected by a11y services when not in select mode

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabstray/browser/SelectionBannerBinding.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/browser/SelectionBannerBinding.kt
@@ -138,6 +138,8 @@ class SelectionBannerBinding(
         if (selectedMode) {
             containerView.multiselect_title.text =
                 context.getString(R.string.tab_tray_multi_select_title, tabCount)
+            containerView.multiselect_title.importantForAccessibility =
+                View.IMPORTANT_FOR_ACCESSIBILITY_YES
         }
     }
 }

--- a/app/src/main/res/layout/component_tabstray2.xml
+++ b/app/src/main/res/layout/component_tabstray2.xml
@@ -62,6 +62,7 @@
         android:focusableInTouchMode="true"
         android:textColor="@color/contrast_text_normal_theme"
         android:textSize="20sp"
+        android:importantForAccessibility="no"
         app:fontFamily="@font/metropolis_semibold"
         app:layout_constraintBottom_toBottomOf="@id/topBar"
         app:layout_constraintEnd_toStartOf="@id/collect_multi_select"


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
