### PR TITLE
For #20250 - Adds FLAG_SECURE to TabsTray dialog

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabstray/SecureTabsTrayBinding.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/SecureTabsTrayBinding.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.fenix.tabstray
 
+import android.view.WindowManager
 import androidx.fragment.app.Fragment
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -22,7 +23,8 @@ import org.mozilla.fenix.utils.Settings
 class SecureTabsTrayBinding(
     store: TabsTrayStore,
     private val settings: Settings,
-    private val fragment: Fragment
+    private val fragment: Fragment,
+    private val dialog: TabsTrayDialog
 ) : AbstractBinding<TabsTrayState>(store) {
 
     override suspend fun onState(flow: Flow<TabsTrayState>) {
@@ -36,8 +38,10 @@ class SecureTabsTrayBinding(
                 if (state.selectedPage == Page.PrivateTabs &&
                     !settings.allowScreenshotsInPrivateMode) {
                     fragment.secure()
+                    dialog.window?.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
                 } else if (!settings.lastKnownMode.isPrivate) {
                     fragment.removeSecure()
+                    dialog.window?.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
                 }
             }
     }

--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
@@ -278,7 +278,8 @@ class TabsTrayFragment : AppCompatDialogFragment() {
             feature = SecureTabsTrayBinding(
                 store = tabsTrayStore,
                 settings = requireComponents.settings,
-                fragment = this
+                fragment = this,
+                dialog = dialog as TabsTrayDialog
             ),
             owner = this,
             view = view

--- a/app/src/test/java/org/mozilla/fenix/tabstray/SecureTabsTrayBindingTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/SecureTabsTrayBindingTest.kt
@@ -4,6 +4,8 @@
 
 package org.mozilla.fenix.tabstray
 
+import android.view.Window
+import android.view.WindowManager
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.fragment.app.Fragment
 import io.mockk.Runs
@@ -31,6 +33,8 @@ class SecureTabsTrayBindingTest {
 
     private val settings: Settings = mockk(relaxed = true)
     private val fragment: Fragment = mockk(relaxed = true)
+    private val dialog: TabsTrayDialog = mockk(relaxed = true)
+    private val window: Window = mockk(relaxed = true)
 
     @Before
     fun setup() {
@@ -38,6 +42,9 @@ class SecureTabsTrayBindingTest {
         every { AppCompatResources.getDrawable(any(), any()) } returns mockk(relaxed = true)
         every { fragment.secure() } just Runs
         every { fragment.removeSecure() } just Runs
+        every { dialog.window } returns window
+        every { window.addFlags(any()) } just Runs
+        every { window.clearFlags(any()) } just Runs
     }
 
     @Test
@@ -46,7 +53,8 @@ class SecureTabsTrayBindingTest {
         val secureTabsTrayBinding = SecureTabsTrayBinding(
             store = tabsTrayStore,
             settings = settings,
-            fragment = fragment
+            fragment = fragment,
+            dialog = dialog
         )
 
         secureTabsTrayBinding.start()
@@ -54,6 +62,7 @@ class SecureTabsTrayBindingTest {
         tabsTrayStore.waitUntilIdle()
 
         verify { fragment.secure() }
+        verify { window.addFlags(WindowManager.LayoutParams.FLAG_SECURE) }
     }
 
     @Test
@@ -62,7 +71,8 @@ class SecureTabsTrayBindingTest {
         val secureTabsTrayBinding = SecureTabsTrayBinding(
             store = tabsTrayStore,
             settings = settings,
-            fragment = fragment
+            fragment = fragment,
+            dialog = dialog
         )
         every { settings.allowScreenshotsInPrivateMode } returns true
 
@@ -71,6 +81,7 @@ class SecureTabsTrayBindingTest {
         tabsTrayStore.waitUntilIdle()
 
         verify { fragment.removeSecure() }
+        verify { window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE) }
     }
 
     @Test
@@ -80,7 +91,8 @@ class SecureTabsTrayBindingTest {
         val secureTabsTrayBinding = SecureTabsTrayBinding(
             store = tabsTrayStore,
             settings = settings,
-            fragment = fragment
+            fragment = fragment,
+            dialog = dialog
         )
 
         secureTabsTrayBinding.start()
@@ -88,6 +100,7 @@ class SecureTabsTrayBindingTest {
         tabsTrayStore.waitUntilIdle()
 
         verify { fragment.removeSecure() }
+        verify { window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE) }
     }
 
     @Test
@@ -97,7 +110,8 @@ class SecureTabsTrayBindingTest {
         val secureTabsTrayBinding = SecureTabsTrayBinding(
             store = tabsTrayStore,
             settings = settings,
-            fragment = fragment
+            fragment = fragment,
+            dialog = dialog
         )
 
         secureTabsTrayBinding.start()
@@ -105,5 +119,6 @@ class SecureTabsTrayBindingTest {
         tabsTrayStore.waitUntilIdle()
 
         verify(exactly = 0) { fragment.removeSecure() }
+        verify(exactly = 0) { window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE) }
     }
 }


### PR DESCRIPTION
For https://github.com/mozilla-mobile/fenix/issues/20250
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests.
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made.
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

🤷‍♂️ : 


https://user-images.githubusercontent.com/60002907/124552287-00ef0300-de3c-11eb-863a-de7d30902065.mp4

