### PR TITLE
For #20890 when TP is off globally hide TP section on quick settings.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/quicksettings/TrackingProtectionView.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/quicksettings/TrackingProtectionView.kt
@@ -6,9 +6,13 @@ package org.mozilla.fenix.settings.quicksettings
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.annotation.VisibleForTesting
+import androidx.core.view.isVisible
 import org.mozilla.fenix.R
 import org.mozilla.fenix.databinding.QuicksettingsTrackingProtectionBinding
+import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.trackingprotection.TrackingProtectionState
+import org.mozilla.fenix.utils.Settings
 
 /**
  * Contract declaring all possible user interactions with [TrackingProtectionView].
@@ -35,24 +39,31 @@ interface TrackingProtectionInteractor {
  *
  * @param containerView [ViewGroup] in which this View will inflate itself.
  * @param interactor [TrackingProtectionInteractor] which will have delegated to all user
+ * @param settings [Settings] application settings.
  * interactions.
  */
 class TrackingProtectionView(
     val containerView: ViewGroup,
     val interactor: TrackingProtectionInteractor,
+    val settings: Settings
 ) {
     private val context = containerView.context
-    private val binding = QuicksettingsTrackingProtectionBinding.inflate(
+    @VisibleForTesting
+    internal val binding = QuicksettingsTrackingProtectionBinding.inflate(
         LayoutInflater.from(containerView.context),
         containerView,
         true
     )
     fun update(state: TrackingProtectionState) {
         bindTrackingProtectionInfo(state.isTrackingProtectionEnabled)
-
+        binding.root.isVisible = settings.shouldUseTrackingProtection
         binding.trackingProtectionDetails.setOnClickListener {
             interactor.onDetailsClicked()
         }
+    }
+
+    fun updateDetailsSection(show: Boolean) {
+        binding.trackingProtectionDetails.isVisible = show
     }
 
     private fun bindTrackingProtectionInfo(isTrackingProtectionEnabled: Boolean) {

--- a/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionPanelDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionPanelDialogFragment.kt
@@ -82,7 +82,7 @@ class TrackingProtectionPanelDialogFragment : AppCompatDialogFragment(), UserInt
     ): View {
         val store = requireComponents.core.store
         val view = inflateRootView(container)
-        val tab = store.state.findTabOrCustomTab(provideTabId())
+        val tab = store.state.findTabOrCustomTab(provideCurrentTabId())
 
         trackingProtectionStore = StoreProvider.get(this) {
             TrackingProtectionStore(
@@ -201,7 +201,7 @@ class TrackingProtectionPanelDialogFragment : AppCompatDialogFragment(), UserInt
     internal fun observeUrlChange(store: BrowserStore) {
         consumeFlow(store) { flow ->
             flow.mapNotNull { state ->
-                state.findTabOrCustomTab(provideTabId())
+                state.findTabOrCustomTab(provideCurrentTabId())
             }.ifChanged { tab -> tab.content.url }
                 .collect {
                     trackingProtectionStore.dispatch(TrackingProtectionAction.UrlChange(it.content.url))
@@ -210,13 +210,13 @@ class TrackingProtectionPanelDialogFragment : AppCompatDialogFragment(), UserInt
     }
 
     @VisibleForTesting
-    internal fun provideTabId(): String = args.sessionId
+    internal fun provideCurrentTabId(): String = args.sessionId
 
     @VisibleForTesting
     internal fun observeTrackersChange(store: BrowserStore) {
         consumeFlow(store) { flow ->
             flow.mapNotNull { state ->
-                state.findTabOrCustomTab(provideTabId())
+                state.findTabOrCustomTab(provideCurrentTabId())
             }.ifAnyChanged { tab ->
                 arrayOf(
                     tab.trackingProtection.blockedTrackers,

--- a/app/src/main/res/layout/quicksettings_tracking_protection.xml
+++ b/app/src/main/res/layout/quicksettings_tracking_protection.xml
@@ -29,6 +29,7 @@
         android:gravity="end|center_vertical"
         android:layout_alignParentEnd="true"
         android:text="@string/enhanced_tracking_protection_details"
+        android:visibility="gone"
         app:drawableEndCompat="@drawable/ic_arrowhead_right"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/test/java/org/mozilla/fenix/settings/quicksettings/TrackingProtectionViewTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/quicksettings/TrackingProtectionViewTest.kt
@@ -1,0 +1,95 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.settings.quicksettings
+
+import android.widget.FrameLayout
+import androidx.core.view.isVisible
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import io.mockk.spyk
+import mozilla.components.browser.state.state.createTab
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.fenix.databinding.QuicksettingsTrackingProtectionBinding
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+import org.mozilla.fenix.trackingprotection.TrackingProtectionState
+import org.mozilla.fenix.utils.Settings
+
+@RunWith(FenixRobolectricTestRunner::class)
+class TrackingProtectionViewTest {
+
+    private lateinit var view: TrackingProtectionView
+    private lateinit var binding: QuicksettingsTrackingProtectionBinding
+    private lateinit var interactor: TrackingProtectionInteractor
+
+    @MockK(relaxed = true)
+    private lateinit var settings: Settings
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this)
+        interactor = mockk(relaxed = true)
+        view = spyk(TrackingProtectionView(FrameLayout(testContext), interactor, settings))
+        binding = view.binding
+    }
+
+    @Test
+    fun `WHEN updating THEN bind checkbox`() {
+        val websiteUrl = "https://mozilla.org"
+        val state = TrackingProtectionState(
+            tab = createTab(url = websiteUrl),
+            url = websiteUrl,
+            isTrackingProtectionEnabled = true,
+            listTrackers = listOf(),
+            mode = TrackingProtectionState.Mode.Normal,
+            lastAccessedCategory = ""
+        )
+
+        every { settings.shouldUseTrackingProtection } returns true
+
+        view.update(state)
+
+        assertTrue(binding.root.isVisible)
+        assertTrue(binding.trackingProtectionSwitch.switchWidget.isChecked)
+    }
+
+    @Test
+    fun `GIVEN TP is globally off WHEN updating THEN hide the TP section`() {
+        val websiteUrl = "https://mozilla.org"
+        val state = TrackingProtectionState(
+            tab = createTab(url = websiteUrl),
+            url = websiteUrl,
+            isTrackingProtectionEnabled = true,
+            listTrackers = listOf(),
+            mode = TrackingProtectionState.Mode.Normal,
+            lastAccessedCategory = ""
+        )
+
+        every { settings.shouldUseTrackingProtection } returns false
+
+        view.update(state)
+
+        assertFalse(binding.root.isVisible)
+    }
+
+    @Test
+    fun `WHEN updateDetailsSection is called THEN update the visibility of the section`() {
+        every { settings.shouldUseTrackingProtection } returns false
+
+        view.updateDetailsSection(false)
+
+        assertFalse(binding.trackingProtectionDetails.isVisible)
+
+        view.updateDetailsSection(true)
+
+        assertTrue(binding.trackingProtectionDetails.isVisible)
+    }
+}


### PR DESCRIPTION
This patch adds:

* Hide the "Details" section when we don't have trackers to show.
* Hide he tracking protection section when TP is globally off.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
