### PR TITLE
For #20936: run perftests with conditioned profiles.

### DIFF
--- a/taskcluster/ci/browsertime/kind.yml
+++ b/taskcluster/ci/browsertime/kind.yml
@@ -92,6 +92,7 @@ job-defaults:
             - '--browsertime-geckodriver=$MOZ_FETCHES_DIR/geckodriver'
             - '--browsertime-ffmpeg=$MOZ_FETCHES_DIR/ffmpeg-4.1.4-i686-static/bin/ffmpeg'
             - '--browsertime-browsertimejs=$MOZ_FETCHES_DIR/browsertime/node_modules/browsertime/bin/browsertime.js'
+            - '--conditioned-profile=settled'
     fetches:
         toolchain:
             - browsertime


### PR DESCRIPTION
We've noticed that geckoview_example is ~300ms faster than fenix in cold page
load tests on arewefastyet for the Pixel 2. We suspect the main
difference is because geckoview_example runs with conditioned profiles
and fenix does not.

This PR is foremost an experiment to see if that's true because, after BZ-1587542, we cannot run get results for fenix perftest PRs (i.e. it needs to be
merged into main). If we find that the results are not noisy, however, we
could end up leaving this in the tree. We've previously seen excessive
noise with fenix start up tests with conditioned profiles which is why
conditioned profiles are not currently enabled.

---

If I am interpreting [the config](https://searchfox.org/mozilla-mobile/source/fenix/taskcluster/ci/browsertime/kind.yml#105) correctly, this should affect the numbers for the page load tests and the youtube playback tests only.

See https://github.com/mozilla-mobile/fenix/pull/21240 for where the CI ran with this change.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
