### PR TITLE
For #22256 re-enable editCustomSearchEngineTest UI test

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -548,7 +548,6 @@ class SmokeTest {
         }
     }
 
-    @Ignore("Failing intermittently https://github.com/mozilla-mobile/fenix/issues/22256")
     @Test
     // Verifies setting as default a customized search engine name and URL
     fun editCustomSearchEngineTest() {


### PR DESCRIPTION
For #22256 re-enable `editCustomSearchEngineTest` UI test
✅  Successfully passed 100x on Firebase

Based on the [logs](https://github.com/mozilla-mobile/fenix/issues/22256#issuecomment-960954454) the failures were caused due to a URL request related issue which happened at a certain time.
`I//system/bin/netd(1912): gethostby*.getanswer: asked for "www.elefant.ro IN A", got type "RRSIG"`

We decided to re-enable the test as it is and if the problem is recurring try a different solution.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
