### PR TITLE
For #21313: Remove expiring/unused metrics for December

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -300,30 +300,6 @@ events:
       - android-probes@mozilla.com
       - erichards@mozilla.com
     expires: never
-  tab_counter_menu_action:
-    type: event
-    description:
-      A tab counter menu item was tapped
-    extra_keys:
-      item:
-        description: |
-          A string containing the name of the item the user tapped. These items
-          are:
-
-            New tab, New private tab, Close tab
-    bugs:
-      - https://github.com/mozilla-mobile/fenix/issues/11442
-      - https://github.com/mozilla-mobile/fenix/issues/19923
-    data_reviews:
-      - https://github.com/mozilla-mobile/fenix/pull/11533
-      - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
-      - https://github.com/mozilla-mobile/fenix/pull/18143
-      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
-    data_sensitivity:
-      - interaction
-    notification_emails:
-      - android-probes@mozilla.com
-    expires: "2021-12-01"
   synced_tab_opened:
     type: event
     description: |

--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -620,47 +620,6 @@ toolbar_settings:
       - android-probes@mozilla.com
     expires: "2022-02-01"
 
-crash_reporter:
-  opened:
-    type: event
-    description: |
-      The crash reporter was displayed
-    bugs:
-      - https://github.com/mozilla-mobile/fenix/issues/1040
-      - https://github.com/mozilla-mobile/fenix/issues/19923
-    data_reviews:
-      - https://github.com/mozilla-mobile/fenix/pull/1214#issue-264756708
-      - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
-      - https://github.com/mozilla-mobile/fenix/pull/18143
-      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
-    data_sensitivity:
-      - interaction
-    notification_emails:
-      - android-probes@mozilla.com
-    expires: "2021-12-01"
-  closed:
-    type: event
-    description: |
-      The crash reporter was closed
-    extra_keys:
-      crash_submitted:
-        description: |
-          A boolean that tells us whether or not the user submitted a crash
-          report
-    bugs:
-      - https://github.com/mozilla-mobile/fenix/issues/1040
-      - https://github.com/mozilla-mobile/fenix/issues/19923
-    data_reviews:
-      - https://github.com/mozilla-mobile/fenix/pull/1214#issue-264756708
-      - https://github.com/mozilla-mobile/fenix/pull/13958#issuecomment-676857877
-      - https://github.com/mozilla-mobile/fenix/pull/18143
-      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
-    data_sensitivity:
-      - interaction
-    notification_emails:
-      - android-probes@mozilla.com
-    expires: "2021-12-01"
-
 context_menu:
   item_tapped:
     type: event

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/Event.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/Event.kt
@@ -632,15 +632,6 @@ sealed class Event {
             get() = mapOf(Events.browserMenuActionKeys.item to item.toString().lowercase(Locale.ROOT))
     }
 
-    data class TabCounterMenuItemTapped(val item: Item) : Event() {
-        enum class Item {
-            NEW_TAB, NEW_PRIVATE_TAB, CLOSE_TAB
-        }
-
-        override val extras: Map<Events.tabCounterMenuActionKeys, String>?
-            get() = mapOf(Events.tabCounterMenuActionKeys.item to item.toString().lowercase(Locale.ROOT))
-    }
-
     object AutoPlaySettingVisited : Event()
 
     data class AutoPlaySettingChanged(val setting: AutoplaySetting) : Event() {

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/Event.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/Event.kt
@@ -14,7 +14,6 @@ import org.mozilla.fenix.GleanMetrics.AppTheme
 import org.mozilla.fenix.GleanMetrics.Autoplay
 import org.mozilla.fenix.GleanMetrics.Collections
 import org.mozilla.fenix.GleanMetrics.ContextMenu
-import org.mozilla.fenix.GleanMetrics.CrashReporter
 import org.mozilla.fenix.GleanMetrics.ErrorPage
 import org.mozilla.fenix.GleanMetrics.Events
 import org.mozilla.fenix.GleanMetrics.History
@@ -618,13 +617,7 @@ sealed class Event {
         }
     }
 
-    object CrashReporterOpened : Event()
     data class AddonInstalled(val addonId: String) : Event()
-
-    data class CrashReporterClosed(val crashSubmitted: Boolean) : Event() {
-        override val extras: Map<CrashReporter.closedKeys, String>?
-            get() = mapOf(CrashReporter.closedKeys.crashSubmitted to crashSubmitted.toString())
-    }
 
     data class BrowserMenuItemTapped(val item: Item) : Event() {
         enum class Item {

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
@@ -19,7 +19,6 @@ import org.mozilla.fenix.GleanMetrics.BrowserSearch
 import org.mozilla.fenix.GleanMetrics.Collections
 import org.mozilla.fenix.GleanMetrics.ContextMenu
 import org.mozilla.fenix.GleanMetrics.ContextualMenu
-import org.mozilla.fenix.GleanMetrics.CrashReporter
 import org.mozilla.fenix.GleanMetrics.CreditCards
 import org.mozilla.fenix.GleanMetrics.CustomTab
 import org.mozilla.fenix.GleanMetrics.CustomizeHome
@@ -157,13 +156,6 @@ private val Event.wrapper: EventWrapper<*>?
         is Event.ContextMenuItemTapped -> EventWrapper(
             { ContextMenu.itemTapped.record(it) },
             { ContextMenu.itemTappedKeys.valueOf(it) }
-        )
-        is Event.CrashReporterOpened -> EventWrapper<NoExtraKeys>(
-            { CrashReporter.opened.record(it) }
-        )
-        is Event.CrashReporterClosed -> EventWrapper(
-            { CrashReporter.closed.record(it) },
-            { CrashReporter.closedKeys.valueOf(it) }
         )
         is Event.BrowserMenuItemTapped -> EventWrapper(
             { Events.browserMenuAction.record(it) },

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
@@ -536,10 +536,6 @@ private val Event.wrapper: EventWrapper<*>?
         is Event.VoiceSearchTapped -> EventWrapper<NoExtraKeys>(
             { VoiceSearch.tapped.record(it) }
         )
-        is Event.TabCounterMenuItemTapped -> EventWrapper(
-            { Events.tabCounterMenuAction.record(it) },
-            { Events.tabCounterMenuActionKeys.valueOf(it) }
-        )
         is Event.OnboardingPrivacyNotice -> EventWrapper<NoExtraKeys>(
             { Onboarding.privacyNotice.record(it) }
         )

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt
@@ -126,9 +126,6 @@ class DefaultBrowserToolbarController(
     override fun handleTabCounterItemInteraction(item: TabCounterMenu.Item) {
         when (item) {
             is TabCounterMenu.Item.CloseTab -> {
-                metrics.track(
-                    Event.TabCounterMenuItemTapped(Event.TabCounterMenuItemTapped.Item.CLOSE_TAB)
-                )
                 store.state.selectedTab?.let {
                     // When closing the last tab we must show the undo snackbar in the home fragment
                     if (store.state.getNormalOrPrivateTabs(it.content.private).count() == 1) {
@@ -143,20 +140,12 @@ class DefaultBrowserToolbarController(
                 }
             }
             is TabCounterMenu.Item.NewTab -> {
-                metrics.track(
-                    Event.TabCounterMenuItemTapped(Event.TabCounterMenuItemTapped.Item.NEW_TAB)
-                )
                 activity.browsingModeManager.mode = BrowsingMode.Normal
                 navController.navigate(
                     BrowserFragmentDirections.actionGlobalHome(focusOnAddressBar = true)
                 )
             }
             is TabCounterMenu.Item.NewPrivateTab -> {
-                metrics.track(
-                    Event.TabCounterMenuItemTapped(
-                        Event.TabCounterMenuItemTapped.Item.NEW_PRIVATE_TAB
-                    )
-                )
                 activity.browsingModeManager.mode = BrowsingMode.Private
                 navController.navigate(
                     BrowserFragmentDirections.actionGlobalHome(focusOnAddressBar = true)

--- a/app/src/main/java/org/mozilla/fenix/crashes/CrashReporterController.kt
+++ b/app/src/main/java/org/mozilla/fenix/crashes/CrashReporterController.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.fenix.crashes
 
+import android.util.Log
 import androidx.navigation.NavController
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
@@ -13,7 +14,6 @@ import kotlinx.coroutines.launch
 import mozilla.components.lib.crash.Crash
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.Components
-import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.utils.Settings
 
@@ -24,10 +24,6 @@ class CrashReporterController(
     private val components: Components,
     private val settings: Settings
 ) {
-
-    init {
-        components.analytics.metrics.track(Event.CrashReporterOpened)
-    }
 
     /**
      * Closes the crash reporter fragment and tries to recover the session.
@@ -82,7 +78,7 @@ class CrashReporterController(
             false
         }
 
-        components.analytics.metrics.track(Event.CrashReporterClosed(didSubmitReport))
+        Log.i("Crash Reporter", "Report submitted: $didSubmitReport")
         return job
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/crashes/CrashReporterControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/crashes/CrashReporterControllerTest.kt
@@ -15,7 +15,6 @@ import org.junit.Before
 import org.junit.Test
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.Components
-import org.mozilla.fenix.components.metrics.Event
 
 import org.mozilla.fenix.utils.Settings
 
@@ -41,18 +40,10 @@ class CrashReporterControllerTest {
     }
 
     @Test
-    fun `reports crash reporter opened`() {
-        CrashReporterController(crash, sessionId, navContoller, components, settings)
-
-        verify { components.analytics.metrics.track(Event.CrashReporterOpened) }
-    }
-
-    @Test
     fun `handle close and restore tab`() {
         val controller = CrashReporterController(crash, sessionId, navContoller, components, settings)
         controller.handleCloseAndRestore(sendCrash = false)?.joinBlocking()
 
-        verify { components.analytics.metrics.track(Event.CrashReporterClosed(false)) }
         verify { components.useCases.sessionUseCases.crashRecovery.invoke() }
         verify { navContoller.popBackStack() }
     }
@@ -62,7 +53,6 @@ class CrashReporterControllerTest {
         val controller = CrashReporterController(crash, sessionId, navContoller, components, settings)
         controller.handleCloseAndRemove(sendCrash = false)?.joinBlocking()
 
-        verify { components.analytics.metrics.track(Event.CrashReporterClosed(false)) }
         verify { components.useCases.tabsUseCases.removeTab(sessionId) }
         verify { components.useCases.sessionUseCases.crashRecovery.invoke() }
         verify {
@@ -77,7 +67,9 @@ class CrashReporterControllerTest {
         val controller = CrashReporterController(crash, sessionId, navContoller, components, settings)
         controller.handleCloseAndRestore(sendCrash = true)?.joinBlocking()
 
-        verify { components.analytics.metrics.track(Event.CrashReporterClosed(false)) }
+        verify(exactly = 0) {
+            components.analytics.crashReporter.submitReport(crash)
+        }
     }
 
     @Test
@@ -87,7 +79,8 @@ class CrashReporterControllerTest {
         val controller = CrashReporterController(crash, sessionId, navContoller, components, settings)
         controller.handleCloseAndRestore(sendCrash = true)?.joinBlocking()
 
-        verify { components.analytics.crashReporter.submitReport(crash) }
-        verify { components.analytics.metrics.track(Event.CrashReporterClosed(true)) }
+        verify {
+            components.analytics.crashReporter.submitReport(crash)
+        }
     }
 }


### PR DESCRIPTION
For #21313

Removing the following metrics: 
* `crash_reporter`: opened, closed
* `tab_counter_menu_action`
* ...

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
