### PR TITLE
SearchDialogFragment: Start to split consumeFrom() into independent observers that trigger less often

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarView.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarView.kt
@@ -202,8 +202,6 @@ class AwesomeBarView(
     }
 
     fun update(state: SearchFragmentState) {
-        updateSuggestionProvidersVisibility(state)
-
         // Do not make suggestions based on user's current URL unless it's a search shortcut
         if (state.query.isNotEmpty() && state.query == state.url && !state.showSearchShortcuts) {
             return
@@ -212,7 +210,9 @@ class AwesomeBarView(
         view.onInputChanged(state.query)
     }
 
-    private fun updateSuggestionProvidersVisibility(state: SearchFragmentState) {
+    fun updateSuggestionProvidersVisibility(
+        state: SearchProviderState
+    ) {
         if (state.showSearchShortcuts) {
             handleDisplayShortcutsProviders()
             return
@@ -244,7 +244,9 @@ class AwesomeBarView(
     }
 
     @Suppress("ComplexMethod")
-    private fun getProvidersToAdd(state: SearchFragmentState): MutableSet<AwesomeBar.SuggestionProvider> {
+    private fun getProvidersToAdd(
+        state: SearchProviderState
+    ): MutableSet<AwesomeBar.SuggestionProvider> {
         val providersToAdd = mutableSetOf<AwesomeBar.SuggestionProvider>()
 
         if (state.showHistorySuggestions) {
@@ -276,7 +278,7 @@ class AwesomeBarView(
         return providersToAdd
     }
 
-    private fun getProvidersToRemove(state: SearchFragmentState): MutableSet<AwesomeBar.SuggestionProvider> {
+    private fun getProvidersToRemove(state: SearchProviderState): MutableSet<AwesomeBar.SuggestionProvider> {
         val providersToRemove = mutableSetOf<AwesomeBar.SuggestionProvider>()
 
         providersToRemove.add(shortcutsEnginePickerProvider)
@@ -308,7 +310,7 @@ class AwesomeBarView(
         return providersToRemove
     }
 
-    private fun getSelectedSearchSuggestionProvider(state: SearchFragmentState): List<AwesomeBar.SuggestionProvider> {
+    private fun getSelectedSearchSuggestionProvider(state: SearchProviderState): List<AwesomeBar.SuggestionProvider> {
         return when (state.searchEngineSource) {
             is SearchEngineSource.Default -> listOf(
                 defaultSearchActionProvider,
@@ -367,8 +369,26 @@ class AwesomeBarView(
         }
     }
 
+    data class SearchProviderState(
+        val showSearchShortcuts: Boolean,
+        val showHistorySuggestions: Boolean,
+        val showBookmarkSuggestions: Boolean,
+        val showSearchSuggestions: Boolean,
+        val showSyncedTabsSuggestions: Boolean,
+        val searchEngineSource: SearchEngineSource
+    )
+
     companion object {
         // Maximum number of suggestions returned from the history metadata storage.
         const val METADATA_SUGGESTION_LIMIT = 3
     }
 }
+
+fun SearchFragmentState.toSearchProviderState() = AwesomeBarView.SearchProviderState(
+    showSearchShortcuts,
+    showHistorySuggestions,
+    showBookmarkSuggestions,
+    showSearchSuggestions,
+    showSyncedTabsSuggestions,
+    searchEngineSource
+)


### PR DESCRIPTION
Currently `SearchDialogFragment` uses `consumeFrom()` and calls various methods for every state change. Since the state contains the typed text, it updates quite often and all those methods get called that often too. Some of them are not interested in the typed text and so we call them over and over for no real reason (for example the code that updates the list of search providers in the awesome bar).

In this patch I moved some of those calls out and invoke them from a separate observer using `consumeFlow()`. The awesome bar reacts much faster than Nightly, but that may be mostly because of the change from #21334.