### PR TITLE
For PR #22362 - Just for Firebase test.

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/ThreeDotMenuMainTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/ThreeDotMenuMainTest.kt
@@ -54,9 +54,14 @@ class ThreeDotMenuMainTest {
             verifyDesktopSite()
             verifyWhatsNewButton()
             verifyHelpButton()
+            verifyCustomizeHomeButton()
             verifySettingsButton()
         }.openSettings {
             verifySettingsView()
+        }.goBack {
+        }.openThreeDotMenu {
+        }.openCustomizeHome {
+            verifyHomePageView()
         }.goBack {
         }.openThreeDotMenu {
         }.openHelp {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuHomepageRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuHomepageRobot.kt
@@ -1,11 +1,17 @@
 package org.mozilla.fenix.ui.robots
 
 import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.hasSibling
+import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.uiautomator.UiSelector
 import org.hamcrest.CoreMatchers.allOf
+import org.junit.Assert.assertTrue
 import org.mozilla.fenix.R
+import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.click
 
 /**
@@ -13,10 +19,45 @@ import org.mozilla.fenix.helpers.click
  */
 class SettingsSubMenuHomepageRobot {
 
+    fun verifyHomePageView() {
+        assertMostVisitedTopSitesButton()
+        assertJumpBackInButton()
+        assertRecentBookmarksButton()
+        assertRecentSearchesButton()
+        assertPocketButton()
+        assertOpeningScreenHeading()
+        assertHomepageButton()
+        assertLastTabButton()
+        assertHomepageAfterFourHoursButton()
+    }
+
     fun clickStartOnHomepageButton() = homepageButton().click()
 
-    class Transition
+    class Transition {
+
+        fun goBack(interact: HomeScreenRobot.() -> Unit): HomeScreenRobot.Transition {
+            goBackButton().click()
+
+            HomeScreenRobot().interact()
+            return HomeScreenRobot.Transition()
+        }
+    }
 }
+
+private fun mostVisitedTopSitesButton() =
+    mDevice.findObject(UiSelector().textContains("Most visited top sites"))
+
+private fun jumpBackInButton() =
+    mDevice.findObject(UiSelector().textContains("Jump back in"))
+
+private fun recentBookmarksButton() =
+    mDevice.findObject(UiSelector().textContains("Recent bookmarks"))
+
+private fun recentSearchesButton() =
+    mDevice.findObject(UiSelector().textContains("Recent searches"))
+
+private fun pocketButton() =
+    mDevice.findObject(UiSelector().textContains("Pocket"))
 
 private fun openingScreenHeading() = onView(withText(R.string.preferences_opening_screen))
 
@@ -29,7 +70,40 @@ private fun homepageButton() =
         )
     )
 
-private fun lastTabButton() = onView(withText(R.string.opening_screen_last_tab))
+private fun lastTabButton() =
+    onView(
+        allOf(
+            withId(R.id.title),
+            withText(R.string.opening_screen_last_tab),
+            hasSibling(withId(R.id.radio_button))
+        )
+    )
 
 private fun homepageAfterFourHoursButton() =
-    onView(withText(R.string.opening_screen_after_four_hours_of_inactivity))
+    onView(
+        allOf(
+            withId(R.id.title),
+            withText(R.string.opening_screen_after_four_hours_of_inactivity),
+            hasSibling(withId(R.id.radio_button))
+        )
+    )
+
+private fun goBackButton() = mDevice.findObject(UiSelector().descriptionContains("Navigate up"))
+
+private fun assertMostVisitedTopSitesButton() =
+    assertTrue(mostVisitedTopSitesButton().waitForExists(waitingTime))
+private fun assertJumpBackInButton() =
+    assertTrue(jumpBackInButton().waitForExists(waitingTime))
+private fun assertRecentBookmarksButton() =
+    assertTrue(recentBookmarksButton().waitForExists(waitingTime))
+private fun assertRecentSearchesButton() =
+    assertTrue(recentSearchesButton().waitForExists(waitingTime))
+private fun assertPocketButton() = assertTrue(pocketButton().waitForExists(waitingTime))
+private fun assertOpeningScreenHeading() =
+    openingScreenHeading().check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+private fun assertHomepageButton() =
+    homepageButton().check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+private fun assertLastTabButton() =
+    lastTabButton().check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+private fun assertHomepageAfterFourHoursButton() =
+    homepageAfterFourHoursButton().check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuMainRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuMainRobot.kt
@@ -49,6 +49,7 @@ class ThreeDotMenuMainRobot {
     fun verifyShareAllTabsButton() = assertShareAllTabsButton()
     fun clickShareAllTabsButton() = shareAllTabsButton().click()
     fun verifySettingsButton() = assertSettingsButton()
+    fun verifyCustomizeHomeButton() = assertCustomizeHomeButton()
     fun verifyAddOnsButton() = assertAddOnsButton()
     fun verifyHistoryButton() = assertHistoryButton()
     fun verifyBookmarksButton() = assertBookmarksButton()
@@ -200,6 +201,18 @@ class ThreeDotMenuMainRobot {
 
             BrowserRobot().interact()
             return BrowserRobot.Transition()
+        }
+
+        fun openCustomizeHome(interact: SettingsSubMenuHomepageRobot.() -> Unit): SettingsSubMenuHomepageRobot.Transition {
+
+            mDevice.findObject(UiSelector().textContains("Customize home")).waitForExists(waitingTime)
+            customizeHomeButton().click()
+            mDevice.findObject(
+                UiSelector().resourceId("$packageName:id/recycler_view")
+            ).waitForExists(waitingTime)
+
+            SettingsSubMenuHomepageRobot().interact()
+            return SettingsSubMenuHomepageRobot.Transition()
         }
 
         fun goForward(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
@@ -356,6 +369,14 @@ private fun threeDotMenuRecyclerViewExists() {
 
 private fun settingsButton() = mDevice.findObject(UiSelector().text("Settings"))
 private fun assertSettingsButton() = assertTrue(settingsButton().waitForExists(waitingTime))
+
+private fun customizeHomeButton() =
+    mDevice.findObject(
+        UiSelector()
+            .resourceId("$packageName:id/text")
+            .textContains("Customize home")
+    )
+private fun assertCustomizeHomeButton() = assertTrue(customizeHomeButton().waitForExists(waitingTime))
 
 private fun addOnsButton() = onView(allOf(withText("Add-ons")))
 private fun assertAddOnsButton() {

--- a/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -5,6 +5,7 @@
 package org.mozilla.fenix
 
 import android.content.Context
+import android.widget.Toast
 import mozilla.components.support.locale.LocaleManager
 import mozilla.components.support.locale.LocaleManager.getSystemDefault
 
@@ -84,7 +85,15 @@ object FeatureFlags {
     fun isPocketRecommendationsFeatureEnabled(context: Context): Boolean {
         val langTag = LocaleManager.getCurrentLocale(context)
             ?.toLanguageTag() ?: getSystemDefault().toLanguageTag()
-        return listOf("en-US", "en-CA").contains(langTag)
+        return listOf("en-US", "en-CA").contains(langTag).also {
+            Toast.makeText(
+                context,
+                "Pocket is ${if (!it) "not " else ""}enabled for" +
+                    "\napp locale:  ${LocaleManager.getCurrentLocale(context)?.toLanguageTag()}" +
+                    "\nsystem locale: ${getSystemDefault().toLanguageTag()}",
+                Toast.LENGTH_LONG
+            ).show()
+        }
     }
 
     /**

--- a/automation/taskcluster/androidTest/flank-x86.yml
+++ b/automation/taskcluster/androidTest/flank-x86.yml
@@ -40,6 +40,7 @@ gcloud:
   test-targets:
    - notPackage org.mozilla.fenix.screenshots
    - notPackage org.mozilla.fenix.syncintegration
+   - class org.mozilla.fenix.ui.ThreeDotMenuMainTest#homeThreeDotMenuItemsTest
 
   device:
    - model: Pixel2


### PR DESCRIPTION
In Firebase tests the "Pocket" preference does not appear in the "Homepage"
screen. The only reason should be another locale than "en-US" / "en-CA".
Show a Toast with the current locale and feature status when this is queried.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
