### PR TITLE
For #20257 - Sets min no. of grid columns to 2 in TabsTray

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabstray/ext/Context.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/ext/Context.kt
@@ -15,5 +15,5 @@ internal val Context.numberOfGridColumns: Int
     get() {
         val displayMetrics = resources.displayMetrics
         val screenWidthDp = displayMetrics.widthPixels / displayMetrics.density
-        return (screenWidthDp / MIN_COLUMN_WIDTH_DP).toInt()
+        return (screenWidthDp / MIN_COLUMN_WIDTH_DP).toInt().coerceAtLeast(2)
     }

--- a/app/src/test/java/org/mozilla/fenix/tabstray/browser/DefaultBrowserTrayInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/browser/DefaultBrowserTrayInteractorTest.kt
@@ -5,10 +5,13 @@
 package org.mozilla.fenix.tabstray.browser
 
 import android.content.Context
+import android.content.res.Resources
+import android.util.DisplayMetrics
 import androidx.recyclerview.widget.GridLayoutManager
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import io.mockk.spyk
 import io.mockk.unmockkStatic
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -78,5 +81,21 @@ class DefaultBrowserTrayInteractorTest {
 
         // Should NOT be 4.
         assertEquals(1, (result as GridLayoutManager).spanCount)
+    }
+
+    @Test
+    fun `WHEN screen density is very low THEN numberOfGridColumns will still be a minimum of 2`() {
+        val context = mockk<Context>()
+        val resources = mockk<Resources>()
+        val displayMetrics = spyk<DisplayMetrics> {
+            widthPixels = 1
+            density = 1f
+        }
+        every { context.resources } returns resources
+        every { resources.displayMetrics } returns displayMetrics
+
+        val result = context.numberOfGridColumns
+
+        assertEquals(2, result)
     }
 }


### PR DESCRIPTION
For https://github.com/mozilla-mobile/fenix/issues/20257
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes no tests as it's only a minor change.
- [x] **Screenshots**: This PR includes screenshots.
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

![image](https://user-images.githubusercontent.com/60002907/124778529-b3f95280-df49-11eb-976e-e755ceb8832b.png)

