### PR TITLE
Add telemetry for Android Autofill feature.

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -5572,6 +5572,155 @@ awesomebar:
       - android-probes@mozilla.com
     expires: "2021-08-01"
 
+android_autofill:
+  supported:
+    type: boolean
+    description: |
+      Whether or not Android Autofill is supported by the device and is
+      supported for this user.
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/10301
+    data_reviews:
+      - TBD
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - android-probes@mozilla.com
+      - skaspari@mozilla.com
+    expires: "2022-01-31"
+  enabled:
+    type: boolean
+    description: |
+      Whether or not Firefox is the Android Autofill provider for this user.
+      provider.
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/10301
+    data_reviews:
+      - TBD
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+      - skaspari@mozilla.com
+    expires: "2022-01-31"
+  request_matching_logins:
+    type: event
+    description: |
+      The app received an Android Autofill request from the system and was
+      able to find matching logins for the request
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/10301
+    data_reviews:
+      - TBD
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+      - skaspari@mozilla.com
+    expires: "2022-01-31"
+  request_no_matching_logins:
+    type: event
+    description: |
+      The app received an Android Autofill request from the system and was
+      not able to find matching logins for the request
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/10301
+    data_reviews:
+      - TBD
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+      - skaspari@mozilla.com
+    expires: "2022-01-31"
+  search_displayed:
+    type: event
+    description: |
+      The user has selected the search option to manually search a
+      matching login
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/10301
+    data_reviews:
+      - TBD
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+      - skaspari@mozilla.com
+    expires: "2022-01-31"
+  search_item_selected:
+    type: event
+    description: |
+      The user has selected a search result for autofilling.
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/10301
+    data_reviews:
+      - TBD
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+      - skaspari@mozilla.com
+    expires: "2022-01-31"
+  unlock_cancelled:
+    type: event
+    description: |
+      The user needed to unlock the app in order to autofill
+      logins, but the process was cancelled.
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/10301
+    data_reviews:
+      - TBD
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+      - skaspari@mozilla.com
+    expires: "2022-01-31"
+  unlock_successful:
+    type: event
+    description: |
+      The user successfully unlock the app in order to autofill logins
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/10301
+    data_reviews:
+      - TBD
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+      - skaspari@mozilla.com
+    expires: "2022-01-31"
+  confirm_cancelled:
+    type: event
+    description: |
+      The user needed to confirm autofilling an unauthenticated
+      application and decided to cancel
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/10301
+    data_reviews:
+      - TBD
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+      - skaspari@mozilla.com
+    expires: "2022-01-31"
+  confirm_successful:
+    type: event
+    description: |
+      The user confirmed autofilling an unauthenticated application
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/10301
+    data_reviews:
+      - TBD
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+      - skaspari@mozilla.com
+    expires: "2022-01-31"
+
 home_menu:
   settings_item_clicked:
     type: event

--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -65,10 +65,12 @@ import org.mozilla.fenix.telemetry.TelemetryLifecycleObserver
 import org.mozilla.fenix.utils.BrowsersCache
 import java.util.concurrent.TimeUnit
 import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.feature.autofill.AutofillUseCases
 import mozilla.components.feature.search.ext.buildSearchUrl
 import mozilla.components.feature.search.ext.waitForSelectedOrDefaultSearchEngine
 import mozilla.components.service.fxa.manager.SyncEnginesStorage
 import org.mozilla.fenix.GleanMetrics.Addons
+import org.mozilla.fenix.GleanMetrics.AndroidAutofill
 import org.mozilla.fenix.GleanMetrics.Preferences
 import org.mozilla.fenix.GleanMetrics.SearchDefaultEngine
 import org.mozilla.fenix.components.metrics.Event
@@ -611,6 +613,12 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
 
             tabViewSetting.set(settings.getTabViewPingString())
             closeTabSetting.set(settings.getTabTimeoutPingString())
+        }
+
+        with(AndroidAutofill) {
+            val autofillUseCases = AutofillUseCases()
+            supported.set(autofillUseCases.isSupported(applicationContext))
+            enabled.set(autofillUseCases.isEnabled(applicationContext))
         }
 
         browserStore.waitForSelectedOrDefaultSearchEngine { searchEngine ->

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/Event.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/Event.kt
@@ -249,6 +249,16 @@ sealed class Event {
     object OpenRecentTab : Event()
     object OpenInProgressMediaTab : Event()
 
+    // Android Autofill
+    object AndroidAutofillUnlockSuccessful : Event()
+    object AndroidAutofillUnlockCanceled : Event()
+    object AndroidAutofillSearchDisplayed : Event()
+    object AndroidAutofillSearchItemSelected : Event()
+    object AndroidAutofillConfirmationSuccessful : Event()
+    object AndroidAutofillConfirmationCanceled : Event()
+    object AndroidAutofillRequestWithLogins : Event()
+    object AndroidAutofillRequestWithoutLogins : Event()
+
     // Interaction events with extras
 
     data class TopSiteSwipeCarousel(val page: Int) : Event() {

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
@@ -10,6 +10,7 @@ import mozilla.components.service.glean.private.NoExtraKeys
 import mozilla.components.support.base.log.logger.Logger
 import org.mozilla.fenix.GleanMetrics.AboutPage
 import org.mozilla.fenix.GleanMetrics.Addons
+import org.mozilla.fenix.GleanMetrics.AndroidAutofill
 import org.mozilla.fenix.GleanMetrics.AndroidKeystoreExperiment
 import org.mozilla.fenix.GleanMetrics.AppTheme
 import org.mozilla.fenix.GleanMetrics.Autoplay
@@ -860,6 +861,31 @@ private val Event.wrapper: EventWrapper<*>?
 
         is Event.ShowAllRecentTabs -> EventWrapper<NoExtraKeys>(
             { RecentTabs.showAllClicked.record(it) }
+        )
+
+        is Event.AndroidAutofillRequestWithLogins -> EventWrapper<NoExtraKeys>(
+            { AndroidAutofill.requestMatchingLogins.record(it) }
+        )
+        is Event.AndroidAutofillRequestWithoutLogins -> EventWrapper<NoExtraKeys>(
+            { AndroidAutofill.requestNoMatchingLogins.record(it) }
+        )
+        is Event.AndroidAutofillSearchDisplayed -> EventWrapper<NoExtraKeys>(
+            { AndroidAutofill.searchDisplayed.record(it) }
+        )
+        is Event.AndroidAutofillSearchItemSelected -> EventWrapper<NoExtraKeys>(
+            { AndroidAutofill.searchItemSelected.record(it) }
+        )
+        is Event.AndroidAutofillUnlockCanceled -> EventWrapper<NoExtraKeys>(
+            { AndroidAutofill.unlockCancelled.record(it) }
+        )
+        is Event.AndroidAutofillUnlockSuccessful -> EventWrapper<NoExtraKeys>(
+            { AndroidAutofill.unlockSuccessful.record(it) }
+        )
+        is Event.AndroidAutofillConfirmationCanceled -> EventWrapper<NoExtraKeys>(
+            { AndroidAutofill.confirmCancelled.record(it) }
+        )
+        is Event.AndroidAutofillConfirmationSuccessful -> EventWrapper<NoExtraKeys>(
+            { AndroidAutofill.confirmSuccessful.record(it) }
         )
 
         // Don't record other events in Glean:

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
@@ -9,6 +9,7 @@ import mozilla.components.browser.awesomebar.facts.BrowserAwesomeBarFacts
 import mozilla.components.browser.menu.facts.BrowserMenuFacts
 import mozilla.components.browser.toolbar.facts.ToolbarFacts
 import mozilla.components.concept.awesomebar.AwesomeBar
+import mozilla.components.feature.autofill.facts.AutofillFacts
 import mozilla.components.feature.awesomebar.facts.AwesomeBarFacts
 import mozilla.components.feature.awesomebar.provider.BookmarksStorageSuggestionProvider
 import mozilla.components.feature.awesomebar.provider.ClipboardSuggestionProvider
@@ -325,6 +326,35 @@ internal class ReleaseMetricController(
         }
         Component.FEATURE_SEARCH to InContentTelemetry.IN_CONTENT_SEARCH -> {
             Event.SearchInContent(value!!)
+        }
+        Component.FEATURE_AUTOFILL to AutofillFacts.Items.AUTOFILL_REQUEST -> {
+            val hasMatchingLogins = metadata?.get(AutofillFacts.Metadata.HAS_MATCHING_LOGINS) as Boolean?
+            if (hasMatchingLogins == true) {
+                Event.AndroidAutofillRequestWithLogins
+            } else {
+                Event.AndroidAutofillRequestWithoutLogins
+            }
+        }
+        Component.FEATURE_AUTOFILL to AutofillFacts.Items.AUTOFILL_SEARCH -> {
+            if (action == Action.SELECT) {
+                Event.AndroidAutofillSearchItemSelected
+            } else {
+                Event.AndroidAutofillSearchDisplayed
+            }
+        }
+        Component.FEATURE_AUTOFILL to AutofillFacts.Items.AUTOFILL_LOCK -> {
+            if (action == Action.CONFIRM) {
+                Event.AndroidAutofillUnlockSuccessful
+            } else {
+                Event.AndroidAutofillUnlockCanceled
+            }
+        }
+        Component.FEATURE_AUTOFILL to AutofillFacts.Items.AUTOFILL_CONFIRMATION -> {
+            if (action == Action.CONFIRM) {
+                Event.AndroidAutofillConfirmationSuccessful
+            } else {
+                Event.AndroidAutofillConfirmationCanceled
+            }
         }
         else -> null
     }


### PR DESCRIPTION
See: https://github.com/mozilla-mobile/android-components/issues/10301

This patch adds:
* 8 events tracking Android Autofill usage
* 2 metrics tracking whether Android Autofill is supported and enabled