### PR TITLE
For #20672 crash when attempting to disconnect from Mozilla account

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/account/SignOutFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/account/SignOutFragment.kt
@@ -57,7 +57,7 @@ class SignOutFragment : AppCompatDialogFragment() {
             ),
             binding.root.context.getString(R.string.app_name)
         )
-        return view
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {


### PR DESCRIPTION
The issue is related to resent view binding update https://github.com/mozilla-mobile/fenix/commit/cca7892e912e2f682ce1ccc4b0a06a4f67511bc9, we inflated the view but never pass the root view the dialog Frament.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
