### PR TITLE
For #20919 quit the app after removing a study.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/studies/StudiesAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/studies/StudiesAdapter.kt
@@ -5,12 +5,15 @@
 package org.mozilla.fenix.settings.studies
 
 import android.annotation.SuppressLint
+import android.content.Context
+import android.content.DialogInterface
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
+import androidx.appcompat.app.AlertDialog
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
@@ -117,8 +120,30 @@ class StudiesAdapter(
         holder.summaryView.text = study.userFacingDescription
 
         holder.deleteButton.setOnClickListener {
-            studiesDelegate.onRemoveButtonClicked(study)
+            showDeleteDialog(holder.titleView.context, study)
         }
+    }
+
+    @VisibleForTesting
+    internal fun showDeleteDialog(context: Context, study: EnrolledExperiment): AlertDialog {
+        val builder = AlertDialog.Builder(context)
+            .setPositiveButton(
+                R.string.studies_restart_dialog_ok
+            ) { dialog, _ ->
+                studiesDelegate.onRemoveButtonClicked(study)
+                dialog.dismiss()
+            }
+            .setNegativeButton(
+                R.string.studies_restart_dialog_cancel
+            ) { dialog: DialogInterface, _ ->
+                dialog.dismiss()
+            }
+            .setTitle(R.string.preference_experiments_2)
+            .setMessage(R.string.studies_restart_app)
+            .setCancelable(false)
+        val alertDialog: AlertDialog = builder.create()
+        alertDialog.show()
+        return alertDialog
     }
 
     internal fun createListWithSections(studies: List<EnrolledExperiment>): List<Any> {

--- a/app/src/main/java/org/mozilla/fenix/settings/studies/StudiesInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/studies/StudiesInteractor.kt
@@ -4,10 +4,12 @@
 
 package org.mozilla.fenix.settings.studies
 
+import androidx.annotation.VisibleForTesting
 import mozilla.components.service.nimbus.NimbusApi
 import org.mozilla.experiments.nimbus.internal.EnrolledExperiment
 import org.mozilla.fenix.BrowserDirection
 import org.mozilla.fenix.HomeActivity
+import kotlin.system.exitProcess
 
 interface StudiesInteractor {
     /**
@@ -35,5 +37,11 @@ class DefaultStudiesInteractor(
 
     override fun removeStudy(experiment: EnrolledExperiment) {
         experiments.optOut(experiment.slug)
+        killApplication()
+    }
+
+    @VisibleForTesting
+    internal fun killApplication() {
+        exitProcess(0)
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -623,6 +623,12 @@
     <string name="studies_description">Firefox may install and run studies from time to time.</string>
     <!-- Learn more link for studies, links to an article for more information about studies. -->
     <string name="studies_learn_more">Learn more</string>
+    <!-- Dialog message shown after removing a study -->
+    <string name="studies_restart_app">The application will quit to apply changes</string>
+    <!-- Dialog button to confirm the removing a study. -->
+    <string name="studies_restart_dialog_ok">OK</string>
+    <!-- Dialog button text for canceling removing a study. -->
+    <string name="studies_restart_dialog_cancel">Cancel</string>
 
     <!-- Sessions -->
     <!-- Title for the list of tabs -->

--- a/app/src/test/java/org/mozilla/fenix/settings/studies/DefaultStudiesInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/studies/DefaultStudiesInteractorTest.kt
@@ -7,7 +7,10 @@ package org.mozilla.fenix.settings.studies
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.RelaxedMockK
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.spyk
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.components.service.nimbus.NimbusApi
@@ -30,7 +33,7 @@ class DefaultStudiesInteractorTest {
     @Before
     fun setup() {
         MockKAnnotations.init(this)
-        interactor = DefaultStudiesInteractor(activity, experiments)
+        interactor = spyk(DefaultStudiesInteractor(activity, experiments))
     }
 
     @Test
@@ -48,6 +51,7 @@ class DefaultStudiesInteractorTest {
         val experiment = mockk<EnrolledExperiment>(relaxed = true)
 
         every { experiment.slug } returns "slug"
+        every { interactor.killApplication() } just runs
 
         interactor.removeStudy(experiment)
 

--- a/app/src/test/java/org/mozilla/fenix/settings/studies/StudiesAdapterTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/studies/StudiesAdapterTest.kt
@@ -16,9 +16,9 @@ import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.spyk
 import io.mockk.verify
-import junit.framework.TestCase.assertTrue
-import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Before
@@ -69,7 +69,7 @@ class StudiesAdapterTest {
     fun `WHEN bindStudy THEN bind the study information`() {
         val holder = mockk<StudyViewHolder>()
         val study = mockk<EnrolledExperiment>()
-        val titleView = mockk<TextView>(relaxed = true)
+        val titleView = spyk(TextView(testContext))
         val summaryView = mockk<TextView>(relaxed = true)
         val deleteButton = spyk(MaterialButton(testContext))
 
@@ -82,6 +82,8 @@ class StudiesAdapterTest {
 
         adapter = spyk(StudiesAdapter(delegate, listOf(study), false))
 
+        every { adapter.showDeleteDialog(any(), any()) } returns mockk()
+
         adapter.bindStudy(holder, study)
 
         verify {
@@ -92,7 +94,7 @@ class StudiesAdapterTest {
         deleteButton.performClick()
 
         verify {
-            delegate.onRemoveButtonClicked(study)
+            adapter.showDeleteDialog(any(), any())
         }
     }
 


### PR DESCRIPTION

The crash on #20919 was caused because the deleted experiment changed UI according with experiment details,  but as we removed the experiment the UI was still there, causing an inconsistent state, as some part of the code know that were are not on a experiment but some part that were not reloaded still have the experiment UI, to avoid similar inconsistencies and be safe let's just quite the app and allow to everything start fresh.

```
java.lang.ClassCastException
	at org.mozilla.fenix.settings.SettingsFragment.updateMakeDefaultBrowserPreference(SettingsFragment.kt:500)
	at org.mozilla.fenix.settings.SettingsFragment.update(SettingsFragment.kt:230)
	at org.mozilla.fenix.settings.SettingsFragment.onResume(SettingsFragment.kt:174)
	at androidx.fragment.app.Fragment.performResume(Fragment.java:3039)
	at androidx.fragment.app.FragmentStateManager.resume(FragmentStateManager.java:607)
	at androidx.fragment.app.FragmentStateManager.moveToExpectedState(FragmentStateManager.java:306)
	at androidx.fragment.app.SpecialEffectsController$FragmentStateManagerOperation.complete(SpecialEffectsController.java:742)
	at androidx.fragment.app.SpecialEffectsController$Operation.completeSpecialEffect(SpecialEffectsController.java:669)
	at androidx.fragment.app.DefaultSpecialEffectsController$SpecialEffectsInfo.completeSpecialEffect(DefaultSpecialEffectsController.java:779)
	at androidx.fragment.app.DefaultSpecialEffectsController.startAnimations(DefaultSpecialEffectsController.java:239)
	at androidx.fragment.app.DefaultSpecialEffectsController.executeOperations(DefaultSpecialEffectsController.java:119)
	at androidx.fragment.app.SpecialEffectsController.executePendingOperations(SpecialEffectsController.java:294)
	at androidx.fragment.app.FragmentManager.executeOpsTogether(FragmentManager.java:2202)
	at androidx.fragment.app.FragmentManager.removeRedundantOperationsAndExecute(FragmentManager.java:2106)
	at androidx.fragment.app.FragmentManager.execPendingActions(FragmentManager.java:2002)
	at androidx.fragment.app.FragmentManager$5.run(FragmentManager.java:524)
	at android.os.Handler.handleCallback(Handler.java:883)
	at android.os.Handler.dispatchMessage(Handler.java:100)
	at android.os.Looper.loop(Looper.java:214)
	at android.app.ActivityThread.main(ActivityThread.java:7682)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:516)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:950)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.
```

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
