### PR TITLE
Closes #20627: Fix intermittent test failures in HistoryItemMenuTest

### DIFF
--- a/app/src/test/java/org/mozilla/fenix/library/history/HistoryItemMenuTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/history/HistoryItemMenuTest.kt
@@ -6,8 +6,6 @@ package org.mozilla.fenix.library.history
 
 import android.content.Context
 import androidx.appcompat.view.ContextThemeWrapper
-import io.mockk.mockk
-import io.mockk.verify
 import mozilla.components.concept.menu.candidate.TextStyle
 import mozilla.components.support.ktx.android.content.getColorFromAttr
 import mozilla.components.support.test.robolectric.testContext
@@ -23,14 +21,16 @@ import org.mozilla.fenix.library.history.HistoryItemMenu.Item
 class HistoryItemMenuTest {
 
     private lateinit var context: Context
-    private lateinit var onItemTapped: (Item) -> Unit
     private lateinit var menu: HistoryItemMenu
+    private var onItemTappedCaptured: Item? = null
 
     @Before
     fun setup() {
         context = ContextThemeWrapper(testContext, R.style.NormalTheme)
-        onItemTapped = mockk(relaxed = true)
-        menu = HistoryItemMenu(context, onItemTapped)
+        onItemTappedCaptured = null
+        menu = HistoryItemMenu(context) {
+            onItemTappedCaptured = it
+        }
     }
 
     @Test
@@ -43,7 +43,7 @@ class HistoryItemMenuTest {
         )
 
         deleteItem.onClick()
-        verify { onItemTapped(Item.Delete) }
+        assertEquals(Item.Delete, onItemTappedCaptured)
     }
 
     @Test
@@ -59,18 +59,18 @@ class HistoryItemMenuTest {
         assertEquals("Delete", delete.text)
 
         copy.onClick()
-        verify { onItemTapped(Item.Copy) }
+        assertEquals(Item.Copy, onItemTappedCaptured)
 
         share.onClick()
-        verify { onItemTapped(Item.Share) }
+        assertEquals(Item.Share, onItemTappedCaptured)
 
         openInNewTab.onClick()
-        verify { onItemTapped(Item.OpenInNewTab) }
+        assertEquals(Item.OpenInNewTab, onItemTappedCaptured)
 
         openInPrivateTab.onClick()
-        verify { onItemTapped(Item.OpenInPrivateTab) }
+        assertEquals(Item.OpenInPrivateTab, onItemTappedCaptured)
 
         delete.onClick()
-        verify { onItemTapped(Item.Delete) }
+        assertEquals(Item.Delete, onItemTappedCaptured)
     }
 }


### PR DESCRIPTION
This will prevent intermittent failures with Java 11.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
