### PR TITLE
Issue #19846: Make sure default browser notification only happens once

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/intent/DefaultBrowserIntentProcessor.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/intent/DefaultBrowserIntentProcessor.kt
@@ -24,7 +24,6 @@ class DefaultBrowserIntentProcessor(
     override fun process(intent: Intent, navController: NavController, out: Intent): Boolean {
         return if (isDefaultBrowserNotificationIntent(intent)) {
             activity.openSetDefaultBrowserOption()
-            activity.settings().defaultBrowserNotificationDisplayed = true
 
             true
         } else {

--- a/app/src/main/java/org/mozilla/fenix/onboarding/DefaultBrowserNotificationWorker.kt
+++ b/app/src/main/java/org/mozilla/fenix/onboarding/DefaultBrowserNotificationWorker.kt
@@ -35,6 +35,10 @@ class DefaultBrowserNotificationWorker(
         ensureChannelExists()
         NotificationManagerCompat.from(applicationContext)
             .notify(NOTIFICATION_TAG, NOTIFICATION_ID, buildNotification())
+
+        // default browser notification should only happen once
+        applicationContext.settings().defaultBrowserNotificationDisplayed = true
+
         return Result.success()
     }
 


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
