### PR TITLE
For #21540 fix flaky editCustomSearchEngineTest UI test

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SearchRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SearchRobot.kt
@@ -75,7 +75,7 @@ class SearchRobot {
     }
     fun verifyDefaultSearchEngine(expectedText: String) = assertDefaultSearchEngine(expectedText)
 
-    fun verifyEnginesListShortcutContains(rule: ComposeTestRule, searchEngineName: String) = rule.assertEngineListShortcutContains(searchEngineName)
+    fun verifyEnginesListShortcutContains(rule: ComposeTestRule, searchEngineName: String) = assertEngineListShortcutContains(rule, searchEngineName)
 
     fun changeDefaultSearchEngine(rule: ComposeTestRule, searchEngineName: String) =
         rule.selectDefaultSearchEngine(searchEngineName)
@@ -378,17 +378,19 @@ private fun ComposeTestRule.assertSearchEngineList() {
 }
 
 @OptIn(ExperimentalTestApi::class)
-private fun ComposeTestRule.assertEngineListShortcutContains(searchEngineName: String) {
-    mDevice.findObject(UiSelector().resourceId("$packageName:id/awesome_bar"))
-        .waitForExists(waitingTime)
+private fun assertEngineListShortcutContains(rule: ComposeTestRule, searchEngineName: String) {
+    rule.waitForIdle()
 
-    mDevice.findObject(UiSelector().text("Google"))
-        .waitForExists(waitingTime)
+    mDevice.waitForObjects(
+        mDevice.findObject(
+            UiSelector().textContains("Google")
+        )
+    )
 
-    onNodeWithTag("mozac.awesomebar.suggestions")
+    rule.onNodeWithTag("mozac.awesomebar.suggestions")
         .performScrollToIndex(5)
 
-    onNodeWithText(searchEngineName)
+    rule.onNodeWithText(searchEngineName)
         .assertExists()
         .assertIsDisplayed()
         .assertHasClickAction()


### PR DESCRIPTION
For #21540 fix flaky `editCustomSearchEngineTest` UI test
✔️   Successfully passed 65x on Firebase


<h1 style="box-sizing: border-box; font-size: 2em; margin: 24px 0px 16px; font-weight: 600; line-height: 1.25; padding-bottom: 0.3em; border-bottom: 1px solid var(--color-border-muted); color: rgb(201, 209, 217); font-family: -apple-system, system-ui, &quot;Segoe UI&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Results</h1>

matrix | result | logs | details
-- | -- | -- | --
matrix-32pz1blqjqvb8 | success | logs | 1 test cases passed
matrix-1txxuf6gwfnez | success | logs | 1 test cases passed
matrix-1c51ebkn52qvc | success | logs | 1 test cases passed
matrix-1s6s4rnxpipxp | success | logs | 1 test cases passed
matrix-1zyhwyf0s7266 | success | logs | 1 test cases passed
matrix-3h0d9neicunjg | success | logs | 1 test cases passed
matrix-32t10nzwytktx | success | logs | 1 test cases passed
matrix-3pk5mk70xclah | success | logs | 1 test cases passed
matrix-fc5n73g8u3mwa | success | logs | 1 test cases passed
matrix-t65tme01vyr2a | success | logs | 1 test cases passed
matrix-nays8ma0su2ia | success | logs | 1 test cases passed
matrix-35gqv6t7ewb5a | success | logs | 1 test cases passed
matrix-3t1rmb9ktzisg | success | logs | 1 test cases passed
matrix-1sh6rqy5fq0k9 | success | logs | 1 test cases passed
matrix-237hjjxsto1ex | success | logs | 1 test cases passed
matrix-18bnk1v07h7mg | success | logs | 1 test cases passed
matrix-1kjmxf5bsz493 | success | logs | 1 test cases passed
matrix-22a5m013kot51 | success | logs | 1 test cases passed
matrix-1vu35g51qnmit | success | logs | 1 test cases passed
matrix-8dic26b4pty4a | success | logs | 1 test cases passed
matrix-rn78swjbcd7ka | success | logs | 1 test cases passed
matrix-3df5hresmzfay | success | logs | 1 test cases passed
matrix-3qirejohsq5f9 | success | logs | 1 test cases passed
matrix-2834grxc7pcz2 | success | logs | 1 test cases passed
matrix-sh80sbp3j8g6a | success | logs | 1 test cases passed
matrix-1jw7vrft86tcm | success | logs | 1 test cases passed
matrix-2etyik63dqn9a | success | logs | 1 test cases passed
matrix-3sgtusg0535w4 | success | logs | 1 test cases passed
matrix-33590nznv3ndd | success | logs | 1 test cases passed
matrix-1kno4r6qgeclz | success | logs | 1 test cases passed
matrix-xxv5dq5vebmna | success | logs | 1 test cases passed
matrix-z37h6ozpvju4a | success | logs | 1 test cases passed
matrix-1jjsnesxawpd5 | success | logs | 1 test cases passed
matrix-a225cldt1r8xa | success | logs | 1 test cases passed
matrix-2po3tdflui3vy | success | logs | 1 test cases passed
matrix-38i68hlz3rk3l | success | logs | 1 test cases passed
matrix-3js9n5p6foc2x | success | logs | 1 test cases passed
matrix-2k7ulm61uh0ta | success | logs | 1 test cases passed
matrix-158g3on1gu93e | success | logs | 1 test cases passed
matrix-xgf02e6pify2a | success | logs | 1 test cases passed
matrix-3mvyawg738bls | success | logs | 1 test cases passed
matrix-1m7j2hkltguv5 | success | logs | 1 test cases passed
matrix-2fwl8ui36fyf3 | success | logs | 1 test cases passed
matrix-12c629yxw25ov | success | logs | 1 test cases passed
matrix-39g3rhmzk2jws | success | logs | 1 test cases passed
matrix-bnd1n7hegglsa | success | logs | 1 test cases passed
matrix-1c00q32ema0ba | success | logs | 1 test cases passed
matrix-2f1ymhw91mlgz | success | logs | 1 test cases passed
matrix-2nxrjhi4jwaes | success | logs | 1 test cases passed
matrix-24omua02z0ljc | success | logs | 1 test cases passed
matrix-ne0lc8m8o5z8a | success | logs | 1 test cases passed
matrix-28ck2tbg7n6rc | success | logs | 1 test cases passed
matrix-c9dd479qlsbpa | success | logs | 1 test cases passed
matrix-3v24tbfv0telg | success | logs | 1 test cases passed
matrix-3thk0jvcr4okz | success | logs | 1 test cases passed
matrix-1rdrduxil5p1n | success | logs | 1 test cases passed
matrix-3vo9nbj49vim2 | success | logs | 1 test cases passed
matrix-1aufcesaqtp6u | success | logs | 1 test cases passed
matrix-2ec0ig0hkd6jt | success | logs | 1 test cases passed
matrix-2kxd5j0820kha | success | logs | 1 test cases passed
matrix-oj6p3idnduq3a | success | logs | 1 test cases passed
matrix-2s5sv6qo5s9wx | success | logs | 1 test cases passed
matrix-hlpe4ryfzb4ca | success | logs | 1 test cases passed
matrix-12ou21r3pjpf7 | success | logs | 1 test cases passed
matrix-3axh81x3sumxn | success | logs | 1 test cases passed




### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
