### PR TITLE
For #19886 improve quick setting dialogs navigation

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/quicksettings/ConnectionDetailsController.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/quicksettings/ConnectionDetailsController.kt
@@ -9,10 +9,9 @@ import androidx.fragment.app.Fragment
 import androidx.navigation.NavController
 import mozilla.components.browser.state.state.SessionState
 import mozilla.components.concept.engine.permission.SitePermissions
-import org.mozilla.fenix.R
 import org.mozilla.fenix.browser.BrowserFragmentDirections
 import org.mozilla.fenix.ext.components
-import org.mozilla.fenix.ext.nav
+import org.mozilla.fenix.ext.navigateBlockingForAsyncNavGraph
 import org.mozilla.fenix.ext.runIfFragmentIsAttached
 
 /**
@@ -36,7 +35,7 @@ interface ConnectionDetailsController {
 class DefaultConnectionDetailsController(
     private val context: Context,
     private val fragment: Fragment,
-    private val navController: NavController,
+    private val navController: () -> NavController,
     internal var sitePermissions: SitePermissions?,
     private val gravity: Int,
     private val getCurrentTab: () -> SessionState?,
@@ -46,7 +45,7 @@ class DefaultConnectionDetailsController(
         getCurrentTab()?.let { tab ->
             context.components.useCases.trackingProtectionUseCases.containsException(tab.id) { contains ->
                 fragment.runIfFragmentIsAttached {
-                    dismiss()
+                    navController().popBackStack()
                     val isTrackingProtectionEnabled = tab.trackingProtection.enabled && !contains
                     val directions =
                         BrowserFragmentDirections.actionGlobalQuickSettingsSheetDialogFragment(
@@ -60,7 +59,7 @@ class DefaultConnectionDetailsController(
                             permissionHighlights = tab.content.permissionHighlights,
                             isTrackingProtectionEnabled = isTrackingProtectionEnabled
                         )
-                    navController.nav(R.id.quickSettingsSheetDialogFragment, directions)
+                    navController().navigateBlockingForAsyncNavGraph(directions)
                 }
             }
         }

--- a/app/src/main/java/org/mozilla/fenix/settings/quicksettings/ConnectionPanelDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/quicksettings/ConnectionPanelDialogFragment.kt
@@ -37,7 +37,7 @@ class ConnectionPanelDialogFragment : FenixDialogFragment() {
         val controller = DefaultConnectionDetailsController(
             context = requireContext(),
             fragment = this,
-            navController = findNavController(),
+            navController = { findNavController() },
             sitePermissions = args.sitePermissions,
             gravity = args.gravity,
             getCurrentTab = ::getCurrentTab,

--- a/app/src/main/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsController.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsController.kt
@@ -16,12 +16,11 @@ import mozilla.components.concept.engine.permission.SitePermissions
 import mozilla.components.feature.session.SessionUseCases.ReloadUrlUseCase
 import mozilla.components.feature.tabs.TabsUseCases.AddNewTabUseCase
 import mozilla.components.support.base.feature.OnNeedToRequestPermissions
-import org.mozilla.fenix.R
+import org.mozilla.fenix.NavGraphDirections
 import org.mozilla.fenix.components.PermissionStorage
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.metrics
-import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.ext.navigateBlockingForAsyncNavGraph
 import org.mozilla.fenix.settings.PhoneFeature
 import org.mozilla.fenix.settings.quicksettings.ext.shouldBeEnabled
@@ -102,7 +101,7 @@ class DefaultQuickSettingsController(
     private val quickSettingsStore: QuickSettingsFragmentStore,
     private val browserStore: BrowserStore,
     private val ioScope: CoroutineScope,
-    private val navController: NavController,
+    private val navController: () -> NavController,
     @VisibleForTesting
     internal val sessionId: String,
     @VisibleForTesting
@@ -199,21 +198,21 @@ class DefaultQuickSettingsController(
     }
 
     override fun handleBlockedItemsClicked() {
-        dismiss.invoke()
+        navController().popBackStack()
 
         val state = quickSettingsStore.state.trackingProtectionState
-        val directions = QuickSettingsSheetDialogFragmentDirections
+        val directions = NavGraphDirections
             .actionGlobalTrackingProtectionPanelDialogFragment(
                 sessionId = sessionId,
                 url = state.url,
                 trackingProtectionEnabled = state.isTrackingProtectionEnabled,
                 gravity = context.components.settings.toolbarPosition.androidGravity
             )
-        navController.nav(R.id.quickSettingsSheetDialogFragment, directions)
+        navController().navigateBlockingForAsyncNavGraph(directions)
     }
 
     override fun handleConnectionDetailsClicked() {
-        dismiss.invoke()
+        navController().popBackStack()
 
         val state = quickSettingsStore.state.webInfoState
         val directions = ConnectionPanelDialogFragmentDirections
@@ -226,7 +225,7 @@ class DefaultQuickSettingsController(
                 gravity = context.components.settings.toolbarPosition.androidGravity,
                 sitePermissions = sitePermissions
             )
-        navController.nav(R.id.quickSettingsSheetDialogFragment, directions)
+        navController().navigateBlockingForAsyncNavGraph(directions)
     }
 
     /**
@@ -271,6 +270,6 @@ class DefaultQuickSettingsController(
     private fun navigateToManagePhoneFeature(phoneFeature: PhoneFeature) {
         val directions = QuickSettingsSheetDialogFragmentDirections
             .actionGlobalSitePermissionsManagePhoneFeature(phoneFeature)
-        navController.navigateBlockingForAsyncNavGraph(directions)
+        navController().navigateBlockingForAsyncNavGraph(directions)
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsSheetDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsSheetDialogFragment.kt
@@ -75,7 +75,7 @@ class QuickSettingsSheetDialogFragment : FenixDialogFragment() {
             quickSettingsStore = quickSettingsStore,
             browserStore = components.core.store,
             ioScope = viewLifecycleOwner.lifecycleScope + Dispatchers.IO,
-            navController = findNavController(),
+            navController = { findNavController() },
             sessionId = args.sessionId,
             sitePermissions = args.sitePermissions,
             settings = components.settings,

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -208,9 +208,6 @@
         <action
             android:id="@+id/action_browserFragment_to_quickSettingsSheetDialogFragment"
             app:destination="@id/quickSettingsSheetDialogFragment" />
-        <action
-            android:id="@+id/action_browserFragment_to_trackingProtectionPanelDialogFragment"
-            app:destination="@id/trackingProtectionPanelDialogFragment" />
     </fragment>
 
     <fragment

--- a/app/src/test/java/org/mozilla/fenix/settings/quicksettings/DefaultConnectionDetailsControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/quicksettings/DefaultConnectionDetailsControllerTest.kt
@@ -7,6 +7,7 @@ package org.mozilla.fenix.settings.quicksettings
 import android.content.Context
 import androidx.fragment.app.Fragment
 import androidx.navigation.NavController
+import androidx.navigation.NavDirections
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
@@ -23,10 +24,8 @@ import mozilla.components.support.test.robolectric.testContext
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mozilla.fenix.R
-import org.mozilla.fenix.browser.BrowserFragmentDirections
 import org.mozilla.fenix.ext.components
-import org.mozilla.fenix.ext.nav
+import org.mozilla.fenix.ext.navigateBlockingForAsyncNavGraph
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
 @ExperimentalCoroutinesApi
@@ -62,7 +61,7 @@ class DefaultConnectionDetailsControllerTest {
         controller = DefaultConnectionDetailsController(
             fragment = fragment,
             context = context,
-            navController = navController,
+            navController = { navController },
             sitePermissions = sitePermissions,
             gravity = gravity,
             getCurrentTab = { tab },
@@ -82,25 +81,13 @@ class DefaultConnectionDetailsControllerTest {
     }
 
     @Test
-    fun `WHEN handleBackPressed is called THEN should call dismiss and navigate`() {
+    fun `WHEN handleBackPressed is called THEN should call popBackStack and navigate`() {
         controller.handleBackPressed()
 
         verify {
-            dismiss.invoke()
+            navController.popBackStack()
 
-            navController.nav(
-                R.id.quickSettingsSheetDialogFragment,
-                BrowserFragmentDirections.actionGlobalQuickSettingsSheetDialogFragment(
-                    sessionId = tab.id,
-                    url = tab.content.url,
-                    title = tab.content.title,
-                    isSecured = tab.content.securityInfo.secure,
-                    sitePermissions = sitePermissions,
-                    certificateName = tab.content.securityInfo.issuer,
-                    permissionHighlights = tab.content.permissionHighlights,
-                    isTrackingProtectionEnabled = true
-                )
-            )
+            navController.navigateBlockingForAsyncNavGraph(any<NavDirections>())
         }
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/settings/quicksettings/DefaultQuickSettingsControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/quicksettings/DefaultQuickSettingsControllerTest.kt
@@ -35,14 +35,13 @@ import org.junit.Assert.assertSame
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mozilla.fenix.R
 import org.mozilla.fenix.components.PermissionStorage
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.components.metrics.MetricController
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.directionsEq
 import org.mozilla.fenix.ext.metrics
-import org.mozilla.fenix.ext.nav
+import org.mozilla.fenix.ext.navigateBlockingForAsyncNavGraph
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.settings.PhoneFeature
 import org.mozilla.fenix.settings.quicksettings.ext.shouldBeEnabled
@@ -105,7 +104,7 @@ class DefaultQuickSettingsControllerTest {
                 browserStore = browserStore,
                 sessionId = tab.id,
                 ioScope = coroutinesScope,
-                navController = navController,
+                navController = { navController },
                 sitePermissions = sitePermissions,
                 settings = appSettings,
                 permissionStorage = permissionStorage,
@@ -176,7 +175,7 @@ class DefaultQuickSettingsControllerTest {
             quickSettingsStore = store,
             browserStore = BrowserStore(),
             ioScope = coroutinesScope,
-            navController = navController,
+            navController = { navController },
             sessionId = "123",
             sitePermissions = null,
             settings = appSettings,
@@ -323,7 +322,7 @@ class DefaultQuickSettingsControllerTest {
     }
 
     @Test
-    fun `handleBlockedItemsClicked should call dismiss and navigate to the tracking protection panel dialog`() {
+    fun `handleBlockedItemsClicked should call popBackStack and navigate to the tracking protection panel dialog`() {
         every { context.components.core.store } returns browserStore
         every { context.components.settings } returns appSettings
         every { context.components.settings.toolbarPosition.androidGravity } returns mockk(relaxed = true)
@@ -341,22 +340,14 @@ class DefaultQuickSettingsControllerTest {
         controller.handleBlockedItemsClicked()
 
         verify {
-            dismiss.invoke()
+            navController.popBackStack()
 
-            navController.nav(
-                R.id.quickSettingsSheetDialogFragment,
-                QuickSettingsSheetDialogFragmentDirections.actionGlobalTrackingProtectionPanelDialogFragment(
-                    sessionId = tab.id,
-                    url = state.url,
-                    trackingProtectionEnabled = state.isTrackingProtectionEnabled,
-                    gravity = context.components.settings.toolbarPosition.androidGravity
-                )
-            )
+            navController.navigateBlockingForAsyncNavGraph(any<NavDirections>())
         }
     }
 
     @Test
-    fun `WHEN handleConnectionDetailsClicked THEN call dismiss and navigate to the connection details dialog`() {
+    fun `WHEN handleConnectionDetailsClicked THEN call popBackStack and navigate to the connection details dialog`() {
         every { context.components.core.store } returns browserStore
         every { context.components.settings } returns appSettings
         every { context.components.settings.toolbarPosition.androidGravity } returns mockk(relaxed = true)
@@ -373,19 +364,9 @@ class DefaultQuickSettingsControllerTest {
         controller.handleConnectionDetailsClicked()
 
         verify {
-            dismiss.invoke()
+            navController.popBackStack()
 
-            navController.nav(
-                R.id.quickSettingsSheetDialogFragment,
-                QuickSettingsSheetDialogFragmentDirections.actionGlobalConnectionDetailsDialogFragment(
-                    sessionId = tab.id,
-                    url = state.websiteUrl,
-                    title = state.websiteTitle,
-                    isSecured = true,
-                    sitePermissions = sitePermissions,
-                    gravity = context.components.settings.toolbarPosition.androidGravity
-                )
-            )
+            navController.navigateBlockingForAsyncNavGraph(any<NavDirections>())
         }
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/settings/quicksettings/WebsiteInfoViewTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/quicksettings/WebsiteInfoViewTest.kt
@@ -85,7 +85,7 @@ class WebsiteInfoViewTest {
 
     @Test
     fun `WHEN updating on not detailed mode THEN only connection details listener should be binded`() {
-        val view = WebsiteInfoView(FrameLayout(testContext), icons, interactor, isDetailsMode = false)
+        val view = spyk(WebsiteInfoView(FrameLayout(testContext), icons, interactor, isDetailsMode = false))
 
         view.update(WebsiteInfoState(
             websiteUrl = "https://mozilla.org",


### PR DESCRIPTION
When we navigate from: 

- `Fragment` to `Dialog`  -> The nav lib does the `dismiss` 
- `Dialog` to `Dialog` ->  We have to dismiss manually, but the manual dismiss it's outside of the nav lib causing some issues,  as loosing which is the current destination, for this reason we have to use `navController().popBackStack()` this gives the nav lib knowledge of what it's happening. 

Additionally, I had to change the `navController: NavController` reference by a `navController: () -> NavController` that will give us the most up to date reference.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
