### PR TITLE
Support Addons in Beta release (and cleanup channels)

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/Config.kt
+++ b/app/src/main/java/org/mozilla/fenix/Config.kt
@@ -29,6 +29,9 @@ enum class ReleaseChannel {
     val isReleaseOrBeta: Boolean
         get() = this == Release || this == Beta
 
+    val isNonstable: Boolean
+        get() = this != Release
+
     val isRelease: Boolean
         get() = when (this) {
             Release -> true

--- a/app/src/main/java/org/mozilla/fenix/components/Components.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Components.kt
@@ -95,7 +95,7 @@ class Components(private val context: Context) {
 
     val addonCollectionProvider by lazyMonitored {
         // Check if we have a customized (overridden) AMO collection (only supported in Nightly)
-        if (Config.channel.isNightlyOrDebug && context.settings().amoCollectionOverrideConfigured()) {
+        if (Config.channel.isNonstable && context.settings().amoCollectionOverrideConfigured()) {
             AddonCollectionProvider(
                 context,
                 core.client,

--- a/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -138,7 +138,7 @@ class Core(
              * disabled in Fenix Release builds for now.
              * This is consistent with both Fennec and Firefox Desktop.
              */
-            if (Config.channel.isNightlyOrDebug || Config.channel.isBeta) {
+            if (Config.channel.isNonstable) {
                 WebCompatReporterFeature.install(it, "fenix")
             }
         }

--- a/app/src/main/java/org/mozilla/fenix/gecko/GeckoProvider.kt
+++ b/app/src/main/java/org/mozilla/fenix/gecko/GeckoProvider.kt
@@ -57,7 +57,7 @@ object GeckoProvider {
             .telemetryDelegate(GeckoAdapter())
             .contentBlocking(policy.toContentBlockingSetting())
             .debugLogging(Config.channel.isDebug)
-            .aboutConfigEnabled(Config.channel.isBeta || Config.channel.isNightlyOrDebug)
+            .aboutConfigEnabled(Config.channel.isNonstable)
             .build()
 
         val settings = context.components.settings

--- a/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
@@ -563,7 +563,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
             findPreference<Preference>(getPreferenceKey(R.string.pref_key_override_amo_collection))
 
         val show = (
-            Config.channel.isNightlyOrDebug && (
+            Config.channel.isNonstable && (
                 settings.amoCollectionOverrideConfigured() || settings.showSecretDebugMenuThisSession
                 )
             )


### PR DESCRIPTION
I and several other users who don't want to use half-completed features are forced onto the Nightly version since that's the only version that supports addons not on the approved whitelist. Addons are still not fully stable, but needing to access the hidden menu and setup an AMO collection should be indication enough that this is done at the user's own risk and it is not fully supported.

Closes #19594 (For Beta at least, Stable addons are presumably a long ways off) and also works as a partial solution for issues related to incomplete features like #20684 and #21360

Also, since there are now a bunch of features gated behind "Beta, Nightly, or Debug" I added "isNonstable" to represent them.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
