### PR TITLE
Closes #19937 close tab on select gridView

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabstray/browser/AbstractBrowserTabViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/browser/AbstractBrowserTabViewHolder.kt
@@ -102,6 +102,7 @@ abstract class AbstractBrowserTabViewHolder(
         }
     }
 
+    // Function for selecting multiple Tabs at Once.
     fun showTabIsMultiSelectEnabled(isSelected: Boolean) {
         itemView.selected_mask.isVisible = isSelected
         closeView.isGone = trayStore.state.mode is TabsTrayState.Mode.Select

--- a/app/src/main/java/org/mozilla/fenix/tabstray/browser/AbstractBrowserTabViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/browser/AbstractBrowserTabViewHolder.kt
@@ -104,7 +104,7 @@ abstract class AbstractBrowserTabViewHolder(
 
     fun showTabIsMultiSelectEnabled(isSelected: Boolean) {
         itemView.selected_mask.isVisible = isSelected
-        closeView.isInvisible = trayStore.state.mode is TabsTrayState.Mode.Select
+        closeView.isGone = trayStore.state.mode is TabsTrayState.Mode.Select
     }
 
     private fun updateFavicon(tab: Tab) {

--- a/app/src/main/java/org/mozilla/fenix/tabstray/browser/BrowserTabsAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/browser/BrowserTabsAdapter.kt
@@ -71,7 +71,9 @@ class BrowserTabsAdapter(
 
         holder.tab?.let { tab ->
             holder.itemView.mozac_browser_tabstray_close.setOnClickListener {
-                interactor.close(tab)
+                if(!holder.itemView.mozac_browser_tabstray_close.isGone) {
+                    interactor.close(tab)
+                }
             }
 
             selectionHolder?.let {


### PR DESCRIPTION
Thanks for the clarification @Mugurell !

I went back to do some debugging on both the layout file and the viewHolder file. From my experience changing "closeView.isInvisible" to "closeView.isGone" wasn't enough to solve the bug.

`        closeView.isGone =  trayStore.state.mode is TabsTrayState.Mode.Select
`

I did make the change to closeView.isGone and looked deeper into the onBindViewHolder and added the condition to prevent the onClickListener to be active when isGone is true. It looks like it solved the problem! :)

![firefox_tabs_gif](https://user-images.githubusercontent.com/65101411/122285421-8c135380-cea3-11eb-943a-c199278f0f65.gif)

