### PR TITLE
Issue #20664: Do not consider newly created tabs as inactive

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayController.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayController.kt
@@ -21,7 +21,7 @@ import org.mozilla.fenix.browser.browsingmode.BrowsingModeManager
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.components.metrics.MetricController
 import org.mozilla.fenix.home.HomeFragment
-import org.mozilla.fenix.tabstray.browser.DEFAULT_INACTIVE_DAYS
+import org.mozilla.fenix.tabstray.browser.DEFAULT_ACTIVE_DAYS
 import java.util.concurrent.TimeUnit
 
 interface TabsTrayController {
@@ -67,7 +67,7 @@ interface TabsTrayController {
      */
     fun forceTabsAsInactive(
         tabs: Collection<Tab>,
-        numOfDays: Long = DEFAULT_INACTIVE_DAYS + 1
+        numOfDays: Long = DEFAULT_ACTIVE_DAYS + 1
     )
 }
 

--- a/app/src/main/java/org/mozilla/fenix/tabstray/browser/NormalBrowserTrayList.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/browser/NormalBrowserTrayList.kt
@@ -20,7 +20,7 @@ import java.util.concurrent.TimeUnit
 /**
  * The time until which a tab is considered in-active (in days).
  */
-const val DEFAULT_INACTIVE_DAYS = 4L
+const val DEFAULT_ACTIVE_DAYS = 4L
 
 class NormalBrowserTrayList @JvmOverloads constructor(
     context: Context,
@@ -31,7 +31,7 @@ class NormalBrowserTrayList @JvmOverloads constructor(
     /**
      * The maximum time from when a tab was created or accessed until it is considered "inactive".
      */
-    var maxActiveTime = TimeUnit.DAYS.toMillis(DEFAULT_INACTIVE_DAYS)
+    var maxActiveTime = TimeUnit.DAYS.toMillis(DEFAULT_ACTIVE_DAYS)
 
     private val concatAdapter by lazy { adapter as ConcatAdapter }
 

--- a/app/src/main/java/org/mozilla/fenix/tabstray/ext/TabSessionState.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/ext/TabSessionState.kt
@@ -7,8 +7,9 @@ package org.mozilla.fenix.tabstray.ext
 import mozilla.components.browser.state.state.TabSessionState
 
 private fun TabSessionState.isActive(maxActiveTime: Long): Boolean {
+    val lastActiveTime = maxOf(lastAccess, createdAt)
     val now = System.currentTimeMillis()
-    return (now - lastAccess <= maxActiveTime)
+    return (now - lastActiveTime <= maxActiveTime)
 }
 
 /**

--- a/app/src/main/res/layout/inactive_footer_item.xml
+++ b/app/src/main/res/layout/inactive_footer_item.xml
@@ -11,7 +11,6 @@
     android:layout_marginEnd="16dp"
     android:layout_marginBottom="8dp"
     android:background="@drawable/rounded_bottom_corners"
-    android:elevation="@dimen/home_item_elevation"
     android:paddingBottom="8dp">
 
     <View

--- a/app/src/main/res/layout/inactive_header_item.xml
+++ b/app/src/main/res/layout/inactive_header_item.xml
@@ -12,7 +12,6 @@
     android:background="@drawable/rounded_top_corners"
     android:clickable="false"
     android:clipToPadding="false"
-    android:elevation="@dimen/home_item_elevation"
     android:focusable="true"
     android:foreground="?android:attr/selectableItemBackground"
     android:paddingStart="16dp"

--- a/app/src/main/res/layout/inactive_tab_list_item.xml
+++ b/app/src/main/res/layout/inactive_tab_list_item.xml
@@ -10,6 +10,5 @@
     android:layout_marginStart="16dp"
     android:layout_marginEnd="16dp"
     android:background="?above"
-    android:elevation="@dimen/home_item_elevation"
     android:foreground="?android:attr/selectableItemBackground"
     android:minHeight="@dimen/mozac_widget_site_item_height" />

--- a/app/src/test/java/org/mozilla/fenix/tabstray/ext/TabSessionStateKtTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/ext/TabSessionStateKtTest.kt
@@ -1,0 +1,106 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabstray.ext
+
+import mozilla.components.browser.state.state.createTab
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mozilla.fenix.tabstray.browser.DEFAULT_ACTIVE_DAYS
+import java.util.concurrent.TimeUnit
+
+class TabSessionStateKtTest {
+
+    private val maxTime = TimeUnit.DAYS.toMillis(DEFAULT_ACTIVE_DAYS)
+    private var inactiveTimestamp = 0L
+
+    @Before
+    fun setup() {
+        // Subtracting an extra 10 seconds in case the test runner is loopy.
+        inactiveTimestamp = System.currentTimeMillis() - maxTime - 10_000
+    }
+
+    @Test
+    fun `WHEN tab was recently accessed THEN isActive is true`() {
+        val tab = createTab(
+            url = "https://mozilla.org",
+            lastAccess = System.currentTimeMillis(),
+            createdAt = 0
+        )
+        assertTrue(tab.isNormalTabActive(maxTime))
+    }
+
+    @Test
+    fun `WHEN tab was recently created THEN isActive is true`() {
+        val tab = createTab(
+            url = "https://mozilla.org",
+            lastAccess = 0,
+            createdAt = System.currentTimeMillis()
+        )
+        assertTrue(tab.isNormalTabActive(maxTime))
+    }
+
+    @Test
+    fun `WHEN tab either was not created or accessed recently THEN isActive is true`() {
+        val tab = createTab(
+            url = "https://mozilla.org",
+            lastAccess = 0,
+            createdAt = inactiveTimestamp
+        )
+        assertFalse(tab.isNormalTabActive(maxTime))
+
+        val tab2 = createTab(
+            url = "https://mozilla.org",
+            lastAccess = inactiveTimestamp,
+            createdAt = 0
+        )
+        assertFalse(tab2.isNormalTabActive(maxTime))
+    }
+
+    @Test
+    fun `WHEN tab has not been accessed or recently created THEN isActive is false`() {
+        val tab = createTab(
+            url = "https://mozilla.org",
+            lastAccess = inactiveTimestamp,
+            createdAt = inactiveTimestamp
+        )
+        assertFalse(tab.isNormalTabActive(maxTime))
+    }
+
+    @Test
+    fun `WHEN normal tab is recently used THEN return true`() {
+        val tab = createTab(
+            url = "https://mozilla.org",
+            lastAccess = System.currentTimeMillis(),
+            createdAt = System.currentTimeMillis(),
+            private = false
+        )
+        val test = tab.isNormalTabActive(maxTime)
+        assertTrue(test)
+    }
+
+    @Test
+    fun `WHEN tabs are private THEN always false`() {
+        val tab = createTab(
+            url = "https://mozilla.org",
+            lastAccess = System.currentTimeMillis(),
+            createdAt = System.currentTimeMillis(),
+            private = true
+        )
+        assertFalse(tab.isNormalTabActive(maxTime))
+    }
+
+    @Test
+    fun `WHEN inactive tabs are private THEN always false`() {
+        val tab = createTab(
+            url = "https://mozilla.org",
+            lastAccess = inactiveTimestamp,
+            createdAt = inactiveTimestamp,
+            private = true
+        )
+        assertFalse(tab.isNormalTabActive(maxTime))
+    }
+}


### PR DESCRIPTION
- Renamed `DEFAULT_INACTIVE_DAYS` -> `DEFAULT_ACTIVE_DAYS` because it's usage was conflicting with the name.
- Also fixes #20674 - putting it in this PR since it's only removing one attribute from the layout files.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
