### PR TITLE
For #8545 - Change home screen recyclerView height to wrap_content

### DIFF
--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -89,7 +89,7 @@
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/sessionControlRecyclerView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:clipChildren="false"
         android:clipToPadding="false"
         android:paddingVertical="16dp"


### PR DESCRIPTION
Fixes #8545

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

This fix had previously been done in this [pull request](https://github.com/mozilla-mobile/fenix/pull/18783) but was rolled back because of an issue where the home screen wouldn't scroll correctly through collections and the rest of the elements.
Before making this pull request I did the following experiment:

1. Added multiple collections to fill my entire view, in my case 5, and expanded all of them;
2. Attempted to scroll at regular home screen, and it was successful;
3. Changed to Private mode and attempted to scroll without doing any search, resulting in nothing happening and the view remaining static;
4. Returning to regular home screen had no impact and functionality was maintained.

Example video:

https://user-images.githubusercontent.com/89925580/138757349-e7b78f4d-d181-4819-b87e-f8e18d2ca1cf.mp4

Using AVD, the emulated device was a Pixel 3 running Android 10 with build number QSR1.190920.001 and Firefox Preview version 1.0.2144.

After thorough testing, accessibility was not impacted after testing with Accessibility Scanner and functionality was gained at no cost on the already functioning _regular_ home screen and any content viewed in it.

All that was done was update one line of the _recyclerView_ in _fragment_home.xml_.
Fixes #8545
Fixes #8545