### PR TITLE
Fix disabled shortcutButtonTest UI test

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/ext/WaitNotNull.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/ext/WaitNotNull.kt
@@ -6,6 +6,7 @@ package org.mozilla.fenix.helpers.ext
 
 import androidx.test.uiautomator.SearchCondition
 import androidx.test.uiautomator.UiDevice
+import androidx.test.uiautomator.UiObject
 import org.junit.Assert.assertNotNull
 import org.mozilla.fenix.helpers.TestAssetHelper
 
@@ -18,3 +19,8 @@ fun UiDevice.waitNotNull(
     searchCondition: SearchCondition<*>,
     waitTime: Long = TestAssetHelper.waitingTime
 ) = assertNotNull(wait(searchCondition, waitTime))
+
+fun UiDevice.waitForAwesomeBarContent(obj: UiObject, waitingTime: Long = TestAssetHelper.waitingTime) {
+    this.waitForIdle()
+    assertNotNull(obj.waitForExists(waitingTime))
+}

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SearchTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SearchTest.kt
@@ -52,7 +52,6 @@ class SearchTest {
         }
     }
 
-    @Ignore("Currently failing at assertSearchEngineResults, will need a re-check")
     @Test
     fun shortcutButtonTest() {
         homeScreen {
@@ -63,7 +62,7 @@ class SearchTest {
         }.goBack {
         }.goBack {
         }.openSearch {
-//            verifySearchWithText()
+            verifySearchBarEmpty()
             clickSearchEngineButton(activityTestRule, "DuckDuckGo")
             typeSearch("mozilla")
             verifySearchEngineResults(activityTestRule, "DuckDuckGo", 4)

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SearchRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SearchRobot.kt
@@ -45,6 +45,7 @@ import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.TestHelper.packageName
 import org.mozilla.fenix.helpers.click
+import org.mozilla.fenix.helpers.ext.waitForAwesomeBarContent
 import org.mozilla.fenix.helpers.ext.waitNotNull
 
 /**
@@ -98,9 +99,18 @@ class SearchRobot {
 
     fun typeSearch(searchTerm: String) {
         browserToolbarEditView().setText(searchTerm)
+        mDevice.waitForIdle()
     }
 
     fun clickSearchEngineButton(rule: ComposeTestRule, searchEngineName: String) {
+        rule.waitForIdle()
+
+        mDevice.waitForAwesomeBarContent(
+            mDevice.findObject(
+                UiSelector().textContains(searchEngineName)
+            )
+        )
+
         rule.onNodeWithText(searchEngineName)
             .assertExists()
             .assertHasClickAction()
@@ -242,6 +252,14 @@ private fun assertSearchEngineURL(searchEngineName: String) {
 }
 
 private fun assertSearchEngineResults(rule: ComposeTestRule, searchEngineName: String, count: Int) {
+    rule.waitForIdle()
+
+    mDevice.waitForAwesomeBarContent(
+        mDevice.findObject(
+            UiSelector().textContains(searchEngineName)
+        )
+    )
+
     rule.onAllNodesWithText(searchEngineName)
         .assertCountEquals(count)
 }


### PR DESCRIPTION
For [#477](https://github.com/mozilla-mobile/mobile-test-eng/issues/477) fix disabled `shortcutButtonTest` UI test
✔️  Successfully ran 50x on Firebase

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
