### PR TITLE
Fix node toolchain task to use correct extension for artifact.

### DIFF
--- a/taskcluster/ci/toolchain/gecko-derived.yml
+++ b/taskcluster/ci/toolchain/gecko-derived.yml
@@ -43,7 +43,7 @@ linux64-minidump-stackwalk:
 
 linux64-node:
     attributes:
-        toolchain-artifact: public/build/node.tar.zst
+        toolchain-artifact: public/build/node.tar.xz
     description: "Node.js toolchain"
     run:
         index-search:


### PR DESCRIPTION
This changed at some point in Gecko (I can't find when), and was only recently rebuilt to take effect. Tasks like https://firefox-ci-tc.services.mozilla.com/tasks/XF8w-CnQTA60AMS4HvkqZg, which we depend on, are publishing xz instead of zstd tarballs.