### PR TITLE
Closes #20901: Do not record viewTime observations when we do not have a set lastAccess

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/historymetadata/HistoryMetadataService.kt
+++ b/app/src/main/java/org/mozilla/fenix/historymetadata/HistoryMetadataService.kt
@@ -81,11 +81,17 @@ class DefaultHistoryMetadataService(
     }
 
     override fun updateMetadata(key: HistoryMetadataKey, tab: TabSessionState) {
-        logger.debug("Updating metadata for tab $tab")
+        val lastAccess = tab.lastAccess
+        if (lastAccess == 0L) {
+            logger.debug("Not updating metadata for tab $tab - lastAccess=0")
+            return
+        } else {
+            logger.debug("Updating metadata for tab $tab")
+        }
 
         scope.launch {
             val viewTimeObservation = HistoryMetadataObservation.ViewTimeObservation(
-                viewTime = (System.currentTimeMillis() - tab.lastAccess).toInt()
+                viewTime = (System.currentTimeMillis() - lastAccess).toInt()
             )
             storage.noteHistoryMetadataObservation(key, viewTimeObservation)
         }


### PR DESCRIPTION
The bug here was that we'd try to record `now - 0` as a viewTime delta.
This isn't just an obviously wrong value to record, but it will also
overflow our storage - we'll end up with a value on disk that doesn't
fit into an i32, but HistoryMetadata.total_view_time is i32 in our Rust
struct. Once that happens, reads that touch this bad row will result in
an overflow and a crash.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
