### PR TITLE
For #21643: Pre-land strings for inactive tabs CFR and section title for non-search group tabs

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabstray/browser/TitleHeaderAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/browser/TitleHeaderAdapter.kt
@@ -60,7 +60,7 @@ class TitleHeaderAdapter(
 
         fun bind() {
             binding.tabTrayHeaderTitle.text =
-                itemView.context.getString(R.string.tab_tray_header_title)
+                itemView.context.getString(R.string.tab_tray_header_title_1)
         }
 
         companion object {

--- a/app/src/main/res/layout/tab_tray_title_header_item.xml
+++ b/app/src/main/res/layout/tab_tray_title_header_item.xml
@@ -17,7 +17,7 @@
     android:focusable="false"
     android:gravity="start"
     android:maxLines="1"
-    android:text="@string/tab_tray_header_title"
+    android:text="@string/tab_tray_header_title_1"
     android:textAppearance="@style/Header16TextStyle"
     app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -104,6 +104,10 @@
     <string name="tab_tray_close_tabs_banner_positive_button_text">View options</string>
     <!-- Text for the negative action button to dismiss the Close Tabs Banner. -->
     <string name="tab_tray_close_tabs_banner_negative_button_text">Dismiss</string>
+    <!-- Text for the banner message to tell users about our inactive tabs feature. -->
+    <string name="tab_tray_inactive_onboarding_message" tools:ignore="UnusedResources">Tabs you haven’t viewed for two weeks get moved here.</string>
+    <!-- Text for the action link to go to Settings for inactive tabs. -->
+    <string name="tab_tray_inactive_onboarding_button_text" tools:ignore="UnusedResources">Turn off in settings</string>
 
     <!-- Home screen icons - Long press shortcuts -->
     <!-- Shortcut action to open new tab -->
@@ -795,7 +799,9 @@
     <!-- Button in the current tab tray header in multiselect mode. Saved the selected tabs to a collection when pressed. -->
     <string name="tab_tray_save_to_collection">Save</string>
     <!-- Title text for the normal tabs header in the tabs tray which are not part of any tab grouping. -->
-    <string name="tab_tray_header_title">Other</string>
+    <string name="tab_tray_header_title" moz:removedIn="94" tools:ignore="UnusedResources">Other</string>
+    <!-- Title text for the normal tabs header in the tabs tray which are not part of any tab grouping. -->
+    <string name="tab_tray_header_title_1">Other tabs</string>
 
     <!-- History -->
     <!-- Text for the button to clear all history -->


### PR DESCRIPTION
For #21643 

- [x] Pre-land inactive tabs CFR strings
- [x] Section title for non-search group tabs (from "Other" -> "Other tabs")

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
