### PR TITLE
For #21294: remove excess allocation in Fact.toEvent

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
@@ -368,35 +368,39 @@ internal class ReleaseMetricController(
             else -> null
         }
 
-        Component.FEATURE_AUTOFILL to AutofillFacts.Items.AUTOFILL_REQUEST -> {
-            val hasMatchingLogins = metadata?.get(AutofillFacts.Metadata.HAS_MATCHING_LOGINS) as Boolean?
-            if (hasMatchingLogins == true) {
-                Event.AndroidAutofillRequestWithLogins
-            } else {
-                Event.AndroidAutofillRequestWithoutLogins
+        Component.FEATURE_AUTOFILL -> when (item) {
+            AutofillFacts.Items.AUTOFILL_REQUEST -> {
+                val hasMatchingLogins = metadata?.get(AutofillFacts.Metadata.HAS_MATCHING_LOGINS) as Boolean?
+                if (hasMatchingLogins == true) {
+                    Event.AndroidAutofillRequestWithLogins
+                } else {
+                    Event.AndroidAutofillRequestWithoutLogins
+                }
             }
-        }
-        Component.FEATURE_AUTOFILL to AutofillFacts.Items.AUTOFILL_SEARCH -> {
-            if (action == Action.SELECT) {
-                Event.AndroidAutofillSearchItemSelected
-            } else {
-                Event.AndroidAutofillSearchDisplayed
+            AutofillFacts.Items.AUTOFILL_SEARCH -> {
+                if (action == Action.SELECT) {
+                    Event.AndroidAutofillSearchItemSelected
+                } else {
+                    Event.AndroidAutofillSearchDisplayed
+                }
             }
-        }
-        Component.FEATURE_AUTOFILL to AutofillFacts.Items.AUTOFILL_LOCK -> {
-            if (action == Action.CONFIRM) {
-                Event.AndroidAutofillUnlockSuccessful
-            } else {
-                Event.AndroidAutofillUnlockCanceled
+            AutofillFacts.Items.AUTOFILL_LOCK -> {
+                if (action == Action.CONFIRM) {
+                    Event.AndroidAutofillUnlockSuccessful
+                } else {
+                    Event.AndroidAutofillUnlockCanceled
+                }
             }
-        }
-        Component.FEATURE_AUTOFILL to AutofillFacts.Items.AUTOFILL_CONFIRMATION -> {
-            if (action == Action.CONFIRM) {
-                Event.AndroidAutofillConfirmationSuccessful
-            } else {
-                Event.AndroidAutofillConfirmationCanceled
+            AutofillFacts.Items.AUTOFILL_CONFIRMATION -> {
+                if (action == Action.CONFIRM) {
+                    Event.AndroidAutofillConfirmationSuccessful
+                } else {
+                    Event.AndroidAutofillConfirmationCanceled
+                }
             }
+            else -> null
         }
+
         else -> null
     }
 

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
@@ -331,25 +331,28 @@ internal class ReleaseMetricController(
             else -> null
         }
 
-        Component.LIB_DATAPROTECT to SecurePrefsReliabilityExperiment.Companion.Actions.EXPERIMENT -> {
-            Event.SecurePrefsExperimentFailure(metadata?.get("javaClass") as String? ?: "null")
-        }
-        Component.LIB_DATAPROTECT to SecurePrefsReliabilityExperiment.Companion.Actions.GET -> {
-            if (SecurePrefsReliabilityExperiment.Companion.Values.FAIL.v == value?.toInt()) {
-                Event.SecurePrefsGetFailure(metadata?.get("javaClass") as String? ?: "null")
-            } else {
-                Event.SecurePrefsGetSuccess(value ?: "")
+        Component.LIB_DATAPROTECT -> when (item) {
+            SecurePrefsReliabilityExperiment.Companion.Actions.EXPERIMENT -> {
+                Event.SecurePrefsExperimentFailure(metadata?.get("javaClass") as String? ?: "null")
             }
-        }
-        Component.LIB_DATAPROTECT to SecurePrefsReliabilityExperiment.Companion.Actions.WRITE -> {
-            if (SecurePrefsReliabilityExperiment.Companion.Values.FAIL.v == value?.toInt()) {
-                Event.SecurePrefsWriteFailure(metadata?.get("javaClass") as String? ?: "null")
-            } else {
-                Event.SecurePrefsWriteSuccess
+            SecurePrefsReliabilityExperiment.Companion.Actions.GET -> {
+                if (SecurePrefsReliabilityExperiment.Companion.Values.FAIL.v == value?.toInt()) {
+                    Event.SecurePrefsGetFailure(metadata?.get("javaClass") as String? ?: "null")
+                } else {
+                    Event.SecurePrefsGetSuccess(value ?: "")
+                }
             }
-        }
-        Component.LIB_DATAPROTECT to SecurePrefsReliabilityExperiment.Companion.Actions.RESET -> {
-            Event.SecurePrefsReset
+            SecurePrefsReliabilityExperiment.Companion.Actions.WRITE -> {
+                if (SecurePrefsReliabilityExperiment.Companion.Values.FAIL.v == value?.toInt()) {
+                    Event.SecurePrefsWriteFailure(metadata?.get("javaClass") as String? ?: "null")
+                } else {
+                    Event.SecurePrefsWriteSuccess
+                }
+            }
+            SecurePrefsReliabilityExperiment.Companion.Actions.RESET -> {
+                Event.SecurePrefsReset
+            }
+            else -> null
         }
 
         Component.FEATURE_SEARCH to AdsTelemetry.SERP_ADD_CLICKED -> {

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
@@ -230,23 +230,28 @@ internal class ReleaseMetricController(
             }
             else -> null
         }
-        Component.SUPPORT_WEBEXTENSIONS to WebExtensionFacts.Items.WEB_EXTENSIONS_INITIALIZED -> {
-            metadata?.get("installed")?.let { installedAddons ->
-                if (installedAddons is List<*>) {
-                    settings.installedAddonsCount = installedAddons.size
-                    settings.installedAddonsList = installedAddons.joinToString(",")
-                }
-            }
 
-            metadata?.get("enabled")?.let { enabledAddons ->
-                if (enabledAddons is List<*>) {
-                    settings.enabledAddonsCount = enabledAddons.size
-                    settings.enabledAddonsList = enabledAddons.joinToString(",")
+        Component.SUPPORT_WEBEXTENSIONS -> when (item) {
+            WebExtensionFacts.Items.WEB_EXTENSIONS_INITIALIZED -> {
+                metadata?.get("installed")?.let { installedAddons ->
+                    if (installedAddons is List<*>) {
+                        settings.installedAddonsCount = installedAddons.size
+                        settings.installedAddonsList = installedAddons.joinToString(",")
+                    }
                 }
-            }
 
-            null
+                metadata?.get("enabled")?.let { enabledAddons ->
+                    if (enabledAddons is List<*>) {
+                        settings.enabledAddonsCount = enabledAddons.size
+                        settings.enabledAddonsList = enabledAddons.joinToString(",")
+                    }
+                }
+
+                null
+            }
+            else -> null
         }
+
         Component.BROWSER_AWESOMEBAR to BrowserAwesomeBarFacts.Items.PROVIDER_DURATION -> {
             metadata?.get(BrowserAwesomeBarFacts.MetadataKeys.DURATION_PAIR)?.let { providerTiming ->
                 require(providerTiming is Pair<*, *>) { "Expected providerTiming to be a Pair" }

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
@@ -274,12 +274,17 @@ internal class ReleaseMetricController(
             }
             else -> null
         }
-        Component.FEATURE_PWA to ProgressiveWebAppFacts.Items.HOMESCREEN_ICON_TAP -> {
-            Event.ProgressiveWebAppOpenFromHomescreenTap
+
+        Component.FEATURE_PWA -> when (item) {
+            ProgressiveWebAppFacts.Items.HOMESCREEN_ICON_TAP -> {
+                Event.ProgressiveWebAppOpenFromHomescreenTap
+            }
+            ProgressiveWebAppFacts.Items.INSTALL_SHORTCUT -> {
+                Event.ProgressiveWebAppInstallAsShortcut
+            }
+            else -> null
         }
-        Component.FEATURE_PWA to ProgressiveWebAppFacts.Items.INSTALL_SHORTCUT -> {
-            Event.ProgressiveWebAppInstallAsShortcut
-        }
+
         Component.FEATURE_TOP_SITES to TopSitesFacts.Items.COUNT -> {
             value?.let {
                 var count = 0

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
@@ -252,24 +252,27 @@ internal class ReleaseMetricController(
             else -> null
         }
 
-        Component.BROWSER_AWESOMEBAR to BrowserAwesomeBarFacts.Items.PROVIDER_DURATION -> {
-            metadata?.get(BrowserAwesomeBarFacts.MetadataKeys.DURATION_PAIR)?.let { providerTiming ->
-                require(providerTiming is Pair<*, *>) { "Expected providerTiming to be a Pair" }
-                when (val provider = providerTiming.first as AwesomeBar.SuggestionProvider) {
-                    is HistoryStorageSuggestionProvider -> PerfAwesomebar.historySuggestions
-                    is BookmarksStorageSuggestionProvider -> PerfAwesomebar.bookmarkSuggestions
-                    is SessionSuggestionProvider -> PerfAwesomebar.sessionSuggestions
-                    is SearchSuggestionProvider -> PerfAwesomebar.searchEngineSuggestions
-                    is ClipboardSuggestionProvider -> PerfAwesomebar.clipboardSuggestions
-                    is ShortcutsSuggestionProvider -> PerfAwesomebar.shortcutsSuggestions
-                    // NB: add PerfAwesomebar.syncedTabsSuggestions once we're using SyncedTabsSuggestionProvider
-                    else -> {
-                        Logger("Metrics").error("Unknown suggestion provider: $provider")
-                        null
-                    }
-                }?.accumulateSamples(longArrayOf(providerTiming.second as Long))
+        Component.BROWSER_AWESOMEBAR -> when (item) {
+            BrowserAwesomeBarFacts.Items.PROVIDER_DURATION -> {
+                metadata?.get(BrowserAwesomeBarFacts.MetadataKeys.DURATION_PAIR)?.let { providerTiming ->
+                    require(providerTiming is Pair<*, *>) { "Expected providerTiming to be a Pair" }
+                    when (val provider = providerTiming.first as AwesomeBar.SuggestionProvider) {
+                        is HistoryStorageSuggestionProvider -> PerfAwesomebar.historySuggestions
+                        is BookmarksStorageSuggestionProvider -> PerfAwesomebar.bookmarkSuggestions
+                        is SessionSuggestionProvider -> PerfAwesomebar.sessionSuggestions
+                        is SearchSuggestionProvider -> PerfAwesomebar.searchEngineSuggestions
+                        is ClipboardSuggestionProvider -> PerfAwesomebar.clipboardSuggestions
+                        is ShortcutsSuggestionProvider -> PerfAwesomebar.shortcutsSuggestions
+                        // NB: add PerfAwesomebar.syncedTabsSuggestions once we're using SyncedTabsSuggestionProvider
+                        else -> {
+                            Logger("Metrics").error("Unknown suggestion provider: $provider")
+                            null
+                        }
+                    }?.accumulateSamples(longArrayOf(providerTiming.second as Long))
+                }
+                null
             }
-            null
+            else -> null
         }
         Component.FEATURE_PWA to ProgressiveWebAppFacts.Items.HOMESCREEN_ICON_TAP -> {
             Event.ProgressiveWebAppOpenFromHomescreenTap

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
@@ -355,15 +355,19 @@ internal class ReleaseMetricController(
             else -> null
         }
 
-        Component.FEATURE_SEARCH to AdsTelemetry.SERP_ADD_CLICKED -> {
-            Event.SearchAdClicked(value!!)
+        Component.FEATURE_SEARCH -> when (item) {
+            AdsTelemetry.SERP_ADD_CLICKED -> {
+                Event.SearchAdClicked(value!!)
+            }
+            AdsTelemetry.SERP_SHOWN_WITH_ADDS -> {
+                Event.SearchWithAds(value!!)
+            }
+            InContentTelemetry.IN_CONTENT_SEARCH -> {
+                Event.SearchInContent(value!!)
+            }
+            else -> null
         }
-        Component.FEATURE_SEARCH to AdsTelemetry.SERP_SHOWN_WITH_ADDS -> {
-            Event.SearchWithAds(value!!)
-        }
-        Component.FEATURE_SEARCH to InContentTelemetry.IN_CONTENT_SEARCH -> {
-            Event.SearchInContent(value!!)
-        }
+
         Component.FEATURE_AUTOFILL to AutofillFacts.Items.AUTOFILL_REQUEST -> {
             val hasMatchingLogins = metadata?.get(AutofillFacts.Metadata.HAS_MATCHING_LOGINS) as Boolean?
             if (hasMatchingLogins == true) {

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
@@ -285,22 +285,30 @@ internal class ReleaseMetricController(
             else -> null
         }
 
-        Component.FEATURE_TOP_SITES to TopSitesFacts.Items.COUNT -> {
-            value?.let {
-                var count = 0
-                try {
-                    count = it.toInt()
-                } catch (e: NumberFormatException) {
-                    // Do nothing
-                }
+        Component.FEATURE_TOP_SITES -> when (item) {
+            TopSitesFacts.Items.COUNT -> {
+                value?.let {
+                    var count = 0
+                    try {
+                        count = it.toInt()
+                    } catch (e: NumberFormatException) {
+                        // Do nothing
+                    }
 
-                settings.topSitesSize = count
+                    settings.topSitesSize = count
+                }
+                null
             }
-            null
+            else -> null
         }
-        Component.FEATURE_SYNCEDTABS to SyncedTabsFacts.Items.SYNCED_TABS_SUGGESTION_CLICKED -> {
-            Event.SyncedTabSuggestionClicked
+
+        Component.FEATURE_SYNCEDTABS -> when (item) {
+            SyncedTabsFacts.Items.SYNCED_TABS_SUGGESTION_CLICKED -> {
+                Event.SyncedTabSuggestionClicked
+            }
+            else -> null
         }
+
         Component.FEATURE_AWESOMEBAR to AwesomeBarFacts.Items.BOOKMARK_SUGGESTION_CLICKED -> {
             Event.BookmarkSuggestionClicked
         }

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
@@ -158,21 +158,23 @@ internal class ReleaseMetricController(
     }
 
     @Suppress("LongMethod")
-    private fun Fact.toEvent(): Event? = when (Pair(component, item)) {
-        Component.FEATURE_PROMPTS to LoginDialogFacts.Items.DISPLAY -> Event.LoginDialogPromptDisplayed
-        Component.FEATURE_PROMPTS to LoginDialogFacts.Items.CANCEL -> Event.LoginDialogPromptCancelled
-        Component.FEATURE_PROMPTS to LoginDialogFacts.Items.NEVER_SAVE -> Event.LoginDialogPromptNeverSave
-        Component.FEATURE_PROMPTS to LoginDialogFacts.Items.SAVE -> Event.LoginDialogPromptSave
-        Component.FEATURE_PROMPTS to CreditCardAutofillDialogFacts.Items.AUTOFILL_CREDIT_CARD_FORM_DETECTED ->
-            Event.CreditCardFormDetected
-        Component.FEATURE_PROMPTS to CreditCardAutofillDialogFacts.Items.AUTOFILL_CREDIT_CARD_SUCCESS ->
-            Event.CreditCardAutofilled
-        Component.FEATURE_PROMPTS to CreditCardAutofillDialogFacts.Items.AUTOFILL_CREDIT_CARD_PROMPT_SHOWN ->
-            Event.CreditCardAutofillPromptShown
-        Component.FEATURE_PROMPTS to CreditCardAutofillDialogFacts.Items.AUTOFILL_CREDIT_CARD_PROMPT_EXPANDED ->
-            Event.CreditCardAutofillPromptExpanded
-        Component.FEATURE_PROMPTS to CreditCardAutofillDialogFacts.Items.AUTOFILL_CREDIT_CARD_PROMPT_DISMISSED ->
-            Event.CreditCardAutofillPromptDismissed
+    private fun Fact.toEvent(): Event? = when (component) {
+        Component.FEATURE_PROMPTS -> when (item) {
+            LoginDialogFacts.Items.DISPLAY -> Event.LoginDialogPromptDisplayed
+            LoginDialogFacts.Items.CANCEL -> Event.LoginDialogPromptCancelled
+            LoginDialogFacts.Items.NEVER_SAVE -> Event.LoginDialogPromptNeverSave
+            LoginDialogFacts.Items.SAVE -> Event.LoginDialogPromptSave
+            CreditCardAutofillDialogFacts.Items.AUTOFILL_CREDIT_CARD_FORM_DETECTED ->
+                Event.CreditCardFormDetected
+            CreditCardAutofillDialogFacts.Items.AUTOFILL_CREDIT_CARD_SUCCESS -> Event.CreditCardAutofilled
+            CreditCardAutofillDialogFacts.Items.AUTOFILL_CREDIT_CARD_PROMPT_SHOWN ->
+                Event.CreditCardAutofillPromptShown
+            CreditCardAutofillDialogFacts.Items.AUTOFILL_CREDIT_CARD_PROMPT_EXPANDED ->
+                Event.CreditCardAutofillPromptExpanded
+            CreditCardAutofillDialogFacts.Items.AUTOFILL_CREDIT_CARD_PROMPT_DISMISSED ->
+                Event.CreditCardAutofillPromptDismissed
+            else -> null
+        }
 
         Component.FEATURE_CONTEXTMENU to ContextMenuFacts.Items.ITEM -> {
             metadata?.get("item")?.let { Event.ContextMenuItemTapped.create(it.toString()) }

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
@@ -192,12 +192,20 @@ internal class ReleaseMetricController(
             else -> null
         }
 
-        Component.BROWSER_TOOLBAR to ToolbarFacts.Items.MENU -> {
-            metadata?.get("customTab")?.let { Event.CustomTabsMenuOpened } ?: Event.ToolbarMenuShown
+        Component.BROWSER_TOOLBAR -> when (item) {
+            ToolbarFacts.Items.MENU -> {
+                metadata?.get("customTab")?.let { Event.CustomTabsMenuOpened } ?: Event.ToolbarMenuShown
+            }
+            else -> null
         }
-        Component.BROWSER_MENU to BrowserMenuFacts.Items.WEB_EXTENSION_MENU_ITEM -> {
-            metadata?.get("id")?.let { Event.AddonsOpenInToolbarMenu(it.toString()) }
+
+        Component.BROWSER_MENU -> when (item) {
+            BrowserMenuFacts.Items.WEB_EXTENSION_MENU_ITEM -> {
+                metadata?.get("id")?.let { Event.AddonsOpenInToolbarMenu(it.toString()) }
+            }
+            else -> null
         }
+
         Component.FEATURE_CUSTOMTABS to CustomTabsFacts.Items.CLOSE -> Event.CustomTabsClosed
         Component.FEATURE_CUSTOMTABS to CustomTabsFacts.Items.ACTION_BUTTON -> Event.CustomTabsActionTapped
 

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
@@ -309,23 +309,26 @@ internal class ReleaseMetricController(
             else -> null
         }
 
-        Component.FEATURE_AWESOMEBAR to AwesomeBarFacts.Items.BOOKMARK_SUGGESTION_CLICKED -> {
-            Event.BookmarkSuggestionClicked
-        }
-        Component.FEATURE_AWESOMEBAR to AwesomeBarFacts.Items.CLIPBOARD_SUGGESTION_CLICKED -> {
-            Event.ClipboardSuggestionClicked
-        }
-        Component.FEATURE_AWESOMEBAR to AwesomeBarFacts.Items.HISTORY_SUGGESTION_CLICKED -> {
-            Event.HistorySuggestionClicked
-        }
-        Component.FEATURE_AWESOMEBAR to AwesomeBarFacts.Items.SEARCH_ACTION_CLICKED -> {
-            Event.SearchActionClicked
-        }
-        Component.FEATURE_AWESOMEBAR to AwesomeBarFacts.Items.SEARCH_SUGGESTION_CLICKED -> {
-            Event.SearchSuggestionClicked
-        }
-        Component.FEATURE_AWESOMEBAR to AwesomeBarFacts.Items.OPENED_TAB_SUGGESTION_CLICKED -> {
-            Event.OpenedTabSuggestionClicked
+        Component.FEATURE_AWESOMEBAR -> when (item) {
+            AwesomeBarFacts.Items.BOOKMARK_SUGGESTION_CLICKED -> {
+                Event.BookmarkSuggestionClicked
+            }
+            AwesomeBarFacts.Items.CLIPBOARD_SUGGESTION_CLICKED -> {
+                Event.ClipboardSuggestionClicked
+            }
+            AwesomeBarFacts.Items.HISTORY_SUGGESTION_CLICKED -> {
+                Event.HistorySuggestionClicked
+            }
+            AwesomeBarFacts.Items.SEARCH_ACTION_CLICKED -> {
+                Event.SearchActionClicked
+            }
+            AwesomeBarFacts.Items.SEARCH_SUGGESTION_CLICKED -> {
+                Event.SearchSuggestionClicked
+            }
+            AwesomeBarFacts.Items.OPENED_TAB_SUGGESTION_CLICKED -> {
+                Event.OpenedTabSuggestionClicked
+            }
+            else -> null
         }
 
         Component.LIB_DATAPROTECT to SecurePrefsReliabilityExperiment.Companion.Actions.EXPERIMENT -> {

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
@@ -157,7 +157,7 @@ internal class ReleaseMetricController(
         MetricServiceType.Marketing -> isMarketingDataTelemetryEnabled()
     }
 
-    @Suppress("LongMethod")
+    @Suppress("LongMethod", "NestedBlockDepth")
     private fun Fact.toEvent(): Event? = when (component) {
         Component.FEATURE_PROMPTS -> when (item) {
             LoginDialogFacts.Items.DISPLAY -> Event.LoginDialogPromptDisplayed

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
@@ -206,8 +206,11 @@ internal class ReleaseMetricController(
             else -> null
         }
 
-        Component.FEATURE_CUSTOMTABS to CustomTabsFacts.Items.CLOSE -> Event.CustomTabsClosed
-        Component.FEATURE_CUSTOMTABS to CustomTabsFacts.Items.ACTION_BUTTON -> Event.CustomTabsActionTapped
+        Component.FEATURE_CUSTOMTABS -> when (item) {
+            CustomTabsFacts.Items.CLOSE -> Event.CustomTabsClosed
+            CustomTabsFacts.Items.ACTION_BUTTON -> Event.CustomTabsActionTapped
+            else -> null
+        }
 
         Component.FEATURE_MEDIA to MediaFacts.Items.NOTIFICATION -> {
             when (action) {

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
@@ -212,20 +212,23 @@ internal class ReleaseMetricController(
             else -> null
         }
 
-        Component.FEATURE_MEDIA to MediaFacts.Items.NOTIFICATION -> {
-            when (action) {
-                Action.PLAY -> Event.NotificationMediaPlay
-                Action.PAUSE -> Event.NotificationMediaPause
-                else -> null
+        Component.FEATURE_MEDIA -> when (item) {
+            MediaFacts.Items.NOTIFICATION -> {
+                when (action) {
+                    Action.PLAY -> Event.NotificationMediaPlay
+                    Action.PAUSE -> Event.NotificationMediaPause
+                    else -> null
+                }
             }
-        }
-        Component.FEATURE_MEDIA to MediaFacts.Items.STATE -> {
-            when (action) {
-                Action.PLAY -> Event.MediaPlayState
-                Action.PAUSE -> Event.MediaPauseState
-                Action.STOP -> Event.MediaStopState
-                else -> null
+            MediaFacts.Items.STATE -> {
+                when (action) {
+                    Action.PLAY -> Event.MediaPlayState
+                    Action.PAUSE -> Event.MediaPauseState
+                    Action.STOP -> Event.MediaStopState
+                    else -> null
+                }
             }
+            else -> null
         }
         Component.SUPPORT_WEBEXTENSIONS to WebExtensionFacts.Items.WEB_EXTENSIONS_INITIALIZED -> {
             metadata?.get("installed")?.let { installedAddons ->

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
@@ -176,17 +176,20 @@ internal class ReleaseMetricController(
             else -> null
         }
 
-        Component.FEATURE_CONTEXTMENU to ContextMenuFacts.Items.ITEM -> {
-            metadata?.get("item")?.let { Event.ContextMenuItemTapped.create(it.toString()) }
-        }
-        Component.FEATURE_CONTEXTMENU to ContextMenuFacts.Items.TEXT_SELECTION_OPTION -> {
-            when (metadata?.get("textSelectionOption")?.toString()) {
-                CONTEXT_MENU_COPY -> Event.ContextMenuCopyTapped
-                CONTEXT_MENU_SEARCH, CONTEXT_MENU_SEARCH_PRIVATELY -> Event.ContextMenuSearchTapped
-                CONTEXT_MENU_SELECT_ALL -> Event.ContextMenuSelectAllTapped
-                CONTEXT_MENU_SHARE -> Event.ContextMenuShareTapped
-                else -> null
+        Component.FEATURE_CONTEXTMENU -> when (item) {
+            ContextMenuFacts.Items.ITEM -> {
+                metadata?.get("item")?.let { Event.ContextMenuItemTapped.create(it.toString()) }
             }
+            ContextMenuFacts.Items.TEXT_SELECTION_OPTION -> {
+                when (metadata?.get("textSelectionOption")?.toString()) {
+                    CONTEXT_MENU_COPY -> Event.ContextMenuCopyTapped
+                    CONTEXT_MENU_SEARCH, CONTEXT_MENU_SEARCH_PRIVATELY -> Event.ContextMenuSearchTapped
+                    CONTEXT_MENU_SELECT_ALL -> Event.ContextMenuSelectAllTapped
+                    CONTEXT_MENU_SHARE -> Event.ContextMenuShareTapped
+                    else -> null
+                }
+            }
+            else -> null
         }
 
         Component.BROWSER_TOOLBAR to ToolbarFacts.Items.MENU -> {


### PR DESCRIPTION
There seem like there could be bigger wins in memory but this one is relatively straightforward to implement.

I tried to be careful to do this in step-by-step commits to avoid introducing regressions. If it's too risky, we can not land this (or write more tests but I'm not sure it's worth the time at that point).

Here's the improvement when opening search, typing "a", starting allocation tracking, and typing "p". Before:
![Screen Shot 2021-09-17 at 16 41 41](https://user-images.githubusercontent.com/759372/133866318-8a0d4191-6540-4e1c-b086-e096e1dc03f0.png)

After:
![Screen Shot 2021-09-17 at 16 40 06](https://user-images.githubusercontent.com/759372/133866325-23dee3db-c774-4686-99b9-6719cc59dd5f.png)

To be fair, these additional `Pair` allocations could have come from something else running at the time but it seems unlikely to be the root cause of the change.

_edit: I realized there is a change in logic. In the original case, if you had a component that matched but an item that did not, you would match against all 35 values. In the new version, you'll match against the component and only **its** items. I'm pretty sure the `when` statement will protect us against duplicate components so this logic would end up being functionally the same but I just thought I'd mention it. The best way to protect against an error being added from this is to add complete coverage, probably._

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
