### PR TITLE
For #17855 - Stops SecureWindowFeature from removing FLAG_SECURE

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -420,7 +420,8 @@ abstract class BaseBrowserFragment : Fragment(), UserInteractionHandler, Activit
                 window = requireActivity().window,
                 store = store,
                 customTabId = customTabSessionId,
-                isSecure = { !allowScreenshotsInPrivateMode && it.content.private }
+                isSecure = { !allowScreenshotsInPrivateMode && it.content.private },
+                clearFlagOnStop = false
             ),
             owner = this,
             view = view


### PR DESCRIPTION
⚠️ **Needs:** https://github.com/mozilla-mobile/android-components/pull/10552

For https://github.com/mozilla-mobile/fenix/issues/17855
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes no tests as it is only a minor change.
- [x] **Screenshots**: This PR doesn't include footage because that's the whole point of this PR. 
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture


