### PR TITLE
Issue #20402: Disable LastMediaAccessMiddleware temporarily

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -33,7 +33,6 @@ import mozilla.components.feature.customtabs.store.CustomTabsServiceStore
 import mozilla.components.feature.downloads.DownloadMiddleware
 import mozilla.components.feature.logins.exceptions.LoginExceptionStorage
 import mozilla.components.feature.media.MediaSessionFeature
-import mozilla.components.feature.media.middleware.LastMediaAccessMiddleware
 import mozilla.components.feature.media.middleware.RecordingDevicesMiddleware
 import mozilla.components.feature.prompts.PromptMiddleware
 import mozilla.components.feature.pwa.ManifestStorage
@@ -209,8 +208,8 @@ class Core(
                 ),
                 RecordingDevicesMiddleware(context),
                 PromptMiddleware(),
-                AdsTelemetryMiddleware(adsTelemetry),
-                LastMediaAccessMiddleware()
+                AdsTelemetryMiddleware(adsTelemetry)
+//                LastMediaAccessMiddleware() // disabled to avoid a nightly crash in #20402
             )
 
         if (FeatureFlags.historyMetadataFeature) {

--- a/app/src/main/java/org/mozilla/fenix/ext/BrowserState.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/BrowserState.kt
@@ -19,11 +19,12 @@ fun BrowserState.asRecentTabs(): List<TabSessionState> {
     return mutableListOf<TabSessionState>().apply {
         val lastOpenedNormalTab = lastOpenedNormalTab
         lastOpenedNormalTab?.let { add(it) }
-        inProgressMediaTab
-            ?.takeUnless { it == lastOpenedNormalTab }
-            ?.let {
-                add(it)
-            }
+        // disabled to avoid a nightly crash in #20402
+//        inProgressMediaTab
+//            ?.takeUnless { it == lastOpenedNormalTab }
+//            ?.let {
+//                add(it)
+//            }
     }
 }
 

--- a/app/src/test/java/org/mozilla/fenix/ext/BrowserStateTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/ext/BrowserStateTest.kt
@@ -9,6 +9,7 @@ import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.createTab
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Ignore
 import org.junit.Test
 
 class BrowserStateTest {
@@ -61,6 +62,7 @@ class BrowserStateTest {
         assertEquals(lastAccessedNormalTab, result[0])
     }
 
+    @Ignore("Temporarily disabled. See #20402.")
     @Test
     fun `GIVEN the selected tab is a normal tab and another media tab exists WHEN asRecentTabs is called THEN return a list of these tabs`() {
         val selectedTab = createTab(url = "url", id = "3")
@@ -77,6 +79,7 @@ class BrowserStateTest {
         assertEquals(mediaTab, result[1])
     }
 
+    @Ignore("Temporarily disabled. See #20402.")
     @Test
     fun `GIVEN the selected tab is a private tab and another media tab exists WHEN asRecentTabs is called THEN return a list of the last normal tab and the media tab`() {
         val lastAccessedNormalTab = createTab(url = "url2", id = "2", lastAccess = 2)

--- a/app/src/test/java/org/mozilla/fenix/home/RecentTabsListFeatureTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/RecentTabsListFeatureTest.kt
@@ -26,6 +26,7 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.home.HomeFragmentAction.RecentTabsChange
@@ -114,6 +115,7 @@ class RecentTabsListFeatureTest {
         assertEquals(1, homeStore.state.recentTabs.size)
     }
 
+    @Ignore("Temporarily disabled. See #20402.")
     @Test
     fun `GIVEN a valid inProgressMediaTabId and another selected tab exists WHEN the feature starts THEN dispatch both as as a recent tabs list`() {
         val mediaTab = createTab("https://mozilla.com", id = "42", lastMediaAccess = 123)
@@ -191,6 +193,7 @@ class RecentTabsListFeatureTest {
         assertEquals(tab2, homeStore.state.recentTabs[0])
     }
 
+    @Ignore("Temporarily disabled. See #20402.")
     @Test
     fun `WHEN the browser state has an in progress media tab THEN dispatch the new recent tab list`() {
         val initialMediaTab = createTab(url = "https://mozilla.com", id = "1", lastMediaAccess = 123)


### PR DESCRIPTION
The reducer in this middleware assumes the SessionState is always a
TabSessionState which holds the lastMediaAccess. This is true for the
lastAccess long.

The list of MediaSessionActions however can also come from Custom Tabs
which relies on a CustomTabSessionState.

For now, the temporary fix is to disable this feature by removing the
middleware and no longer adding the last accessed media to the
recent tabs list ("Jump back in") to avoid crashing users while we think
of a real fix.

cc: @Mugurell 