### PR TITLE
For #19922 Update the default autoplay setting to be block audio only

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuSitePermissionsCommonRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuSitePermissionsCommonRobot.kt
@@ -139,11 +139,11 @@ private fun assertCheckAutoPayRadioButtonDefault() {
 
     // Block audio only
     onView(withId(R.id.third_radio))
-        .assertIsChecked(isChecked = false)
+        .assertIsChecked(isChecked = true)
 
     // Block audio and video
     onView(withId(R.id.fourth_radio))
-        .assertIsChecked(isChecked = true)
+        .assertIsChecked(isChecked = false)
 }
 
 private fun assertAskToAllowRecommended() = onView(withId(R.id.ask_to_allow_radio))

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuSitePermissionsRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuSitePermissionsRobot.kt
@@ -159,7 +159,7 @@ class SettingsSubMenuSitePermissionsRobot {
         onView(withText("Autoplay"))
             .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
-        val autoplayText = "Block audio and video"
+        val autoplayText = "Block audio only"
         onView(withText(autoplayText))
             .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 

--- a/app/src/main/java/org/mozilla/fenix/settings/PhoneFeature.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/PhoneFeature.kt
@@ -99,9 +99,9 @@ enum class PhoneFeature(val androidPermissionsList: Array<String>) : Parcelable 
             LOCATION -> R.string.pref_key_phone_feature_location
             MICROPHONE -> R.string.pref_key_phone_feature_microphone
             NOTIFICATION -> R.string.pref_key_phone_feature_notification
-            AUTOPLAY -> R.string.pref_key_browser_feature_autoplay_audible
-            AUTOPLAY_AUDIBLE -> R.string.pref_key_browser_feature_autoplay_audible
-            AUTOPLAY_INAUDIBLE -> R.string.pref_key_browser_feature_autoplay_inaudible
+            AUTOPLAY -> R.string.pref_key_browser_feature_autoplay_audible_v1
+            AUTOPLAY_AUDIBLE -> R.string.pref_key_browser_feature_autoplay_audible_v1
+            AUTOPLAY_INAUDIBLE -> R.string.pref_key_browser_feature_autoplay_inaudible_v1
             PERSISTENT_STORAGE -> R.string.pref_key_browser_feature_persistent_storage
             MEDIA_KEY_SYSTEM_ACCESS -> R.string.pref_key_browser_feature_media_key_system_access
         }

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -44,6 +44,7 @@ import org.mozilla.fenix.settings.logins.SavedLoginsSortingStrategyMenu
 import org.mozilla.fenix.settings.logins.SortingStrategy
 import org.mozilla.fenix.settings.registerOnSharedPreferenceChangeListener
 import org.mozilla.fenix.settings.sitepermissions.AUTOPLAY_BLOCK_ALL
+import org.mozilla.fenix.settings.sitepermissions.AUTOPLAY_BLOCK_AUDIBLE
 import java.security.InvalidParameterException
 
 private const val AUTOPLAY_USER_SETTING = "AUTOPLAY_USER_SETTING"
@@ -814,7 +815,7 @@ class Settings(private val appContext: Context) : PreferencesHolder {
      * either [AUTOPLAY_ALLOW_ALL] or [AUTOPLAY_BLOCK_ALL]. Because of this, we are forced to save
      * the user selected setting as well.
      */
-    fun getAutoplayUserSetting() = preferences.getInt(AUTOPLAY_USER_SETTING, AUTOPLAY_BLOCK_ALL)
+    fun getAutoplayUserSetting() = preferences.getInt(AUTOPLAY_USER_SETTING, AUTOPLAY_BLOCK_AUDIBLE)
 
     private fun getSitePermissionsPhoneFeatureAutoplayAction(
         feature: PhoneFeature,
@@ -834,8 +835,14 @@ class Settings(private val appContext: Context) : PreferencesHolder {
             microphone = getSitePermissionsPhoneFeatureAction(PhoneFeature.MICROPHONE),
             location = getSitePermissionsPhoneFeatureAction(PhoneFeature.LOCATION),
             camera = getSitePermissionsPhoneFeatureAction(PhoneFeature.CAMERA),
-            autoplayAudible = getSitePermissionsPhoneFeatureAutoplayAction(PhoneFeature.AUTOPLAY_AUDIBLE),
-            autoplayInaudible = getSitePermissionsPhoneFeatureAutoplayAction(PhoneFeature.AUTOPLAY_INAUDIBLE),
+            autoplayAudible = getSitePermissionsPhoneFeatureAutoplayAction(
+                feature = PhoneFeature.AUTOPLAY_AUDIBLE,
+                default = AutoplayAction.ALLOWED
+            ),
+            autoplayInaudible = getSitePermissionsPhoneFeatureAutoplayAction(
+                feature = PhoneFeature.AUTOPLAY_INAUDIBLE,
+                default = AutoplayAction.BLOCKED
+            ),
             persistentStorage = getSitePermissionsPhoneFeatureAction(PhoneFeature.PERSISTENT_STORAGE),
             mediaKeySystemAccess = getSitePermissionsPhoneFeatureAction(PhoneFeature.MEDIA_KEY_SYSTEM_ACCESS)
         )

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -115,9 +115,9 @@
     <string name="pref_key_show_site_exceptions" translatable="false">pref_key_show_site_exceptions</string>
     <string name="pref_key_recommended_settings" translatable="false">pref_key_recommended_settings</string>
     <string name="pref_key_custom_settings" translatable="false">pref_key_custom_settings</string>
-    <string name="pref_key_browser_feature_autoplay" translatable="false">pref_key_browser_feature_autoplay</string>
-    <string name="pref_key_browser_feature_autoplay_audible" translatable="false">pref_key_browser_feature_autoplay</string>
-    <string name="pref_key_browser_feature_autoplay_inaudible" translatable="false">pref_key_browser_feature_autoplay_inaudible</string>
+    <string name="pref_key_browser_feature_autoplay_v1" translatable="false">pref_key_browser_feature_autoplay_v1</string>
+    <string name="pref_key_browser_feature_autoplay_audible_v1" translatable="false">pref_key_browser_feature_autoplay_v1</string>
+    <string name="pref_key_browser_feature_autoplay_inaudible_v1" translatable="false">pref_key_browser_feature_autoplay_inaudible_v1</string>
     <string name="pref_key_browser_feature_persistent_storage" translatable="false">pref_key_browser_feature_persistent_storage</string>
     <string name="pref_key_browser_feature_media_key_system_access" translatable="false">pref_key_browser_feature_media_key_system_access</string>
     <string name="pref_key_phone_feature_camera" translatable="false">pref_key_phone_feature_camera</string>

--- a/app/src/main/res/xml/site_permissions_details_exceptions_preferences.xml
+++ b/app/src/main/res/xml/site_permissions_details_exceptions_preferences.xml
@@ -42,7 +42,7 @@
 
     <androidx.preference.Preference
         android:icon="@drawable/ic_autoplay"
-        android:key="@string/pref_key_browser_feature_autoplay"
+        android:key="@string/pref_key_browser_feature_autoplay_v1"
         android:title="@string/preference_browser_feature_autoplay"
         android:summary="@string/preference_option_phone_feature_ask_to_allow"/>
 

--- a/app/src/main/res/xml/site_permissions_preferences.xml
+++ b/app/src/main/res/xml/site_permissions_preferences.xml
@@ -7,7 +7,7 @@
 
     <androidx.preference.Preference
             android:icon="@drawable/ic_autoplay_enabled"
-            android:key="@string/pref_key_browser_feature_autoplay_audible"
+            android:key="@string/pref_key_browser_feature_autoplay_audible_v1"
             android:title="@string/preference_browser_feature_autoplay"
             android:summary="@string/preference_option_autoplay_blocked3"/>
 

--- a/app/src/test/java/org/mozilla/fenix/settings/PhoneFeatureTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/PhoneFeatureTest.kt
@@ -74,12 +74,12 @@ class PhoneFeatureTest {
         assertEquals(R.string.pref_key_phone_feature_location, PhoneFeature.LOCATION.getPreferenceId())
         assertEquals(R.string.pref_key_phone_feature_microphone, PhoneFeature.MICROPHONE.getPreferenceId())
         assertEquals(R.string.pref_key_phone_feature_notification, PhoneFeature.NOTIFICATION.getPreferenceId())
-        assertEquals(R.string.pref_key_browser_feature_autoplay_audible, PhoneFeature.AUTOPLAY_AUDIBLE.getPreferenceId())
-        assertEquals(R.string.pref_key_browser_feature_autoplay_inaudible, PhoneFeature.AUTOPLAY_INAUDIBLE.getPreferenceId())
-        assertEquals(R.string.pref_key_browser_feature_autoplay_audible, PhoneFeature.AUTOPLAY.getPreferenceId())
+        assertEquals(R.string.pref_key_browser_feature_autoplay_audible_v1, PhoneFeature.AUTOPLAY_AUDIBLE.getPreferenceId())
+        assertEquals(R.string.pref_key_browser_feature_autoplay_inaudible_v1, PhoneFeature.AUTOPLAY_INAUDIBLE.getPreferenceId())
+        assertEquals(R.string.pref_key_browser_feature_autoplay_audible_v1, PhoneFeature.AUTOPLAY.getPreferenceId())
 
         assertEquals(
-            "pref_key_browser_feature_autoplay_inaudible",
+            "pref_key_browser_feature_autoplay_inaudible_v1",
             PhoneFeature.AUTOPLAY_INAUDIBLE.getPreferenceKey(testContext)
         )
     }

--- a/app/src/test/java/org/mozilla/fenix/utils/SettingsTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/utils/SettingsTest.kt
@@ -33,7 +33,7 @@ class SettingsTest {
         location = ASK_TO_ALLOW,
         microphone = ASK_TO_ALLOW,
         notification = ASK_TO_ALLOW,
-        autoplayAudible = AutoplayAction.BLOCKED,
+        autoplayAudible = AutoplayAction.ALLOWED,
         autoplayInaudible = AutoplayAction.BLOCKED,
         persistentStorage = ASK_TO_ALLOW,
         mediaKeySystemAccess = ASK_TO_ALLOW
@@ -601,7 +601,7 @@ class SettingsTest {
         val settings = Settings(testContext)
 
         assertEquals(
-            AutoplayAction.BLOCKED,
+            AutoplayAction.ALLOWED,
             settings.getSitePermissionsCustomSettingsRules().autoplayAudible
         )
 


### PR DESCRIPTION
Let's land this on next week.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
