### PR TITLE
For #21397: disabled homescreen features to improve collections visibility

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/CollectionTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/CollectionTest.kt
@@ -9,11 +9,10 @@ import androidx.test.uiautomator.UiDevice
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
-import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
+import org.mozilla.fenix.helpers.FeatureSettingsHelper
 import org.mozilla.fenix.helpers.HomeActivityTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper.getGenericAsset
 import org.mozilla.fenix.ui.robots.browserScreen
@@ -34,13 +33,17 @@ class CollectionTest {
     private lateinit var mockWebServer: MockWebServer
     private val firstCollectionName = "testcollection_1"
     private val secondCollectionName = "testcollection_2"
+    private val featureSettingsHelper = FeatureSettingsHelper()
 
     @get:Rule
     val activityTestRule = HomeActivityTestRule()
 
     @Before
     fun setUp() {
-        activityTestRule.activity.applicationContext.settings().shouldShowJumpBackInCFR = false
+        // disabling these features to have better visibility of Collections
+        featureSettingsHelper.setRecentTabsFeatureEnabled(false)
+        featureSettingsHelper.setPocketEnabled(false)
+        featureSettingsHelper.setJumpBackCFREnabled(false)
 
         mockWebServer = MockWebServer().apply {
             dispatcher = AndroidAssetDispatcher()
@@ -51,6 +54,9 @@ class CollectionTest {
     @After
     fun tearDown() {
         mockWebServer.shutdown()
+
+        // resetting modified features enabled setting to default
+        featureSettingsHelper.resetAllFeatureFlags()
     }
 
     @Test
@@ -81,7 +87,6 @@ class CollectionTest {
     }
 
     @Test
-    @Ignore("https://github.com/mozilla-mobile/fenix/issues/21397")
     fun verifyAddTabButtonOfCollectionMenu() {
         val firstWebPage = getGenericAsset(mockWebServer, 1)
         val secondWebPage = getGenericAsset(mockWebServer, 2)
@@ -108,7 +113,6 @@ class CollectionTest {
     }
 
     @Test
-    @Ignore("https://github.com/mozilla-mobile/fenix/issues/21397")
     fun renameCollectionTest() {
         val webPage = getGenericAsset(mockWebServer, 1)
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -823,8 +823,11 @@ class SmokeTest {
     }
 
     @Test
-    @Ignore("https://github.com/mozilla-mobile/fenix/issues/21397")
     fun createFirstCollectionTest() {
+        // disabling these features to have better visibility of Collections
+        featureSettingsHelper.setRecentTabsFeatureEnabled(false)
+        featureSettingsHelper.setPocketEnabled(false)
+
         val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
         val secondWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 2)
 
@@ -855,8 +858,11 @@ class SmokeTest {
     }
 
     @Test
-    @Ignore("https://github.com/mozilla-mobile/fenix/issues/21397")
     fun verifyExpandedCollectionItemsTest() {
+        // disabling these features to have better visibility of Collections
+        featureSettingsHelper.setRecentTabsFeatureEnabled(false)
+        featureSettingsHelper.setPocketEnabled(false)
+
         val webPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {


### PR DESCRIPTION
For #21397: new features added to the home screen can refresh or make the scrolling needs different (depending on the screen's size) so the visibility of the collections is affected. Disabling these features and resetting them after to make sure we can test only what is required.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
