### PR TITLE
use prod signers for {beta,release}-mozillaonline (#20134)

### DIFF
--- a/taskcluster/fenix_taskgraph/transforms/signing.py
+++ b/taskcluster/fenix_taskgraph/transforms/signing.py
@@ -38,7 +38,7 @@ def set_worker_type(config, tasks):
         if (
             str(config.params["level"]) == "3"
             and task["attributes"]["build-type"]
-            in ("nightly", "beta", "release", "android-test-nightly")
+            in ("nightly", "beta", "release", "android-test-nightly", "beta-mozillaonline", "release-mozillaonline")
             and config.params["tasks_for"] in ("cron", "github-release", "action")
         ):
             worker_type = "signing"


### PR DESCRIPTION
Cherry-pick d24e3b9410e2a6b44e720df75c96710d9328b5f8 to releases_v90.0.0.