### PR TITLE
For #21593 - Persist selected categories status

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "com.jetbrains.python.envs" version "0.0.26"
+    id "com.google.protobuf" version "0.8.17"
 }
 
 apply plugin: 'com.android.application'
@@ -525,6 +526,8 @@ dependencies {
     implementation Deps.androidx_core_ktx
     implementation Deps.androidx_transition
     implementation Deps.androidx_work_ktx
+    implementation Deps.androidx_datastore
+    implementation Deps.protobuf_javalite
     implementation Deps.google_material
 
     implementation Deps.adjust
@@ -587,6 +590,25 @@ dependencies {
     testImplementation "org.mozilla.telemetry:glean-native-forUnitTests:${project.ext.glean_version}"
 
     lintChecks project(":mozilla-lint-rules")
+}
+
+protobuf {
+    protoc {
+        artifact = Deps.protobuf_compiler
+    }
+
+    // Generates the java Protobuf-lite code for the Protobufs in this project. See
+    // https://github.com/google/protobuf-gradle-plugin#customizing-protobuf-compilation
+    // for more information.
+    generateProtoTasks {
+        all().each { task ->
+            task.builtins {
+                java {
+                    option 'lite'
+                }
+            }
+        }
+    }
 }
 
 if (project.hasProperty("coverage")) {

--- a/app/src/main/java/org/mozilla/fenix/datastore/DataStores.kt
+++ b/app/src/main/java/org/mozilla/fenix/datastore/DataStores.kt
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.datastore
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.dataStore
+
+/**
+ * Application / process unique [DataStore] for IO operations related to Pocket recommended stories selected categories.
+ */
+internal val Context.pocketStoriesSelectedCategoriesDataStore: DataStore<SelectedPocketStoriesCategories> by dataStore(
+    fileName = "pocket_recommendations_selected_categories.pb",
+    serializer = SelectedPocketStoriesCategorySerializer
+)

--- a/app/src/main/java/org/mozilla/fenix/datastore/SelectedPocketStoriesCategorySerializer.kt
+++ b/app/src/main/java/org/mozilla/fenix/datastore/SelectedPocketStoriesCategorySerializer.kt
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.datastore
+
+import androidx.datastore.core.Serializer
+import java.io.InputStream
+import java.io.OutputStream
+
+/**
+ * Serializer for [SelectedPocketStoriesCategories] defined in selected_pocket_stories_categories.proto.
+ */
+@Suppress("BlockingMethodInNonBlockingContext")
+object SelectedPocketStoriesCategorySerializer : Serializer<SelectedPocketStoriesCategories> {
+    override val defaultValue: SelectedPocketStoriesCategories = SelectedPocketStoriesCategories.getDefaultInstance()
+
+    override suspend fun readFrom(input: InputStream): SelectedPocketStoriesCategories {
+        return SelectedPocketStoriesCategories.parseFrom(input)
+    }
+
+    override suspend fun writeTo(t: SelectedPocketStoriesCategories, output: OutputStream) {
+        t.writeTo(output)
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/ext/HomeFragmentState.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/HomeFragmentState.kt
@@ -8,7 +8,7 @@ import androidx.annotation.VisibleForTesting
 import mozilla.components.service.pocket.PocketRecommendedStory
 import org.mozilla.fenix.home.HomeFragmentState
 import org.mozilla.fenix.home.sessioncontrol.viewholders.pocket.POCKET_STORIES_DEFAULT_CATEGORY_NAME
-import org.mozilla.fenix.home.sessioncontrol.viewholders.pocket.PocketRecommendedStoryCategory
+import org.mozilla.fenix.home.sessioncontrol.viewholders.pocket.PocketRecommendedStoriesCategory
 
 /**
  * Get the list of stories to be displayed based on the user selected categories.
@@ -21,9 +21,7 @@ import org.mozilla.fenix.home.sessioncontrol.viewholders.pocket.PocketRecommende
 fun HomeFragmentState.getFilteredStories(
     neededStoriesCount: Int
 ): List<PocketRecommendedStory> {
-    val currentlySelectedCategories = pocketStoriesCategories.filter { it.isSelected }
-
-    if (currentlySelectedCategories.isEmpty()) {
+    if (pocketStoriesCategoriesSelections.isEmpty()) {
         return pocketStoriesCategories
             .find {
                 it.name == POCKET_STORIES_DEFAULT_CATEGORY_NAME
@@ -32,8 +30,13 @@ fun HomeFragmentState.getFilteredStories(
             ?.take(neededStoriesCount) ?: emptyList()
     }
 
-    val oldestSortedCategories = currentlySelectedCategories
-        .sortedByDescending { it.lastInteractedWithTimestamp }
+    val oldestSortedCategories = pocketStoriesCategoriesSelections
+        .sortedByDescending { it.selectionTimestamp }
+        .map { selectedCategory ->
+            pocketStoriesCategories.first {
+                it.name == selectedCategory.name
+            }
+        }
 
     val filteredStoriesCount = getFilteredStoriesCount(
         oldestSortedCategories, neededStoriesCount
@@ -57,7 +60,7 @@ fun HomeFragmentState.getFilteredStories(
 @VisibleForTesting
 @Suppress("ReturnCount", "NestedBlockDepth")
 internal fun getFilteredStoriesCount(
-    selectedCategories: List<PocketRecommendedStoryCategory>,
+    selectedCategories: List<PocketRecommendedStoriesCategory>,
     neededStoriesCount: Int
 ): Map<String, Int> {
     val totalStoriesInFilteredCategories = selectedCategories.fold(0) { availableStories, category ->

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -116,7 +116,7 @@ import org.mozilla.fenix.home.sessioncontrol.SessionControlInteractor
 import org.mozilla.fenix.home.sessioncontrol.SessionControlView
 import org.mozilla.fenix.home.sessioncontrol.viewholders.CollectionViewHolder
 import org.mozilla.fenix.home.sessioncontrol.viewholders.pocket.DefaultPocketStoriesController
-import org.mozilla.fenix.home.sessioncontrol.viewholders.pocket.PocketRecommendedStoryCategory
+import org.mozilla.fenix.home.sessioncontrol.viewholders.pocket.PocketRecommendedStoriesCategory
 import org.mozilla.fenix.home.sessioncontrol.viewholders.topsites.DefaultTopSitesView
 import org.mozilla.fenix.onboarding.FenixOnboarding
 import org.mozilla.fenix.settings.SupportUtils
@@ -258,7 +258,7 @@ class HomeFragment : Fragment() {
             if (requireContext().settings().showPocketRecommendationsFeature) {
                 val categories = components.core.pocketStoriesService.getStories()
                     .groupBy { story -> story.category }
-                    .map { (category, stories) -> PocketRecommendedStoryCategory(category, stories) }
+                    .map { (category, stories) -> PocketRecommendedStoriesCategory(category, stories) }
 
                 homeFragmentStore.dispatch(HomeFragmentAction.PocketStoriesCategoriesChange(categories))
             } else {

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -93,6 +93,7 @@ import org.mozilla.fenix.components.tips.providers.MasterPasswordTipProvider
 import org.mozilla.fenix.components.toolbar.FenixTabCounterMenu
 import org.mozilla.fenix.components.toolbar.ToolbarPosition
 import org.mozilla.fenix.databinding.FragmentHomeBinding
+import org.mozilla.fenix.datastore.pocketStoriesSelectedCategoriesDataStore
 import org.mozilla.fenix.ext.asRecentTabs
 import org.mozilla.fenix.experiments.FeatureId
 import org.mozilla.fenix.ext.components
@@ -248,7 +249,9 @@ class HomeFragment : Fragment() {
                 ),
                 listOf(
                     PocketUpdatesMiddleware(
-                        lifecycleScope, requireComponents.core.pocketStoriesService
+                        lifecycleScope,
+                        requireComponents.core.pocketStoriesService,
+                        requireContext().pocketStoriesSelectedCategoriesDataStore
                     )
                 )
             )

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragmentStore.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragmentStore.kt
@@ -18,7 +18,8 @@ import org.mozilla.fenix.ext.getFilteredStories
 import org.mozilla.fenix.historymetadata.HistoryMetadataGroup
 import org.mozilla.fenix.home.recenttabs.RecentTab
 import org.mozilla.fenix.home.sessioncontrol.viewholders.pocket.POCKET_STORIES_TO_SHOW_COUNT
-import org.mozilla.fenix.home.sessioncontrol.viewholders.pocket.PocketRecommendedStoryCategory
+import org.mozilla.fenix.home.sessioncontrol.viewholders.pocket.PocketRecommendedStoriesCategory
+import org.mozilla.fenix.home.sessioncontrol.viewholders.pocket.PocketRecommendedStoriesSelectedCategory
 
 /**
  * The [Store] for holding the [HomeFragmentState] and applying [HomeFragmentAction]s.
@@ -69,7 +70,8 @@ data class HomeFragmentState(
     val recentBookmarks: List<BookmarkNode> = emptyList(),
     val historyMetadata: List<HistoryMetadataGroup> = emptyList(),
     val pocketStories: List<PocketRecommendedStory> = emptyList(),
-    val pocketStoriesCategories: List<PocketRecommendedStoryCategory> = emptyList()
+    val pocketStoriesCategories: List<PocketRecommendedStoriesCategory> = emptyList(),
+    val pocketStoriesCategoriesSelections: List<PocketRecommendedStoriesSelectedCategory> = emptyList()
 ) : State
 
 sealed class HomeFragmentAction : Action {
@@ -99,7 +101,7 @@ sealed class HomeFragmentAction : Action {
     data class DeselectPocketStoriesCategory(val categoryName: String) : HomeFragmentAction()
     data class PocketStoriesShown(val storiesShown: List<PocketRecommendedStory>) : HomeFragmentAction()
     data class PocketStoriesChange(val pocketStories: List<PocketRecommendedStory>) : HomeFragmentAction()
-    data class PocketStoriesCategoriesChange(val storiesCategories: List<PocketRecommendedStoryCategory>) :
+    data class PocketStoriesCategoriesChange(val storiesCategories: List<PocketRecommendedStoriesCategory>) :
         HomeFragmentAction()
     object RemoveCollectionsPlaceholder : HomeFragmentAction()
     object RemoveSetDefaultBrowserCard : HomeFragmentAction()
@@ -145,29 +147,26 @@ private fun homeFragmentStateReducer(
         is HomeFragmentAction.RecentBookmarksChange -> state.copy(recentBookmarks = action.recentBookmarks)
         is HomeFragmentAction.HistoryMetadataChange -> state.copy(historyMetadata = action.historyMetadata)
         is HomeFragmentAction.SelectPocketStoriesCategory -> {
-            // Selecting a category means the stories to be displayed needs to also be changed.
             val updatedCategoriesState = state.copy(
-                pocketStoriesCategories = state.pocketStoriesCategories.map {
-                    when (it.name == action.categoryName) {
-                        true -> it.copy(isSelected = true, lastInteractedWithTimestamp = System.currentTimeMillis())
-                        false -> it
-                    }
-                }
+                pocketStoriesCategoriesSelections =
+                state.pocketStoriesCategoriesSelections + PocketRecommendedStoriesSelectedCategory(
+                    name = action.categoryName
+                )
             )
+
+            // Selecting a category means the stories to be displayed needs to also be changed.
             return updatedCategoriesState.copy(
                 pocketStories = updatedCategoriesState.getFilteredStories(POCKET_STORIES_TO_SHOW_COUNT)
             )
         }
         is HomeFragmentAction.DeselectPocketStoriesCategory -> {
             val updatedCategoriesState = state.copy(
-                // Deselecting a category means the stories to be displayed needs to also be changed.
-                pocketStoriesCategories = state.pocketStoriesCategories.map {
-                    when (it.name == action.categoryName) {
-                        true -> it.copy(isSelected = false, lastInteractedWithTimestamp = System.currentTimeMillis())
-                        false -> it
-                    }
+                pocketStoriesCategoriesSelections = state.pocketStoriesCategoriesSelections.filterNot {
+                    it.name == action.categoryName
                 }
             )
+
+            // Deselecting a category means the stories to be displayed needs to also be changed.
             return updatedCategoriesState.copy(
                 pocketStories = updatedCategoriesState.getFilteredStories(POCKET_STORIES_TO_SHOW_COUNT)
             )

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragmentStore.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragmentStore.kt
@@ -103,6 +103,10 @@ sealed class HomeFragmentAction : Action {
     data class PocketStoriesChange(val pocketStories: List<PocketRecommendedStory>) : HomeFragmentAction()
     data class PocketStoriesCategoriesChange(val storiesCategories: List<PocketRecommendedStoriesCategory>) :
         HomeFragmentAction()
+    data class PocketStoriesCategoriesSelectionsChange(
+        val storiesCategories: List<PocketRecommendedStoriesCategory>,
+        val categoriesSelected: List<PocketRecommendedStoriesSelectedCategory>
+    ) : HomeFragmentAction()
     object RemoveCollectionsPlaceholder : HomeFragmentAction()
     object RemoveSetDefaultBrowserCard : HomeFragmentAction()
 }
@@ -172,8 +176,18 @@ private fun homeFragmentStateReducer(
             )
         }
         is HomeFragmentAction.PocketStoriesCategoriesChange -> {
-            // Whenever categories change stories to be displayed needs to also be changed.
             val updatedCategoriesState = state.copy(pocketStoriesCategories = action.storiesCategories)
+            // Whenever categories change stories to be displayed needs to also be changed.
+            return updatedCategoriesState.copy(
+                pocketStories = updatedCategoriesState.getFilteredStories(POCKET_STORIES_TO_SHOW_COUNT)
+            )
+        }
+        is HomeFragmentAction.PocketStoriesCategoriesSelectionsChange -> {
+            val updatedCategoriesState = state.copy(
+                pocketStoriesCategories = action.storiesCategories,
+                pocketStoriesCategoriesSelections = action.categoriesSelected
+            )
+            // Whenever categories change stories to be displayed needs to also be changed.
             return updatedCategoriesState.copy(
                 pocketStories = updatedCategoriesState.getFilteredStories(POCKET_STORIES_TO_SHOW_COUNT)
             )

--- a/app/src/main/java/org/mozilla/fenix/home/PocketUpdatesMiddleware.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/PocketUpdatesMiddleware.kt
@@ -4,25 +4,57 @@
 
 package org.mozilla.fenix.home
 
+import androidx.annotation.VisibleForTesting
+import androidx.datastore.core.DataStore
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import mozilla.components.lib.state.Action
 import mozilla.components.lib.state.Middleware
 import mozilla.components.lib.state.MiddlewareContext
+import mozilla.components.lib.state.Store
 import mozilla.components.service.pocket.PocketStoriesService
+import org.mozilla.fenix.datastore.SelectedPocketStoriesCategories
+import org.mozilla.fenix.datastore.SelectedPocketStoriesCategories.SelectedPocketStoriesCategory
+import org.mozilla.fenix.home.sessioncontrol.viewholders.pocket.PocketRecommendedStoriesCategory
+import org.mozilla.fenix.home.sessioncontrol.viewholders.pocket.PocketRecommendedStoriesSelectedCategory
 
 /**
  * [HomeFragmentStore] middleware reacting in response to Pocket related [Action]s.
+ *
+ * @param coroutineScope [CoroutineScope] used for long running operations like disk IO.
+ * @param pocketStoriesService [PocketStoriesService] used for updating details about the Pocket recommended stories.
+ * @param selectedPocketCategoriesDataStore [DataStore] used for reading or persisting details about the
+ * currently selected Pocket recommended stories categories.
  */
 class PocketUpdatesMiddleware(
     private val coroutineScope: CoroutineScope,
-    private val pocketStoriesService: PocketStoriesService
+    private val pocketStoriesService: PocketStoriesService,
+    private val selectedPocketCategoriesDataStore: DataStore<SelectedPocketStoriesCategories>
 ) : Middleware<HomeFragmentState, HomeFragmentAction> {
     override fun invoke(
         context: MiddlewareContext<HomeFragmentState, HomeFragmentAction>,
         next: (HomeFragmentAction) -> Unit,
         action: HomeFragmentAction
     ) {
+        // Pre process actions
+        when (action) {
+            is HomeFragmentAction.PocketStoriesCategoriesChange -> {
+                // Intercept the original action which would only update categories and
+                // dispatch a new action which also updates which categories are selected by the user
+                // from previous locally persisted data.
+                restoreSelectedCategories(
+                    coroutineScope = coroutineScope,
+                    currentCategories = action.storiesCategories,
+                    store = context.store,
+                    selectedPocketCategoriesDataStore = selectedPocketCategoriesDataStore
+                )
+            }
+            else -> {
+                // no-op
+            }
+        }
+
         next(action)
 
         // Post process actions
@@ -36,9 +68,80 @@ class PocketUpdatesMiddleware(
                     )
                 }
             }
+            is HomeFragmentAction.SelectPocketStoriesCategory,
+            is HomeFragmentAction.DeselectPocketStoriesCategory -> {
+                persistSelectedCategories(
+                    coroutineScope = coroutineScope,
+                    currentCategoriesSelections = context.state.pocketStoriesCategoriesSelections,
+                    selectedPocketCategoriesDataStore = selectedPocketCategoriesDataStore
+                )
+            }
             else -> {
                 // no-op
             }
+        }
+    }
+}
+
+/**
+ * Persist [currentCategoriesSelections] for making this details available in between app restarts.
+ *
+ * @param coroutineScope [CoroutineScope] used for reading the locally persisted data.
+ * @param currentCategoriesSelections Currently selected Pocket recommended stories categories.
+ * @param selectedPocketCategoriesDataStore - DataStore used for persisting [currentCategoriesSelections].
+ */
+@VisibleForTesting
+internal fun persistSelectedCategories(
+    coroutineScope: CoroutineScope,
+    currentCategoriesSelections: List<PocketRecommendedStoriesSelectedCategory>,
+    selectedPocketCategoriesDataStore: DataStore<SelectedPocketStoriesCategories>
+) {
+    val selectedCategories = currentCategoriesSelections
+        .map {
+            SelectedPocketStoriesCategory.newBuilder().apply {
+                name = it.name
+                selectionTimestamp = it.selectionTimestamp
+            }.build()
+        }
+
+    // Irrespective of the current selections or their number overwrite everything we had.
+    coroutineScope.launch {
+        selectedPocketCategoriesDataStore.updateData { data ->
+            data.newBuilderForType().addAllValues(selectedCategories).build()
+        }
+    }
+}
+
+/**
+ * Combines [currentCategories] with the locally persisted data about previously selected categories
+ * and emits a new [HomeFragmentAction.PocketStoriesCategoriesSelectionsChange] to update these in store.
+ *
+ * @param coroutineScope [CoroutineScope] used for reading the locally persisted data.
+ * @param currentCategories Stories categories currently available
+ * @param store [Store] that will be updated.
+ * @param selectedPocketCategoriesDataStore [DataStore] containing details about the previously selected
+ * stories categories.
+ */
+@VisibleForTesting
+internal fun restoreSelectedCategories(
+    coroutineScope: CoroutineScope,
+    currentCategories: List<PocketRecommendedStoriesCategory>,
+    store: Store<HomeFragmentState, HomeFragmentAction>,
+    selectedPocketCategoriesDataStore: DataStore<SelectedPocketStoriesCategories>
+) {
+    coroutineScope.launch {
+        selectedPocketCategoriesDataStore.data.collect { persistedSelectedCategories ->
+            store.dispatch(
+                HomeFragmentAction.PocketStoriesCategoriesSelectionsChange(
+                    currentCategories,
+                    persistedSelectedCategories.valuesList.map {
+                        PocketRecommendedStoriesSelectedCategory(
+                            name = it.name,
+                            selectionTimestamp = it.selectionTimestamp
+                        )
+                    }
+                )
+            )
         }
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlInteractor.kt
@@ -18,7 +18,7 @@ import org.mozilla.fenix.home.recentbookmarks.controller.RecentBookmarksControll
 import org.mozilla.fenix.home.recentbookmarks.interactor.RecentBookmarksInteractor
 import org.mozilla.fenix.home.recenttabs.controller.RecentTabController
 import org.mozilla.fenix.home.recenttabs.interactor.RecentTabInteractor
-import org.mozilla.fenix.home.sessioncontrol.viewholders.pocket.PocketRecommendedStoryCategory
+import org.mozilla.fenix.home.sessioncontrol.viewholders.pocket.PocketRecommendedStoriesCategory
 import org.mozilla.fenix.home.sessioncontrol.viewholders.pocket.PocketStoriesController
 import org.mozilla.fenix.home.sessioncontrol.viewholders.pocket.PocketStoriesInteractor
 
@@ -391,7 +391,7 @@ class SessionControlInteractor(
         controller.handleCustomizeHomeTapped()
     }
 
-    override fun onCategoryClick(categoryClicked: PocketRecommendedStoryCategory) {
+    override fun onCategoryClick(categoryClicked: PocketRecommendedStoriesCategory) {
         pocketStoriesController.handleCategoryClick(categoryClicked)
     }
 

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/pocket/PocketRecommendedStoriesCategory.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/pocket/PocketRecommendedStoriesCategory.kt
@@ -13,18 +13,15 @@ import mozilla.components.service.pocket.PocketRecommendedStory
 const val POCKET_STORIES_DEFAULT_CATEGORY_NAME = "general"
 
 /**
- * Pocket assigned topic of interest for each story.
+ * In memory cache of Pocket assigned topic of interest for recommended stories.
+ * Avoids multiple stories mappings for each time we are interested in their categories.
  *
  * One to many relationship with [PocketRecommendedStory]es.
  *
  * @property name The exact name of each category. Case sensitive.
- * @property stories All [PocketRecommendedStory]es with this category.
- * @property isSelected Whether this category is currently selected by the user.
- * @property lastInteractedWithTimestamp Last time the user selected or deselected this category.
+ * @property stories All [PocketRecommendedStory]s with this category.
  */
-data class PocketRecommendedStoryCategory(
+data class PocketRecommendedStoriesCategory(
     val name: String,
-    val stories: List<PocketRecommendedStory> = emptyList(),
-    val isSelected: Boolean = false,
-    val lastInteractedWithTimestamp: Long = 0L
+    val stories: List<PocketRecommendedStory> = emptyList()
 )

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/pocket/PocketRecommendedStoriesSelectedCategory.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/pocket/PocketRecommendedStoriesSelectedCategory.kt
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.home.sessioncontrol.viewholders.pocket
+
+/**
+ * Details about a selected Pocket recommended stories category.
+ *
+ * @property name The exact name of a selected category. Case sensitive.
+ * @property selectionTimestamp The exact time at which a category was selected. Defaults to [System.currentTimeMillis].
+ */
+data class PocketRecommendedStoriesSelectedCategory(
+    val name: String,
+    val selectionTimestamp: Long = System.currentTimeMillis()
+)

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/pocket/PocketStoriesComposables.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/pocket/PocketStoriesComposables.kt
@@ -150,21 +150,22 @@ fun PocketStories(
 }
 
 /**
- * Displays a list of [PocketRecommendedStoryCategory].
+ * Displays a list of [PocketRecommendedStoriesCategory]s.
  *
  * @param categories The categories needed to be displayed.
  * @param onCategoryClick Callback for when the user taps a category.
  */
 @Composable
 fun PocketStoriesCategories(
-    categories: List<PocketRecommendedStoryCategory>,
-    onCategoryClick: (PocketRecommendedStoryCategory) -> Unit
+    categories: List<PocketRecommendedStoriesCategory>,
+    selections: List<PocketRecommendedStoriesSelectedCategory>,
+    onCategoryClick: (PocketRecommendedStoriesCategory) -> Unit
 ) {
     StaggeredHorizontalGrid(
         horizontalItemsSpacing = 16.dp
     ) {
         categories.filter { it.name != POCKET_STORIES_DEFAULT_CATEGORY_NAME }.forEach { category ->
-            SelectableChip(category.name, category.isSelected) {
+            SelectableChip(category.name, selections.map { it.name }.contains(category.name)) {
                 onCategoryClick(category)
             }
         }
@@ -241,8 +242,9 @@ private fun PocketStoriesComposablesPreview() {
 
                 PocketStoriesCategories(
                     "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor".split(" ").map {
-                        PocketRecommendedStoryCategory(it)
-                    }
+                        PocketRecommendedStoriesCategory(it)
+                    },
+                    emptyList()
                 ) { }
                 Spacer(Modifier.height(10.dp))
 

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/pocket/PocketStoriesInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/pocket/PocketStoriesInteractor.kt
@@ -13,9 +13,9 @@ interface PocketStoriesInteractor {
     /**
      * Callback for when the user clicked a specific category.
      *
-     * @param categoryClicked the just clicked [PocketRecommendedStoryCategory].
+     * @param categoryClicked the just clicked [PocketRecommendedStoriesCategory].
      */
-    fun onCategoryClick(categoryClicked: PocketRecommendedStoryCategory)
+    fun onCategoryClick(categoryClicked: PocketRecommendedStoriesCategory)
 
     /**
      * Callback for then new stories are shown to the user.

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/pocket/PocketStoriesViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/pocket/PocketStoriesViewHolder.kt
@@ -72,7 +72,7 @@ fun PocketStories(
     store: HomeFragmentStore,
     client: Client,
     onStoriesShown: (List<PocketRecommendedStory>) -> Unit,
-    onCategoryClick: (PocketRecommendedStoryCategory) -> Unit,
+    onCategoryClick: (PocketRecommendedStoriesCategory) -> Unit,
     onExternalLinkClicked: (String) -> Unit
 ) {
     val stories = store
@@ -80,6 +80,9 @@ fun PocketStories(
 
     val categories = store
         .observeAsComposableState { state -> state.pocketStoriesCategories }.value
+
+    val categoriesSelections = store
+        .observeAsComposableState { state -> state.pocketStoriesCategoriesSelections }.value
 
     LaunchedEffect(stories) {
         // We should report back when a certain story is actually being displayed.
@@ -109,7 +112,10 @@ fun PocketStories(
 
         Spacer(Modifier.height(17.dp))
 
-        PocketStoriesCategories(categories ?: emptyList()) {
+        PocketStoriesCategories(
+            categories = categories ?: emptyList(),
+            selections = categoriesSelections ?: emptyList()
+        ) {
             onCategoryClick(it)
         }
 

--- a/app/src/main/proto/selected_pocket_stories_categories.proto
+++ b/app/src/main/proto/selected_pocket_stories_categories.proto
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+syntax = "proto3";
+
+package proto;
+
+option java_package = "org.mozilla.fenix.datastore";
+option java_multiple_files = true;
+
+// List of currently selected Pocket recommended stories categories.
+message SelectedPocketStoriesCategories {
+
+  // Details about a selected Pocket recommended stories category.
+  // See [org.mozilla.fenix.home.sessioncontrol.viewholders.pocket.PocketRecommendedStoriesSelectedCategory]
+  message SelectedPocketStoriesCategory {
+    // Name of this category.
+    string name = 1;
+    // Timestamp for when this category was selected.
+    int64 selectionTimestamp = 2;
+  }
+
+  // Currently selected Pocket stories categories.
+  repeated SelectedPocketStoriesCategory values = 1;
+}

--- a/app/src/test/java/org/mozilla/fenix/home/PocketUpdatesMiddlewareTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/PocketUpdatesMiddlewareTest.kt
@@ -4,17 +4,26 @@
 
 package org.mozilla.fenix.home
 
+import androidx.datastore.core.DataStore
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.TestCoroutineScope
 import mozilla.components.service.pocket.PocketRecommendedStory
 import mozilla.components.service.pocket.PocketStoriesService
 import mozilla.components.support.test.ext.joinBlocking
 import org.junit.Test
+import org.mozilla.fenix.datastore.SelectedPocketStoriesCategories
+import org.mozilla.fenix.datastore.SelectedPocketStoriesCategories.SelectedPocketStoriesCategory
+import org.mozilla.fenix.home.sessioncontrol.viewholders.pocket.PocketRecommendedStoriesCategory
+import org.mozilla.fenix.home.sessioncontrol.viewholders.pocket.PocketRecommendedStoriesSelectedCategory
 
+@ExperimentalCoroutinesApi
 class PocketUpdatesMiddlewareTest {
-    @ExperimentalCoroutinesApi
     @Test
     fun `WHEN PocketStoriesShown is dispatched THEN update PocketStoriesService`() {
         val story1 = PocketRecommendedStory("title", "url1", "imageUrl", "publisher", "category", 0, timesShown = 0)
@@ -22,7 +31,7 @@ class PocketUpdatesMiddlewareTest {
         val story3 = story1.copy("title3", "url3")
         val coroutineScope = TestCoroutineScope()
         val pocketService: PocketStoriesService = mockk(relaxed = true)
-        val pocketMiddleware = PocketUpdatesMiddleware(coroutineScope, pocketService)
+        val pocketMiddleware = PocketUpdatesMiddleware(coroutineScope, pocketService, mockk())
         val homeStore = HomeFragmentStore(
             HomeFragmentState(
                 pocketStories = listOf(story1, story2, story3)
@@ -33,5 +42,130 @@ class PocketUpdatesMiddlewareTest {
         homeStore.dispatch(HomeFragmentAction.PocketStoriesShown(listOf(story2))).joinBlocking()
 
         coVerify { pocketService.updateStoriesTimesShown(listOf(story2.copy(timesShown = 1))) }
+    }
+
+    @Test
+    fun `WHEN PocketStoriesCategoriesChange is dispatched THEN intercept and dispatch PocketStoriesCategoriesSelectionsChange`() {
+        val persistedSelectedCategory: SelectedPocketStoriesCategory = mockk {
+            every { name } returns "testCategory"
+            every { selectionTimestamp } returns 123
+        }
+        val persistedSelectedCategories: SelectedPocketStoriesCategories = mockk {
+            every { valuesList } returns mutableListOf(persistedSelectedCategory)
+        }
+        val dataStore: DataStore<SelectedPocketStoriesCategories> = mockk {
+            every { data } returns flowOf(persistedSelectedCategories)
+        }
+        val currentCategories = listOf(mockk<PocketRecommendedStoriesCategory>())
+        val pocketMiddleware = PocketUpdatesMiddleware(TestCoroutineScope(), mockk(), dataStore)
+        val homeStore = spyk(
+            HomeFragmentStore(
+                HomeFragmentState(
+                    pocketStoriesCategories = currentCategories
+                ),
+                listOf(pocketMiddleware)
+            )
+        )
+
+        homeStore.dispatch(HomeFragmentAction.PocketStoriesCategoriesChange(currentCategories)).joinBlocking()
+
+        verify {
+            homeStore.dispatch(
+                HomeFragmentAction.PocketStoriesCategoriesSelectionsChange(
+                    storiesCategories = currentCategories,
+                    categoriesSelected = listOf(
+                        PocketRecommendedStoriesSelectedCategory("testCategory", 123)
+                    )
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `WHEN SelectPocketStoriesCategory is dispatched THEN persist details in DataStore`() {
+        val categ1 = PocketRecommendedStoriesCategory("categ1")
+        val categ2 = PocketRecommendedStoriesCategory("categ2")
+        val dataStore: DataStore<SelectedPocketStoriesCategories> = mockk(relaxed = true)
+        val pocketMiddleware = PocketUpdatesMiddleware(TestCoroutineScope(), mockk(), dataStore)
+        val homeStore = spyk(
+            HomeFragmentStore(
+                HomeFragmentState(
+                    pocketStoriesCategories = listOf(categ1, categ2)
+                ),
+                listOf(pocketMiddleware)
+            )
+        )
+
+        homeStore.dispatch(HomeFragmentAction.SelectPocketStoriesCategory(categ2.name)).joinBlocking()
+
+        // Seems like the most we can test is that an update was made.
+        coVerify { dataStore.updateData(any()) }
+    }
+
+    @Test
+    fun `WHEN DeselectPocketStoriesCategory is dispatched THEN persist details in DataStore`() {
+        val categ1 = PocketRecommendedStoriesCategory("categ1")
+        val categ2 = PocketRecommendedStoriesCategory("categ2")
+        val dataStore: DataStore<SelectedPocketStoriesCategories> = mockk(relaxed = true)
+        val pocketMiddleware = PocketUpdatesMiddleware(TestCoroutineScope(), mockk(), dataStore)
+        val homeStore = spyk(
+            HomeFragmentStore(
+                HomeFragmentState(
+                    pocketStoriesCategories = listOf(categ1, categ2)
+                ),
+                listOf(pocketMiddleware)
+            )
+        )
+
+        homeStore.dispatch(HomeFragmentAction.DeselectPocketStoriesCategory(categ2.name)).joinBlocking()
+
+        // Seems like the most we can test is that an update was made.
+        coVerify { dataStore.updateData(any()) }
+    }
+
+    @Test
+    fun `WHEN persistCategories is called THEN update dataStore`() {
+        val dataStore: DataStore<SelectedPocketStoriesCategories> = mockk(relaxed = true)
+
+        persistSelectedCategories(TestCoroutineScope(), listOf(mockk(relaxed = true)), dataStore)
+
+        // Seems like the most we can test is that an update was made.
+        coVerify { dataStore.updateData(any()) }
+    }
+
+    @Test
+    fun `WHEN restoreSelectedCategories is called THEN dispatch PocketStoriesCategoriesSelectionsChange with data read from the persistence layer`() {
+        val persistedSelectedCategory: SelectedPocketStoriesCategory = mockk {
+            every { name } returns "testCategory"
+            every { selectionTimestamp } returns 123
+        }
+        val persistedSelectedCategories: SelectedPocketStoriesCategories = mockk {
+            every { valuesList } returns mutableListOf(persistedSelectedCategory)
+        }
+        val dataStore: DataStore<SelectedPocketStoriesCategories> = mockk {
+            every { data } returns flowOf(persistedSelectedCategories)
+        }
+        val currentCategories = listOf(mockk<PocketRecommendedStoriesCategory>())
+        val homeStore = spyk(
+            HomeFragmentStore(HomeFragmentState())
+        )
+
+        restoreSelectedCategories(
+            coroutineScope = TestCoroutineScope(),
+            currentCategories = currentCategories,
+            store = homeStore,
+            selectedPocketCategoriesDataStore = dataStore
+        )
+
+        coVerify {
+            homeStore.dispatch(
+                HomeFragmentAction.PocketStoriesCategoriesSelectionsChange(
+                    storiesCategories = currentCategories,
+                    categoriesSelected = listOf(
+                        PocketRecommendedStoriesSelectedCategory("testCategory", 123)
+                    )
+                )
+            )
+        }
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/home/PocketUpdatesMiddlewareTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/PocketUpdatesMiddlewareTest.kt
@@ -45,6 +45,20 @@ class PocketUpdatesMiddlewareTest {
     }
 
     @Test
+    fun `WHEN persistStories is called THEN update PocketStoriesService`() {
+        val stories: List<PocketRecommendedStory> = mockk()
+        val pocketService: PocketStoriesService = mockk(relaxed = true)
+
+        persistStories(
+            coroutineScope = TestCoroutineScope(),
+            pocketStoriesService = pocketService,
+            updatedStories = stories
+        )
+
+        coVerify { pocketService.updateStoriesTimesShown(stories) }
+    }
+
+    @Test
     fun `WHEN PocketStoriesCategoriesChange is dispatched THEN intercept and dispatch PocketStoriesCategoriesSelectionsChange`() {
         val persistedSelectedCategory: SelectedPocketStoriesCategory = mockk {
             every { name } returns "testCategory"

--- a/app/src/test/java/org/mozilla/fenix/home/SessionControlInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/SessionControlInteractorTest.kt
@@ -18,7 +18,7 @@ import org.mozilla.fenix.home.recentbookmarks.controller.RecentBookmarksControll
 import org.mozilla.fenix.home.recenttabs.controller.RecentTabController
 import org.mozilla.fenix.home.sessioncontrol.DefaultSessionControlController
 import org.mozilla.fenix.home.sessioncontrol.SessionControlInteractor
-import org.mozilla.fenix.home.sessioncontrol.viewholders.pocket.PocketRecommendedStoryCategory
+import org.mozilla.fenix.home.sessioncontrol.viewholders.pocket.PocketRecommendedStoriesCategory
 import org.mozilla.fenix.home.sessioncontrol.viewholders.pocket.PocketStoriesController
 
 class SessionControlInteractorTest {
@@ -215,7 +215,7 @@ class SessionControlInteractorTest {
 
     @Test
     fun `GIVEN a PocketStoriesInteractor WHEN a category is clicked THEN handle it in a PocketStoriesController`() {
-        val clickedCategory: PocketRecommendedStoryCategory = mockk()
+        val clickedCategory: PocketRecommendedStoriesCategory = mockk()
 
         interactor.onCategoryClick(clickedCategory)
 

--- a/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/viewholders/pocket/DefaultPocketStoriesControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/viewholders/pocket/DefaultPocketStoriesControllerTest.kt
@@ -21,11 +21,15 @@ import org.mozilla.fenix.home.HomeFragmentStore
 class DefaultPocketStoriesControllerTest {
     @Test
     fun `GIVEN a category is selected WHEN that same category is clicked THEN deselect it`() {
-        val category1 = PocketRecommendedStoryCategory("cat1", emptyList(), isSelected = false)
-        val category2 = PocketRecommendedStoryCategory("cat2", emptyList(), isSelected = true)
+        val category1 = PocketRecommendedStoriesCategory("cat1", emptyList())
+        val category2 = PocketRecommendedStoriesCategory("cat2", emptyList())
+        val selections = listOf(PocketRecommendedStoriesSelectedCategory(category2.name))
         val store = spyk(
             HomeFragmentStore(
-                HomeFragmentState(pocketStoriesCategories = listOf(category1, category2))
+                HomeFragmentState(
+                    pocketStoriesCategories = listOf(category1, category2),
+                    pocketStoriesCategoriesSelections = selections
+                )
             )
         )
         val controller = DefaultPocketStoriesController(mockk(), store, mockk())
@@ -39,23 +43,19 @@ class DefaultPocketStoriesControllerTest {
 
     @Test
     fun `GIVEN 8 categories are selected WHEN when a new one is clicked THEN the oldest selected is deselected before selecting the new one`() {
-        val category1 = PocketRecommendedStoryCategory(
-            "cat1", emptyList(), isSelected = true, lastInteractedWithTimestamp = 111
-        )
-        val category2 = category1.copy("cat2", lastInteractedWithTimestamp = 222)
-        val category3 = category1.copy("cat3", lastInteractedWithTimestamp = 333)
-        val oldestSelectedCategory = category1.copy("oldestSelectedCategory", lastInteractedWithTimestamp = 0)
-        val category4 = category1.copy("cat4", lastInteractedWithTimestamp = 444)
-        val category5 = category1.copy("cat5", lastInteractedWithTimestamp = 555)
-        val category6 = category1.copy("cat6", lastInteractedWithTimestamp = 678)
-        val category7 = category1.copy("cat6", lastInteractedWithTimestamp = 890)
-        val newSelectedCategory = category1.copy(
-            "newSelectedCategory", isSelected = false, lastInteractedWithTimestamp = 654321
-        )
+        val category1 = PocketRecommendedStoriesSelectedCategory(name = "cat1", selectionTimestamp = 111)
+        val category2 = PocketRecommendedStoriesSelectedCategory(name = "cat2", selectionTimestamp = 222)
+        val category3 = PocketRecommendedStoriesSelectedCategory(name = "cat3", selectionTimestamp = 333)
+        val oldestSelectedCategory = PocketRecommendedStoriesSelectedCategory(name = "oldestSelectedCategory", selectionTimestamp = 0)
+        val category4 = PocketRecommendedStoriesSelectedCategory(name = "cat4", selectionTimestamp = 444)
+        val category5 = PocketRecommendedStoriesSelectedCategory(name = "cat5", selectionTimestamp = 555)
+        val category6 = PocketRecommendedStoriesSelectedCategory(name = "cat6", selectionTimestamp = 678)
+        val category7 = PocketRecommendedStoriesSelectedCategory(name = "cat7", selectionTimestamp = 890)
+        val newSelectedCategory = PocketRecommendedStoriesSelectedCategory(name = "newSelectedCategory", selectionTimestamp = 654321)
         val store = spyk(
             HomeFragmentStore(
                 HomeFragmentState(
-                    pocketStoriesCategories = listOf(
+                    pocketStoriesCategoriesSelections = listOf(
                         category1, category2, category3, category4, category5, category6, category7, oldestSelectedCategory
                     )
                 )
@@ -63,7 +63,7 @@ class DefaultPocketStoriesControllerTest {
         )
         val controller = DefaultPocketStoriesController(mockk(), store, mockk())
 
-        controller.handleCategoryClick(newSelectedCategory)
+        controller.handleCategoryClick(PocketRecommendedStoriesCategory(newSelectedCategory.name))
 
         verify { store.dispatch(HomeFragmentAction.DeselectPocketStoriesCategory(oldestSelectedCategory.name)) }
         verify { store.dispatch(HomeFragmentAction.SelectPocketStoriesCategory(newSelectedCategory.name)) }
@@ -71,22 +71,17 @@ class DefaultPocketStoriesControllerTest {
 
     @Test
     fun `GIVEN fewer than 8 categories are selected WHEN when a new one is clicked THEN don't deselect anything but select the newly clicked category`() {
-        val category1 = PocketRecommendedStoryCategory(
-            "cat1", emptyList(), isSelected = true, lastInteractedWithTimestamp = 111
-        )
-        val category2 = category1.copy("cat2", lastInteractedWithTimestamp = 222)
-        val category3 = category1.copy("cat3", lastInteractedWithTimestamp = 333)
-        val oldestSelectedCategory = category1.copy("oldestSelectedCategory", lastInteractedWithTimestamp = 0)
-        val category4 = category1.copy("cat4", lastInteractedWithTimestamp = 444)
-        val category5 = category1.copy("cat5", lastInteractedWithTimestamp = 555)
-        val category6 = category1.copy("cat6", lastInteractedWithTimestamp = 678)
-        val newSelectedCategory = category1.copy(
-            "newSelectedCategory", isSelected = false, lastInteractedWithTimestamp = 654321
-        )
+        val category1 = PocketRecommendedStoriesSelectedCategory(name = "cat1", selectionTimestamp = 111)
+        val category2 = PocketRecommendedStoriesSelectedCategory(name = "cat2", selectionTimestamp = 222)
+        val category3 = PocketRecommendedStoriesSelectedCategory(name = "cat3", selectionTimestamp = 333)
+        val oldestSelectedCategory = PocketRecommendedStoriesSelectedCategory(name = "oldestSelectedCategory", selectionTimestamp = 0)
+        val category4 = PocketRecommendedStoriesSelectedCategory(name = "cat4", selectionTimestamp = 444)
+        val category5 = PocketRecommendedStoriesSelectedCategory(name = "cat5", selectionTimestamp = 555)
+        val category6 = PocketRecommendedStoriesSelectedCategory(name = "cat6", selectionTimestamp = 678)
         val store = spyk(
             HomeFragmentStore(
                 HomeFragmentState(
-                    pocketStoriesCategories = listOf(
+                    pocketStoriesCategoriesSelections = listOf(
                         category1, category2, category3, category4, category5, category6, oldestSelectedCategory
                     )
                 )
@@ -94,10 +89,10 @@ class DefaultPocketStoriesControllerTest {
         )
         val controller = DefaultPocketStoriesController(mockk(), store, mockk())
 
-        controller.handleCategoryClick(newSelectedCategory)
+        controller.handleCategoryClick(PocketRecommendedStoriesCategory("newSelectedCategory"))
 
         verify(exactly = 0) { store.dispatch(HomeFragmentAction.DeselectPocketStoriesCategory(oldestSelectedCategory.name)) }
-        verify { store.dispatch(HomeFragmentAction.SelectPocketStoriesCategory(newSelectedCategory.name)) }
+        verify { store.dispatch(HomeFragmentAction.SelectPocketStoriesCategory("newSelectedCategory")) }
     }
 
     @Test

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -35,6 +35,7 @@ object Versions {
     const val androidx_paging = "2.1.2"
     const val androidx_transition = "1.4.0"
     const val androidx_work = "2.5.0"
+    const val androidx_datastore = "1.0.0"
     const val google_material = "1.2.1"
 
     const val mozilla_android_components = AndroidComponents.VERSION
@@ -52,6 +53,8 @@ object Versions {
     const val google_ads_id_version = "16.0.0"
 
     const val google_play_store_version = "1.8.0"
+
+    const val protobuf = "3.11.4" // keep in sync with the version used in AS.
 }
 
 @Suppress("unused")
@@ -199,7 +202,11 @@ object Deps {
     const val androidx_transition = "androidx.transition:transition:${Versions.androidx_transition}"
     const val androidx_work_ktx = "androidx.work:work-runtime-ktx:${Versions.androidx_work}"
     const val androidx_work_testing = "androidx.work:work-testing:${Versions.androidx_work}"
+    const val androidx_datastore = "androidx.datastore:datastore:${Versions.androidx_datastore}"
     const val google_material = "com.google.android.material:material:${Versions.google_material}"
+
+    const val protobuf_javalite = "com.google.protobuf:protobuf-javalite:${Versions.protobuf}"
+    const val protobuf_compiler = "com.google.protobuf:protoc:${Versions.protobuf}"
 
     const val adjust = "com.adjust.sdk:adjust-android:${Versions.adjust}"
     const val installreferrer = "com.android.installreferrer:installreferrer:${Versions.installreferrer}"


### PR DESCRIPTION
Refactored out `isSelected` from `PocketRecommendedStoriesCategory` to a new `PocketRecommendedStoriesSelectedCategory` which will be part of the same `HomeFragmentState` to support updating them independently.

Used Proto Datastore for persisting Pocket stories categories selections as a fast and easy solution with all the ACID requirements that also supports easy migrations if we later need to change the persisted data.


https://user-images.githubusercontent.com/11428869/135449582-6198449e-16d8-4a0a-ba0a-6e47b5df98f7.mp4



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
