### PR TITLE
Fix description for `home_screen_displayed` metric

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -5519,7 +5519,7 @@ home_menu:
 home_screen:
   home_screen_displayed:
     type: event
-    description: The user clicked the settings option in home menu.
+    description: The home screen was displayed.
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/18856
     data_reviews:

--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -5521,7 +5521,7 @@ home_screen:
     type: event
     description: The home screen was displayed.
     bugs:
-      - https://github.com/mozilla-mobile/fenix/issues/18856
+      - https://github.com/mozilla-mobile/fenix/issues/18854
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/19025
       - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789


### PR DESCRIPTION
The current description appears to be incorrect by my reading of the source. This is a documentation-only change.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [N/A] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [N/A] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [N/A] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
