### PR TITLE
Fix intermittent test failures in TabsTouchHelperTest

### DIFF
--- a/app/src/test/java/org/mozilla/fenix/tabstray/browser/TabsTouchHelperTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/browser/TabsTouchHelperTest.kt
@@ -25,7 +25,7 @@ class TabsTouchHelperTest {
         val recyclerView = RecyclerView(testContext)
         val layout = FrameLayout(testContext)
         val viewHolder = SyncedTabsPageViewHolder(layout, mockk())
-        val callback = TouchCallback(mockk(), { true }, mockk())
+        val callback = TouchCallback(mockk(), { true }, { false })
 
         assertEquals(0, callback.getDragDirs(recyclerView, viewHolder))
         assertEquals(
@@ -44,7 +44,7 @@ class TabsTouchHelperTest {
         val recyclerView = RecyclerView(testContext)
         val layout = FrameLayout(testContext)
         val viewHolder = SyncedTabsPageViewHolder(layout, mockk())
-        val callback = TouchCallback(mockk(), { false }, mockk())
+        val callback = TouchCallback(mockk(), { false }, { false })
 
         assertEquals(0, callback.getDragDirs(recyclerView, viewHolder))
         assertEquals(


### PR DESCRIPTION
Another one with:

> io.mockk.MockKException: Can't instantiate proxy for class kotlin.Function1

Happened in https://github.com/mozilla-mobile/fenix/pull/20621