### PR TITLE
Closes #21388: Only parse clipboard content when search fragment is attached

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt
@@ -382,11 +382,9 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
             // We delay querying the clipboard by posting this code to the main thread message queue,
             // because ClipboardManager will return null if the does app not have input focus yet.
             lifecycleScope.launch(Dispatchers.Cached) {
-                store.dispatch(
-                    SearchFragmentAction.UpdateClipboardUrl(
-                        requireContext().components.clipboardHandler.url
-                    )
-                )
+                context?.components?.clipboardHandler?.url?.let { clipboardUrl ->
+                    store.dispatch(SearchFragmentAction.UpdateClipboardUrl(clipboardUrl))
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #21388. `requireContext` caused the crash. Changed it to only dispatch if attached and only if we actually have a clipboard URL, which seems right for this use case.