### PR TITLE
Use theming in debug screen.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/SecretDebugSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SecretDebugSettingsFragment.kt
@@ -21,6 +21,7 @@ import androidx.fragment.app.Fragment
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.components
 import org.mozilla.fenix.ext.showToolbar
+import org.mozilla.fenix.theme.FirefoxTheme
 
 class SecretDebugSettingsFragment : Fragment() {
 
@@ -36,7 +37,11 @@ class SecretDebugSettingsFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View {
         return ComposeView(requireContext()).apply {
-            setContent { DebugInfo() }
+            setContent {
+                FirefoxTheme {
+                    DebugInfo()
+                }
+            }
         }
     }
 }
@@ -46,24 +51,29 @@ private fun DebugInfo() {
     val store = components.core.store
 
     Column(
-        modifier = Modifier.padding(8.dp)
+        modifier = Modifier
+            .padding(8.dp)
     ) {
         Text(
             text = stringResource(R.string.debug_info_region_home),
             style = MaterialTheme.typography.h6,
-            modifier = Modifier.padding(4.dp)
+            color = MaterialTheme.colors.onBackground,
+            modifier = Modifier.padding(4.dp),
         )
         Text(
             text = store.state.search.region?.home ?: "Unknown",
+            color = MaterialTheme.colors.onBackground,
             modifier = Modifier.padding(4.dp)
         )
         Text(
             text = stringResource(R.string.debug_info_region_current),
             style = MaterialTheme.typography.h6,
+            color = MaterialTheme.colors.onBackground,
             modifier = Modifier.padding(4.dp)
         )
         Text(
             text = store.state.search.region?.current ?: "Unknown",
+            color = MaterialTheme.colors.onBackground,
             modifier = Modifier.padding(4.dp)
         )
     }

--- a/app/src/main/java/org/mozilla/fenix/theme/FirefoxTheme.kt
+++ b/app/src/main/java/org/mozilla/fenix/theme/FirefoxTheme.kt
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.theme
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Colors
+import androidx.compose.material.darkColors
+import androidx.compose.material.lightColors
+import androidx.compose.runtime.Composable
+
+/**
+ * The theme for Mozilla Firefox for Android (Fenix).
+ */
+@Composable
+fun FirefoxTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    content: @Composable () -> Unit
+) {
+    MaterialTheme(
+        content = content,
+        colors = if (darkTheme) darkColorPalette else lightColorPalette
+    )
+}
+
+private val darkColorPalette: Colors = darkColors()
+
+private val lightColorPalette: Colors = lightColors()


### PR DESCRIPTION
This adds the first humble beginnings for a `FirefoxTheme`, to make `SecretDebugSettingsFragment` adapt to dark/light theming.