### PR TITLE
For #20402 - Re-enable "in progress media tab"

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -33,6 +33,7 @@ import mozilla.components.feature.customtabs.store.CustomTabsServiceStore
 import mozilla.components.feature.downloads.DownloadMiddleware
 import mozilla.components.feature.logins.exceptions.LoginExceptionStorage
 import mozilla.components.feature.media.MediaSessionFeature
+import mozilla.components.feature.media.middleware.LastMediaAccessMiddleware
 import mozilla.components.feature.media.middleware.RecordingDevicesMiddleware
 import mozilla.components.feature.prompts.PromptMiddleware
 import mozilla.components.feature.pwa.ManifestStorage
@@ -208,8 +209,8 @@ class Core(
                 ),
                 RecordingDevicesMiddleware(context),
                 PromptMiddleware(),
-                AdsTelemetryMiddleware(adsTelemetry)
-//                LastMediaAccessMiddleware() // disabled to avoid a nightly crash in #20402
+                AdsTelemetryMiddleware(adsTelemetry),
+                LastMediaAccessMiddleware()
             )
 
         if (FeatureFlags.historyMetadataFeature) {

--- a/app/src/main/java/org/mozilla/fenix/ext/BrowserState.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/BrowserState.kt
@@ -8,6 +8,7 @@ import mozilla.components.browser.state.selector.normalTabs
 import mozilla.components.browser.state.selector.selectedNormalTab
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.TabSessionState
+import mozilla.components.feature.tabs.ext.hasMediaPlayed
 
 /**
  * Get the last opened normal tab and the last tab with in progress media, if available.
@@ -19,12 +20,11 @@ fun BrowserState.asRecentTabs(): List<TabSessionState> {
     return mutableListOf<TabSessionState>().apply {
         val lastOpenedNormalTab = lastOpenedNormalTab
         lastOpenedNormalTab?.let { add(it) }
-        // disabled to avoid a nightly crash in #20402
-//        inProgressMediaTab
-//            ?.takeUnless { it == lastOpenedNormalTab }
-//            ?.let {
-//                add(it)
-//            }
+        inProgressMediaTab
+            ?.takeUnless { it == lastOpenedNormalTab }
+            ?.let {
+                add(it)
+            }
     }
 }
 
@@ -40,5 +40,5 @@ val BrowserState.lastOpenedNormalTab: TabSessionState?
  */
 val BrowserState.inProgressMediaTab: TabSessionState?
     get() = normalTabs
-        .filter { it.lastMediaAccess > 0 }
-        .maxByOrNull { it.lastMediaAccess }
+        .filter { it.hasMediaPlayed() }
+        .maxByOrNull { it.lastMediaAccessState.lastMediaAccess }

--- a/app/src/test/java/org/mozilla/fenix/ext/BrowserStateTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/ext/BrowserStateTest.kt
@@ -6,17 +6,20 @@ package org.mozilla.fenix.ext
 
 import io.mockk.mockk
 import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.state.LastMediaAccessState
 import mozilla.components.browser.state.state.createTab
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
-import org.junit.Ignore
 import org.junit.Test
 
 class BrowserStateTest {
 
     @Test
     fun `GIVEN a tab which had media playing WHEN inProgressMediaTab is called THEN return that tab`() {
-        val inProgressMediaTab = createTab(url = "mediaUrl", id = "2", lastMediaAccess = 123)
+        val inProgressMediaTab = createTab(
+            url = "mediaUrl", id = "2",
+            lastMediaAccessState = LastMediaAccessState("https://mozilla.com", 123)
+        )
         val browserState = BrowserState(
             tabs = listOf(mockk(relaxed = true), inProgressMediaTab, mockk(relaxed = true))
         )
@@ -27,17 +30,17 @@ class BrowserStateTest {
     @Test
     fun `GIVEN no tab which had media playing exists WHEN inProgressMediaTab is called THEN return null`() {
         val browserState = BrowserState(
-            tabs = listOf(mockk(relaxed = true), mockk(relaxed = true), mockk(relaxed = true))
+            tabs = listOf(createTab("tab1"), createTab("tab2"), createTab("tab3"))
         )
 
         assertNull(browserState.inProgressMediaTab)
     }
 
     @Test
-    fun `GIVEN the selected tab is a normal tab and no media tab WHEN asRecentTabs is called THEN return a list of that tab`() {
+    fun `GIVEN the selected tab is a normal tab and no media tab exists WHEN asRecentTabs is called THEN return a list of that tab`() {
         val selectedTab = createTab(url = "url", id = "3")
         val browserState = BrowserState(
-            tabs = listOf(mockk(relaxed = true), selectedTab, mockk(relaxed = true)),
+            tabs = listOf(createTab("tab1"), selectedTab, createTab("tab3")),
             selectedTabId = selectedTab.id
         )
 
@@ -48,11 +51,11 @@ class BrowserStateTest {
     }
 
     @Test
-    fun `GIVEN the selected tab is a private tab and no media tab WHEN asRecentTabs is called THEN return a list of the last accessed normal tab`() {
+    fun `GIVEN the selected tab is a private tab and no media tab exists WHEN asRecentTabs is called THEN return a list of the last accessed normal tab`() {
         val selectedPrivateTab = createTab(url = "url", id = "1", lastAccess = 1, private = true)
         val lastAccessedNormalTab = createTab(url = "url2", id = "2", lastAccess = 2)
         val browserState = BrowserState(
-            tabs = listOf(mockk(relaxed = true), lastAccessedNormalTab, selectedPrivateTab),
+            tabs = listOf(createTab("https://mozilla.org"), lastAccessedNormalTab, selectedPrivateTab),
             selectedTabId = selectedPrivateTab.id
         )
 
@@ -62,11 +65,13 @@ class BrowserStateTest {
         assertEquals(lastAccessedNormalTab, result[0])
     }
 
-    @Ignore("Temporarily disabled. See #20402.")
     @Test
     fun `GIVEN the selected tab is a normal tab and another media tab exists WHEN asRecentTabs is called THEN return a list of these tabs`() {
         val selectedTab = createTab(url = "url", id = "3")
-        val mediaTab = createTab("mediaUrl", id = "23", lastMediaAccess = 123)
+        val mediaTab = createTab(
+            "mediaUrl", id = "23",
+            lastMediaAccessState = LastMediaAccessState("https://mozilla.com", 123)
+        )
         val browserState = BrowserState(
             tabs = listOf(mockk(relaxed = true), selectedTab, mediaTab),
             selectedTabId = selectedTab.id
@@ -79,12 +84,14 @@ class BrowserStateTest {
         assertEquals(mediaTab, result[1])
     }
 
-    @Ignore("Temporarily disabled. See #20402.")
     @Test
     fun `GIVEN the selected tab is a private tab and another media tab exists WHEN asRecentTabs is called THEN return a list of the last normal tab and the media tab`() {
         val lastAccessedNormalTab = createTab(url = "url2", id = "2", lastAccess = 2)
         val selectedPrivateTab = createTab(url = "url", id = "1", lastAccess = 1, private = true)
-        val mediaTab = createTab("mediaUrl", id = "12", lastAccess = 0, lastMediaAccess = 123)
+        val mediaTab = createTab(
+            "mediaUrl", id = "12", lastAccess = 0,
+            lastMediaAccessState = LastMediaAccessState("https://mozilla.com", 123)
+        )
         val browserState = BrowserState(
             tabs = listOf(mockk(relaxed = true), lastAccessedNormalTab, selectedPrivateTab, mediaTab),
             selectedTabId = selectedPrivateTab.id
@@ -101,7 +108,10 @@ class BrowserStateTest {
     fun `GIVEN the selected tab is a private tab and the media tab is the last accessed normal tab WHEN asRecentTabs is called THEN a list of the media tab`() {
         val selectedPrivateTab = createTab(url = "url", id = "1", lastAccess = 1, private = true)
         val normalTab = createTab(url = "url2", id = "2", lastAccess = 2)
-        val mediaTab = createTab("mediaUrl", id = "12", lastAccess = 20, lastMediaAccess = 123)
+        val mediaTab = createTab(
+            "mediaUrl", id = "12", lastAccess = 20,
+            lastMediaAccessState = LastMediaAccessState("https://mozilla.com", 123)
+        )
         val browserState = BrowserState(
             tabs = listOf(mockk(relaxed = true), normalTab, selectedPrivateTab, mediaTab),
             selectedTabId = selectedPrivateTab.id


### PR DESCRIPTION
The crash for when media starts playing in a custom tab is now resolved in AC.



https://user-images.githubusercontent.com/11428869/126511757-4db76666-c10c-4a2b-a077-aff77e9de93e.mp4





### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
