### PR TITLE
For #20081: Define the width/height for homescreen empty collections button

### DIFF
--- a/app/src/main/res/layout/no_collections_message.xml
+++ b/app/src/main/res/layout/no_collections_message.xml
@@ -53,6 +53,9 @@
     <com.google.android.material.button.MaterialButton
         android:id="@+id/add_tabs_to_collections_button"
         style="@style/PositiveButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:maxLines="2"
         android:layout_marginTop="8dp"
         android:text="@string/tabs_menu_save_to_collection1"
         android:visibility="gone"


### PR DESCRIPTION
For #20081

<img width="324" alt="image" src="https://user-images.githubusercontent.com/43795363/122473620-bb02f580-cf87-11eb-81e0-4cbceb3bb4d4.png"> <img width="327" alt="image" src="https://user-images.githubusercontent.com/43795363/122474352-b4c14900-cf88-11eb-9b5f-0f758e84e54c.png">


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
