### PR TITLE
For #19922 Fix the default autoplay setting to be block audio only

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/PhoneFeature.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/PhoneFeature.kt
@@ -99,9 +99,9 @@ enum class PhoneFeature(val androidPermissionsList: Array<String>) : Parcelable 
             LOCATION -> R.string.pref_key_phone_feature_location
             MICROPHONE -> R.string.pref_key_phone_feature_microphone
             NOTIFICATION -> R.string.pref_key_phone_feature_notification
-            AUTOPLAY -> R.string.pref_key_browser_feature_autoplay_audible_v1
-            AUTOPLAY_AUDIBLE -> R.string.pref_key_browser_feature_autoplay_audible_v1
-            AUTOPLAY_INAUDIBLE -> R.string.pref_key_browser_feature_autoplay_inaudible_v1
+            AUTOPLAY -> R.string.pref_key_browser_feature_autoplay_v2
+            AUTOPLAY_AUDIBLE -> R.string.pref_key_browser_feature_autoplay_audible_v2
+            AUTOPLAY_INAUDIBLE -> R.string.pref_key_browser_feature_autoplay_inaudible_v2
             PERSISTENT_STORAGE -> R.string.pref_key_browser_feature_persistent_storage
             MEDIA_KEY_SYSTEM_ACCESS -> R.string.pref_key_browser_feature_media_key_system_access
         }

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -837,11 +837,11 @@ class Settings(private val appContext: Context) : PreferencesHolder {
             camera = getSitePermissionsPhoneFeatureAction(PhoneFeature.CAMERA),
             autoplayAudible = getSitePermissionsPhoneFeatureAutoplayAction(
                 feature = PhoneFeature.AUTOPLAY_AUDIBLE,
-                default = AutoplayAction.ALLOWED
+                default = AutoplayAction.BLOCKED
             ),
             autoplayInaudible = getSitePermissionsPhoneFeatureAutoplayAction(
                 feature = PhoneFeature.AUTOPLAY_INAUDIBLE,
-                default = AutoplayAction.BLOCKED
+                default = AutoplayAction.ALLOWED
             ),
             persistentStorage = getSitePermissionsPhoneFeatureAction(PhoneFeature.PERSISTENT_STORAGE),
             mediaKeySystemAccess = getSitePermissionsPhoneFeatureAction(PhoneFeature.MEDIA_KEY_SYSTEM_ACCESS)

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -115,9 +115,9 @@
     <string name="pref_key_show_site_exceptions" translatable="false">pref_key_show_site_exceptions</string>
     <string name="pref_key_recommended_settings" translatable="false">pref_key_recommended_settings</string>
     <string name="pref_key_custom_settings" translatable="false">pref_key_custom_settings</string>
-    <string name="pref_key_browser_feature_autoplay_v1" translatable="false">pref_key_browser_feature_autoplay_v1</string>
-    <string name="pref_key_browser_feature_autoplay_audible_v1" translatable="false">pref_key_browser_feature_autoplay_v1</string>
-    <string name="pref_key_browser_feature_autoplay_inaudible_v1" translatable="false">pref_key_browser_feature_autoplay_inaudible_v1</string>
+    <string name="pref_key_browser_feature_autoplay_v2" translatable="false">pref_key_browser_feature_autoplay_v2</string>
+    <string name="pref_key_browser_feature_autoplay_audible_v2" translatable="false">pref_key_browser_feature_autoplay_v2</string>
+    <string name="pref_key_browser_feature_autoplay_inaudible_v2" translatable="false">pref_key_browser_feature_autoplay_inaudible_v2</string>
     <string name="pref_key_browser_feature_persistent_storage" translatable="false">pref_key_browser_feature_persistent_storage</string>
     <string name="pref_key_browser_feature_media_key_system_access" translatable="false">pref_key_browser_feature_media_key_system_access</string>
     <string name="pref_key_phone_feature_camera" translatable="false">pref_key_phone_feature_camera</string>

--- a/app/src/main/res/xml/site_permissions_details_exceptions_preferences.xml
+++ b/app/src/main/res/xml/site_permissions_details_exceptions_preferences.xml
@@ -42,7 +42,7 @@
 
     <androidx.preference.Preference
         android:icon="@drawable/ic_autoplay"
-        android:key="@string/pref_key_browser_feature_autoplay_v1"
+        android:key="@string/pref_key_browser_feature_autoplay_v2"
         android:title="@string/preference_browser_feature_autoplay"
         android:summary="@string/preference_option_phone_feature_ask_to_allow"/>
 

--- a/app/src/main/res/xml/site_permissions_preferences.xml
+++ b/app/src/main/res/xml/site_permissions_preferences.xml
@@ -7,7 +7,7 @@
 
     <androidx.preference.Preference
             android:icon="@drawable/ic_autoplay_enabled"
-            android:key="@string/pref_key_browser_feature_autoplay_audible_v1"
+            android:key="@string/pref_key_browser_feature_autoplay_v2"
             android:title="@string/preference_browser_feature_autoplay"
             android:summary="@string/preference_option_autoplay_blocked3"/>
 

--- a/app/src/test/java/org/mozilla/fenix/settings/PhoneFeatureTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/PhoneFeatureTest.kt
@@ -74,14 +74,9 @@ class PhoneFeatureTest {
         assertEquals(R.string.pref_key_phone_feature_location, PhoneFeature.LOCATION.getPreferenceId())
         assertEquals(R.string.pref_key_phone_feature_microphone, PhoneFeature.MICROPHONE.getPreferenceId())
         assertEquals(R.string.pref_key_phone_feature_notification, PhoneFeature.NOTIFICATION.getPreferenceId())
-        assertEquals(R.string.pref_key_browser_feature_autoplay_audible_v1, PhoneFeature.AUTOPLAY_AUDIBLE.getPreferenceId())
-        assertEquals(R.string.pref_key_browser_feature_autoplay_inaudible_v1, PhoneFeature.AUTOPLAY_INAUDIBLE.getPreferenceId())
-        assertEquals(R.string.pref_key_browser_feature_autoplay_audible_v1, PhoneFeature.AUTOPLAY.getPreferenceId())
-
-        assertEquals(
-            "pref_key_browser_feature_autoplay_inaudible_v1",
-            PhoneFeature.AUTOPLAY_INAUDIBLE.getPreferenceKey(testContext)
-        )
+        assertEquals(R.string.pref_key_browser_feature_autoplay_audible_v2, PhoneFeature.AUTOPLAY_AUDIBLE.getPreferenceId())
+        assertEquals(R.string.pref_key_browser_feature_autoplay_inaudible_v2, PhoneFeature.AUTOPLAY_INAUDIBLE.getPreferenceId())
+        assertEquals(R.string.pref_key_browser_feature_autoplay_v2, PhoneFeature.AUTOPLAY.getPreferenceId())
     }
 
     @Test

--- a/app/src/test/java/org/mozilla/fenix/utils/SettingsTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/utils/SettingsTest.kt
@@ -33,8 +33,8 @@ class SettingsTest {
         location = ASK_TO_ALLOW,
         microphone = ASK_TO_ALLOW,
         notification = ASK_TO_ALLOW,
-        autoplayAudible = AutoplayAction.ALLOWED,
-        autoplayInaudible = AutoplayAction.BLOCKED,
+        autoplayAudible = AutoplayAction.BLOCKED,
+        autoplayInaudible = AutoplayAction.ALLOWED,
         persistentStorage = ASK_TO_ALLOW,
         mediaKeySystemAccess = ASK_TO_ALLOW
     )
@@ -601,12 +601,12 @@ class SettingsTest {
         val settings = Settings(testContext)
 
         assertEquals(
-            AutoplayAction.ALLOWED,
+            AutoplayAction.BLOCKED,
             settings.getSitePermissionsCustomSettingsRules().autoplayAudible
         )
 
         assertEquals(
-            AutoplayAction.BLOCKED,
+            AutoplayAction.ALLOWED,
             settings.getSitePermissionsCustomSettingsRules().autoplayInaudible
         )
     }


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
