### PR TITLE
Filter out test target packages in Flank-x86

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/perf/StartupExcessiveResourceUseTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/perf/StartupExcessiveResourceUseTest.kt
@@ -14,6 +14,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import kotlinx.android.synthetic.main.activity_home.*
 import org.junit.Assert.assertEquals
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.ext.components
@@ -81,6 +82,7 @@ class StartupExcessiveResourceUseTest {
 
     private val uiDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
 
+    @Ignore("See: https://github.com/mozilla-mobile/fenix/pull/20841#issuecomment-898630241c")
     @Test
     fun verifyRunBlockingAndStrictModeSuppresionCount() {
         uiDevice.waitForIdle() // wait for async UI to load.

--- a/automation/taskcluster/androidTest/flank-x86.yml
+++ b/automation/taskcluster/androidTest/flank-x86.yml
@@ -38,8 +38,8 @@ gcloud:
   performance-metrics: true
 
   test-targets:
-   - package org.mozilla.fenix.ui
-   - package org.mozilla.fenix.glean
+   - notPackage org.mozilla.fenix.screenshots
+   - notPackage org.mozilla.fenix.syncintegration
 
   device:
    - model: Pixel2


### PR DESCRIPTION
AndroidJUnitRunner filters are supported on FTL (through Flank). This is a test to try inverse package selection of test packages we do not wish to run (on the daily in flank-x86) by using `notPackage` and specifying the the packages.

https://developer.android.com/reference/androidx/test/runner/AndroidJUnitRunner#typical-usage
https://flank.github.io/flank/