### PR TITLE
Close #20945: Fix failing test in AccountSettingsInteractorTest

### DIFF
--- a/app/src/test/java/org/mozilla/fenix/settings/account/AccountSettingsInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/account/AccountSettingsInteractorTest.kt
@@ -37,7 +37,8 @@ class AccountSettingsInteractorTest {
     @Test
     fun onChangeDeviceName() {
         val store: AccountSettingsFragmentStore = mockk(relaxed = true)
-        val invalidNameResponse = mockk<() -> Unit>(relaxed = true)
+        var invalidResponseInvoked = false
+        val invalidNameResponse = { invalidResponseInvoked = true }
 
         val interactor = AccountSettingsInteractor(
             mockk(),
@@ -49,13 +50,14 @@ class AccountSettingsInteractorTest {
         assertTrue(interactor.onChangeDeviceName("New Name", invalidNameResponse))
 
         verify { store.dispatch(AccountSettingsFragmentAction.UpdateDeviceName("New Name")) }
-        verify { invalidNameResponse wasNot Called }
+        assertFalse(invalidResponseInvoked)
     }
 
     @Test
     fun onChangeDeviceNameSyncFalse() {
         val store: AccountSettingsFragmentStore = mockk(relaxed = true)
-        val invalidNameResponse = mockk<() -> Unit>(relaxed = true)
+        var invalidResponseInvoked = false
+        val invalidNameResponse = { invalidResponseInvoked = true }
 
         val interactor = AccountSettingsInteractor(
             mockk(),
@@ -67,7 +69,7 @@ class AccountSettingsInteractorTest {
         assertFalse(interactor.onChangeDeviceName("New Name", invalidNameResponse))
 
         verify { store wasNot Called }
-        verify { invalidNameResponse() }
+        assertTrue(invalidResponseInvoked)
     }
 
     @Test


### PR DESCRIPTION
The right fix would be to also re-write these tests to verify actual state changes to the `AccountSettingsFragmentStore` but I wanted to fix the immediate problem first.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
