### PR TITLE
Fix default of start_on_home setting in UI

### DIFF
--- a/app/src/main/res/xml/home_preferences.xml
+++ b/app/src/main/res/xml/home_preferences.xml
@@ -38,7 +38,7 @@
         app:iconSpaceReserved="false">
 
         <org.mozilla.fenix.settings.RadioButtonPreference
-            android:defaultValue="true"
+            android:defaultValue="false"
             android:key="@string/pref_key_start_on_home_always"
             android:title="@string/opening_screen_homepage" />
 
@@ -48,7 +48,7 @@
             android:title="@string/opening_screen_last_tab" />
 
         <org.mozilla.fenix.settings.RadioButtonPreference
-            android:defaultValue="false"
+            android:defaultValue="true"
             android:key="@string/pref_key_start_on_home_after_four_hours"
             android:title="@string/opening_screen_after_four_hours_of_inactivity" />
 


### PR DESCRIPTION
https://github.com/mozilla-mobile/fenix/pull/21722/ changed the order of those radio buttons and incorrectly kept the first one the default, which now is "always start on home".

It's important that the default is set to "after 4 hours" as before. What's worse is that the actual default in `Settings.kt` is still correctly set to "after 4 hours": https://github.com/mozilla-mobile/fenix/blob/main/app/src/main/java/org/mozilla/fenix/utils/Settings.kt#L386

So, the UI isn't in sync and the app behaves differently than "configured" in the UI.