### PR TITLE
Docs: Add extra context to `events.browser_menu_action`

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -108,7 +108,8 @@ events:
     type: event
     description: |
       A browser menu item was tapped.
-      The name of the item that the user tapped is stored in extras with the key `item`.
+      The name of the item that the user tapped is stored in extras with the
+      key `item`.
     extra_keys:
       item:
         description: |

--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -107,7 +107,8 @@ events:
   browser_menu_action:
     type: event
     description: |
-      A browser menu item was tapped
+      A browser menu item was tapped.
+      The name of the item that the user tapped is stored in extras with the key `item`.
     extra_keys:
       item:
         description: |


### PR DESCRIPTION
This came up as a potential point of confusion in a discussion with DS, since you can only see the description "above the fold" when using tools like the Glean Dictionary (i.e. the events extra piece which gives extra context is invisible). This is a docs only change.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
