### PR TITLE
No issue: Update Flank to v21.08.1

### DIFF
--- a/taskcluster/docker/ui-tests/Dockerfile
+++ b/taskcluster/docker/ui-tests/Dockerfile
@@ -27,7 +27,7 @@ RUN curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud
     && ${TEST_TOOLS}/google-cloud-sdk/install.sh --quiet \
     && ${TEST_TOOLS}/google-cloud-sdk/bin/gcloud --quiet components update
 
-# Flank v21.07.1
+# Flank v21.08.1
 
 RUN URL_FLANK_BIN="$($CURL --silent 'https://api.github.com/repos/Flank/flank/releases/latest' | jq -r '.assets[] | select(.browser_download_url | test("flank.jar")) .browser_download_url')" \
     && $CURL --output "${TEST_TOOLS}/flank.jar" "${URL_FLANK_BIN}" \


### PR DESCRIPTION
Flank https://github.com/Flank/flank/releases/tag/v21.08.1 has the fix for avoiding crash one of their API calls that we hit a couple times.
