### PR TITLE
Ignore github-release events in Taskcluster

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -104,7 +104,6 @@ tasks:
                 tasks_for in ["action", "cron"]
                 || (tasks_for == "github-pull-request" && pullRequestAction in ["opened", "reopened", "synchronize"])
                 || (tasks_for == "github-push" && head_branch[:10] != "refs/tags/") && (head_branch != "staging.tmp") && (head_branch != "trying.tmp") && (head_branch[:8] != "mergify/")
-                || (tasks_for == "github-release" && releaseAction == "published" && (ownerEmail != "mozilla-release-automation-bot@users.noreply.github.com") && (ownerEmail != "mozilla-release-automation-bot-staging@users.noreply.github.com"))
               then:
                   $let:
                       level:


### PR DESCRIPTION
There are no more known use cases for watching them now that we use Ship It for releases, and they sometimes cause issues such as https://github.com/mozilla-mobile/fenix/issues/20815.