### PR TITLE
Issue #16330: Remove remaining usages of Sentry.capture

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/ext/NavController.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/NavController.kt
@@ -8,8 +8,7 @@ import androidx.annotation.IdRes
 import androidx.navigation.NavController
 import androidx.navigation.NavDirections
 import androidx.navigation.NavOptions
-import io.sentry.Sentry
-import org.mozilla.fenix.components.isSentryEnabled
+import mozilla.components.support.base.log.logger.Logger
 
 /**
  * Navigate from the fragment with [id] using the given [directions].
@@ -19,18 +18,12 @@ fun NavController.nav(@IdRes id: Int?, directions: NavDirections, navOptions: Na
     if (id == null || this.currentDestination?.id == id) {
         this.navigate(directions, navOptions)
     } else {
-        recordIdException(this.currentDestination?.id, id)
+        Logger.error("Fragment id ${this.currentDestination?.id} did not match expected $id")
     }
 }
 
 fun NavController.alreadyOnDestination(@IdRes destId: Int?): Boolean {
     return destId?.let { currentDestination?.id == it || popBackStack(it, false) } ?: false
-}
-
-fun recordIdException(actual: Int?, expected: Int?) {
-    if (isSentryEnabled()) {
-        Sentry.capture("Fragment id $actual did not match expected $expected")
-    }
 }
 
 fun NavController.navigateSafe(

--- a/app/src/test/java/org/mozilla/fenix/ext/NavControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/ext/NavControllerTest.kt
@@ -9,17 +9,11 @@ import androidx.navigation.NavDestination
 import androidx.navigation.NavDirections
 import androidx.navigation.NavOptions
 import io.mockk.MockKAnnotations
-import io.mockk.Runs
-import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
-import io.mockk.just
-import io.mockk.mockkStatic
 import io.mockk.verify
-import io.sentry.Sentry
 import org.junit.Before
 import org.junit.Test
-import org.mozilla.fenix.components.isSentryEnabled
 
 class NavControllerTest {
 
@@ -32,12 +26,9 @@ class NavControllerTest {
     @Before
     fun setUp() {
         MockKAnnotations.init(this)
-        mockkStatic("io.sentry.Sentry", "org.mozilla.fenix.components.AnalyticsKt")
 
         every { navController.currentDestination } returns mockDestination
         every { mockDestination.id } returns currentDestId
-        every { isSentryEnabled() } returns true
-        every { Sentry.capture(any<String>()) } just Runs
     }
 
     @Test
@@ -52,22 +43,5 @@ class NavControllerTest {
         navController.nav(currentDestId, navDirections, mockOptions)
         verify { navController.currentDestination }
         verify { navController.navigate(navDirections, mockOptions) }
-    }
-
-    @Test
-    fun `Test error response for id exception in-block`() {
-        navController.nav(7, navDirections)
-        verify { navController.currentDestination }
-        verify { Sentry.capture("Fragment id 4 did not match expected 7") }
-        confirmVerified(navController)
-    }
-
-    @Test
-    fun `Test record id exception fun`() {
-        val actual = 7
-        val expected = 4
-
-        recordIdException(actual, expected)
-        verify { Sentry.capture("Fragment id 7 did not match expected 4") }
     }
 }


### PR DESCRIPTION
There were two remaining call-site of `Sentry.capture`, which didn't work and was never set up.

We want to know how often we generate a new encryption key so I migrated that to our `submitCaughtException`. 

The other call-site, is not worth migrating. An error there would result in a navigation simply not working which should be obvious during application usage i.e, it wouldn't be intermittent or just affect some users, we would see this use case generally not working which we don't to log to Sentry but catch during testing. Decided to log instead. It would also be messy and a bigger refactoring to get access to our crashreporter there. :)