### PR TITLE
For #22032: add padding to private browsing description text

### DIFF
--- a/app/src/main/res/layout/private_browsing_description.xml
+++ b/app/src/main/res/layout/private_browsing_description.xml
@@ -10,7 +10,7 @@
     android:layout_margin="0.5dp"
     android:importantForAccessibility="no"
     android:orientation="vertical"
-    android:layout_marginHorizontal="@dimen/home_item_horizontal_margin">
+    android:paddingHorizontal="16dp">
 
     <TextView
         android:id="@+id/private_session_description"


### PR DESCRIPTION
It's a such a minor change that I don't think tests are needed. Also I'm not sure of how to test this. If I do need to test, do let me know. I'm including before and after screenshots.

<img src="https://user-images.githubusercontent.com/92792093/138091623-90e859e7-5f85-4494-9202-84666a3f9d38.png" width="300"> <img src="https://user-images.githubusercontent.com/92792093/138095641-e55436ed-dd1f-4ced-84d8-2c95942d4049.png" width="300">

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
