### PR TITLE
Close #19950: Fix intermittent failure in SearchDialogControllerTest

### DIFF
--- a/app/src/test/java/org/mozilla/fenix/search/SearchDialogControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/search/SearchDialogControllerTest.kt
@@ -23,6 +23,7 @@ import mozilla.components.browser.state.search.SearchEngine
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.feature.tabs.TabsUseCases
+import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import mozilla.components.support.test.middleware.CaptureActionsMiddleware
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -58,6 +59,7 @@ class SearchDialogControllerTest {
 
     private lateinit var controller: SearchDialogController
     private lateinit var middleware: CaptureActionsMiddleware<BrowserState, BrowserAction>
+    private lateinit var browserStore: BrowserStore
 
     @get:Rule
     val disableNavGraphProviderAssertionRule = DisableNavGraphProviderAssertionRule()
@@ -67,7 +69,7 @@ class SearchDialogControllerTest {
         MockKAnnotations.init(this)
         mockkObject(MetricsUtils)
         middleware = CaptureActionsMiddleware()
-        val browserStore = BrowserStore(
+        browserStore = BrowserStore(
             middleware = listOf(middleware)
         )
         every { store.state.tabId } returns "test-tab-id"
@@ -336,6 +338,8 @@ class SearchDialogControllerTest {
     fun handleExistingSessionSelected() {
         controller.handleExistingSessionSelected("selected")
 
+        browserStore.waitUntilIdle()
+
         middleware.assertFirstAction(TabListAction.SelectTabAction::class) { action ->
             assertEquals("selected", action.tabId)
         }
@@ -346,6 +350,8 @@ class SearchDialogControllerTest {
     @Test
     fun handleExistingSessionSelected_tabId() {
         controller.handleExistingSessionSelected("tab-id")
+
+        browserStore.waitUntilIdle()
 
         middleware.assertFirstAction(TabListAction.SelectTabAction::class) { action ->
             assertEquals("tab-id", action.tabId)


### PR DESCRIPTION
This intermittent test failure has hit me twice in one day already. Time to fix it!

These are the only two places where we need to assert actions on the browser store.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
