### PR TITLE
For #21708 - Fixes missing header bottom border

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabstray/browser/InactiveTabViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/browser/InactiveTabViewHolder.kt
@@ -38,6 +38,8 @@ sealed class InactiveTabViewHolder(itemView: View) : RecyclerView.ViewHolder(ite
             itemView.apply {
                 isActivated = InactiveTabsState.isExpanded
 
+                correctHeaderBorder(isActivated)
+
                 setOnClickListener {
                     val newState = !it.isActivated
 
@@ -46,16 +48,22 @@ sealed class InactiveTabViewHolder(itemView: View) : RecyclerView.ViewHolder(ite
                     it.isActivated = newState
                     binding.chevron.rotation = ROTATION_DEGREE
 
-                    // When the header is collapsed we use its bottom border instead of the footer's
-                    binding.inactiveHeaderBorder.updatePadding(
-                        bottom = binding.root.context.dpToPx(if (it.isActivated) 0f else 1f)
-                    )
+                    correctHeaderBorder(isActivated)
                 }
 
                 binding.delete.setOnClickListener {
                     tabsTrayInteractor.onDeleteInactiveTabs()
                 }
             }
+        }
+
+        /**
+         * When the header is collapsed we use its bottom border instead of the footer's
+         */
+        private fun correctHeaderBorder(isActivated: Boolean) {
+            binding.inactiveHeaderBorder.updatePadding(
+                bottom = binding.root.context.dpToPx(if (isActivated) 0f else 1f)
+            )
         }
 
         companion object {


### PR DESCRIPTION
 The bottom gray border of the header item from the Inactive Tabs section was correctly set when collapsing or expanding said section, but not on init. So if the section was initialized collapsed the gray border would not be present.


For https://github.com/mozilla-mobile/fenix/issues/21708
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes no tests as it's only a minor change
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made.
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md).

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

<img src="https://user-images.githubusercontent.com/60002907/136017969-de4e00f6-64c2-44a0-ab56-2794ba4b1df0.png" width="300" />
