### PR TITLE
Don't send notification for android-test-mozillaonline tasks

### DIFF
--- a/taskcluster/ci/signing/kind.yml
+++ b/taskcluster/ci/signing/kind.yml
@@ -55,7 +55,7 @@ job-template:
         tier: 1
     notify:
         by-build-type:
-            .*mozillaonline:
+            .*(beta|release)-mozillaonline:
                 by-level:
                     '3':
                         email:


### PR DESCRIPTION
These are just adding noise for the Mozilla Online folks.