### PR TITLE
Disables "Inactive Tabs" feature

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -52,7 +52,7 @@ object FeatureFlags {
     /**
      * Identifies and separates the tabs list with a secondary section containing least used tabs.
      */
-    val inactiveTabs = Config.channel.isNightlyOrDebug
+    val inactiveTabs = false
 
     /**
      * Enables showing the home screen behind the search dialog


### PR DESCRIPTION
This was widely disliked in #20684, and should be disabled until a configuration option to disable it is built.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
