### PR TITLE
For #18421 re-enable verifyContextOpenImageNewTab, verifyContextOpenLinkNewTab & verifyContextOpenLinkPrivateTab UI tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/ContextMenusTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/ContextMenusTest.kt
@@ -9,7 +9,6 @@ import androidx.test.uiautomator.UiDevice
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.ext.settings
@@ -54,7 +53,6 @@ class ContextMenusTest {
         mockWebServer.shutdown()
     }
 
-    @Ignore("Test failures: https://github.com/mozilla-mobile/fenix/issues/18421")
     @Test
     fun verifyContextOpenLinkNewTab() {
         val pageLinks =
@@ -69,7 +67,7 @@ class ContextMenusTest {
             verifyLinkContextMenuItems(genericURL.url)
             clickContextOpenLinkInNewTab()
             verifySnackBarText("New tab opened")
-            snackBarButtonClick("Switch")
+            snackBarButtonClick()
             verifyUrl(genericURL.url.toString())
         }.openTabDrawer {
             verifyNormalModeSelected()
@@ -78,7 +76,6 @@ class ContextMenusTest {
         }
     }
 
-    @Ignore("Test failures: https://github.com/mozilla-mobile/fenix/issues/18421")
     @Test
     fun verifyContextOpenLinkPrivateTab() {
         val pageLinks =
@@ -93,7 +90,7 @@ class ContextMenusTest {
             verifyLinkContextMenuItems(genericURL.url)
             clickContextOpenLinkInPrivateTab()
             verifySnackBarText("New private tab opened")
-            snackBarButtonClick("Switch")
+            snackBarButtonClick()
             verifyUrl(genericURL.url.toString())
         }.openTabDrawer {
             verifyPrivateModeSelected()
@@ -137,7 +134,6 @@ class ContextMenusTest {
         }
     }
 
-    @Ignore("Intermittent: https://github.com/mozilla-mobile/fenix/issues/12367")
     @Test
     fun verifyContextOpenImageNewTab() {
         val pageLinks =
@@ -152,7 +148,7 @@ class ContextMenusTest {
             verifyLinkImageContextMenuItems(imageResource.url)
             clickContextOpenImageNewTab()
             verifySnackBarText("New tab opened")
-            snackBarButtonClick("Switch")
+            snackBarButtonClick()
             verifyUrl(imageResource.url.toString())
         }
     }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -20,7 +20,6 @@ import androidx.test.espresso.intent.matcher.IntentMatchers
 import androidx.test.espresso.matcher.RootMatchers.isDialog
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.Visibility
-import androidx.test.espresso.matcher.ViewMatchers.isCompletelyDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
@@ -46,6 +45,7 @@ import org.mozilla.fenix.helpers.Constants.LONG_CLICK_DURATION
 import org.mozilla.fenix.helpers.SessionLoadedIdlingResource
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.TestHelper.packageName
+import org.mozilla.fenix.helpers.TestHelper.waitForObjects
 import org.mozilla.fenix.helpers.click
 import org.mozilla.fenix.helpers.ext.waitNotNull
 
@@ -108,11 +108,13 @@ class BrowserRobot {
     }
 
     fun verifySnackBarText(expectedText: String) {
-        val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-        mDevice.waitNotNull(Until.findObject(text(expectedText)), waitingTime)
+        mDevice.waitForObjects(mDevice.findObject(UiSelector().textContains(expectedText)))
 
-        onView(withText(expectedText)).check(
-            matches(isCompletelyDisplayed())
+        assertTrue(
+            mDevice.findObject(
+                UiSelector()
+                    .textContains(expectedText)
+            ).waitForExists(waitingTime)
         )
     }
 
@@ -397,10 +399,14 @@ class BrowserRobot {
         }
     }
 
-    fun snackBarButtonClick(expectedText: String) {
-        onView(allOf(withId(R.id.snackbar_btn), withText(expectedText))).check(
-            matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE))
-        ).perform(ViewActions.click())
+    fun snackBarButtonClick() {
+        val switchButton =
+            mDevice.findObject(
+                UiSelector()
+                    .resourceId("$packageName:id/snackbar_btn")
+            )
+        switchButton.waitForExists(waitingTime)
+        switchButton.clickAndWaitForNewWindow(waitingTime)
     }
 
     fun verifySaveLoginPromptIsShown() {


### PR DESCRIPTION
For #18421 re-enable:
✅   `verifyContextOpenImageNewTab `  successfully passed 500x on Firebase
✅   `verifyContextOpenLinkNewTab ` successfully passed 500x on Firebase
✅   `verifyContextOpenLinkPrivateTab ` successfully passed 500x on Firebase


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
