### PR TITLE
Closes #22083 - Match history groups to history pages by all items within the group

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/history/PagedHistoryProvider.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/history/PagedHistoryProvider.kt
@@ -155,8 +155,10 @@ class DefaultPagedHistoryProvider(
         // items.
         val historyGroupsInOffset = if (history.isNotEmpty()) {
             historyGroups?.filter {
-                history.last().visitedAt <= it.visitedAt - visitedAtBuffer &&
-                    it.visitedAt - visitedAtBuffer <= (history.first().visitedAt + visitedAtBuffer)
+                it.items.any { item ->
+                    history.last().visitedAt <= item.visitedAt - visitedAtBuffer &&
+                        item.visitedAt - visitedAtBuffer <= (history.first().visitedAt + visitedAtBuffer)
+                }
             } ?: emptyList()
         } else {
             emptyList()

--- a/app/src/test/java/org/mozilla/fenix/components/history/PagedHistoryProviderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/history/PagedHistoryProviderTest.kt
@@ -59,7 +59,7 @@ class PagedHistoryProviderTest {
         val historyEntry1 = HistoryMetadata(
             key = historyMetadataKey1,
             title = "mozilla",
-            createdAt = 5,
+            createdAt = 150000000, // a large amount to fall outside of the history page.
             updatedAt = 10,
             totalViewTime = 10,
             documentType = DocumentType.Regular,


### PR DESCRIPTION
When deciding if we should include a history group within the "page of
history" results on the History View UI, we used to look at the most
recent timestamp of the metadata items within the group, and see if that
falls within the range of the timestamps of the history page, +/- some
buffer.

This assumes that each metadata entry will have a corresponding history
item. However, that's not true - when restarting the app, the selected
tab will be restored, and when opening History View right after we'll
record some metadata for it. However, we won't record a history visit
during the app restore for the selected tab.

That's all correct, but the assumption around group matching to history is now incorrect.

This patch changes the logic to instead look at every item within the
group, and see if any of them match the time window of the current
history page. This has a side-effect of also displaying search groups
multiple times on diffenent pages of history, if it makes sense to do so chronologically.
I think that's fine, it reflects reality at least (e.g. items within the
group may have been visited at very different points in time).



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
