### PR TITLE
Closes #20276: Fall-back to URL parsing for tabs with parents to obtain search terms

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/historymetadata/HistoryMetadataMiddleware.kt
+++ b/app/src/main/java/org/mozilla/fenix/historymetadata/HistoryMetadataMiddleware.kt
@@ -116,7 +116,9 @@ class HistoryMetadataMiddleware(
         // Obtain search terms and referrer url either from tab parent, or from the history stack.
         val (searchTerm, referrerUrl) = when {
             tabParent != null -> {
-                tabParent.content.searchTerms.takeUnless { it.isEmpty() } to tabParent.content.url
+                val searchTerms = tabParent.content.searchTerms.takeUnless { it.isEmpty() }
+                    ?: context.state.search.parseSearchTerms(tabParent.content.url)
+                searchTerms to tabParent.content.url
             }
             previousUrlIndex >= 0 -> {
                 val previousUrl = tab.content.history.items[previousUrlIndex].uri


### PR DESCRIPTION


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
