### PR TITLE
For #21644 fix disabled alwaysStartOnHomeTest UI test

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -1438,7 +1438,6 @@ class SmokeTest {
         }
     }
 
-    @Ignore // to be fixed here https://github.com/mozilla-mobile/fenix/issues/21644
     @Test
     fun alwaysStartOnHomeTest() {
         val settings = activityTestRule.activity.applicationContext.settings()

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuTabsRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuTabsRobot.kt
@@ -31,7 +31,7 @@ class SettingsSubMenuTabsRobot {
     fun verifyStartOnHomeOptions() = assertStartOnHomeOptions()
 
     fun clickAlwaysStartOnHomeToggle() {
-        scrollToElementByText("Always")
+        scrollToElementByText("Move old tabs to inactive")
         alwaysStartOnHomeToggle().click()
     }
 


### PR DESCRIPTION
For #21644 fix disabled `alwaysStartOnHomeTest` UI test
✔️  Successfully passed 50x on Firebase

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
