### PR TITLE
Delete browsing data tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsPrivacyTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsPrivacyTest.kt
@@ -23,6 +23,7 @@ import org.mozilla.fenix.ui.robots.addToHomeScreen
 import org.mozilla.fenix.ui.robots.browserScreen
 import org.mozilla.fenix.ui.robots.homeScreen
 import org.mozilla.fenix.ui.robots.navigationToolbar
+import org.mozilla.fenix.ui.robots.settingsScreen
 
 /**
  *  Tests for verifying the main three dot menu options
@@ -380,175 +381,140 @@ class SettingsPrivacyTest {
         }
     }
 
-    @Ignore("This is a stub test, ignore for now")
     @Test
-    fun toggleTrackingProtection() {
-        // Open static test website to verify TP is turned on (default): https://github.com/rpappalax/testapp
-        // (static content needs to be migrated to assets folder)
-        // Open 3dot (main) menu
-        // Select settings
-        // Toggle Tracking Protection to 'off'
-        // Back arrow to Home
-        // Open static test website to verify TP is now off: https://github.com/rpappalax/testapp
+    fun deleteBrowsingDataOptionStatesTest() {
+        homeScreen {
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openSettingsSubMenuDeleteBrowsingData {
+            verifyAllCheckBoxesAreChecked()
+            switchBrowsingHistoryCheckBox()
+            switchCachedFilesCheckBox()
+            verifyOpenTabsCheckBox(true)
+            verifyBrowsingHistoryDetails(false)
+            verifyCookiesCheckBox(true)
+            verifyCachedFilesCheckBox(false)
+            verifySitePermissionsCheckBox(true)
+            verifyDownloadsCheckBox(true)
+        }
+
+        restartApp(activityTestRule)
+
+        homeScreen {
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openSettingsSubMenuDeleteBrowsingData {
+            verifyOpenTabsCheckBox(true)
+            verifyBrowsingHistoryDetails(false)
+            verifyCookiesCheckBox(true)
+            verifyCachedFilesCheckBox(false)
+            verifySitePermissionsCheckBox(true)
+            verifyDownloadsCheckBox(true)
+            switchOpenTabsCheckBox()
+            switchBrowsingHistoryCheckBox()
+            switchCookiesCheckBox()
+            switchCachedFilesCheckBox()
+            switchSitePermissionsCheckBox()
+            switchDownloadsCheckBox()
+            verifyOpenTabsCheckBox(false)
+            verifyBrowsingHistoryDetails(true)
+            verifyCookiesCheckBox(false)
+            verifyCachedFilesCheckBox(true)
+            verifySitePermissionsCheckBox(false)
+            verifyDownloadsCheckBox(false)
+        }
+
+        restartApp(activityTestRule)
+
+        homeScreen {
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openSettingsSubMenuDeleteBrowsingData {
+            verifyOpenTabsCheckBox(false)
+            verifyBrowsingHistoryDetails(true)
+            verifyCookiesCheckBox(false)
+            verifyCachedFilesCheckBox(true)
+            verifySitePermissionsCheckBox(false)
+            verifyDownloadsCheckBox(false)
+        }
     }
 
-    @Ignore("This is a stub test, ignore for now")
     @Test
-    fun verifySitePermissions() {
-        // Open 3dot (main) menu
-        // Select settings
-        // Click on: "Site permissions"
-        // Verify sub-menu items...
-        // Click on: "Exceptions"
-        // Verify: "No site exceptions"
-        // TBD: create a site exception
-        // TBD: return to this UI and verify
-
-        //
-        // Open browser to static test website: https://github.com/rpappalax/testapp
-        // Click on "Test site permissions: geolocation"
-        // Verify that geolocation permissions dialogue is opened
-        // Verify text: "Allow <website URL> to use your geolocation?
-        // Verify toggle: 'Remember decision for this site?"
-        // Verify button: "Don't Allow"
-        // Verify button: "Allow" (default)
-        // Select "Remember decision for this site"
-        // Refresh page
-        // Click on "Test site permissions: geolocation"
-        // Verify that geolocation permissions dialogue is not opened
-        //
-        //
-        // Open browser to static test website: https://github.com/rpappalax/testapp
-        // Click on "Test site permissions: camera"
-        // Verify that camera permissions dialogue is opened
-        // Verify text: "Allow <website URL> to use your camera?
-        // Verify toggle: 'Remember decision for this site?"
-        // Verify button: "Don't Allow"
-        // Verify button: "Allow" (default)
-        // Select "Remember decision for this site"
-        // Refresh page
-        // Click on "Test site permissions: camera"
-        // Verify that camera permissions dialogue is not opened
-        //
-        //
-        // Open browser to static test website: https://github.com/rpappalax/testapp
-        // Click on "Test site permissions: microphone"
-        // Verify that microphone permissions dialogue is opened
-        // Verify text: "Allow <website URL> to use your microphone?
-        // Verify toggle: 'Remember decision for this site?"
-        // Verify button: "Don't Allow"
-        // Verify button: "Allow" (default)
-        // Select "Remember decision for this site"
-        // Refresh page
-        // Click on "Test site permissions: microphone"
-        // Verify that microphone permissions dialogue is not opened
-        //
-        //
-        // Open browser to static test website: https://github.com/rpappalax/testapp
-        // Click on "Test site permissions: notifications dialogue"
-        // Verify that notifications dialogue permissions dialogue is opened
-        // Verify text: "Allow <website URL> to send notifications?
-        // Verify toggle: 'Remember decision for this site?"
-        // Verify button: "Never"
-        // Verify button: "Always" (default)
-        // Select "Remember decision for this site"
-        // Refresh page
-        // Click on "Test site permissions: notifications dialogue"
-        // Verify that notifications dialogue permissions dialogue is not opened
-        //
-
-        // Open 3dot (main) menu
-        // Select settings
-        // Click on: "Site permissions"
-        // Select: Camera
-        // Switch from "ask to allow" (default) to "blocked"
-        // Click back arrow
-        //
-        // Select: Location
-        // Switch from "ask to allow" (default) to "blocked"
-        // Click back arrow
-        //
-        // Select: Microphone
-        // Switch from "ask to allow" (default) to "blocked"
-        // Click back arrow
-        //
-        // Select: Notification
-        // Switch from "ask to allow" (default) to "blocked"
-        // Click back arrow
-        //
-
-        // Open browser to static test website: https://github.com/rpappalax/testapp
-        // Click on "Test site permissions: camera dialogue"
-        // Verify that notifications dialogue permissions dialogue is not opened
-        //
-        // Open browser to static test website: https://github.com/rpappalax/testapp
-        // Click on "Test site permissions: geolocation dialogue"
-        // Verify that notifications dialogue permissions dialogue is not opened
-        //
-        // Open browser to static test website: https://github.com/rpappalax/testapp
-        // Click on "Test site permissions: microphone dialogue"
-        // Verify that notifications dialogue permissions dialogue is not opened
-        //
-        // Open browser to static test website: https://github.com/rpappalax/testapp
-        // Click on "Test site permissions: notifications dialogue"
-        // Verify that notifications dialogue permissions dialogue is not opened
+    fun deleteTabsDataWithNoOpenTabsTest() {
+        homeScreen {
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openSettingsSubMenuDeleteBrowsingData {
+            verifyAllCheckBoxesAreChecked()
+            selectOnlyOpenTabsCheckBox()
+            clickDeleteBrowsingDataButton()
+            confirmDeletionAndAssertSnackbar()
+        }
+        settingsScreen {
+            verifyBasicsHeading()
+        }
     }
 
-    @Ignore("This is a stub test, ignore for now")
     @Test
-    fun deleteBrowsingData() {
-        // Setup:
-        // Open 2 websites as 2 tabs
-        // Save as 1 collection
-        // Open 2 more websites in 2 other tabs
-        // Save as a 2nd collection
+    fun deleteTabsDataTest() {
+        val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
-        // Open 3dot (main) menu
-        // Select settings
-        // Click on "Delete browsing data"
-        // Verify correct number of tabs, addresses and collections are indicated
-        // Select all 3 checkboxes
-        // Click on "Delete browsing data button"
-        // Return to home screen and verify that all tabs, history and collection are gone
-        //
-        // Verify xxx
-        //
-        // New: If coming from  tab -> settings -> delete browsing data
-        // then expect to return to home screen
-        // If coming from tab -> home -> settings -> delete browsing data
-        // then expect return to settings (after which you can return to home manually)
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(defaultWebPage.url) {
+            mDevice.waitForIdle()
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openSettingsSubMenuDeleteBrowsingData {
+            verifyAllCheckBoxesAreChecked()
+            selectOnlyOpenTabsCheckBox()
+            clickDeleteBrowsingDataButton()
+            clickDialogCancelButton()
+            verifyOpenTabsCheckBox(true)
+            clickDeleteBrowsingDataButton()
+            confirmDeletionAndAssertSnackbar()
+        }
+        settingsScreen {
+            verifyBasicsHeading()
+        }.openSettingsSubMenuDeleteBrowsingData {
+            verifyOpenTabsDetails("0")
+        }.goBack {
+        }.goBack {
+        }.openTabDrawer {
+            verifyNoTabsOpened()
+        }
     }
 
-    @Ignore("This is a stub test, ignore for now")
     @Test
-    fun verifyDataCollection() {
-        // Open 3dot (main) menu
-        // Select settings
-        // Click on "Data collection"
-        // Verify header: "Usage and technical data"
-        // Verify text: "Shares performance, usage, hardware and customization data about your browser with Mozilla"
-        //               " to help us make Firefox preview better"
-        // Verify toggle is on by default
-        // TBD:
-        // see: telemetry testcases
-    }
+    fun deleteDeleteBrowsingHistoryDataTest() {
+        val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+        val secondWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 2)
 
-    @Ignore("This is a stub test, ignore for now")
-    @Test
-    fun openPrivacyNotice() {
-        // Open 3dot (main) menu
-        // Select settings
-        // Click on "Privacy notice"
-        // Verify redirect to: mozilla.org Privacy notice page"
-    }
-
-    @Ignore("This is a stub test, ignore for now")
-    @Test
-    fun checkLeakCanary() {
-        // Open 3dot (main) menu
-        // Select settings
-        // Click on Leak Canary toggle
-        // Verify 'dump' message
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(firstWebPage.url) {
+            mDevice.waitForIdle()
+        }.openNavigationToolbar {
+        }.enterURLAndEnterToBrowser(secondWebPage.url) {
+            mDevice.waitForIdle()
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openSettingsSubMenuDeleteBrowsingData {
+            verifyBrowsingHistoryDetails("2")
+            selectOnlyBrowsingHistoryCheckBox()
+            clickDeleteBrowsingDataButton()
+            clickDialogCancelButton()
+            verifyBrowsingHistoryDetails(true)
+            clickDeleteBrowsingDataButton()
+            confirmDeletionAndAssertSnackbar()
+            verifyBrowsingHistoryDetails("0")
+        }.goBack {
+            verifyBasicsHeading()
+        }.goBack {
+        }
+        navigationToolbar {
+        }.openThreeDotMenu {
+        }.openHistory {
+            verifyEmptyHistoryView()
+        }
     }
 }
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
@@ -272,6 +272,11 @@ class SettingsRobot {
     }
 }
 
+fun settingsScreen(interact: SettingsRobot.() -> Unit): SettingsRobot.Transition {
+    SettingsRobot().interact()
+    return SettingsRobot.Transition()
+}
+
 private fun assertSettingsView() {
     // verify that we are in the correct library view
     assertGeneralHeading()

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuDeleteBrowsingDataOnQuitRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuDeleteBrowsingDataOnQuitRobot.kt
@@ -36,9 +36,9 @@ class SettingsSubMenuDeleteBrowsingDataOnQuitRobot {
 
     fun clickDeleteBrowsingOnQuitButtonSwitchDefaultChange() = verifyDeleteBrowsingOnQuitButtonSwitchDefault().click()
 
-    fun verifyAllTheCheckBoxesText() = assertAllTheCheckBoxesText()
+    fun verifyAllTheCheckBoxesText() = assertAllOptionsAndCheckBoxes()
 
-    fun verifyAllTheCheckBoxesChecked() = assertAllTheCheckBoxesChecked()
+    fun verifyAllTheCheckBoxesChecked() = assertAllCheckBoxesAreChecked()
 
     fun verifyDeleteBrowsingDataOnQuitSubMenuItems() {
         verifyDeleteBrowsingOnQuitButton()
@@ -88,7 +88,7 @@ private fun assertDeleteBrowsingOnQuitButtonSummary() = onView(
 private fun assertDeleteBrowsingOnQuitButtonSwitchDefault() = onView(withResourceName("switch_widget"))
     .check(matches(isChecked(false)))
 
-private fun assertAllTheCheckBoxesText() {
+private fun assertAllOptionsAndCheckBoxes() {
     onView(withText(R.string.preferences_delete_browsing_data_tabs_title_2))
         .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
@@ -111,6 +111,6 @@ private fun assertAllTheCheckBoxesText() {
         .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 }
 
-private fun assertAllTheCheckBoxesChecked() {
+private fun assertAllCheckBoxesAreChecked() {
     // Only verifying the options, checkboxes default value can't be verified due to issue #9471
 }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuDeleteBrowsingDataRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuDeleteBrowsingDataRobot.kt
@@ -20,8 +20,10 @@ import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
 import org.hamcrest.CoreMatchers.allOf
+import org.junit.Assert.assertTrue
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.TestAssetHelper
+import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.TestHelper.appName
 import org.mozilla.fenix.helpers.assertIsChecked
 import org.mozilla.fenix.helpers.click
@@ -32,42 +34,57 @@ import org.mozilla.fenix.helpers.click
 class SettingsSubMenuDeleteBrowsingDataRobot {
 
     fun verifyNavigationToolBarHeader() = assertNavigationToolBarHeader()
-
     fun verifyDeleteBrowsingDataButton() = assertDeleteBrowsingDataButton()
-
-    fun verifyClickDeleteBrowsingDataButton() = assertClickDeleteBrowsingDataButton()
-
     fun verifyMessageInDialogBox() = assertMessageInDialogBox()
-
     fun verifyDeleteButtonInDialogBox() = assertDeleteButtonInDialogBox()
-
     fun verifyCancelButtonInDialogBox() = assertCancelButtonInDialogBox()
+    fun verifyAllOptionsAndCheckBoxes() = assertAllOptionsAndCheckBoxes()
+    fun verifyAllCheckBoxesAreChecked() = assertAllCheckBoxesAreChecked()
+    fun verifyOpenTabsCheckBox(status: Boolean) = assertOpenTabsCheckBox(status)
+    fun verifyBrowsingHistoryDetails(status: Boolean) = assertBrowsingHistoryCheckBox(status)
+    fun verifyCookiesCheckBox(status: Boolean) = assertCookiesCheckBox(status)
+    fun verifyCachedFilesCheckBox(status: Boolean) = assertCachedFilesCheckBox(status)
+    fun verifySitePermissionsCheckBox(status: Boolean) = assertSitePermissionsCheckBox(status)
+    fun verifyDownloadsCheckBox(status: Boolean) = assertDownloadsCheckBox(status)
+    fun verifyOpenTabsDetails(tabNumber: String) = assertOpenTabsDescription(tabNumber)
+    fun verifyBrowsingHistoryDetails(addresses: String) = assertBrowsingHistoryDescription(addresses)
 
-    fun verifyAllTheCheckBoxesText() = assertAllTheCheckBoxesText()
-
-    fun verifyAllTheCheckBoxesChecked() = assertAllTheCheckBoxesChecked()
-
-    fun verifyContentsInDialogBox() {
+    fun verifyDialogElements() {
         verifyMessageInDialogBox()
         verifyDeleteButtonInDialogBox()
         verifyCancelButtonInDialogBox()
     }
+
+    fun switchOpenTabsCheckBox() = clickOpenTabsCheckBox()
+    fun switchBrowsingHistoryCheckBox() = clickBrowsingHistoryCheckBox()
+    fun switchCookiesCheckBox() = clickCookiesCheckBox()
+    fun switchCachedFilesCheckBox() = clickCachedFilesCheckBox()
+    fun switchSitePermissionsCheckBox() = clickSitePermissionsCheckBox()
+    fun switchDownloadsCheckBox() = clickDownloadsCheckBox()
+    fun clickDeleteBrowsingDataButton() = deleteBrowsingDataButton().click()
+    fun clickDialogCancelButton() = dialogCancelButton().click()
+    fun selectOnlyOpenTabsCheckBox() = checkOnlyOpenTabsCheckBox()
+    fun selectOnlyBrowsingHistoryCheckBox() = checkOnlyBrowsingHistoryCheckBox()
 
     fun clickCancelButtonInDialogBoxAndVerifyContentsInDialogBox() {
         mDevice.wait(
             Until.findObject(By.text("Delete browsing data")),
             TestAssetHelper.waitingTime
         )
-        verifyClickDeleteBrowsingDataButton()
-        verifyContentsInDialogBox()
+        clickDeleteBrowsingDataButton()
+        verifyDialogElements()
         cancelButton().click()
+    }
+    fun confirmDeletionAndAssertSnackbar() {
+        dialogDeleteButton().click()
+        assertDeleteBrowsingDataSnackbar()
     }
 
     fun verifyDeleteBrowsingDataSubMenuItems() {
         verifyDeleteBrowsingDataButton()
         clickCancelButtonInDialogBoxAndVerifyContentsInDialogBox()
-        verifyAllTheCheckBoxesText()
-        verifyAllTheCheckBoxesChecked()
+        verifyAllOptionsAndCheckBoxes()
+        verifyAllCheckBoxesAreChecked()
     }
 
     class Transition {
@@ -85,82 +102,174 @@ class SettingsSubMenuDeleteBrowsingDataRobot {
 private fun goBackButton() =
     onView(allOf(withContentDescription("Navigate up")))
 
-private fun assertNavigationToolBarHeader() {
+private fun navigationToolBarHeader() =
     onView(
         allOf(
             withId(R.id.navigationToolbar),
             withChild(withText(R.string.preferences_delete_browsing_data))
         )
     )
-        .check((matches(withEffectiveVisibility(Visibility.VISIBLE))))
-}
 
-private fun assertDeleteBrowsingDataButton() {
-    onView(withId(R.id.delete_data))
-        .check((matches(withEffectiveVisibility(Visibility.VISIBLE))))
-}
+private fun deleteBrowsingDataButton() = onView(withId(R.id.delete_data))
 
-private fun assertClickDeleteBrowsingDataButton() {
-    onView(withId(R.id.delete_data))
-        .check((matches(withEffectiveVisibility(Visibility.VISIBLE)))).click()
-}
+private fun assertNavigationToolBarHeader() =
+    navigationToolBarHeader().check((matches(withEffectiveVisibility(Visibility.VISIBLE))))
+
+private fun assertDeleteBrowsingDataButton() =
+    deleteBrowsingDataButton().check((matches(withEffectiveVisibility(Visibility.VISIBLE))))
 
 private fun cancelButton() =
     mDevice.findObject(UiSelector().textStartsWith("CANCEL"))
 
-private fun assertMessageInDialogBox() =
+private fun dialogDeleteButton() = onView(withText("Delete")).inRoot(isDialog())
+
+private fun dialogCancelButton() = onView(withText("Cancel")).inRoot(isDialog())
+
+private fun openTabsSubsection() = onView(withText(R.string.preferences_delete_browsing_data_tabs_title_2))
+
+private fun openTabsDescription(tabNumber: String) = onView(withText("$tabNumber tabs"))
+
+private fun openTabsCheckBox() = onView(allOf(withId(R.id.checkbox), hasSibling(withText("Open tabs"))))
+
+private fun browsingHistorySubsection() =
+    onView(withText(R.string.preferences_delete_browsing_data_browsing_data_title))
+
+private fun browsingHistoryDescription(addresses: String) = onView(withText("$addresses addresses"))
+
+private fun browsingHistoryCheckBox() =
+    onView(allOf(withId(R.id.checkbox), hasSibling(withText("Browsing history and site data"))))
+
+private fun cookiesSubsection() =
+    onView(withText(R.string.preferences_delete_browsing_data_cookies))
+
+private fun cookiesDescription() = onView(withText(R.string.preferences_delete_browsing_data_cookies_subtitle))
+
+private fun cookiesCheckBox() =
+    onView(allOf(withId(R.id.checkbox), hasSibling(withText("Cookies"))))
+
+private fun cachedFilesSubsection() =
+    onView(withText(R.string.preferences_delete_browsing_data_cached_files))
+
+private fun cachedFilesDescription() =
+    onView(withText(R.string.preferences_delete_browsing_data_cached_files_subtitle))
+
+private fun cachedFilesCheckBox() =
+    onView(allOf(withId(R.id.checkbox), hasSibling(withText("Cached images and files"))))
+
+private fun sitePermissionsSubsection() =
+    onView(withText(R.string.preferences_delete_browsing_data_site_permissions))
+
+private fun sitePermissionsCheckBox() =
+    onView(allOf(withId(R.id.checkbox), hasSibling(withText("Site permissions"))))
+
+private fun downloadsSubsection() =
+    onView(withText(R.string.preferences_delete_browsing_data_downloads))
+
+private fun downloadsCheckBox() =
+    onView(allOf(withId(R.id.checkbox), hasSibling(withText("Downloads"))))
+
+private fun dialogMessage() =
     onView(withText("$appName will delete the selected browsing data."))
         .inRoot(isDialog())
-        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+
+private fun assertMessageInDialogBox() =
+    dialogMessage().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
 private fun assertDeleteButtonInDialogBox() =
-    onView(withText("Delete"))
-        .inRoot(isDialog())
-        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+    dialogDeleteButton().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
 private fun assertCancelButtonInDialogBox() =
-    onView(withText("Cancel"))
-        .inRoot(isDialog())
-        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+    dialogCancelButton().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
-private fun assertAllTheCheckBoxesText() {
-
-    onView(withText(R.string.preferences_delete_browsing_data_tabs_title_2))
-        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-
-    onView(withText("0 tabs"))
-        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-
-    onView(withText(R.string.preferences_delete_browsing_data_browsing_data_title))
-        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-
-    onView(withText("0 addresses"))
-        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-
-    onView(withText(R.string.preferences_delete_browsing_data_cookies))
-        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-
-    onView(withText(R.string.preferences_delete_browsing_data_cookies_subtitle))
-        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-
-    onView(withText(R.string.preferences_delete_browsing_data_cached_files))
-        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-
-    onView(withText(R.string.preferences_delete_browsing_data_cached_files_subtitle))
-        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-
-    onView(withText(R.string.preferences_delete_browsing_data_site_permissions))
-        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+private fun assertAllOptionsAndCheckBoxes() {
+    openTabsSubsection().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+    openTabsDescription("0").check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+    openTabsCheckBox().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+    browsingHistorySubsection().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+    browsingHistoryDescription("0").check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+    browsingHistoryCheckBox().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+    cookiesSubsection().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+    cookiesDescription().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+    cookiesCheckBox().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+    cachedFilesSubsection().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+    cachedFilesDescription().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+    cachedFilesCheckBox().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+    sitePermissionsSubsection().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+    sitePermissionsCheckBox().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+    downloadsSubsection().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+    downloadsCheckBox().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 }
 
-private fun assertAllTheCheckBoxesChecked() {
-    onView(allOf(withId(R.id.checkbox), hasSibling(withText("Open tabs")))).assertIsChecked(true)
+private fun assertAllCheckBoxesAreChecked() {
+    openTabsCheckBox().assertIsChecked(true)
+    browsingHistoryCheckBox().assertIsChecked(true)
+    cookiesCheckBox().assertIsChecked(true)
+    cachedFilesCheckBox().assertIsChecked(true)
+    sitePermissionsCheckBox().assertIsChecked(true)
+    downloadsCheckBox().assertIsChecked(true)
+}
 
-    onView(allOf(withId(R.id.checkbox), hasSibling(withText("Browsing history and site data")))).assertIsChecked(true)
+private fun assertOpenTabsDescription(tabNumber: String) =
+    openTabsDescription(tabNumber).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
-    onView(allOf(withId(R.id.checkbox), hasSibling(withText("Cookies")))).assertIsChecked(true)
+private fun assertBrowsingHistoryDescription(addresses: String) =
+    browsingHistoryDescription(addresses).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
-    onView(allOf(withId(R.id.checkbox), hasSibling(withText("Cached images and files")))).assertIsChecked(true)
+private fun assertDeleteBrowsingDataSnackbar() {
+    assertTrue(
+        mDevice.findObject(
+            UiSelector().text("Browsing data deleted")
+        ).waitUntilGone(waitingTime)
+    )
+}
 
-    onView(allOf(withId(R.id.checkbox), hasSibling(withText("Site permissions")))).assertIsChecked(true)
+private fun clickOpenTabsCheckBox() = openTabsCheckBox().click()
+private fun assertOpenTabsCheckBox(status: Boolean) = openTabsCheckBox().assertIsChecked(status)
+private fun clickBrowsingHistoryCheckBox() = browsingHistoryCheckBox().click()
+private fun assertBrowsingHistoryCheckBox(status: Boolean) = browsingHistoryCheckBox().assertIsChecked(status)
+private fun clickCookiesCheckBox() = cookiesCheckBox().click()
+private fun assertCookiesCheckBox(status: Boolean) = cookiesCheckBox().assertIsChecked(status)
+private fun clickCachedFilesCheckBox() = cachedFilesCheckBox().click()
+private fun assertCachedFilesCheckBox(status: Boolean) = cachedFilesCheckBox().assertIsChecked(status)
+private fun clickSitePermissionsCheckBox() = sitePermissionsCheckBox().click()
+private fun assertSitePermissionsCheckBox(status: Boolean) = sitePermissionsCheckBox().assertIsChecked(status)
+private fun clickDownloadsCheckBox() = downloadsCheckBox().click()
+private fun assertDownloadsCheckBox(status: Boolean) = downloadsCheckBox().assertIsChecked(status)
+
+fun checkOnlyOpenTabsCheckBox() {
+    clickBrowsingHistoryCheckBox()
+    assertBrowsingHistoryCheckBox(false)
+
+    clickCookiesCheckBox()
+    assertCookiesCheckBox(false)
+
+    clickCachedFilesCheckBox()
+    assertCachedFilesCheckBox(false)
+
+    clickSitePermissionsCheckBox()
+    assertSitePermissionsCheckBox(false)
+
+    clickDownloadsCheckBox()
+    assertDownloadsCheckBox(false)
+
+    assertOpenTabsCheckBox(true)
+}
+
+fun checkOnlyBrowsingHistoryCheckBox() {
+    clickOpenTabsCheckBox()
+    assertOpenTabsCheckBox(false)
+
+    clickCookiesCheckBox()
+    assertCookiesCheckBox(false)
+
+    clickCachedFilesCheckBox()
+    assertCachedFilesCheckBox(false)
+
+    clickSitePermissionsCheckBox()
+    assertSitePermissionsCheckBox(false)
+
+    clickDownloadsCheckBox()
+    assertDownloadsCheckBox(false)
+
+    assertBrowsingHistoryCheckBox(true)
 }


### PR DESCRIPTION
Delete browsing data UI tests
`deleteBrowsingDataOptionStatesTest` ✔️ Successfully ran 40x on Firebase
`deleteTabsDataWithNoOpenTabsTest` ✔️ Successfully ran 40x on Firebase
`deleteTabsDataTest` ✔️ Successfully ran 40x on Firebase
`deleteDeleteBrowsingHistoryDataTest` ✔️ Successfully ran 40x on Firebase

I've also ran `settingsPrivacyItemsTest` to be sure I didn't brake anything and ✔️ Successfully passed 40x on Firebase

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
