### PR TITLE
Close #22305: Add tab state into the TabsTrayStore 

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
@@ -26,6 +26,7 @@ import mozilla.appservices.places.BookmarkRoot
 import mozilla.components.browser.state.selector.normalTabs
 import mozilla.components.browser.state.selector.privateTabs
 import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.feature.tabs.tabstray.TabsFeature
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.NavGraphDirections
@@ -48,6 +49,7 @@ import org.mozilla.fenix.tabstray.browser.DefaultBrowserTrayInteractor
 import org.mozilla.fenix.tabstray.browser.SelectionBannerBinding
 import org.mozilla.fenix.tabstray.browser.SelectionBannerBinding.VisibilityModifier
 import org.mozilla.fenix.tabstray.browser.SelectionHandleBinding
+import org.mozilla.fenix.tabstray.browser.TabSorter
 import org.mozilla.fenix.tabstray.ext.anchorWithAction
 import org.mozilla.fenix.tabstray.ext.bookmarkMessage
 import org.mozilla.fenix.tabstray.ext.collectionMessage
@@ -72,6 +74,7 @@ class TabsTrayFragment : AppCompatDialogFragment() {
     private val selectionHandleBinding = ViewBoundFeatureWrapper<SelectionHandleBinding>()
     private val tabsTrayCtaBinding = ViewBoundFeatureWrapper<TabsTrayInfoBannerBinding>()
     private val secureTabsTrayBinding = ViewBoundFeatureWrapper<SecureTabsTrayBinding>()
+    private val tabsFeature = ViewBoundFeatureWrapper<TabsFeature>()
     private val tabsTrayInactiveTabsOnboardingBinding = ViewBoundFeatureWrapper<TabsTrayInactiveTabsOnboardingBinding>()
 
     @VisibleForTesting @Suppress("VariableNaming")
@@ -221,6 +224,19 @@ class TabsTrayFragment : AppCompatDialogFragment() {
             },
             navigationInteractor = navigationInteractor,
             displayMetrics = requireContext().resources.displayMetrics
+        )
+
+        tabsFeature.set(
+            feature = TabsFeature(
+                tabsTray = TabSorter(
+                    requireContext().settings(),
+                    requireContext().components.analytics.metrics,
+                    tabsTrayStore
+                ),
+                store = requireContext().components.core.store,
+            ),
+            owner = this,
+            view = view
         )
 
         tabsTrayCtaBinding.set(

--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayStore.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayStore.kt
@@ -4,11 +4,13 @@
 
 package org.mozilla.fenix.tabstray
 
+import mozilla.components.browser.state.state.ContentState
 import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.lib.state.Action
 import mozilla.components.lib.state.Middleware
 import mozilla.components.lib.state.State
 import mozilla.components.lib.state.Store
+import org.mozilla.fenix.tabstray.browser.TabGroup
 
 /**
  * Value type that represents the state of the tabs tray.
@@ -16,13 +18,20 @@ import mozilla.components.lib.state.Store
  * @property selectedPage The current page in the tray can be on.
  * @property mode Whether the browser tab list is in multi-select mode or not with the set of
  * currently selected tabs.
- * @property syncing Whether the Synced Tabs feature should fetch the latest tabs from paired
- * devices.
+ * @property inactiveTabs The list of tabs are considered inactive.
+ * @property searchTermGroups The list of tab groups.
+ * @property normalTabs The list of normal tabs that do not fall under [inactiveTabs] or [searchTermGroups].
+ * @property privateTabs The list of tabs that are [ContentState.private].
+ * @property syncing Whether the Synced Tabs feature should fetch the latest tabs from paired devices.
  * @property focusGroupTabId The search group tab id to focus. Defaults to null.
  */
 data class TabsTrayState(
     val selectedPage: Page = Page.NormalTabs,
     val mode: Mode = Mode.Normal,
+    val inactiveTabs: List<TabSessionState> = emptyList(),
+    val searchTermGroups: List<TabGroup> = emptyList(),
+    val normalTabs: List<TabSessionState> = emptyList(),
+    val privateTabs: List<TabSessionState> = emptyList(),
     val syncing: Boolean = false,
     val focusGroupTabId: String? = null
 ) : State {
@@ -126,6 +135,26 @@ sealed class TabsTrayAction : Action {
      * Removes the [TabsTrayState.focusGroupTabId] of the [TabsTrayState].
      */
     object ConsumeFocusGroupTabIdAction : TabsTrayAction()
+
+    /**
+     * Updates the list of tabs in [TabsTrayState.inactiveTabs].
+     */
+    data class UpdateInactiveTabs(val tabs: List<TabSessionState>) : TabsTrayAction()
+
+    /**
+     * Updates the list of tab groups in [TabsTrayState.searchTermGroups].
+     */
+    data class UpdateSearchGroupTabs(val groups: List<TabGroup>) : TabsTrayAction()
+
+    /**
+     * Updates the list of tabs in [TabsTrayState.normalTabs].
+     */
+    data class UpdateNormalTabs(val tabs: List<TabSessionState>) : TabsTrayAction()
+
+    /**
+     * Updates the list of tabs in [TabsTrayState.privateTabs].
+     */
+    data class UpdatePrivateTabs(val tabs: List<TabSessionState>) : TabsTrayAction()
 }
 
 /**
@@ -158,6 +187,14 @@ internal object TabsTrayReducer {
                 state.copy(syncing = false)
             is TabsTrayAction.ConsumeFocusGroupTabIdAction ->
                 state.copy(focusGroupTabId = null)
+            is TabsTrayAction.UpdateInactiveTabs ->
+                state.copy(inactiveTabs = action.tabs)
+            is TabsTrayAction.UpdateSearchGroupTabs ->
+                state.copy(searchTermGroups = action.groups)
+            is TabsTrayAction.UpdateNormalTabs ->
+                state.copy(normalTabs = action.tabs)
+            is TabsTrayAction.UpdatePrivateTabs ->
+                state.copy(privateTabs = action.tabs)
         }
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayStore.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayStore.kt
@@ -134,7 +134,7 @@ sealed class TabsTrayAction : Action {
     /**
      * Removes the [TabsTrayState.focusGroupTabId] of the [TabsTrayState].
      */
-    object ConsumeFocusGroupTabIdAction : TabsTrayAction()
+    object ConsumeFocusGroupTabId : TabsTrayAction()
 
     /**
      * Updates the list of tabs in [TabsTrayState.inactiveTabs].
@@ -185,7 +185,7 @@ internal object TabsTrayReducer {
                 state.copy(syncing = true)
             is TabsTrayAction.SyncCompleted ->
                 state.copy(syncing = false)
-            is TabsTrayAction.ConsumeFocusGroupTabIdAction ->
+            is TabsTrayAction.ConsumeFocusGroupTabId ->
                 state.copy(focusGroupTabId = null)
             is TabsTrayAction.UpdateInactiveTabs ->
                 state.copy(inactiveTabs = action.tabs)

--- a/app/src/main/java/org/mozilla/fenix/tabstray/browser/AbstractBrowserTrayList.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/browser/AbstractBrowserTrayList.kt
@@ -7,8 +7,6 @@ package org.mozilla.fenix.tabstray.browser
 import android.content.Context
 import android.util.AttributeSet
 import androidx.recyclerview.widget.RecyclerView
-import mozilla.components.feature.tabs.tabstray.TabsFeature
-import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.tabstray.TabsTrayInteractor
 import org.mozilla.fenix.tabstray.TabsTrayStore
 
@@ -23,27 +21,6 @@ abstract class AbstractBrowserTrayList @JvmOverloads constructor(
 
     lateinit var interactor: TabsTrayInteractor
     lateinit var tabsTrayStore: TabsTrayStore
-
-    /**
-     * A [TabsFeature] is required for each browser list to ensure one always exists for displaying
-     * tabs.
-     */
-    abstract val tabsFeature: TabsFeature
-
-    // NB: The use cases here are duplicated because there isn't a nicer
-    // way to share them without a better dependency injection solution.
-    protected val selectTabUseCase = SelectTabUseCaseWrapper(
-        context.components.analytics.metrics,
-        context.components.useCases.tabsUseCases.selectTab
-    ) {
-        interactor.onBrowserTabSelected()
-    }
-
-    protected val removeTabUseCase = RemoveTabUseCaseWrapper(
-        context.components.analytics.metrics
-    ) { sessionId ->
-        interactor.onDeleteTab(sessionId)
-    }
 
     protected val swipeToDelete by lazy {
         SwipeToDeleteBinding(tabsTrayStore)

--- a/app/src/main/java/org/mozilla/fenix/tabstray/browser/InactiveTabsAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/browser/InactiveTabsAdapter.kt
@@ -41,7 +41,7 @@ class InactiveTabsAdapter(
 ) : Adapter(DiffCallback), TabsTray, FeatureNameHolder {
 
     internal lateinit var inactiveTabsInteractor: InactiveTabsInteractor
-    internal var inActiveTabsCount: Int = 0
+    private var inActiveTabsCount: Int = 0
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): InactiveTabViewHolder {
         val view = LayoutInflater.from(parent.context)

--- a/app/src/main/java/org/mozilla/fenix/tabstray/browser/InactiveTabsBinding.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/browser/InactiveTabsBinding.kt
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabstray.browser
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.map
+import mozilla.components.browser.tabstray.TabsTray
+import mozilla.components.lib.state.helpers.AbstractBinding
+import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
+import org.mozilla.fenix.tabstray.TabsTrayState
+import org.mozilla.fenix.tabstray.TabsTrayStore
+
+/**
+ * An inactive tabs observer that updates the provided [TabsTray].
+ */
+class InactiveTabsBinding(
+    store: TabsTrayStore,
+    private val tray: TabsTray
+) : AbstractBinding<TabsTrayState>(store) {
+    override suspend fun onState(flow: Flow<TabsTrayState>) {
+        flow.map { it.inactiveTabs }
+            .ifChanged()
+            .collect {
+                // We pass null for the selected tab id here, because inactive tabs doesn't care.
+                tray.updateTabs(it, null)
+            }
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/tabstray/browser/NormalTabsBinding.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/browser/NormalTabsBinding.kt
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabstray.browser
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.map
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.browser.tabstray.TabsTray
+import mozilla.components.lib.state.helpers.AbstractBinding
+import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
+import org.mozilla.fenix.tabstray.TabsTrayState
+import org.mozilla.fenix.tabstray.TabsTrayStore
+
+/**
+ * A normal tabs observer that updates the provided [TabsTray].
+ */
+class NormalTabsBinding(
+    store: TabsTrayStore,
+    private val browserStore: BrowserStore,
+    private val tabsTray: TabsTray
+) : AbstractBinding<TabsTrayState>(store) {
+    override suspend fun onState(flow: Flow<TabsTrayState>) {
+        flow.map { it.normalTabs }
+            .ifChanged()
+            .collect {
+                // Getting the selectedTabId from the BrowserStore at a different time might lead to a race.
+                tabsTray.updateTabs(it, browserStore.state.selectedTabId)
+            }
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/tabstray/browser/OtherHeaderBinding.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/browser/OtherHeaderBinding.kt
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabstray.browser
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import mozilla.components.lib.state.helpers.AbstractBinding
+import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifAnyChanged
+import org.mozilla.fenix.tabstray.TabsTrayState
+import org.mozilla.fenix.tabstray.TabsTrayStore
+
+/**
+ * A tabs observer that informs [showHeader] if an "Other tabs" title should be displayed in the tray.
+ */
+class OtherHeaderBinding(
+    store: TabsTrayStore,
+    private val showHeader: (Boolean) -> Unit
+) : AbstractBinding<TabsTrayState>(store) {
+    override suspend fun onState(flow: Flow<TabsTrayState>) {
+        flow.ifAnyChanged { arrayOf(it.normalTabs, it.searchTermGroups) }
+            .collect {
+                if (it.searchTermGroups.isNotEmpty() && it.normalTabs.isNotEmpty()) {
+                    showHeader(true)
+                } else {
+                    showHeader(false)
+                }
+            }
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/tabstray/browser/PrivateBrowserTrayList.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/browser/PrivateBrowserTrayList.kt
@@ -8,7 +8,6 @@ import android.content.Context
 import android.util.AttributeSet
 import androidx.annotation.VisibleForTesting
 import androidx.annotation.VisibleForTesting.PACKAGE_PRIVATE
-import mozilla.components.feature.tabs.tabstray.TabsFeature
 import org.mozilla.fenix.ext.components
 
 class PrivateBrowserTrayList @JvmOverloads constructor(
@@ -17,14 +16,10 @@ class PrivateBrowserTrayList @JvmOverloads constructor(
     defStyleAttr: Int = 0
 ) : AbstractBrowserTrayList(context, attrs, defStyleAttr) {
 
-    override val tabsFeature by lazy {
-        // NB: The use cases here are duplicated because there isn't a nicer
-        // way to share them without a better dependency injection solution.
-        TabsFeature(
-            adapter as BrowserTabsAdapter,
-            context.components.core.store,
-        ) { it.content.private }
+    private val privateTabsBinding by lazy {
+        PrivateTabsBinding(tabsTrayStore, context.components.core.store, adapter as BrowserTabsAdapter)
     }
+
     private val touchHelper by lazy {
         TabsTouchHelper(
             interactionDelegate = (adapter as BrowserTabsAdapter).delegate,
@@ -37,7 +32,7 @@ class PrivateBrowserTrayList @JvmOverloads constructor(
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
 
-        tabsFeature.start()
+        privateTabsBinding.start()
         swipeToDelete.start()
 
         adapter?.onAttachedToRecyclerView(this)
@@ -49,7 +44,7 @@ class PrivateBrowserTrayList @JvmOverloads constructor(
     public override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
 
-        tabsFeature.stop()
+        privateTabsBinding.stop()
         swipeToDelete.stop()
 
         // Notify the adapter that it is released from the view preemptively.

--- a/app/src/main/java/org/mozilla/fenix/tabstray/browser/PrivateTabsBinding.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/browser/PrivateTabsBinding.kt
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabstray.browser
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.map
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.browser.tabstray.TabsTray
+import mozilla.components.lib.state.helpers.AbstractBinding
+import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
+import org.mozilla.fenix.tabstray.TabsTrayState
+import org.mozilla.fenix.tabstray.TabsTrayStore
+
+/**
+ * A private tabs observer that updates the provided [TabsTray].
+ */
+class PrivateTabsBinding(
+    store: TabsTrayStore,
+    private val browserStore: BrowserStore,
+    private val tray: TabsTray
+) : AbstractBinding<TabsTrayState>(store) {
+    override suspend fun onState(flow: Flow<TabsTrayState>) {
+        flow.map { it.privateTabs }
+            .ifChanged()
+            .collect {
+                // Getting the selectedTabId from the BrowserStore at a different time might lead to a race.
+                tray.updateTabs(it, browserStore.state.selectedTabId)
+            }
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/tabstray/browser/TabGroupBinding.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/browser/TabGroupBinding.kt
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabstray.browser
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.map
+import mozilla.components.lib.state.helpers.AbstractBinding
+import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
+import org.mozilla.fenix.tabstray.TabsTrayState
+import org.mozilla.fenix.tabstray.TabsTrayStore
+
+/**
+ * A search-term tab group observer that updates the provided [tray].
+ */
+class TabGroupBinding(
+    store: TabsTrayStore,
+    private val tray: (List<TabGroup>) -> Unit
+) : AbstractBinding<TabsTrayState>(store) {
+    override suspend fun onState(flow: Flow<TabsTrayState>) {
+        flow.map { it.searchTermGroups }
+            .ifChanged()
+            .collect {
+                tray.invoke(it)
+            }
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/tabstray/viewholders/NormalBrowserPageViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/viewholders/NormalBrowserPageViewHolder.kt
@@ -135,7 +135,7 @@ class NormalBrowserPageViewHolder(
                         layoutManager.scrollToPosition(indexToScrollTo)
 
                         if (focusGroupTabId != null) {
-                            tabsTrayStore.dispatch(TabsTrayAction.ConsumeFocusGroupTabIdAction)
+                            tabsTrayStore.dispatch(TabsTrayAction.ConsumeFocusGroupTabId)
                         }
                         return@observeFirstInsert
                     }

--- a/app/src/test/java/org/mozilla/fenix/tabstray/TabsTrayStoreReducerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/TabsTrayStoreReducerTest.kt
@@ -16,7 +16,7 @@ class TabsTrayStoreReducerTest {
 
         val resultState = TabsTrayReducer.reduce(
             initialState,
-            TabsTrayAction.ConsumeFocusGroupTabIdAction
+            TabsTrayAction.ConsumeFocusGroupTabId
         )
 
         assertEquals(expectedState, resultState)

--- a/app/src/test/java/org/mozilla/fenix/tabstray/TabsTrayStoreReducerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/TabsTrayStoreReducerTest.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.fenix.tabstray
 
+import mozilla.components.browser.state.state.createTab
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -16,6 +17,54 @@ class TabsTrayStoreReducerTest {
         val resultState = TabsTrayReducer.reduce(
             initialState,
             TabsTrayAction.ConsumeFocusGroupTabIdAction
+        )
+
+        assertEquals(expectedState, resultState)
+    }
+
+    @Test
+    fun `WHEN UpdateInactiveTabs THEN inactive tabs are added`() {
+        val inactiveTabs = listOf(
+            createTab("https://mozilla.org")
+        )
+        val initialState = TabsTrayState()
+        val expectedState = initialState.copy(inactiveTabs = inactiveTabs)
+
+        val resultState = TabsTrayReducer.reduce(
+            initialState,
+            TabsTrayAction.UpdateInactiveTabs(inactiveTabs)
+        )
+
+        assertEquals(expectedState, resultState)
+    }
+
+    @Test
+    fun `WHEN UpdateNormalTabs THEN normal tabs are added`() {
+        val normalTabs = listOf(
+            createTab("https://mozilla.org")
+        )
+        val initialState = TabsTrayState()
+        val expectedState = initialState.copy(normalTabs = normalTabs)
+
+        val resultState = TabsTrayReducer.reduce(
+            initialState,
+            TabsTrayAction.UpdateNormalTabs(normalTabs)
+        )
+
+        assertEquals(expectedState, resultState)
+    }
+
+    @Test
+    fun `WHEN UpdatePrivateTabs THEN private tabs are added`() {
+        val privateTabs = listOf(
+            createTab("https://mozilla.org", private = true)
+        )
+        val initialState = TabsTrayState()
+        val expectedState = initialState.copy(privateTabs = privateTabs)
+
+        val resultState = TabsTrayReducer.reduce(
+            initialState,
+            TabsTrayAction.UpdatePrivateTabs(privateTabs)
         )
 
         assertEquals(expectedState, resultState)

--- a/app/src/test/java/org/mozilla/fenix/tabstray/browser/InactiveTabsBindingTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/browser/InactiveTabsBindingTest.kt
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabstray.browser
+
+import io.mockk.mockk
+import io.mockk.verify
+import mozilla.components.browser.state.state.createTab
+import mozilla.components.browser.tabstray.TabsTray
+import mozilla.components.support.test.ext.joinBlocking
+import mozilla.components.support.test.rule.MainCoroutineRule
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.mozilla.fenix.tabstray.TabsTrayAction
+import org.mozilla.fenix.tabstray.TabsTrayStore
+
+class InactiveTabsBindingTest {
+    val store = TabsTrayStore()
+    val tray: TabsTray = mockk(relaxed = true)
+    val binding = InactiveTabsBinding(store, tray)
+
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
+
+    @After
+    fun teardown() {
+        binding.stop()
+    }
+
+    @Test
+    fun `WHEN the store is updated THEN notify the tabs tray`() {
+        assertTrue(store.state.inactiveTabs.isEmpty())
+
+        store.dispatch(TabsTrayAction.UpdateInactiveTabs(listOf(createTab("https://mozilla.org")))).joinBlocking()
+
+        binding.start()
+
+        assertTrue(store.state.inactiveTabs.isNotEmpty())
+
+        verify { tray.updateTabs(any(), any()) }
+    }
+
+    @Test
+    fun `WHEN non-inactive tabs are updated THEN do not notify the tabs tray`() {
+        assertTrue(store.state.inactiveTabs.isEmpty())
+
+        store.dispatch(TabsTrayAction.UpdatePrivateTabs(listOf(createTab("https://mozilla.org")))).joinBlocking()
+
+        binding.start()
+
+        assertTrue(store.state.inactiveTabs.isEmpty())
+
+        verify { tray.updateTabs(emptyList(), null) }
+    }
+}

--- a/app/src/test/java/org/mozilla/fenix/tabstray/browser/InactiveTabsControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/browser/InactiveTabsControllerTest.kt
@@ -11,7 +11,6 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.spyk
 import io.mockk.verify
-import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.browser.tabstray.TabsTray
@@ -21,6 +20,8 @@ import org.junit.Test
 import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.components.metrics.MetricController
+import org.mozilla.fenix.tabstray.TabsTrayState
+import org.mozilla.fenix.tabstray.TabsTrayStore
 import org.mozilla.fenix.utils.Settings
 
 class InactiveTabsControllerTest {
@@ -31,20 +32,18 @@ class InactiveTabsControllerTest {
 
     @Test
     fun `WHEN expanded THEN notify filtered card`() {
-        val filter: (TabSessionState) -> Boolean = { !it.content.private }
-        val store = BrowserStore(
-            BrowserState(
-                tabs = listOf(
+        val store = TabsTrayStore(
+            TabsTrayState(
+                inactiveTabs = listOf(
                     createTabState("https://mozilla.org", id = "1"),
-                    createTabState("https://firefox.com", id = "2"),
-                    createTabState("https://getpocket.com", id = "3", private = true)
+                    createTabState("https://firefox.com", id = "2")
                 )
             )
         )
         val tray: TabsTray = mockk(relaxed = true)
         val tabsSlot = slot<List<TabSessionState>>()
         val controller =
-            InactiveTabsController(store, appStore, filter, tray, mockk(relaxed = true), settings)
+            InactiveTabsController(store, appStore, tray, mockk(relaxed = true), settings)
 
         controller.updateCardExpansion(true)
 
@@ -56,9 +55,9 @@ class InactiveTabsControllerTest {
 
     @Test
     fun `WHEN expanded THEN track telemetry event`() {
-        val store = BrowserStore(BrowserState())
+        val store = TabsTrayStore()
         val controller = InactiveTabsController(
-            store, appStore, mockk(relaxed = true), mockk(relaxed = true), metrics, settings
+            store, appStore, mockk(relaxed = true), metrics, settings
         )
 
         controller.updateCardExpansion(true)
@@ -68,9 +67,9 @@ class InactiveTabsControllerTest {
 
     @Test
     fun `WHEN collapsed THEN track telemetry event`() {
-        val store = BrowserStore(BrowserState())
+        val store = TabsTrayStore()
         val controller = InactiveTabsController(
-            store, appStore, mockk(relaxed = true), mockk(relaxed = true), metrics, settings
+            store, appStore, mockk(relaxed = true), metrics, settings
         )
 
         controller.updateCardExpansion(false)
@@ -80,10 +79,10 @@ class InactiveTabsControllerTest {
 
     @Test
     fun `WHEN close THEN update settings and refresh`() {
-        val store = BrowserStore()
+        val store = TabsTrayStore()
         val controller = spyk(
             InactiveTabsController(
-                store, appStore, mockk(relaxed = true), mockk(relaxed = true), metrics, settings
+                store, appStore, mockk(relaxed = true), metrics, settings
             )
         )
 

--- a/app/src/test/java/org/mozilla/fenix/tabstray/browser/NormalTabsBindingTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/browser/NormalTabsBindingTest.kt
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabstray.browser
+
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.state.TabSessionState
+import mozilla.components.browser.state.state.createTab
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.browser.tabstray.TabsTray
+import mozilla.components.support.test.ext.joinBlocking
+import mozilla.components.support.test.rule.MainCoroutineRule
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.mozilla.fenix.tabstray.TabsTrayAction
+import org.mozilla.fenix.tabstray.TabsTrayStore
+
+class NormalTabsBindingTest {
+    val store = TabsTrayStore()
+    val browserStore = BrowserStore(BrowserState(tabs = listOf(createTab("", id = "1")), selectedTabId = "1"))
+    val tray: TabsTray = mockk(relaxed = true)
+    val binding = NormalTabsBinding(store, browserStore, tray)
+
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
+
+    @After
+    fun teardown() {
+        binding.stop()
+    }
+
+    @Test
+    fun `WHEN the store is updated THEN notify the tabs tray`() {
+        val slotTabs = slot<List<TabSessionState>>()
+        val expectedTabs = listOf(createTab("https://mozilla.org"))
+
+        assertTrue(store.state.normalTabs.isEmpty())
+
+        store.dispatch(TabsTrayAction.UpdateNormalTabs(expectedTabs)).joinBlocking()
+
+        binding.start()
+
+        assertTrue(store.state.normalTabs.isNotEmpty())
+
+        verify { tray.updateTabs(capture(slotTabs), "1") }
+        assertEquals(expectedTabs, slotTabs.captured)
+    }
+
+    @Test
+    fun `WHEN non-inactive tabs are updated THEN do not notify the tabs tray`() {
+        assertTrue(store.state.normalTabs.isEmpty())
+
+        store.dispatch(TabsTrayAction.UpdatePrivateTabs(listOf(createTab("https://mozilla.org")))).joinBlocking()
+
+        binding.start()
+
+        assertTrue(store.state.normalTabs.isEmpty())
+
+        verify { tray.updateTabs(emptyList(), "1") }
+    }
+}

--- a/app/src/test/java/org/mozilla/fenix/tabstray/browser/OtherHeaderBindingTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/browser/OtherHeaderBindingTest.kt
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabstray.browser
+
+import io.mockk.mockk
+import mozilla.components.support.test.libstate.ext.waitUntilIdle
+import mozilla.components.support.test.rule.MainCoroutineRule
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.mozilla.fenix.tabstray.TabsTrayState
+import org.mozilla.fenix.tabstray.TabsTrayStore
+
+class OtherHeaderBindingTest {
+
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
+
+    @Test
+    fun `WHEN there are no tabs THEN show no header`() {
+        val store = TabsTrayStore()
+        var result: Boolean? = null
+        val binding = OtherHeaderBinding(store) { result = it }
+
+        binding.start()
+
+        store.waitUntilIdle()
+
+        assertFalse(result!!)
+    }
+
+    @Test
+    fun `WHEN tabs for only groups THEN show no header`() {
+        val store = TabsTrayStore(TabsTrayState(searchTermGroups = listOf(mockk())))
+        var result: Boolean? = null
+        val binding = OtherHeaderBinding(store) { result = it }
+
+        binding.start()
+
+        store.waitUntilIdle()
+
+        assertFalse(result!!)
+    }
+
+    @Test
+    fun `WHEN tabs for only normal tabs THEN show no header`() {
+        val store = TabsTrayStore(TabsTrayState(normalTabs = listOf(mockk())))
+        var result: Boolean? = null
+        val binding = OtherHeaderBinding(store) { result = it }
+
+        binding.start()
+
+        store.waitUntilIdle()
+
+        assertFalse(result!!)
+    }
+
+    @Test
+    fun `WHEN normal tabs and groups exist THEN show header`() {
+        val store = TabsTrayStore(TabsTrayState(normalTabs = listOf(mockk()), searchTermGroups = listOf(mockk())))
+        var result: Boolean? = null
+        val binding = OtherHeaderBinding(store) { result = it }
+
+        binding.start()
+
+        store.waitUntilIdle()
+
+        assertTrue(result!!)
+    }
+}

--- a/app/src/test/java/org/mozilla/fenix/tabstray/browser/PrivateTabsBindingTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/browser/PrivateTabsBindingTest.kt
@@ -1,0 +1,72 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ */
+
+package org.mozilla.fenix.tabstray.browser
+
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.state.TabSessionState
+import mozilla.components.browser.state.state.createTab
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.browser.tabstray.TabsTray
+import mozilla.components.support.test.ext.joinBlocking
+import mozilla.components.support.test.rule.MainCoroutineRule
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.mozilla.fenix.tabstray.TabsTrayAction
+import org.mozilla.fenix.tabstray.TabsTrayStore
+
+class PrivateTabsBindingTest {
+    val store = TabsTrayStore()
+    val browserStore = BrowserStore(BrowserState(tabs = listOf(createTab("", id = "1")), selectedTabId = "1"))
+    val tray: TabsTray = mockk(relaxed = true)
+    val binding = PrivateTabsBinding(store, browserStore, tray)
+
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
+
+    @After
+    fun teardown() {
+        binding.stop()
+    }
+
+    @Test
+    fun `WHEN the store is updated THEN notify the tabs tray`() {
+        val slotTabs = slot<List<TabSessionState>>()
+        val expectedTabs = listOf(createTab("https://mozilla.org", private = true))
+
+        assertTrue(store.state.privateTabs.isEmpty())
+
+        store.dispatch(TabsTrayAction.UpdatePrivateTabs(expectedTabs)).joinBlocking()
+
+        binding.start()
+
+        assertTrue(store.state.privateTabs.isNotEmpty())
+
+        verify { tray.updateTabs(capture(slotTabs), "1") }
+        assertEquals(expectedTabs, slotTabs.captured)
+    }
+
+    @Test
+    fun `WHEN non-inactive tabs are updated THEN do not notify the tabs tray`() {
+        assertTrue(store.state.privateTabs.isEmpty())
+
+        store.dispatch(TabsTrayAction.UpdateInactiveTabs(listOf(createTab("https://mozilla.org", private = true))))
+            .joinBlocking()
+
+        binding.start()
+
+        assertTrue(store.state.privateTabs.isEmpty())
+
+        verify { tray.updateTabs(emptyList(), "1") }
+    }
+}

--- a/app/src/test/java/org/mozilla/fenix/tabstray/browser/TabGroupBindingTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/browser/TabGroupBindingTest.kt
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabstray.browser
+
+import mozilla.components.browser.state.state.createTab
+import mozilla.components.support.test.ext.joinBlocking
+import mozilla.components.support.test.rule.MainCoroutineRule
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.mozilla.fenix.tabstray.TabsTrayAction
+import org.mozilla.fenix.tabstray.TabsTrayStore
+
+class TabGroupBindingTest {
+    val store = TabsTrayStore()
+    var captured: List<TabGroup>? = null
+    val binding = TabGroupBinding(store) { captured = it }
+
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
+
+    @After
+    fun teardown() {
+        binding.stop()
+    }
+
+    @Test
+    fun `WHEN the store is updated THEN notify the adapter`() {
+        val expectedGroups = listOf(TabGroup("cats", emptyList(), 0))
+
+        assertTrue(store.state.searchTermGroups.isEmpty())
+
+        store.dispatch(TabsTrayAction.UpdateSearchGroupTabs(expectedGroups)).joinBlocking()
+
+        binding.start()
+
+        assertTrue(store.state.searchTermGroups.isNotEmpty())
+
+        assertEquals(expectedGroups, captured)
+    }
+
+    @Test
+    fun `WHEN non-group tabs are updated THEN do not notify the adapter`() {
+        assertTrue(store.state.searchTermGroups.isEmpty())
+
+        store.dispatch(TabsTrayAction.UpdatePrivateTabs(listOf(createTab("https://mozilla.org")))).joinBlocking()
+
+        binding.start()
+
+        assertTrue(store.state.searchTermGroups.isEmpty())
+
+        assertEquals(emptyList<TabGroup>(), captured)
+    }
+}

--- a/app/src/test/java/org/mozilla/fenix/tabstray/browser/TabSorterTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/browser/TabSorterTest.kt
@@ -16,6 +16,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.components.metrics.MetricController
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+import org.mozilla.fenix.tabstray.TabsTrayStore
 import org.mozilla.fenix.tabstray.TrayPagerAdapter.Companion.INACTIVE_TABS_FEATURE_NAME
 import org.mozilla.fenix.tabstray.TrayPagerAdapter.Companion.TABS_TRAY_FEATURE_NAME
 import org.mozilla.fenix.tabstray.TrayPagerAdapter.Companion.TAB_GROUP_FEATURE_NAME
@@ -31,6 +32,7 @@ class TabSorterTest {
     private val settings: Settings = mockk()
     private val metrics: MetricController = mockk()
     private var inactiveTimestamp = 0L
+    private val tabsTrayStore = TabsTrayStore()
 
     @Before
     fun setUp() {
@@ -42,7 +44,7 @@ class TabSorterTest {
     @Test
     fun `WHEN updated with one normal tab THEN adapter have only one normal tab and no header`() {
         val adapter = ConcatAdapter(
-            InactiveTabsAdapter(context, mock(), mock(), INACTIVE_TABS_FEATURE_NAME, settings),
+            InactiveTabsAdapter(context, tabsTrayStore, mock(), mock(), INACTIVE_TABS_FEATURE_NAME, settings),
             TabGroupAdapter(context, mock(), mock(), TAB_GROUP_FEATURE_NAME),
             TitleHeaderAdapter(),
             BrowserTabsAdapter(context, mock(), mock(), TABS_TRAY_FEATURE_NAME)
@@ -66,7 +68,7 @@ class TabSorterTest {
     @Test
     fun `WHEN updated with one normal tab and two search term tab THEN adapter have normal tab and a search group`() {
         val adapter = ConcatAdapter(
-            InactiveTabsAdapter(context, mock(), mock(), INACTIVE_TABS_FEATURE_NAME, settings),
+            InactiveTabsAdapter(context, tabsTrayStore, mock(), mock(), INACTIVE_TABS_FEATURE_NAME, settings),
             TabGroupAdapter(context, mock(), mock(), TAB_GROUP_FEATURE_NAME),
             TitleHeaderAdapter(),
             BrowserTabsAdapter(context, mock(), mock(), TABS_TRAY_FEATURE_NAME)
@@ -102,7 +104,7 @@ class TabSorterTest {
     @Test
     fun `WHEN updated with one normal tab, one inactive tab and two search term tab THEN adapter have normal tab, inactive tab and a search group`() {
         val adapter = ConcatAdapter(
-            InactiveTabsAdapter(context, mock(), mock(), INACTIVE_TABS_FEATURE_NAME, settings),
+            InactiveTabsAdapter(context, tabsTrayStore, mock(), mock(), INACTIVE_TABS_FEATURE_NAME, settings),
             TabGroupAdapter(context, mock(), mock(), TAB_GROUP_FEATURE_NAME),
             TitleHeaderAdapter(),
             BrowserTabsAdapter(context, mock(), mock(), TABS_TRAY_FEATURE_NAME)
@@ -145,7 +147,7 @@ class TabSorterTest {
     fun `WHEN inactive tabs is off THEN adapter have no inactive tab`() {
         every { settings.inactiveTabsAreEnabled }.answers { false }
         val adapter = ConcatAdapter(
-            InactiveTabsAdapter(context, mock(), mock(), INACTIVE_TABS_FEATURE_NAME, settings),
+            InactiveTabsAdapter(context, tabsTrayStore, mock(), mock(), INACTIVE_TABS_FEATURE_NAME, settings),
             TabGroupAdapter(context, mock(), mock(), TAB_GROUP_FEATURE_NAME),
             TitleHeaderAdapter(),
             BrowserTabsAdapter(context, mock(), mock(), TABS_TRAY_FEATURE_NAME)
@@ -188,7 +190,7 @@ class TabSorterTest {
     fun `WHEN search term tabs is off THEN adapter have no search term group`() {
         every { settings.searchTermTabGroupsAreEnabled }.answers { false }
         val adapter = ConcatAdapter(
-            InactiveTabsAdapter(context, mock(), mock(), INACTIVE_TABS_FEATURE_NAME, settings),
+            InactiveTabsAdapter(context, tabsTrayStore, mock(), mock(), INACTIVE_TABS_FEATURE_NAME, settings),
             TabGroupAdapter(context, mock(), mock(), TAB_GROUP_FEATURE_NAME),
             TitleHeaderAdapter(),
             BrowserTabsAdapter(context, mock(), mock(), TABS_TRAY_FEATURE_NAME)
@@ -232,7 +234,7 @@ class TabSorterTest {
         every { settings.inactiveTabsAreEnabled }.answers { false }
         every { settings.searchTermTabGroupsAreEnabled }.answers { false }
         val adapter = ConcatAdapter(
-            InactiveTabsAdapter(context, mock(), mock(), INACTIVE_TABS_FEATURE_NAME, settings),
+            InactiveTabsAdapter(context, tabsTrayStore, mock(), mock(), INACTIVE_TABS_FEATURE_NAME, settings),
             TabGroupAdapter(context, mock(), mock(), TAB_GROUP_FEATURE_NAME),
             TitleHeaderAdapter(),
             BrowserTabsAdapter(context, mock(), mock(), TABS_TRAY_FEATURE_NAME)
@@ -273,7 +275,7 @@ class TabSorterTest {
     @Test
     fun `WHEN only one search term tab THEN there is no search group`() {
         val adapter = ConcatAdapter(
-            InactiveTabsAdapter(context, mock(), mock(), INACTIVE_TABS_FEATURE_NAME, settings),
+            InactiveTabsAdapter(context, tabsTrayStore, mock(), mock(), INACTIVE_TABS_FEATURE_NAME, settings),
             TabGroupAdapter(context, mock(), mock(), TAB_GROUP_FEATURE_NAME),
             TitleHeaderAdapter(),
             BrowserTabsAdapter(context, mock(), mock(), TABS_TRAY_FEATURE_NAME)
@@ -300,7 +302,7 @@ class TabSorterTest {
     @Test
     fun `WHEN remove second last one search term tab THEN search group is kept even if there's only one tab`() {
         val adapter = ConcatAdapter(
-            InactiveTabsAdapter(context, mock(), mock(), INACTIVE_TABS_FEATURE_NAME, settings),
+            InactiveTabsAdapter(context, tabsTrayStore, mock(), mock(), INACTIVE_TABS_FEATURE_NAME, settings),
             TabGroupAdapter(context, mock(), mock(), TAB_GROUP_FEATURE_NAME),
             TitleHeaderAdapter(),
             BrowserTabsAdapter(context, mock(), mock(), TABS_TRAY_FEATURE_NAME)


### PR DESCRIPTION
TL;DR: the simplest way to understand what this change does is to read `TabSorterTest`.

## Problem
1. In our `TabSorter`, we are doing many things:
   1. Organizing tabs in different sections.
   2. Updating the UI adapters for those sections.
   3. Telemetry.
2. For other parts of the code base, we re-calculate the tabs for each section in those individual places. This is a problem because there is duplication, room for error, and we have to pass things like `context.settings()` everywhere to know what the right state should be.
3. We're unable to write simple tests because of the interchanging UI components.

In this change, we put the tabs into the `TabsTrayStore` so that we have one place to hold all the final state. This means we only have to access settings once when we do the sorting and all other observers can react accordingly.

## AC partitions

When AC adds support for our various groupings, we can then remove `TabSorter` and use the APIs to feed the tabs into `TabsTrayStore` without needing to change the implementation of any UI components.

## What does this mean for Compose?

With the tabs in the store, we have existing helper extensions for compose made specifically for working on `Store` so we can leverage those and have a straight-forward list to consume in Compose. For example:
```kotlin
fun BrowserList(store: TabsTrayStore) {
  val inactiveTabs = store.observeAsComposableState { state -> state.inactiveTabs }
  items(inactiveTabs) { tab ->
    InactiveTab(tab)
  }
  // etc..
}
```

See https://github.com/mozilla-mobile/fenix/issues/21898, https://github.com/mozilla-mobile/fenix/issues/21899, https://github.com/mozilla-mobile/fenix/issues/21901 for when this will help.

---

Some simple next things to do:
 - Remove the telemetry from `TabSorter` as well and put it in a `Middleware` on the `TabsTrayStore`.
 - Move some of the remaining bits of code that calculate inactive tabs manually to use the store.
 - Move the `InactiveTabsInteractor` out of the UI class too.
 - Write more test for `TabSorter` where needed.
 - Refactor the `scrollToTab` to use the store to know how to scroll (then write tests for that too!)

I've also sneaked in one commit that corrects the naming convention of a `TabsTrayAction`.

cc: @csadilek @MozillaNoah 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
