### PR TITLE
use prod signers for {beta,release}-mozillaonline

### DIFF
--- a/taskcluster/fenix_taskgraph/transforms/signing.py
+++ b/taskcluster/fenix_taskgraph/transforms/signing.py
@@ -38,7 +38,7 @@ def set_worker_type(config, tasks):
         if (
             str(config.params["level"]) == "3"
             and task["attributes"]["build-type"]
-            in ("nightly", "beta", "release", "android-test-nightly")
+            in ("nightly", "beta", "release", "android-test-nightly", "beta-mozillaonline", "release-mozillaonline")
             and config.params["tasks_for"] in ("cron", "github-release", "action")
         ):
             worker_type = "signing"


### PR DESCRIPTION
https://firefox-ci-tc.services.mozilla.com/tasks/WfIuUW2NQii03k9Uk3N82g ran against the dep signers; let's use prod signers for `{beta,release}-mozillaonline`