### PR TITLE
For #20811: sign in sync button size

### DIFF
--- a/app/src/main/res/layout/sync_tabs_error_row.xml
+++ b/app/src/main/res/layout/sync_tabs_error_row.xml
@@ -31,5 +31,6 @@
         android:maxLines="2"
         android:text="@string/synced_tabs_sign_in_button"
         android:visibility="gone"
+
         app:icon="@drawable/ic_sign_in" />
 </LinearLayout>

--- a/app/src/main/res/layout/sync_tabs_error_row.xml
+++ b/app/src/main/res/layout/sync_tabs_error_row.xml
@@ -24,12 +24,12 @@
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/sync_tabs_error_cta_button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:maxLines="2"
         style="@style/PositiveButton"
-        app:icon="@drawable/ic_sign_in"
-        android:visibility="gone"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:maxLines="2"
         android:text="@string/synced_tabs_sign_in_button"
-        android:layout_marginTop="8dp"/>
+        android:visibility="gone"
+        app:icon="@drawable/ic_sign_in" />
 </LinearLayout>


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

#20811  issue solved

dropping a screen short
![Screenshot 2021-09-28 125933](https://user-images.githubusercontent.com/74723804/135042879-c8322e61-ae94-4577-a21f-a842bf37fc9a.png)
