### PR TITLE
Fix another round of intermittent test failures after Java 11/mockk/robolectric upgrade

### DIFF
--- a/app/src/test/java/org/mozilla/fenix/tabstray/ext/FenixSnackbarKtTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/ext/FenixSnackbarKtTest.kt
@@ -77,7 +77,7 @@ class FenixSnackbarKtTest {
         every { snackbar.setAction(any(), any()) }.answers { mockk(relaxed = true) }
         every { snackbar.anchorView }.answers { anchor }
 
-        snackbar.anchorWithAction(anchor, mockk(relaxed = true))
+        snackbar.anchorWithAction(anchor, {})
 
         verifyOrder {
             snackbar.anchorView = anchor


### PR DESCRIPTION
See https://github.com/mozilla-mobile/fenix/pull/20551#issue-698773022.