### PR TITLE
No issue: Add Slack Notify event for UI test failure

### DIFF
--- a/taskcluster/ci/ui-test/kind.yml
+++ b/taskcluster/ci/ui-test/kind.yml
@@ -18,6 +18,48 @@ job-defaults:
             signing: signing-debug
             signing-android-test: signing-android-test-debug
     include-pull-request-number: true
+    routes:
+        - notify.slack-channel.G016BC5FUHJ.on-failed
+    scopes:
+        - queue:route:notify.slack-channel.G016BC5FUHJ.on-failed
+        - notify:slack-channel:G016BC5FUHJ
+    extra:
+        notify:
+            # slackText: 'https://firefox-ci-tc.services.mozilla.com/tasks/${status.taskId} | ${task.metadata.name} | ${task.metadata.source}'
+            slackBlocks: |
+                [
+                  {
+                    "type": "header",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "UI Test Failure\nFenix :firefox: ${task.metadata.name} failure :x:\n "
+                    }
+                  },
+                  {
+                    "type": "divider"
+                  },
+                  {
+                     "type": "section",
+                     "text": {
+                         "type": "mrkdwn",
+                         "text": "*Task*: <https://firefox-ci-tc.services.mozilla.com/tasks/${status.taskId}|Taskcluster>"
+                    }
+                  },                  
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": "*Owner*: ${task.metadata.owner}"
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": "*Source*: <${task.metadata.source}|Github :github:>"
+                    }
+                  }
+                ]
     run:
         commands:
             - [wget, {artifact-reference: '<signing/public/build/x86/target.apk>'}, '-O', app.apk]


### PR DESCRIPTION
Add's a Taskcluster Slack notify `on-failure` event for UI test failures in the mobile alerts channel.

@rpappalax we can try this out for a bit to see if it gets too noisy or if there's other data we can grab from the metadata to append to or format in the message payload. Currently with Slack blocks it looks like:
![Capture](https://user-images.githubusercontent.com/102331/134973603-ac8b7515-27ec-447b-9c5e-cb162b5e2325.JPG)

Blocks can be pieced together in the https://app.slack.com/block-kit-builder