### PR TITLE
Put the Start On home setting behind a feature flag.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -35,6 +35,11 @@ object FeatureFlags {
     val showHomeButtonFeature = Config.channel.isNightlyOrDebug
 
     /**
+     * Enables the Start On Home feature in the settings page.
+     */
+    val showStartOnHomeSettings = Config.channel.isNightlyOrDebug
+
+    /**
      * Enables the "recent" tabs feature in the home screen.
      */
     val showRecentTabsFeature = Config.channel.isNightlyOrDebug

--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -220,7 +220,7 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
             shouldNavigateBrowserFragmentOnCouldStart(savedInstanceState)
         ) {
             navigateToBrowserOnColdStart()
-        } else {
+        } else if (FeatureFlags.showStartOnHomeSettings) {
             components.analytics.metrics.track(Event.StartOnHomeEnterHomeScreen)
         }
 
@@ -974,6 +974,9 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
      *  links from an external apps should always opened in the [BrowserFragment].
      */
     fun shouldStartOnHome(intent: Intent? = this.intent): Boolean {
+        if (!FeatureFlags.showStartOnHomeSettings) {
+            return false
+        }
         return components.strictMode.resetAfter(StrictMode.allowThreadDiskReads()) {
             // We only want to open on home when users tap the app,
             // we want to ignore other cases when the app gets open by users clicking on links.

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -461,7 +461,9 @@ class HomeFragment : Fragment() {
             }
 
             view.tab_button.setOnClickListener {
-                requireComponents.analytics.metrics.track(Event.StartOnHomeOpenTabsTray)
+                if (FeatureFlags.showStartOnHomeSettings) {
+                    requireComponents.analytics.metrics.track(Event.StartOnHomeOpenTabsTray)
+                }
                 openTabsTray()
             }
 

--- a/app/src/main/java/org/mozilla/fenix/settings/TabsSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/TabsSettingsFragment.kt
@@ -6,7 +6,9 @@ package org.mozilla.fenix.settings
 
 import android.os.Bundle
 import android.view.View
+import androidx.preference.PreferenceCategory
 import androidx.preference.PreferenceFragmentCompat
+import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.components
@@ -57,8 +59,12 @@ class TabsSettingsFragment : PreferenceFragmentCompat() {
         radioOneMonth = requirePreference(R.string.pref_key_close_tabs_after_one_month)
 
         startOnHomeRadioFourHours = requirePreference(R.string.pref_key_start_on_home_after_four_hours)
+        startOnHomeRadioFourHours = requirePreference(R.string.pref_key_start_on_home_after_four_hours)
         startOnHomeRadioAlways = requirePreference(R.string.pref_key_start_on_home_always)
         startOnHomeRadioNever = requirePreference(R.string.pref_key_start_on_home_never)
+
+        requirePreference<PreferenceCategory>(R.string.pref_key_start_on_home_category).isVisible =
+            FeatureFlags.showStartOnHomeSettings
 
         setupRadioGroups()
     }

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -268,6 +268,7 @@
     <string name="pref_key_start_on_home_after_four_hours" translatable="false">pref_key_start_on_home_after_four_hours</string>
     <string name="pref_key_start_on_home_always" translatable="false">pref_key_start_on_home_always</string>
     <string name="pref_key_start_on_home_never" translatable="false">pref_key_start_on_home_never</string>
+    <string name="pref_key_start_on_home_category" translatable="false">pref_key_start_on_home_category</string>
     <string name="pref_key_camera_permissions_needed" translatable="false">pref_key_camera_permissions_needed</string>
 
     <string name="pref_key_return_to_browser" translatable="false">pref_key_return_to_browser</string>

--- a/app/src/main/res/xml/tabs_preferences.xml
+++ b/app/src/main/res/xml/tabs_preferences.xml
@@ -50,6 +50,8 @@
         android:layout="@layout/preference_cat_style"
         android:title="@string/preferences_start_on_home"
         app:allowDividerAbove="true"
+        app:isPreferenceVisible="false"
+        android:key="pref_key_start_on_home_category"
         app:iconSpaceReserved="false">
 
         <org.mozilla.fenix.settings.RadioButtonPreference


### PR DESCRIPTION
Related conversation https://github.com/mozilla-mobile/fenix/issues/19876#issuecomment-888445331

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
