### PR TITLE
[SDK-279] Adds a way to switch to the "preview" collection in Nimbus

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/experiments/NimbusSetup.kt
+++ b/app/src/main/java/org/mozilla/fenix/experiments/NimbusSetup.kt
@@ -31,7 +31,11 @@ fun createNimbus(context: Context, url: String?): NimbusApi {
         // Eventually we'll want to use `NimbusDisabled` when we have no NIMBUS_ENDPOINT.
         // but we keep this here to not mix feature flags and how we configure Nimbus.
         val serverSettings = if (!url.isNullOrBlank()) {
-            NimbusServerSettings(url = Uri.parse(url))
+            if (context.settings().nimbusUsePreview) {
+                NimbusServerSettings(url = Uri.parse(url), collection = "nimbus-preview")
+            } else {
+                NimbusServerSettings(url = Uri.parse(url))
+            }
         } else {
             null
         }

--- a/app/src/main/java/org/mozilla/fenix/settings/SecretSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SecretSettingsFragment.kt
@@ -41,5 +41,11 @@ class SecretSettingsFragment : PreferenceFragmentCompat() {
                 }
             }
         }
+
+        requirePreference<SwitchPreference>(R.string.pref_key_nimbus_use_preview).apply {
+            isVisible = true
+            isChecked = context.settings().nimbusUsePreview
+            onPreferenceChangeListener = SharedPreferenceUpdater()
+        }
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -353,6 +353,11 @@ class Settings(private val appContext: Context) : PreferencesHolder {
         default = false
     )
 
+    var nimbusUsePreview by booleanPreference(
+        appContext.getPreferenceKey(R.string.pref_key_nimbus_use_preview),
+        default = false
+    )
+
     /**
      * Indicates the last time when the user was interacting with the [BrowserFragment],
      * This is useful to determine if the user has to start on the [HomeFragment]

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -284,4 +284,5 @@
     <!-- Secret Settings -->
     <string name="pref_key_show_address_feature" translatable="false">pref_key_show_address_feature</string>
     <string name="pref_key_nimbus_experiments" translatable="false">pref_key_nimbus_experiments</string>
+    <string name="pref_key_nimbus_use_preview" translatable="false">pref_key_nimbus_use_preview</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1764,5 +1764,6 @@
 
     <!-- Content description for privacy content close button -->
     <string name="privacy_content_close_button_content_description">Close</string>
+    <string name="mozac_service_nimbus_use_preview_collection">Use Nimbus Preview Collection (requires restart)</string>
 
 </resources>

--- a/app/src/main/res/xml/secret_settings_preferences.xml
+++ b/app/src/main/res/xml/secret_settings_preferences.xml
@@ -15,4 +15,9 @@
         android:title="@string/preferences_debug_settings_allow_third_party_root_certs"
         android:summary="@string/preferences_debug_settings_allow_third_party_root_certs_summary"
         app:iconSpaceReserved="false" />
+    <SwitchPreference
+        android:defaultValue="false"
+        android:key="@string/pref_key_nimbus_use_preview"
+        android:title="@string/mozac_service_nimbus_use_preview_collection"
+        app:iconSpaceReserved="false" />
 </PreferenceScreen>


### PR DESCRIPTION
This adds a toggle/switch to the debug settings menu that causes Nimbus to use the "preview" collection rather than the "main" collection when it initializes.  Since it is only applied during init, it does require a restart in order to take effect.