### PR TITLE
Do not show home screen behind search if we have search terms

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt
@@ -92,7 +92,11 @@ class DefaultBrowserToolbarController(
 
     override fun handleToolbarClick() {
         metrics.track(Event.SearchBarTapped(Event.SearchBarTapped.Source.BROWSER))
-        if (FeatureFlags.showHomeBehindSearch) {
+        // If we're displaying awesomebar search results, Home screen will not be visible (it's
+        // covered up with the search results). So, skip the navigation event in that case.
+        // If we don't, there's a visual flickr as we navigate to Home and then display search
+        // results on top it.
+        if (FeatureFlags.showHomeBehindSearch && currentSession?.content?.searchTerms.isNullOrBlank()) {
             navController.navigate(
                 BrowserFragmentDirections.actionGlobalHome()
             )

--- a/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt
@@ -434,7 +434,10 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
                 true
             }
             else -> {
-                if (FeatureFlags.showHomeBehindSearch) {
+                // In case we're displaying search results, we wouldn't have navigated to home, and
+                // so we don't need to navigate "back to" browser fragment.
+                // See mirror of this logic in BrowserToolbarController#handleToolbarClick.
+                if (FeatureFlags.showHomeBehindSearch && store.state.searchTerms.isBlank()) {
                     val args by navArgs<SearchDialogFragmentArgs>()
                     args.sessionId?.let {
                         findNavController().navigate(

--- a/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarControllerTest.kt
@@ -239,6 +239,31 @@ class DefaultBrowserToolbarControllerTest {
     }
 
     @Test
+    fun handleToolbackClickWithSearchTerms() {
+        val searchResultsTab = createTab("https://google.com?q=mozilla+website", searchTerms = "mozilla website")
+        store.dispatch(TabListAction.AddTabAction(searchResultsTab, select = true)).joinBlocking()
+
+        val controller = createController()
+        controller.handleToolbarClick()
+
+        val homeDirections = BrowserFragmentDirections.actionGlobalHome()
+        val searchDialogDirections = BrowserFragmentDirections.actionGlobalSearchDialog(
+            sessionId = searchResultsTab.id
+        )
+
+        verify {
+            metrics.track(Event.SearchBarTapped(Event.SearchBarTapped.Source.BROWSER))
+        }
+        // Does not show the home screen "behind" the search dialog if the current session has search terms.
+        verify(exactly = 0) {
+            navController.navigate(homeDirections)
+        }
+        verify {
+            navController.navigate(searchDialogDirections, any<NavOptions>())
+        }
+    }
+
+    @Test
     fun handleToolbarCloseTabPressWithLastPrivateSession() {
         val item = TabCounterMenu.Item.CloseTab
 


### PR DESCRIPTION
Home screen isn't actually visible in case we're displaying awesomebar
search results. The navigation is thus unnecessary and actually causes visual
jankiness as we display home for a moment before covering it up with
search results.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
