### PR TITLE
Android Autofill: Use AppCompat theme for UnlockActivity.

### DIFF
--- a/app/src/beta/AndroidManifest.xml
+++ b/app/src/beta/AndroidManifest.xml
@@ -8,7 +8,7 @@
 
         <activity android:name=".autofill.AutofillUnlockActivity"
             android:exported="false"
-            android:theme="@android:style/Theme.Translucent.NoTitleBar" />
+            android:theme="@style/Theme.AppCompat.Translucent" />
 
         <activity android:name=".autofill.AutofillConfirmActivity"
             android:exported="false"

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -22,7 +22,7 @@
 
         <activity android:name=".autofill.AutofillUnlockActivity"
             android:exported="false"
-            android:theme="@android:style/Theme.Translucent.NoTitleBar" />
+            android:theme="@style/Theme.AppCompat.Translucent" />
 
         <activity android:name=".autofill.AutofillConfirmActivity"
             android:exported="false"

--- a/app/src/nightly/AndroidManifest.xml
+++ b/app/src/nightly/AndroidManifest.xml
@@ -6,7 +6,7 @@
 
         <activity android:name=".autofill.AutofillUnlockActivity"
             android:exported="false"
-            android:theme="@android:style/Theme.Translucent.NoTitleBar" />
+            android:theme="@style/Theme.AppCompat.Translucent" />
 
         <activity android:name=".autofill.AutofillConfirmActivity"
             android:exported="false"


### PR DESCRIPTION
I hope this is fixing https://github.com/mozilla-mobile/android-components/issues/10792. Unfortunately I was not able to reproduce this problem and it only happened for a very small set of users. However since this never happened for `AutofillConfirmActivity` I am quite confident that this is the right fix.