### PR TITLE
Issue #21102: Set compileSdkVersion to 31.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/ext/String.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/String.kt
@@ -81,6 +81,7 @@ fun String.toShortUrl(publicSuffixList: PublicSuffixList): String {
 }
 
 // impl via FFTV https://searchfox.org/mozilla-mobile/source/firefox-echo-show/app/src/main/java/org/mozilla/focus/utils/FormattedDomain.java#129
+@Suppress("DEPRECATION")
 fun String.isIpv4(): Boolean = Patterns.IP_ADDRESS.matcher(this).matches()
 
 // impl via FFiOS: https://github.com/mozilla-mobile/firefox-ios/blob/deb9736c905cdf06822ecc4a20152df7b342925d/Shared/Extensions/NSURLExtensions.swift#L292

--- a/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt
@@ -411,6 +411,7 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
         if (!dialogHandledAction) {
             val imm =
                 requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+            @Suppress("DEPRECATION")
             imm.toggleSoftInput(InputMethodManager.HIDE_IMPLICIT_ONLY, 0)
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/AddLoginFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/AddLoginFragment.kt
@@ -109,6 +109,7 @@ class AddLoginFragment : Fragment(R.layout.fragment_add_login) {
         binding.hostnameText.requestFocus()
         val imm =
             requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+        @Suppress("DEPRECATION")
         imm.toggleSoftInput(InputMethodManager.SHOW_IMPLICIT, 0)
 
         binding.clearHostnameTextButton.setOnClickListener {

--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -13,7 +13,7 @@ import java.util.Locale
 
 object Config {
     // Synchronized build configuration for all modules
-    const val compileSdkVersion = 30
+    const val compileSdkVersion = 31
     const val minSdkVersion = 21
     const val targetSdkVersion = 30
 


### PR DESCRIPTION
The API 31 SDK is available now and we can start building against it.

Let's see what our automation thinks. [In A-C everything seems to be green so far](https://github.com/mozilla-mobile/android-components/pull/10911).