### PR TITLE
For #21838 wait until experiments have been completely opt-out on the nimbus SDK.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/studies/StudiesInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/studies/StudiesInteractor.kt
@@ -6,6 +6,7 @@ package org.mozilla.fenix.settings.studies
 
 import androidx.annotation.VisibleForTesting
 import mozilla.components.service.nimbus.NimbusApi
+import org.mozilla.experiments.nimbus.NimbusInterface
 import org.mozilla.experiments.nimbus.internal.EnrolledExperiment
 import org.mozilla.fenix.BrowserDirection
 import org.mozilla.fenix.HomeActivity
@@ -36,8 +37,14 @@ class DefaultStudiesInteractor(
     }
 
     override fun removeStudy(experiment: EnrolledExperiment) {
+        experiments.register(object : NimbusInterface.Observer {
+            override fun onUpdatesApplied(updated: List<EnrolledExperiment>) {
+                // Wait until the experiment is unrolled from nimbus to restart.
+                killApplication()
+            }
+        })
         experiments.optOut(experiment.slug)
-        killApplication()
+        experiments.applyPendingExperiments()
     }
 
     @VisibleForTesting


### PR DESCRIPTION
`experiments.optOut()` is an async operation on the nimbus SDK, as we were kill the app after calling it in some cases it wasn't enough time for the experiment to be  opt out completely. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
