### PR TITLE
For #20516: Remove tabs_tray.cfr telemetry probes

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -2650,38 +2650,6 @@ reader_mode:
       - android-probes@mozilla.com
     expires: "2022-02-01"
 
-tabs_tray.cfr:
-  dismiss:
-    type: event
-    description: |
-      A user dismisses the tabs tray CFR.
-    bugs:
-      - https://github.com/mozilla-mobile/fenix/issues/16485
-    data_reviews:
-      - https://github.com/mozilla-mobile/fenix/pull/17442
-      - https://github.com/mozilla-mobile/fenix/issues/16485#issuecomment-759641324
-      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
-    data_sensitivity:
-      - interaction
-    notification_emails:
-      - android-probes@mozilla.com
-    expires: "2021-08-01"
-  go_to_settings:
-    type: event
-    description: |
-      A user selects the CFR option to navigate to settings.
-    bugs:
-      - https://github.com/mozilla-mobile/fenix/issues/16485
-    data_reviews:
-      - https://github.com/mozilla-mobile/fenix/pull/17442
-      - https://github.com/mozilla-mobile/fenix/issues/16485#issuecomment-759641324
-      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
-    data_sensitivity:
-      - interaction
-    notification_emails:
-      - android-probes@mozilla.com
-    expires: "2021-08-01"
-
 tabs_tray:
   opened:
     type: event

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/Event.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/Event.kt
@@ -190,8 +190,6 @@ sealed class Event {
     object TabsTraySaveToCollectionPressed : Event()
     object TabsTrayShareAllTabsPressed : Event()
     object TabsTrayCloseAllTabsPressed : Event()
-    object TabsTrayCfrDismissed : Event()
-    object TabsTrayCfrTapped : Event()
 
     object ProgressiveWebAppOpenFromHomescreenTap : Event()
     object ProgressiveWebAppInstallAsShortcut : Event()

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
@@ -59,7 +59,6 @@ import org.mozilla.fenix.GleanMetrics.SyncedTabs
 import org.mozilla.fenix.GleanMetrics.Tab
 import org.mozilla.fenix.GleanMetrics.Tabs
 import org.mozilla.fenix.GleanMetrics.TabsTray
-import org.mozilla.fenix.GleanMetrics.TabsTrayCfr
 import org.mozilla.fenix.GleanMetrics.Tip
 import org.mozilla.fenix.GleanMetrics.ToolbarSettings
 import org.mozilla.fenix.GleanMetrics.TopSites
@@ -700,12 +699,6 @@ private val Event.wrapper: EventWrapper<*>?
         )
         is Event.TabsTrayCloseAllTabsPressed -> EventWrapper<NoExtraKeys>(
             { TabsTray.closeAllTabs.record(it) }
-        )
-        is Event.TabsTrayCfrDismissed -> EventWrapper<NoExtraKeys>(
-            { TabsTrayCfr.dismiss.record(it) }
-        )
-        is Event.TabsTrayCfrTapped -> EventWrapper<NoExtraKeys>(
-            { TabsTrayCfr.goToSettings.record(it) }
         )
         is Event.AutoPlaySettingVisited -> EventWrapper<NoExtraKeys>(
             { Autoplay.visitedSetting.record(it) }

--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
@@ -202,8 +202,7 @@ class TabsTrayFragment : AppCompatDialogFragment() {
                 store = requireComponents.core.store,
                 infoBannerView = view.info_banner,
                 settings = requireComponents.settings,
-                navigationInteractor = navigationInteractor,
-                metrics = requireComponents.analytics.metrics
+                navigationInteractor = navigationInteractor
             ),
             owner = this,
             view = view

--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayInfoBannerBinding.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayInfoBannerBinding.kt
@@ -21,8 +21,6 @@ import mozilla.components.lib.state.helpers.AbstractBinding
 import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
 import org.mozilla.fenix.R
 import org.mozilla.fenix.browser.infobanner.InfoBanner
-import org.mozilla.fenix.components.metrics.Event
-import org.mozilla.fenix.components.metrics.MetricController
 import org.mozilla.fenix.utils.Settings
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -31,8 +29,7 @@ class TabsTrayInfoBannerBinding(
     store: BrowserStore,
     private val infoBannerView: ViewGroup,
     private val settings: Settings,
-    private val navigationInteractor: NavigationInteractor,
-    private val metrics: MetricController?
+    private val navigationInteractor: NavigationInteractor
 ) : AbstractBinding<BrowserState>(store) {
 
     @VisibleForTesting

--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayInfoBannerBinding.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayInfoBannerBinding.kt
@@ -70,12 +70,10 @@ class TabsTrayInfoBannerBinding(
                 container = infoBannerView,
                 dismissByHiding = true,
                 dismissAction = {
-                    metrics?.track(Event.TabsTrayCfrDismissed)
                     settings.shouldShowAutoCloseTabsBanner = false
                 }
             ) {
                 navigationInteractor.onTabSettingsClicked()
-                metrics?.track(Event.TabsTrayCfrTapped)
                 settings.shouldShowAutoCloseTabsBanner = false
             }
         } else {

--- a/app/src/test/java/org/mozilla/fenix/components/metrics/GleanMetricsServiceTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/metrics/GleanMetricsServiceTest.kt
@@ -21,7 +21,6 @@ import org.mozilla.fenix.GleanMetrics.Events
 import org.mozilla.fenix.GleanMetrics.History
 import org.mozilla.fenix.GleanMetrics.SyncedTabs
 import org.mozilla.fenix.GleanMetrics.TabsTray
-import org.mozilla.fenix.GleanMetrics.TabsTrayCfr
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
 @RunWith(FenixRobolectricTestRunner::class)
@@ -250,14 +249,6 @@ class GleanMetricsServiceTest {
         assertFalse(TabsTray.closeAllTabs.testHasValue())
         gleanService.track(Event.TabsTrayCloseAllTabsPressed)
         assertTrue(TabsTray.closeAllTabs.testHasValue())
-
-        assertFalse(TabsTrayCfr.dismiss.testHasValue())
-        gleanService.track(Event.TabsTrayCfrDismissed)
-        assertTrue(TabsTrayCfr.dismiss.testHasValue())
-
-        assertFalse(TabsTrayCfr.goToSettings.testHasValue())
-        gleanService.track(Event.TabsTrayCfrTapped)
-        assertTrue(TabsTrayCfr.goToSettings.testHasValue())
     }
 
     @Test

--- a/app/src/test/java/org/mozilla/fenix/tabstray/TabsTrayInfoBannerBindingTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/TabsTrayInfoBannerBindingTest.kt
@@ -22,8 +22,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mozilla.fenix.components.metrics.Event
-import org.mozilla.fenix.components.metrics.MetricController
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.tabstray.TabsTrayInfoBannerBinding.Companion.TAB_COUNT_SHOW_CFR
 import org.mozilla.fenix.utils.Settings
@@ -35,7 +33,6 @@ class TabsTrayInfoBannerBindingTest {
     private lateinit var store: BrowserStore
     private lateinit var view: ViewGroup
     private lateinit var interactor: NavigationInteractor
-    private lateinit var metrics: MetricController
     private lateinit var settings: Settings
 
     @get:Rule
@@ -46,7 +43,6 @@ class TabsTrayInfoBannerBindingTest {
         store = BrowserStore()
         view = CoordinatorLayout(testContext)
         interactor = mockk(relaxed = true)
-        metrics = mockk(relaxed = true)
         settings = Settings(testContext)
     }
 
@@ -60,8 +56,7 @@ class TabsTrayInfoBannerBindingTest {
                 store = store,
                 infoBannerView = view,
                 settings = settings,
-                navigationInteractor = interactor,
-                metrics = metrics
+                navigationInteractor = interactor
             )
 
         binding.start()
@@ -88,8 +83,7 @@ class TabsTrayInfoBannerBindingTest {
                 store = store,
                 infoBannerView = view,
                 settings = settings,
-                navigationInteractor = interactor,
-                metrics = metrics
+                navigationInteractor = interactor
             )
 
         binding.start()
@@ -103,7 +97,5 @@ class TabsTrayInfoBannerBindingTest {
 
         verify(exactly = 0) { interactor.onTabSettingsClicked() }
         assert(!settings.shouldShowAutoCloseTabsBanner)
-        verify(exactly = 0) { metrics.track(Event.TabsTrayCfrTapped) }
-        verify(exactly = 1) { metrics.track(Event.TabsTrayCfrDismissed) }
     }
 }


### PR DESCRIPTION
For #20516 
Renewal PR: https://github.com/mozilla-mobile/fenix/pull/20517
Doc with details and Vesta's approval: https://docs.google.com/document/d/1NGlnTa9TPyTnd3ciUPbwujbITjkX8p8vJybXcZrrM2w/edit#

This PR removes the following probes entirely:
- `tabs_tray.cfr.dismiss`
- `tabs_tray.cfr.go_to_settings`

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
