### PR TITLE
For #21621 - Add invdividual paddings to each home item

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/historymetadata/view/HistoryMetadataGroupViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/historymetadata/view/HistoryMetadataGroupViewHolder.kt
@@ -30,6 +30,9 @@ class HistoryMetadataGroupViewHolder(
 ) : ViewHolder(composeView) {
 
     init {
+        val horizontalPadding = composeView.resources.getDimensionPixelSize(R.dimen.home_item_horizontal_margin)
+        composeView.setPadding(horizontalPadding, 0, horizontalPadding, 0)
+
         composeView.setViewCompositionStrategy(
             ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed
         )

--- a/app/src/main/java/org/mozilla/fenix/home/recenttabs/view/RecentTabViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recenttabs/view/RecentTabViewHolder.kt
@@ -8,6 +8,7 @@ import android.view.View
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import mozilla.components.lib.state.ext.observeAsComposableState
+import org.mozilla.fenix.R
 import org.mozilla.fenix.home.HomeFragmentStore
 import org.mozilla.fenix.home.recenttabs.interactor.RecentTabInteractor
 import org.mozilla.fenix.theme.FirefoxTheme
@@ -27,6 +28,9 @@ class RecentTabViewHolder(
 ) : ViewHolder(composeView) {
 
     init {
+        val horizontalPadding = composeView.resources.getDimensionPixelSize(R.dimen.home_item_horizontal_margin)
+        composeView.setPadding(horizontalPadding, 0, horizontalPadding, 0)
+
         composeView.setViewCompositionStrategy(
             ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed
         )

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/pocket/PocketStoriesViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/pocket/PocketStoriesViewHolder.kt
@@ -5,6 +5,7 @@
 package org.mozilla.fenix.home.sessioncontrol.viewholders.pocket
 
 import android.view.View
+import androidx.annotation.Dimension
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -52,7 +53,10 @@ class PocketStoriesViewHolder(
                     store,
                     interactor::onStoriesShown,
                     interactor::onCategoryClick,
-                    interactor::onExternalLinkClicked
+                    interactor::onExternalLinkClicked,
+                    with(composeView.resources) {
+                        getDimensionPixelSize(R.dimen.home_item_horizontal_margin) / displayMetrics.density
+                    }
                 )
             }
         }
@@ -68,7 +72,8 @@ fun PocketStories(
     store: HomeFragmentStore,
     onStoriesShown: (List<PocketRecommendedStory>) -> Unit,
     onCategoryClick: (PocketRecommendedStoriesCategory) -> Unit,
-    onExternalLinkClicked: (String) -> Unit
+    onExternalLinkClicked: (String) -> Unit,
+    @Dimension horizontalPadding: Float = 0f
 ) {
     val stories = store
         .observeAsComposableState { state -> state.pocketStories }.value
@@ -87,35 +92,45 @@ fun PocketStories(
         }
     }
 
-    Column(modifier = Modifier.padding(vertical = 48.dp)) {
+    Column(modifier = Modifier.padding(vertical = 44.dp)) {
         HomeSectionHeader(
             text = stringResource(R.string.pocket_stories_header_1),
             modifier = Modifier
                 .fillMaxWidth()
+                .padding(horizontal = horizontalPadding.dp)
         )
 
         Spacer(Modifier.height(17.dp))
 
-        PocketStories(stories ?: emptyList(), onExternalLinkClicked)
+        PocketStories(stories ?: emptyList(), horizontalPadding.dp, onExternalLinkClicked)
 
         Spacer(Modifier.height(24.dp))
 
         HomeSectionHeader(
             text = stringResource(R.string.pocket_stories_categories_header),
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = horizontalPadding.dp)
         )
 
         Spacer(Modifier.height(17.dp))
 
         PocketStoriesCategories(
             categories = categories ?: emptyList(),
-            selections = categoriesSelections ?: emptyList()
-        ) {
-            onCategoryClick(it)
-        }
+            selections = categoriesSelections ?: emptyList(),
+            onCategoryClick = onCategoryClick,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = horizontalPadding.dp)
+        )
 
         Spacer(Modifier.height(24.dp))
 
-        PoweredByPocketHeader(onExternalLinkClicked)
+        PoweredByPocketHeader(
+            onExternalLinkClicked,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = horizontalPadding.dp)
+        )
     }
 }

--- a/app/src/main/res/layout/button_tip_item.xml
+++ b/app/src/main/res/layout/button_tip_item.xml
@@ -9,8 +9,8 @@
     style="@style/OnboardingCardLight"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="@drawable/cfr_background_gradient"
-    android:padding="0dp">
+    android:layout_marginHorizontal="@dimen/home_item_horizontal_margin"
+    android:background="@drawable/cfr_background_gradient">
 
     <TextView
         android:id="@+id/tip_header_text"

--- a/app/src/main/res/layout/collection_header.xml
+++ b/app/src/main/res/layout/collection_header.xml
@@ -7,6 +7,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_marginHorizontal="@dimen/home_item_horizontal_margin"
     android:layout_marginTop="40dp">
 
     <androidx.appcompat.widget.AppCompatTextView

--- a/app/src/main/res/layout/collection_home_list_row.xml
+++ b/app/src/main/res/layout/collection_home_list_row.xml
@@ -7,6 +7,7 @@
     android:id="@+id/item_collection"
     android:layout_width="match_parent"
     android:layout_height="48dp"
+    android:layout_marginHorizontal="@dimen/home_item_horizontal_margin"
     android:layout_marginTop="12dp"
     android:background="@drawable/card_list_row_background"
     android:clickable="true"

--- a/app/src/main/res/layout/component_recent_bookmarks.xml
+++ b/app/src/main/res/layout/component_recent_bookmarks.xml
@@ -7,6 +7,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_marginHorizontal="@dimen/home_item_horizontal_margin"
     android:clipChildren="false"
     android:clipToPadding="false"
     android:orientation="vertical">

--- a/app/src/main/res/layout/component_top_sites_pager.xml
+++ b/app/src/main/res/layout/component_top_sites_pager.xml
@@ -6,6 +6,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_marginHorizontal="@dimen/home_item_horizontal_margin"
     android:orientation="vertical">
 
     <androidx.viewpager2.widget.ViewPager2

--- a/app/src/main/res/layout/customize_home_list_item.xml
+++ b/app/src/main/res/layout/customize_home_list_item.xml
@@ -9,6 +9,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:paddingVertical="16dp"
+    android:layout_marginHorizontal="@dimen/home_item_horizontal_margin"
     android:layout_marginTop="24dp"
     android:background="?android:attr/selectableItemBackground">
 

--- a/app/src/main/res/layout/default_browser_experiment_preference.xml
+++ b/app/src/main/res/layout/default_browser_experiment_preference.xml
@@ -8,7 +8,8 @@
     style="@style/OnboardingCardLightWithPadding"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_margin="8dp">
+    android:layout_marginVertical="8dp"
+    android:layout_marginHorizontal="24dp">
 
     <ImageView
         android:id="@+id/app_icon"

--- a/app/src/main/res/layout/experiment_default_browser.xml
+++ b/app/src/main/res/layout/experiment_default_browser.xml
@@ -7,7 +7,8 @@
     android:id="@+id/experiment_card"
     style="@style/OnboardingCardLightWithPadding"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:layout_marginHorizontal="@dimen/home_item_horizontal_margin">
 
     <ImageButton
         android:id="@+id/close"

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -69,7 +69,7 @@
         android:clipChildren="false"
         android:clipToPadding="false"
         android:layout_marginBottom="88dp"
-        android:padding="16dp"
+        android:paddingVertical="16dp"
         android:scrollbars="none"
         android:transitionGroup="false"
         android:importantForAccessibility="yes"

--- a/app/src/main/res/layout/history_metadata_header.xml
+++ b/app/src/main/res/layout/history_metadata_header.xml
@@ -7,6 +7,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_marginHorizontal="@dimen/home_item_horizontal_margin"
     android:layout_marginTop="40dp">
 
     <androidx.appcompat.widget.AppCompatTextView

--- a/app/src/main/res/layout/no_collections_message.xml
+++ b/app/src/main/res/layout/no_collections_message.xml
@@ -7,6 +7,7 @@
     android:id="@+id/no_collections_wrapper"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_marginHorizontal="@dimen/home_item_horizontal_margin"
     android:layout_marginTop="40dp"
     android:layout_marginBottom="12dp"
     android:background="@drawable/empty_session_control_background"

--- a/app/src/main/res/layout/onboarding_automatic_signin.xml
+++ b/app/src/main/res/layout/onboarding_automatic_signin.xml
@@ -9,6 +9,7 @@
     style="@style/OnboardingCardDark"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_marginHorizontal="@dimen/home_item_horizontal_margin"
     android:orientation="vertical">
 
     <TextView

--- a/app/src/main/res/layout/onboarding_finish.xml
+++ b/app/src/main/res/layout/onboarding_finish.xml
@@ -8,4 +8,5 @@
     android:background="@drawable/onboarding_padded_background"
     android:backgroundTint="?accent"
     android:layout_marginBottom="10dp"
+    android:layout_marginHorizontal="@dimen/home_item_horizontal_margin"
     android:text="@string/onboarding_finish" />

--- a/app/src/main/res/layout/onboarding_header.xml
+++ b/app/src/main/res/layout/onboarding_header.xml
@@ -8,7 +8,8 @@
         android:id="@+id/onboarding_header"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="8dp">
+        android:layout_marginBottom="8dp"
+        android:layout_marginHorizontal="@dimen/home_item_horizontal_margin">
     <TextView
             android:id="@+id/header_text"
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/onboarding_manual_signin.xml
+++ b/app/src/main/res/layout/onboarding_manual_signin.xml
@@ -10,6 +10,7 @@
     style="@style/OnboardingCardLightWithPadding"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_marginHorizontal="@dimen/home_item_horizontal_margin"
     android:orientation="vertical">
 
     <androidx.appcompat.widget.AppCompatImageView

--- a/app/src/main/res/layout/onboarding_privacy_notice.xml
+++ b/app/src/main/res/layout/onboarding_privacy_notice.xml
@@ -9,7 +9,8 @@
         android:id="@+id/onboarding_card"
         style="@style/OnboardingCardLightWithPadding"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/home_item_horizontal_margin">
     <TextView
             android:id="@+id/header_text"
             android:layout_width="0dp"

--- a/app/src/main/res/layout/onboarding_section_header.xml
+++ b/app/src/main/res/layout/onboarding_section_header.xml
@@ -10,4 +10,5 @@
         android:layout_height="wrap_content"
         android:textAppearance="@style/HeaderTextStyle"
         tools:text="@tools:sample/lorem"
-        android:layout_marginBottom="16dp" />
+        android:layout_marginBottom="16dp"
+        android:layout_marginHorizontal="@dimen/home_item_horizontal_margin"/>

--- a/app/src/main/res/layout/onboarding_theme_picker.xml
+++ b/app/src/main/res/layout/onboarding_theme_picker.xml
@@ -9,7 +9,8 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     style="@style/OnboardingCardLight"
-    android:paddingTop="16dp">
+    android:paddingTop="16dp"
+    android:layout_marginHorizontal="@dimen/home_item_horizontal_margin">
 
     <TextView
         android:id="@+id/header_text"

--- a/app/src/main/res/layout/onboarding_toolbar_position_picker.xml
+++ b/app/src/main/res/layout/onboarding_toolbar_position_picker.xml
@@ -8,6 +8,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     style="@style/OnboardingCardLight"
+    android:layout_marginHorizontal="@dimen/home_item_horizontal_margin"
     android:paddingTop="16dp"
     android:paddingBottom="16dp">
 

--- a/app/src/main/res/layout/onboarding_tracking_protection.xml
+++ b/app/src/main/res/layout/onboarding_tracking_protection.xml
@@ -8,6 +8,7 @@
     style="@style/OnboardingCardLightWithPadding"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_marginHorizontal="@dimen/home_item_horizontal_margin"
     android:clipChildren="false"
     android:clipToPadding="false">
 

--- a/app/src/main/res/layout/private_browsing_description.xml
+++ b/app/src/main/res/layout/private_browsing_description.xml
@@ -9,7 +9,8 @@
     android:layout_height="wrap_content"
     android:layout_margin="0.5dp"
     android:importantForAccessibility="no"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:layout_marginHorizontal="@dimen/home_item_horizontal_margin">
 
     <TextView
         android:id="@+id/private_session_description"

--- a/app/src/main/res/layout/recent_tabs_header.xml
+++ b/app/src/main/res/layout/recent_tabs_header.xml
@@ -2,11 +2,11 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_marginHorizontal="@dimen/home_item_horizontal_margin"
     android:layout_marginTop="40dp">
 
     <androidx.appcompat.widget.AppCompatTextView

--- a/app/src/main/res/layout/site_list_item.xml
+++ b/app/src/main/res/layout/site_list_item.xml
@@ -2,9 +2,9 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<mozilla.components.ui.widgets.WidgetSiteItemView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<mozilla.components.ui.widgets.WidgetSiteItemView xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/site_list_item"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_marginHorizontal="@dimen/home_item_horizontal_margin"
     android:minHeight="@dimen/mozac_widget_site_item_height" />

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -93,6 +93,7 @@
     <!-- Home Fragment -->
     <dimen name="home_fragment_top_toolbar_header_margin">60dp</dimen>
     <dimen name="home_item_elevation">5dp</dimen>
+    <dimen name="home_item_horizontal_margin">16dp</dimen>
 
     <!-- Home - Recently saved bookmarks -->
     <dimen name="recent_bookmark_item_height">132dp</dimen>


### PR DESCRIPTION
Removed the 16dp padding from the RecyclerView holding all home items and added the appropriate spacing to each individual item.
This all is needed to be able to use [contentPadding](https://developer.android.com/jetpack/compose/lists#content-padding) for the list showing Pocket recommended stories in such allowing the stories (when scrolled) and their shadows to extend on the main axis until screen width.


https://user-images.githubusercontent.com/11428869/135870190-d9054321-e59d-48a2-91db-bc1d2d858554.mp4



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
