### PR TITLE
For #22155 - Inactive tabs count telemetry

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -1315,6 +1315,23 @@ metrics:
     notification_emails:
       - android-probes@mozilla.com
     expires: "2022-02-01"
+  inactive_tabs_count:
+    type: quantity
+    lifetime: application
+    description: |
+      How many inactive tabs does the user have.
+    send_in_pings:
+      - metrics
+    bugs:
+      - https://github.com/mozilla-mobile/fenix/issues/22155
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/22163#issuecomment-957636802
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: "2022-02-01"
+    unit: integer
 
 customize_home:
   most_visited_sites:

--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -81,6 +81,7 @@ import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.components.metrics.MozillaProductDetector
 import org.mozilla.fenix.components.toolbar.ToolbarPosition
 import org.mozilla.fenix.perf.MarkersActivityLifecycleCallbacks
+import org.mozilla.fenix.tabstray.ext.inactiveTabs
 import org.mozilla.fenix.utils.Settings
 
 /**
@@ -626,6 +627,8 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
 
             tabViewSetting.set(settings.getTabViewPingString())
             closeTabSetting.set(settings.getTabTimeoutPingString())
+
+            inactiveTabsCount.set(browserStore.state.inactiveTabs.size.toLong())
 
             val installSourcePackage = if (SDK_INT >= Build.VERSION_CODES.R) {
                 packageManager.getInstallSourceInfo(packageName).installingPackageName

--- a/app/src/test/java/org/mozilla/fenix/FenixApplicationTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/FenixApplicationTest.kt
@@ -11,6 +11,7 @@ import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkStatic
 import io.mockk.spyk
 import io.mockk.verify
 import mozilla.components.browser.state.store.BrowserStore
@@ -32,6 +33,7 @@ import org.mozilla.fenix.GleanMetrics.SearchDefaultEngine
 import org.mozilla.fenix.components.metrics.MozillaProductDetector
 import org.mozilla.fenix.components.toolbar.ToolbarPosition
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+import org.mozilla.fenix.tabstray.ext.inactiveTabs
 import org.mozilla.fenix.utils.BrowsersCache
 import org.mozilla.fenix.utils.Settings
 import org.robolectric.annotation.Config
@@ -140,8 +142,13 @@ class FenixApplicationTest {
         every { settings.showPocketRecommendationsFeature } returns true
         every { application.reportHomeScreenMetrics(settings) } just Runs
         every { settings.inactiveTabsAreEnabled } returns true
+        mockkStatic("org.mozilla.fenix.tabstray.ext.TabSelectorsKt") {
+            every { browserStore.state.inactiveTabs } returns listOf(mockk(), mockk())
 
-        application.setStartupMetrics(browserStore, settings, browsersCache, mozillaProductDetector)
+            application.setStartupMetrics(browserStore, settings, browsersCache, mozillaProductDetector)
+
+            assertEquals(2, Metrics.inactiveTabsCount.testGetValue())
+        }
 
         // Verify that browser defaults metrics are set.
         assertEquals("Mozilla", Metrics.distributionId.testGetValue())


### PR DESCRIPTION
A quantity probe in the metrics ping means we'll loose the granularity events
provided but it will be easier to extract the values.

For reporting whether the inactive tabs feature is enabled or not we already
have the "preferences.inactive_tabs_enabled" probe so I didn't duplicate this.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
