### PR TITLE
Sort history metadata on home and allow limiting results

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/historymetadata/HistoryMetadataGroup.kt
+++ b/app/src/main/java/org/mozilla/fenix/historymetadata/HistoryMetadataGroup.kt
@@ -18,3 +18,6 @@ data class HistoryMetadataGroup(
     val historyMetadata: List<HistoryMetadata>,
     val expanded: Boolean = false
 )
+
+// The last updated time of the group is based on the most recently updated item in the group
+fun HistoryMetadataGroup.lastUpdated(): Long = historyMetadata.maxOf { it.updatedAt }


### PR DESCRIPTION
We should sort metadata groups based on `lastUpdated` time and not show more than 9 groups on home. This will later get more flexible once we add highlights.