### PR TITLE
Disable run-ui in build-contributor-pr.yml

### DIFF
--- a/.github/workflows/build-contributor-pr.yml
+++ b/.github/workflows/build-contributor-pr.yml
@@ -106,6 +106,7 @@ jobs:
           path: app/build/reports/lint-results-debug.html
 
   run-ui:
+    if: ${{ false }} # disable for now
     runs-on: macos-11
     if: github.event.pull_request.head.repo.full_name != github.repository && github.actor != 'MickeyMoz'
 


### PR DESCRIPTION
Disable `run-ui` in `build-contributor-pr.yml` for now as we investigate the issue causing `INSTALL_FAILED_INSUFFICIENT_STORAGE` possibly related to the need to raise `disk.dataPartition.size` which is outside of our control in `android-emulator-runner`. 

Opened https://github.com/ReactiveCircus/android-emulator-runner/issues/184 to see if we can get the default size which would help for investigation.