### PR TITLE
For #19910, #18581, #20081: Beta uplift to fix L10n button heights

### DIFF
--- a/app/src/main/res/layout/no_collections_message.xml
+++ b/app/src/main/res/layout/no_collections_message.xml
@@ -53,6 +53,9 @@
     <com.google.android.material.button.MaterialButton
         android:id="@+id/add_tabs_to_collections_button"
         style="@style/PositiveButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:maxLines="2"
         android:layout_marginTop="8dp"
         android:text="@string/tabs_menu_save_to_collection1"
         android:visibility="gone"

--- a/app/src/main/res/layout/preference_widget_radiobutton_with_info.xml
+++ b/app/src/main/res/layout/preference_widget_radiobutton_with_info.xml
@@ -31,14 +31,15 @@
     <TextView
         android:id="@+id/title"
         android:layout_width="0dp"
-        android:layout_height="0dp"
+        android:layout_height="wrap_content"
         android:gravity="center|start"
         android:textAlignment="viewStart"
         android:textAppearance="?android:attr/textAppearanceListItem"
-        app:layout_constraintBottom_toBottomOf="@id/radio_button"
+        android:paddingTop="6dp"
+        android:paddingBottom="6dp"
         app:layout_constraintEnd_toStartOf="@+id/vertical_divider"
         app:layout_constraintStart_toEndOf="@+id/radio_button"
-        app:layout_constraintTop_toTopOf="@id/radio_button"
+        app:layout_constraintTop_toTopOf="parent"
         tools:text="Use recommended settings" />
 
     <TextView

--- a/app/src/main/res/layout/sync_tabs_error_row.xml
+++ b/app/src/main/res/layout/sync_tabs_error_row.xml
@@ -24,6 +24,9 @@
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/sync_tabs_error_cta_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:maxLines="2"
         style="@style/PositiveButton"
         app:icon="@drawable/ic_sign_in"
         android:visibility="gone"


### PR DESCRIPTION
For #19910, #18581, #20081

Fixes three different buttons for l10n when the language wraps to a second line: 
- Homescreen Collections button
- Tabs tray Sync Sign In button
- ETP standard option

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
