### PR TITLE
For #16330 - Replaces Sentry.capture with submitCaughtException

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/tips/providers/MasterPasswordTipProvider.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/tips/providers/MasterPasswordTipProvider.kt
@@ -14,7 +14,6 @@ import androidx.core.view.isVisible
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
-import io.sentry.Sentry
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Dispatchers.IO
@@ -198,13 +197,13 @@ class MasterPasswordTipProvider(
                     context.components.core.passwordsStorage.add(it)
                 } catch (e: InvalidRecordException) {
                     // This record was invalid and we couldn't save this login
-                    Sentry.capture("Master Password migration add login error $e for reason ${e.message}")
+                    context.components.analytics.crashReporter.submitCaughtException(e)
                 } catch (e: IdCollisionException) {
                     // Nonempty ID was provided
-                    Sentry.capture("Master Password migration add login error $e")
+                    context.components.analytics.crashReporter.submitCaughtException(e)
                 } catch (e: LoginsStorageException) {
                     // Some other error occurred
-                    Sentry.capture("Master Password migration add login error $e")
+                    context.components.analytics.crashReporter.submitCaughtException(e)
                 }
             }
             withContext(Dispatchers.Main) {

--- a/app/src/main/java/org/mozilla/fenix/experiments/NimbusSetup.kt
+++ b/app/src/main/java/org/mozilla/fenix/experiments/NimbusSetup.kt
@@ -7,7 +7,6 @@ package org.mozilla.fenix.experiments
 import android.content.Context
 import android.net.Uri
 import android.os.StrictMode
-import io.sentry.Sentry
 import mozilla.components.service.nimbus.NimbusApi
 import mozilla.components.service.nimbus.Nimbus
 import mozilla.components.service.nimbus.NimbusAppInfo
@@ -84,7 +83,7 @@ fun createNimbus(context: Context, url: String?): NimbusApi =
         // Something went wrong. We'd like not to, but stability of the app is more important than
         // failing fast here.
         if (isSentryEnabled()) {
-            Sentry.capture(e)
+            context.components.analytics.crashReporter.submitCaughtException(e)
         } else {
             Logger.error("Failed to initialize Nimbus", e)
         }


### PR DESCRIPTION
For https://github.com/mozilla-mobile/fenix/issues/16330#issuecomment-862597707

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR doesn't include any tests as it is only a minor change.
- [x] **Screenshots**: This PR includes no user facing changes.
- [x] **Accessibility**: The code in this PR does not include any user facing features.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

@csadilek I haven't replaced the instances of `Sentry.capture` from `Core.kt:415` and `NavController.kt:53` (they're sending strings) as I'm not sure what to replace them with. Please advise.