### PR TITLE
Closes #20631: remove @Ignore on StorageStats tests.

### DIFF
--- a/app/src/test/java/org/mozilla/fenix/perf/StorageStatsMetricsTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/perf/StorageStatsMetricsTest.kt
@@ -16,7 +16,6 @@ import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -42,7 +41,6 @@ class StorageStatsMetricsTest {
     }
 
     @Test
-    @Ignore("These metrics have expired.")
     fun `WHEN reporting THEN the values from the storageStats are accumulated`() {
         every { storageStats.appBytes } returns 100
         every { storageStats.cacheBytes } returns 200
@@ -56,7 +54,6 @@ class StorageStatsMetricsTest {
     }
 
     @Test
-    @Ignore("These metrics have expired.")
     fun `WHEN reporting THEN the query duration is measured`() {
         StorageStatsMetrics.reportSync(mockContext)
         assertTrue(Metrics.queryStatsDuration.testHasValue())


### PR DESCRIPTION
The errors that caused this to be @Ignored were addressed by a recent PR
landing on master (i.e. the one that renewed the probes this test is
testing).

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
