### PR TITLE
Closes #20123: PlacesException when recording history metadata

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -42,5 +42,5 @@ object FeatureFlags {
     /**
      * Enables recording of history metadata.
      */
-    const val historyMetadataFeature = false
+    val historyMetadataFeature = Config.channel.isDebug
 }


### PR DESCRIPTION
Making sure we don't store metadata records that have itself as a referrer.