### PR TITLE
For #17917 - Migrate `browser` from Kotlin synthetics to View Binding.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -13,8 +13,6 @@ import androidx.appcompat.content.res.AppCompatResources
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.snackbar.Snackbar
-import kotlinx.android.synthetic.main.fragment_browser.*
-import kotlinx.android.synthetic.main.fragment_browser.view.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.components.browser.state.selector.findTab
 import mozilla.components.browser.state.state.SessionState
@@ -64,11 +62,11 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
         val components = context.components
 
         if (context.settings().isSwipeToolbarToSwitchTabsEnabled) {
-            gestureLayout.addGestureListener(
+            binding.gestureLayout.addGestureListener(
                 ToolbarGestureHandler(
                     activity = requireActivity(),
-                    contentLayout = browserLayout,
-                    tabPreview = tabPreview,
+                    contentLayout = binding.browserLayout,
+                    tabPreview = binding.tabPreview,
                     toolbarLayout = browserToolbarView.view,
                     store = components.core.store,
                     selectTabUseCase = components.useCases.tabsUseCases.selectTab
@@ -196,7 +194,7 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
         browserToolbarView.view.addPageAction(readerModeAction)
 
         thumbnailsFeature.set(
-            feature = BrowserThumbnails(context, view.engineView, components.core.store),
+            feature = BrowserThumbnails(context, binding.engineView, components.core.store),
             owner = this,
             view = view
         )
@@ -207,7 +205,7 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
                     context,
                     components.core.engine,
                     components.core.store,
-                    view.readerViewControlsBar
+                    binding.readerViewControlsBar
                 ) { available, active ->
                     if (available) {
                         components.analytics.metrics.track(Event.ReaderModeAvailable)
@@ -240,7 +238,7 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
                     navController = findNavController(),
                     settings = context.settings(),
                     appLinksUseCases = context.components.useCases.appLinksUseCases,
-                    container = browserLayout as ViewGroup,
+                    container = binding.browserLayout as ViewGroup,
                     shouldScrollWithTopToolbar = !context.settings().shouldUseBottomToolbar
                 ),
                 owner = this,
@@ -355,7 +353,7 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
                     }
                 }
                 FenixSnackbar.make(
-                    view = view.browserLayout,
+                    view = binding.browserLayout,
                     duration = Snackbar.LENGTH_SHORT,
                     isDisplayedWithBrowserToolbar = true
                 )

--- a/app/src/main/java/org/mozilla/fenix/browser/TabPreview.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/TabPreview.kt
@@ -13,11 +13,10 @@ import android.widget.FrameLayout
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.view.doOnNextLayout
 import androidx.core.view.updateLayoutParams
-import kotlinx.android.synthetic.main.tab_preview.view.*
-import kotlinx.android.synthetic.main.tabs_tray_tab_counter.view.*
 import mozilla.components.browser.thumbnails.loader.ThumbnailLoader
 import mozilla.components.concept.base.images.ImageLoadRequest
 import org.mozilla.fenix.R
+import org.mozilla.fenix.databinding.TabPreviewBinding
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.theme.ThemeManager
@@ -29,32 +28,30 @@ class TabPreview @JvmOverloads constructor(
     defStyle: Int = 0
 ) : FrameLayout(context, attrs, defStyle) {
 
+    private val binding = TabPreviewBinding.inflate(LayoutInflater.from(context), this)
     private val thumbnailLoader = ThumbnailLoader(context.components.core.thumbnailStorage)
 
     init {
-        val inflater = LayoutInflater.from(context)
-        inflater.inflate(R.layout.tab_preview, this, true)
-
         if (!context.settings().shouldUseBottomToolbar) {
-            fakeToolbar.updateLayoutParams<LayoutParams> {
+            binding.fakeToolbar.updateLayoutParams<LayoutParams> {
                 gravity = Gravity.TOP
             }
 
-            fakeToolbar.background = AppCompatResources.getDrawable(
+            binding.fakeToolbar.background = AppCompatResources.getDrawable(
                 context,
                 ThemeManager.resolveAttribute(R.attr.bottomBarBackgroundTop, context)
             )
         }
 
         // Change view properties to avoid confusing the UI tests
-        tab_button.counter_box.id = View.NO_ID
-        tab_button.counter_text.id = View.NO_ID
+        binding.tabButton.findViewById<View>(R.id.counter_box).id = View.NO_ID
+        binding.tabButton.findViewById<View>(R.id.counter_text).id = View.NO_ID
     }
 
     override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
         super.onLayout(changed, left, top, right, bottom)
-        previewThumbnail.translationY = if (!context.settings().shouldUseBottomToolbar) {
-            fakeToolbar.height.toFloat()
+        binding.previewThumbnail.translationY = if (!context.settings().shouldUseBottomToolbar) {
+            binding.fakeToolbar.height.toFloat()
         } else {
             0f
         }
@@ -62,6 +59,7 @@ class TabPreview @JvmOverloads constructor(
 
     fun loadPreviewThumbnail(thumbnailId: String) {
         doOnNextLayout {
+            val previewThumbnail = binding.previewThumbnail
             val thumbnailSize = max(previewThumbnail.height, previewThumbnail.width)
             thumbnailLoader.loadIntoView(
                 previewThumbnail,

--- a/app/src/main/java/org/mozilla/fenix/browser/infobanner/DynamicInfoBanner.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/infobanner/DynamicInfoBanner.kt
@@ -34,7 +34,7 @@ class DynamicInfoBanner(
         super.showBanner()
 
         if (shouldScrollWithTopToolbar) {
-            (bannerLayout.layoutParams as CoordinatorLayout.LayoutParams).behavior = DynamicInfoBannerBehavior(
+            (binding.root.layoutParams as CoordinatorLayout.LayoutParams).behavior = DynamicInfoBannerBehavior(
                 context, null
             )
         }

--- a/app/src/main/java/org/mozilla/fenix/browser/infobanner/InfoBanner.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/infobanner/InfoBanner.kt
@@ -10,8 +10,7 @@ import android.view.LayoutInflater
 import android.view.View.GONE
 import android.view.ViewGroup
 import androidx.annotation.VisibleForTesting
-import kotlinx.android.synthetic.main.info_banner.view.*
-import org.mozilla.fenix.R
+import org.mozilla.fenix.databinding.InfoBannerBinding
 import org.mozilla.fenix.ext.settings
 
 /**
@@ -40,27 +39,26 @@ open class InfoBanner(
 ) {
     @SuppressLint("InflateParams")
     @VisibleForTesting
-    internal val bannerLayout = LayoutInflater.from(context)
-        .inflate(R.layout.info_banner, null)
+    internal val binding = InfoBannerBinding.inflate(LayoutInflater.from(context), container, false)
 
     internal open fun showBanner() {
-        bannerLayout.banner_info_message.text = message
-        bannerLayout.dismiss.text = dismissText
+        binding.bannerInfoMessage.text = message
+        binding.dismiss.text = dismissText
 
         if (actionText.isNullOrEmpty()) {
-            bannerLayout.action.visibility = GONE
+            binding.action.visibility = GONE
         } else {
-            bannerLayout.action.text = actionText
+            binding.action.text = actionText
         }
 
-        container.addView(bannerLayout)
+        container.addView(binding.root)
 
-        bannerLayout.dismiss.setOnClickListener {
+        binding.dismiss.setOnClickListener {
             dismissAction?.invoke()
-            if (dismissByHiding) { bannerLayout.visibility = GONE } else { dismiss() }
+            if (dismissByHiding) { binding.root.visibility = GONE } else { dismiss() }
         }
 
-        bannerLayout.action.setOnClickListener {
+        binding.action.setOnClickListener {
             actionToPerform?.invoke()
         }
 
@@ -68,6 +66,6 @@ open class InfoBanner(
     }
 
     internal fun dismiss() {
-        container.removeView(bannerLayout)
+        container.removeView(binding.root)
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/browser/BrowserFragmentTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/browser/BrowserFragmentTest.kt
@@ -90,7 +90,7 @@ class BrowserFragmentTest {
         every { browserFragment.requireContext() } returns context
         every { browserFragment.initializeUI(any(), any()) } returns mockk()
         every { browserFragment.fullScreenChanged(any()) } returns Unit
-        every { browserFragment.resumeDownloadDialogState(any(), any(), any(), any(), any()) } returns Unit
+        every { browserFragment.resumeDownloadDialogState(any(), any(), any(), any()) } returns Unit
 
         testTab = createTab(url = "https://mozilla.org")
         store = BrowserStore()
@@ -160,7 +160,7 @@ class BrowserFragmentTest {
         val newSelectedTab = createTab("https://firefox.com")
         addAndSelectTab(newSelectedTab)
         verify(exactly = 1) {
-            browserFragment.resumeDownloadDialogState(newSelectedTab.id, store, view, context, any())
+            browserFragment.resumeDownloadDialogState(newSelectedTab.id, store, context, any())
         }
     }
 

--- a/app/src/test/java/org/mozilla/fenix/browser/OpenInAppOnboardingObserverTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/browser/OpenInAppOnboardingObserverTest.kt
@@ -6,6 +6,7 @@ package org.mozilla.fenix.browser
 
 import android.content.Context
 import android.view.ViewGroup
+import android.widget.FrameLayout
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
@@ -172,7 +173,7 @@ class OpenInAppOnboardingObserverTest {
 
         openInAppOnboardingObserver = spyk(
             OpenInAppOnboardingObserver(
-                testContext, mockk(), mockk(), mockk(), mockk(), mockk(), mockk(), shouldScrollWithTopToolbar = true
+                testContext, mockk(), mockk(), mockk(), mockk(), mockk(), FrameLayout(testContext), shouldScrollWithTopToolbar = true
             )
         )
         val banner1 = openInAppOnboardingObserver.createInfoBanner()
@@ -180,7 +181,7 @@ class OpenInAppOnboardingObserverTest {
 
         openInAppOnboardingObserver = spyk(
             OpenInAppOnboardingObserver(
-                testContext, mockk(), mockk(), mockk(), mockk(), mockk(), mockk(), shouldScrollWithTopToolbar = false
+                testContext, mockk(), mockk(), mockk(), mockk(), mockk(), FrameLayout(testContext), shouldScrollWithTopToolbar = false
             )
         )
         val banner2 = openInAppOnboardingObserver.createInfoBanner()

--- a/app/src/test/java/org/mozilla/fenix/browser/infobanner/DynamicInfoBannerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/browser/infobanner/DynamicInfoBannerTest.kt
@@ -25,7 +25,7 @@ class DynamicInfoBannerTest {
 
         banner.showBanner()
 
-        assertTrue((banner.bannerLayout.layoutParams as CoordinatorLayout.LayoutParams).behavior is DynamicInfoBannerBehavior)
+        assertTrue((banner.binding.root.layoutParams as CoordinatorLayout.LayoutParams).behavior is DynamicInfoBannerBehavior)
     }
 
     @Test
@@ -38,6 +38,6 @@ class DynamicInfoBannerTest {
 
         banner.showBanner()
 
-        assertNull((banner.bannerLayout.layoutParams as CoordinatorLayout.LayoutParams).behavior)
+        assertNull((banner.binding.root.layoutParams as CoordinatorLayout.LayoutParams).behavior)
     }
 }


### PR DESCRIPTION
Everything works as before but there's no kotlinx.android.* in this package anymore.


https://user-images.githubusercontent.com/11428869/129694472-8e7175f4-6346-4895-bda0-5cd2a52a4cbd.mp4



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
