### PR TITLE
For #15624 & #17484: improves tab drawer locator & avoids homescreen refreshing

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/FeatureSettingsHelper.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/FeatureSettingsHelper.kt
@@ -1,0 +1,36 @@
+package org.mozilla.fenix.helpers
+
+import android.content.Context
+import androidx.test.platform.app.InstrumentationRegistry
+import org.mozilla.fenix.ext.settings
+
+class FeatureSettingsHelper {
+    private val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
+    private val settings = context.settings()
+
+    // saving default values of feature flags
+    private var isPocketEnabled: Boolean = settings.showPocketRecommendationsFeature
+    private var isJumpBackInCFREnabled: Boolean = settings.shouldShowJumpBackInCFR
+    private var isRecentTabsFeatureEnabled: Boolean = settings.showRecentTabsFeature
+
+    fun setPocketEnabled(enabled: Boolean) {
+        settings.showPocketRecommendationsFeature = enabled
+    }
+
+    fun setJumpBackCFREnabled(enabled: Boolean) {
+        settings.shouldShowJumpBackInCFR = enabled
+    }
+
+    fun setRecentTabsFeatureEnabled(enabled: Boolean) {
+        settings.showRecentTabsFeature = enabled
+    }
+
+    // Important:
+    // Use this after each test if you have modified these feature settings
+    // to make sure the app goes back to the default state
+    fun resetAllFeatureFlags() {
+        settings.showPocketRecommendationsFeature = isPocketEnabled
+        settings.shouldShowJumpBackInCFR = isJumpBackInCFREnabled
+        settings.showRecentTabsFeature = isRecentTabsFeatureEnabled
+    }
+}

--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/TestHelper.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/TestHelper.kt
@@ -16,7 +16,6 @@ import android.net.Uri
 import android.os.Build
 import android.os.Environment
 import androidx.browser.customtabs.CustomTabsIntent
-import androidx.preference.PreferenceManager
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.IdlingRegistry
@@ -33,6 +32,7 @@ import androidx.test.uiautomator.UiObject
 import androidx.test.uiautomator.UiScrollable
 import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
+import java.io.File
 import kotlinx.coroutines.runBlocking
 import mozilla.components.support.ktx.android.content.appName
 import org.hamcrest.CoreMatchers
@@ -43,7 +43,6 @@ import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.ext.waitNotNull
 import org.mozilla.fenix.helpers.idlingresource.NetworkConnectionIdlingResource
 import org.mozilla.fenix.ui.robots.mDevice
-import java.io.File
 
 object TestHelper {
 
@@ -69,13 +68,6 @@ object TestHelper {
                 withText(url.toString())
             )
         ).perform(longClick())
-    }
-
-    fun setPreference(context: Context, pref: String, value: Int) {
-        val preferences = PreferenceManager.getDefaultSharedPreferences(context)
-        val editor = preferences.edit()
-        editor.putInt(pref, value)
-        editor.apply()
     }
 
     fun restartApp(activity: HomeActivityIntentTestRule) {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -26,6 +26,7 @@ import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.Constants.PackageName.YOUTUBE_APP
+import org.mozilla.fenix.helpers.FeatureSettingsHelper
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.RecyclerViewIdlingResource
 import org.mozilla.fenix.helpers.TestAssetHelper
@@ -85,6 +86,8 @@ class SmokeTest {
 
     private lateinit var browserStore: BrowserStore
 
+    private val featureSettingsHelper = FeatureSettingsHelper()
+
     @get:Rule
     val activityTestRule = AndroidComposeTestRule(
         HomeActivityIntentTestRule(),
@@ -108,7 +111,9 @@ class SmokeTest {
         // So we are initializing this here instead of in all related tests.
         browserStore = activityTestRule.activity.components.core.store
 
-        activityTestRule.activity.applicationContext.settings().shouldShowJumpBackInCFR = false
+        // disabling the new homepage pop-up that interferes with the tests.
+        featureSettingsHelper.setJumpBackCFREnabled(false)
+
         mockWebServer = MockWebServer().apply {
             dispatcher = AndroidAssetDispatcher()
             start()
@@ -144,6 +149,9 @@ class SmokeTest {
         if (localeListIdlingResource != null) {
             IdlingRegistry.getInstance().unregister(localeListIdlingResource)
         }
+
+        // resetting modified features enabled setting to default
+        featureSettingsHelper.resetAllFeatureFlags()
     }
 
     // Verifies the first run onboarding screen
@@ -311,9 +319,6 @@ class SmokeTest {
     @Test
     // Verifies the Add to top sites option in a tab's 3 dot menu
     fun openMainMenuAddTopSiteTest() {
-        val settings = activityTestRule.activity.applicationContext.settings()
-        settings.shouldShowJumpBackInCFR = false
-
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {
@@ -820,8 +825,6 @@ class SmokeTest {
     @Test
     @Ignore("https://github.com/mozilla-mobile/fenix/issues/21397")
     fun createFirstCollectionTest() {
-        val settings = activityTestRule.activity.applicationContext.settings()
-        settings.shouldShowJumpBackInCFR = false
         val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
         val secondWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 2)
 
@@ -854,8 +857,6 @@ class SmokeTest {
     @Test
     @Ignore("https://github.com/mozilla-mobile/fenix/issues/21397")
     fun verifyExpandedCollectionItemsTest() {
-        val settings = activityTestRule.activity.applicationContext.settings()
-        settings.shouldShowJumpBackInCFR = false
         val webPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {
@@ -908,9 +909,6 @@ class SmokeTest {
 
     @Test
     fun shareCollectionTest() {
-        val settings = activityTestRule.activity.applicationContext.settings()
-        settings.shouldShowJumpBackInCFR = false
-
         val webPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {
@@ -934,8 +932,6 @@ class SmokeTest {
     // Test running on beta/release builds in CI:
     // caution when making changes to it, so they don't block the builds
     fun deleteCollectionTest() {
-        val settings = activityTestRule.activity.applicationContext.settings()
-        settings.shouldShowJumpBackInCFR = false
         val webPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {
@@ -1353,8 +1349,6 @@ class SmokeTest {
 
     @Test
     fun goToHomeScreenBottomToolbarTest() {
-        val settings = activityTestRule.activity.applicationContext.settings()
-        settings.shouldShowJumpBackInCFR = false
         val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {
@@ -1367,9 +1361,6 @@ class SmokeTest {
 
     @Test
     fun goToHomeScreenTopToolbarTest() {
-        val settings = activityTestRule.activity.applicationContext.settings()
-        settings.shouldShowJumpBackInCFR = false
-
         val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         homeScreen {
@@ -1437,8 +1428,6 @@ class SmokeTest {
 
     @Test
     fun startOnHomepageTest() {
-        val settings = activityTestRule.activity.applicationContext.settings()
-        settings.shouldShowJumpBackInCFR = false
         val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
@@ -12,8 +12,8 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
+import org.mozilla.fenix.helpers.FeatureSettingsHelper
 import org.mozilla.fenix.helpers.HomeActivityTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.ui.robots.browserScreen
@@ -41,6 +41,7 @@ import org.mozilla.fenix.ui.robots.notificationShade
 class TabbedBrowsingTest {
     private val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
     private lateinit var mockWebServer: MockWebServer
+    private val featureSettingsHelper = FeatureSettingsHelper()
 
     /* ktlint-disable no-blank-line-before-rbrace */ // This imposes unreadable grouping.
     @get:Rule
@@ -48,7 +49,9 @@ class TabbedBrowsingTest {
 
     @Before
     fun setUp() {
-        activityTestRule.activity.applicationContext.settings().shouldShowJumpBackInCFR = false
+        // disabling the new homepage pop-up that interferes with the tests.
+        featureSettingsHelper.setJumpBackCFREnabled(false)
+
         mockWebServer = MockWebServer().apply {
             dispatcher = AndroidAssetDispatcher()
             start()
@@ -58,6 +61,7 @@ class TabbedBrowsingTest {
     @After
     fun tearDown() {
         mockWebServer.shutdown()
+        featureSettingsHelper.resetAllFeatureFlags()
     }
 
     @Test
@@ -142,7 +146,41 @@ class TabbedBrowsingTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(genericURL.url) {
-            mDevice.waitForIdle()
+        }.openTabDrawer {
+            verifyExistingOpenTabs("Test_Page_1")
+            closeTab()
+        }
+        homeScreen {
+            verifyNoTabsOpened()
+        }.openNavigationToolbar {
+        }.enterURLAndEnterToBrowser(genericURL.url) {
+        }.openTabDrawer {
+            verifyExistingOpenTabs("Test_Page_1")
+            swipeTabRight("Test_Page_1")
+        }
+        homeScreen {
+            verifyNoTabsOpened()
+        }.openNavigationToolbar {
+        }.enterURLAndEnterToBrowser(genericURL.url) {
+        }.openTabDrawer {
+            verifyExistingOpenTabs("Test_Page_1")
+            swipeTabLeft("Test_Page_1")
+        }
+        homeScreen {
+            verifyNoTabsOpened()
+        }
+    }
+
+    @Test
+    fun verifyUndoSnackBarTest() {
+        // disabling these features because they interfere with the snackbar visibility
+        featureSettingsHelper.setPocketEnabled(false)
+        featureSettingsHelper.setRecentTabsFeatureEnabled(false)
+
+        val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(genericURL.url) {
         }.openTabDrawer {
             verifyExistingOpenTabs("Test_Page_1")
             closeTab()
@@ -150,32 +188,11 @@ class TabbedBrowsingTest {
             snackBarButtonClick("UNDO")
         }
 
-        mDevice.waitForIdle()
-
         browserScreen {
+            verifyTabCounter("1")
         }.openTabDrawer {
             verifyExistingOpenTabs("Test_Page_1")
-            swipeTabRight("Test_Page_1")
-            verifySnackBarText("Tab closed")
-            snackBarButtonClick("UNDO")
         }
-
-        mDevice.waitForIdle()
-
-        browserScreen {
-        }.openTabDrawer {
-            verifyExistingOpenTabs("Test_Page_1")
-            swipeTabLeft("Test_Page_1")
-            verifySnackBarText("Tab closed")
-            snackBarButtonClick("UNDO")
-        }
-
-        mDevice.waitForIdle()
-
-        browserScreen {
-        }.openTabDrawer {
-            verifyExistingOpenTabs("Test_Page_1")
-        }.closeTabDrawer { }
     }
 
     @Test
@@ -185,7 +202,39 @@ class TabbedBrowsingTest {
         homeScreen { }.togglePrivateBrowsingMode()
         navigationToolbar {
         }.enterURLAndEnterToBrowser(genericURL.url) {
-            mDevice.waitForIdle()
+        }.openTabDrawer {
+            verifyExistingOpenTabs("Test_Page_1")
+            verifyCloseTabsButton("Test_Page_1")
+            closeTab()
+        }
+        homeScreen {
+            verifyNoTabsOpened()
+        }.openNavigationToolbar {
+        }.enterURLAndEnterToBrowser(genericURL.url) {
+        }.openTabDrawer {
+            verifyExistingOpenTabs("Test_Page_1")
+            swipeTabRight("Test_Page_1")
+        }
+        homeScreen {
+            verifyNoTabsOpened()
+        }.openNavigationToolbar {
+        }.enterURLAndEnterToBrowser(genericURL.url) {
+        }.openTabDrawer {
+            verifyExistingOpenTabs("Test_Page_1")
+            swipeTabLeft("Test_Page_1")
+        }
+        homeScreen {
+            verifyNoTabsOpened()
+        }
+    }
+
+    @Test
+    fun verifyPrivateTabUndoSnackBarTest() {
+        val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        homeScreen { }.togglePrivateBrowsingMode()
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(genericURL.url) {
         }.openTabDrawer {
             verifyExistingOpenTabs("Test_Page_1")
             verifyCloseTabsButton("Test_Page_1")
@@ -194,31 +243,11 @@ class TabbedBrowsingTest {
             snackBarButtonClick("UNDO")
         }
 
-        mDevice.waitForIdle()
-
         browserScreen {
+            verifyTabCounter("1")
         }.openTabDrawer {
             verifyExistingOpenTabs("Test_Page_1")
-            swipeTabRight("Test_Page_1")
-            verifySnackBarText("Private tab closed")
-            snackBarButtonClick("UNDO")
-        }
-
-        mDevice.waitForIdle()
-
-        browserScreen {
-        }.openTabDrawer {
-            verifyExistingOpenTabs("Test_Page_1")
-            swipeTabLeft("Test_Page_1")
-            verifySnackBarText("Private tab closed")
-            snackBarButtonClick("UNDO")
-        }
-
-        mDevice.waitForIdle()
-
-        browserScreen {
-        }.openTabDrawer {
-            verifyExistingOpenTabs("Test_Page_1")
+            verifyPrivateModeSelected()
         }
     }
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -37,7 +37,6 @@ import mozilla.components.browser.state.selector.selectedTab
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.engine.mediasession.MediaSession
 import org.hamcrest.CoreMatchers.allOf
-import org.hamcrest.CoreMatchers.containsString
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.mozilla.fenix.R
@@ -103,8 +102,13 @@ class BrowserRobot {
     }
 
     fun verifyTabCounter(expectedText: String) {
-        onView(withId(R.id.counter_text))
-            .check((matches(withText(containsString(expectedText)))))
+        val counter =
+            mDevice.findObject(
+                UiSelector()
+                    .resourceId("$packageName:id/counter_text")
+                    .text(expectedText)
+            )
+        assertTrue(counter.waitForExists(waitingTime))
     }
 
     fun verifySnackBarText(expectedText: String) {
@@ -546,7 +550,10 @@ class BrowserRobot {
         }
 
         fun openTabDrawer(interact: TabDrawerRobot.() -> Unit): TabDrawerRobot.Transition {
-            mDevice.waitNotNull(Until.findObject(By.desc("Tabs")))
+            mDevice.findObject(
+                UiSelector().descriptionContains("open tab. Tap to switch tabs.")
+            ).waitForExists(waitingTime)
+
             tabsCounter().click()
             mDevice.waitNotNull(Until.findObject(By.res("$packageName:id/tab_layout")))
 
@@ -644,7 +651,7 @@ private fun assertMenuButton() {
         .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 }
 
-private fun tabsCounter() = mDevice.findObject(By.desc("Tabs"))
+private fun tabsCounter() = mDevice.findObject(By.res("$packageName:id/counter_root"))
 
 private fun mediaPlayerPlayButton() =
     mDevice.findObject(

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/TabDrawerRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/TabDrawerRobot.kt
@@ -39,8 +39,8 @@ import org.hamcrest.CoreMatchers.anyOf
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.Matcher
 import org.mozilla.fenix.R
-import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
+import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeShort
 import org.mozilla.fenix.helpers.TestHelper.packageName
 import org.mozilla.fenix.helpers.click
 import org.mozilla.fenix.helpers.clickAtLocationInView
@@ -101,7 +101,12 @@ class TabDrawerRobot {
 
     fun swipeTabRight(title: String) {
         var retries = 0 // number of retries before failing, will stop at 2
-        while (mDevice.findObject(UiSelector().text(title)).exists() && retries < 3) {
+        while (!mDevice.findObject(
+                UiSelector()
+                    .resourceId("$packageName:id/mozac_browser_tabstray_title")
+                    .text(title)
+            ).waitUntilGone(waitingTimeShort) && retries < 2
+        ) {
             tab(title).perform(ViewActions.swipeRight())
             retries++
         }
@@ -109,24 +114,35 @@ class TabDrawerRobot {
 
     fun swipeTabLeft(title: String) {
         var retries = 0 // number of retries before failing, will stop at 2
-        while (mDevice.findObject(UiSelector().text(title)).exists() && retries < 3) {
+        while (!mDevice.findObject(
+                UiSelector()
+                    .resourceId("$packageName:id/mozac_browser_tabstray_title")
+                    .text(title)
+            ).waitUntilGone(waitingTimeShort) && retries < 2
+        ) {
             tab(title).perform(ViewActions.swipeLeft())
             retries++
         }
     }
 
     fun verifySnackBarText(expectedText: String) {
-        val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-        mDevice.waitNotNull(findObject(By.text(expectedText)), TestAssetHelper.waitingTime)
+        assertTrue(
+            mDevice.findObject(
+                UiSelector().text(expectedText)
+            ).waitForExists(waitingTime)
+        )
     }
 
     fun snackBarButtonClick(expectedText: String) {
-        mDevice.findObject(
-            UiSelector().resourceId("$packageName:id/snackbar_btn")
-        ).waitForExists(waitingTime)
-        onView(allOf(withId(R.id.snackbar_btn), withText(expectedText))).check(
-            matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE))
-        ).perform(click())
+        val snackBarButton =
+            mDevice.findObject(
+                UiSelector()
+                    .resourceId("$packageName:id/snackbar_btn")
+                    .text(expectedText)
+            )
+
+        snackBarButton.waitForExists(waitingTime)
+        snackBarButton.click()
     }
 
     fun verifyTabMediaControlButtonState(action: String) {


### PR DESCRIPTION
For #15624 & #17484 UI tests.
I disabled the recent tabs and Pocket sections in these tests because they were refreshing in the background, and I think it interfered with the test's ability to locate the Undo snackbar.
Tested on Firebase 300 times and all passed.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
