### PR TITLE
For #19910: Define the width/height for sync sign in button on tabs tray

### DIFF
--- a/app/src/main/res/layout/sync_tabs_error_row.xml
+++ b/app/src/main/res/layout/sync_tabs_error_row.xml
@@ -24,6 +24,9 @@
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/sync_tabs_error_cta_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:maxLines="2"
         style="@style/PositiveButton"
         app:icon="@drawable/ic_sign_in"
         android:visibility="gone"


### PR DESCRIPTION
For #19910 

<img width="321" alt="image" src="https://user-images.githubusercontent.com/43795363/122471610-154e8700-cf85-11eb-9ffc-5594a5ef6e02.png"> <img width="324" alt="image" src="https://user-images.githubusercontent.com/43795363/122472426-319ef380-cf86-11eb-967d-98b98d24ac78.png">

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
