### PR TITLE
For #21287: Long press menu on homescreen

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/historymetadata/controller/HistoryMetadataController.kt
+++ b/app/src/main/java/org/mozilla/fenix/historymetadata/controller/HistoryMetadataController.kt
@@ -7,7 +7,11 @@ package org.mozilla.fenix.historymetadata.controller
 import androidx.annotation.VisibleForTesting
 import androidx.annotation.VisibleForTesting.PRIVATE
 import androidx.navigation.NavController
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import mozilla.components.concept.storage.HistoryMetadataStorage
 import org.mozilla.fenix.R
+import org.mozilla.fenix.browser.BrowserFragmentDirections
 import org.mozilla.fenix.historymetadata.HistoryMetadataGroup
 import org.mozilla.fenix.historymetadata.interactor.HistoryMetadataInteractor
 import org.mozilla.fenix.home.HomeFragmentDirections
@@ -27,13 +31,20 @@ interface HistoryMetadataController {
      * @see [HistoryMetadataInteractor.onHistoryMetadataGroupClicked]
      */
     fun handleHistoryMetadataGroupClicked(historyMetadataGroup: HistoryMetadataGroup)
+
+    /**
+     * @see [HistoryMetadataInteractor.onRemoveGroup]
+     */
+    fun handleRemoveGroup(searchTerm: String)
 }
 
 /**
  * The default implementation of [HistoryMetadataController].
  */
 class DefaultHistoryMetadataController(
-    private val navController: NavController
+    private val navController: NavController,
+    private val storage: HistoryMetadataStorage,
+    private val scope: CoroutineScope
 ) : HistoryMetadataController {
 
     override fun handleHistoryShowAllClicked() {
@@ -50,6 +61,15 @@ class DefaultHistoryMetadataController(
                 historyMetadataItems = historyMetadataGroup.historyMetadata
                     .map { it.toHistoryMetadata() }.toTypedArray()
             )
+        )
+    }
+
+    override fun handleRemoveGroup(searchTerm: String) {
+        scope.launch {
+            storage.deleteHistoryMetadata(searchTerm)
+        }
+        navController.navigate(
+            BrowserFragmentDirections.actionGlobalHome()
         )
     }
 

--- a/app/src/main/java/org/mozilla/fenix/historymetadata/interactor/HistoryMetadataInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/historymetadata/interactor/HistoryMetadataInteractor.kt
@@ -24,4 +24,11 @@ interface HistoryMetadataInteractor {
      * @param historyMetadataGroup The [HistoryMetadataGroup] to toggle its expanded state.
      */
     fun onHistoryMetadataGroupClicked(historyMetadataGroup: HistoryMetadataGroup)
+
+    /**
+     * Removes a history metadata group with the given search term from the homescreen.
+     *
+     * @param searchTerm The search term to be removed.
+     */
+    fun onRemoveGroup(searchTerm: String)
 }

--- a/app/src/main/java/org/mozilla/fenix/historymetadata/view/HistoryMetadataGroupViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/historymetadata/view/HistoryMetadataGroupViewHolder.kt
@@ -42,8 +42,8 @@ class HistoryMetadataGroupViewHolder(
                     menuItems = listOfNotNull(
                         RecentVisitMenuItem(
                             title = stringResource(R.string.recently_visited_menu_item_remove),
-                            onClick = {
-                                // no-op
+                            onClick = { group ->
+                                interactor.onRemoveGroup(group.title)
                             }
                         )
                     ),

--- a/app/src/main/java/org/mozilla/fenix/historymetadata/view/RecentlyVisited.kt
+++ b/app/src/main/java/org/mozilla/fenix/historymetadata/view/RecentlyVisited.kt
@@ -6,15 +6,20 @@ package org.mozilla.fenix.historymetadata.view
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.scrollable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -33,6 +38,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -63,7 +69,7 @@ fun RecentlyVisited(
         modifier = Modifier.fillMaxWidth(),
         shape = RoundedCornerShape(8.dp),
         backgroundColor = FirefoxTheme.colors.surface,
-        elevation = 6.dp,
+        elevation = 6.dp
     ) {
         LazyRow(
             contentPadding = PaddingValues(16.dp),
@@ -73,7 +79,7 @@ fun RecentlyVisited(
 
             items(itemsList) { items ->
                 Column(
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth().clip(RoundedCornerShape(8.dp))
                 ) {
                     items.forEachIndexed { index, recentVisit ->
                         RecentVisitItem(
@@ -112,7 +118,8 @@ private fun RecentVisitItem(
                 onClick = { onRecentVisitClick(recentVisit) },
                 onLongClick = { menuExpanded = true }
             )
-            .size(268.dp, 56.dp),
+            .size(268.dp, 56.dp)
+            .background(color = FirefoxTheme.colors.surface),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Image(
@@ -150,17 +157,32 @@ private fun RecentVisitItem(
             expanded = menuExpanded,
             onDismissRequest = { menuExpanded = false },
             modifier = Modifier.background(color = FirefoxTheme.colors.surface)
+                .height(52.dp)
+                .scrollable(
+                    state = ScrollState(0),
+                    orientation = Orientation.Vertical,
+                    enabled = false
+                )
         ) {
             for (item in menuItems) {
                 DropdownMenuItem(
                     onClick = {
                         menuExpanded = false
                         item.onClick(recentVisit)
-                    }
+                    },
+                    modifier = Modifier.fillMaxHeight()
                 ) {
                     Text(
                         text = item.title,
-                        color = FirefoxTheme.colors.textPrimary
+                        color = FirefoxTheme.colors.textPrimary,
+                        maxLines = 1,
+                        modifier = Modifier.align(Alignment.Top)
+                            .padding(top = 6.dp)
+                            .scrollable(
+                                state = ScrollState(0),
+                                orientation = Orientation.Vertical,
+                                enabled = false
+                            ).fillMaxHeight()
                     )
                 }
             }

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -345,7 +345,9 @@ class HomeFragment : Fragment() {
                 navController = findNavController()
             ),
             historyMetadataController = DefaultHistoryMetadataController(
-                navController = findNavController()
+                navController = findNavController(),
+                storage = components.core.historyStorage,
+                scope = viewLifecycleOwner.lifecycleScope
             ),
             pocketStoriesController = DefaultPocketStoriesController(
                 homeActivity = activity,

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlInteractor.kt
@@ -226,7 +226,8 @@ interface ExperimentCardInteractor {
 /**
  * Interactor for the Home screen. Provides implementations for the CollectionInteractor,
  * OnboardingInteractor, TopSiteInteractor, TipInteractor, TabSessionInteractor,
- * ToolbarInteractor, ExperimentCardInteractor, RecentTabInteractor, RecentBookmarksInteractor and others.
+ * ToolbarInteractor, ExperimentCardInteractor, RecentTabInteractor, RecentBookmarksInteractor
+ * and others.
  */
 @SuppressWarnings("TooManyFunctions")
 class SessionControlInteractor(
@@ -380,6 +381,10 @@ class SessionControlInteractor(
         historyMetadataController.handleHistoryMetadataGroupClicked(
             historyMetadataGroup
         )
+    }
+
+    override fun onRemoveGroup(searchTerm: String) {
+        historyMetadataController.handleRemoveGroup(searchTerm)
     }
 
     override fun openCustomizeHomePage() {

--- a/app/src/test/java/org/mozilla/fenix/historymetadata/interactor/HistoryMetadataInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/historymetadata/interactor/HistoryMetadataInteractorTest.kt
@@ -1,0 +1,127 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.historymetadata.interactor
+
+import androidx.navigation.NavController
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import mozilla.components.concept.storage.DocumentType
+import mozilla.components.concept.storage.HistoryMetadata
+import mozilla.components.concept.storage.HistoryMetadataKey
+import mozilla.components.support.test.rule.MainCoroutineRule
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mozilla.fenix.R
+import org.mozilla.fenix.historymetadata.HistoryMetadataGroup
+import org.mozilla.fenix.historymetadata.controller.HistoryMetadataController
+import org.mozilla.fenix.home.recentbookmarks.controller.RecentBookmarksController
+import org.mozilla.fenix.home.recenttabs.controller.RecentTabController
+import org.mozilla.fenix.home.sessioncontrol.DefaultSessionControlController
+import org.mozilla.fenix.home.sessioncontrol.SessionControlInteractor
+import org.mozilla.fenix.home.sessioncontrol.viewholders.pocket.PocketStoriesController
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class HistoryMetadataInteractorTest {
+    private val testDispatcher = TestCoroutineDispatcher()
+
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule(testDispatcher)
+
+    private val navController = mockk<NavController>(relaxed = true)
+    private val defaultSessionControlController: DefaultSessionControlController =
+        mockk(relaxed = true)
+    private val recentTabController: RecentTabController = mockk(relaxed = true)
+    private val recentBookmarksController: RecentBookmarksController = mockk(relaxed = true)
+    private val pocketStoriesController: PocketStoriesController = mockk(relaxed = true)
+    private val historyMetadataController: HistoryMetadataController = mockk(relaxed = true)
+
+    private lateinit var interactor: SessionControlInteractor
+
+    @Before
+    fun setup() {
+        every { navController.currentDestination } returns mockk {
+            every { id } returns R.id.homeFragment
+        }
+
+        interactor = SessionControlInteractor(
+            defaultSessionControlController,
+            recentTabController,
+            recentBookmarksController,
+            historyMetadataController,
+            pocketStoriesController
+        )
+    }
+
+    @After
+    fun cleanUp() {
+        testDispatcher.cleanupTestCoroutines()
+    }
+
+    @Test
+    fun onHistoryMetadataGroupClicked() {
+        val historyGroup =
+            HistoryMetadataGroup(
+                title = "mozilla",
+                historyMetadata = listOf(
+                    HistoryMetadata(
+                        key = HistoryMetadataKey("http://www.mozilla.com", null, null),
+                        title = "mozilla",
+                        createdAt = System.currentTimeMillis(),
+                        updatedAt = System.currentTimeMillis(),
+                        totalViewTime = 10,
+                        documentType = DocumentType.Regular,
+                        previewImageUrl = null
+                    )
+                )
+            )
+
+        interactor.onHistoryMetadataGroupClicked(historyGroup)
+        verify {
+            historyMetadataController.handleHistoryMetadataGroupClicked(historyGroup)
+        }
+    }
+
+    @Test
+    fun onHistoryMetadataShowAllClicked() {
+        interactor.onHistoryMetadataShowAllClicked()
+        verify { historyMetadataController.handleHistoryShowAllClicked() }
+    }
+
+    @Test
+    fun onRemoveItem() {
+        val historyMetadataKey = HistoryMetadataKey(
+            "http://www.mozilla.com",
+            "mozilla",
+            null
+        )
+
+        val historyGroup =
+            HistoryMetadataGroup(
+                title = "mozilla",
+                historyMetadata = listOf(
+                    HistoryMetadata(
+                        key = historyMetadataKey,
+                        title = "mozilla",
+                        createdAt = System.currentTimeMillis(),
+                        updatedAt = System.currentTimeMillis(),
+                        totalViewTime = 10,
+                        documentType = DocumentType.Regular,
+                        previewImageUrl = null
+                    )
+                )
+            )
+
+        interactor.onRemoveGroup(historyGroup.title)
+
+        verify {
+            historyMetadataController.handleRemoveGroup(historyGroup.title)
+        }
+    }
+}

--- a/app/src/test/java/org/mozilla/fenix/historymetadata/view/HistoryMetadataViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/historymetadata/view/HistoryMetadataViewHolderTest.kt
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.historymetadata.view
+
+// TODO: Needs testImplementation 'androidx.compose.ui:ui-test-junit4:1.0.0-beta04'
+@Suppress("ForbiddenComment")
+class HistoryMetadataViewHolderTest {
+    /*
+    @get:Rule
+    val composeTestRule = ComposeTestRule()
+
+    @Test
+    fun `WHEN a group is removed via long press menu THEN interactor is called`() {
+
+            val historyGroup = HistoryMetadataGroup(
+                title = "mozilla",
+                historyMetadata = listOf(
+                    HistoryMetadata(
+                        key = historyMetadataKey,
+                        title = "mozilla",
+                        createdAt = System.currentTimeMillis(),
+                        updatedAt = System.currentTimeMillis(),
+                        totalViewTime = 10,
+                        documentType = DocumentType.Regular,
+                        previewImageUrl = null
+                    )
+                )
+        )
+
+        composeView.menuItems.performClick()
+         verify { interactor.onRemoveGroups(setOf(group)) }
+    }
+
+    */
+}

--- a/app/src/test/java/org/mozilla/fenix/home/SessionControlInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/SessionControlInteractorTest.kt
@@ -8,15 +8,11 @@ import io.mockk.mockk
 import io.mockk.verify
 import mozilla.components.concept.storage.BookmarkNode
 import mozilla.components.concept.storage.BookmarkNodeType
-import mozilla.components.concept.storage.DocumentType
-import mozilla.components.concept.storage.HistoryMetadata
-import mozilla.components.concept.storage.HistoryMetadataKey
 import mozilla.components.feature.tab.collections.Tab
 import mozilla.components.feature.tab.collections.TabCollection
 import org.junit.Before
 import org.junit.Test
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
-import org.mozilla.fenix.historymetadata.HistoryMetadataGroup
 import org.mozilla.fenix.historymetadata.controller.HistoryMetadataController
 import org.mozilla.fenix.home.recentbookmarks.controller.RecentBookmarksController
 import org.mozilla.fenix.home.recenttabs.controller.RecentTabController
@@ -30,8 +26,10 @@ class SessionControlInteractorTest {
     private val controller: DefaultSessionControlController = mockk(relaxed = true)
     private val recentTabController: RecentTabController = mockk(relaxed = true)
     private val recentBookmarksController: RecentBookmarksController = mockk(relaxed = true)
-    private val historyMetadataController: HistoryMetadataController = mockk(relaxed = true)
     private val pocketStoriesController: PocketStoriesController = mockk(relaxed = true)
+
+    // Note: the historyMetadata tests are handled in [HistoryMetadataInteractorTest] and [HistoryMetadataControllerTest]
+    private val historyMetadataController: HistoryMetadataController = mockk(relaxed = true)
 
     private lateinit var interactor: SessionControlInteractor
 
@@ -169,31 +167,6 @@ class SessionControlInteractorTest {
     fun onRecentTabShowAllClicked() {
         interactor.onRecentTabShowAllClicked()
         verify { recentTabController.handleRecentTabShowAllClicked() }
-    }
-
-    @Test
-    fun onHistoryMetadataShowAllClicked() {
-        interactor.onHistoryMetadataShowAllClicked()
-        verify { historyMetadataController.handleHistoryShowAllClicked() }
-    }
-
-    @Test
-    fun onToggleHistoryMetadataGroupExpanded() {
-        val historyEntry = HistoryMetadata(
-            key = HistoryMetadataKey("http://www.mozilla.com", "mozilla", null),
-            title = "mozilla",
-            createdAt = System.currentTimeMillis(),
-            updatedAt = System.currentTimeMillis(),
-            totalViewTime = 10,
-            documentType = DocumentType.Regular,
-            previewImageUrl = null
-        )
-        val historyGroup = HistoryMetadataGroup(
-            title = "mozilla",
-            historyMetadata = listOf(historyEntry)
-        )
-        interactor.onHistoryMetadataGroupClicked(historyGroup)
-        verify { historyMetadataController.handleHistoryMetadataGroupClicked(historyGroup) }
     }
 
     @Test


### PR DESCRIPTION
For #21287

- [x] long press "remove" menu on homescreen "Recently visited" groups
- [x] tests
- [x] updated API

[N/A] long press "remove" for "recently visited" individual items - this functionality isn't being implemented
[N/A] select + delete items from history 3-dot menu -> @gabrielluong taking care of this
[N/A] select + delete All items from history 3-dot -> @gabrielluong taking care of this


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
