### PR TITLE
Closes #19755: Handle topsite special urls during shopping festivals.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
@@ -377,6 +377,7 @@ class DefaultSessionControlController(
         metrics.track(Event.CollectionRenamePressed)
     }
 
+    @Suppress("ComplexMethod")
     override fun handleSelectTopSite(url: String, type: TopSite.Type) {
         dismissSearchDialogIfDisplayed()
 
@@ -409,8 +410,18 @@ class DefaultSessionControlController(
             }
         event?.let { activity.metrics.track(it) }
 
+        var specialUrl = url
+        if (SupportUtils.isShoppingFesForJD && url == SupportUtils.JD_URL &&
+            SupportUtils.shoppingFesJD.url.isNotEmpty()) {
+            specialUrl = SupportUtils.shoppingFesJD.url
+        }
+        if (SupportUtils.isShoppingFesForPDD && url == SupportUtils.PDD_URL &&
+            SupportUtils.shoppingFesPDD.url.isNotEmpty()) {
+            specialUrl = SupportUtils.shoppingFesPDD.url
+        }
+
         val tabId = addTabUseCase.invoke(
-            url = appendSearchAttributionToUrlIfNeeded(url),
+            url = appendSearchAttributionToUrlIfNeeded(specialUrl),
             selectTab = true,
             startLoading = true
         )

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/topsites/TopSiteItemViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/topsites/TopSiteItemViewHolder.kt
@@ -79,10 +79,38 @@ class TopSiteItemViewHolder(
                 favicon_image.setImageDrawable(getDrawable(itemView.context, R.drawable.ic_baidu))
             }
             SupportUtils.JD_URL -> {
-                favicon_image.setImageDrawable(getDrawable(itemView.context, R.drawable.ic_jd))
+                if (SupportUtils.isShoppingFesForJD) {
+                    favicon_image.setImageDrawable(
+                        getDrawable(
+                            itemView.context,
+                            SupportUtils.shoppingFesJD.icon
+                        )
+                    )
+                } else {
+                    favicon_image.setImageDrawable(
+                        getDrawable(
+                            itemView.context,
+                            R.drawable.ic_jd
+                        )
+                    )
+                }
             }
             SupportUtils.PDD_URL -> {
-                favicon_image.setImageDrawable(getDrawable(itemView.context, R.drawable.ic_pdd))
+                if (SupportUtils.isShoppingFesForPDD) {
+                    favicon_image.setImageDrawable(
+                        getDrawable(
+                            itemView.context,
+                            SupportUtils.shoppingFesPDD.icon
+                        )
+                    )
+                } else {
+                    favicon_image.setImageDrawable(
+                        getDrawable(
+                            itemView.context,
+                            R.drawable.ic_pdd
+                        )
+                    )
+                }
             }
             else -> {
                 itemView.context.components.core.icons.loadIntoView(favicon_image, topSite.url)

--- a/app/src/main/java/org/mozilla/fenix/settings/SupportUtils.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SupportUtils.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.fenix.settings
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import androidx.browser.customtabs.CustomTabColorSchemeParams
@@ -18,6 +19,8 @@ import org.mozilla.fenix.settings.account.AuthIntentReceiverActivity
 import java.io.UnsupportedEncodingException
 import java.net.URLEncoder
 import java.util.Locale
+import java.text.SimpleDateFormat
+import java.util.Date
 
 object SupportUtils {
     const val RATE_APP_URL = "market://details?id=" + BuildConfig.APPLICATION_ID
@@ -36,6 +39,33 @@ object SupportUtils {
             "cpsSign=CM_210309_13289095_194240604_8bcfd56d5db3c43d983014d2658ec26e&duoduo_type=2"
     const val GOOGLE_US_URL = "https://www.google.com/webhp?client=firefox-b-1-m&channel=ts"
     const val GOOGLE_XX_URL = "https://www.google.com/webhp?client=firefox-b-m&channel=ts"
+
+    data class ShoppingFes(
+        val website: String,
+        val shoppingFesName: String = "",
+        val icon: Int,
+        val url: String = "",
+        val startDate: String = "", // Format in "dd/MM/yyyy".
+        val endDate: String = "" // Format in "dd/MM/yyyy".
+    )
+
+    // Initialize these two value with fresh params for every shopping fes.
+    val shoppingFesJD = ShoppingFes("JD", icon = R.drawable.ic_jd)
+    val shoppingFesPDD = ShoppingFes("PDD", icon = R.drawable.ic_pdd)
+
+    @SuppressLint("SimpleDateFormat")
+    val sdf = SimpleDateFormat("dd/MM/yyyy")
+    val currentDate: String = sdf.format(Date())
+    val isShoppingFesForJD = currentDate.isNotEmpty() &&
+            shoppingFesJD.endDate.isNotEmpty() &&
+            shoppingFesJD.startDate.isNotEmpty() &&
+            sdf.parse(currentDate)!!.before(sdf.parse(shoppingFesJD.endDate)) &&
+            sdf.parse(currentDate)!!.after(sdf.parse(shoppingFesJD.startDate))
+    val isShoppingFesForPDD = currentDate.isNotEmpty() &&
+            shoppingFesPDD.endDate.isNotEmpty() &&
+            shoppingFesPDD.startDate.isNotEmpty() &&
+            sdf.parse(currentDate)!!.before(sdf.parse(shoppingFesPDD.endDate)) &&
+            sdf.parse(currentDate)!!.after(sdf.parse(shoppingFesPDD.startDate))
 
     enum class SumoTopic(internal val topicStr: String) {
         FENIX_MOVING("sync-delist"),


### PR DESCRIPTION
This patch handles shopping festival special icons & urls for e-commercial topsites according to system date.

Need to modify the code manually every shopping festival to edit the special links and icons.
