### PR TITLE
For #19886 - Add right arrowheader to tracking protection navigators

### DIFF
--- a/app/src/main/res/layout/component_tracking_protection_panel.xml
+++ b/app/src/main/res/layout/component_tracking_protection_panel.xml
@@ -187,7 +187,6 @@
             style="@style/QuickSettingsLargeText.Icon"
             android:layout_width="match_parent"
             android:layout_height="@dimen/tracking_protection_item_height"
-            android:paddingEnd="24dp"
             android:text="@string/etp_settings"
             app:drawableStartCompat="@drawable/ic_settings"
             app:layout_constraintTop_toBottomOf="@id/line_divider" />

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -469,6 +469,7 @@
 
     <style name="QuickSettingsLargeText.Icon">
         <item name="android:drawablePadding">8dp</item>
+        <item name="drawableEndCompat">@drawable/ic_arrowhead_right</item>
     </style>
 
     <style name="QuickSettingsText.Icon">


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
