### PR TITLE
For #22070 - Prevent crash for when a selected topic does not exist anymore

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/ext/HomeFragmentState.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/HomeFragmentState.kt
@@ -32,8 +32,8 @@ fun HomeFragmentState.getFilteredStories(
 
     val oldestSortedCategories = pocketStoriesCategoriesSelections
         .sortedByDescending { it.selectionTimestamp }
-        .map { selectedCategory ->
-            pocketStoriesCategories.first {
+        .mapNotNull { selectedCategory ->
+            pocketStoriesCategories.find {
                 it.name == selectedCategory.name
             }
         }

--- a/app/src/test/java/org/mozilla/fenix/ext/HomeFragmentStateTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/ext/HomeFragmentStateTest.kt
@@ -258,6 +258,22 @@ class HomeFragmentStateTest {
         assertSame(firstCategory.stories[0], result[4])
         assertSame(firstCategory.stories[2], result[5])
     }
+
+    @Test
+    fun `GIVEN old selections of categories which do not exist anymore WHEN getFilteredStories is called THEN ignore not found selections`() {
+        val homeState = HomeFragmentState(
+            pocketStoriesCategories = listOf(otherStoriesCategory, anotherStoriesCategory, defaultStoriesCategory),
+            pocketStoriesCategoriesSelections = listOf(
+                PocketRecommendedStoriesSelectedCategory("unexistent"),
+                PocketRecommendedStoriesSelectedCategory(anotherStoriesCategory.name)
+            )
+        )
+
+        val result = homeState.getFilteredStories(6)
+
+        assertEquals(3, result.size)
+        assertNull(result.firstOrNull { it.category != anotherStoriesCategory.name })
+    }
 }
 
 private fun getFakePocketStories(


### PR DESCRIPTION
The list of selected topics overwrites old data whenever user selects or
deselects another so the old selections will not leak for long.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
