### PR TITLE
Use UpdateUrlAction to record viewTime observations

### DIFF
--- a/app/src/test/java/org/mozilla/fenix/historymetadata/HistoryMetadataMiddlewareTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/historymetadata/HistoryMetadataMiddlewareTest.kt
@@ -174,18 +174,30 @@ class HistoryMetadataMiddlewareTest {
     }
 
     @Test
-    fun `GIVEN normal tab WHEN user navigates and new page starts loading THEN meta data is updated`() {
+    fun `GIVEN normal tab WHEN update url action event with a different url is received THEN meta data is updated`() {
         val existingKey = HistoryMetadataKey(url = "https://mozilla.org")
         val tab = createTab(url = existingKey.url, historyMetadata = existingKey)
 
         store.dispatch(TabListAction.AddTabAction(tab)).joinBlocking()
         verify { service wasNot Called }
 
-        store.dispatch(ContentAction.UpdateLoadingStateAction(tab.id, true)).joinBlocking()
+        store.dispatch(ContentAction.UpdateUrlAction(tab.id, "https://www.someother.url")).joinBlocking()
         val capturedTab = slot<TabSessionState>()
         verify { service.updateMetadata(existingKey, capture(capturedTab)) }
 
         assertEquals(tab.id, capturedTab.captured.id)
+    }
+
+    @Test
+    fun `GIVEN normal tab WHEN update url action event with the same url is received THEN meta data is not updated`() {
+        val existingKey = HistoryMetadataKey(url = "https://mozilla.org")
+        val tab = createTab(url = existingKey.url, historyMetadata = existingKey)
+
+        store.dispatch(TabListAction.AddTabAction(tab)).joinBlocking()
+        verify { service wasNot Called }
+
+        store.dispatch(ContentAction.UpdateUrlAction(tab.id, existingKey.url)).joinBlocking()
+        verify { service wasNot Called }
     }
 
     @Test


### PR DESCRIPTION
We discovered that in a tab restore scenario we were recording view time
observations that were wrong - we'd record time deltas as-if user was
looking at the page while the browser wasn't running.

This happens because when we record a viewTime observation, we compare
current time with lastAccess time of the tab. In a restore scenario,
that lastAccess time happens to be from when the browser was last
running - which could be days ago.

The simplest solution was to not record a viewTime observation if the
url for a tab didn't change during a load event. To achieve this, we
needed to change which action we were using as a proxy for "navigation
events" - UpdateUrlAction contains the new url, allowing us to compare
against the current tab url.

Alternative solutions would be to keep using loading actions, but
dispatch a lastAccess event before performing a metadata update. This
would have worked, but would result in two lastAccess events being
dispatched for each navigation event instead of just one.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
