### PR TITLE
For #17917 - Add a Kotlin synthetics Lint detector

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -61936,4 +61936,1258 @@
             column="21"/>
     </issue>
 
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.checkbox_item.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/tabstray/browser/AbstractBrowserTabViewHolder.kt"
+            line="16"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.fragment_edit_bookmark.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/library/bookmarks/addfolder/AddBookmarkFolderFragment.kt"
+            line="17"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.fragment_add_new_device.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/share/AddNewDeviceFragment.kt"
+            line="11"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.fragment_add_on_details.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/addons/AddonDetailsView.kt"
+            line="17"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.fragment_add_on_internal_settings.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/addons/AddonInternalSettingsFragment.kt"
+            line="13"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.fragment_add_on_permissions.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/addons/AddonPermissionsDetailsView.kt"
+            line="12"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.fragment_add_ons_management.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/addons/AddonsManagementFragment.kt"
+            line="20"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.fragment_add_ons_management.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/addons/AddonsManagementFragment.kt"
+            line="21"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.overlay_add_on_progress.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/addons/AddonsManagementFragment.kt"
+            line="22"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.fragment_browser.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt"
+            line="33"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.fragment_browser.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt"
+            line="34"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.component_bookmark.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragment.kt"
+            line="24"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.fragment_bookmark.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragment.kt"
+            line="25"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.component_bookmark.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkView.kt"
+            line="12"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.fragment_browser.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt"
+            line="16"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.fragment_browser.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt"
+            line="17"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.tab_tray_grid_item.view.tab_tray_grid_item"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/tabstray/browser/BrowserTabGridViewHolder.kt"
+            line="18"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.tab_tray_item.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/tabstray/browser/BrowserTabsAdapter.kt"
+            line="11"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.fragment_create_collection.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/collections/CollectionCreationFragment.kt"
+            line="15"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.collection_tab_list_row.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/collections/CollectionCreationTabListAdapter.kt"
+            line="14"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.component_collection_creation.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/collections/CollectionCreationView.kt"
+            line="22"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.fragment_crash_reporter.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/crashes/CrashReporterFragment.kt"
+            line="12"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.fragment_create_shortcut.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/shortcut/CreateShortcutFragment.kt"
+            line="14"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.fragment_downloads.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/library/downloads/DownloadFragment.kt"
+            line="19"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.component_downloads.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/library/downloads/DownloadView.kt"
+            line="13"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.component_downloads.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/library/downloads/DownloadView.kt"
+            line="14"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.component_history.view.progress_bar"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/library/downloads/DownloadView.kt"
+            line="15"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.component_history.view.swipe_refresh"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/library/downloads/DownloadView.kt"
+            line="16"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.download_list_item.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/library/downloads/viewholders/DownloadsListItemViewHolder.kt"
+            line="10"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.library_site_item.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/library/downloads/viewholders/DownloadsListItemViewHolder.kt"
+            line="11"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.download_dialog_layout.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/downloads/DynamicDownloadDialog.kt"
+            line="13"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.fragment_edit_bookmark.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/library/bookmarks/edit/EditBookmarkFragment.kt"
+            line="26"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.fragment_edit_bookmark.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/library/bookmarks/edit/EditBookmarkFragment.kt"
+            line="27"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.component_exceptions.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/exceptions/ExceptionsView.kt"
+            line="13"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.activity_home.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/customtabs/ExternalAppBrowserActivity.kt"
+            line="11"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.component_browser_top_toolbar.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/customtabs/ExternalAppBrowserFragment.kt"
+            line="14"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.fragment_browser.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/customtabs/ExternalAppBrowserFragment.kt"
+            line="15"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.fenix_snackbar.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/components/FenixSnackbar.kt"
+            line="21"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.fragment_history.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/library/history/HistoryFragment.kt"
+            line="23"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.history_list_item.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/library/history/viewholders/HistoryListItemViewHolder.kt"
+            line="11"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.library_site_item.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/library/history/viewholders/HistoryListItemViewHolder.kt"
+            line="12"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.recently_closed_nav_item.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/library/history/viewholders/HistoryListItemViewHolder.kt"
+            line="13"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.history_metadata_group.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/historymetadata/view/HistoryMetadataGroupViewHolder.kt"
+            line="8"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.history_metadata_header.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/historymetadata/view/HistoryMetadataHeaderViewHolder.kt"
+            line="8"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.history_metadata_list_row.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/historymetadata/view/HistoryMetadataViewHolder.kt"
+            line="8"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.component_history.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/library/history/HistoryView.kt"
+            line="13"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.component_history.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/library/history/HistoryView.kt"
+            line="14"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.recently_closed_nav_item.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/library/history/HistoryView.kt"
+            line="15"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.activity_home.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/HomeActivity.kt"
+            line="35"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.fragment_home.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/home/HomeFragment.kt"
+            line="47"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.fragment_home.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/home/HomeFragment.kt"
+            line="48"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.no_collections_message.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/home/HomeFragment.kt"
+            line="49"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.info_banner.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/browser/infobanner/InfoBanner.kt"
+            line="13"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.fragment_installed_add_on_details.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/addons/InstalledAddonDetailsFragment.kt"
+            line="18"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.library_site_item.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/library/LibrarySiteItemView.kt"
+            line="15"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.fragment_login_detail.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/settings/logins/view/LoginDetailView.kt"
+            line="9"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.fragment_exceptions.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/exceptions/login/LoginExceptionsFragment.kt"
+            line="14"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.component_exceptions.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/exceptions/login/LoginExceptionsView.kt"
+            line="9"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.activity_migration.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/migration/MigrationProgressActivity.kt"
+            line="12"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.migration_list_item.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/migration/MigrationStatusAdapter.kt"
+            line="16"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.fragment_not_yet_supported_addons.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/addons/NotYetSupportedAddonFragment.kt"
+            line="15"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.fragment_create_shortcut.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/shortcut/PwaOnboardingDialogFragment.kt"
+            line="13"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.recent_bookmark_item.bookmark_title"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/home/recentbookmarks/view/RecentBookmarkItemViewHolder.kt"
+            line="8"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.recent_bookmark_item.bookmark_subtitle"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/home/recentbookmarks/view/RecentBookmarkItemViewHolder.kt"
+            line="9"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.recent_bookmark_item.bookmark_item"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/home/recentbookmarks/view/RecentBookmarkItemViewHolder.kt"
+            line="10"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.recent_bookmark_item.favicon_image"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/home/recentbookmarks/view/RecentBookmarkItemViewHolder.kt"
+            line="11"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.component_recent_bookmarks.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/home/recentbookmarks/view/RecentBookmarksViewHolder.kt"
+            line="10"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.recent_bookmarks_header.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/home/recentbookmarks/view/RecentBookmarksViewHolder.kt"
+            line="11"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.fragment_recently_closed_tabs.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/library/recentlyclosed/RecentlyClosedFragment.kt"
+            line="18"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.component_recently_closed.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/library/recentlyclosed/RecentlyClosedFragmentView.kt"
+            line="14"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.history_list_item.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/library/recentlyclosed/RecentlyClosedItemViewHolder.kt"
+            line="9"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.library_site_item.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/library/recentlyclosed/RecentlyClosedItemViewHolder.kt"
+            line="10"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.collections_list_item.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/collections/SaveCollectionListAdapter.kt"
+            line="13"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.component_saved_logins.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/settings/logins/view/SavedLoginsListView.kt"
+            line="14"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.fragment_search_dialog.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt"
+            line="38"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.fragment_search_dialog.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt"
+            line="39"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.search_suggestions_hint.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt"
+            line="40"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.fragment_select_bookmark_folder.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/library/bookmarks/selectfolder/SelectBookmarkFolderFragment.kt"
+            line="18"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.component_tabstray2.view.exit_multi_select"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/tabstray/browser/SelectionBannerBinding.kt"
+            line="12"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.component_tabstray2.view.multiselect_title"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/tabstray/browser/SelectionBannerBinding.kt"
+            line="13"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.tabstray_multiselect_items.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/tabstray/browser/SelectionBannerBinding.kt"
+            line="14"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.share_close.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/share/ShareCloseView.kt"
+            line="11"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.fragment_share.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/share/ShareFragment.kt"
+            line="19"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.share_to_account_devices.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/share/ShareToAccountDevicesView.kt"
+            line="10"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.share_to_apps.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/share/ShareToAppsView.kt"
+            line="11"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.switch_with_description.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/trackingprotection/SwitchWithDescription.kt"
+            line="13"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.component_sync_tabs_tray_layout.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/tabstray/syncedtabs/SyncedTabsTrayLayout.kt"
+            line="13"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.sync_tabs_error_row.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/sync/SyncedTabsViewHolder.kt"
+            line="13"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.sync_tabs_list_item.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/sync/SyncedTabsViewHolder.kt"
+            line="14"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.view_synced_tabs_group.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/sync/SyncedTabsViewHolder.kt"
+            line="15"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.view_synced_tabs_title.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/sync/SyncedTabsViewHolder.kt"
+            line="16"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.fragment_tab_history_dialog.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/tabhistory/TabHistoryDialogFragment.kt"
+            line="15"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.component_tabhistory.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/tabhistory/TabHistoryView.kt"
+            line="13"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.tab_preview.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/browser/TabPreview.kt"
+            line="16"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.tabs_tray_tab_counter.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/browser/TabPreview.kt"
+            line="17"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.component_tabstray2.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt"
+            line="24"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.component_tabstray2.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt"
+            line="25"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.component_tabstray_fab.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt"
+            line="26"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.fragment_tab_tray_dialog.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt"
+            line="27"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.tabs_tray_tab_counter2.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt"
+            line="28"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.tabstray_multiselect_items.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt"
+            line="29"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.browser_toolbar_popup_window.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/utils/ToolbarPopupWindow.kt"
+            line="17"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.top_site_item.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/topsites/TopSiteItemViewHolder.kt"
+            line="13"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.fragment_tracking_protection_blocking.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionBlockingFragment.kt"
+            line="12"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.tracking_protection_category.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionCategoryItem.kt"
+            line="12"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.fragment_exceptions.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/exceptions/trackingprotection/TrackingProtectionExceptionsFragment.kt"
+            line="12"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.component_exceptions.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/exceptions/trackingprotection/TrackingProtectionExceptionsView.kt"
+            line="9"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.tracking_protection_onboarding_popup.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionOverlay.kt"
+            line="21"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.tracking_protection_onboarding_popup.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionOverlay.kt"
+            line="22"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.fragment_tracking_protection.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionPanelDialogFragment.kt"
+            line="25"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.component_tracking_protection_panel.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionPanelView.kt"
+            line="19"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.component_tracking_protection_panel.details_blocking_header"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionPanelView.kt"
+            line="20"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.switch_with_description.view.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionPanelView.kt"
+            line="21"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="KotlinSyntheticsDeprecation"
+        message="Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        errorLine1="import kotlinx.android.synthetic.main.fragment_add_on_internal_settings.*"
+        errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/org/mozilla/fenix/addons/WebExtensionActionPopupFragment.kt"
+            line="13"
+            column="1"/>
+    </issue>
+
 </issues>

--- a/mozilla-lint-rules/src/main/java/org/mozilla/fenix/lintrules/KotlinSyntheticsDetector.kt
+++ b/mozilla-lint-rules/src/main/java/org/mozilla/fenix/lintrules/KotlinSyntheticsDetector.kt
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+@file:Suppress("UnstableApiUsage")
+
+package org.mozilla.fenix.lintrules
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import org.jetbrains.uast.UElement
+import org.jetbrains.uast.UImportStatement
+
+/**
+ * Custom Lint detector that checks for deprecated "kotlinx.android.synthetic" imports.
+ */
+class KotlinSyntheticsDetector : Detector(), SourceCodeScanner {
+
+    override fun createUastHandler(context: JavaContext) = object : UElementHandler() {
+        override fun visitImportStatement(node: UImportStatement) {
+            node.importReference?.asSourceString()?.let { import ->
+                if (import.startsWith(SYNTHETIC_IMPORT_PATTERN)) {
+                    context.report(
+                        DEPRECATED_KOTLIN_SYNTHETICS_ISSUE,
+                        node,
+                        context.getLocation(node),
+                        DEPRECATED_KOTLIN_SYNTHETICS_MESSAGE
+                    )
+                }
+            }
+        }
+    }
+
+    override fun getApplicableUastTypes(): List<Class<out UElement>> {
+        return listOf(UImportStatement::class.java)
+    }
+
+    companion object {
+        private const val DEPRECATED_KOTLIN_SYNTHETICS_MESSAGE = "Kotlin synthetics are to be replaced with Jetpack View Binding. " +
+            "Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details."
+        private const val SYNTHETIC_IMPORT_PATTERN = "kotlinx.android.synthetic"
+
+        val DEPRECATED_KOTLIN_SYNTHETICS_ISSUE = Issue.create(
+            "KotlinSyntheticsDeprecation",
+            briefDescription = "Kotlin synthetics are deprecated and actively refactored out",
+            explanation = "The 'kotlin-android-extensions' Gradle plugin is deprecated and " +
+                "will be removed in a future Kotlin release in (or after) September 2021. " +
+                "We are to migrate to Jetpack View Binding. " +
+                "Please refer to https://github.com/mozilla-mobile/fenix/issues/17917",
+            category = Category.PRODUCTIVITY,
+            severity = Severity.ERROR,
+            implementation = Implementation(KotlinSyntheticsDetector::class.java, Scope.JAVA_FILE_SCOPE)
+        )
+    }
+}

--- a/mozilla-lint-rules/src/main/java/org/mozilla/fenix/lintrules/LintIssueRegistry.kt
+++ b/mozilla-lint-rules/src/main/java/org/mozilla/fenix/lintrules/LintIssueRegistry.kt
@@ -21,7 +21,8 @@ class LintIssueRegistry : IssueRegistry() {
         TextViewAndroidSrcXmlDetector.ISSUE_XML_SRC_USAGE,
         ImageViewAndroidTintXmlDetector.ISSUE_XML_SRC_USAGE,
         LicenseDetector.ISSUE_MISSING_LICENSE,
-        LicenseDetector.ISSUE_INVALID_LICENSE_FORMAT
+        LicenseDetector.ISSUE_INVALID_LICENSE_FORMAT,
+        KotlinSyntheticsDetector.DEPRECATED_KOTLIN_SYNTHETICS_ISSUE
     ) + ConstraintLayoutPerfDetector.ISSUES + ContextCompatDetector.ISSUES
     override val vendor: Vendor = Vendor(
         vendorName = "Mozilla",

--- a/mozilla-lint-rules/src/test/java/org/mozilla/fenix/lintrules/KotlinSyntheticsDetectorTest.kt
+++ b/mozilla-lint-rules/src/test/java/org/mozilla/fenix/lintrules/KotlinSyntheticsDetectorTest.kt
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+@file:Suppress("UnstableApiUsage")
+
+package org.mozilla.fenix.lintrules
+
+import com.android.tools.lint.checks.infrastructure.LintDetectorTest
+import com.android.tools.lint.checks.infrastructure.TestFiles
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Issue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import org.mozilla.fenix.lintrules.KotlinSyntheticsDetector.Companion.DEPRECATED_KOTLIN_SYNTHETICS_ISSUE
+
+@RunWith(JUnit4::class)
+class KotlinSyntheticsDetectorTest : LintDetectorTest() {
+
+    override fun getIssues(): MutableList<Issue> = mutableListOf(DEPRECATED_KOTLIN_SYNTHETICS_ISSUE)
+
+    override fun getDetector(): Detector = KotlinSyntheticsDetector()
+
+    @Test
+    fun `GIVEN no kotlin synthetics import WHEN KotlinSyntheticsDetector runs THEN there are no errors or exceptions`() {
+        val code = """
+            |package example
+            |
+            |import org.mozilla.fenix.databinding.OnboardingTrackingProtectionBinding
+            |
+            |class SomeExample {
+            |   fun hello() {
+            |       println("World")
+            |   }
+            |}""".trimMargin()
+
+        lint()
+            .files(TestFiles.kt(code))
+            .allowCompilationErrors()
+            .allowMissingSdk(true)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun `GIVEN a kotlin synthetics import WHEN KotlinSyntheticsDetector runs THEN there are no errors or exceptions`() {
+        val code = """
+            |package example
+            |
+            |import kotlinx.android.synthetic.main.layout
+            |
+            |class SomeExample {
+            |   fun hello() {
+            |       println("World")
+            |   }
+            |}""".trimMargin()
+
+        val expectedReport = """
+            |src/example/SomeExample.kt:3: Error: Kotlin synthetics are to be replaced with Jetpack View Binding. Please refer to https://github.com/mozilla-mobile/fenix/issues/17917 for more details. [KotlinSyntheticsDeprecation]
+            |import kotlinx.android.synthetic.main.layout
+            |~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            |1 errors, 0 warnings""".trimMargin()
+
+        lint()
+            .files(TestFiles.kt(code))
+            .allowMissingSdk(true)
+            .run()
+            .expect(expectedReport)
+    }
+}


### PR DESCRIPTION
This would help ease the current refactoring effort by ensuring no new
synthetics usages.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
