### PR TITLE
For #4134: Add Forward/Back/Reload to Toolbar on Tablets

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -33,6 +33,7 @@ import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.components.TabCollectionStorage
+import org.mozilla.fenix.components.toolbar.ToolbarMenu
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.nav
@@ -82,10 +83,10 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
         if (FeatureFlags.showHomeButtonFeature) {
             val homeAction = BrowserToolbar.Button(
                 imageDrawable = AppCompatResources.getDrawable(
-                    requireContext(),
+                    context,
                     R.drawable.mozac_ic_home
                 )!!,
-                contentDescription = requireContext().getString(R.string.browser_toolbar_home),
+                contentDescription = context.getString(R.string.browser_toolbar_home),
                 iconTintColorResource = ThemeManager.resolveAttribute(R.attr.primaryText, context),
                 listener = browserToolbarInteractor::onHomeButtonClicked
             )
@@ -93,19 +94,100 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
             browserToolbarView.view.addNavigationAction(homeAction)
         }
 
+        if (resources.getBoolean(R.bool.tablet)) {
+            val enableTint = ThemeManager.resolveAttribute(R.attr.primaryText, context)
+            val disableTint = ThemeManager.resolveAttribute(R.attr.disabled, context)
+            val backAction = BrowserToolbar.TwoStateButton(
+                primaryImage = AppCompatResources.getDrawable(
+                    context,
+                    R.drawable.mozac_ic_back
+                )!!,
+                primaryContentDescription = context.getString(R.string.browser_menu_back),
+                primaryImageTintResource = enableTint,
+                isInPrimaryState = { getCurrentTab()?.content?.canGoBack ?: false },
+                secondaryImageTintResource = disableTint,
+                disableInSecondaryState = true,
+                longClickListener = {
+                    browserToolbarInteractor.onBrowserToolbarMenuItemTapped(
+                        ToolbarMenu.Item.Back(viewHistory = true)
+                    )
+                },
+                listener = {
+                    browserToolbarInteractor.onBrowserToolbarMenuItemTapped(
+                        ToolbarMenu.Item.Back(viewHistory = false)
+                    )
+                }
+            )
+            browserToolbarView.view.addNavigationAction(backAction)
+            val forwardAction = BrowserToolbar.TwoStateButton(
+                primaryImage = AppCompatResources.getDrawable(
+                    context,
+                    R.drawable.mozac_ic_forward
+                )!!,
+                primaryContentDescription = context.getString(R.string.browser_menu_forward),
+                primaryImageTintResource = enableTint,
+                isInPrimaryState = { getCurrentTab()?.content?.canGoForward ?: false },
+                secondaryImageTintResource = disableTint,
+                disableInSecondaryState = true,
+                longClickListener = {
+                    browserToolbarInteractor.onBrowserToolbarMenuItemTapped(
+                        ToolbarMenu.Item.Forward(viewHistory = true)
+                    )
+                },
+                listener = {
+                    browserToolbarInteractor.onBrowserToolbarMenuItemTapped(
+                        ToolbarMenu.Item.Forward(viewHistory = false)
+                    )
+                }
+            )
+            browserToolbarView.view.addNavigationAction(forwardAction)
+            val refreshAction = BrowserToolbar.TwoStateButton(
+                primaryImage = AppCompatResources.getDrawable(
+                    context,
+                    R.drawable.mozac_ic_refresh
+                )!!,
+                primaryContentDescription = context.getString(R.string.browser_menu_refresh),
+                primaryImageTintResource = enableTint,
+                isInPrimaryState = {
+                    getCurrentTab()?.content?.loading == false
+                },
+                secondaryImage = AppCompatResources.getDrawable(
+                    context,
+                    R.drawable.mozac_ic_stop
+                )!!,
+                secondaryContentDescription = context.getString(R.string.browser_menu_stop),
+                disableInSecondaryState = false,
+                longClickListener = {
+                    browserToolbarInteractor.onBrowserToolbarMenuItemTapped(
+                        ToolbarMenu.Item.Reload(bypassCache = true)
+                    )
+                },
+                listener = {
+                    if (getCurrentTab()?.content?.loading == true) {
+                        browserToolbarInteractor.onBrowserToolbarMenuItemTapped(ToolbarMenu.Item.Stop)
+                    } else {
+                        browserToolbarInteractor.onBrowserToolbarMenuItemTapped(
+                            ToolbarMenu.Item.Reload(bypassCache = false)
+                        )
+                    }
+                }
+            )
+            browserToolbarView.view.addNavigationAction(refreshAction)
+        }
+
         val readerModeAction =
             BrowserToolbar.ToggleButton(
                 image = AppCompatResources.getDrawable(
-                    requireContext(),
+                    context,
                     R.drawable.ic_readermode
                 )!!,
                 imageSelected =
                 AppCompatResources.getDrawable(
-                    requireContext(),
+                    context,
                     R.drawable.ic_readermode_selected
                 )!!,
-                contentDescription = requireContext().getString(R.string.browser_menu_read),
-                contentDescriptionSelected = requireContext().getString(R.string.browser_menu_read_close),
+                contentDescription = context.getString(R.string.browser_menu_read),
+                contentDescriptionSelected = context.getString(R.string.browser_menu_read_close),
                 visible = {
                     readerModeAvailable
                 },

--- a/app/src/main/res/values-sw600dp/bools.xml
+++ b/app/src/main/res/values-sw600dp/bools.xml
@@ -3,8 +3,5 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <resources>
-    <bool name="theme_is_light">true</bool>
-    <bool name="API28">false</bool>
-    <bool name="underAPI28">true</bool>
-    <bool name="tablet">false</bool>
+    <bool name="tablet">true</bool>
 </resources>


### PR DESCRIPTION
Closes #4134

This PR will add the Forward, Back, and Reload buttons to the URL bar if the device has at least 600dp on its shortest axis (the seeming standard for "being a tablet-sized device").

I'm unsure how to properly test these changes, they're almost purely user-facing.  No current tests seem to check for the existence of buttons. I did manually test the changes and they seem to work (I did get a couple crashes but those seem to also happen if I don't make any changes, likely an issue with my compiler/emulator setup)

The behavior is not optimal for foldables (For the buttons to appear/disappear you need to refresh the URL bar by going to Home or restarting Firefox) but I think it's good enough.

For accessibility I'm doing the same thing as the other buttons. I did not set up the Accessibility Auditor.

![UI_tablet](https://user-images.githubusercontent.com/8648826/128093272-062b6bb4-fcd5-4c13-a6d3-b2c2bc1c3543.png)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
