### PR TITLE
For #19988 - Load tab icon from BrowserIcons cache if needed for the recent tab

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -115,7 +115,7 @@ import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.home.mozonline.showPrivacyPopWindow
 import org.mozilla.fenix.home.recenttabs.controller.DefaultRecentTabsController
 import org.mozilla.fenix.home.sessioncontrol.DefaultSessionControlController
-import org.mozilla.fenix.home.sessioncontrol.RecentTabsListFeature
+import org.mozilla.fenix.home.recenttabs.RecentTabsListFeature
 import org.mozilla.fenix.home.sessioncontrol.SessionControlInteractor
 import org.mozilla.fenix.home.sessioncontrol.SessionControlView
 import org.mozilla.fenix.home.sessioncontrol.viewholders.CollectionViewHolder

--- a/app/src/main/java/org/mozilla/fenix/home/recenttabs/RecentTabsListFeature.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recenttabs/RecentTabsListFeature.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.fenix.home.sessioncontrol
+package org.mozilla.fenix.home.recenttabs
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow

--- a/app/src/main/java/org/mozilla/fenix/home/recenttabs/view/RecentTabViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recenttabs/view/RecentTabViewHolder.kt
@@ -6,8 +6,11 @@ package org.mozilla.fenix.home.recenttabs.view
 
 import android.view.View
 import kotlinx.android.synthetic.main.recent_tabs_list_row.*
+import mozilla.components.browser.icons.BrowserIcons
 import mozilla.components.browser.state.state.TabSessionState
 import org.mozilla.fenix.R
+import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.loadIntoView
 import org.mozilla.fenix.home.recenttabs.interactor.RecentTabInteractor
 import org.mozilla.fenix.utils.view.ViewHolder
 
@@ -15,15 +18,22 @@ import org.mozilla.fenix.utils.view.ViewHolder
  * View holder for a recent tab item.
  *
  * @param interactor [RecentTabInteractor] which will have delegated to all user interactions.
+ * @param icons
  */
 class RecentTabViewHolder(
     view: View,
-    private val interactor: RecentTabInteractor
+    private val interactor: RecentTabInteractor,
+    private val icons: BrowserIcons = view.context.components.core.icons
 ) : ViewHolder(view) {
 
     fun bindTab(tab: TabSessionState) {
         recent_tab_title.text = tab.content.title
-        recent_tab_icon.setImageBitmap(tab.content.icon)
+
+        if (tab.content.icon != null) {
+            recent_tab_icon.setImageBitmap(tab.content.icon)
+        } else {
+            icons.loadIntoView(recent_tab_icon, tab.content.url)
+        }
 
         itemView.setOnClickListener {
             interactor.onRecentTabClicked(tab.id)

--- a/app/src/test/java/org/mozilla/fenix/home/RecentTabsListFeatureTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/RecentTabsListFeatureTest.kt
@@ -16,7 +16,7 @@ import mozilla.components.support.test.rule.MainCoroutineRule
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
-import org.mozilla.fenix.home.sessioncontrol.RecentTabsListFeature
+import org.mozilla.fenix.home.recenttabs.RecentTabsListFeature
 
 class RecentTabsListFeatureTest {
 

--- a/app/src/test/java/org/mozilla/fenix/home/recenttabs/view/RecentTabViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/recenttabs/view/RecentTabViewHolderTest.kt
@@ -6,9 +6,13 @@ package org.mozilla.fenix.home.recenttabs.view
 
 import android.view.LayoutInflater
 import android.view.View
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.android.synthetic.main.recent_tabs_list_row.*
 import kotlinx.android.synthetic.main.recent_tabs_list_row.view.*
+import mozilla.components.browser.icons.BrowserIcons
+import mozilla.components.browser.icons.IconRequest
 import mozilla.components.browser.state.state.createTab
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
@@ -23,6 +27,7 @@ class RecentTabViewHolderTest {
 
     private lateinit var view: View
     private lateinit var interactor: SessionControlInteractor
+    private lateinit var icons: BrowserIcons
 
     private val tab = createTab(
         url = "https://mozilla.org",
@@ -33,18 +38,23 @@ class RecentTabViewHolderTest {
     fun setup() {
         view = LayoutInflater.from(testContext).inflate(RecentTabViewHolder.LAYOUT_ID, null)
         interactor = mockk(relaxed = true)
+        icons = mockk(relaxed = true)
+
+        every { icons.loadIntoView(view.recent_tab_icon, any()) } returns mockk()
     }
 
     @Test
-    fun `GIVEN a new recent tab on bind THEN set the title text`() {
-        RecentTabViewHolder(view, interactor).bindTab(tab)
+    fun `GIVEN a new recent tab on bind THEN set the title text and load the tab icon`() {
+        RecentTabViewHolder(view, interactor, icons).bindTab(tab)
 
         assertEquals(tab.content.title, view.recent_tab_title.text)
+
+        verify { icons.loadIntoView(view.recent_tab_icon, IconRequest(tab.content.url)) }
     }
 
     @Test
-    fun `WHEN a recent tab item is clicked THEN interactor iis called`() {
-        RecentTabViewHolder(view, interactor).bindTab(tab)
+    fun `WHEN a recent tab item is clicked THEN interactor is called`() {
+        RecentTabViewHolder(view, interactor, icons).bindTab(tab)
 
         view.performClick()
 


### PR DESCRIPTION
Fixes #19988

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
