### PR TITLE
For #20893: Dedupe urls/site in history groups

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/history/PagedHistoryProvider.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/history/PagedHistoryProvider.kt
@@ -132,10 +132,14 @@ class DefaultPagedHistoryProvider(
         // item.
         result.addAll(history.filter { item -> historyMetadata.find { it.url == item.url } == null })
 
-        // Filter history metadata items with no view time.
+        // Filter history metadata items with no view time and dedupe by url.
+        // Note that distinctBy is sufficient here as it keeps the order of the source
+        // collection, and we're only sorting by visitedAt (=updatedAt) currently.
+        // If we needed the view time we'd have to aggregate it for entries with the same
+        // url, but we don't have a use case for this currently in the history view.
         result.addAll(
             historyGroupsInOffset.map { group ->
-                group.copy(items = group.items.filter { it.totalViewTime > 0 })
+                group.copy(items = group.items.filter { it.totalViewTime > 0 }.distinctBy { it.url })
             }
         )
 

--- a/app/src/test/java/org/mozilla/fenix/components/history/PagedHistoryProviderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/history/PagedHistoryProviderTest.kt
@@ -73,8 +73,20 @@ class PagedHistoryProviderTest {
             previewImageUrl = null
         )
 
+        // Adding a third entry with same url to test deduping
+        val historyMetadataKey3 = HistoryMetadataKey("http://www.firefox.com", "mozilla", null)
+        val historyEntry3 = HistoryMetadata(
+            key = historyMetadataKey3,
+            title = "firefox",
+            createdAt = 3,
+            updatedAt = 3,
+            totalViewTime = 30,
+            documentType = DocumentType.Regular,
+            previewImageUrl = null
+        )
+
         coEvery { storage.getVisitsPaginated(any(), any(), any()) } returns listOf(visitInfo1, visitInfo2, visitInfo3)
-        coEvery { storage.getHistoryMetadataSince(any()) } returns listOf(historyEntry1, historyEntry2)
+        coEvery { storage.getHistoryMetadataSince(any()) } returns listOf(historyEntry1, historyEntry2, historyEntry3)
 
         var actualResults: List<History>? = null
         provider.getHistory(10L, 5) {


### PR DESCRIPTION
For Home we already do that and also correctly count the number of sites in the group. In history we count and display the duplicates which looking at my groups feels really off. One of the motivations here it to make it as easy as possible for users to get back to where they left off, so we shouldn't add a new group entry every time the user opens the site again.

It's also easier to fix in history as we're only sorting by `updatedAt` -> `visitedAt`, and we don't need to aggregate view times.