### PR TITLE
CI For #19992: Dismisses search dialog if active before navigating to TabsTrayFragment

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/recenttabs/controller/RecentTabController.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recenttabs/controller/RecentTabController.kt
@@ -45,9 +45,17 @@ class DefaultRecentTabsController(
     }
 
     override fun handleRecentTabShowAllClicked() {
+        dismissSearchDialogIfDisplayed()
+
         navController.nav(
             R.id.homeFragment,
             HomeFragmentDirections.actionGlobalTabsTrayFragment()
         )
+    }
+
+    private fun dismissSearchDialogIfDisplayed() {
+        if (navController.currentDestination?.id == R.id.searchDialogFragment) {
+            navController.navigateUp()
+        }
     }
 }


### PR DESCRIPTION
CI for https://github.com/mozilla-mobile/fenix/pull/20028


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
