### PR TITLE
Start on home UI smoke tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/TestHelper.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/TestHelper.kt
@@ -73,7 +73,7 @@ object TestHelper {
         editor.apply()
     }
 
-    fun restartApp(activity: HomeActivityTestRule) {
+    fun restartApp(activity: HomeActivityIntentTestRule) {
         with(activity) {
             finishActivity()
             mDevice.waitForIdle()

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsPrivacyTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsPrivacyTest.kt
@@ -13,7 +13,7 @@ import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
-import org.mozilla.fenix.helpers.HomeActivityTestRule
+import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.helpers.TestHelper
 import org.mozilla.fenix.helpers.TestHelper.openAppFromExternalLink
@@ -36,7 +36,7 @@ class SettingsPrivacyTest {
     private val pageShortcutName = "TestShortcut"
 
     @get:Rule
-    val activityTestRule = HomeActivityTestRule()
+    val activityTestRule = HomeActivityIntentTestRule()
 
     @Before
     fun setUp() {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -32,6 +32,7 @@ import org.mozilla.fenix.helpers.TestHelper
 import org.mozilla.fenix.helpers.TestHelper.appName
 import org.mozilla.fenix.helpers.TestHelper.createCustomTabIntent
 import org.mozilla.fenix.helpers.TestHelper.deleteDownloadFromStorage
+import org.mozilla.fenix.helpers.TestHelper.restartApp
 import org.mozilla.fenix.helpers.TestHelper.scrollToElementByText
 import org.mozilla.fenix.helpers.ViewVisibilityIdlingResource
 import org.mozilla.fenix.ui.robots.browserScreen
@@ -1410,6 +1411,103 @@ class SmokeTest {
             selectLanguage(FRENCH_SYSTEM_LOCALE_OPTION)
             verifyLanguageHeaderIsTranslated("Language")
             IdlingRegistry.getInstance().unregister(localeListIdlingResource)
+        }
+    }
+
+    @Test
+    fun goToHomeScreenBottomToolbarTest() {
+        val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(genericURL.url) {
+            mDevice.waitForIdle()
+        }.goToHomescreen {
+            verifyHomeScreen()
+        }
+    }
+
+    @Test
+    fun goToHomeScreenTopToolbarTest() {
+        val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        homeScreen {
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openCustomizeSubMenu {
+            clickTopToolbarToggle()
+        }.goBack {
+        }.goBack {
+        }.openNavigationToolbar {
+        }.enterURLAndEnterToBrowser(genericURL.url) {
+            mDevice.waitForIdle()
+        }.goToHomescreen {
+            verifyHomeScreen()
+        }
+    }
+
+    @Test
+    fun goToHomeScreenBottomToolbarPrivateModeTest() {
+        val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        homeScreen {
+            togglePrivateBrowsingModeOnOff()
+        }
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(genericURL.url) {
+            mDevice.waitForIdle()
+        }.goToHomescreen {
+            verifyHomeScreen()
+        }
+    }
+
+    @Test
+    fun goToHomeScreenTopToolbarPrivateModeTest() {
+        val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        homeScreen {
+            togglePrivateBrowsingModeOnOff()
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openCustomizeSubMenu {
+            clickTopToolbarToggle()
+        }.goBack {
+        }.goBack {
+        }.openNavigationToolbar {
+        }.enterURLAndEnterToBrowser(genericURL.url) {
+            mDevice.waitForIdle()
+        }.goToHomescreen {
+            verifyHomeScreen()
+        }
+    }
+
+    @Test
+    fun startOnHomeSettingsMenuItemsTest() {
+        homeScreen {
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openTabsSubMenu {
+            verifyStartOnHomeOptions()
+        }
+    }
+
+    @Test
+    fun alwaysStartOnHomeTest() {
+        val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(genericURL.url) {
+            mDevice.waitForIdle()
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openTabsSubMenu {
+            clickAlwaysStartOnHomeToggle()
+        }
+
+        restartApp(activityTestRule)
+
+        homeScreen {
+            verifyHomeScreen()
         }
     }
 }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuTabsRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuTabsRobot.kt
@@ -9,11 +9,14 @@ package org.mozilla.fenix.ui.robots
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.assertion.ViewAssertions
+import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import org.hamcrest.CoreMatchers.allOf
+import org.mozilla.fenix.helpers.click
 
 /**
  * Implementation of Robot Pattern for the settings Tabs sub menu.
@@ -21,6 +24,10 @@ import org.hamcrest.CoreMatchers.allOf
 class SettingsSubMenuTabsRobot {
 
     fun verifyOptions() = assertOptions()
+
+    fun verifyStartOnHomeOptions() = assertStartOnHomeOptions()
+
+    fun clickAlwaysStartOnHomeToggle() = alwaysStartOnHomeToggle().click()
 
     class Transition {
         val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
@@ -46,6 +53,17 @@ private fun assertOptions() {
         .check(ViewAssertions.matches(ViewMatchers.withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 }
 
+private fun assertStartOnHomeOptions() {
+    startOnHomeHeading()
+        .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+    afterFourHoursToggle()
+        .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+    alwaysStartOnHomeToggle()
+        .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+    neverStartOnHomeToggle()
+        .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+}
+
 private fun manualToggle() = onView(withText("Manually"))
 
 private fun afterOneDayToggle() = onView(withText("After one day"))
@@ -53,6 +71,14 @@ private fun afterOneDayToggle() = onView(withText("After one day"))
 private fun afterOneWeekToggle() = onView(withText("After one week"))
 
 private fun afterOneMonthToggle() = onView(withText("After one month"))
+
+private fun startOnHomeHeading() = onView(withText("Start on home"))
+
+private fun afterFourHoursToggle() = onView(withText("After four hours"))
+
+private fun alwaysStartOnHomeToggle() = onView(withText("Always"))
+
+private fun neverStartOnHomeToggle() = onView(withText("Never"))
 
 private fun goBackButton() =
     onView(allOf(ViewMatchers.withContentDescription("Navigate up")))

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuThemeRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuThemeRobot.kt
@@ -36,6 +36,10 @@ class SettingsSubMenuThemeRobot {
 
     fun selectLightMode() = lightModeToggle().click()
 
+    fun clickTopToolbarToggle() = topToolbarToggle().click()
+
+    fun clickBottomToolbarToggle() = bottomToolbarToggle().click()
+
     class Transition {
         val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
 
@@ -61,6 +65,10 @@ private fun assertThemes() {
 private fun darkModeToggle() = onView(withText("Dark"))
 
 private fun lightModeToggle() = onView(withText("Light"))
+
+private fun topToolbarToggle() = onView(withText("Top"))
+
+private fun bottomToolbarToggle() = onView(withText("Bottom"))
 
 private fun deviceModeToggle(): ViewInteraction {
     val followDeviceThemeText =


### PR DESCRIPTION
• Start on home toolbar button and tabs settings options UI smoke tests:
`goToHomeScreenBottomToolbarTest` ✔️ Successfully ran 30x on Firebase
`goToHomeScreenTopToolbarTest` ✔️ Successfully ran 30x on Firebase
`goToHomeScreenBottomToolbarPrivateModeTest` ✔️ Successfully ran 30x on Firebase
`goToHomeScreenTopToolbarPrivateModeTest` ✔️ Successfully ran 30x on Firebase
`startOnHomeSettingsMenuItemsTest` ✔️ Successfully ran 30x on Firebase
`alwaysStartOnHomeTest` ✔️ Successfully ran 30x on Firebase

• Made minor parameter change for the `restartApp` method.
Re-ran the affected test:
`launchPageShortcutInPrivateModeTest` ✔️ Successfully ran 30x on Firebase
`launchLinksInPrivateToggleOffStateDoesntChangeTest` ✔️ Successfully ran 30x on Firebase

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
