### PR TITLE
For #21680 - Pocket composables testing using Robolectric

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -576,6 +576,7 @@ dependencies {
     testImplementation Deps.mozilla_support_test_libstate
     testImplementation Deps.androidx_junit
     testImplementation Deps.androidx_work_testing
+    testImplementation Deps.androidx_compose_ui_test
     testImplementation (Deps.robolectric) {
         exclude group: 'org.apache.maven'
     }

--- a/app/src/main/java/org/mozilla/fenix/compose/CustomSemantics.kt
+++ b/app/src/main/java/org/mozilla/fenix/compose/CustomSemantics.kt
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.compose
+
+import androidx.compose.ui.semantics.SemanticsPropertyKey
+import androidx.compose.ui.semantics.SemanticsPropertyReceiver
+
+/**
+ * Custom semantics key for the url this composable uses.
+ * No guarantee that the value is set. Users must check everytime the result validity.
+ *
+ * See [custom-semantics-properties](https://developer.android.com/jetpack/compose/testing#custom-semantics-properties)
+ */
+val urlKey = SemanticsPropertyKey<String>("url")
+
+/**
+ * Custom semantics property for exposing in tests the url this composable uses.
+ */
+var SemanticsPropertyReceiver.url by urlKey

--- a/app/src/main/java/org/mozilla/fenix/compose/ListItemTabLarge.kt
+++ b/app/src/main/java/org/mozilla/fenix/compose/ListItemTabLarge.kt
@@ -18,6 +18,8 @@ import androidx.compose.material.Card
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.mozilla.fenix.theme.FirefoxTheme
@@ -104,7 +106,10 @@ private fun ListItemTabSurface(
     onClick: (() -> Unit)? = null,
     tabDetails: @Composable () -> Unit
 ) {
-    var modifier = Modifier.size(328.dp, 116.dp)
+    var modifier = Modifier
+        .size(328.dp, 116.dp)
+        .testTag("ListItemTabLarge")
+        .semantics { url = imageUrl }
     if (onClick != null) modifier = modifier.then(Modifier.clickable { onClick() })
 
     Card(

--- a/app/src/main/java/org/mozilla/fenix/compose/StaggeredHorizontalGrid.kt
+++ b/app/src/main/java/org/mozilla/fenix/compose/StaggeredHorizontalGrid.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.Placeable
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
@@ -44,7 +45,12 @@ fun StaggeredHorizontalGrid(
 ) {
     val currentLayoutDirection = LocalLayoutDirection.current
 
-    Layout(content, modifier) { items, constraints ->
+    Layout(
+        content,
+        modifier.then(
+            Modifier.testTag("StaggeredHorizontalGrid")
+        )
+    ) { items, constraints ->
         val horizontalItemsSpacingPixels = horizontalItemsSpacing.roundToPx()
         val verticalItemsSpacingPixels = verticalItemsSpacing.roundToPx()
         var totalHeight = 0

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/pocket/PocketStoriesComposables.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/pocket/PocketStoriesComposables.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
@@ -208,9 +209,10 @@ fun PoweredByPocketHeader(
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Row(
-            Modifier
+            modifier = Modifier
                 .fillMaxWidth()
-                .semantics(mergeDescendants = true) { },
+                .semantics(mergeDescendants = true) { }
+                .testTag("PoweredByPocketHeader"),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Icon(

--- a/app/src/test/java/org/mozilla/fenix/ComposeContentTestRule.kt
+++ b/app/src/test/java/org/mozilla/fenix/ComposeContentTestRule.kt
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix
+
+import androidx.compose.ui.semantics.SemanticsPropertyKey
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.onChildAt
+import androidx.compose.ui.test.onRoot
+import org.junit.Assert.assertEquals
+
+/**
+ * Check recursively all first children starting from the root for one with the indicated testTag.
+ * Allows inferring that a particular child composable is all that this composable displays.
+ *
+ * @param tag TestTag to find in the layout.
+ */
+fun ComposeContentTestRule.onFirstChildWithTag(tag: String): SemanticsNodeInteraction {
+    return getFirstChildWithTag(onRoot(true), tag)
+}
+
+/**
+ * Assert that the semantic identified by [keyForActual] is set and has the value of [expected].
+ *
+ * @param expected The expected value of a certain semantic set for this node.
+ * @param keyForActual Semantics key set for this node, value of which will be compare to [expected].
+ */
+fun <T> SemanticsNodeInteraction.assertSemanticsEquals(expected: T, keyForActual: SemanticsPropertyKey<T>) {
+    val actual = fetchSemanticsNode().config.getOrElse(keyForActual) {
+        throw AssertionError("\"$keyForActual\" cannot be found.")
+    }
+
+    assertEquals(expected, actual)
+}
+
+private fun getFirstChildWithTag(parent: SemanticsNodeInteraction, tag: String): SemanticsNodeInteraction {
+    val firstChild = parent.onChildAt(0)
+
+    firstChild.assertExists("No first child found with tag: \"$tag\"")
+
+    return try {
+        firstChild.assert(hasTestTag(tag))
+    } catch (e: AssertionError) {
+        return getFirstChildWithTag(firstChild, tag)
+    }
+}

--- a/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/viewholders/pocket/PocketStoriesComposablesTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/viewholders/pocket/PocketStoriesComposablesTest.kt
@@ -1,0 +1,264 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.home.sessioncontrol.viewholders.pocket
+
+import android.content.Context
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onChildAt
+import androidx.compose.ui.test.onChildren
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.text.capitalize
+import androidx.compose.ui.text.intl.Locale
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import mozilla.components.service.pocket.PocketRecommendedStory
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.fenix.R
+import org.mozilla.fenix.assertSemanticsEquals
+import org.mozilla.fenix.compose.urlKey
+import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+import org.mozilla.fenix.onFirstChildWithTag
+import org.mozilla.fenix.theme.FirefoxTheme
+import org.robolectric.Robolectric
+import org.robolectric.annotation.Config
+
+@RunWith(FenixRobolectricTestRunner::class)
+class PocketStoriesComposablesTest {
+    private val activity = Robolectric.buildActivity(ComponentActivity::class.java).create().get()
+    @get:Rule
+    internal val composeTestRule = createAndroidComposeRule(activity::class.java)
+
+    private var story = PocketRecommendedStory("storyTitle", "storyUrl", "storyImageUrl", "storyPublisher", "storyCategory", 3, 41)
+
+    @Test
+    fun `WHEN displaying a story THEN show all details in a ListItemTabLarge composable`() {
+        addStoryOnScreen(composeTestRule, story)
+
+        composeTestRule.onFirstChildWithTag("ListItemTabLarge").assertExists()
+    }
+
+    @Test
+    fun `WHEN displaying a story THEN show it's title`() {
+        addStoryOnScreen(composeTestRule, story)
+
+        composeTestRule.onNodeWithText(story.title).assertExists()
+    }
+
+    @Test
+    fun `WHEN displaying a story THEN show an image for it's url`() {
+        addStoryOnScreen(composeTestRule, story)
+
+        // Would've been nice to check the URL in the Image composable
+        // but the compose finders seem to no go that deep in the hierarchy.
+        // ListItemTabLarge should guarantee though that the imageUrl will be used to display an image.
+        composeTestRule.onNodeWithTag("ListItemTabLarge")
+            .assertSemanticsEquals(story.imageUrl, urlKey)
+    }
+
+    @Test
+    @Config(qualifiers = "mdpi") // 1x density
+    fun `WHEN displaying a story THEN show an image for it's url configured with appropriate dimensions`() {
+        val imageUrlWithDimensionsPlaceholder = "https://image{wh}.url"
+        val imageUrlWithAppropriateDimensions = "https://image116x84.url"
+        story = story.copy(imageUrl = imageUrlWithDimensionsPlaceholder)
+
+        addStoryOnScreen(composeTestRule, story)
+
+        composeTestRule.onNodeWithTag("ListItemTabLarge")
+            .assertSemanticsEquals(imageUrlWithAppropriateDimensions, urlKey)
+    }
+
+    @Test
+    fun `WHEN displaying a story THEN show it's publisher`() {
+        addStoryOnScreen(composeTestRule, story)
+
+        composeTestRule.onNodeWithText(story.publisher).assertExists()
+    }
+
+    @Test
+    fun `WHEN displaying a story THEN show it's time to read`() {
+        addStoryOnScreen(composeTestRule, story)
+
+        composeTestRule.onNodeWithText("${story.timeToRead} min").assertExists()
+    }
+
+    @Test
+    fun `GIVEN a story with 9 as time to read WHEN displaying THEN show the 0 value for time to read`() {
+        // Just because Pocket sets -1 when the value can't be calculated 0 could be valid. Though unlikely.
+        story = story.copy(timeToRead = 0)
+
+        addStoryOnScreen(composeTestRule, story)
+
+        composeTestRule.onNodeWithText("${story.timeToRead} min").assertExists()
+    }
+
+    @Test
+    fun `GIVEN a story with valid publisher and time to read WHEN displaying THEN show an interdot`() {
+        addStoryOnScreen(composeTestRule, story)
+
+        composeTestRule.onNodeWithText(" · ").assertExists()
+    }
+
+    @Test
+    fun `GIVEN a story with invalid publisher but valid time to read WHEN displaying THEN show an just the time to read`() {
+        addStoryOnScreen(composeTestRule, story.copy(publisher = ""))
+
+        composeTestRule.onNodeWithText(" · ").assertDoesNotExist()
+        composeTestRule.onNodeWithText("${story.timeToRead} min").assertExists()
+    }
+
+    @Test
+    fun `GIVEN a story with valid publisher but invalid time to read WHEN displaying THEN show an just the publisher`() {
+        story = story.copy(timeToRead = -1)
+
+        addStoryOnScreen(composeTestRule, story)
+
+        composeTestRule.onNodeWithText(" · ").assertDoesNotExist()
+        composeTestRule.onNodeWithText("${story.timeToRead} min").assertDoesNotExist()
+        composeTestRule.onNodeWithText(story.publisher).assertExists()
+    }
+
+    @Test
+    fun `GIVEN a story with invalid publisher and invalid time to read WHEN displaying THEN don't show even the interdot`() {
+        story = story.copy(publisher = "", timeToRead = -1)
+
+        addStoryOnScreen(composeTestRule, story)
+
+        composeTestRule.onNodeWithText(" · ").assertDoesNotExist()
+        composeTestRule.onNodeWithText("${story.timeToRead} min").assertDoesNotExist()
+    }
+
+    @Test
+    fun `WHEN a story is clicked THEN inform through callback`() {
+        var storyWasClicked = true
+
+        addStoryOnScreen(composeTestRule, story) {
+            assertSame(story, it)
+            storyWasClicked = true
+        }
+        composeTestRule.onRoot().performClick()
+
+        assertTrue(storyWasClicked)
+    }
+
+    @Test
+    fun `WHEN displaying categories THEN show them in a StaggeredHorizontalGrid`() {
+        val category1 = PocketRecommendedStoriesCategory("category1")
+        val category2 = PocketRecommendedStoriesCategory("category2")
+
+        composeTestRule.setContent {
+            PocketStoriesCategories(listOf(category1, category2), emptyList(), { })
+        }
+
+        composeTestRule.onFirstChildWithTag("StaggeredHorizontalGrid").assertExists()
+    }
+
+    @Test
+    fun `WHEN displaying categories THEN all their names are displayed`() {
+        val category1 = PocketRecommendedStoriesCategory("category1")
+        val category2 = PocketRecommendedStoriesCategory("category2")
+
+        composeTestRule.setContent {
+            PocketStoriesCategories(listOf(category1, category2), emptyList(), { })
+        }
+
+        val gridLayout = composeTestRule.onFirstChildWithTag("StaggeredHorizontalGrid")
+        gridLayout.onChildren().assertCountEquals(2)
+        gridLayout.onChildAt(0).onChildAt(0)
+            .assertTextEquals(category1.name.capitalize(Locale.current))
+        gridLayout.onChildAt(1).onChildAt(0)
+            .assertTextEquals(category2.name.capitalize(Locale.current))
+    }
+
+    @Test
+    @Config(qualifiers = "mdpi") // 1x density
+    fun `WHEN displaying categories THEN show them with 16dp horizontal spacing`() {
+        val category1 = PocketRecommendedStoriesCategory("category1")
+        val category2 = PocketRecommendedStoriesCategory("category2")
+
+        composeTestRule.setContent {
+            PocketStoriesCategories(listOf(category1, category2), emptyList(), { })
+        }
+
+        val gridSemantics =
+            composeTestRule.onFirstChildWithTag("StaggeredHorizontalGrid").fetchSemanticsNode()
+        val firstItemRight = gridSemantics.children[0].layoutInfo.width
+        val secondItemLeft = gridSemantics.children[1].positionInWindow.x.toInt()
+        assertEquals(firstItemRight + 16, secondItemLeft)
+    }
+
+    @Test
+    fun `GIVEN a list of displayed categories WHEN one is clicked THEN inform through callback`() {
+        var wasCategoryClicked = false
+        val category1 = PocketRecommendedStoriesCategory("category1")
+        val category2 = PocketRecommendedStoriesCategory("category2")
+        composeTestRule.setContent {
+            PocketStoriesCategories(
+                listOf(category1, category2), emptyList(),
+                {
+                    assertSame(category2, it)
+                    wasCategoryClicked = true
+                }
+            )
+        }
+
+        composeTestRule.onNodeWithText(category2.name.capitalize(Locale.current)).performClick()
+
+        assertTrue(wasCategoryClicked)
+    }
+
+    @Test
+    fun `WHEN showing the Pocket header THEN it has a default text`() {
+        val resources = testContext.resources
+
+        composeTestRule.setContent {
+            PoweredByPocketHeader({ })
+        }
+
+        val header = composeTestRule.onFirstChildWithTag("PoweredByPocketHeader")
+        header.onChildren().assertCountEquals(2)
+        header.onChildAt(0).assertTextEquals(
+            resources.getString(R.string.pocket_stories_feature_title)
+        )
+        header.onChildAt(1).assertTextEquals(
+            resources.getString(
+                R.string.pocket_stories_feature_caption,
+                resources.getString(R.string.pocket_stories_feature_learn_more)
+            )
+        )
+    }
+}
+
+private fun addStoryOnScreen(
+    composeRule: ComposeContentTestRule,
+    story: PocketRecommendedStory,
+    onClick: (PocketRecommendedStory) -> Unit = { }
+) {
+    mockkStatic("org.mozilla.fenix.ext.ContextKt") {
+        // PocketStory uses an Image that uses a Client that will try to fetch from story's imageUrl. Avoid that.
+        every { any<Context>().components.core.client } returns mockk(relaxed = true)
+
+        composeRule.setContent {
+            FirefoxTheme {
+                PocketStory(story, onClick)
+            }
+        }
+    }
+}

--- a/app/src/test/resources/robolectric.properties
+++ b/app/src/test/resources/robolectric.properties
@@ -1,2 +1,4 @@
 sdk=28
 application=org.mozilla.fenix.helpers.FenixRobolectricTestApplication
+# Workaround for https://github.com/robolectric/robolectric/issues/6593
+instrumentedPackages=androidx.loader.content


### PR DESCRIPTION
Important notes:
- to "instantiate" and test composables we need to use an `AndroidComposeTestRule` for an activity in which to add them.
The default activity `createComposeRule` is trying to use - `androidx.activity.ComponentActivity` is not found in the manifest so I went with using an empty Robolectric built instance of `ComponentActivity` in which we'll add the composables we need testing. 
If this approach becomes a pattern we might create our own rule for this
- testing `PocketStories` wasn't possible since just trying to add that with `setContent` would throw a `org.robolectric.android.internal.AndroidTestEnvironment$UnExecutedRunnablesException: Main looper has queued unexecuted runnables.`. Not sure why and how to get past this, needs more investigations.
- finders (onNodeWith..) are cumbersome to use and don't seem to reach in the entire graph, they only go a few levels deep. Haven't found a way to increase this. 
- for composables without a text or contentDescription we'll need to add a `testTag` to easily use them in tests.
Created an accompanying `onFirstChildWithTag()` for then easily finding them through recursion checking only the first child - this being useful for when the composables we need are the content of others serving as decorations.
- assertions seem a bit cumbersome - failed assertions on text values do not provide an immediately straight-forward way to see the difference. Might want to have our own.
- this is more of a poc. We'll probably have to adapt a bit the way we design tests - what scenarios need testing and how to organize the test.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
