### PR TITLE
No issue: Apply workaround for run-ui in contributor workflow

### DIFF
--- a/.github/workflows/build-contributor-pr.yml
+++ b/.github/workflows/build-contributor-pr.yml
@@ -123,6 +123,7 @@ jobs:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}
           arch: x86_64
+          emulator-build: 6110076
           profile: pixel_3a
           script:
             "./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=\


### PR DESCRIPTION
Due to https://issuetracker.google.com/issues/191799887 the newest Android emulators are not working on `macOS-latest` (10.5) VMs in Github Actions. There is a workaround of using an old emulator. Let's see if this works, otherwise I'll disable this particular job but not the workflow.