### PR TITLE
No issue: remove escape chars on add logins string

### DIFF
--- a/app/src/main/res/layout/fragment_add_login.xml
+++ b/app/src/main/res/layout/fragment_add_login.xml
@@ -44,7 +44,7 @@
         app:layout_constraintStart_toStartOf="@id/hostnameHeaderText"
         app:layout_constraintTop_toBottomOf="@id/hostnameHeaderText"
         app:helperTextEnabled="true"
-        app:helperText="@string/add_login_hostname_invalid_text_1"
+        app:helperText="@string/add_login_hostname_invalid_text_3"
         app:hintEnabled="false" >
 
         <com.google.android.material.textfield.TextInputEditText

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1805,7 +1805,9 @@
     <!-- This is the hint text that is shown inline on the hostname field of the create new login page. 'https://www.example.com' intentionally hardcoded here -->
     <string name="add_login_hostname_hint_text">https://www.example.com</string>
     <!-- This is an error message shown below the hostname field of the add login page when a hostname does not contain http or https. -->
-    <string name="add_login_hostname_invalid_text_1">Web address must contain \“https://\“ or \“http://\“</string>
+    <string name="add_login_hostname_invalid_text_1" moz:removedIn="94" tools:ignore="UnusedResources">Web address must contain "https://" or "http://"</string>
+    <!-- This is an error message shown below the hostname field of the add login page when a hostname does not contain http or https. -->
+    <string name="add_login_hostname_invalid_text_3">Web address must contain "https://" or "http://"</string>
     <!-- This is an error message shown below the hostname field of the add login page when a hostname is invalid. -->
     <string name="add_login_hostname_invalid_text_2">Valid hostname required</string>
 


### PR DESCRIPTION
Fixes the `add_login_hostname_invalid_text_1` string to remove the escape characters on the quotes and increment the string's name so that it populates back to Pontoon.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
