### PR TITLE
Improve coverage for cancelCreateBookmarkFolderTest UI test

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
@@ -166,6 +166,7 @@ class BookmarksTest {
             addNewFolderName(bookmarksFolderName)
             navigateUp()
             verifyKeyboardHidden()
+            verifyBookmarkFolderIsNotCreated(bookmarksFolderName)
         }
     }
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BookmarksRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BookmarksRobot.kt
@@ -32,6 +32,7 @@ import androidx.test.uiautomator.Until
 import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.containsString
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
@@ -66,6 +67,8 @@ class BookmarksRobot {
         mDevice.findObject(UiSelector().text(title)).waitForExists(waitingTime)
         assertFolderTitle(title)
     }
+
+    fun verifyBookmarkFolderIsNotCreated(title: String) = assertBookmarkFolderIsNotCreated(title)
 
     fun verifyBookmarkTitle(title: String) {
         mDevice.findObject(UiSelector().text(title)).waitForExists(waitingTime)
@@ -317,6 +320,20 @@ private fun assertCloseButton() = closeButton().check(matches(withEffectiveVisib
 
 private fun assertEmptyBookmarksList() =
     onView(withId(R.id.bookmarks_empty_view)).check(matches(withText("No bookmarks here")))
+
+private fun assertBookmarkFolderIsNotCreated(title: String) {
+    mDevice.findObject(
+        UiSelector()
+            .resourceId("$packageName:id/bookmarks_wrapper")
+    ).waitForExists(waitingTime)
+
+    assertFalse(
+        mDevice.findObject(
+            UiSelector()
+                .textContains(title)
+        ).waitForExists(waitingTime)
+    )
+}
 
 private fun assertBookmarkFavicon(forUrl: Uri) = bookmarkFavicon(forUrl.toString()).check(
     matches(


### PR DESCRIPTION
Improve coverage for `cancelCreateBookmarkFolderTest` UI test.
✅   Successfully passed 100x on Firebase

<details>

<summary> 📈 Results (dropdown)</summary>

matrix | result | logs | details
-- | -- | -- | --
matrix-2yp942zztlmt0 | success | logs | 1 test cases passed
matrix-1yhzhqyd6oheg | success | logs | 1 test cases passed
matrix-1cb7yiv7wrins | success | logs | 1 test cases passed
matrix-3292jwb8ztuje | success | logs | 1 test cases passed
matrix-wh4ei4072n1fa | success | logs | 1 test cases passed
matrix-we6bojycw0fka | success | logs | 1 test cases passed
matrix-7uhsxgkvxh1sa | success | logs | 1 test cases passed
matrix-2vzgnpohscx45 | success | logs | 1 test cases passed
matrix-mex0limixul1a | success | logs | 1 test cases passed
matrix-300og9ourecn8 | success | logs | 1 test cases passed
matrix-2aq50v534f624 | success | logs | 1 test cases passed
matrix-c7ldq6hvrng3a | success | logs | 1 test cases passed
matrix-3vdmqe0cayqlb | success | logs | 1 test cases passed
matrix-26evuzcta4cla | success | logs | 1 test cases passed
matrix-1eb5zv8t1j65z | success | logs | 1 test cases passed
matrix-10m3k6jym7bot | success | logs | 1 test cases passed
matrix-s0d65bc53i52a | success | logs | 1 test cases passed
matrix-3ovzzujcnprxs | success | logs | 1 test cases passed
matrix-24h989xzfq5i5 | success | logs | 1 test cases passed
matrix-12558hidi88qg | success | logs | 1 test cases passed
matrix-3tw8izdhlut5a | success | logs | 1 test cases passed
matrix-30d8ggf9wjvnf | success | logs | 1 test cases passed
matrix-3dcicztw1abt2 | success | logs | 1 test cases passed
matrix-2vmsq8ul91aee | success | logs | 1 test cases passed
matrix-2p2d9blemdrt8 | success | logs | 1 test cases passed
matrix-3k1ubskxjv400 | success | logs | 1 test cases passed
matrix-ubu1dj8c6utwa | success | logs | 1 test cases passed
matrix-uwvopagyf3w1a | success | logs | 1 test cases passed
matrix-3v1ilp26hgz47 | success | logs | 1 test cases passed
matrix-1jr07vewanhze | success | logs | 1 test cases passed
matrix-2s7pvqxa7yv51 | success | logs | 1 test cases passed
matrix-13egudi1appnx | success | logs | 1 test cases passed
matrix-1e44ji1lzce9m | success | logs | 1 test cases passed
matrix-1ernxiazznumq | success | logs | 1 test cases passed
matrix-11aqo8mt8xoto | success | logs | 1 test cases passed
matrix-1o3tesyr4g2oq | success | logs | 1 test cases passed
matrix-11p2b8vgmgtdi | success | logs | 1 test cases passed
matrix-3nhtt1r92asax | success | logs | 1 test cases passed
matrix-1djdhk1fcs86b | success | logs | 1 test cases passed
matrix-19gsr1zclr6qb | success | logs | 1 test cases passed
matrix-pbnwcs58us3ma | success | logs | 1 test cases passed
matrix-2oto7f2dv7g4f | success | logs | 1 test cases passed
matrix-23ynq1zj8443n | success | logs | 1 test cases passed
matrix-2pi8qifha2qvc | success | logs | 1 test cases passed
matrix-mvvisxcxri58a | success | logs | 1 test cases passed
matrix-2c3wcbk6pa5cj | success | logs | 1 test cases passed
matrix-3o3gn61h33wes | success | logs | 1 test cases passed
matrix-28i340l9tp6cq | success | logs | 1 test cases passed
matrix-2ijuap6egpnrv | success | logs | 1 test cases passed
matrix-3rmcucob9z852 | success | logs | 1 test cases passed
matrix-3s5s2qivr6i1l | success | logs | 1 test cases passed
matrix-226tie0r8poa5 | success | logs | 1 test cases passed
matrix-1w8yh4jshs6x5 | success | logs | 1 test cases passed
matrix-2al97eb15hdny | success | logs | 1 test cases passed
matrix-2ncu632ikfisg | success | logs | 1 test cases passed
matrix-1ll0tiho6114e | success | logs | 1 test cases passed
matrix-3d284xm3q2ko8 | success | logs | 1 test cases passed
matrix-1abl05mx29shr | success | logs | 1 test cases passed
matrix-umz6otud8wkza | success | logs | 1 test cases passed
matrix-3paua4uxn1a82 | success | logs | 1 test cases passed
matrix-hrb7xza9a87xa | success | logs | 1 test cases passed
matrix-6uxtchngi0nea | success | logs | 1 test cases passed
matrix-1yqnbg6e56k5e | success | logs | 1 test cases passed
matrix-kyfgpt9b7c96a | success | logs | 1 test cases passed
matrix-izji5gct4t43a | success | logs | 1 test cases passed
matrix-1wixy7f62tvyd | success | logs | 1 test cases passed
matrix-shge7ruepm18a | success | logs | 1 test cases passed
matrix-3roubu02usca0 | success | logs | 1 test cases passed
matrix-2j9p9lk0bla19 | success | logs | 1 test cases passed
matrix-1y4auq68mqxha | success | logs | 1 test cases passed
matrix-3cpufxg8mesf8 | success | logs | 1 test cases passed
matrix-3c3cuqbsk89lp | success | logs | 1 test cases passed
matrix-2p2a5dyttfe6x | success | logs | 1 test cases passed
matrix-3aqarghlstw18 | success | logs | 1 test cases passed
matrix-26bhp6plqxyqj | success | logs | 1 test cases passed
matrix-1a5tgj1uz59eo | success | logs | 1 test cases passed
matrix-1f23b3993hrd0 | success | logs | 1 test cases passed
matrix-2d77x44ofihms | success | logs | 1 test cases passed
matrix-3f5qg4r1ot8r5 | success | logs | 1 test cases passed
matrix-3ul3ynssbkx1g | success | logs | 1 test cases passed
matrix-2a3klqb7hzt53 | success | logs | 1 test cases passed
matrix-3ncikvjapaii2 | success | logs | 1 test cases passed
matrix-xd0zjosuvsrna | success | logs | 1 test cases passed
matrix-3r0wlto8y4b62 | success | logs | 1 test cases passed
matrix-33rw21fmr2zdx | success | logs | 1 test cases passed
matrix-11gxhbgfjijx5 | success | logs | 1 test cases passed
matrix-dplie09u8ld1a | success | logs | 1 test cases passed
matrix-3oco00tvx06ss | success | logs | 1 test cases passed
matrix-7pqfa013vdn1a | success | logs | 1 test cases passed
matrix-tzg41s947q77a | success | logs | 1 test cases passed
matrix-14zp7m6fd04ja | success | logs | 1 test cases passed
matrix-3j396ifd6wk0x | success | logs | 1 test cases passed
matrix-2d9glu5h30fev | success | logs | 1 test cases passed
matrix-3flm012fg4xt3 | success | logs | 1 test cases passed
matrix-2ztzgo3cyziia | success | logs | 1 test cases passed
matrix-3mwjs6nnap53n | success | logs | 1 test cases passed
matrix-2lsp1vslwxaqo | success | logs | 1 test cases passed
matrix-3t4djzeybkjhh | success | logs | 1 test cases passed
matrix-27850jadkqdy5 | success | logs | 1 test cases passed
matrix-2pxbj0duwxfc5 | success | logs | 1 test cases passed
matrix-2m4nmrj7vwima | success | logs | 1 test cases passed




</details>

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
