### PR TITLE
Improve coverage for addPrivateBrowsingShortcut UI test

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsPrivacyTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsPrivacyTest.kt
@@ -364,6 +364,7 @@ class SettingsPrivacyTest {
         }.openThreeDotMenu {
         }.openSettings {
         }.openPrivateBrowsingSubMenu {
+            cancelPrivateShortcutAddition()
             addPrivateShortcutToHomescreen()
             verifyPrivateBrowsingShortcutIcon()
         }.openPrivateBrowsingShortcut {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuPrivateBrowsingRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuPrivateBrowsingRobot.kt
@@ -51,6 +51,18 @@ class SettingsSubMenuPrivateBrowsingRobot {
 
     fun clickOpenLinksInPrivateTabSwitch() = openLinksInPrivateTabSwitch().click()
 
+    fun cancelPrivateShortcutAddition() {
+        mDevice.wait(
+            Until.findObject(text("Add private browsing shortcut")),
+            waitingTime
+        )
+        addPrivateBrowsingShortcutButton().click()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            mDevice.wait(Until.findObject(By.textContains("CANCEL")), waitingTime)
+            cancelShortcutAdditionButton().click()
+        }
+    }
+
     fun addPrivateShortcutToHomescreen() {
         mDevice.wait(
             Until.findObject(text("Add private browsing shortcut")),
@@ -104,6 +116,9 @@ private fun goBackButton() = onView(withContentDescription("Navigate up"))
 
 private fun addAutomaticallyButton() =
     mDevice.findObject(UiSelector().textStartsWith("add automatically"))
+
+private fun cancelShortcutAdditionButton() =
+    mDevice.findObject(UiSelector().textContains("CANCEL"))
 
 private fun privateBrowsingShortcutIcon() = mDevice.findObject(text("Private $appName"))
 


### PR DESCRIPTION
Added missing cancel Private Browsing shortcut addition.
✔️ Successfully ran 30x on Firebase

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
