### PR TITLE
For #17917 - Migrate `home` from Kotlin synthetics to View Binding.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -32,7 +32,6 @@ import androidx.navigation.NavDirections
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.NavigationUI
-import kotlinx.android.synthetic.main.activity_home.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.Dispatchers
@@ -74,6 +73,7 @@ import org.mozilla.fenix.browser.browsingmode.BrowsingModeManager
 import org.mozilla.fenix.browser.browsingmode.DefaultBrowsingModeManager
 import org.mozilla.fenix.components.metrics.BreadcrumbsRecorder
 import org.mozilla.fenix.components.metrics.Event
+import org.mozilla.fenix.databinding.ActivityHomeBinding
 import org.mozilla.fenix.exceptions.trackingprotection.TrackingProtectionExceptionsFragmentDirections
 import org.mozilla.fenix.ext.alreadyOnDestination
 import org.mozilla.fenix.ext.breadcrumb
@@ -134,6 +134,7 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
     // components requires context to access.
     protected val homeActivityInitTimeStampNanoSeconds = SystemClock.elapsedRealtimeNanos()
 
+    private lateinit var binding: ActivityHomeBinding
     lateinit var themeManager: ThemeManager
     lateinit var browsingModeManager: BrowsingModeManager
 
@@ -203,8 +204,9 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
 
         // Must be after we set the content view
         if (isVisuallyComplete) {
+            binding = ActivityHomeBinding.bind(window.decorView.findViewById(R.id.rootContainer))
             components.performance.visualCompletenessQueue
-                .attachViewToRunVisualCompletenessQueueLater(WeakReference(rootContainer))
+                .attachViewToRunVisualCompletenessQueueLater(WeakReference(binding.rootContainer))
         }
 
         privateNotificationObserver = PrivateNotificationFeature(
@@ -270,7 +272,7 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
             components.performance.visualCompletenessQueue,
             components.startupStateProvider,
             safeIntent,
-            rootContainer
+            binding.rootContainer
         )
     }
 
@@ -310,7 +312,7 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
             message = "onStart()"
         )
 
-        ProfilerMarkers.homeActivityOnStart(rootContainer, components.core.engine.profiler)
+        ProfilerMarkers.homeActivityOnStart(binding.rootContainer, components.core.engine.profiler)
     }
 
     override fun onStop() {
@@ -651,7 +653,7 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
      */
     override fun getSupportActionBarAndInflateIfNecessary(): ActionBar {
         if (!isToolbarInflated) {
-            navigationToolbar = navigationToolbarStub.inflate() as Toolbar
+            navigationToolbar = binding.navigationToolbarStub.inflate() as Toolbar
 
             setSupportActionBar(navigationToolbar)
             // Add ids to this that we don't want to have a toolbar back button

--- a/app/src/main/java/org/mozilla/fenix/home/recentbookmarks/view/RecentBookmarkItemViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recentbookmarks/view/RecentBookmarkItemViewHolder.kt
@@ -5,13 +5,10 @@
 package org.mozilla.fenix.home.recentbookmarks.view
 
 import android.view.View
-import kotlinx.android.synthetic.main.recent_bookmark_item.bookmark_title
-import kotlinx.android.synthetic.main.recent_bookmark_item.bookmark_subtitle
-import kotlinx.android.synthetic.main.recent_bookmark_item.bookmark_item
-import kotlinx.android.synthetic.main.recent_bookmark_item.favicon_image
 import mozilla.components.concept.storage.BookmarkNode
 import mozilla.components.support.ktx.kotlin.tryGetHostFromUrl
 import org.mozilla.fenix.R
+import org.mozilla.fenix.databinding.RecentBookmarkItemBinding
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.loadIntoView
 import org.mozilla.fenix.home.recentbookmarks.interactor.RecentBookmarksInteractor
@@ -23,15 +20,17 @@ class RecentBookmarkItemViewHolder(
 ) : ViewHolder(view) {
 
     fun bind(bookmark: BookmarkNode) {
-        bookmark_title.text = bookmark.title ?: bookmark.url
-        bookmark_subtitle.text = bookmark.url?.tryGetHostFromUrl() ?: bookmark.title ?: ""
+        val binding = RecentBookmarkItemBinding.bind(view)
 
-        bookmark_item.setOnClickListener {
+        binding.bookmarkTitle.text = bookmark.title ?: bookmark.url
+        binding.bookmarkSubtitle.text = bookmark.url?.tryGetHostFromUrl() ?: bookmark.title ?: ""
+
+        binding.bookmarkItem.setOnClickListener {
             interactor.onRecentBookmarkClicked(bookmark)
         }
 
         bookmark.url?.let {
-            view.context.components.core.icons.loadIntoView(favicon_image, it)
+            view.context.components.core.icons.loadIntoView(binding.faviconImage, it)
         }
     }
 

--- a/app/src/main/java/org/mozilla/fenix/home/recentbookmarks/view/RecentBookmarksViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recentbookmarks/view/RecentBookmarksViewHolder.kt
@@ -8,10 +8,9 @@ import android.view.View
 import androidx.navigation.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager.HORIZONTAL
-import kotlinx.android.synthetic.main.component_recent_bookmarks.view.*
-import kotlinx.android.synthetic.main.recent_bookmarks_header.*
 import mozilla.components.concept.storage.BookmarkNode
 import org.mozilla.fenix.R
+import org.mozilla.fenix.databinding.ComponentRecentBookmarksBinding
 import org.mozilla.fenix.home.recentbookmarks.RecentBookmarksItemAdapter
 import org.mozilla.fenix.home.recentbookmarks.interactor.RecentBookmarksInteractor
 import org.mozilla.fenix.utils.view.ViewHolder
@@ -24,14 +23,17 @@ class RecentBookmarksViewHolder(
     private val recentBookmarksAdapter = RecentBookmarksItemAdapter(interactor)
 
     init {
+        val recentBookmarksBinding = ComponentRecentBookmarksBinding.bind(view)
+        val recentBookmarksHeaderBinding = recentBookmarksBinding.recentBookmarksHeader
+
         val linearLayoutManager = LinearLayoutManager(view.context, HORIZONTAL, false)
 
-        view.recent_bookmarks_list.apply {
+        recentBookmarksBinding.recentBookmarksList.apply {
             adapter = recentBookmarksAdapter
             layoutManager = linearLayoutManager
         }
 
-        showAllBookmarksButton.setOnClickListener {
+        recentBookmarksHeaderBinding.showAllBookmarksButton.setOnClickListener {
             dismissSearchDialogIfDisplayed()
             interactor.onShowAllBookmarksClicked()
         }

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlView.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlView.kt
@@ -10,7 +10,6 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import kotlinx.android.extensions.LayoutContainer
 import mozilla.components.concept.storage.BookmarkNode
 import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.feature.tab.collections.TabCollection
@@ -207,11 +206,11 @@ private fun collectionTabItems(collection: TabCollection) =
     }
 
 class SessionControlView(
-    override val containerView: View,
+    val containerView: View,
     viewLifecycleOwner: LifecycleOwner,
     interactor: SessionControlInteractor,
     private var homeScreenViewModel: HomeScreenViewModel
-) : LayoutContainer {
+) {
 
     val view: RecyclerView = containerView as RecyclerView
 

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/topsites/TopSiteItemViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/topsites/TopSiteItemViewHolder.kt
@@ -10,7 +10,6 @@ import android.view.MotionEvent
 import android.view.View
 import android.widget.PopupWindow
 import androidx.appcompat.content.res.AppCompatResources.getDrawable
-import kotlinx.android.synthetic.main.top_site_item.*
 import mozilla.components.browser.menu.BrowserMenuBuilder
 import mozilla.components.browser.menu.item.SimpleBrowserMenuItem
 import mozilla.components.feature.top.sites.TopSite
@@ -19,6 +18,7 @@ import mozilla.components.feature.top.sites.TopSite.Type.FRECENT
 import mozilla.components.feature.top.sites.TopSite.Type.PINNED
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.metrics.Event
+import org.mozilla.fenix.databinding.TopSiteItemBinding
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.loadIntoView
 import org.mozilla.fenix.home.sessioncontrol.TopSiteInteractor
@@ -30,13 +30,14 @@ class TopSiteItemViewHolder(
     private val interactor: TopSiteInteractor
 ) : ViewHolder(view) {
     private lateinit var topSite: TopSite
+    private val binding = TopSiteItemBinding.bind(view)
 
     init {
-        top_site_item.setOnClickListener {
+        binding.topSiteItem.setOnClickListener {
             interactor.onSelectTopSite(topSite.url, topSite.type)
         }
 
-        top_site_item.setOnLongClickListener {
+        binding.topSiteItem.setOnLongClickListener {
             interactor.onTopSiteMenuOpened()
             it.context.components.analytics.metrics.track(Event.TopSiteLongPress(topSite.type))
 
@@ -62,30 +63,30 @@ class TopSiteItemViewHolder(
     }
 
     fun bind(topSite: TopSite) {
-        top_site_title.text = topSite.title
+        binding.topSiteTitle.text = topSite.title
 
         if (topSite.type == PINNED || topSite.type == DEFAULT) {
             val pinIndicator = getDrawable(itemView.context, R.drawable.ic_new_pin)
-            top_site_title.setCompoundDrawablesWithIntrinsicBounds(pinIndicator, null, null, null)
+            binding.topSiteTitle.setCompoundDrawablesWithIntrinsicBounds(pinIndicator, null, null, null)
         } else {
-            top_site_title.setCompoundDrawablesWithIntrinsicBounds(null, null, null, null)
+            binding.topSiteTitle.setCompoundDrawablesWithIntrinsicBounds(null, null, null, null)
         }
 
         when (topSite.url) {
             SupportUtils.POCKET_TRENDING_URL -> {
-                favicon_image.setImageDrawable(getDrawable(itemView.context, R.drawable.ic_pocket))
+                binding.faviconImage.setImageDrawable(getDrawable(itemView.context, R.drawable.ic_pocket))
             }
             SupportUtils.BAIDU_URL -> {
-                favicon_image.setImageDrawable(getDrawable(itemView.context, R.drawable.ic_baidu))
+                binding.faviconImage.setImageDrawable(getDrawable(itemView.context, R.drawable.ic_baidu))
             }
             SupportUtils.JD_URL -> {
-                favicon_image.setImageDrawable(getDrawable(itemView.context, R.drawable.ic_jd))
+                binding.faviconImage.setImageDrawable(getDrawable(itemView.context, R.drawable.ic_jd))
             }
             SupportUtils.PDD_URL -> {
-                favicon_image.setImageDrawable(getDrawable(itemView.context, R.drawable.ic_pdd))
+                binding.faviconImage.setImageDrawable(getDrawable(itemView.context, R.drawable.ic_pdd))
             }
             else -> {
-                itemView.context.components.core.icons.loadIntoView(favicon_image, topSite.url)
+                itemView.context.components.core.icons.loadIntoView(binding.faviconImage, topSite.url)
             }
         }
 

--- a/app/src/main/res/layout/component_recent_bookmarks.xml
+++ b/app/src/main/res/layout/component_recent_bookmarks.xml
@@ -9,7 +9,9 @@
     android:layout_height="wrap_content"
     android:orientation="vertical">
 
-    <include layout="@layout/recent_bookmarks_header" />
+    <include
+        android:id="@+id/recent_bookmarks_header"
+        layout="@layout/recent_bookmarks_header" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recent_bookmarks_list"

--- a/app/src/test/java/org/mozilla/fenix/home/recentbookmarks/view/RecentBookmarkItemViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/recentbookmarks/view/RecentBookmarkItemViewHolderTest.kt
@@ -5,9 +5,7 @@
 package org.mozilla.fenix.home.recentbookmarks.view
 
 import android.view.LayoutInflater
-import android.view.View
 import io.mockk.mockk
-import kotlinx.android.synthetic.main.recent_bookmark_item.view.*
 import mozilla.components.concept.storage.BookmarkNode
 import mozilla.components.concept.storage.BookmarkNodeType
 import mozilla.components.support.ktx.kotlin.tryGetHostFromUrl
@@ -16,13 +14,14 @@ import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mozilla.fenix.databinding.RecentBookmarkItemBinding
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.home.sessioncontrol.SessionControlInteractor
 
 @RunWith(FenixRobolectricTestRunner::class)
 class RecentBookmarkItemViewHolderTest {
 
-    private lateinit var view: View
+    private lateinit var binding: RecentBookmarkItemBinding
     private lateinit var interactor: SessionControlInteractor
 
     private val bookmarkNoUrl = BookmarkNode(
@@ -60,37 +59,36 @@ class RecentBookmarkItemViewHolderTest {
 
     @Before
     fun setup() {
-        view = LayoutInflater.from(testContext)
-            .inflate(RecentBookmarkItemViewHolder.LAYOUT_ID, null)
+        binding = RecentBookmarkItemBinding.inflate(LayoutInflater.from(testContext))
 
         interactor = mockk(relaxed = true)
     }
 
     @Test
     fun `GIVEN a bookmark exists in the list THEN set the title text and subtitle from item`() {
-        RecentBookmarkItemViewHolder(view, interactor).bind(bookmarkWithUrl)
+        RecentBookmarkItemViewHolder(binding.root, interactor).bind(bookmarkWithUrl)
 
         val hostFromUrl = bookmarkWithUrl.url?.tryGetHostFromUrl()
 
-        Assert.assertEquals(bookmarkWithUrl.title, view.bookmark_title.text)
-        Assert.assertEquals(hostFromUrl, view.bookmark_subtitle.text)
+        Assert.assertEquals(bookmarkWithUrl.title, binding.bookmarkTitle.text)
+        Assert.assertEquals(hostFromUrl, binding.bookmarkSubtitle.text)
     }
 
     @Test
     fun `WHEN there is no url for the bookmark THEN do not load an icon `() {
-        val viewHolder = RecentBookmarkItemViewHolder(view, interactor)
+        val viewHolder = RecentBookmarkItemViewHolder(binding.root, interactor)
 
-        Assert.assertNull(view.favicon_image.drawable)
+        Assert.assertNull(binding.faviconImage.drawable)
 
         viewHolder.bind(bookmarkNoUrl)
 
-        Assert.assertNull(view.favicon_image.drawable)
+        Assert.assertNull(binding.faviconImage.drawable)
     }
 
     @Test
     fun `WHEN a bookmark does not have a title THEN show the url`() {
-        RecentBookmarkItemViewHolder(view, interactor).bind(bookmarkNoTitle)
+        RecentBookmarkItemViewHolder(binding.root, interactor).bind(bookmarkNoTitle)
 
-        Assert.assertEquals(bookmarkNoTitle.url, view.bookmark_title.text)
+        Assert.assertEquals(bookmarkNoTitle.url, binding.bookmarkTitle.text)
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/home/recentbookmarks/view/RecentBookmarksViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/recentbookmarks/view/RecentBookmarksViewHolderTest.kt
@@ -5,24 +5,23 @@
 package org.mozilla.fenix.home.recentbookmarks.view
 
 import android.view.LayoutInflater
-import android.view.View
 import androidx.navigation.Navigation
 import io.mockk.mockk
 import io.mockk.verify
-import kotlinx.android.synthetic.main.recent_bookmarks_header.view.*
 import mozilla.components.concept.storage.BookmarkNode
 import mozilla.components.concept.storage.BookmarkNodeType
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mozilla.fenix.databinding.ComponentRecentBookmarksBinding
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.home.sessioncontrol.SessionControlInteractor
 
 @RunWith(FenixRobolectricTestRunner::class)
 class RecentBookmarksViewHolderTest {
 
-    private lateinit var view: View
+    private lateinit var binding: ComponentRecentBookmarksBinding
     private lateinit var interactor: SessionControlInteractor
 
     private val bookmark = BookmarkNode(
@@ -38,16 +37,15 @@ class RecentBookmarksViewHolderTest {
 
     @Before
     fun setup() {
-        view = LayoutInflater.from(testContext)
-            .inflate(RecentBookmarksViewHolder.LAYOUT_ID, null)
-        Navigation.setViewNavController(view, mockk(relaxed = true))
+        binding = ComponentRecentBookmarksBinding.inflate(LayoutInflater.from(testContext))
+        Navigation.setViewNavController(binding.root, mockk(relaxed = true))
         interactor = mockk(relaxed = true)
     }
 
     @Test
     fun `WHEN show all bookmarks button is clicked THEN interactor is called`() {
-        RecentBookmarksViewHolder(view, interactor).bind(listOf(bookmark))
-        view.showAllBookmarksButton.performClick()
+        RecentBookmarksViewHolder(binding.root, interactor).bind(listOf(bookmark))
+        binding.recentBookmarksHeader.showAllBookmarksButton.performClick()
 
         verify { interactor.onShowAllBookmarksClicked() }
     }

--- a/app/src/test/java/org/mozilla/fenix/home/recenttabs/view/RecentTabViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/recenttabs/view/RecentTabViewHolderTest.kt
@@ -5,13 +5,10 @@
 package org.mozilla.fenix.home.recenttabs.view
 
 import android.view.LayoutInflater
-import android.view.View
 import androidx.core.graphics.drawable.toBitmap
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import kotlinx.android.synthetic.main.recent_tabs_list_row.*
-import kotlinx.android.synthetic.main.recent_tabs_list_row.view.*
 import mozilla.components.browser.icons.BrowserIcons
 import mozilla.components.browser.icons.IconRequest
 import mozilla.components.browser.state.state.createTab
@@ -23,13 +20,14 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.R
+import org.mozilla.fenix.databinding.RecentTabsListRowBinding
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.home.sessioncontrol.SessionControlInteractor
 
 @RunWith(FenixRobolectricTestRunner::class)
 class RecentTabViewHolderTest {
 
-    private lateinit var view: View
+    private lateinit var binding: RecentTabsListRowBinding
     private lateinit var interactor: SessionControlInteractor
     private lateinit var icons: BrowserIcons
 
@@ -40,27 +38,27 @@ class RecentTabViewHolderTest {
 
     @Before
     fun setup() {
-        view = LayoutInflater.from(testContext).inflate(RecentTabViewHolder.LAYOUT_ID, null)
+        binding = RecentTabsListRowBinding.inflate(LayoutInflater.from(testContext))
         interactor = mockk(relaxed = true)
         icons = mockk(relaxed = true)
 
-        every { icons.loadIntoView(view.recent_tab_icon, any()) } returns mockk()
+        every { icons.loadIntoView(binding.recentTabIcon, any()) } returns mockk()
     }
 
     @Test
     fun `GIVEN a new recent tab on bind THEN set the title text and load the tab icon`() {
-        RecentTabViewHolder(view, interactor, icons).bindTab(tab)
+        RecentTabViewHolder(binding.root, interactor, icons).bindTab(tab)
 
-        assertEquals(tab.content.title, view.recent_tab_title.text)
+        assertEquals(tab.content.title, binding.recentTabTitle.text)
 
-        verify { icons.loadIntoView(view.recent_tab_icon, IconRequest(tab.content.url)) }
+        verify { icons.loadIntoView(binding.recentTabIcon, IconRequest(tab.content.url)) }
     }
 
     @Test
     fun `WHEN a recent tab item is clicked THEN interactor is called`() {
-        RecentTabViewHolder(view, interactor, icons).bindTab(tab)
+        RecentTabViewHolder(binding.root, interactor, icons).bindTab(tab)
 
-        view.performClick()
+        binding.root.performClick()
 
         verify { interactor.onRecentTabClicked(tab.id) }
     }
@@ -69,21 +67,21 @@ class RecentTabViewHolderTest {
     fun `WHEN a recent tab icon exists THEN load it`() {
         val bitmap = testContext.getDrawable(R.drawable.ic_search)!!.toBitmap()
         val tabWithIcon = tab.copy(content = tab.content.copy(icon = bitmap))
-        val viewHolder = RecentTabViewHolder(view, interactor, icons)
+        val viewHolder = RecentTabViewHolder(binding.root, interactor, icons)
 
-        assertNull(view.recent_tab_icon.drawable)
+        assertNull(binding.recentTabIcon.drawable)
 
         viewHolder.bindTab(tabWithIcon)
 
-        assertNotNull(view.recent_tab_icon.drawable)
+        assertNotNull(binding.recentTabIcon.drawable)
     }
 
     @Test
     fun `WHEN a recent tab does not have a title THEN show the url`() {
         val tabWithoutTitle = createTab(url = "https://mozilla.org")
 
-        RecentTabViewHolder(view, interactor, icons).bindTab(tabWithoutTitle)
+        RecentTabViewHolder(binding.root, interactor, icons).bindTab(tabWithoutTitle)
 
-        assertEquals(tabWithoutTitle.content.url, view.recent_tab_title.text)
+        assertEquals(tabWithoutTitle.content.url, binding.recentTabTitle.text)
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/home/recenttabs/view/RecentTabsHeaderViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/recenttabs/view/RecentTabsHeaderViewHolderTest.kt
@@ -5,37 +5,35 @@
 package org.mozilla.fenix.home.recenttabs.view
 
 import android.view.LayoutInflater
-import android.view.View
 import androidx.navigation.Navigation
 import io.mockk.mockk
 import io.mockk.verify
-import kotlinx.android.synthetic.main.recent_tabs_header.view.*
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mozilla.fenix.databinding.RecentTabsHeaderBinding
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.home.sessioncontrol.SessionControlInteractor
 
 @RunWith(FenixRobolectricTestRunner::class)
 class RecentTabsHeaderViewHolderTest {
 
-    private lateinit var view: View
+    private lateinit var binding: RecentTabsHeaderBinding
     private lateinit var interactor: SessionControlInteractor
 
     @Before
     fun setup() {
-        view = LayoutInflater.from(testContext)
-            .inflate(RecentTabsHeaderViewHolder.LAYOUT_ID, null)
-        Navigation.setViewNavController(view, mockk(relaxed = true))
+        binding = RecentTabsHeaderBinding.inflate(LayoutInflater.from(testContext))
+        Navigation.setViewNavController(binding.root, mockk(relaxed = true))
         interactor = mockk(relaxed = true)
     }
 
     @Test
     fun `WHEN show all button is clicked THEN interactor is called`() {
-        RecentTabsHeaderViewHolder(view, interactor)
+        RecentTabsHeaderViewHolder(binding.root, interactor)
 
-        view.show_all_button.performClick()
+        binding.showAllButton.performClick()
 
         verify { interactor.onRecentTabShowAllClicked() }
     }

--- a/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/viewholders/NoCollectionsMessageViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/viewholders/NoCollectionsMessageViewHolderTest.kt
@@ -5,13 +5,10 @@
 package org.mozilla.fenix.home.sessioncontrol.viewholders
 
 import android.view.LayoutInflater
-import android.view.View
-import androidx.appcompat.view.ContextThemeWrapper
 import androidx.core.view.isVisible
 import androidx.lifecycle.LifecycleOwner
 import io.mockk.mockk
 import io.mockk.verify
-import kotlinx.android.synthetic.main.no_collections_message.view.*
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.createTab
 import mozilla.components.browser.state.store.BrowserStore
@@ -21,14 +18,14 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mozilla.fenix.R
+import org.mozilla.fenix.databinding.NoCollectionsMessageBinding
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.home.sessioncontrol.CollectionInteractor
 
 @RunWith(FenixRobolectricTestRunner::class)
 class NoCollectionsMessageViewHolderTest {
 
-    private lateinit var view: View
+    private lateinit var binding: NoCollectionsMessageBinding
     private val store: BrowserStore = BrowserStore(
         initialState = BrowserState(
             listOf(
@@ -41,9 +38,7 @@ class NoCollectionsMessageViewHolderTest {
 
     @Before
     fun setup() {
-        val appCompatContext = ContextThemeWrapper(testContext, R.style.NormalTheme)
-        view = LayoutInflater.from(appCompatContext)
-            .inflate(NoCollectionsMessageViewHolder.LAYOUT_ID, null)
+        binding = NoCollectionsMessageBinding.inflate(LayoutInflater.from(testContext))
         lifecycleOwner = mockk(relaxed = true)
         interactor = mockk(relaxed = true)
     }
@@ -51,31 +46,31 @@ class NoCollectionsMessageViewHolderTest {
     @Test
     fun `hide add to collection button when there are no tabs open`() {
         val noTabsStore = BrowserStore()
-        NoCollectionsMessageViewHolder(view, lifecycleOwner, noTabsStore, interactor)
+        NoCollectionsMessageViewHolder(binding.root, lifecycleOwner, noTabsStore, interactor)
 
-        assertFalse(view.add_tabs_to_collections_button.isVisible)
+        assertFalse(binding.addTabsToCollectionsButton.isVisible)
     }
 
     @Test
     fun `show add to collection button when there are tabs`() {
-        NoCollectionsMessageViewHolder(view, lifecycleOwner, store, interactor)
+        NoCollectionsMessageViewHolder(binding.root, lifecycleOwner, store, interactor)
 
-        assertTrue(view.add_tabs_to_collections_button.isVisible)
+        assertTrue(binding.addTabsToCollectionsButton.isVisible)
     }
 
     @Test
     fun `call interactor on click`() {
-        NoCollectionsMessageViewHolder(view, lifecycleOwner, store, interactor)
+        NoCollectionsMessageViewHolder(binding.root, lifecycleOwner, store, interactor)
 
-        view.add_tabs_to_collections_button.performClick()
+        binding.addTabsToCollectionsButton.performClick()
         verify { interactor.onAddTabsToCollectionTapped() }
     }
 
     @Test
     fun `hide view and change setting on remove placeholder click`() {
-        NoCollectionsMessageViewHolder(view, lifecycleOwner, store, interactor)
+        NoCollectionsMessageViewHolder(binding.root, lifecycleOwner, store, interactor)
 
-        view.remove_collection_placeholder.performClick()
+        binding.removeCollectionPlaceholder.performClick()
         verify {
             interactor.onRemoveCollectionsPlaceholder()
         }

--- a/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/viewholders/PrivateBrowsingDescriptionViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/viewholders/PrivateBrowsingDescriptionViewHolderTest.kt
@@ -5,35 +5,33 @@
 package org.mozilla.fenix.home.sessioncontrol.viewholders
 
 import android.view.LayoutInflater
-import android.view.View
 import io.mockk.mockk
 import io.mockk.verify
-import kotlinx.android.synthetic.main.private_browsing_description.view.*
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mozilla.fenix.databinding.PrivateBrowsingDescriptionBinding
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.home.sessioncontrol.TabSessionInteractor
 
 @RunWith(FenixRobolectricTestRunner::class)
 class PrivateBrowsingDescriptionViewHolderTest {
 
-    private lateinit var view: View
+    private lateinit var binding: PrivateBrowsingDescriptionBinding
     private lateinit var interactor: TabSessionInteractor
 
     @Before
     fun setup() {
-        view = LayoutInflater.from(testContext)
-            .inflate(PrivateBrowsingDescriptionViewHolder.LAYOUT_ID, null)
+        binding = PrivateBrowsingDescriptionBinding.inflate(LayoutInflater.from(testContext))
         interactor = mockk(relaxed = true)
     }
 
     @Test
     fun `call interactor on click`() {
-        PrivateBrowsingDescriptionViewHolder(view, interactor)
+        PrivateBrowsingDescriptionViewHolder(binding.root, interactor)
 
-        view.private_session_common_myths.performClick()
+        binding.privateSessionCommonMyths.performClick()
         verify { interactor.onPrivateBrowsingLearnMoreClicked() }
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/viewholders/TopSiteViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/viewholders/TopSiteViewHolderTest.kt
@@ -5,34 +5,32 @@
 package org.mozilla.fenix.home.sessioncontrol.viewholders
 
 import android.view.LayoutInflater
-import android.view.View
 import io.mockk.mockk
-import kotlinx.android.synthetic.main.component_top_sites.view.*
 import mozilla.components.feature.top.sites.TopSite
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mozilla.fenix.databinding.ComponentTopSitesBinding
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.home.sessioncontrol.TopSiteInteractor
 
 @RunWith(FenixRobolectricTestRunner::class)
 class TopSiteViewHolderTest {
 
-    private lateinit var view: View
+    private lateinit var binding: ComponentTopSitesBinding
     private lateinit var interactor: TopSiteInteractor
 
     @Before
     fun setup() {
-        view = LayoutInflater.from(testContext)
-            .inflate(TopSiteViewHolder.LAYOUT_ID, null)
+        binding = ComponentTopSitesBinding.inflate(LayoutInflater.from(testContext))
         interactor = mockk()
     }
 
     @Test
     fun `binds list of top sites`() {
-        TopSiteViewHolder(view, interactor).bind(
+        TopSiteViewHolder(binding.root, interactor).bind(
             listOf(
                 TopSite(
                     id = 1L,
@@ -44,6 +42,6 @@ class TopSiteViewHolderTest {
             )
         )
 
-        assertEquals(1, view.top_sites_list.adapter!!.itemCount)
+        assertEquals(1, binding.topSitesList.adapter!!.itemCount)
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/viewholders/topsites/TopSiteItemViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/viewholders/topsites/TopSiteItemViewHolderTest.kt
@@ -5,11 +5,8 @@
 package org.mozilla.fenix.home.sessioncontrol.viewholders.topsites
 
 import android.view.LayoutInflater
-import android.view.View
-import android.widget.TextView
 import io.mockk.mockk
 import io.mockk.verify
-import kotlinx.android.synthetic.main.top_site_item.view.*
 import mozilla.components.feature.top.sites.TopSite
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertNotNull
@@ -17,14 +14,14 @@ import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mozilla.fenix.R
+import org.mozilla.fenix.databinding.TopSiteItemBinding
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.home.sessioncontrol.TopSiteInteractor
 
 @RunWith(FenixRobolectricTestRunner::class)
 class TopSiteItemViewHolderTest {
 
-    private lateinit var view: View
+    private lateinit var binding: TopSiteItemBinding
     private lateinit var interactor: TopSiteInteractor
     private val pocket = TopSite(
         id = 1L,
@@ -36,24 +33,23 @@ class TopSiteItemViewHolderTest {
 
     @Before
     fun setup() {
-        view = LayoutInflater.from(testContext)
-            .inflate(TopSiteItemViewHolder.LAYOUT_ID, null)
+        binding = TopSiteItemBinding.inflate(LayoutInflater.from(testContext))
         interactor = mockk(relaxed = true)
     }
 
     @Test
     fun `calls interactor on click`() {
-        TopSiteItemViewHolder(view, interactor).bind(pocket)
+        TopSiteItemViewHolder(binding.root, interactor).bind(pocket)
 
-        view.top_site_item.performClick()
+        binding.topSiteItem.performClick()
         verify { interactor.onSelectTopSite("https://getpocket.com", TopSite.Type.DEFAULT) }
     }
 
     @Test
     fun `calls interactor on long click`() {
-        TopSiteItemViewHolder(view, interactor).bind(pocket)
+        TopSiteItemViewHolder(binding.root, interactor).bind(pocket)
 
-        view.top_site_item.performLongClick()
+        binding.topSiteItem.performLongClick()
         verify { interactor.onTopSiteMenuOpened() }
     }
 
@@ -67,8 +63,8 @@ class TopSiteItemViewHolderTest {
             type = TopSite.Type.DEFAULT
         )
 
-        TopSiteItemViewHolder(view, interactor).bind(defaultTopSite)
-        val pinIndicator = view.findViewById<TextView>(R.id.top_site_title).compoundDrawables[0]
+        TopSiteItemViewHolder(binding.root, interactor).bind(defaultTopSite)
+        val pinIndicator = binding.topSiteTitle.compoundDrawables[0]
 
         assertNotNull(pinIndicator)
     }
@@ -83,8 +79,8 @@ class TopSiteItemViewHolderTest {
             type = TopSite.Type.PINNED
         )
 
-        TopSiteItemViewHolder(view, interactor).bind(pinnedTopSite)
-        val pinIndicator = view.findViewById<TextView>(R.id.top_site_title).compoundDrawables[0]
+        TopSiteItemViewHolder(binding.root, interactor).bind(pinnedTopSite)
+        val pinIndicator = binding.topSiteTitle.compoundDrawables[0]
 
         assertNotNull(pinIndicator)
     }
@@ -99,8 +95,8 @@ class TopSiteItemViewHolderTest {
             type = TopSite.Type.FRECENT
         )
 
-        TopSiteItemViewHolder(view, interactor).bind(frecentTopSite)
-        val pinIndicator = view.findViewById<TextView>(R.id.top_site_title).compoundDrawables[0]
+        TopSiteItemViewHolder(binding.root, interactor).bind(frecentTopSite)
+        val pinIndicator = binding.topSiteTitle.compoundDrawables[0]
 
         assertNull(pinIndicator)
     }

--- a/app/src/test/java/org/mozilla/fenix/home/tips/ButtonTipViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/tips/ButtonTipViewHolderTest.kt
@@ -16,7 +16,6 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
-import kotlinx.android.synthetic.main.button_tip_item.*
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -29,6 +28,7 @@ import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.components.metrics.MetricController
 import org.mozilla.fenix.components.tips.Tip
 import org.mozilla.fenix.components.tips.TipType
+import org.mozilla.fenix.databinding.ButtonTipItemBinding
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.home.sessioncontrol.SessionControlInteractor
 import org.mozilla.fenix.utils.Settings
@@ -43,6 +43,7 @@ class ButtonTipViewHolderTest {
     @MockK private lateinit var sharedPrefs: SharedPreferences
     @MockK private lateinit var sharedPrefsEditor: SharedPreferences.Editor
     private lateinit var viewHolder: ButtonTipViewHolder
+    private lateinit var binding: ButtonTipItemBinding
 
     @Before
     fun setup() {
@@ -53,6 +54,7 @@ class ButtonTipViewHolderTest {
         )
 
         viewHolder = ButtonTipViewHolder(view, interactor, metrics, settings)
+        binding = ButtonTipItemBinding.bind(view)
         every { view.context } returns activity
         every { activity.openToBrowserAndLoad(any(), any(), any()) } just Runs
         every { interactor.onCloseTip(any()) } just Runs
@@ -66,9 +68,9 @@ class ButtonTipViewHolderTest {
     fun `text is displayed based on given tip`() {
         viewHolder.bind(defaultTip())
 
-        assertEquals("Tip Title", viewHolder.tip_header_text.text)
-        assertEquals("Tip description", viewHolder.tip_description_text.text)
-        assertEquals("button", viewHolder.tip_button.text)
+        assertEquals("Tip Title", binding.tipHeaderText.text)
+        assertEquals("Tip description", binding.tipDescriptionText.text)
+        assertEquals("button", binding.tipButton.text)
 
         verify { metrics.track(Event.TipDisplayed("tipIdentifier")) }
     }
@@ -77,16 +79,16 @@ class ButtonTipViewHolderTest {
     fun `learn more is hidden if learnMoreURL is null`() {
         viewHolder.bind(defaultTip(learnMoreUrl = null))
 
-        assertTrue(viewHolder.tip_learn_more.isGone)
+        assertTrue(binding.tipLearnMore.isGone)
     }
 
     @Test
     fun `learn more is visible if learnMoreURL is not null`() {
         viewHolder.bind(defaultTip(learnMoreUrl = "https://learnmore.com"))
 
-        assertTrue(viewHolder.tip_learn_more.isVisible)
+        assertTrue(binding.tipLearnMore.isVisible)
 
-        viewHolder.tip_learn_more.performClick()
+        binding.tipLearnMore.performClick()
         verify {
             activity.openToBrowserAndLoad(
                 searchTermOrURL = "https://learnmore.com",
@@ -101,7 +103,7 @@ class ButtonTipViewHolderTest {
         val action = mockk<() -> Unit>(relaxed = true)
         viewHolder.bind(defaultTip(action))
 
-        viewHolder.tip_button.performClick()
+        binding.tipButton.performClick()
         verify { action() }
         verify { metrics.track(Event.TipPressed("tipIdentifier")) }
     }
@@ -111,7 +113,7 @@ class ButtonTipViewHolderTest {
         val tip = defaultTip()
         viewHolder.bind(tip)
 
-        viewHolder.tip_close.performClick()
+        binding.tipClose.performClick()
         verify { interactor.onCloseTip(tip) }
         verify { metrics.track(Event.TipClosed("tipIdentifier")) }
         verify { sharedPrefsEditor.putBoolean("tipIdentifier", false) }

--- a/app/src/test/java/org/mozilla/fenix/perf/StartupReportFullyDrawnTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/perf/StartupReportFullyDrawnTest.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.fenix.perf
 
+import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewTreeObserver
 import android.widget.LinearLayout
@@ -15,16 +16,21 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
+import io.mockk.spyk
 import io.mockk.verify
-import kotlinx.android.synthetic.main.top_site_item.view.*
+import mozilla.components.support.test.robolectric.testContext
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
+import org.mozilla.fenix.databinding.TopSiteItemBinding
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.home.sessioncontrol.viewholders.topsites.TopSiteItemViewHolder
 import org.mozilla.fenix.perf.StartupTimelineStateMachine.StartupDestination
 import org.mozilla.fenix.perf.StartupTimelineStateMachine.StartupState
 
+@RunWith(FenixRobolectricTestRunner::class)
 class StartupReportFullyDrawnTest {
 
     @MockK private lateinit var activity: HomeActivity
@@ -37,9 +43,10 @@ class StartupReportFullyDrawnTest {
     @Before
     fun setup() {
         MockKAnnotations.init(this)
+        val binding = TopSiteItemBinding.inflate(LayoutInflater.from(testContext), rootContainer, false)
+        holderItemView = spyk(binding.root)
         every { activity.findViewById<LinearLayout>(R.id.rootContainer) } returns rootContainer
         every { holderItemView.context } returns activity
-        every { holderItemView.top_site_item } returns mockk(relaxed = true)
         holder = TopSiteItemViewHolder(holderItemView, mockk())
         every { rootContainer.viewTreeObserver } returns viewTreeObserver
         every { holderItemView.viewTreeObserver } returns viewTreeObserver


### PR DESCRIPTION
Everything works as before but there's no `kotlinx.android.*` in this package anymore.

https://user-images.githubusercontent.com/11428869/129686827-6c4d7be3-e755-4874-8817-c1bd2a9a639d.mp4

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
