### PR TITLE
Fixes #12717 - Bookmark search for bookmark add / select screen

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/selectfolder/SelectBookmarkFolderAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/selectfolder/SelectBookmarkFolderAdapter.kt
@@ -32,6 +32,16 @@ class SelectBookmarkFolderAdapter(private val sharedViewModel: BookmarksSharedVi
         submitList(updatedData)
     }
 
+    fun updateSearchData(tree: BookmarkNode?, queryText: String){
+        val updatedData = tree
+            ?.flatNodeList(null)
+            ?.filter { node: BookmarkNodeWithDepth ->
+                (node.node.title?.contains(queryText) == true || node.node.url?.contains(queryText) == true)
+             }
+            .orEmpty()
+        submitList(updatedData)
+    }
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): BookmarkFolderViewHolder {
         val view = LibrarySiteItemView(parent.context).apply {
             layoutParams = ViewGroup.LayoutParams(

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/selectfolder/SelectBookmarkFolderFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/selectfolder/SelectBookmarkFolderFragment.kt
@@ -11,6 +11,7 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import android.widget.SearchView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
@@ -29,12 +30,14 @@ import org.mozilla.fenix.ext.showToolbar
 import org.mozilla.fenix.library.bookmarks.BookmarksSharedViewModel
 import org.mozilla.fenix.library.bookmarks.DesktopFolders
 
-class SelectBookmarkFolderFragment : Fragment() {
+class SelectBookmarkFolderFragment : Fragment(), SearchView.OnQueryTextListener {
     private var _binding: FragmentSelectBookmarkFolderBinding? = null
     private val binding get() = _binding!!
 
     private val sharedViewModel: BookmarksSharedViewModel by activityViewModels()
     private var bookmarkNode: BookmarkNode? = null
+    private var search: SearchView? = null
+    private var adapter: SelectBookmarkFolderAdapter? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -66,9 +69,10 @@ class SelectBookmarkFolderFragment : Fragment() {
                     .getTree(BookmarkRoot.Root.id, recursive = true)
                     ?.let { DesktopFolders(context, showMobileRoot = true).withOptionalDesktopFolders(it) }
             }
-            val adapter = SelectBookmarkFolderAdapter(sharedViewModel)
+            adapter = SelectBookmarkFolderAdapter(sharedViewModel)
+
             binding.recylerViewBookmarkFolders.adapter = adapter
-            adapter.updateData(bookmarkNode, args.hideFolderGuid)
+            adapter!!.updateData(bookmarkNode, args.hideFolderGuid)
         }
     }
 
@@ -76,6 +80,8 @@ class SelectBookmarkFolderFragment : Fragment() {
         val args: SelectBookmarkFolderFragmentArgs by navArgs()
         if (!args.allowCreatingNewFolder) {
             inflater.inflate(R.menu.bookmarks_select_folder, menu)
+            search = menu.findItem(R.id.bookmark_select_search).actionView as SearchView
+            search!!.setOnQueryTextListener(this)
         }
     }
 
@@ -93,5 +99,19 @@ class SelectBookmarkFolderFragment : Fragment() {
             }
             else -> super.onOptionsItemSelected(item)
         }
+    }
+
+    override fun onQueryTextSubmit(query: String?): Boolean {
+        return true
+    }
+
+    override fun onQueryTextChange(newText: String?): Boolean {
+        if(adapter != null){
+            if(newText == null || newText == "")
+                adapter!!.updateData(bookmarkNode, "")
+            else
+                adapter!!.updateSearchData(bookmarkNode, newText)
+        }
+        return true
     }
 }

--- a/app/src/main/res/menu/bookmarks_select_folder.xml
+++ b/app/src/main/res/menu/bookmarks_select_folder.xml
@@ -4,6 +4,13 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
       xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item android:id="@+id/bookmark_select_search"
+        android:icon="@drawable/ic_search"
+        app:iconTint="?primaryText"
+        android:title="@string/search_bookmarks"
+        app:showAsAction="ifRoom"
+        app:actionViewClass="android.widget.SearchView" />
+
     <item
             android:id="@+id/add_folder_button"
             android:icon="@drawable/ic_new"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1904,5 +1904,6 @@
 
     <!-- Content description for privacy content close button -->
     <string name="privacy_content_close_button_content_description">Close</string>
+    <string name="search_bookmarks">Search Bookmarks</string>
 
 </resources>


### PR DESCRIPTION
For #12717

### Feature demo
- Open a site and add it as a bookmark.
- Go to edit bookmark.
- Click on folder.
- Click on search icon at top.
- Search for a folder.
- Folder selection persists too.

### Changelog

#### 2021-09-29
- Add bookmark search capability in bookmark select screen. 
- So far this works at a rudimentary level in this PR. 
- The search happens on folder names.



### Pending issues
- [ ] Tests
- [ ] Search icon aligns with cursor to left when first clicked (unexpected)
- [ ] No message for empty results (Need UX input)
- [ ] Properly display hierarchy?
- [ ] Support typos in search
- [ ] Subsequence search
- [ ] Port to other features requiring browsing bookmarks



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: No tests included yet.
- [x ] **Screenshots**:  Available
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

![Screenshot_1632968326](https://user-images.githubusercontent.com/5524161/135375080-babef128-e1b4-4fc4-bf0a-772cc23442a7.png)

![Screenshot_1632968218](https://user-images.githubusercontent.com/5524161/135375076-6a359d3e-1c4f-461c-a422-fdc07ab6f290.png)
