### PR TITLE
For #21771 - Show url when recent tab's title is not available

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/recenttabs/view/RecentTabs.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recenttabs/view/RecentTabs.kt
@@ -78,7 +78,11 @@ fun RecentTabs(
                     RecentTabItem(
                         tabId = tab.state.id,
                         url = tab.state.content.url,
-                        title = tab.state.content.title,
+                        title = if (tab.state.content.title.isNotEmpty()) {
+                            tab.state.content.title
+                        } else {
+                            tab.state.content.url
+                        },
                         thumbnail = tab.state.content.thumbnail,
                         onRecentTabClick = onRecentTabClick
                     )


### PR DESCRIPTION
This is the same previously used approach and the same used for tabs tray.


https://user-images.githubusercontent.com/11428869/138660581-9f6eed08-9024-4841-9f44-d890a852e77b.mp4



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
