### PR TITLE
No issue: Update Flank to v21.07.1

### DIFF
--- a/automation/taskcluster/androidTest/parse-ui-test.py
+++ b/automation/taskcluster/androidTest/parse-ui-test.py
@@ -55,7 +55,7 @@ def main():
     print("| matrix | result | logs | details \n")
     print("| --- | --- | --- | --- |\n")
     for matrix, matrix_result in matrix_ids.items():
-        print("| {matrixId} | {outcome} | [logs]({webLink}) | {testAxises[0][details]}\n".format(**matrix_result))
+        print("| {matrixId} | {outcome} | [logs]({webLink}) | {axes[0][details]}\n".format(**matrix_result))
 
 
 if __name__ == "__main__":

--- a/taskcluster/docker/ui-tests/Dockerfile
+++ b/taskcluster/docker/ui-tests/Dockerfile
@@ -7,11 +7,13 @@ LABEL maintainer="Richard Pappalardo <rpappalax@gmail.com>"
 #-- Test tools --------------------------------------------------------------------------------------------------------
 #----------------------------------------------------------------------------------------------------------------------
 
+RUN apt-get install -y jq \
+    && apt-get clean
+
 USER worker:worker
 
 ENV GOOGLE_SDK_DOWNLOAD ./gcloud.tar.gz
 ENV GOOGLE_SDK_VERSION 233
-ENV FLANK_VERSION v21.07.1
 
 ENV TEST_TOOLS /builds/worker/test-tools
 ENV PATH ${PATH}:${TEST_TOOLS}:${TEST_TOOLS}/google-cloud-sdk/bin
@@ -25,9 +27,11 @@ RUN curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud
     && ${TEST_TOOLS}/google-cloud-sdk/install.sh --quiet \
     && ${TEST_TOOLS}/google-cloud-sdk/bin/gcloud --quiet components update
 
-RUN URL_FLANK_BIN=$(curl -s "https://api.github.com/repos/Flank/flank/releases" | grep "browser_download_url*" | grep "${FLANK_VERSION}" | sed -r "s/\"//g" | cut -d ":" -f3) \
-    && wget "https:${URL_FLANK_BIN}" -O ${TEST_TOOLS}/flank.jar \
-    && chmod +x ${TEST_TOOLS}/flank.jar
+# Flank v21.07.1
+
+RUN URL_FLANK_BIN="$($CURL --silent 'https://api.github.com/repos/Flank/flank/releases/latest' | jq -r '.assets[] | select(.browser_download_url | test("flank.jar")) .browser_download_url')" \
+    && $CURL --output "${TEST_TOOLS}/flank.jar" "${URL_FLANK_BIN}" \
+    && chmod +x "${TEST_TOOLS}/flank.jar"
 
 
 # run-task expects to run as root

--- a/taskcluster/docker/ui-tests/Dockerfile
+++ b/taskcluster/docker/ui-tests/Dockerfile
@@ -11,7 +11,7 @@ USER worker:worker
 
 ENV GOOGLE_SDK_DOWNLOAD ./gcloud.tar.gz
 ENV GOOGLE_SDK_VERSION 233
-ENV FLANK_VERSION v21.05.0
+ENV FLANK_VERSION v21.07.1
 
 ENV TEST_TOOLS /builds/worker/test-tools
 ENV PATH ${PATH}:${TEST_TOOLS}:${TEST_TOOLS}/google-cloud-sdk/bin


### PR DESCRIPTION
Flank changed some of the JSON in `matrix_ids.json` that I am parsing across projects (A-C upgraded already) in a separate project, which means time to update again. Also Flank adds a second `.sha256` release, so we need a little more finesse in downloading the `jar`. This also updates `parse-ui-test.py`
