### PR TITLE
Enable recording of history metadata for all builds

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -45,9 +45,9 @@ object FeatureFlags {
     val showRecentTabsFeature = Config.channel.isNightlyOrDebug
 
     /**
-     * Enables recording of history metadata.
+     * Enables UI features based on history metadata.
      */
-    val historyMetadataFeature = Config.channel.isDebug
+    val historyMetadataUIFeature = Config.channel.isDebug
 
     /**
      * Enables the recently saved bookmarks feature in the home screen.

--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -272,9 +272,7 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
     override fun onStop() {
         super.onStop()
         updateLastBrowseActivity()
-        if (requireContext().settings().historyMetadataFeature) {
-            updateHistoryMetadata()
-        }
+        updateHistoryMetadata()
         pwaOnboardingObserver?.stop()
     }
 

--- a/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -208,12 +208,9 @@ class Core(
                 RecordingDevicesMiddleware(context),
                 PromptMiddleware(),
                 AdsTelemetryMiddleware(adsTelemetry),
-                LastMediaAccessMiddleware()
+                LastMediaAccessMiddleware(),
+                HistoryMetadataMiddleware(historyMetadataService)
             )
-
-        if (context.settings().historyMetadataFeature) {
-            middlewareList += HistoryMetadataMiddleware(historyMetadataService)
-        }
 
         BrowserStore(
             middleware = middlewareList + EngineMiddleware.create(engine)

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -270,7 +270,7 @@ class HomeFragment : Fragment() {
             )
         }
 
-        if (requireContext().settings().historyMetadataFeature) {
+        if (requireContext().settings().historyMetadataUIFeature) {
             historyMetadataFeature.set(
                 feature = HistoryMetadataFeature(
                     homeStore = homeFragmentStore,

--- a/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarView.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarView.kt
@@ -251,7 +251,7 @@ class AwesomeBarView(
         val providersToAdd = mutableSetOf<AwesomeBar.SuggestionProvider>()
 
         if (state.showHistorySuggestions) {
-            if (activity.settings().historyMetadataFeature) {
+            if (activity.settings().historyMetadataUIFeature) {
                 providersToAdd.add(combinedHistoryProvider)
             } else {
                 providersToAdd.add(historyStorageProvider)
@@ -285,7 +285,7 @@ class AwesomeBarView(
         providersToRemove.add(shortcutsEnginePickerProvider)
 
         if (!state.showHistorySuggestions) {
-            if (activity.settings().historyMetadataFeature) {
+            if (activity.settings().historyMetadataUIFeature) {
                 providersToRemove.add(combinedHistoryProvider)
             } else {
                 providersToRemove.add(historyStorageProvider)

--- a/app/src/main/java/org/mozilla/fenix/settings/SecretSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SecretSettingsFragment.kt
@@ -36,7 +36,7 @@ class SecretSettingsFragment : PreferenceFragmentCompat() {
 
         requirePreference<SwitchPreference>(R.string.pref_key_history_metadata_feature).apply {
             isVisible = true
-            isChecked = context.settings().historyMetadataFeature
+            isChecked = context.settings().historyMetadataUIFeature
             onPreferenceChangeListener = object : SharedPreferenceUpdater() {
                 override fun onPreferenceChange(preference: Preference, newValue: Any?): Boolean {
                     val result = super.onPreferenceChange(preference, newValue)

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -1101,10 +1101,10 @@ class Settings(private val appContext: Context) : PreferencesHolder {
         default = false
     )
 
-    var historyMetadataFeature by featureFlagPreference(
+    var historyMetadataUIFeature by featureFlagPreference(
         appContext.getPreferenceKey(R.string.pref_key_history_metadata_feature),
-        default = FeatureFlags.historyMetadataFeature,
-        featureFlag = FeatureFlags.historyMetadataFeature || isHistoryMetadataEnabled
+        default = FeatureFlags.historyMetadataUIFeature,
+        featureFlag = FeatureFlags.historyMetadataUIFeature || isHistoryMetadataEnabled
     )
 
     /**


### PR DESCRIPTION
This allows recording part of history metadata to ride the trains.
The UI features are still guarded by the secret settings flag (or,
enabled on debug builds).


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
