### PR TITLE
For #20952 - Increase run-ui emulator storage to 2GB

### DIFF
--- a/.github/workflows/build-contributor-pr.yml
+++ b/.github/workflows/build-contributor-pr.yml
@@ -124,6 +124,7 @@ jobs:
           target: ${{ matrix.target }}
           arch: x86_64
           profile: pixel_3a
+          sdcard-path-or-size: 3072M
           script:
             "JAVA_HOME=$JAVA_HOME_11_X64 && ./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=\
             org.mozilla.fenix.ui.NavigationToolbarTest#visitURLTest"


### PR DESCRIPTION


### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
