### PR TITLE
Backport Mozilla Online builds to 90.0 release branch

### DIFF
--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -122,6 +122,23 @@ jobs:
         treeherder:
             symbol: beta(Bat)
 
+    android-test-mozillaonline:
+        apk-artifact-template:
+            # 3 differences here:
+            #  * "androidTest/" is added
+            #  * "{gradle_build_type}" is forced to "beta"
+            #  * "{fileName}" is forced to "app-beta-androidTest.apk"
+            path: '/builds/worker/checkouts/src/app/build/outputs/apk/androidTest/beta/app-beta-androidTest.apk'
+        disable-optimization: true
+        run:
+            gradle-build-type: androidTest
+            gradle-extra-options:
+                - -PmozillaOnline
+            test-build-type: beta
+        run-on-tasks-for: [github-push] # We want this on push so that we detect problem before triggering a new beta
+        treeherder:
+            symbol: beta(Bat-mo)
+
     nightly-simulation:
         attributes:
             nightly: false
@@ -155,6 +172,21 @@ jobs:
         treeherder:
             symbol: beta(B)
 
+    beta-mozillaonline:
+        apk-artifact-template:
+            github-name: 'fenix-mozillaonline-{version}-{abi}.apk'
+        attributes:
+            release-type: beta
+        include-release-version: true
+        include-shippable-secrets: true
+        filter-incomplete-translations: true
+        run:
+            gradle-build-type: beta
+            gradle-extra-options:
+                - -PmozillaOnline
+        treeherder:
+            symbol: beta(Bmo)
+
     release:
         attributes:
             release-type: release
@@ -165,3 +197,18 @@ jobs:
             gradle-build-type: release
         treeherder:
             symbol: release(B)
+
+    release-mozillaonline:
+        apk-artifact-template:
+            github-name: 'fenix-mozillaonline-{version}-{abi}.apk'
+        attributes:
+            release-type: release
+        include-release-version: true
+        include-shippable-secrets: true
+        filter-incomplete-translations: true
+        run:
+            gradle-build-type: release
+            gradle-extra-options:
+                - -PmozillaOnline
+        treeherder:
+            symbol: release(Bmo)

--- a/taskcluster/ci/signing/kind.yml
+++ b/taskcluster/ci/signing/kind.yml
@@ -7,6 +7,7 @@ loader: fenix_taskgraph.loader.multi_dep:loader
 transforms:
     - fenix_taskgraph.transforms.multi_dep:transforms
     - fenix_taskgraph.transforms.signing:transforms
+    - fenix_taskgraph.transforms.notify:transforms
     - taskgraph.transforms.task:transforms
 
 kind-dependencies:
@@ -19,12 +20,16 @@ group-by: build-type
 job-template:
     description: Sign Fenix
     worker: {}
-    signing-format: autograph_apk
+    signing-format:
+        by-build-type:
+            beta-mozillaonline: autograph_apk_mozillaonline
+            release-mozillaonline: autograph_apk_mozillaonline
+            default: autograph_apk
     index:
         by-tasks-for:
             (action|cron|github-release):
                 by-build-type:
-                    (nightly|debug|nightly-simulation|beta|release):
+                    (nightly|debug|nightly-simulation|beta|beta-mozillaonline|release|release-mozillaonline):
                         type: signing
                     default: {}
             default: {}
@@ -33,15 +38,33 @@ job-template:
             # No test job runs on push against this build type. Although we do want nightly-simulation
             # signed to use it in the gecko trees.
             # We want beta on push so that we detect problem before shipping it
-            (nightly-simulation|beta-firebase|android-test-beta|nightly-firebase|android-test-nightly): [github-push]
+            (nightly-simulation|beta-firebase|android-test-beta|android-test-mozillaonline|nightly-firebase|android-test-nightly): [github-push]
             default: []
     treeherder:
         job-symbol:
             by-build-type:
                 android-test.+: Bats
+                android-test-mozillaonline: Bats-mo
                 beta-firebase: Bfs
                 nightly-firebase: Bfs
+                beta-mozillaonline: Bmos
+                release-mozillaonline: Bmos
                 default: Bs
         kind: build
         platform: android-all/opt
         tier: 1
+    notify:
+        by-build-type:
+            .*mozillaonline:
+                by-level:
+                    '3':
+                        email:
+                            content: The Mozilla Online Fenix {version} APKs are now available
+                            link:
+                                text: Taskcluster Task
+                                href: 'https://firefox-ci-tc.services.mozilla.com/tasks/${status.taskId}'
+                            on-reasons: [completed]
+                            subject: Mozilla Online Fenix {version} APKs are now available
+                            to-addresses: [mozillaonline-fenix@mozilla.com]
+                    default: {}
+            default: {}

--- a/taskcluster/fenix_taskgraph/transforms/build.py
+++ b/taskcluster/fenix_taskgraph/transforms/build.py
@@ -75,6 +75,14 @@ def build_gradle_command(config, tasks):
         yield task
 
 @transforms.add
+def extra_gradle_options(config, tasks):
+    for task in tasks:
+        for extra in task["run"].pop("gradle-extra-options", []):
+            task["run"]["gradlew"].append(extra)
+
+        yield task
+
+@transforms.add
 def add_test_build_type(config, tasks):
     for task in tasks:
         test_build_type = task["run"].pop("test-build-type", "")

--- a/taskcluster/fenix_taskgraph/transforms/signing.py
+++ b/taskcluster/fenix_taskgraph/transforms/signing.py
@@ -18,7 +18,7 @@ transforms = TransformSequence()
 @transforms.add
 def resolve_keys(config, tasks):
     for task in tasks:
-        for key in ("run-on-tasks-for",):
+        for key in ("run-on-tasks-for", "signing-format", "notify"):
             resolve_keyed_by(
                 task,
                 key,
@@ -56,7 +56,7 @@ def set_signing_type(config, tasks):
         ):
             if task["attributes"]["build-type"] in ("beta", "release"):
                 signing_type = "fennec-production-signing"
-            elif task["attributes"]["build-type"] in ("nightly", "android-test-nightly"):
+            elif task["attributes"]["build-type"] in ("nightly", "android-test-nightly", "beta-mozillaonline", "release-mozillaonline"):
                 signing_type = "production-signing"
         task.setdefault("worker", {})["signing-type"] = signing_type
         yield task
@@ -89,4 +89,18 @@ def set_signing_format(config, tasks):
         signing_format = task.pop("signing-format")
         for upstream_artifact in task["worker"]["upstream-artifacts"]:
             upstream_artifact["formats"] = [signing_format]
+        yield task
+
+
+@transforms.add
+def format_email(config, tasks):
+    version = config.params["version"]
+
+    for task in tasks:
+        if "notify" in task:
+            email = task["notify"].get("email")
+            if email:
+                email["subject"] = email["subject"].format(version=version)
+                email["content"] = email["content"].format(version=version)
+
         yield task


### PR DESCRIPTION
This is just a roll-up of #19898, #20006, and #20010 for the 90.0 release branch.