### PR TITLE
For #20195 - Adds tabsTray allowScreenshotsInPrivateMode check

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabstray/SecureTabsTrayBinding.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/SecureTabsTrayBinding.kt
@@ -33,7 +33,8 @@ class SecureTabsTrayBinding(
                 )
             }
             .collect { state ->
-                if (state.selectedPage == Page.PrivateTabs) {
+                if (state.selectedPage == Page.PrivateTabs &&
+                    !settings.allowScreenshotsInPrivateMode) {
                     fragment.secure()
                 } else if (!settings.lastKnownMode.isPrivate) {
                     fragment.removeSecure()

--- a/app/src/test/java/org/mozilla/fenix/tabstray/SecureTabsTrayBindingTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/SecureTabsTrayBindingTest.kt
@@ -57,6 +57,23 @@ class SecureTabsTrayBindingTest {
     }
 
     @Test
+    fun `WHEN tab selected page switches to private  and allowScreenshotsInPrivateMode true THEN set fragment to un-secure`() {
+        val tabsTrayStore = TabsTrayStore(TabsTrayState())
+        val secureTabsTrayBinding = SecureTabsTrayBinding(
+            store = tabsTrayStore,
+            settings = settings,
+            fragment = fragment
+        )
+        every { settings.allowScreenshotsInPrivateMode } returns true
+
+        secureTabsTrayBinding.start()
+        tabsTrayStore.dispatch(TabsTrayAction.PageSelected(Page.positionToPage(Page.PrivateTabs.ordinal)))
+        tabsTrayStore.waitUntilIdle()
+
+        verify { fragment.removeSecure() }
+    }
+
+    @Test
     fun `GIVEN not in private mode WHEN tab selected page switches to normal tabs from private THEN set fragment to un-secure`() {
         every { settings.lastKnownMode.isPrivate } returns false
         val tabsTrayStore = TabsTrayStore(TabsTrayState())


### PR DESCRIPTION
For https://github.com/mozilla-mobile/fenix/issues/20195
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests.
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

Before fix:


https://user-images.githubusercontent.com/60002907/123818526-bb917980-d901-11eb-8ecb-e8ac3d5eb219.mp4


After fix:

https://user-images.githubusercontent.com/60002907/123818151-69e8ef00-d901-11eb-856d-9b49666ff9a5.mp4

