### PR TITLE
Deactivate jacoco and coverage report uploads

### DIFF
--- a/taskcluster/ci/test/kind.yml
+++ b/taskcluster/ci/test/kind.yml
@@ -43,15 +43,8 @@ jobs:
                 - ['java', '-version']
             gradlew:
                 - 'clean'
-                - '-Pcoverage'
-                - 'jacocoDebugTestReport'
+                - 'testDebugUnitTest'
                 - 'githubTestDetails'
-            post-gradlew:
-                - ['automation/taskcluster/upload_coverage_report.sh']
-            secrets:
-                - name: project/mobile/fenix/public-tokens
-                  key: codecov
-                  path: .cc_token
         treeherder:
             platform: 'android-all/opt'
             symbol: debug(T)


### PR DESCRIPTION
This is to investigate our intermittent test failures, crashes in jdk internal classes. We're no longer activating jacoco to see if this makes a difference at all. Since we can't reproduce locally, this is worth verifying.

See:
https://github.com/mozilla-mobile/fenix/issues/21952
https://github.com/mozilla-mobile/fenix/issues/21438

This would be fine to land as we're not using codecov anymore, and we can still generate reports locally.