### PR TITLE
Fix intermittent test failures after Java 11/mockk/robolectric upgrade

### DIFF
--- a/app/src/test/java/org/mozilla/fenix/components/history/PagedHistoryProviderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/history/PagedHistoryProviderTest.kt
@@ -7,10 +7,10 @@ package org.mozilla.fenix.components.history
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
-import io.mockk.verify
 import mozilla.components.concept.storage.HistoryStorage
 import mozilla.components.concept.storage.VisitInfo
 import mozilla.components.concept.storage.VisitType
+import org.junit.Assert.assertSame
 import org.junit.Before
 import org.junit.Test
 
@@ -27,11 +27,12 @@ class PagedHistoryProviderTest {
     fun `getHistory uses getVisitsPaginated`() {
         val provider = storage.createSynchronousPagedHistoryProvider()
         val results = listOf<VisitInfo>(mockk(), mockk())
-        val onComplete = mockk<(List<VisitInfo>) -> Unit>(relaxed = true)
-
         coEvery { storage.getVisitsPaginated(any(), any(), any()) } returns results
 
-        provider.getHistory(10L, 5, onComplete)
+        var actualResults: List<VisitInfo>? = null
+        provider.getHistory(10L, 5) {
+            actualResults = it
+        }
 
         coVerify {
             storage.getVisitsPaginated(
@@ -48,6 +49,7 @@ class PagedHistoryProviderTest {
                 )
             )
         }
-        verify { onComplete(results) }
+
+        assertSame(results, actualResults)
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/exceptions/trackingprotection/TrackingProtectionExceptionsInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/exceptions/trackingprotection/TrackingProtectionExceptionsInteractorTest.kt
@@ -4,14 +4,10 @@
 
 package org.mozilla.fenix.exceptions.trackingprotection
 
-import io.mockk.CapturingSlot
 import io.mockk.MockKAnnotations
-import io.mockk.Runs
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
-import io.mockk.just
 import io.mockk.mockk
-import io.mockk.slot
 import io.mockk.verify
 import io.mockk.verifySequence
 import mozilla.components.concept.engine.content.blocking.TrackingProtectionException
@@ -28,7 +24,7 @@ class TrackingProtectionExceptionsInteractorTest {
     @MockK(relaxed = true) private lateinit var exceptionsStore: ExceptionsFragmentStore
     @MockK(relaxed = true) private lateinit var trackingProtectionUseCases: TrackingProtectionUseCases
     private lateinit var interactor: TrackingProtectionExceptionsInteractor
-    private lateinit var onResult: CapturingSlot<(List<TrackingProtectionException>) -> Unit>
+    private lateinit var results: List<TrackingProtectionException>
 
     @Before
     fun setup() {
@@ -39,8 +35,10 @@ class TrackingProtectionExceptionsInteractorTest {
             trackingProtectionUseCases = trackingProtectionUseCases
         )
 
-        onResult = slot()
-        every { trackingProtectionUseCases.fetchExceptions(capture(onResult)) } just Runs
+        results = emptyList()
+        every { trackingProtectionUseCases.fetchExceptions(any()) } answers {
+            firstArg<(List<TrackingProtectionException>) -> Unit>()(results)
+        }
     }
 
     @Test
@@ -67,8 +65,6 @@ class TrackingProtectionExceptionsInteractorTest {
             trackingProtectionUseCases.fetchExceptions(any())
         }
 
-        val results = mockk<List<TrackingProtectionException>>()
-        onResult.captured(results)
         verify { exceptionsStore.dispatch(ExceptionsFragmentAction.Change(results)) }
     }
 
@@ -81,8 +77,6 @@ class TrackingProtectionExceptionsInteractorTest {
             trackingProtectionUseCases.fetchExceptions(any())
         }
 
-        val results = mockk<List<TrackingProtectionException>>()
-        onResult.captured(results)
         verify { exceptionsStore.dispatch(ExceptionsFragmentAction.Change(results)) }
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkControllerTest.kt
@@ -4,7 +4,6 @@
 
 package org.mozilla.fenix.library.bookmarks
 
-import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
 import androidx.navigation.NavController
@@ -30,6 +29,7 @@ import mozilla.components.concept.storage.BookmarkNodeType
 import mozilla.components.feature.tabs.TabsUseCases
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.mozilla.fenix.BrowserDirection
@@ -45,8 +45,6 @@ import org.mozilla.fenix.ext.components
 @ExperimentalCoroutinesApi
 class BookmarkControllerTest {
 
-    private lateinit var controller: BookmarkController
-
     private val bookmarkStore = spyk(BookmarkFragmentStore(BookmarkFragmentState(null)))
     private val context: Context = mockk(relaxed = true)
     private val scope = TestCoroutineScope()
@@ -54,13 +52,6 @@ class BookmarkControllerTest {
     private val navController: NavController = mockk(relaxed = true)
     private val sharedViewModel: BookmarksSharedViewModel = mockk()
     private val tabsUseCases: TabsUseCases = mockk()
-    private val loadBookmarkNode: suspend (String) -> BookmarkNode? = mockk(relaxed = true)
-    private val showSnackbar: (String) -> Unit = mockk(relaxed = true)
-    private val deleteBookmarkNodes: (Set<BookmarkNode>, Event) -> Unit = mockk(relaxed = true)
-    private val deleteBookmarkFolder: (Set<BookmarkNode>) -> Unit = mockk(relaxed = true)
-    private val invokePendingDeletion: () -> Unit = mockk(relaxed = true)
-    private val showTabTray: () -> Unit = mockk(relaxed = true)
-
     private val homeActivity: HomeActivity = mockk(relaxed = true)
     private val services: Services = mockk(relaxed = true)
     private val addNewTabUseCase: TabsUseCases.AddNewTabUseCase = mockk(relaxed = true)
@@ -102,8 +93,295 @@ class BookmarkControllerTest {
         every { bookmarkStore.dispatch(any()) } returns mockk()
         every { sharedViewModel.selectedFolder = any() } just runs
         every { tabsUseCases.addTab } returns addNewTabUseCase
+    }
 
-        controller = DefaultBookmarkController(
+    @After
+    fun cleanUp() {
+        scope.cleanupTestCoroutines()
+    }
+
+    @Test
+    fun `handleBookmarkChanged updates the selected bookmark node`() {
+        createController().handleBookmarkChanged(tree)
+
+        verify {
+            sharedViewModel.selectedFolder = tree
+            bookmarkStore.dispatch(BookmarkFragmentAction.Change(tree))
+        }
+    }
+
+    @Test
+    fun `handleBookmarkTapped should load the bookmark in a new tab`() {
+        var invokePendingDeletionInvoked = false
+        createController(invokePendingDeletion = {
+            invokePendingDeletionInvoked = true
+        }).handleBookmarkTapped(item)
+
+        assertTrue(invokePendingDeletionInvoked)
+        verify {
+            homeActivity.openToBrowserAndLoad(item.url!!, true, BrowserDirection.FromBookmarks)
+        }
+    }
+
+    @Test
+    fun `handleBookmarkTapped should respect browsing mode`() {
+        // if in normal mode, should be in normal mode
+        every { homeActivity.browsingModeManager.mode } returns BrowsingMode.Normal
+
+        val controller = createController()
+        controller.handleBookmarkTapped(item)
+        assertEquals(BrowsingMode.Normal, homeActivity.browsingModeManager.mode)
+
+        // if in private mode, should be in private mode
+        every { homeActivity.browsingModeManager.mode } returns BrowsingMode.Private
+
+        controller.handleBookmarkTapped(item)
+        assertEquals(BrowsingMode.Private, homeActivity.browsingModeManager.mode)
+    }
+
+    @Test
+    fun `handleBookmarkExpand clears selection and invokes pending deletions`() {
+        var invokePendingDeletionInvoked = false
+        createController(invokePendingDeletion = {
+            invokePendingDeletionInvoked = true
+        }).handleBookmarkExpand(tree)
+
+        assertTrue(invokePendingDeletionInvoked)
+    }
+
+    @Test
+    fun `handleBookmarkExpand should refresh and change the active bookmark node`() {
+        var loadBookmarkNodeInvoked = false
+        createController(loadBookmarkNode = {
+            loadBookmarkNodeInvoked = true
+            tree
+        }).handleBookmarkExpand(tree)
+
+        assertTrue(loadBookmarkNodeInvoked)
+        coVerify {
+            sharedViewModel.selectedFolder = tree
+            bookmarkStore.dispatch(BookmarkFragmentAction.Change(tree))
+        }
+    }
+
+    @Test
+    fun `handleSelectionModeSwitch should invalidateOptionsMenu`() {
+        createController().handleSelectionModeSwitch()
+
+        verify {
+            homeActivity.invalidateOptionsMenu()
+        }
+    }
+
+    @Test
+    fun `handleBookmarkEdit should navigate to the 'Edit' fragment`() {
+        var invokePendingDeletionInvoked = false
+        createController(invokePendingDeletion = {
+            invokePendingDeletionInvoked = true
+        }).handleBookmarkEdit(item)
+
+        assertTrue(invokePendingDeletionInvoked)
+        verify {
+            navController.navigate(
+                BookmarkFragmentDirections.actionBookmarkFragmentToBookmarkEditFragment(
+                    item.guid
+                ),
+                null
+            )
+        }
+    }
+
+    @Test
+    fun `handleBookmarkSelected dispatches Select action when selecting a non-root folder`() {
+        createController().handleBookmarkSelected(item)
+
+        verify {
+            bookmarkStore.dispatch(BookmarkFragmentAction.Select(item))
+        }
+    }
+
+    @Test
+    fun `handleBookmarkSelected should show a toast when selecting a root folder`() {
+        val errorMessage = context.getString(R.string.bookmark_cannot_edit_root)
+
+        var showSnackbarInvoked = false
+        createController(showSnackbar = {
+            assertEquals(errorMessage, it)
+            showSnackbarInvoked = true
+        }).handleBookmarkSelected(root)
+
+        assertTrue(showSnackbarInvoked)
+    }
+
+    @Test
+    fun `handleBookmarkSelected does not select in Syncing mode`() {
+        every { bookmarkStore.state.mode } returns BookmarkFragmentState.Mode.Syncing
+
+        createController().handleBookmarkSelected(item)
+
+        verify { bookmarkStore.dispatch(BookmarkFragmentAction.Select(item)) wasNot called }
+    }
+
+    @Test
+    fun `handleBookmarkDeselected dispatches Deselect action`() {
+        createController().handleBookmarkDeselected(item)
+
+        verify {
+            bookmarkStore.dispatch(BookmarkFragmentAction.Deselect(item))
+        }
+    }
+
+    @Test
+    fun `handleCopyUrl should copy bookmark url to clipboard and show a toast`() {
+        val urlCopiedMessage = context.getString(R.string.url_copied)
+
+        var showSnackbarInvoked = false
+        createController(showSnackbar = {
+            assertEquals(urlCopiedMessage, it)
+            showSnackbarInvoked = true
+        }).handleCopyUrl(item)
+
+        assertTrue(showSnackbarInvoked)
+    }
+
+    @Test
+    fun `handleBookmarkSharing should navigate to the 'Share' fragment`() {
+        val navDirectionsSlot = slot<NavDirections>()
+        every { navController.navigate(capture(navDirectionsSlot), null) } just Runs
+
+        createController().handleBookmarkSharing(item)
+
+        verify {
+            navController.navigate(navDirectionsSlot.captured, null)
+        }
+    }
+
+    @Test
+    fun `handleBookmarkTapped should open the bookmark`() {
+        var invokePendingDeletionInvoked = false
+        createController(invokePendingDeletion = {
+            invokePendingDeletionInvoked = true
+        }).handleBookmarkTapped(item)
+
+        assertTrue(invokePendingDeletionInvoked)
+        verify {
+            homeActivity.openToBrowserAndLoad(item.url!!, true, BrowserDirection.FromBookmarks)
+        }
+    }
+
+    @Test
+    fun `handleOpeningBookmark should open the bookmark a new 'Normal' tab`() {
+        var invokePendingDeletionInvoked = false
+        var showTabTrayInvoked = false
+        createController(invokePendingDeletion = {
+            invokePendingDeletionInvoked = true
+        }, showTabTray = {
+            showTabTrayInvoked = true
+        }
+        ).handleOpeningBookmark(item, BrowsingMode.Normal)
+
+        assertTrue(invokePendingDeletionInvoked)
+        assertTrue(showTabTrayInvoked)
+        verifyOrder {
+            homeActivity.browsingModeManager.mode = BrowsingMode.Normal
+            addNewTabUseCase.invoke(item.url!!, private = false)
+        }
+    }
+
+    @Test
+    fun `handleOpeningBookmark should open the bookmark a new 'Private' tab`() {
+        var invokePendingDeletionInvoked = false
+        var showTabTrayInvoked = false
+        createController(invokePendingDeletion = {
+            invokePendingDeletionInvoked = true
+        }, showTabTray = {
+            showTabTrayInvoked = true
+        }
+        ).handleOpeningBookmark(item, BrowsingMode.Private)
+
+        assertTrue(invokePendingDeletionInvoked)
+        assertTrue(showTabTrayInvoked)
+        verifyOrder {
+            homeActivity.browsingModeManager.mode = BrowsingMode.Private
+            addNewTabUseCase.invoke(item.url!!, private = true)
+        }
+    }
+
+    @Test
+    fun `handleBookmarkDeletion for an item should properly call a passed in delegate`() {
+        var deleteBookmarkNodesInvoked = false
+        createController(deleteBookmarkNodes = { nodes, event ->
+            assertEquals(setOf(item), nodes)
+            assertEquals(Event.RemoveBookmark, event)
+            deleteBookmarkNodesInvoked = true
+        }).handleBookmarkDeletion(setOf(item), Event.RemoveBookmark)
+
+        assertTrue(deleteBookmarkNodesInvoked)
+    }
+
+    @Test
+    fun `handleBookmarkDeletion for multiple bookmarks should properly call a passed in delegate`() {
+        var deleteBookmarkNodesInvoked = false
+        createController(deleteBookmarkNodes = { nodes, event ->
+            assertEquals(setOf(item, subfolder), nodes)
+            assertEquals(Event.RemoveBookmarks, event)
+            deleteBookmarkNodesInvoked = true
+        }).handleBookmarkDeletion(setOf(item, subfolder), Event.RemoveBookmarks)
+
+        assertTrue(deleteBookmarkNodesInvoked)
+    }
+
+    @Test
+    fun `handleBookmarkDeletion for a folder should properly call the delete folder delegate`() {
+        var deleteBookmarkFolderInvoked = false
+        createController(deleteBookmarkFolder = { nodes ->
+            assertEquals(setOf(subfolder), nodes)
+            deleteBookmarkFolderInvoked = true
+        }).handleBookmarkFolderDeletion(setOf(subfolder))
+
+        assertTrue(deleteBookmarkFolderInvoked)
+    }
+
+    @Test
+    fun `handleRequestSync dispatches actions in the correct order`() {
+        every { homeActivity.components.backgroundServices.accountManager } returns mockk(relaxed = true)
+        coEvery { homeActivity.bookmarkStorage.getBookmark(any()) } returns tree
+
+        createController().handleRequestSync()
+
+        verifyOrder {
+            bookmarkStore.dispatch(BookmarkFragmentAction.StartSync)
+            bookmarkStore.dispatch(BookmarkFragmentAction.FinishSync)
+        }
+    }
+
+    @Test
+    fun `handleBackPressed with one item in backstack should trigger handleBackPressed in NavController`() {
+        every { bookmarkStore.state.guidBackstack } returns listOf(tree.guid)
+        every { bookmarkStore.state.tree } returns tree
+
+        var invokePendingDeletionInvoked = false
+        createController(invokePendingDeletion = {
+            invokePendingDeletionInvoked = true
+        }).handleBackPressed()
+
+        assertTrue(invokePendingDeletionInvoked)
+
+        verify {
+            navController.popBackStack()
+        }
+    }
+
+    @Suppress("LongParameterList")
+    private fun createController(
+        loadBookmarkNode: suspend (String) -> BookmarkNode? = { _ -> null },
+        showSnackbar: (String) -> Unit = { _ -> },
+        deleteBookmarkNodes: (Set<BookmarkNode>, Event) -> Unit = { _, _ -> },
+        deleteBookmarkFolder: (Set<BookmarkNode>) -> Unit = { _ -> },
+        invokePendingDeletion: () -> Unit = { },
+        showTabTray: () -> Unit = { }
+    ): BookmarkController {
+        return DefaultBookmarkController(
             activity = homeActivity,
             navController = navController,
             clipboardManager = clipboardManager,
@@ -118,244 +396,5 @@ class BookmarkControllerTest {
             invokePendingDeletion = invokePendingDeletion,
             showTabTray = showTabTray
         )
-    }
-
-    @After
-    fun cleanUp() {
-        scope.cleanupTestCoroutines()
-    }
-
-    @Test
-    fun `handleBookmarkChanged updates the selected bookmark node`() {
-        controller.handleBookmarkChanged(tree)
-
-        verify {
-            sharedViewModel.selectedFolder = tree
-            bookmarkStore.dispatch(BookmarkFragmentAction.Change(tree))
-        }
-    }
-
-    @Test
-    fun `handleBookmarkTapped should load the bookmark in a new tab`() {
-        controller.handleBookmarkTapped(item)
-
-        verifyOrder {
-            invokePendingDeletion.invoke()
-            homeActivity.openToBrowserAndLoad(item.url!!, true, BrowserDirection.FromBookmarks)
-        }
-    }
-
-    @Test
-    fun `handleBookmarkTapped should respect browsing mode`() {
-        // if in normal mode, should be in normal mode
-        every { homeActivity.browsingModeManager.mode } returns BrowsingMode.Normal
-
-        controller.handleBookmarkTapped(item)
-        assertEquals(BrowsingMode.Normal, homeActivity.browsingModeManager.mode)
-
-        // if in private mode, should be in private mode
-        every { homeActivity.browsingModeManager.mode } returns BrowsingMode.Private
-
-        controller.handleBookmarkTapped(item)
-        assertEquals(BrowsingMode.Private, homeActivity.browsingModeManager.mode)
-    }
-
-    @Test
-    fun `handleBookmarkExpand clears selection and invokes pending deletions`() {
-        coEvery { loadBookmarkNode.invoke(any()) } returns tree
-
-        controller.handleBookmarkExpand(tree)
-
-        verify {
-            invokePendingDeletion.invoke()
-            controller.handleAllBookmarksDeselected()
-        }
-    }
-
-    @Test
-    fun `handleBookmarkExpand should refresh and change the active bookmark node`() {
-        coEvery { loadBookmarkNode.invoke(any()) } returns tree
-
-        controller.handleBookmarkExpand(tree)
-
-        coVerify {
-            loadBookmarkNode.invoke(tree.guid)
-            sharedViewModel.selectedFolder = tree
-            bookmarkStore.dispatch(BookmarkFragmentAction.Change(tree))
-        }
-    }
-
-    @Test
-    fun `handleSelectionModeSwitch should invalidateOptionsMenu`() {
-        controller.handleSelectionModeSwitch()
-
-        verify {
-            homeActivity.invalidateOptionsMenu()
-        }
-    }
-
-    @Test
-    fun `handleBookmarkEdit should navigate to the 'Edit' fragment`() {
-        controller.handleBookmarkEdit(item)
-
-        verify {
-            invokePendingDeletion.invoke()
-            navController.navigate(
-                BookmarkFragmentDirections.actionBookmarkFragmentToBookmarkEditFragment(
-                    item.guid
-                ),
-                null
-            )
-        }
-    }
-
-    @Test
-    fun `handleBookmarkSelected dispatches Select action when selecting a non-root folder`() {
-        controller.handleBookmarkSelected(item)
-
-        verify {
-            bookmarkStore.dispatch(BookmarkFragmentAction.Select(item))
-        }
-    }
-
-    @Test
-    fun `handleBookmarkSelected should show a toast when selecting a root folder`() {
-        val errorMessage = context.getString(R.string.bookmark_cannot_edit_root)
-
-        controller.handleBookmarkSelected(root)
-
-        verify {
-            showSnackbar(errorMessage)
-        }
-    }
-
-    @Test
-    fun `handleBookmarkSelected does not select in Syncing mode`() {
-        every { bookmarkStore.state.mode } returns BookmarkFragmentState.Mode.Syncing
-
-        controller.handleBookmarkSelected(item)
-
-        verify { bookmarkStore.dispatch(BookmarkFragmentAction.Select(item)) wasNot called }
-    }
-
-    @Test
-    fun `handleBookmarkDeselected dispatches Deselect action`() {
-        controller.handleBookmarkDeselected(item)
-
-        verify {
-            bookmarkStore.dispatch(BookmarkFragmentAction.Deselect(item))
-        }
-    }
-
-    @Test
-    fun `handleCopyUrl should copy bookmark url to clipboard and show a toast`() {
-        val urlCopiedMessage = context.getString(R.string.url_copied)
-
-        controller.handleCopyUrl(item)
-
-        verifyOrder {
-            ClipData.newPlainText(item.url, item.url)
-            showSnackbar(urlCopiedMessage)
-        }
-    }
-
-    @Test
-    fun `handleBookmarkSharing should navigate to the 'Share' fragment`() {
-        val navDirectionsSlot = slot<NavDirections>()
-        every { navController.navigate(capture(navDirectionsSlot), null) } just Runs
-
-        controller.handleBookmarkSharing(item)
-
-        verify {
-            navController.navigate(navDirectionsSlot.captured, null)
-        }
-    }
-
-    @Test
-    fun `handleBookmarkTapped should open the bookmark`() {
-        controller.handleBookmarkTapped(item)
-
-        verifyOrder {
-            invokePendingDeletion.invoke()
-            homeActivity.openToBrowserAndLoad(item.url!!, true, BrowserDirection.FromBookmarks)
-        }
-    }
-
-    @Test
-    fun `handleOpeningBookmark should open the bookmark a new 'Normal' tab`() {
-        controller.handleOpeningBookmark(item, BrowsingMode.Normal)
-
-        verifyOrder {
-            invokePendingDeletion.invoke()
-            homeActivity.browsingModeManager.mode = BrowsingMode.Normal
-            addNewTabUseCase.invoke(item.url!!, private = false)
-            showTabTray
-        }
-    }
-
-    @Test
-    fun `handleOpeningBookmark should open the bookmark a new 'Private' tab`() {
-        controller.handleOpeningBookmark(item, BrowsingMode.Private)
-
-        verifyOrder {
-            invokePendingDeletion.invoke()
-            homeActivity.browsingModeManager.mode = BrowsingMode.Private
-            addNewTabUseCase.invoke(item.url!!, private = true)
-            showTabTray
-        }
-    }
-
-    @Test
-    fun `handleBookmarkDeletion for an item should properly call a passed in delegate`() {
-        controller.handleBookmarkDeletion(setOf(item), Event.RemoveBookmark)
-
-        verify {
-            deleteBookmarkNodes(setOf(item), Event.RemoveBookmark)
-        }
-    }
-
-    @Test
-    fun `handleBookmarkDeletion for multiple bookmarks should properly call a passed in delegate`() {
-        controller.handleBookmarkDeletion(setOf(item, subfolder), Event.RemoveBookmarks)
-
-        verify {
-            deleteBookmarkNodes(setOf(item, subfolder), Event.RemoveBookmarks)
-        }
-    }
-
-    @Test
-    fun `handleBookmarkDeletion for a folder should properly call the delete folder delegate`() {
-        controller.handleBookmarkFolderDeletion(setOf(subfolder))
-
-        verify {
-            deleteBookmarkFolder(setOf(subfolder))
-        }
-    }
-
-    @Test
-    fun `handleRequestSync dispatches actions in the correct order`() {
-        every { homeActivity.components.backgroundServices.accountManager } returns mockk(relaxed = true)
-        coEvery { homeActivity.bookmarkStorage.getBookmark(any()) } returns tree
-        coEvery { loadBookmarkNode.invoke(any()) } returns tree
-
-        controller.handleRequestSync()
-
-        verifyOrder {
-            bookmarkStore.dispatch(BookmarkFragmentAction.StartSync)
-            bookmarkStore.dispatch(BookmarkFragmentAction.FinishSync)
-        }
-    }
-
-    @Test
-    fun `handleBackPressed with one item in backstack should trigger handleBackPressed in NavController`() {
-        every { bookmarkStore.state.guidBackstack } returns listOf(tree.guid)
-        every { bookmarkStore.state.tree } returns tree
-
-        controller.handleBackPressed()
-
-        verify {
-            invokePendingDeletion.invoke()
-            navController.popBackStack()
-        }
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/library/recentlyclosed/DefaultRecentlyClosedControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/recentlyclosed/DefaultRecentlyClosedControllerTest.kt
@@ -44,24 +44,11 @@ class DefaultRecentlyClosedControllerTest {
     private val resources: Resources = mockk(relaxed = true)
     private val snackbar: FenixSnackbar = mockk(relaxed = true)
     private val clipboardManager: ClipboardManager = mockk(relaxed = true)
-    private val openToBrowser: (RecoverableTab, BrowsingMode?) -> Unit = mockk(relaxed = true)
     private val activity: HomeActivity = mockk(relaxed = true)
     private val browserStore: BrowserStore = mockk(relaxed = true)
     private val recentlyClosedStore: RecentlyClosedFragmentStore = mockk(relaxed = true)
     private val tabsUseCases: TabsUseCases = mockk(relaxed = true)
     val mockedTab: RecoverableTab = mockk(relaxed = true)
-
-    private val controller = DefaultRecentlyClosedController(
-        navController,
-        browserStore,
-        recentlyClosedStore,
-        tabsUseCases,
-        resources,
-        snackbar,
-        clipboardManager,
-        activity,
-        openToBrowser
-    )
 
     @Before
     fun setUp() {
@@ -77,43 +64,69 @@ class DefaultRecentlyClosedControllerTest {
     fun handleOpen() {
         val item: RecoverableTab = mockk(relaxed = true)
 
+        var actualtab: RecoverableTab? = null
+        var actualBrowsingMode: BrowsingMode? = null
+
+        val controller = createController(
+            openToBrowser = { tab, browsingMode ->
+                actualtab = tab
+                actualBrowsingMode = browsingMode
+            }
+        )
+
         controller.handleOpen(item, BrowsingMode.Private)
 
-        verify {
-            openToBrowser(item, BrowsingMode.Private)
-        }
+        assertEquals(item, actualtab)
+        assertEquals(actualBrowsingMode, BrowsingMode.Private)
+
+        actualtab = null
+        actualBrowsingMode = null
 
         controller.handleOpen(item, BrowsingMode.Normal)
 
-        verify {
-            openToBrowser(item, BrowsingMode.Normal)
-        }
+        assertEquals(item, actualtab)
+        assertEquals(actualBrowsingMode, BrowsingMode.Normal)
     }
 
     @Test
     fun `open multiple tabs`() {
         val tabs = createFakeTabList(2)
 
+        val actualTabs = mutableListOf<RecoverableTab>()
+        val actualBrowsingModes = mutableListOf<BrowsingMode?>()
+
+        val controller = createController(
+            openToBrowser = { tab, mode ->
+                actualTabs.add(tab)
+                actualBrowsingModes.add(mode)
+            }
+        )
+
         controller.handleOpen(tabs.toSet(), BrowsingMode.Normal)
 
-        verify {
-            openToBrowser(tabs[0], BrowsingMode.Normal)
-            openToBrowser(tabs[1], BrowsingMode.Normal)
-        }
+        assertEquals(2, actualTabs.size)
+        assertEquals(tabs[0], actualTabs[0])
+        assertEquals(tabs[1], actualTabs[1])
+        assertEquals(BrowsingMode.Normal, actualBrowsingModes[0])
+        assertEquals(BrowsingMode.Normal, actualBrowsingModes[1])
+
+        actualTabs.clear()
+        actualBrowsingModes.clear()
 
         controller.handleOpen(tabs.toSet(), BrowsingMode.Private)
 
-        verify {
-            openToBrowser(tabs[0], BrowsingMode.Private)
-            openToBrowser(tabs[1], BrowsingMode.Private)
-        }
+        assertEquals(2, actualTabs.size)
+        assertEquals(tabs[0], actualTabs[0])
+        assertEquals(tabs[1], actualTabs[1])
+        assertEquals(BrowsingMode.Private, actualBrowsingModes[0])
+        assertEquals(BrowsingMode.Private, actualBrowsingModes[1])
     }
 
     @Test
     fun `handle select tab`() {
         val selectedTab = createFakeTab()
 
-        controller.handleSelect(selectedTab)
+        createController().handleSelect(selectedTab)
 
         verify { recentlyClosedStore.dispatch(RecentlyClosedFragmentAction.Select(selectedTab)) }
     }
@@ -122,7 +135,7 @@ class DefaultRecentlyClosedControllerTest {
     fun `handle deselect tab`() {
         val deselectedTab = createFakeTab()
 
-        controller.handleDeselect(deselectedTab)
+        createController().handleDeselect(deselectedTab)
 
         verify { recentlyClosedStore.dispatch(RecentlyClosedFragmentAction.Deselect(deselectedTab)) }
     }
@@ -131,7 +144,7 @@ class DefaultRecentlyClosedControllerTest {
     fun handleDelete() {
         val item: RecoverableTab = mockk(relaxed = true)
 
-        controller.handleDelete(item)
+        createController().handleDelete(item)
 
         verify {
             browserStore.dispatch(RecentlyClosedAction.RemoveClosedTabAction(item))
@@ -142,7 +155,7 @@ class DefaultRecentlyClosedControllerTest {
     fun `delete multiple tabs`() {
         val tabs = createFakeTabList(2)
 
-        controller.handleDelete(tabs.toSet())
+        createController().handleDelete(tabs.toSet())
 
         verify {
             browserStore.dispatch(RecentlyClosedAction.RemoveClosedTabAction(tabs[0]))
@@ -152,7 +165,7 @@ class DefaultRecentlyClosedControllerTest {
 
     @Test
     fun handleNavigateToHistory() {
-        controller.handleNavigateToHistory()
+        createController().handleNavigateToHistory()
 
         verify {
             navController.navigate(
@@ -170,7 +183,7 @@ class DefaultRecentlyClosedControllerTest {
 
         val clipdata = slot<ClipData>()
 
-        controller.handleCopyUrl(item)
+        createController().handleCopyUrl(item)
 
         verify {
             clipboardManager.setPrimaryClip(capture(clipdata))
@@ -187,7 +200,7 @@ class DefaultRecentlyClosedControllerTest {
     fun handleShare() {
         val item = RecoverableTab(id = "tab-id", title = "Mozilla", url = "mozilla.org", lastAccess = 1L)
 
-        controller.handleShare(item)
+        createController().handleShare(item)
 
         verify {
             navController.navigate(
@@ -204,7 +217,7 @@ class DefaultRecentlyClosedControllerTest {
     fun `share multiple tabs`() {
         val tabs = createFakeTabList(2)
 
-        controller.handleShare(tabs.toSet())
+        createController().handleShare(tabs.toSet())
 
         verify {
             val data = arrayOf(
@@ -219,7 +232,7 @@ class DefaultRecentlyClosedControllerTest {
 
     @Test
     fun handleRestore() {
-        controller.handleRestore(mockedTab)
+        createController().handleRestore(mockedTab)
 
         dispatcher.advanceUntilIdle()
 
@@ -230,9 +243,25 @@ class DefaultRecentlyClosedControllerTest {
     fun `exist multi-select mode when back is pressed`() {
         every { recentlyClosedStore.state.selectedTabs } returns createFakeTabList(3).toSet()
 
-        controller.handleBackPressed()
+        createController().handleBackPressed()
 
         verify { recentlyClosedStore.dispatch(RecentlyClosedFragmentAction.DeselectAll) }
+    }
+
+    private fun createController(
+        openToBrowser: (RecoverableTab, BrowsingMode?) -> Unit = { _, _ -> }
+    ): RecentlyClosedController {
+        return DefaultRecentlyClosedController(
+            navController,
+            browserStore,
+            recentlyClosedStore,
+            tabsUseCases,
+            resources,
+            snackbar,
+            clipboardManager,
+            activity,
+            openToBrowser
+        )
     }
 
     private fun createFakeTab(id: String = "FakeId", url: String = "www.fake.com"): RecoverableTab =

--- a/app/src/test/java/org/mozilla/fenix/tabstray/browser/RemoveTabUseCaseWrapperTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/browser/RemoveTabUseCaseWrapperTest.kt
@@ -6,6 +6,7 @@ package org.mozilla.fenix.tabstray.browser
 
 import io.mockk.mockk
 import io.mockk.verify
+import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.components.metrics.MetricController
@@ -16,12 +17,15 @@ class RemoveTabUseCaseWrapperTest {
 
     @Test
     fun `WHEN invoked THEN metrics, use case and callback are triggered`() {
-        val onRemove: (String) -> Unit = mockk(relaxed = true)
+        var actualTabId: String? = null
+        val onRemove: (String) -> Unit = { tabId ->
+            actualTabId = tabId
+        }
         val wrapper = RemoveTabUseCaseWrapper(metricController, onRemove)
 
         wrapper("123")
 
         verify { metricController.track(Event.ClosedExistingTab) }
-        verify { onRemove("123") }
+        assertEquals("123", actualTabId)
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/trackingprotection/TrackingProtectionPanelInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/trackingprotection/TrackingProtectionPanelInteractorTest.kt
@@ -15,8 +15,7 @@ class TrackingProtectionPanelInteractorTest {
     @Test
     fun openDetails() {
         val store: TrackingProtectionStore = mockk(relaxed = true)
-        val interactor =
-            TrackingProtectionPanelInteractor(store, mockk(), mockk())
+        val interactor = TrackingProtectionPanelInteractor(store, {}, {})
         interactor.openDetails(TrackingProtectionCategory.FINGERPRINTERS, true)
         verify {
             store.dispatch(
@@ -32,7 +31,7 @@ class TrackingProtectionPanelInteractorTest {
     fun openDetailsForRedirectTrackers() {
         val store: TrackingProtectionStore = mockk(relaxed = true)
         val interactor =
-            TrackingProtectionPanelInteractor(store, mockk(), mockk())
+            TrackingProtectionPanelInteractor(store, {}, {})
         interactor.openDetails(TrackingProtectionCategory.REDIRECT_TRACKERS, true)
         verify {
             store.dispatch(
@@ -49,7 +48,7 @@ class TrackingProtectionPanelInteractorTest {
         var openSettings = false
         val interactor = TrackingProtectionPanelInteractor(
             mockk(),
-            mockk(),
+            { },
             { openSettings = true }
         )
         interactor.selectTrackingProtectionSettings()
@@ -72,7 +71,7 @@ class TrackingProtectionPanelInteractorTest {
     fun onBackPressed() {
         val store: TrackingProtectionStore = mockk(relaxed = true)
         val interactor =
-            TrackingProtectionPanelInteractor(store, mockk(), mockk())
+            TrackingProtectionPanelInteractor(store, {}, {})
         interactor.onBackPressed()
         verify { store.dispatch(TrackingProtectionAction.ExitDetailsMode) }
     }


### PR DESCRIPTION
Tests we need to fix because of mocked lambdas:
- [x] `TrackingProtectionExceptionsInteractorTest` (@pocmo)
- [x] `DefaultRecentlyClosedControllerTest`
- [x] `BookmarkControllerTest`
- [x] `HistoryControllerTest`
- [x] `DefaultBrowserToolbarMenuControllerTest`
- [x] `TrackingProtectionPanelInteractorTest`
- [x] `RemoveTabUseCaseWrapperTest`
- [x]  `PagedHistoryProviderTest`
- [x]  `NavigationInteractorTest`

We will work around this for now by not mocking lambdas with mockk until we have an upstream fix.