### PR TITLE
Don't manually exclude glean-native

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -479,9 +479,7 @@ dependencies {
     implementation Deps.mozilla_service_sync_autofill
     implementation Deps.mozilla_service_sync_logins
     implementation Deps.mozilla_service_firefox_accounts
-    implementation(Deps.mozilla_service_glean) {
-      exclude group: 'org.mozilla.telemetry', module: 'glean-native'
-    }
+    implementation(Deps.mozilla_service_glean)
     implementation Deps.mozilla_service_location
     implementation Deps.mozilla_service_nimbus
 


### PR DESCRIPTION
The latest geckoview-omni package correctly declares its capabilities,
including the `glean-native` one.
Additionally it is able to pick geckoview-omni over glean-native in all
configurations.

---

Requires https://github.com/mozilla-mobile/android-components/pull/11045 and an updated a-c then.
The Fenix APK should _not_ contain a `libglean_ffi.so` anymore (with or without this patch),
this simplifies it further.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
