### PR TITLE
Update Android Components to 94.0.20210914144027

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -478,7 +478,9 @@ dependencies {
     implementation Deps.mozilla_service_sync_autofill
     implementation Deps.mozilla_service_sync_logins
     implementation Deps.mozilla_service_firefox_accounts
-    implementation Deps.mozilla_service_glean
+    implementation(Deps.mozilla_service_glean) {
+      exclude group: 'org.mozilla.telemetry', module: 'glean-native'
+    }
     implementation Deps.mozilla_service_location
     implementation Deps.mozilla_service_nimbus
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -583,7 +583,7 @@ dependencies {
 
     // For the initial release of Glean 19, we require consumer applications to
     // depend on a separate library for unit tests. This will be removed in future releases.
-    testImplementation "org.mozilla.telemetry:glean-forUnitTests:${project.ext.glean_version}"
+    testImplementation "org.mozilla.telemetry:glean-native-forUnitTests:${project.ext.glean_version}"
 
     lintChecks project(":mozilla-lint-rules")
 }

--- a/app/src/test/java/org/mozilla/fenix/historymetadata/HistoryMetadataFeatureTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/historymetadata/HistoryMetadataFeatureTest.kt
@@ -52,7 +52,8 @@ class HistoryMetadataFeatureTest {
                 createdAt = System.currentTimeMillis(),
                 updatedAt = System.currentTimeMillis(),
                 totalViewTime = 10,
-                documentType = DocumentType.Regular
+                documentType = DocumentType.Regular,
+                previewImageUrl = null
             )
             val expectedHistoryGroup = HistoryMetadataGroup(
                 title = "mozilla",
@@ -81,7 +82,8 @@ class HistoryMetadataFeatureTest {
                 createdAt = System.currentTimeMillis(),
                 updatedAt = 1,
                 totalViewTime = 10,
-                documentType = DocumentType.Regular
+                documentType = DocumentType.Regular,
+                previewImageUrl = null
             )
 
             val historyEntry2 = HistoryMetadata(
@@ -90,7 +92,8 @@ class HistoryMetadataFeatureTest {
                 createdAt = System.currentTimeMillis(),
                 updatedAt = 2,
                 totalViewTime = 20,
-                documentType = DocumentType.Regular
+                documentType = DocumentType.Regular,
+                previewImageUrl = "http://firefox.com/image1"
             )
 
             val historyEntry3 = HistoryMetadata(
@@ -99,7 +102,8 @@ class HistoryMetadataFeatureTest {
                 createdAt = System.currentTimeMillis(),
                 updatedAt = 3,
                 totalViewTime = 30,
-                documentType = DocumentType.Regular
+                documentType = DocumentType.Regular,
+                previewImageUrl = null
             )
 
             val expectedHistoryGroup = HistoryMetadataGroup(
@@ -136,7 +140,8 @@ class HistoryMetadataFeatureTest {
                 createdAt = System.currentTimeMillis(),
                 updatedAt = System.currentTimeMillis(),
                 totalViewTime = 10,
-                documentType = DocumentType.Regular
+                documentType = DocumentType.Regular,
+                previewImageUrl = null
             )
 
             val historyEntry2 = HistoryMetadata(
@@ -145,7 +150,8 @@ class HistoryMetadataFeatureTest {
                 createdAt = System.currentTimeMillis(),
                 updatedAt = System.currentTimeMillis(),
                 totalViewTime = 20,
-                documentType = DocumentType.Regular
+                documentType = DocumentType.Regular,
+                previewImageUrl = null
             )
 
             val historyEntry3 = HistoryMetadata(
@@ -154,7 +160,8 @@ class HistoryMetadataFeatureTest {
                 createdAt = System.currentTimeMillis(),
                 updatedAt = System.currentTimeMillis(),
                 totalViewTime = 30,
-                documentType = DocumentType.Regular
+                documentType = DocumentType.Regular,
+                previewImageUrl = null
             )
 
             val expectedHistoryGroup1 = HistoryMetadataGroup(

--- a/app/src/test/java/org/mozilla/fenix/historymetadata/controller/HistoryMetadataControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/historymetadata/controller/HistoryMetadataControllerTest.kt
@@ -75,7 +75,8 @@ class HistoryMetadataControllerTest {
             createdAt = System.currentTimeMillis(),
             updatedAt = System.currentTimeMillis(),
             totalViewTime = 10,
-            documentType = DocumentType.Regular
+            documentType = DocumentType.Regular,
+            previewImageUrl = null
         )
 
         controller.handleHistoryMetadataItemClicked(historyEntry.key.url, historyEntry.key)
@@ -106,7 +107,8 @@ class HistoryMetadataControllerTest {
             createdAt = System.currentTimeMillis(),
             updatedAt = System.currentTimeMillis(),
             totalViewTime = 10,
-            documentType = DocumentType.Regular
+            documentType = DocumentType.Regular,
+            previewImageUrl = null
         )
         val historyGroup = HistoryMetadataGroup(
             title = "mozilla",

--- a/app/src/test/java/org/mozilla/fenix/historymetadata/view/HistoryMetadataGroupViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/historymetadata/view/HistoryMetadataGroupViewHolderTest.kt
@@ -32,7 +32,8 @@ class HistoryMetadataGroupViewHolderTest {
         createdAt = System.currentTimeMillis(),
         updatedAt = System.currentTimeMillis(),
         totalViewTime = 10,
-        documentType = DocumentType.Regular
+        documentType = DocumentType.Regular,
+        previewImageUrl = null
     )
     private val historyGroup = HistoryMetadataGroup(
         title = "mozilla",

--- a/app/src/test/java/org/mozilla/fenix/historymetadata/view/HistoryMetadataViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/historymetadata/view/HistoryMetadataViewHolderTest.kt
@@ -35,7 +35,8 @@ class HistoryMetadataViewHolderTest {
         createdAt = System.currentTimeMillis(),
         updatedAt = System.currentTimeMillis(),
         totalViewTime = 10,
-        documentType = DocumentType.Regular
+        documentType = DocumentType.Regular,
+        previewImageUrl = null
     )
 
     @Before
@@ -74,7 +75,8 @@ class HistoryMetadataViewHolderTest {
             createdAt = System.currentTimeMillis(),
             updatedAt = System.currentTimeMillis(),
             totalViewTime = 10,
-            documentType = DocumentType.Regular
+            documentType = DocumentType.Regular,
+            previewImageUrl = null
         )
 
         HistoryMetadataViewHolder(binding.root, interactor, icons).bind(historyEntryWithoutTitle)

--- a/app/src/test/java/org/mozilla/fenix/home/HomeFragmentStoreTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/HomeFragmentStoreTest.kt
@@ -131,7 +131,8 @@ class HomeFragmentStoreTest {
             createdAt = System.currentTimeMillis(),
             updatedAt = System.currentTimeMillis(),
             totalViewTime = 10,
-            documentType = DocumentType.Regular
+            documentType = DocumentType.Regular,
+            previewImageUrl = null
         )
         val historyGroup = HistoryMetadataGroup(
             title = "mozilla",

--- a/app/src/test/java/org/mozilla/fenix/home/SessionControlInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/SessionControlInteractorTest.kt
@@ -167,7 +167,8 @@ class SessionControlInteractorTest {
             createdAt = System.currentTimeMillis(),
             updatedAt = System.currentTimeMillis(),
             totalViewTime = 10,
-            documentType = DocumentType.Regular
+            documentType = DocumentType.Regular,
+            previewImageUrl = null
         )
 
         interactor.onHistoryMetadataItemClicked(historyEntry.key.url, historyEntry.key)
@@ -193,7 +194,8 @@ class SessionControlInteractorTest {
             createdAt = System.currentTimeMillis(),
             updatedAt = System.currentTimeMillis(),
             totalViewTime = 10,
-            documentType = DocumentType.Regular
+            documentType = DocumentType.Regular,
+            previewImageUrl = null
         )
         val historyGroup = HistoryMetadataGroup(
             title = "mozilla",

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "94.0.20210913143315"
+    const val VERSION = "94.0.20210914144027"
 }


### PR DESCRIPTION
We have to do this manually due to API breaking and the new way of consuming Glean.