### PR TITLE
possibly fix if statement in sync-strings

### DIFF
--- a/.github/workflows/sync-strings.yml
+++ b/.github/workflows/sync-strings.yml
@@ -18,7 +18,7 @@ jobs:
         uses: mozilla-mobile/fenix-beta-version@2.0.0
       - name: "Skip non-beta versions"
         uses: andymckay/cancel-action@0.2
-        if: steps.fenix-beta-version.outputs.fenix-beta-version == ""
+        if: ${{ steps.fenix-beta-version.outputs.fenix-beta-version == '' }}
       - name: "Checkout Master Branch"
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions?query=quote

https://github.com/mozilla-mobile/fenix/actions/runs/966447381/workflow : 

> GitHub Actions / Sync Strings
> 
> Invalid workflow file
> 
> The workflow is not valid. .github/workflows/sync-strings.yml (Line: 21, Col: 13): Unexpected symbol: '""'. Located at position 56 within expression: steps.fenix-beta-version.outputs.fenix-beta-version == ""