### PR TITLE
Ship nightlies to Google Play twice a day

### DIFF
--- a/.cron.yml
+++ b/.cron.yml
@@ -11,14 +11,6 @@ jobs:
           target-tasks-method: nightly
       when:
           - {hour: 5, minute: 0}
-    # This is a temporary hook in order to not overload Google Play.
-    # See bug 1628413 for more context.
-    - name: nightly-on-google-play
-      job:
-          type: decision-task
-          treeherder-symbol: Nd-gp
-          target-tasks-method: nightly-on-google-play
-      when:
           - {hour: 17, minute: 0}
     - name: fennec-production
       job:

--- a/taskcluster/fenix_taskgraph/target_tasks.py
+++ b/taskcluster/fenix_taskgraph/target_tasks.py
@@ -28,25 +28,7 @@ def target_tasks_nightly(full_task_graph, parameters, graph_config):
     """Select the set of tasks required for a nightly build."""
 
     def filter(task, parameters):
-        # We don't want to ship nightly while Google Play is still behind manual review.
-        # See bug 1628413 for more context.
-        return task.attributes.get("nightly", False) and task.kind != "push-apk"
-
-    return [l for l, t in full_task_graph.tasks.items() if filter(t, parameters)]
-
-
-@_target_task("nightly-on-google-play")
-def target_tasks_nightly_on_google_play(full_task_graph, parameters, graph_config):
-    """Select the set of tasks required for a nightly build that goes on Google Play."""
-
-    def filter(task, parameters):
-        return (
-            task.attributes.get("nightly", False) and
-            # This target_task is temporary while Google Play processes APKs slower than usually
-            # (bug 1628413). So we want this target task to be only about shipping APKs to GP and
-            # not doing any other miscellaneous tasks like performance testing
-            task.kind not in ("browsertime", "visual-metrics", "raptor")
-        )
+        return task.attributes.get("nightly", False)
 
     return [l for l, t in full_task_graph.tasks.items() if filter(t, parameters)]
 


### PR DESCRIPTION
This was moved to once per day in https://bugzilla.mozilla.org/show_bug.cgi?id=1628413 when Google Play reviews were very slow. That hasn't been a problem for awhile, and the less frequent nightlies are causing delays getting new Android Components bumps shipped out.