### PR TITLE
Enable Android Autofill in Beta builds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -167,7 +167,6 @@ android {
         }
         beta {
             java.srcDirs = ['src/migration/java']
-            manifest.srcFile "src/migration/AndroidManifest.xml"
         }
         release {
             java.srcDirs = ['src/migration/java']

--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -1355,6 +1355,36 @@ metrics:
       - perf-android-fe@mozilla.com
       - mcomella@mozilla.com
     expires: "2021-08-11"
+  android_autofill_supported:
+    type: boolean
+    description: |
+      Whether or not Android Autofill is supported by the device and is
+      supported for this user.
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/10301
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/20547#issuecomment-888273073
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - android-probes@mozilla.com
+      - skaspari@mozilla.com
+    expires: "2022-01-31"
+  android_autofill_enabled:
+    type: boolean
+    description: |
+      Whether or not Firefox is the Android Autofill provider for this user.
+      provider.
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/10301
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/20547#issuecomment-888273073
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+      - skaspari@mozilla.com
+    expires: "2022-01-31"
 
 preferences:
   search_suggestions_enabled:
@@ -5568,6 +5598,125 @@ awesomebar:
     notification_emails:
       - android-probes@mozilla.com
     expires: "2021-08-01"
+
+android_autofill:
+  request_matching_logins:
+    type: event
+    description: |
+      The app received an Android Autofill request from the system and was
+      able to find matching logins for the request
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/10301
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/20547#issuecomment-888273073
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+      - skaspari@mozilla.com
+    expires: "2022-01-31"
+  request_no_matching_logins:
+    type: event
+    description: |
+      The app received an Android Autofill request from the system and was
+      not able to find matching logins for the request
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/10301
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/20547#issuecomment-888273073
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+      - skaspari@mozilla.com
+    expires: "2022-01-31"
+  search_displayed:
+    type: event
+    description: |
+      The user has selected the search option to manually search a
+      matching login
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/10301
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/20547#issuecomment-888273073
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+      - skaspari@mozilla.com
+    expires: "2022-01-31"
+  search_item_selected:
+    type: event
+    description: |
+      The user has selected a search result for autofilling.
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/10301
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/20547#issuecomment-888273073
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+      - skaspari@mozilla.com
+    expires: "2022-01-31"
+  unlock_cancelled:
+    type: event
+    description: |
+      The user needed to unlock the app in order to autofill
+      logins, but the process was cancelled.
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/10301
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/20547#issuecomment-888273073
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+      - skaspari@mozilla.com
+    expires: "2022-01-31"
+  unlock_successful:
+    type: event
+    description: |
+      The user successfully unlock the app in order to autofill logins
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/10301
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/20547#issuecomment-888273073
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+      - skaspari@mozilla.com
+    expires: "2022-01-31"
+  confirm_cancelled:
+    type: event
+    description: |
+      The user needed to confirm autofilling an unauthenticated
+      application and decided to cancel
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/10301
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/20547#issuecomment-888273073
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+      - skaspari@mozilla.com
+    expires: "2022-01-31"
+  confirm_successful:
+    type: event
+    description: |
+      The user confirmed autofilling an unauthenticated application
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/10301
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/20547#issuecomment-888273073
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+      - skaspari@mozilla.com
+    expires: "2022-01-31"
 
 home_menu:
   settings_item_clicked:

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuLoginsAndPasswordRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuLoginsAndPasswordRobot.kt
@@ -97,7 +97,7 @@ private fun goBackButton() =
 private fun assertDefaultView() = onView(ViewMatchers.withText("Sync logins across devices"))
         .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
-private fun assertDefaultValueAutofillLogins() = onView(ViewMatchers.withText("Autofill"))
+private fun assertDefaultValueAutofillLogins() = onView(ViewMatchers.withText("Autofill websites"))
     .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
 private fun assertDefaultValueExceptions() = onView(ViewMatchers.withText("Exceptions"))

--- a/app/src/beta/AndroidManifest.xml
+++ b/app/src/beta/AndroidManifest.xml
@@ -1,0 +1,44 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="org.mozilla.fenix"
+    android:sharedUserId="${sharedUserId}">
+    <application
+        android:name="org.mozilla.fenix.MigratingFenixApplication"
+        tools:replace="android:name">
+
+        <activity android:name=".autofill.AutofillUnlockActivity"
+            android:exported="false"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar" />
+
+        <activity android:name=".autofill.AutofillConfirmActivity"
+            android:exported="false"
+            android:theme="@style/Theme.AppCompat.Translucent" />
+
+        <activity android:name=".autofill.AutofillSearchActivity"
+            android:exported="false"
+            android:theme="@style/DialogActivityTheme" />
+
+        <service
+            android:name=".autofill.AutofillService"
+            android:label="@string/app_name"
+            android:permission="android.permission.BIND_AUTOFILL_SERVICE">
+            <intent-filter>
+                <action android:name="android.service.autofill.AutofillService"/>
+            </intent-filter>
+        </service>
+
+        <!-- Overriding the alias of the main manifest to route app launches through our
+             MigrationDecisionActivity which will show the migration screen before launching
+             into the app if needed. -->
+        <activity-alias
+            android:name="${applicationId}.App"
+            android:targetActivity="org.mozilla.fenix.MigrationDecisionActivity"
+            tools:replace="android:targetActivity" />
+
+        <activity
+            android:name="org.mozilla.fenix.MigrationDecisionActivity"
+            android:exported="false" />
+
+        <service android:name="org.mozilla.fenix.MigrationService" />
+    </application>
+</manifest>

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -29,7 +29,8 @@
             android:theme="@style/Theme.AppCompat.Translucent" />
 
         <activity android:name=".autofill.AutofillSearchActivity"
-            android:exported="false" />
+            android:exported="false"
+            android:theme="@style/DialogActivityTheme" />
 
         <service
             android:name=".autofill.AutofillService"

--- a/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -48,4 +48,12 @@ object FeatureFlags {
      * Enables the recently saved bookmarks feature in the home screen.
      */
     val recentBookmarksFeature = Config.channel.isNightlyOrDebug
+
+    /**
+     * Enables support for Android Autofill.
+     *
+     * In addition to toggling this flag, matching entries in the Android Manifest of the build
+     * type need to present.
+     */
+    val androidAutofill = Config.channel.isNightlyOrDebug
 }

--- a/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -55,5 +55,5 @@ object FeatureFlags {
      * In addition to toggling this flag, matching entries in the Android Manifest of the build
      * type need to present.
      */
-    val androidAutofill = Config.channel.isNightlyOrDebug
+    val androidAutofill = Config.channel.isNightlyOrDebug || Config.channel.isBeta
 }

--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -64,6 +64,7 @@ import org.mozilla.fenix.telemetry.TelemetryLifecycleObserver
 import org.mozilla.fenix.utils.BrowsersCache
 import java.util.concurrent.TimeUnit
 import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.feature.autofill.AutofillUseCases
 import mozilla.components.feature.search.ext.buildSearchUrl
 import mozilla.components.feature.search.ext.waitForSelectedOrDefaultSearchEngine
 import mozilla.components.service.fxa.manager.SyncEnginesStorage
@@ -601,6 +602,10 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
 
             tabViewSetting.set(settings.getTabViewPingString())
             closeTabSetting.set(settings.getTabTimeoutPingString())
+
+            val autofillUseCases = AutofillUseCases()
+            androidAutofillSupported.set(autofillUseCases.isSupported(applicationContext))
+            androidAutofillEnabled.set(autofillUseCases.isEnabled(applicationContext))
         }
 
         browserStore.waitForSelectedOrDefaultSearchEngine { searchEngine ->

--- a/app/src/main/java/org/mozilla/fenix/autofill/AutofillSearchActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/autofill/AutofillSearchActivity.kt
@@ -5,6 +5,8 @@
 package org.mozilla.fenix.autofill
 
 import android.os.Build
+import android.os.Bundle
+import android.view.ViewGroup
 import androidx.annotation.RequiresApi
 import mozilla.components.feature.autofill.AutofillConfiguration
 import mozilla.components.feature.autofill.ui.AbstractAutofillSearchActivity
@@ -17,4 +19,15 @@ import org.mozilla.fenix.ext.components
 @RequiresApi(Build.VERSION_CODES.O)
 class AutofillSearchActivity : AbstractAutofillSearchActivity() {
     override val configuration: AutofillConfiguration by lazy { components.autofillConfiguration }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        // To avoid the dialog constantly resizing horizontally while typing, let's always use
+        // the full width of the screen for the dialog.
+        window.setLayout(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.WRAP_CONTENT
+        )
+    }
 }

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/Event.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/Event.kt
@@ -244,6 +244,16 @@ sealed class Event {
     object StartOnHomeEnterHomeScreen : Event()
     object StartOnHomeOpenTabsTray : Event()
 
+    // Android Autofill
+    object AndroidAutofillUnlockSuccessful : Event()
+    object AndroidAutofillUnlockCanceled : Event()
+    object AndroidAutofillSearchDisplayed : Event()
+    object AndroidAutofillSearchItemSelected : Event()
+    object AndroidAutofillConfirmationSuccessful : Event()
+    object AndroidAutofillConfirmationCanceled : Event()
+    object AndroidAutofillRequestWithLogins : Event()
+    object AndroidAutofillRequestWithoutLogins : Event()
+
     // Interaction events with extras
 
     data class TopSiteSwipeCarousel(val page: Int) : Event() {

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
@@ -10,6 +10,7 @@ import mozilla.components.service.glean.private.NoExtraKeys
 import mozilla.components.support.base.log.logger.Logger
 import org.mozilla.fenix.GleanMetrics.AboutPage
 import org.mozilla.fenix.GleanMetrics.Addons
+import org.mozilla.fenix.GleanMetrics.AndroidAutofill
 import org.mozilla.fenix.GleanMetrics.AndroidKeystoreExperiment
 import org.mozilla.fenix.GleanMetrics.AppTheme
 import org.mozilla.fenix.GleanMetrics.Autoplay
@@ -847,6 +848,31 @@ private val Event.wrapper: EventWrapper<*>?
 
         is Event.StartOnHomeOpenTabsTray -> EventWrapper<NoExtraKeys>(
             { StartOnHome.openTabsTray.record(it) }
+        )
+
+        is Event.AndroidAutofillRequestWithLogins -> EventWrapper<NoExtraKeys>(
+            { AndroidAutofill.requestMatchingLogins.record(it) }
+        )
+        is Event.AndroidAutofillRequestWithoutLogins -> EventWrapper<NoExtraKeys>(
+            { AndroidAutofill.requestNoMatchingLogins.record(it) }
+        )
+        is Event.AndroidAutofillSearchDisplayed -> EventWrapper<NoExtraKeys>(
+            { AndroidAutofill.searchDisplayed.record(it) }
+        )
+        is Event.AndroidAutofillSearchItemSelected -> EventWrapper<NoExtraKeys>(
+            { AndroidAutofill.searchItemSelected.record(it) }
+        )
+        is Event.AndroidAutofillUnlockCanceled -> EventWrapper<NoExtraKeys>(
+            { AndroidAutofill.unlockCancelled.record(it) }
+        )
+        is Event.AndroidAutofillUnlockSuccessful -> EventWrapper<NoExtraKeys>(
+            { AndroidAutofill.unlockSuccessful.record(it) }
+        )
+        is Event.AndroidAutofillConfirmationCanceled -> EventWrapper<NoExtraKeys>(
+            { AndroidAutofill.confirmCancelled.record(it) }
+        )
+        is Event.AndroidAutofillConfirmationSuccessful -> EventWrapper<NoExtraKeys>(
+            { AndroidAutofill.confirmSuccessful.record(it) }
         )
 
         // Don't record other events in Glean:

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
@@ -9,6 +9,7 @@ import mozilla.components.browser.awesomebar.facts.BrowserAwesomeBarFacts
 import mozilla.components.browser.menu.facts.BrowserMenuFacts
 import mozilla.components.browser.toolbar.facts.ToolbarFacts
 import mozilla.components.concept.awesomebar.AwesomeBar
+import mozilla.components.feature.autofill.facts.AutofillFacts
 import mozilla.components.feature.awesomebar.facts.AwesomeBarFacts
 import mozilla.components.feature.awesomebar.provider.BookmarksStorageSuggestionProvider
 import mozilla.components.feature.awesomebar.provider.ClipboardSuggestionProvider
@@ -314,7 +315,35 @@ internal class ReleaseMetricController(
         Component.LIB_DATAPROTECT to SecurePrefsReliabilityExperiment.Companion.Actions.RESET -> {
             Event.SecurePrefsReset
         }
-
+        Component.FEATURE_AUTOFILL to AutofillFacts.Items.AUTOFILL_REQUEST -> {
+            val hasMatchingLogins = metadata?.get(AutofillFacts.Metadata.HAS_MATCHING_LOGINS) as Boolean?
+            if (hasMatchingLogins == true) {
+                Event.AndroidAutofillRequestWithLogins
+            } else {
+                Event.AndroidAutofillRequestWithoutLogins
+            }
+        }
+        Component.FEATURE_AUTOFILL to AutofillFacts.Items.AUTOFILL_SEARCH -> {
+            if (action == Action.SELECT) {
+                Event.AndroidAutofillSearchItemSelected
+            } else {
+                Event.AndroidAutofillSearchDisplayed
+            }
+        }
+        Component.FEATURE_AUTOFILL to AutofillFacts.Items.AUTOFILL_LOCK -> {
+            if (action == Action.CONFIRM) {
+                Event.AndroidAutofillUnlockSuccessful
+            } else {
+                Event.AndroidAutofillUnlockCanceled
+            }
+        }
+        Component.FEATURE_AUTOFILL to AutofillFacts.Items.AUTOFILL_CONFIRMATION -> {
+            if (action == Action.CONFIRM) {
+                Event.AndroidAutofillConfirmationSuccessful
+            } else {
+                Event.AndroidAutofillConfirmationCanceled
+            }
+        }
         else -> null
     }
 

--- a/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/SavedLoginsAuthFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/SavedLoginsAuthFragment.kt
@@ -22,8 +22,10 @@ import androidx.preference.SwitchPreference
 import kotlinx.coroutines.Dispatchers.Main
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import mozilla.components.feature.autofill.preference.AutofillPreference
 import mozilla.components.service.fxa.SyncEngine
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
+import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.components
@@ -39,7 +41,6 @@ import org.mozilla.fenix.settings.requirePreference
 
 @Suppress("TooManyFunctions")
 class SavedLoginsAuthFragment : PreferenceFragmentCompat() {
-
     private val biometricPromptFeature = ViewBoundFeatureWrapper<BiometricPromptFeature>()
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
@@ -96,6 +97,14 @@ class SavedLoginsAuthFragment : PreferenceFragmentCompat() {
             setOnPreferenceClickListener {
                 navigateToSaveLoginSettingFragment()
                 true
+            }
+        }
+
+        requirePreference<AutofillPreference>(R.string.pref_key_android_autofill).apply {
+            update()
+
+            if (!FeatureFlags.androidAutofill) {
+                isVisible = false
             }
         }
 

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -169,6 +169,7 @@
     <string name="pref_key_save_logins_settings" translatable="false">pref_key_save_logins_settings</string>
     <string name="pref_key_save_logins" translatable="false">pref_key_save_logins</string>
     <string name="pref_key_autofill_logins" translatable="false">pref_key_autofill_logins</string>
+    <string name="pref_key_android_autofill" translatable="false">pref_key_android_autofill</string>
     <string name="pref_key_never_save_logins" translatable="false">pref_key_never_save_logins</string>
     <string name="pref_key_saved_logins" translatable="false">pref_key_saved_logins</string>
     <string name="pref_key_password_sync_logins" translatable="false">pref_key_password_sync_logins</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1452,6 +1452,11 @@
     <string name="preferences_passwords_save_logins_never_save">Never save</string>
     <!-- Preference for autofilling saved logins in Fenix -->
     <string name="preferences_passwords_autofill">Autofill</string>
+    <!-- Preference for autofilling saved logins in Fenix (in web content) -->
+    <string name="preferences_passwords_autofill2">Autofill websites</string>
+    <!-- Preference for autofilling logins from Fenix in other apps (e.g. autofilling the Twitter app) -->
+    <string name="preferences_android_autofill">Autofill other apps</string>
+
     <!-- Preference for syncing saved logins in Fenix -->
     <string name="preferences_passwords_sync_logins">Sync logins</string>
     <!-- Preference for syncing saved logins in Fenix, when not signed in-->

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -116,6 +116,33 @@
         <item name="tabCounterTintColor">?primaryText</item>
     </style>
 
+    <!-- A theme derived from the normal activity theme, but to look and behave like a dialog -->
+    <style name="DialogActivityTheme" parent="NormalTheme">
+        <item name="android:windowElevation">16dp</item>
+        <item name="android:colorBackground">?attr/colorBackgroundFloating</item>
+        <item name="android:colorBackgroundCacheHint">@null</item>
+        <item name="android:windowFrame">@null</item>
+        <item name="android:windowTitleStyle">@style/RtlOverlay.DialogWindowTitle.AppCompat</item>
+        <item name="android:windowTitleBackgroundStyle">@style/Base.DialogWindowTitleBackground.AppCompat</item>
+        <item name="android:windowIsFloating">true</item>
+        <item name="android:backgroundDimEnabled">true</item>
+        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowAnimationStyle">@style/Animation.AppCompat.Dialog</item>
+        <item name="android:windowSoftInputMode">stateUnspecified|adjustPan</item>
+
+        <item name="windowActionBar">false</item>
+        <item name="windowActionModeOverlay">true</item>
+
+        <item name="listPreferredItemPaddingLeft">24dip</item>
+        <item name="listPreferredItemPaddingRight">24dip</item>
+
+        <item name="android:listDivider">@null</item>
+
+        <item name="android:buttonBarStyle">@style/Widget.AppCompat.ButtonBar.AlertDialog</item>
+        <item name="android:borderlessButtonStyle">@style/Widget.AppCompat.Button.Borderless</item>
+        <item name="android:windowCloseOnTouchOutside">true</item>
+    </style>
+
     <style name="NormalTheme" parent="NormalThemeBase" />
 
     <style name="BaseDialogStyle" parent="Theme.MaterialComponents.Dialog.Alert">

--- a/app/src/main/res/xml/logins_preferences.xml
+++ b/app/src/main/res/xml/logins_preferences.xml
@@ -11,7 +11,10 @@
     <SwitchPreference
         android:defaultValue="true"
         android:key="@string/pref_key_autofill_logins"
-        android:title="@string/preferences_passwords_autofill" />
+        android:title="@string/preferences_passwords_autofill2" />
+    <mozilla.components.feature.autofill.preference.AutofillPreference
+        android:key="@string/pref_key_android_autofill"
+        android:title="@string/preferences_android_autofill" />
     <org.mozilla.fenix.settings.SyncPreference
         android:key="@string/pref_key_sync_logins"
         android:title="@string/preferences_passwords_sync_logins" />


### PR DESCRIPTION
This patch enables Android Autofill support in beta builds and uplifts the patches from #20547, #20397 and #20395.