### PR TITLE
For FNX-22820: uplift expired telemetry and update glean notification email address

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -134,7 +134,7 @@ events:
       - interaction
     notification_emails:
       - telemetry-client-dev@mozilla.com
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
   search_bar_tapped:
     type: event
@@ -156,7 +156,7 @@ events:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
   entered_url:
     type: event
@@ -178,7 +178,7 @@ events:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
   performed_search:
     type: event
@@ -206,7 +206,7 @@ events:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
   browser_menu_action:
     type: event
@@ -237,7 +237,7 @@ events:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
   default_browser_changed:
     type: event
@@ -251,7 +251,7 @@ events:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-10-01"
   toolbar_menu_visible:
     type: event
@@ -265,7 +265,7 @@ events:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-10-01"
   total_uri_count:
     type: counter
@@ -288,7 +288,7 @@ events:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   normal_and_private_uri_count:
     type: counter
@@ -308,7 +308,7 @@ events:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2022-08-01"
   preference_toggled:
     type: event
@@ -352,7 +352,7 @@ events:
       - technical
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
   whats_new_tapped:
     type: event
@@ -369,7 +369,7 @@ events:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
   opened_link:
     type: event
@@ -392,7 +392,7 @@ events:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
   tab_counter_menu_action:
     type: event
@@ -416,7 +416,7 @@ events:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
   synced_tab_opened:
     type: event
@@ -431,7 +431,7 @@ events:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-10"
   recently_closed_tabs_opened:
     type: event
@@ -447,7 +447,7 @@ events:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-10"
   copy_url_tapped:
     type: event
@@ -459,26 +459,10 @@ events:
       - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/16915
-      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
-    expires: "2021-12-10"
-  browser_toolbar_home_tapped:
-    type: event
-    description: |
-      An event that indicates that a user has tapped
-      home button on browser toolbar.
-    bugs:
-      - https://github.com/mozilla-mobile/fenix/issues/19915
-    data_reviews:
-      - https://github.com/mozilla-mobile/fenix/pull/19936
-      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
-    data_sensitivity:
-      - interaction
-    notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-10"
 
 onboarding:
@@ -495,7 +479,7 @@ onboarding:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
       - erichards@mozilla.com
     expires: "2021-08-01"
   fxa_manual_signin:
@@ -511,7 +495,7 @@ onboarding:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
       - erichards@mozilla.com
     expires: "2021-08-01"
   privacy_notice:
@@ -527,7 +511,7 @@ onboarding:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
       - erichards@mozilla.com
     expires: "2021-08-01"
   pref_toggled_private_browsing:
@@ -543,7 +527,7 @@ onboarding:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
       - erichards@mozilla.com
     expires: "2021-08-01"
   pref_toggled_toolbar_position:
@@ -564,7 +548,7 @@ onboarding:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
       - erichards@mozilla.com
     expires: "2021-08-01"
   pref_toggled_tracking_prot:
@@ -585,7 +569,7 @@ onboarding:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
       - erichards@mozilla.com
     expires: "2021-08-01"
   pref_toggled_theme_picker:
@@ -606,7 +590,7 @@ onboarding:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
       - erichards@mozilla.com
     expires: "2021-08-01"
   finish:
@@ -622,7 +606,7 @@ onboarding:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
       - erichards@mozilla.com
     expires: "2021-08-01"
 
@@ -642,7 +626,7 @@ search_shortcuts:
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
       - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
 
 experiments_default_browser:
@@ -658,7 +642,7 @@ experiments_default_browser:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-10-01"
 toolbar_settings:
   changed_position:
@@ -678,7 +662,7 @@ toolbar_settings:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
 
 crash_reporter:
@@ -697,7 +681,7 @@ crash_reporter:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
   closed:
     type: event
@@ -719,7 +703,7 @@ crash_reporter:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
 
 context_menu:
@@ -749,7 +733,7 @@ context_menu:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
 
 login_dialog:
@@ -765,7 +749,7 @@ login_dialog:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   cancelled:
     type: event
@@ -779,7 +763,7 @@ login_dialog:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   saved:
     type: event
@@ -793,7 +777,7 @@ login_dialog:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   never_save:
     type: event
@@ -807,7 +791,7 @@ login_dialog:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
 
 find_in_page:
@@ -824,7 +808,7 @@ find_in_page:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   closed:
     type: event
@@ -839,7 +823,7 @@ find_in_page:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   searched_page:
     type: event
@@ -854,7 +838,7 @@ find_in_page:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
 
 metrics:
@@ -874,7 +858,7 @@ metrics:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   distribution_id:
     type: string
@@ -892,7 +876,7 @@ metrics:
     data_sensitivity:
       - technical
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: never
   mobile_bookmarks_count:
     type: counter
@@ -914,7 +898,7 @@ metrics:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   has_mobile_bookmarks:
     type: boolean
@@ -932,7 +916,7 @@ metrics:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   desktop_bookmarks_count:
     type: counter
@@ -954,7 +938,7 @@ metrics:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   has_desktop_bookmarks:
     type: boolean
@@ -972,7 +956,7 @@ metrics:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   top_sites_count:
     type: counter
@@ -994,7 +978,7 @@ metrics:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   has_top_sites:
     type: boolean
@@ -1012,7 +996,7 @@ metrics:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   recently_used_pwa_count:
     type: counter
@@ -1038,7 +1022,7 @@ metrics:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   has_recent_pwas:
     type: boolean
@@ -1057,7 +1041,7 @@ metrics:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   search_count:
     type: labeled_counter
@@ -1087,7 +1071,7 @@ metrics:
       - technical
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   credit_cards_saved_count:
     type: counter
@@ -1105,7 +1089,7 @@ metrics:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-10-01"
   credit_cards_deleted_count:
     type: counter
@@ -1123,7 +1107,7 @@ metrics:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-10-01"
   credit_cards_autofill_count:
     type: counter
@@ -1141,7 +1125,7 @@ metrics:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-10-01"
   mozilla_products:
     type: string_list
@@ -1164,7 +1148,7 @@ metrics:
       - technical
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   default_moz_browser:
     type: string
@@ -1185,7 +1169,7 @@ metrics:
       - technical
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   adjust_campaign:
     type: string
@@ -1206,7 +1190,7 @@ metrics:
     data_sensitivity:
       - technical
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   adjust_ad_group:
     type: string
@@ -1227,7 +1211,7 @@ metrics:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   adjust_creative:
     type: string
@@ -1248,7 +1232,7 @@ metrics:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   adjust_network:
     type: string
@@ -1269,7 +1253,7 @@ metrics:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   toolbar_position:
     type: string
@@ -1287,7 +1271,7 @@ metrics:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   close_tab_setting:
     type: string
@@ -1305,7 +1289,7 @@ metrics:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   tab_view_setting:
     type: string
@@ -1323,7 +1307,7 @@ metrics:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   search_widget_installed:
     type: boolean
@@ -1341,7 +1325,7 @@ metrics:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   tabs_open_count:
     type: counter
@@ -1363,7 +1347,7 @@ metrics:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   has_open_tabs:
     type: boolean
@@ -1381,7 +1365,7 @@ metrics:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   start_reason_process_error:
     type: boolean
@@ -1435,7 +1419,7 @@ preferences:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   remote_debugging_enabled:
     type: boolean
@@ -1453,7 +1437,7 @@ preferences:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   telemetry_enabled:
     type: boolean
@@ -1473,7 +1457,7 @@ preferences:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   enhanced_tracking_protection:
     type: string
@@ -1492,7 +1476,7 @@ preferences:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   bookmarks_suggestion:
     type: boolean
@@ -1510,7 +1494,7 @@ preferences:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   browsing_history_suggestion:
     type: boolean
@@ -1528,7 +1512,7 @@ preferences:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   clipboard_suggestions_enabled:
     type: boolean
@@ -1546,7 +1530,7 @@ preferences:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   search_shortcuts_enabled:
     type: boolean
@@ -1564,7 +1548,7 @@ preferences:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   open_links_in_private:
     type: boolean
@@ -1582,7 +1566,7 @@ preferences:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   signed_in_sync:
     type: boolean
@@ -1600,7 +1584,7 @@ preferences:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   sync_items:
     type: string_list
@@ -1620,7 +1604,7 @@ preferences:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   voice_search_enabled:
     type: boolean
@@ -1638,7 +1622,7 @@ preferences:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   private_search_suggestions:
     type: boolean
@@ -1657,7 +1641,7 @@ preferences:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   toolbar_position_setting:
     type: string
@@ -1675,7 +1659,7 @@ preferences:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   accessibility_services:
     type: string_list
@@ -1694,7 +1678,7 @@ preferences:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   open_links_in_app_enabled:
     type: boolean
@@ -1712,7 +1696,7 @@ preferences:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   user_theme:
     type: string
@@ -1730,7 +1714,7 @@ preferences:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
 
 search.default_engine:
@@ -1755,7 +1739,7 @@ search.default_engine:
       - technical
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   name:
     type: string
@@ -1778,7 +1762,7 @@ search.default_engine:
       - technical
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   submission_url:
     type: string
@@ -1802,7 +1786,7 @@ search.default_engine:
       - technical
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
 
 bookmarks_management:
@@ -1818,7 +1802,7 @@ bookmarks_management:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2022-08-01"
   open_in_new_tab:
     type: event
@@ -1834,7 +1818,7 @@ bookmarks_management:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
   open_in_new_tabs:
     type: event
@@ -1850,7 +1834,7 @@ bookmarks_management:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
   open_in_private_tab:
     type: event
@@ -1867,7 +1851,7 @@ bookmarks_management:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
   open_in_private_tabs:
     type: event
@@ -1884,7 +1868,7 @@ bookmarks_management:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
   edited:
     type: event
@@ -1901,7 +1885,7 @@ bookmarks_management:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
   moved:
     type: event
@@ -1918,7 +1902,7 @@ bookmarks_management:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
   removed:
     type: event
@@ -1935,7 +1919,7 @@ bookmarks_management:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
   multi_removed:
     type: event
@@ -1952,7 +1936,7 @@ bookmarks_management:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
   shared:
     type: event
@@ -1969,7 +1953,7 @@ bookmarks_management:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
   copied:
     type: event
@@ -1986,7 +1970,7 @@ bookmarks_management:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
   folder_add:
     type: event
@@ -2003,7 +1987,7 @@ bookmarks_management:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
   folder_remove:
     type: event
@@ -2020,7 +2004,7 @@ bookmarks_management:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
 
 custom_tab:
@@ -2039,7 +2023,7 @@ custom_tab:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
   action_button:
     type: event
@@ -2056,7 +2040,7 @@ custom_tab:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
   menu:
     type: event
@@ -2073,7 +2057,7 @@ custom_tab:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
 
 activation:
@@ -2097,7 +2081,7 @@ activation:
     data_sensitivity:
       - highly_sensitive
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
   activation_id:
     type: uuid
@@ -2118,7 +2102,7 @@ activation:
     data_sensitivity:
       - highly_sensitive
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
     no_lint:
       - USER_LIFETIME_EXPIRATION
@@ -2142,7 +2126,7 @@ error_page:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
 
 sync_auth:
@@ -2159,7 +2143,7 @@ sync_auth:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   closed:
     type: event
@@ -2174,7 +2158,7 @@ sync_auth:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   use_email:
     type: event
@@ -2190,7 +2174,7 @@ sync_auth:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   use_email_problem:
     type: event
@@ -2205,7 +2189,7 @@ sync_auth:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   sign_in:
     type: event
@@ -2221,7 +2205,7 @@ sync_auth:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   sign_out:
     type: event
@@ -2237,7 +2221,7 @@ sync_auth:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   sign_up:
     type: event
@@ -2253,7 +2237,7 @@ sync_auth:
       - technical
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   paired:
     type: event
@@ -2270,7 +2254,7 @@ sync_auth:
       - technical
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   recovered:
     type: event
@@ -2287,7 +2271,7 @@ sync_auth:
       - technical
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   other_external:
     type: event
@@ -2304,7 +2288,7 @@ sync_auth:
       - technical
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   scan_pairing:
     type: event
@@ -2319,7 +2303,7 @@ sync_auth:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
 
 sync_account:
@@ -2336,7 +2320,7 @@ sync_account:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   sync_now:
     type: event
@@ -2351,7 +2335,7 @@ sync_account:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   send_tab:
     type: event
@@ -2366,7 +2350,7 @@ sync_account:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   sign_in_to_send_tab:
     type: event
@@ -2381,7 +2365,7 @@ sync_account:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
 
 history:
@@ -2398,7 +2382,7 @@ history:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   removed:
     type: event
@@ -2413,7 +2397,7 @@ history:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   removed_all:
     type: event
@@ -2428,7 +2412,7 @@ history:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   shared:
     type: event
@@ -2443,7 +2427,7 @@ history:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   opened_item:
     type: event
@@ -2457,7 +2441,7 @@ history:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2022-08-01"
   opened_item_in_new_tab:
     type: event
@@ -2471,7 +2455,7 @@ history:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2022-08-01"
   opened_items_in_new_tabs:
     type: event
@@ -2486,7 +2470,7 @@ history:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2022-08-01"
   opened_item_in_private_tab:
     type: event
@@ -2500,7 +2484,7 @@ history:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2022-08-01"
   opened_items_in_private_tabs:
     type: event
@@ -2514,7 +2498,7 @@ history:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2022-08-01"
 
 tip:
@@ -2534,7 +2518,7 @@ tip:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   pressed:
     type: event
@@ -2552,7 +2536,7 @@ tip:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   closed:
     type: event
@@ -2570,7 +2554,7 @@ tip:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
 
 reader_mode:
@@ -2587,7 +2571,7 @@ reader_mode:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   opened:
     type: event
@@ -2602,7 +2586,7 @@ reader_mode:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   closed:
     type: event
@@ -2617,7 +2601,7 @@ reader_mode:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   appearance:
     type: event
@@ -2632,7 +2616,7 @@ reader_mode:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
 
 tabs_tray.cfr:
@@ -2649,7 +2633,7 @@ tabs_tray.cfr:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   go_to_settings:
     type: event
@@ -2664,7 +2648,7 @@ tabs_tray.cfr:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
 
 tabs_tray:
@@ -2681,7 +2665,7 @@ tabs_tray:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   closed:
     type: event
@@ -2696,7 +2680,7 @@ tabs_tray:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   opened_existing_tab:
     type: event
@@ -2711,7 +2695,7 @@ tabs_tray:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   closed_existing_tab:
     type: event
@@ -2726,7 +2710,7 @@ tabs_tray:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   private_mode_tapped:
     type: event
@@ -2741,7 +2725,7 @@ tabs_tray:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   normal_mode_tapped:
     type: event
@@ -2756,7 +2740,7 @@ tabs_tray:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   synced_mode_tapped:
     type: event
@@ -2770,7 +2754,7 @@ tabs_tray:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2022-08-01"
   new_tab_tapped:
     type: event
@@ -2785,7 +2769,7 @@ tabs_tray:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   new_private_tab_tapped:
     type: event
@@ -2800,7 +2784,7 @@ tabs_tray:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   menu_opened:
     type: event
@@ -2815,7 +2799,7 @@ tabs_tray:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   save_to_collection:
     type: event
@@ -2830,7 +2814,7 @@ tabs_tray:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   share_all_tabs:
     type: event
@@ -2846,7 +2830,7 @@ tabs_tray:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   close_all_tabs:
     type: event
@@ -2862,7 +2846,7 @@ tabs_tray:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
 
 collections:
@@ -2882,7 +2866,7 @@ collections:
       - technical
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
   tab_restored:
     type: event
@@ -2900,7 +2884,7 @@ collections:
       - technical
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
   all_tabs_restored:
     type: event
@@ -2918,7 +2902,7 @@ collections:
       - technical
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
   tab_removed:
     type: event
@@ -2936,7 +2920,7 @@ collections:
       - technical
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
   shared:
     type: event
@@ -2954,7 +2938,7 @@ collections:
       - technical
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
   removed:
     type: event
@@ -2972,7 +2956,7 @@ collections:
       - technical
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
   saved:
     type: event
@@ -2995,7 +2979,7 @@ collections:
       - technical
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
   tabs_added:
     type: event
@@ -3018,7 +3002,7 @@ collections:
       - technical
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
   tab_select_opened:
     type: event
@@ -3037,7 +3021,7 @@ collections:
       - technical
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
   add_tab_button:
     type: event
@@ -3054,7 +3038,7 @@ collections:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
   long_press:
     type: event
@@ -3071,7 +3055,7 @@ collections:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
   save_button:
     type: event
@@ -3090,7 +3074,7 @@ collections:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
     extra_keys:
       from_screen:
@@ -3112,7 +3096,7 @@ collections:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
 
 search_widget:
@@ -3130,7 +3114,7 @@ search_widget:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   voice_button:
     type: event
@@ -3145,7 +3129,7 @@ search_widget:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
 
 private_browsing_mode:
@@ -3163,7 +3147,7 @@ private_browsing_mode:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   notification_tapped:
     type: event
@@ -3178,7 +3162,7 @@ private_browsing_mode:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
 
 contextual_hint.tracking_protection:
@@ -3197,7 +3181,7 @@ contextual_hint.tracking_protection:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-07-01"
   dismiss:
     type: event
@@ -3215,7 +3199,7 @@ contextual_hint.tracking_protection:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-07-01"
   outside_tap:
     type: event
@@ -3232,7 +3216,7 @@ contextual_hint.tracking_protection:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-07-01"
   inside_tap:
     type: event
@@ -3249,7 +3233,7 @@ contextual_hint.tracking_protection:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-07-01"
 
 tracking_protection:
@@ -3267,7 +3251,7 @@ tracking_protection:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   panel_settings:
     type: event
@@ -3282,7 +3266,7 @@ tracking_protection:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   etp_shield:
     type: event
@@ -3297,7 +3281,7 @@ tracking_protection:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   etp_tracker_list:
     type: event
@@ -3313,7 +3297,7 @@ tracking_protection:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   etp_settings:
     type: event
@@ -3328,7 +3312,7 @@ tracking_protection:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   etp_setting_changed:
     type: event
@@ -3349,7 +3333,7 @@ tracking_protection:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
 
 private_browsing_shortcut:
@@ -3366,7 +3350,7 @@ private_browsing_shortcut:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   cfr_add_shortcut:
     type: event
@@ -3382,7 +3366,7 @@ private_browsing_shortcut:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   cfr_cancel:
     type: event
@@ -3398,7 +3382,7 @@ private_browsing_shortcut:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   pinned_shortcut_priv:
     type: event
@@ -3414,7 +3398,7 @@ private_browsing_shortcut:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   static_shortcut_tab:
     type: event
@@ -3430,7 +3414,7 @@ private_browsing_shortcut:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   static_shortcut_priv:
     type: event
@@ -3446,7 +3430,7 @@ private_browsing_shortcut:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
 
 tab:
@@ -3463,7 +3447,7 @@ tab:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
     no_lint:
       - COMMON_PREFIX
@@ -3480,7 +3464,7 @@ tab:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
 
 media_notification:
@@ -3497,7 +3481,7 @@ media_notification:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   pause:
     type: event
@@ -3512,7 +3496,7 @@ media_notification:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
 
 media_state:
@@ -3529,7 +3513,7 @@ media_state:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   pause:
     type: event
@@ -3544,7 +3528,7 @@ media_state:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   stop:
     type: event
@@ -3559,7 +3543,7 @@ media_state:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   fullscreen:
     type: event
@@ -3573,7 +3557,7 @@ media_state:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   picture_in_picture:
     type: event
@@ -3587,7 +3571,7 @@ media_state:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
 
 logins:
@@ -3604,7 +3588,7 @@ logins:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   open_individual_login:
     type: event
@@ -3619,7 +3603,7 @@ logins:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   copy_login:
     type: event
@@ -3634,7 +3618,7 @@ logins:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   view_password_login:
     type: event
@@ -3649,7 +3633,7 @@ logins:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   save_logins_setting_changed:
     type: event
@@ -3669,7 +3653,7 @@ logins:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   open_login_editor:
     type: event
@@ -3684,7 +3668,7 @@ logins:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   delete_saved_login:
     type: event
@@ -3699,7 +3683,7 @@ logins:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   save_edited_login:
     type: event
@@ -3714,7 +3698,7 @@ logins:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
 
 download_notification:
@@ -3732,7 +3716,7 @@ download_notification:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-07-01"
   pause:
     type: event
@@ -3748,7 +3732,7 @@ download_notification:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-07-01"
   cancel:
     type: event
@@ -3764,7 +3748,7 @@ download_notification:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-07-01"
   try_again:
     type: event
@@ -3781,7 +3765,7 @@ download_notification:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-07-01"
   open:
     type: event
@@ -3797,7 +3781,7 @@ download_notification:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-07-01"
   in_app_open:
     type: event
@@ -3813,7 +3797,7 @@ download_notification:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-07-01"
   in_app_try_again:
     type: event
@@ -3830,7 +3814,7 @@ download_notification:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-07-01"
 
 downloads_misc:
@@ -3845,7 +3829,7 @@ downloads_misc:
       - https://github.com/mozilla-mobile/fenix/pull/18143
       - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-07-01"
 
 downloads_management:
@@ -3861,7 +3845,7 @@ downloads_management:
       - https://github.com/mozilla-mobile/fenix/pull/18143
       - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-07-01"
 
   item_opened:
@@ -3877,7 +3861,7 @@ downloads_management:
       - https://github.com/mozilla-mobile/fenix/pull/18143
       - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
 
   item_deleted:
@@ -3892,7 +3876,7 @@ downloads_management:
       - https://github.com/mozilla-mobile/fenix/pull/18143
       - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
 
 user_specified_search_engines:
@@ -3909,7 +3893,7 @@ user_specified_search_engines:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
     no_lint:
       - COMMON_PREFIX
@@ -3927,7 +3911,7 @@ user_specified_search_engines:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
 
 search_suggestions:
@@ -3945,7 +3929,7 @@ search_suggestions:
       - technical
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
 
 voice_search:
@@ -3962,7 +3946,7 @@ voice_search:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
 
 top_sites:
@@ -3979,7 +3963,7 @@ top_sites:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   open_google_search_attribution:
     type: event
@@ -3993,7 +3977,7 @@ top_sites:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   open_frecency:
     type: event
@@ -4008,7 +3992,7 @@ top_sites:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   open_pinned:
     type: event
@@ -4023,7 +4007,7 @@ top_sites:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   swipe_carousel:
     type: event
@@ -4042,7 +4026,7 @@ top_sites:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   long_press:
     type: event
@@ -4061,7 +4045,7 @@ top_sites:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   open_in_new_tab:
     type: event
@@ -4076,7 +4060,7 @@ top_sites:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   open_in_private_tab:
     type: event
@@ -4091,7 +4075,7 @@ top_sites:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   remove:
     type: event
@@ -4106,7 +4090,7 @@ top_sites:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
 
 about_page:
@@ -4124,7 +4108,7 @@ about_page:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-07-01"
   privacy_notice_tapped:
     type: event
@@ -4140,7 +4124,7 @@ about_page:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-07-01"
 
 app_theme:
@@ -4164,7 +4148,7 @@ app_theme:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
 
 pocket:
@@ -4181,7 +4165,7 @@ pocket:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
     no_lint:
       - COMMON_PREFIX
@@ -4199,7 +4183,7 @@ pocket:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
 
 first_session:
@@ -4219,7 +4203,7 @@ first_session:
       - technical
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   network:
     type: string
@@ -4237,7 +4221,7 @@ first_session:
       - technical
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   adgroup:
     type: string
@@ -4255,7 +4239,7 @@ first_session:
       - technical
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   creative:
     send_in_pings:
@@ -4273,7 +4257,7 @@ first_session:
       - technical
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   timestamp:
     send_in_pings:
@@ -4293,7 +4277,7 @@ first_session:
       - technical
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
 
 browser.search:
@@ -4313,7 +4297,7 @@ browser.search:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   ad_clicks:
     type: labeled_counter
@@ -4331,7 +4315,7 @@ browser.search:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   in_content:
     type: labeled_counter
@@ -4348,7 +4332,7 @@ browser.search:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
 
 addons:
@@ -4367,7 +4351,7 @@ addons:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
   open_addon_in_toolbar_menu:
     type: event
@@ -4388,7 +4372,7 @@ addons:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
   open_addon_setting:
     type: event
@@ -4406,7 +4390,7 @@ addons:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2022-08-01"
   has_installed_addons:
     type: boolean
@@ -4425,7 +4409,7 @@ addons:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
   has_enabled_addons:
     type: boolean
@@ -4444,7 +4428,7 @@ addons:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
   installed_addons:
     type: string_list
@@ -4463,7 +4447,7 @@ addons:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
   enabled_addons:
     type: string_list
@@ -4482,7 +4466,7 @@ addons:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
 
 startup.timeline:
@@ -4953,7 +4937,7 @@ perf.awesomebar:
       - technical
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
       - gkruglov@mozilla.com
     expires: "2021-11-15"
   bookmark_suggestions:
@@ -4972,7 +4956,7 @@ perf.awesomebar:
       - technical
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
       - gkruglov@mozilla.com
     expires: "2021-11-15"
   search_engine_suggestions:
@@ -4991,7 +4975,7 @@ perf.awesomebar:
       - technical
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
       - gkruglov@mozilla.com
     expires: "2021-11-15"
   session_suggestions:
@@ -5010,7 +4994,7 @@ perf.awesomebar:
       - technical
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
       - gkruglov@mozilla.com
     expires: "2021-11-15"
   synced_tabs_suggestions:
@@ -5029,7 +5013,7 @@ perf.awesomebar:
       - technical
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
       - gkruglov@mozilla.com
     expires: "2021-11-15"
   clipboard_suggestions:
@@ -5048,7 +5032,7 @@ perf.awesomebar:
       - technical
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
       - gkruglov@mozilla.com
     expires: "2021-11-15"
   shortcuts_suggestions:
@@ -5067,7 +5051,7 @@ perf.awesomebar:
       - technical
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
       - gkruglov@mozilla.com
     expires: "2021-11-15"
 
@@ -5083,7 +5067,7 @@ autoplay:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   setting_changed:
     type: event
@@ -5103,7 +5087,7 @@ autoplay:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
 
 storage.stats:
@@ -5126,7 +5110,7 @@ storage.stats:
       - technical
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
       - perf-android-fe@mozilla.com
       - mcomella@mozilla.com
     expires: "2021-08-01"
@@ -5152,7 +5136,7 @@ storage.stats:
       - technical
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
       - perf-android-fe@mozilla.com
       - mcomella@mozilla.com
     expires: "2021-08-01"
@@ -5175,7 +5159,7 @@ storage.stats:
       - technical
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
       - perf-android-fe@mozilla.com
       - mcomella@mozilla.com
     expires: "2021-08-01"
@@ -5200,7 +5184,7 @@ storage.stats:
       - technical
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
       - perf-android-fe@mozilla.com
       - mcomella@mozilla.com
     expires: "2021-08-01"
@@ -5219,7 +5203,7 @@ progressive_web_app:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
       - erichards@mozilla.com
     expires: "2021-09-01"
   install_tap:
@@ -5235,7 +5219,7 @@ progressive_web_app:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
       - erichards@mozilla.com
     expires: "2021-09-01"
   foreground:
@@ -5255,7 +5239,7 @@ progressive_web_app:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
       - erichards@mozilla.com
     expires: "2021-09-01"
   background:
@@ -5275,7 +5259,7 @@ progressive_web_app:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
       - erichards@mozilla.com
     expires: "2021-09-01"
 
@@ -5293,7 +5277,7 @@ master_password:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-09-01"
   migration:
     type: event
@@ -5308,7 +5292,7 @@ master_password:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-09-01"
 
 tabs:
@@ -5324,7 +5308,7 @@ tabs:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
 
 banner_open_in_app:
@@ -5340,7 +5324,7 @@ banner_open_in_app:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   dismissed:
     type: event
@@ -5354,7 +5338,7 @@ banner_open_in_app:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   go_to_settings:
     type: event
@@ -5368,7 +5352,7 @@ banner_open_in_app:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
 
 contextual_menu:
@@ -5385,7 +5369,7 @@ contextual_menu:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
   search_tapped:
     type: event
@@ -5400,7 +5384,7 @@ contextual_menu:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
   select_all_tapped:
     type: event
@@ -5415,7 +5399,7 @@ contextual_menu:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
   share_tapped:
     type: event
@@ -5430,7 +5414,7 @@ contextual_menu:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-12-01"
 
 engine_tab:
@@ -5450,7 +5434,7 @@ engine_tab:
     data_sensitivity:
       - technical
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
       - skaspari@mozilla.com
     expires: "2021-12-31"
   kill_foreground_age:
@@ -5467,7 +5451,7 @@ engine_tab:
     data_sensitivity:
       - technical
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
       - skaspari@mozilla.com
     expires: "2021-12-31"
   kill_background_age:
@@ -5484,7 +5468,7 @@ engine_tab:
     data_sensitivity:
       - technical
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
       - skaspari@mozilla.com
     expires: "2021-12-31"
   foreground_metrics:
@@ -5500,7 +5484,7 @@ engine_tab:
     data_sensitivity:
       - technical
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
       - skaspari@mozilla.com
     expires: "2021-12-31"
     extra_keys:
@@ -5542,7 +5526,7 @@ synced_tabs:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
 
 awesomebar:
@@ -5558,7 +5542,7 @@ awesomebar:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   clipboard_suggestion_clicked:
     type: event
@@ -5572,7 +5556,7 @@ awesomebar:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   history_suggestion_clicked:
     type: event
@@ -5586,7 +5570,7 @@ awesomebar:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   search_action_clicked:
     type: event
@@ -5600,7 +5584,7 @@ awesomebar:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   search_suggestion_clicked:
     type: event
@@ -5614,7 +5598,7 @@ awesomebar:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
   opened_tab_suggestion_clicked:
     type: event
@@ -5628,7 +5612,7 @@ awesomebar:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-08-01"
 
 home_menu:
@@ -5643,7 +5627,7 @@ home_menu:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-10-01"
 
 home_screen:
@@ -5658,7 +5642,7 @@ home_screen:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-10-01"
 
 android_keystore_experiment:
@@ -5679,7 +5663,7 @@ android_keystore_experiment:
     data_sensitivity:
       - technical
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-09-01"
   get_failure:
     type: event
@@ -5698,7 +5682,7 @@ android_keystore_experiment:
     data_sensitivity:
       - technical
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-09-01"
   get_result:
     type: event
@@ -5717,7 +5701,7 @@ android_keystore_experiment:
     data_sensitivity:
       - technical
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-09-01"
   write_failure:
     type: event
@@ -5736,7 +5720,7 @@ android_keystore_experiment:
     data_sensitivity:
       - technical
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-09-01"
   write_success:
     type: event
@@ -5750,7 +5734,7 @@ android_keystore_experiment:
     data_sensitivity:
       - technical
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-09-01"
   reset:
     type: event
@@ -5765,7 +5749,7 @@ android_keystore_experiment:
     data_sensitivity:
       - technical
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-09-01"
 
 set_default_newtab_experiment:
@@ -5781,7 +5765,7 @@ set_default_newtab_experiment:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-10-01"
   close_experiment_card_clicked:
     type: event
@@ -5795,7 +5779,7 @@ set_default_newtab_experiment:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-10-01"
 
 set_default_setting_experiment:
@@ -5811,5 +5795,5 @@ set_default_setting_experiment:
     data_sensitivity:
       - interaction
     notification_emails:
-      - firefox-android-team@mozilla.com
+      - android-probes@mozilla.com
     expires: "2021-10-01"

--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -70,17 +70,19 @@ events:
       - https://github.com/mozilla-mobile/fenix/issues/12573
       - https://github.com/mozilla-mobile/fenix/pull/13494
       - https://github.com/mozilla-mobile/fenix/issues/10069
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/12114#pullrequestreview-445245341
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/13494#pullrequestreview-474050499
       - https://github.com/mozilla-mobile/fenix/pull/15605#issuecomment-702365594
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
       - esmyth@mozilla.com
       - perf-android-fe@mozilla.com
-    expires: "2021-06-01"
+    expires: "2021-12-01"
   app_received_intent:
     type: event
     description: |
@@ -101,13 +103,15 @@ events:
           `custom_tab`, `link` or `unknown`
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/11830
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/11940/
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     notification_emails:
       - esmyth@mozilla.com
       - perf-android-fe@mozilla.com
-    expires: "2021-06-01"
+    expires: "2021-12-01"
   app_opened:
     type: event
     description: |
@@ -120,16 +124,18 @@ events:
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/968
       - https://github.com/mozilla-mobile/fenix/issues/10616
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/1067#issuecomment-474598673
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
       - telemetry-client-dev@mozilla.com
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
   search_bar_tapped:
     type: event
     description: |
@@ -141,15 +147,17 @@ events:
           `Home` or `Browser`)
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/959
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/1067#issuecomment-474598673
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
   entered_url:
     type: event
     description: |
@@ -161,15 +169,17 @@ events:
           Autocomplete suggestion
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/959
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/1067#issuecomment-474598673
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
   performed_search:
     type: event
     description: |
@@ -186,16 +196,18 @@ events:
           * shortcut.suggestion
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/959
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/1067#issuecomment-474598673
       - https://github.com/mozilla-mobile/fenix/pull/1677
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
   browser_menu_action:
     type: event
     description: |
@@ -214,17 +226,19 @@ events:
           sync_tabs.
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/1024
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/1214#issue-264756708
       - https://github.com/mozilla-mobile/fenix/pull/5098#issuecomment-529658996
       - https://github.com/mozilla-mobile/fenix/pull/6310
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
   default_browser_changed:
     type: event
     description: |
@@ -233,10 +247,11 @@ events:
       - https://github.com/mozilla-mobile/fenix/issues/18857
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/18895
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-10-01"
   toolbar_menu_visible:
     type: event
@@ -246,10 +261,11 @@ events:
       - https://github.com/mozilla-mobile/fenix/issues/18855
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/18895
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-10-01"
   total_uri_count:
     type: counter
@@ -268,10 +284,11 @@ events:
       - https://github.com/mozilla-mobile/fenix/pull/1785
       - https://github.com/mozilla-mobile/fenix/pull/8314
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   normal_and_private_uri_count:
     type: counter
@@ -287,10 +304,11 @@ events:
       - https://github.com/mozilla-mobile/fenix/issues/17089
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/17935
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2022-08-01"
   preference_toggled:
     type: event
@@ -319,6 +337,7 @@ events:
       - https://github.com/mozilla-mobile/fenix/issues/5586
       - https://github.com/mozilla-mobile/fenix/issues/6396
       - https://github.com/mozilla-mobile/fenix/issues/6070
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/1896
       - https://github.com/mozilla-mobile/fenix/pull/5704
@@ -328,27 +347,30 @@ events:
       - https://github.com/mozilla-mobile/fenix/pull/6601
       - https://github.com/mozilla-mobile/fenix/pull/6746
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-06-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
   whats_new_tapped:
     type: event
     description: |
       A user opened the "what's new" page button
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/5021
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/5090
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
   opened_link:
     type: event
     description: |
@@ -361,15 +383,17 @@ events:
           https://github.com/mozilla-mobile/fenix/issues/14133
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/5737
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/5975
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
   tab_counter_menu_action:
     type: event
     description:
@@ -383,28 +407,32 @@ events:
             New tab, New private tab, Close tab
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/11442
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/11533
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
   synced_tab_opened:
     type: event
     description: >
       An event that indicates that a synced tab was opened.
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/15369
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/16727
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-05-10"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-10"
   recently_closed_tabs_opened:
     type: event
     description: |
@@ -412,13 +440,15 @@ events:
       has accessed recently closed tabs list.
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/15366
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/16739
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-05-10"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-10"
   copy_url_tapped:
     type: event
     description: |
@@ -426,13 +456,30 @@ events:
       copy option when long pressing on url bar.
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/16827
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/16915
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-05-10"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-10"
+  browser_toolbar_home_tapped:
+    type: event
+    description: |
+      An event that indicates that a user has tapped
+      home button on browser toolbar.
+    bugs:
+      - https://github.com/mozilla-mobile/fenix/issues/19915
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/19936
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-10"
 
 onboarding:
   fxa_auto_signin:
@@ -444,10 +491,11 @@ onboarding:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/11867
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
       - erichards@mozilla.com
     expires: "2021-08-01"
   fxa_manual_signin:
@@ -459,10 +507,11 @@ onboarding:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/11867
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
       - erichards@mozilla.com
     expires: "2021-08-01"
   privacy_notice:
@@ -474,10 +523,11 @@ onboarding:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/11867
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
       - erichards@mozilla.com
     expires: "2021-08-01"
   pref_toggled_private_browsing:
@@ -489,10 +539,11 @@ onboarding:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/11867
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
       - erichards@mozilla.com
     expires: "2021-08-01"
   pref_toggled_toolbar_position:
@@ -509,10 +560,11 @@ onboarding:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/11867
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
       - erichards@mozilla.com
     expires: "2021-08-01"
   pref_toggled_tracking_prot:
@@ -529,10 +581,11 @@ onboarding:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/11867
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
       - erichards@mozilla.com
     expires: "2021-08-01"
   pref_toggled_theme_picker:
@@ -549,10 +602,11 @@ onboarding:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/11867
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
       - erichards@mozilla.com
     expires: "2021-08-01"
   finish:
@@ -564,10 +618,11 @@ onboarding:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/11867
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
       - erichards@mozilla.com
     expires: "2021-08-01"
 
@@ -585,8 +640,9 @@ search_shortcuts:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/1202#issuecomment-476870449
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
 
 experiments_default_browser:
@@ -598,10 +654,11 @@ experiments_default_browser:
       - https://github.com/mozilla-mobile/fenix/issues/18851
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/18895
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-10-01"
 toolbar_settings:
   changed_position:
@@ -617,10 +674,11 @@ toolbar_settings:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/6608
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
 
 crash_reporter:
@@ -630,15 +688,17 @@ crash_reporter:
       The crash reporter was displayed
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/1040
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/1214#issue-264756708
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
   closed:
     type: event
     description: |
@@ -650,15 +710,17 @@ crash_reporter:
           report
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/1040
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/1214#issue-264756708
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
 
 context_menu:
   item_tapped:
@@ -677,16 +739,18 @@ context_menu:
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/957
       - https://github.com/mozilla-mobile/fenix/issues/16076
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/1344#issuecomment-479285010
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/issues/16076#issuecomment-726216734
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
 
 login_dialog:
   displayed:
@@ -697,10 +761,11 @@ login_dialog:
       - https://github.com/mozilla-mobile/fenix/issues/9730
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/13050
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   cancelled:
     type: event
@@ -710,10 +775,11 @@ login_dialog:
       - https://github.com/mozilla-mobile/fenix/issues/9730
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/13050
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   saved:
     type: event
@@ -723,10 +789,11 @@ login_dialog:
       - https://github.com/mozilla-mobile/fenix/issues/9730
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/13050
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   never_save:
     type: event
@@ -736,10 +803,11 @@ login_dialog:
       - https://github.com/mozilla-mobile/fenix/issues/9730
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/13050
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
 
 find_in_page:
@@ -752,10 +820,11 @@ find_in_page:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/1344#issuecomment-479285010
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   closed:
     type: event
@@ -766,10 +835,11 @@ find_in_page:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/1344#issuecomment-479285010
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   searched_page:
     type: event
@@ -780,10 +850,11 @@ find_in_page:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/1344#issuecomment-479285010
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
 
 metrics:
@@ -799,10 +870,11 @@ metrics:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/1067#issuecomment-474598673
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   distribution_id:
     type: string
@@ -816,10 +888,11 @@ metrics:
       - https://github.com/mozilla-mobile/fenix/issues/16075
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/issues/16075
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: never
   mobile_bookmarks_count:
     type: counter
@@ -837,10 +910,11 @@ metrics:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/16942
       - https://github.com/mozilla-mobile/fenix/pull/16942#issuecomment-742794701
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   has_mobile_bookmarks:
     type: boolean
@@ -854,10 +928,11 @@ metrics:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/16942
       - https://github.com/mozilla-mobile/fenix/pull/16942#issuecomment-742794701
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   desktop_bookmarks_count:
     type: counter
@@ -875,10 +950,11 @@ metrics:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/16942
       - https://github.com/mozilla-mobile/fenix/pull/16942#issuecomment-742794701
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   has_desktop_bookmarks:
     type: boolean
@@ -892,10 +968,11 @@ metrics:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/16942
       - https://github.com/mozilla-mobile/fenix/pull/16942#issuecomment-742794701
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   top_sites_count:
     type: counter
@@ -913,10 +990,11 @@ metrics:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/9556
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   has_top_sites:
     type: boolean
@@ -930,10 +1008,11 @@ metrics:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/9556
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   recently_used_pwa_count:
     type: counter
@@ -955,10 +1034,11 @@ metrics:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/11982#pullrequestreview-437963817
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   has_recent_pwas:
     type: boolean
@@ -973,10 +1053,11 @@ metrics:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/11982#pullrequestreview-437963817
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   search_count:
     type: labeled_counter
@@ -1001,11 +1082,12 @@ metrics:
       - https://github.com/mozilla-mobile/fenix/pull/5216
       - https://github.com/mozilla-mobile/fenix/pull/7310
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   credit_cards_saved_count:
     type: counter
@@ -1019,10 +1101,11 @@ metrics:
       - https://github.com/mozilla-mobile/fenix/issues/18711
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/19548#issuecomment-848811030
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-10-01"
   credit_cards_deleted_count:
     type: counter
@@ -1036,10 +1119,11 @@ metrics:
       - https://github.com/mozilla-mobile/fenix/issues/18711
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/19548#issuecomment-848811030
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-10-01"
   credit_cards_autofill_count:
     type: counter
@@ -1053,10 +1137,11 @@ metrics:
       - https://github.com/mozilla-mobile/fenix/issues/18711
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/19548#issuecomment-848811030
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-10-01"
   mozilla_products:
     type: string_list
@@ -1074,11 +1159,12 @@ metrics:
       - https://github.com/mozilla-mobile/fenix/pull/1953/
       - https://github.com/mozilla-mobile/fenix/pull/5216
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   default_moz_browser:
     type: string
@@ -1094,11 +1180,12 @@ metrics:
       - https://github.com/mozilla-mobile/fenix/pull/1953/
       - https://github.com/mozilla-mobile/fenix/pull/5216
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   adjust_campaign:
     type: string
@@ -1115,10 +1202,11 @@ metrics:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/5579
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   adjust_ad_group:
     type: string
@@ -1135,10 +1223,11 @@ metrics:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/9253
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   adjust_creative:
     type: string
@@ -1155,10 +1244,11 @@ metrics:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/9253
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   adjust_network:
     type: string
@@ -1175,10 +1265,11 @@ metrics:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/9253
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   toolbar_position:
     type: string
@@ -1192,10 +1283,11 @@ metrics:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/6608
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   close_tab_setting:
     type: string
@@ -1209,10 +1301,11 @@ metrics:
       - https://github.com/mozilla-mobile/fenix/issues/15347#issue-707408975
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/15811#issuecomment-706402952
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   tab_view_setting:
     type: string
@@ -1226,10 +1319,11 @@ metrics:
       - https://github.com/mozilla-mobile/fenix/issues/15347#issue-707408975
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/15811#issuecomment-706402952
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   search_widget_installed:
     type: boolean
@@ -1243,10 +1337,11 @@ metrics:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/10958
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   tabs_open_count:
     type: counter
@@ -1264,10 +1359,11 @@ metrics:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/12024
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   has_open_tabs:
     type: boolean
@@ -1281,10 +1377,11 @@ metrics:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/12024
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   start_reason_process_error:
     type: boolean
@@ -1334,10 +1431,11 @@ preferences:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/11211
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   remote_debugging_enabled:
     type: boolean
@@ -1351,10 +1449,11 @@ preferences:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/11211
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   telemetry_enabled:
     type: boolean
@@ -1370,10 +1469,11 @@ preferences:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/11211
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   enhanced_tracking_protection:
     type: string
@@ -1388,10 +1488,11 @@ preferences:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/11211
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   bookmarks_suggestion:
     type: boolean
@@ -1405,10 +1506,11 @@ preferences:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/11211
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   browsing_history_suggestion:
     type: boolean
@@ -1422,10 +1524,11 @@ preferences:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/11211
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   clipboard_suggestions_enabled:
     type: boolean
@@ -1439,10 +1542,11 @@ preferences:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/11211
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   search_shortcuts_enabled:
     type: boolean
@@ -1456,10 +1560,11 @@ preferences:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/11211
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   open_links_in_private:
     type: boolean
@@ -1473,10 +1578,11 @@ preferences:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/11211
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   signed_in_sync:
     type: boolean
@@ -1490,10 +1596,11 @@ preferences:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/11211
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   sync_items:
     type: string_list
@@ -1509,10 +1616,11 @@ preferences:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/11211
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   voice_search_enabled:
     type: boolean
@@ -1526,10 +1634,11 @@ preferences:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/11211
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   private_search_suggestions:
     type: boolean
@@ -1544,10 +1653,11 @@ preferences:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/11211
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   toolbar_position_setting:
     type: string
@@ -1561,10 +1671,11 @@ preferences:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/11211
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   accessibility_services:
     type: string_list
@@ -1579,10 +1690,11 @@ preferences:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/11211
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   open_links_in_app_enabled:
     type: boolean
@@ -1596,10 +1708,11 @@ preferences:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/11446
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   user_theme:
     type: string
@@ -1613,10 +1726,11 @@ preferences:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/11446
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
 
 search.default_engine:
@@ -1636,11 +1750,12 @@ search.default_engine:
       - https://github.com/mozilla-mobile/fenix/pull/1606
       - https://github.com/mozilla-mobile/fenix/pull/5216
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   name:
     type: string
@@ -1658,11 +1773,12 @@ search.default_engine:
       - https://github.com/mozilla-mobile/fenix/pull/1606
       - https://github.com/mozilla-mobile/fenix/pull/5216
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   submission_url:
     type: string
@@ -1681,11 +1797,12 @@ search.default_engine:
       - https://github.com/mozilla-mobile/fenix/pull/1606
       - https://github.com/mozilla-mobile/fenix/pull/5216
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
 
 bookmarks_management:
@@ -1697,10 +1814,11 @@ bookmarks_management:
       - https://github.com/mozilla-mobile/fenix/issues/18173
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/18174
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2022-08-01"
   open_in_new_tab:
     type: event
@@ -1712,11 +1830,12 @@ bookmarks_management:
       - https://github.com/mozilla-mobile/fenix/pull/1708
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
   open_in_new_tabs:
     type: event
     description: |
@@ -1727,161 +1846,182 @@ bookmarks_management:
       - https://github.com/mozilla-mobile/fenix/pull/1708
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
   open_in_private_tab:
     type: event
     description: |
       A user opened a bookmark in a new private tab.
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/974
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/1708
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
   open_in_private_tabs:
     type: event
     description: |
       A user opened multiple bookmarks at once in new private tabs.
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/974
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/1708
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
   edited:
     type: event
     description: |
       A user edited the title and/or URL of an existing bookmark.
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/974
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/1708
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
   moved:
     type: event
     description: |
       A user moved an existing bookmark or folder to another folder.
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/974
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/1708
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
   removed:
     type: event
     description: |
       A user removed a bookmark item.
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/974
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/1708
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
   multi_removed:
     type: event
     description: |
       A user removed multiple bookmarks at once.
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/974
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/1708
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
   shared:
     type: event
     description: |
       A user shared a bookmark.
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/974
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/1708
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
   copied:
     type: event
     description: |
       A user copied a bookmark.
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/974
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/1708
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
   folder_add:
     type: event
     description: |
       A user added a new bookmark folder.
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/974
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/1708
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
   folder_remove:
     type: event
     description: |
       A user removed a bookmark folder.
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/3174
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/3724
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
 
 custom_tab:
   closed:
@@ -1890,45 +2030,51 @@ custom_tab:
       A user closed the custom tab
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/977
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/1697
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
   action_button:
     type: event
     description: |
       A user pressed the action button provided by the launching app
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/977
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/1697
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
   menu:
     type: event
     description: |
       A user opened the custom tabs menu
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/977
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/1697
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
 
 activation:
   identifier:
@@ -1942,15 +2088,17 @@ activation:
     bugs:
       - https://bugzilla.mozilla.org/1538011
       - https://bugzilla.mozilla.org/1501822
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/1707#issuecomment-486972209
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - highly_sensitive
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
   activation_id:
     type: uuid
     lifetime: user
@@ -1961,15 +2109,17 @@ activation:
       - activation
     bugs:
       - https://bugzilla.mozilla.org/1538011
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/1707#issuecomment-486972209
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - highly_sensitive
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
     no_lint:
       - USER_LIFETIME_EXPIRATION
 
@@ -1983,15 +2133,17 @@ error_page:
         description: "The error type of the error page encountered"
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/1242
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/2491#issuecomment-492414486
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
 
 sync_auth:
   opened:
@@ -2003,10 +2155,11 @@ sync_auth:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/2745#issuecomment-494918532
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   closed:
     type: event
@@ -2017,10 +2170,11 @@ sync_auth:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/2745#issuecomment-494918532
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   use_email:
     type: event
@@ -2032,10 +2186,11 @@ sync_auth:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/9835#pullrequestreview-398641844
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   use_email_problem:
     type: event
@@ -2046,10 +2201,11 @@ sync_auth:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/9835#pullrequestreview-398641844
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   sign_in:
     type: event
@@ -2061,10 +2217,11 @@ sync_auth:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/2745#issuecomment-494918532
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   sign_out:
     type: event
@@ -2076,10 +2233,11 @@ sync_auth:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/2745#issuecomment-494918532
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   sign_up:
     type: event
@@ -2090,11 +2248,12 @@ sync_auth:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/4931#issuecomment-529740300
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   paired:
     type: event
@@ -2106,11 +2265,12 @@ sync_auth:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/4931#issuecomment-529740300
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   recovered:
     type: event
@@ -2122,11 +2282,12 @@ sync_auth:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/4931#issuecomment-529740300
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   other_external:
     type: event
@@ -2138,11 +2299,12 @@ sync_auth:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/4931#issuecomment-529740300
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   scan_pairing:
     type: event
@@ -2153,10 +2315,11 @@ sync_auth:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/2745#issuecomment-494918532
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
 
 sync_account:
@@ -2169,10 +2332,11 @@ sync_account:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/2745#issuecomment-494918532
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   sync_now:
     type: event
@@ -2183,10 +2347,11 @@ sync_account:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/2745#issuecomment-494918532
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   send_tab:
     type: event
@@ -2197,10 +2362,11 @@ sync_account:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/5106
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   sign_in_to_send_tab:
     type: event
@@ -2211,10 +2377,11 @@ sync_account:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/5106
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
 
 history:
@@ -2227,10 +2394,11 @@ history:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/3940
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   removed:
     type: event
@@ -2241,10 +2409,11 @@ history:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/3940
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   removed_all:
     type: event
@@ -2255,10 +2424,11 @@ history:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/3940
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   shared:
     type: event
@@ -2269,10 +2439,11 @@ history:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/3940
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   opened_item:
     type: event
@@ -2282,10 +2453,11 @@ history:
       - https://github.com/mozilla-mobile/fenix/issues/18178
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/18261
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2022-08-01"
   opened_item_in_new_tab:
     type: event
@@ -2295,10 +2467,11 @@ history:
       - https://github.com/mozilla-mobile/fenix/issues/18178
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/18261
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2022-08-01"
   opened_items_in_new_tabs:
     type: event
@@ -2306,12 +2479,14 @@ history:
       A user opened multiple history items in new tabs
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/18178
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
-      - https://gith ub.com/mozilla-mobile/fenix/pull/18261
+      - https://github.com/mozilla-mobile/fenix/pull/18261
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2022-08-01"
   opened_item_in_private_tab:
     type: event
@@ -2321,10 +2496,11 @@ history:
       - https://github.com/mozilla-mobile/fenix/issues/18178
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/18261
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2022-08-01"
   opened_items_in_private_tabs:
     type: event
@@ -2334,10 +2510,11 @@ history:
       - https://github.com/mozilla-mobile/fenix/issues/18178
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/18261
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2022-08-01"
 
 tip:
@@ -2353,10 +2530,11 @@ tip:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/9836
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   pressed:
     type: event
@@ -2370,10 +2548,11 @@ tip:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/9836
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   closed:
     type: event
@@ -2387,10 +2566,11 @@ tip:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/9836
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
 
 reader_mode:
@@ -2403,10 +2583,11 @@ reader_mode:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/3941
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   opened:
     type: event
@@ -2417,10 +2598,11 @@ reader_mode:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/3941
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   closed:
     type: event
@@ -2431,10 +2613,11 @@ reader_mode:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/4328
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   appearance:
     type: event
@@ -2445,10 +2628,11 @@ reader_mode:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/3941
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
 
 tabs_tray.cfr:
@@ -2461,10 +2645,11 @@ tabs_tray.cfr:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/17442
       - https://github.com/mozilla-mobile/fenix/issues/16485#issuecomment-759641324
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   go_to_settings:
     type: event
@@ -2475,10 +2660,11 @@ tabs_tray.cfr:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/17442
       - https://github.com/mozilla-mobile/fenix/issues/16485#issuecomment-759641324
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
 
 tabs_tray:
@@ -2491,10 +2677,11 @@ tabs_tray:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/12036
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   closed:
     type: event
@@ -2505,10 +2692,11 @@ tabs_tray:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/12036
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   opened_existing_tab:
     type: event
@@ -2519,10 +2707,11 @@ tabs_tray:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/12036
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   closed_existing_tab:
     type: event
@@ -2533,10 +2722,11 @@ tabs_tray:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/12036
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   private_mode_tapped:
     type: event
@@ -2547,10 +2737,11 @@ tabs_tray:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/12036
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   normal_mode_tapped:
     type: event
@@ -2561,10 +2752,11 @@ tabs_tray:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/12036
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   synced_mode_tapped:
     type: event
@@ -2574,10 +2766,11 @@ tabs_tray:
       - https://github.com/mozilla-mobile/fenix/issues/18948
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/19004
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2022-08-01"
   new_tab_tapped:
     type: event
@@ -2588,10 +2781,11 @@ tabs_tray:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/12036
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   new_private_tab_tapped:
     type: event
@@ -2602,10 +2796,11 @@ tabs_tray:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/12036
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   menu_opened:
     type: event
@@ -2616,10 +2811,11 @@ tabs_tray:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/12036
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   save_to_collection:
     type: event
@@ -2630,10 +2826,11 @@ tabs_tray:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/12036
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   share_all_tabs:
     type: event
@@ -2645,10 +2842,11 @@ tabs_tray:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/12036
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   close_all_tabs:
     type: event
@@ -2660,10 +2858,11 @@ tabs_tray:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/12036
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
 
 collections:
@@ -2673,96 +2872,108 @@ collections:
       A user renamed a collection
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/969
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/3935
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
   tab_restored:
     type: event
     description: |
       A user restored a tab from collection tab list
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/969
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/3935
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
   all_tabs_restored:
     type: event
     description: |
       A user tapped "open tabs" from collection menu
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/969
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/3935
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
   tab_removed:
     type: event
     description: |
       A user tapped remove tab from collection tab list
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/969
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/3935
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
   shared:
     type: event
     description: |
       A user tapped share collection
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/969
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/3935
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
   removed:
     type: event
     description: |
       A user tapped delete collection from collection menu
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/969
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/3935
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
   saved:
     type: event
     description: |
@@ -2774,16 +2985,18 @@ collections:
         description: "The number of tabs added to the collection"
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/969
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/3935
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
   tabs_added:
     type: event
     description: |
@@ -2795,16 +3008,18 @@ collections:
         description: "The number of tabs added to the collection"
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/969
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/3935
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
   tab_select_opened:
     type: event
     description: |
@@ -2812,46 +3027,52 @@ collections:
       creation flow)
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/969
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/3935
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
   add_tab_button:
     type: event
     description: |
       A user tapped the "add tab" button in the three dot menu of collections
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/969
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/4358
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
   long_press:
     type: event
     description: |
       A user long pressed on a tab, triggering the collection creation screen
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/969
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/4358
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
   save_button:
     type: event
     description: |
@@ -2860,15 +3081,17 @@ collections:
       (tab_select_opened)
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/969
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/4358
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
     extra_keys:
       from_screen:
         description: |
@@ -2880,15 +3103,17 @@ collections:
       A user pressed the "rename collection" button in the three dot menu
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/969
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/4539
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
 
 search_widget:
   new_tab_button:
@@ -2901,10 +3126,11 @@ search_widget:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/4714
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   voice_button:
     type: event
@@ -2915,10 +3141,11 @@ search_widget:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/4714
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
 
 private_browsing_mode:
@@ -2932,10 +3159,11 @@ private_browsing_mode:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/4968
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   notification_tapped:
     type: event
@@ -2946,10 +3174,11 @@ private_browsing_mode:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/4968
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
 
 contextual_hint.tracking_protection:
@@ -2964,10 +3193,11 @@ contextual_hint.tracking_protection:
       - https://github.com/mozilla-mobile/fenix/pull/11923
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-07-01"
   dismiss:
     type: event
@@ -2981,10 +3211,11 @@ contextual_hint.tracking_protection:
       - https://github.com/mozilla-mobile/fenix/pull/11923
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-07-01"
   outside_tap:
     type: event
@@ -2997,10 +3228,11 @@ contextual_hint.tracking_protection:
       - https://github.com/mozilla-mobile/fenix/pull/11923
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-07-01"
   inside_tap:
     type: event
@@ -3013,10 +3245,11 @@ contextual_hint.tracking_protection:
       - https://github.com/mozilla-mobile/fenix/pull/11923
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-07-01"
 
 tracking_protection:
@@ -3030,10 +3263,11 @@ tracking_protection:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/5414#issuecomment-532847188
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   panel_settings:
     type: event
@@ -3044,10 +3278,11 @@ tracking_protection:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/5414#issuecomment-532847188
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   etp_shield:
     type: event
@@ -3058,10 +3293,11 @@ tracking_protection:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/5414#issuecomment-532847188
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   etp_tracker_list:
     type: event
@@ -3073,10 +3309,11 @@ tracking_protection:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/5414#issuecomment-532847188
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   etp_settings:
     type: event
@@ -3087,10 +3324,11 @@ tracking_protection:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/5414#issuecomment-532847188
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   etp_setting_changed:
     type: event
@@ -3107,10 +3345,11 @@ tracking_protection:
       - https://github.com/mozilla-mobile/fenix/pull/5414#issuecomment-532847188
       - https://github.com/mozilla-mobile/fenix/pull/11383
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
 
 private_browsing_shortcut:
@@ -3123,10 +3362,11 @@ private_browsing_shortcut:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/5194
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   cfr_add_shortcut:
     type: event
@@ -3138,10 +3378,11 @@ private_browsing_shortcut:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/5194
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   cfr_cancel:
     type: event
@@ -3153,10 +3394,11 @@ private_browsing_shortcut:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/5194
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   pinned_shortcut_priv:
     type: event
@@ -3168,10 +3410,11 @@ private_browsing_shortcut:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/5194
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   static_shortcut_tab:
     type: event
@@ -3183,10 +3426,11 @@ private_browsing_shortcut:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/5194
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   static_shortcut_priv:
     type: event
@@ -3198,10 +3442,11 @@ private_browsing_shortcut:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/5194
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
 
 tab:
@@ -3214,10 +3459,11 @@ tab:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/5266
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
     no_lint:
       - COMMON_PREFIX
@@ -3230,10 +3476,11 @@ tab:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/5266
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
 
 media_notification:
@@ -3246,10 +3493,11 @@ media_notification:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/5520
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   pause:
     type: event
@@ -3260,10 +3508,11 @@ media_notification:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/5520
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
 
 media_state:
@@ -3276,10 +3525,11 @@ media_state:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/6463
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   pause:
     type: event
@@ -3290,10 +3540,11 @@ media_state:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/6463
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   stop:
     type: event
@@ -3304,10 +3555,11 @@ media_state:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/6463
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   fullscreen:
     type: event
@@ -3317,10 +3569,11 @@ media_state:
       - https://github.com/mozilla-mobile/fenix/issues/15368
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/16833
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   picture_in_picture:
     type: event
@@ -3330,10 +3583,11 @@ media_state:
       - https://github.com/mozilla-mobile/fenix/issues/15368
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/16833
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
 
 logins:
@@ -3346,10 +3600,11 @@ logins:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/6352
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   open_individual_login:
     type: event
@@ -3360,10 +3615,11 @@ logins:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/6352
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   copy_login:
     type: event
@@ -3374,10 +3630,11 @@ logins:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/6352
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   view_password_login:
     type: event
@@ -3388,10 +3645,11 @@ logins:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/6352
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   save_logins_setting_changed:
     type: event
@@ -3407,10 +3665,11 @@ logins:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/7767
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   open_login_editor:
     type: event
@@ -3421,10 +3680,11 @@ logins:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/issues/11208
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   delete_saved_login:
     type: event
@@ -3435,10 +3695,11 @@ logins:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/issues/11208
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   save_edited_login:
     type: event
@@ -3449,10 +3710,11 @@ logins:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/issues/11208
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
 
 download_notification:
@@ -3466,10 +3728,11 @@ download_notification:
       - https://github.com/mozilla-mobile/fenix/pull/6554
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-07-01"
   pause:
     type: event
@@ -3481,10 +3744,11 @@ download_notification:
       - https://github.com/mozilla-mobile/fenix/pull/6554
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-07-01"
   cancel:
     type: event
@@ -3496,10 +3760,11 @@ download_notification:
       - https://github.com/mozilla-mobile/fenix/pull/6554
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-07-01"
   try_again:
     type: event
@@ -3512,10 +3777,11 @@ download_notification:
       - https://github.com/mozilla-mobile/fenix/pull/6554
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-07-01"
   open:
     type: event
@@ -3527,10 +3793,11 @@ download_notification:
       - https://github.com/mozilla-mobile/fenix/pull/6554
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-07-01"
   in_app_open:
     type: event
@@ -3542,10 +3809,11 @@ download_notification:
       - https://github.com/mozilla-mobile/fenix/pull/6554
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-07-01"
   in_app_try_again:
     type: event
@@ -3558,10 +3826,11 @@ download_notification:
       - https://github.com/mozilla-mobile/fenix/pull/6554
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-07-01"
 
 downloads_misc:
@@ -3574,8 +3843,9 @@ downloads_misc:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/16730
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-07-01"
 
 downloads_management:
@@ -3589,8 +3859,9 @@ downloads_management:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/16728
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-07-01"
 
   item_opened:
@@ -3600,12 +3871,14 @@ downloads_management:
       "Downloads" folder.
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/15367
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/16728
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
 
   item_deleted:
     type: event
@@ -3613,12 +3886,14 @@ downloads_management:
       A counter for how often a user deletes one / more downloads at a time.
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/15367
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/16728
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
 
 user_specified_search_engines:
   custom_engine_added:
@@ -3630,10 +3905,11 @@ user_specified_search_engines:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/6918
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
     no_lint:
       - COMMON_PREFIX
@@ -3647,10 +3923,11 @@ user_specified_search_engines:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/6918
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
 
 search_suggestions:
@@ -3663,11 +3940,12 @@ search_suggestions:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/6746
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
 
 voice_search:
@@ -3680,10 +3958,11 @@ voice_search:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/10785
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
 
 top_sites:
@@ -3696,10 +3975,11 @@ top_sites:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/10752
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   open_google_search_attribution:
     type: event
@@ -3709,10 +3989,11 @@ top_sites:
       - https://github.com/mozilla-mobile/fenix/issues/17418
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/17637
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   open_frecency:
     type: event
@@ -3723,10 +4004,11 @@ top_sites:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/15136
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   open_pinned:
     type: event
@@ -3737,10 +4019,11 @@ top_sites:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/15136
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   swipe_carousel:
     type: event
@@ -3755,10 +4038,11 @@ top_sites:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/15136
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   long_press:
     type: event
@@ -3773,10 +4057,11 @@ top_sites:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/15136
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   open_in_new_tab:
     type: event
@@ -3787,10 +4072,11 @@ top_sites:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/7523
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   open_in_private_tab:
     type: event
@@ -3801,10 +4087,11 @@ top_sites:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/7523
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   remove:
     type: event
@@ -3815,10 +4102,11 @@ top_sites:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/7523
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
 
 about_page:
@@ -3832,10 +4120,11 @@ about_page:
       - https://github.com/mozilla-mobile/fenix/pull/8047
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-07-01"
   privacy_notice_tapped:
     type: event
@@ -3847,10 +4136,11 @@ about_page:
       - https://github.com/mozilla-mobile/fenix/pull/8047
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-07-01"
 
 app_theme:
@@ -3865,15 +4155,17 @@ app_theme:
           'SETTINGS' or 'ONBOARDING'
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/7289
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/7968
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
 
 pocket:
   pocket_top_site_clicked:
@@ -3885,10 +4177,11 @@ pocket:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/8098
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
     no_lint:
       - COMMON_PREFIX
@@ -3902,10 +4195,11 @@ pocket:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/8098
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
 
 first_session:
@@ -3920,11 +4214,12 @@ first_session:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/8074#issuecomment-586512202
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   network:
     type: string
@@ -3937,11 +4232,12 @@ first_session:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/8074#issuecomment-586512202
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   adgroup:
     type: string
@@ -3954,11 +4250,12 @@ first_session:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/8074#issuecomment-586480836
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   creative:
     send_in_pings:
@@ -3971,11 +4268,12 @@ first_session:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/8074#issuecomment-586512202
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   timestamp:
     send_in_pings:
@@ -3990,11 +4288,12 @@ first_session:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/8074#issuecomment-586512202
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
 
 browser.search:
@@ -4010,10 +4309,11 @@ browser.search:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/10112
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   ad_clicks:
     type: labeled_counter
@@ -4027,10 +4327,11 @@ browser.search:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/10112
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   in_content:
     type: labeled_counter
@@ -4043,10 +4344,11 @@ browser.search:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/10167
       - https://github.com/mozilla-mobile/fenix/pull/15713#issuecomment-703972068
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
 
 addons:
@@ -4056,15 +4358,17 @@ addons:
       A user accessed "Add-ons" from the Settings
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/6174
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/8318
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
   open_addon_in_toolbar_menu:
     type: event
     description: |
@@ -4075,15 +4379,17 @@ addons:
           The id of the add-on that was interacted with in the toolbar menu
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/6174
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/8318
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
   open_addon_setting:
     type: event
     description: |
@@ -4096,10 +4402,11 @@ addons:
       - https://github.com/mozilla-mobile/fenix/issues/17644
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/18504
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2022-08-01"
   has_installed_addons:
     type: boolean
@@ -4109,15 +4416,17 @@ addons:
       - metrics
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/6174
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/8318
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
   has_enabled_addons:
     type: boolean
     description: |
@@ -4126,15 +4435,17 @@ addons:
       - metrics
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/6174
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/8318
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
   installed_addons:
     type: string_list
     description: |
@@ -4143,15 +4454,17 @@ addons:
       - metrics
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/8920
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/11080
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
   enabled_addons:
     type: string_list
     description: |
@@ -4160,15 +4473,17 @@ addons:
       - metrics
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/8920
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/11080
       - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
       - https://github.com/mozilla-mobile/fenix/pull/18143
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-07-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
 
 startup.timeline:
   framework_primary:
@@ -4633,11 +4948,12 @@ perf.awesomebar:
       - https://github.com/mozilla-mobile/android-components/issues/4992
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/10276#pullrequestreview-411101979
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
       - gkruglov@mozilla.com
     expires: "2021-11-15"
   bookmark_suggestions:
@@ -4651,11 +4967,12 @@ perf.awesomebar:
       - https://github.com/mozilla-mobile/android-components/issues/4992
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/10276#pullrequestreview-411101979
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
       - gkruglov@mozilla.com
     expires: "2021-11-15"
   search_engine_suggestions:
@@ -4669,11 +4986,12 @@ perf.awesomebar:
       - https://github.com/mozilla-mobile/android-components/issues/4992
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/10276#pullrequestreview-411101979
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
       - gkruglov@mozilla.com
     expires: "2021-11-15"
   session_suggestions:
@@ -4687,11 +5005,12 @@ perf.awesomebar:
       - https://github.com/mozilla-mobile/android-components/issues/4992
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/10276#pullrequestreview-411101979
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
       - gkruglov@mozilla.com
     expires: "2021-11-15"
   synced_tabs_suggestions:
@@ -4705,11 +5024,12 @@ perf.awesomebar:
       - https://github.com/mozilla-mobile/android-components/issues/4992
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/10276#pullrequestreview-411101979
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
       - gkruglov@mozilla.com
     expires: "2021-11-15"
   clipboard_suggestions:
@@ -4723,11 +5043,12 @@ perf.awesomebar:
       - https://github.com/mozilla-mobile/android-components/issues/4992
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/10276#pullrequestreview-411101979
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
       - gkruglov@mozilla.com
     expires: "2021-11-15"
   shortcuts_suggestions:
@@ -4741,11 +5062,12 @@ perf.awesomebar:
       - https://github.com/mozilla-mobile/android-components/issues/4992
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/10276#pullrequestreview-411101979
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
       - gkruglov@mozilla.com
     expires: "2021-11-15"
 
@@ -4757,10 +5079,11 @@ autoplay:
       - https://github.com/mozilla-mobile/fenix/issues/11579
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/13041#issuecomment-665777411
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   setting_changed:
     type: event
@@ -4776,10 +5099,11 @@ autoplay:
       - https://github.com/mozilla-mobile/fenix/issues/11579
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/13041#issuecomment-665777411
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
 
 storage.stats:
@@ -4797,11 +5121,12 @@ storage.stats:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/12876#issuecomment-666770732
       - https://github.com/mozilla-mobile/fenix/pull/17704#issue-564299127
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
       - perf-android-fe@mozilla.com
       - mcomella@mozilla.com
     expires: "2021-08-01"
@@ -4822,11 +5147,12 @@ storage.stats:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/12876#issuecomment-666770732
       - https://github.com/mozilla-mobile/fenix/pull/17704#issue-564299127
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
       - perf-android-fe@mozilla.com
       - mcomella@mozilla.com
     expires: "2021-08-01"
@@ -4844,11 +5170,12 @@ storage.stats:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/12876#issuecomment-666770732
       - https://github.com/mozilla-mobile/fenix/pull/17704#issue-564299127
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
       - perf-android-fe@mozilla.com
       - mcomella@mozilla.com
     expires: "2021-08-01"
@@ -4868,11 +5195,12 @@ storage.stats:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/12876#issuecomment-666770732
       - https://github.com/mozilla-mobile/fenix/pull/17704#issue-564299127
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
       - perf-android-fe@mozilla.com
       - mcomella@mozilla.com
     expires: "2021-08-01"
@@ -4887,10 +5215,11 @@ progressive_web_app:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/11859
       - https://github.com/mozilla-mobile/fenix/pull/18071
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
       - erichards@mozilla.com
     expires: "2021-09-01"
   install_tap:
@@ -4902,10 +5231,11 @@ progressive_web_app:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/11859
       - https://github.com/mozilla-mobile/fenix/pull/18071
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
       - erichards@mozilla.com
     expires: "2021-09-01"
   foreground:
@@ -4921,10 +5251,11 @@ progressive_web_app:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/11859
       - https://github.com/mozilla-mobile/fenix/pull/18071
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
       - erichards@mozilla.com
     expires: "2021-09-01"
   background:
@@ -4940,10 +5271,11 @@ progressive_web_app:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/11859
       - https://github.com/mozilla-mobile/fenix/pull/18071
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
       - erichards@mozilla.com
     expires: "2021-09-01"
 
@@ -4957,10 +5289,11 @@ master_password:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/14468#issuecomment-684114534
       - https://github.com/mozilla-mobile/fenix/pull/18071
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-09-01"
   migration:
     type: event
@@ -4971,10 +5304,11 @@ master_password:
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/14468#issuecomment-684114534
       - https://github.com/mozilla-mobile/fenix/pull/18071
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-09-01"
 
 tabs:
@@ -4986,10 +5320,11 @@ tabs:
       - https://github.com/mozilla-mobile/fenix/issues/15347#issue-707408975
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/15811#issuecomment-706402952
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
 
 banner_open_in_app:
@@ -5001,10 +5336,11 @@ banner_open_in_app:
       - https://github.com/mozilla-mobile/fenix/issues/16828
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/17049
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   dismissed:
     type: event
@@ -5014,10 +5350,11 @@ banner_open_in_app:
       - https://github.com/mozilla-mobile/fenix/issues/16828
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/17049
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   go_to_settings:
     type: event
@@ -5027,10 +5364,11 @@ banner_open_in_app:
       - https://github.com/mozilla-mobile/fenix/issues/16828
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/17049
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
 
 contextual_menu:
@@ -5040,52 +5378,60 @@ contextual_menu:
       The context menu's 'copy' option was used.
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/11580
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/16968
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-06-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
   search_tapped:
     type: event
     description: |
       The context menu's 'search' option was used.
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/11580
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/16968
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-06-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
   select_all_tapped:
     type: event
     description: |
       The context menu's 'select all' option was used.
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/11580
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/16968
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-06-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
   share_tapped:
     type: event
     description: |
       The context menu's 'share' option was used.
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/11580
+      - https://github.com/mozilla-mobile/fenix/issues/19923
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/16968
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
-    expires: "2021-06-01"
+      - firefox-android-team@mozilla.com
+    expires: "2021-12-01"
 
 engine_tab:
   kills:
@@ -5100,10 +5446,11 @@ engine_tab:
       - https://github.com/mozilla-mobile/android-components/issues/9366
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/17864
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
       - skaspari@mozilla.com
     expires: "2021-12-31"
   kill_foreground_age:
@@ -5116,10 +5463,11 @@ engine_tab:
       - https://github.com/mozilla-mobile/android-components/issues/9366
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/17864
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
       - skaspari@mozilla.com
     expires: "2021-12-31"
   kill_background_age:
@@ -5132,10 +5480,11 @@ engine_tab:
       - https://github.com/mozilla-mobile/android-components/issues/9366
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/17864
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
       - skaspari@mozilla.com
     expires: "2021-12-31"
   foreground_metrics:
@@ -5147,10 +5496,11 @@ engine_tab:
       - https://github.com/mozilla-mobile/android-components/issues/9997
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/18747#issuecomment-815731764
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
       - skaspari@mozilla.com
     expires: "2021-12-31"
     extra_keys:
@@ -5188,10 +5538,11 @@ synced_tabs:
       - https://github.com/mozilla-mobile/fenix/issues/18163
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/18172
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
 
 awesomebar:
@@ -5203,10 +5554,11 @@ awesomebar:
       - https://github.com/mozilla-mobile/fenix/issues/18068
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/18090
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   clipboard_suggestion_clicked:
     type: event
@@ -5216,10 +5568,11 @@ awesomebar:
       - https://github.com/mozilla-mobile/fenix/issues/18068
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/18090
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   history_suggestion_clicked:
     type: event
@@ -5229,10 +5582,11 @@ awesomebar:
       - https://github.com/mozilla-mobile/fenix/issues/18068
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/18090
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   search_action_clicked:
     type: event
@@ -5242,10 +5596,11 @@ awesomebar:
       - https://github.com/mozilla-mobile/fenix/issues/18068
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/18090
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   search_suggestion_clicked:
     type: event
@@ -5255,10 +5610,11 @@ awesomebar:
       - https://github.com/mozilla-mobile/fenix/issues/18068
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/18090
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
   opened_tab_suggestion_clicked:
     type: event
@@ -5268,10 +5624,11 @@ awesomebar:
       - https://github.com/mozilla-mobile/fenix/issues/18068
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/18090
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-08-01"
 
 home_menu:
@@ -5282,10 +5639,11 @@ home_menu:
       - https://github.com/mozilla-mobile/fenix/issues/18856
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/18987
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-10-01"
 
 home_screen:
@@ -5296,10 +5654,11 @@ home_screen:
       - https://github.com/mozilla-mobile/fenix/issues/18856
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/19025
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-10-01"
 
 android_keystore_experiment:
@@ -5316,10 +5675,11 @@ android_keystore_experiment:
       - https://github.com/mozilla-mobile/fenix/issues/17869
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/18333#pullrequestreview-612447395
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-09-01"
   get_failure:
     type: event
@@ -5334,10 +5694,11 @@ android_keystore_experiment:
       - https://github.com/mozilla-mobile/fenix/issues/17869
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/18333#pullrequestreview-612447395
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-09-01"
   get_result:
     type: event
@@ -5352,10 +5713,11 @@ android_keystore_experiment:
       - https://github.com/mozilla-mobile/fenix/issues/17869
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/18333#pullrequestreview-612447395
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-09-01"
   write_failure:
     type: event
@@ -5370,10 +5732,11 @@ android_keystore_experiment:
       - https://github.com/mozilla-mobile/fenix/issues/17869
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/18333#pullrequestreview-612447395
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-09-01"
   write_success:
     type: event
@@ -5383,10 +5746,11 @@ android_keystore_experiment:
       - https://github.com/mozilla-mobile/fenix/issues/17869
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/18333#pullrequestreview-612447395
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-09-01"
   reset:
     type: event
@@ -5397,10 +5761,11 @@ android_keystore_experiment:
       - https://github.com/mozilla-mobile/fenix/issues/17869
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/18333#pullrequestreview-612447395
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - technical
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-09-01"
 
 set_default_newtab_experiment:
@@ -5412,10 +5777,11 @@ set_default_newtab_experiment:
       - https://github.com/mozilla-mobile/fenix/issues/18853
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/18895
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-10-01"
   close_experiment_card_clicked:
     type: event
@@ -5425,10 +5791,11 @@ set_default_newtab_experiment:
       - https://github.com/mozilla-mobile/fenix/issues/18853
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/18895
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-10-01"
 
 set_default_setting_experiment:
@@ -5440,8 +5807,9 @@ set_default_setting_experiment:
       - https://github.com/mozilla-mobile/fenix/issues/18852
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/19047
+      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
     data_sensitivity:
       - interaction
     notification_emails:
-      - fenix-core@mozilla.com
+      - firefox-android-team@mozilla.com
     expires: "2021-10-01"

--- a/app/pings.yaml
+++ b/app/pings.yaml
@@ -17,7 +17,7 @@ activation:
   data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/1707#issuecomment-486972209
   notification_emails:
-    - fenix-core@mozilla.com
+    - android-probes@mozilla.com
 
 first-session:
   description: |
@@ -29,7 +29,7 @@ first-session:
   data_reviews:
     - https://github.com/mozilla-mobile/fenix/pull/8074#issuecomment-586512202
   notification_emails:
-    - fenix-core@mozilla.com
+    - android-probes@mozilla.com
 
 startup-timeline:
   description: |


### PR DESCRIPTION
For [FNX-22820](https://jira.mozilla.com/browse/FNX-22820): uplift changes for [FNX-22713](https://jira.mozilla.com/browse/FNX-22713) and [FNX-22819](https://jira.mozilla.com/browse/FNX-22819) into beta 90

~DO NOT MERGE we should wait until Monday to handle this uplift so we aren't doing it right before the weekend.~

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
