### PR TITLE
Improve homeThreeDotMenuItemsTest UI test coverage

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/ThreeDotMenuMainTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/ThreeDotMenuMainTest.kt
@@ -54,9 +54,14 @@ class ThreeDotMenuMainTest {
             verifyDesktopSite()
             verifyWhatsNewButton()
             verifyHelpButton()
+            verifyCustomizeHomeButton()
             verifySettingsButton()
         }.openSettings {
             verifySettingsView()
+        }.goBack {
+        }.openThreeDotMenu {
+        }.openCustomizeHome {
+            verifyHomePageView()
         }.goBack {
         }.openThreeDotMenu {
         }.openHelp {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuHomepageRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuHomepageRobot.kt
@@ -1,7 +1,11 @@
 package org.mozilla.fenix.ui.robots
 
 import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.Visibility
 import androidx.test.espresso.matcher.ViewMatchers.hasSibling
+import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
+import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import org.hamcrest.CoreMatchers.allOf
@@ -13,10 +17,45 @@ import org.mozilla.fenix.helpers.click
  */
 class SettingsSubMenuHomepageRobot {
 
+    fun verifyHomePageView() {
+        assertMostVisitedTopSitesButton()
+        assertJumpBackInButton()
+        assertRecentBookmarksButton()
+        assertRecentSearchesButton()
+        assertPocketButton()
+        assertOpeningScreenHeading()
+        assertHomepageButton()
+        assertLastTabButton()
+        assertHomepageAfterFourHoursButton()
+    }
+
     fun clickStartOnHomepageButton() = homepageButton().click()
 
-    class Transition
+    class Transition {
+
+        fun goBack(interact: HomeScreenRobot.() -> Unit): HomeScreenRobot.Transition {
+            goBackButton().click()
+
+            HomeScreenRobot().interact()
+            return HomeScreenRobot.Transition()
+        }
+    }
 }
+
+private fun mostVisitedTopSitesButton() =
+    onView(allOf(withText(R.string.top_sites_toggle_top_recent_sites_3)))
+
+private fun jumpBackInButton() =
+    onView(allOf(withText(R.string.customize_toggle_jump_back_in)))
+
+private fun recentBookmarksButton() =
+    onView(allOf(withText(R.string.customize_toggle_recent_bookmarks)))
+
+private fun recentSearchesButton() =
+    onView(allOf(withText(R.string.customize_toggle_recent_searches)))
+
+private fun pocketButton() =
+    onView(allOf(withText(R.string.customize_toggle_pocket)))
 
 private fun openingScreenHeading() = onView(withText(R.string.preferences_opening_screen))
 
@@ -29,7 +68,41 @@ private fun homepageButton() =
         )
     )
 
-private fun lastTabButton() = onView(withText(R.string.opening_screen_last_tab))
+private fun lastTabButton() =
+    onView(
+        allOf(
+            withId(R.id.title),
+            withText(R.string.opening_screen_last_tab),
+            hasSibling(withId(R.id.radio_button))
+        )
+    )
 
 private fun homepageAfterFourHoursButton() =
-    onView(withText(R.string.opening_screen_after_four_hours_of_inactivity))
+    onView(
+        allOf(
+            withId(R.id.title),
+            withText(R.string.opening_screen_after_four_hours_of_inactivity),
+            hasSibling(withId(R.id.radio_button))
+        )
+    )
+
+private fun goBackButton() = onView(allOf(withContentDescription(R.string.action_bar_up_description)))
+
+private fun assertMostVisitedTopSitesButton() =
+    mostVisitedTopSitesButton().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+private fun assertJumpBackInButton() =
+    jumpBackInButton().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+private fun assertRecentBookmarksButton() =
+    recentBookmarksButton().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+private fun assertRecentSearchesButton() =
+    recentSearchesButton().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+private fun assertPocketButton() =
+    pocketButton().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+private fun assertOpeningScreenHeading() =
+    openingScreenHeading().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+private fun assertHomepageButton() =
+    homepageButton().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+private fun assertLastTabButton() =
+    lastTabButton().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+private fun assertHomepageAfterFourHoursButton() =
+    homepageAfterFourHoursButton().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuMainRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuMainRobot.kt
@@ -49,6 +49,7 @@ class ThreeDotMenuMainRobot {
     fun verifyShareAllTabsButton() = assertShareAllTabsButton()
     fun clickShareAllTabsButton() = shareAllTabsButton().click()
     fun verifySettingsButton() = assertSettingsButton()
+    fun verifyCustomizeHomeButton() = assertCustomizeHomeButton()
     fun verifyAddOnsButton() = assertAddOnsButton()
     fun verifyHistoryButton() = assertHistoryButton()
     fun verifyBookmarksButton() = assertBookmarksButton()
@@ -200,6 +201,26 @@ class ThreeDotMenuMainRobot {
 
             BrowserRobot().interact()
             return BrowserRobot.Transition()
+        }
+
+        fun openCustomizeHome(interact: SettingsSubMenuHomepageRobot.() -> Unit): SettingsSubMenuHomepageRobot.Transition {
+
+            mDevice.wait(
+                Until
+                    .findObject(
+                        By.textContains("$packageName:id/browser_menu_customize_home")
+                    ),
+                waitingTime
+            )
+
+            customizeHomeButton().click()
+
+            mDevice.findObject(
+                UiSelector().resourceId("$packageName:id/recycler_view")
+            ).waitForExists(waitingTime)
+
+            SettingsSubMenuHomepageRobot().interact()
+            return SettingsSubMenuHomepageRobot.Transition()
         }
 
         fun goForward(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
@@ -356,6 +377,17 @@ private fun threeDotMenuRecyclerViewExists() {
 
 private fun settingsButton() = mDevice.findObject(UiSelector().text("Settings"))
 private fun assertSettingsButton() = assertTrue(settingsButton().waitForExists(waitingTime))
+
+private fun customizeHomeButton() =
+    onView(
+        allOf(
+            withId(R.id.text),
+            withText(R.string.browser_menu_customize_home)
+        )
+    )
+
+private fun assertCustomizeHomeButton() =
+    customizeHomeButton().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
 private fun addOnsButton() = onView(allOf(withText("Add-ons")))
 private fun assertAddOnsButton() {

--- a/automation/taskcluster/androidTest/flank-x86.yml
+++ b/automation/taskcluster/androidTest/flank-x86.yml
@@ -44,6 +44,7 @@ gcloud:
   device:
    - model: Pixel2
      version: 28
+     locale: en_US
 
 flank:
   project: GOOGLE_PROJECT


### PR DESCRIPTION
Improve coverage for `homeThreeDotMenuItemsTest` UI test
✅ Successfully passed 100x on Firebase


Also, changed scrollToElementByText to "Set as default browser" in `openLanguageSubMenu` because it failed to click the "Language" button, this being caused caused by the fact that it wasn't at least 90 percent displayed to the user 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
