### PR TITLE
Rollback Flank to v21.08.1

### DIFF
--- a/taskcluster/docker/ui-tests/Dockerfile
+++ b/taskcluster/docker/ui-tests/Dockerfile
@@ -29,7 +29,7 @@ RUN curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud
 
 # Flank v21.08.1
 
-RUN URL_FLANK_BIN="$($CURL --silent 'https://api.github.com/repos/Flank/flank/releases/latest' | jq -r '.assets[] | select(.browser_download_url | test("flank.jar")) .browser_download_url')" \
+RUN URL_FLANK_BIN="$($CURL --silent 'https://api.github.com/repos/Flank/flank/releases/48276753' | jq -r '.assets[] | select(.browser_download_url | test("flank.jar")) .browser_download_url')" \
     && $CURL --output "${TEST_TOOLS}/flank.jar" "${URL_FLANK_BIN}" \
     && chmod +x "${TEST_TOOLS}/flank.jar"
 


### PR DESCRIPTION
Flank v21.09.0 introduced a XML tree change to `JUnitReport.xml` which breaks our daily reporting. While I figure out this new schema change, I don't want to break reporting. This was introduced with a [forced Docker update](https://github.com/mozilla-mobile/fenix/pull/21107) which tagged this Docker and pulled in a new version. Pinning an older version here.

https://api.github.com/repos/Flank/flank/releases/48276753 -> Flank v21.08.1