### PR TITLE
Updating Fenix to work with the new logins API

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/logins/LoginsFragmentStore.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/LoginsFragmentStore.kt
@@ -31,7 +31,7 @@ data class SavedLogin(
 
 fun Login.mapToSavedLogin(): SavedLogin =
     SavedLogin(
-        guid = this.guid!!,
+        guid = this.guid,
         origin = this.origin,
         username = this.username,
         password = this.password,


### PR DESCRIPTION
Switched to always using `Login` instead of the `SavedPassword` alias.

Moved the `SavedLoginsStorageController.kt.syncAndUpdateList` call
inside `add()` and `update()`.  This simplifies the error handling a
bit.

Refactored `findPotentialDuplicates()`:
  - Use getByBaseDomain() now that potentialDupesIgnoringUsername() is
    no longer available.
  - Put the common code in one method
  - Moved the coroutine to fetch the logins inside the main coroutine.
    I think this simplifies the cancellation handling, since the child
    coroutine should be cancelled when its parent is cancelled.

Updated the tests.  I wasn't exactly sure how that mockk code is
supposed to work, please double-check that I'm didn't break them.

The tests are passing, but I haven't done any manual testing because I'm not sure how to install the preview on my emulator yet.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
