### PR TITLE
Update TabSessionState.createdAt for inactive tabs debugging

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayController.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayController.kt
@@ -7,6 +7,7 @@ package org.mozilla.fenix.tabstray
 import androidx.annotation.VisibleForTesting
 import androidx.navigation.NavController
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import mozilla.components.browser.state.action.DebugAction
 import mozilla.components.browser.state.action.LastAccessAction
 import mozilla.components.browser.state.selector.findTab
 import mozilla.components.browser.state.selector.getNormalOrPrivateTabs
@@ -15,6 +16,7 @@ import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.base.profiler.Profiler
 import mozilla.components.concept.tabstray.Tab
 import mozilla.components.feature.tabs.TabsUseCases
+import mozilla.components.lib.state.DelicateAction
 import org.mozilla.fenix.R
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.browser.browsingmode.BrowsingModeManager
@@ -180,10 +182,14 @@ class DefaultTabsTrayController(
      *
      * ⚠️ DO NOT USE THIS OUTSIDE OF DEBUGGING/TESTING.
      */
+    @OptIn(DelicateAction::class)
     override fun forceTabsAsInactive(tabs: Collection<Tab>, numOfDays: Long) {
         tabs.forEach { tab ->
             val daysSince = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(numOfDays)
-            browserStore.dispatch(LastAccessAction.UpdateLastAccessAction(tab.id, daysSince))
+            browserStore.apply {
+                dispatch(LastAccessAction.UpdateLastAccessAction(tab.id, daysSince))
+                dispatch(DebugAction.UpdateCreatedAtAction(tab.id, daysSince))
+            }
         }
     }
 


### PR DESCRIPTION
Requires https://github.com/mozilla-mobile/android-components/pull/10770.