### PR TITLE
Add preference for enabling/disabling Android Autofill from within the app.

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/DeepLinkTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/DeepLinkTest.kt
@@ -108,7 +108,7 @@ class DeepLinkTest {
     fun openSettingsLogins() {
         robot.openSettingsLogins {
             verifyDefaultView()
-            verifyDefaultValueAutofillLogins()
+            verifyDefaultValueAutofillLogins(InstrumentationRegistry.getInstrumentation().targetContext)
         }
     }
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsPrivacyTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsPrivacyTest.kt
@@ -176,7 +176,7 @@ class SettingsPrivacyTest {
             TestHelper.scrollToElementByText("Logins and passwords")
         }.openLoginsAndPasswordSubMenu {
             verifyDefaultView()
-            verifyDefaultValueAutofillLogins()
+            verifyDefaultValueAutofillLogins(InstrumentationRegistry.getInstrumentation().targetContext)
             verifyDefaultValueExceptions()
         }.openSavedLogins {
             verifySecurityPromptForLogins()

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuLoginsAndPasswordRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuLoginsAndPasswordRobot.kt
@@ -6,6 +6,7 @@
 
 package org.mozilla.fenix.ui.robots
 
+import android.content.Context
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.assertion.ViewAssertions.matches
@@ -16,6 +17,7 @@ import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.Until
 import org.hamcrest.CoreMatchers
+import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.helpers.click
 import org.mozilla.fenix.helpers.ext.waitNotNull
@@ -40,7 +42,7 @@ class SettingsSubMenuLoginsAndPasswordRobot {
 
     fun verifyDefaultValueExceptions() = assertDefaultValueExceptions()
 
-    fun verifyDefaultValueAutofillLogins() = assertDefaultValueAutofillLogins()
+    fun verifyDefaultValueAutofillLogins(context: Context) = assertDefaultValueAutofillLogins(context)
 
     class Transition {
         val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
@@ -97,7 +99,14 @@ private fun goBackButton() =
 private fun assertDefaultView() = onView(ViewMatchers.withText("Sync logins across devices"))
     .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
-private fun assertDefaultValueAutofillLogins() = onView(ViewMatchers.withText("Autofill websites"))
+private fun assertDefaultValueAutofillLogins(context: Context) = onView(
+    ViewMatchers.withText(
+        context.getString(
+            R.string.preferences_passwords_autofill2,
+            context.getString(R.string.app_name)
+        )
+    )
+)
     .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
 private fun assertDefaultValueExceptions() = onView(ViewMatchers.withText("Exceptions"))

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuLoginsAndPasswordRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuLoginsAndPasswordRobot.kt
@@ -97,7 +97,7 @@ private fun goBackButton() =
 private fun assertDefaultView() = onView(ViewMatchers.withText("Sync logins across devices"))
     .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
-private fun assertDefaultValueAutofillLogins() = onView(ViewMatchers.withText("Autofill"))
+private fun assertDefaultValueAutofillLogins() = onView(ViewMatchers.withText("Autofill websites"))
     .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
 private fun assertDefaultValueExceptions() = onView(ViewMatchers.withText("Exceptions"))

--- a/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -58,7 +58,7 @@ object FeatureFlags {
      * Identifies and separates the tabs list with a secondary section containing least used tabs.
      */
     val inactiveTabs = Config.channel.isNightlyOrDebug
-     
+
     /**
      * Enables support for Android Autofill.
      *

--- a/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -58,4 +58,12 @@ object FeatureFlags {
      * Identifies and separates the tabs list with a secondary section containing least used tabs.
      */
     val inactiveTabs = Config.channel.isNightlyOrDebug
+     
+    /**
+     * Enables support for Android Autofill.
+     *
+     * In addition to toggling this flag, matching entries in the Android Manifest of the build
+     * type need to present.
+     */
+    val androidAutofill = Config.channel.isNightlyOrDebug
 }

--- a/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/SavedLoginsAuthFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/SavedLoginsAuthFragment.kt
@@ -22,8 +22,10 @@ import androidx.preference.SwitchPreference
 import kotlinx.coroutines.Dispatchers.Main
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import mozilla.components.feature.autofill.preference.AutofillPreference
 import mozilla.components.service.fxa.SyncEngine
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
+import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.components
@@ -39,7 +41,6 @@ import org.mozilla.fenix.settings.requirePreference
 
 @Suppress("TooManyFunctions")
 class SavedLoginsAuthFragment : PreferenceFragmentCompat() {
-
     private val biometricPromptFeature = ViewBoundFeatureWrapper<BiometricPromptFeature>()
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
@@ -99,6 +100,14 @@ class SavedLoginsAuthFragment : PreferenceFragmentCompat() {
             }
         }
 
+        requirePreference<AutofillPreference>(R.string.pref_key_android_autofill).apply {
+            update()
+
+            if (!FeatureFlags.androidAutofill) {
+                isVisible = false
+            }
+        }
+
         requirePreference<Preference>(R.string.pref_key_login_exceptions).apply {
             setOnPreferenceClickListener {
                 navigateToLoginExceptionFragment()
@@ -107,6 +116,14 @@ class SavedLoginsAuthFragment : PreferenceFragmentCompat() {
         }
 
         requirePreference<SwitchPreference>(R.string.pref_key_autofill_logins).apply {
+            title = context.getString(
+                R.string.preferences_passwords_autofill2,
+                getString(R.string.app_name)
+            )
+            summary = context.getString(
+                R.string.preferences_passwords_autofill_description,
+                getString(R.string.app_name)
+            )
             isChecked = context.settings().shouldAutofillLogins
             onPreferenceChangeListener = object : SharedPreferenceUpdater() {
                 override fun onPreferenceChange(preference: Preference, newValue: Any?): Boolean {

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -169,6 +169,7 @@
     <string name="pref_key_save_logins_settings" translatable="false">pref_key_save_logins_settings</string>
     <string name="pref_key_save_logins" translatable="false">pref_key_save_logins</string>
     <string name="pref_key_autofill_logins" translatable="false">pref_key_autofill_logins</string>
+    <string name="pref_key_android_autofill" translatable="false">pref_key_android_autofill</string>
     <string name="pref_key_never_save_logins" translatable="false">pref_key_never_save_logins</string>
     <string name="pref_key_saved_logins" translatable="false">pref_key_saved_logins</string>
     <string name="pref_key_password_sync_logins" translatable="false">pref_key_password_sync_logins</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?><!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <!-- App name for private browsing mode. The first parameter is the name of the app defined in app_name (for example: Fenix)-->
     <string name="app_name_private_5">Private %s</string>
     <!-- App name for private browsing mode. The first parameter is the name of the app defined in app_name (for example: Fenix)-->
@@ -1456,7 +1456,7 @@
     <!-- Preference option for never saving passwords in Fenix -->
     <string name="preferences_passwords_save_logins_never_save">Never save</string>
     <!-- Preference for autofilling saved logins in Fenix -->
-    <string name="preferences_passwords_autofill">Autofill</string>
+    <string name="preferences_passwords_autofill" tools:ignore="UnusedResources">Autofill</string>
     <!-- Preference for autofilling saved logins in Firefox (in web content), %1$s will be replaced with the app name -->
     <string name="preferences_passwords_autofill2">Autofill in %1$s</string>
     <!-- Description for the preference for autofilling saved logins in Firefox (in web content), %1$s will be replaced with the app name -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1457,6 +1457,15 @@
     <string name="preferences_passwords_save_logins_never_save">Never save</string>
     <!-- Preference for autofilling saved logins in Fenix -->
     <string name="preferences_passwords_autofill">Autofill</string>
+    <!-- Preference for autofilling saved logins in Firefox (in web content), %1$s will be replaced with the app name -->
+    <string name="preferences_passwords_autofill2">Autofill in %1$s</string>
+    <!-- Description for the preference for autofilling saved logins in Firefox (in web content), %1$s will be replaced with the app name -->
+    <string name="preferences_passwords_autofill_description">Fill and save usernames and passwords in websites while using %1$s.</string>
+    <!-- Preference for autofilling logins from Fenix in other apps (e.g. autofilling the Twitter app) -->
+    <string name="preferences_android_autofill">Autofill in other apps</string>
+    <!-- Description for the preference for autofilling logins from Fenix in other apps (e.g. autofilling the Twitter app) -->
+    <string name="preferences_android_autofill_description">Fill usernames and passwords in other apps on your device.</string>
+
     <!-- Preference for syncing saved logins in Fenix -->
     <string name="preferences_passwords_sync_logins">Sync logins</string>
     <!-- Preference for syncing saved logins in Fenix, when not signed in-->

--- a/app/src/main/res/xml/logins_preferences.xml
+++ b/app/src/main/res/xml/logins_preferences.xml
@@ -11,7 +11,12 @@
     <SwitchPreference
         android:defaultValue="true"
         android:key="@string/pref_key_autofill_logins"
-        android:title="@string/preferences_passwords_autofill" />
+        android:title="@string/preferences_passwords_autofill2"
+        android:summary="@string/preferences_passwords_autofill_description" />
+    <mozilla.components.feature.autofill.preference.AutofillPreference
+        android:key="@string/pref_key_android_autofill"
+        android:title="@string/preferences_android_autofill"
+        android:summary="@string/preferences_android_autofill_description" />
     <org.mozilla.fenix.settings.SyncPreference
         android:key="@string/pref_key_sync_logins"
         android:title="@string/preferences_passwords_sync_logins" />


### PR DESCRIPTION
This adds a preference to Fenix for enabling/disabling Android Autofill support from within the app. To distinguish the setting from the one for autofilling logins in web content, I changed the string:

![autofill_preference](https://user-images.githubusercontent.com/89638/125961838-80bc4cd8-1dac-482f-85a6-1675bcb96e11.png)
