### PR TITLE
For #22147 - New search term groups telemetry

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -2653,6 +2653,45 @@ history:
     notification_emails:
       - android-probes@mozilla.com
     expires: "2022-11-01"
+  search_term_group_open_tab:
+    type: event
+    description: |
+      A user opens a tab from the search term group in history.
+    bugs:
+      - https://github.com/mozilla-mobile/fenix/issues/22147
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/22368#issuecomment-964223263
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: "2022-11-01"
+  search_term_group_remove_tab:
+    type: event
+    description: |
+      A user closes a single tab in the search term group in history.
+    bugs:
+      - https://github.com/mozilla-mobile/fenix/issues/22147
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/22368#issuecomment-964223263
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: "2022-11-01"
+  search_term_group_remove_all:
+    type: event
+    description: |
+      A user closes all tabs in the search term group in history.
+    bugs:
+      - https://github.com/mozilla-mobile/fenix/issues/22147
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/22368#issuecomment-964223263
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: "2022-11-01"
 
 reader_mode:
   available:

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/Event.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/Event.kt
@@ -86,6 +86,9 @@ sealed class Event {
         override val extras = mapOf(History.recentSearchesTappedKeys.pageNumber to source)
     }
     object HistorySearchTermGroupTapped : Event()
+    object HistorySearchTermGroupOpenTab : Event()
+    object HistorySearchTermGroupRemoveTab : Event()
+    object HistorySearchTermGroupRemoveAll : Event()
     object ReaderModeAvailable : Event()
     object ReaderModeOpened : Event()
     object ReaderModeClosed : Event()

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
@@ -315,6 +315,15 @@ private val Event.wrapper: EventWrapper<*>?
         is Event.HistorySearchTermGroupTapped -> EventWrapper<NoExtraKeys>(
             { History.searchTermGroupTapped.record(it) }
         )
+        is Event.HistorySearchTermGroupOpenTab -> EventWrapper<NoExtraKeys>(
+            { History.searchTermGroupOpenTab.record(it) }
+        )
+        is Event.HistorySearchTermGroupRemoveTab -> EventWrapper<NoExtraKeys>(
+            { History.searchTermGroupRemoveTab.record(it) }
+        )
+        is Event.HistorySearchTermGroupRemoveAll -> EventWrapper<NoExtraKeys>(
+            { History.searchTermGroupRemoveAll.record(it) }
+        )
         is Event.CollectionRenamed -> EventWrapper<NoExtraKeys>(
             { Collections.renamed.record(it) }
         )

--- a/app/src/main/java/org/mozilla/fenix/library/historymetadata/HistoryMetadataGroupFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/historymetadata/HistoryMetadataGroupFragment.kt
@@ -23,6 +23,7 @@ import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.components.StoreProvider
 import org.mozilla.fenix.databinding.FragmentHistoryMetadataGroupBinding
 import org.mozilla.fenix.ext.nav
+import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.setTextColor
 import org.mozilla.fenix.ext.showToolbar
 import org.mozilla.fenix.library.LibraryPageFragment
@@ -73,6 +74,7 @@ class HistoryMetadataGroupFragment :
             controller = DefaultHistoryMetadataGroupController(
                 activity = activity as HomeActivity,
                 store = historyMetadataGroupStore,
+                metrics = requireComponents.analytics.metrics,
                 navController = findNavController(),
                 scope = lifecycleScope,
                 searchTerm = args.title

--- a/app/src/main/java/org/mozilla/fenix/library/historymetadata/controller/HistoryMetadataGroupController.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/historymetadata/controller/HistoryMetadataGroupController.kt
@@ -10,6 +10,8 @@ import kotlinx.coroutines.launch
 import mozilla.components.concept.engine.prompt.ShareData
 import org.mozilla.fenix.BrowserDirection
 import org.mozilla.fenix.HomeActivity
+import org.mozilla.fenix.components.metrics.Event
+import org.mozilla.fenix.components.metrics.MetricController
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.library.history.History
 import org.mozilla.fenix.library.historymetadata.HistoryMetadataGroupFragmentAction
@@ -74,6 +76,7 @@ interface HistoryMetadataGroupController {
 class DefaultHistoryMetadataGroupController(
     private val activity: HomeActivity,
     private val store: HistoryMetadataGroupFragmentStore,
+    private val metrics: MetricController,
     private val navController: NavController,
     private val scope: CoroutineScope,
     private val searchTerm: String,
@@ -86,6 +89,7 @@ class DefaultHistoryMetadataGroupController(
             from = BrowserDirection.FromHistoryMetadataGroup,
             historyMetadata = item.historyMetadataKey
         )
+        metrics.track(Event.HistorySearchTermGroupOpenTab)
     }
 
     override fun handleSelect(item: History.Metadata) {
@@ -118,6 +122,7 @@ class DefaultHistoryMetadataGroupController(
             items.forEach {
                 store.dispatch(HistoryMetadataGroupFragmentAction.Delete(it))
                 activity.components.core.historyStorage.deleteHistoryMetadata(it.historyMetadataKey)
+                metrics.track(Event.HistorySearchTermGroupRemoveTab)
             }
         }
     }
@@ -126,6 +131,7 @@ class DefaultHistoryMetadataGroupController(
         scope.launch {
             store.dispatch(HistoryMetadataGroupFragmentAction.DeleteAll)
             activity.components.core.historyStorage.deleteHistoryMetadata(searchTerm)
+            metrics.track(Event.HistorySearchTermGroupRemoveAll)
         }
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/components/metrics/GleanMetricsServiceTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/metrics/GleanMetricsServiceTest.kt
@@ -180,6 +180,18 @@ class GleanMetricsServiceTest {
         assertFalse(History.searchTermGroupTapped.testHasValue())
         gleanService.track(Event.HistorySearchTermGroupTapped)
         assertTrue(History.searchTermGroupTapped.testHasValue())
+
+        assertFalse(History.searchTermGroupOpenTab.testHasValue())
+        gleanService.track(Event.HistorySearchTermGroupOpenTab)
+        assertTrue(History.searchTermGroupOpenTab.testHasValue())
+
+        assertFalse(History.searchTermGroupRemoveTab.testHasValue())
+        gleanService.track(Event.HistorySearchTermGroupRemoveTab)
+        assertTrue(History.searchTermGroupRemoveTab.testHasValue())
+
+        assertFalse(History.searchTermGroupRemoveAll.testHasValue())
+        gleanService.track(Event.HistorySearchTermGroupRemoveAll)
+        assertTrue(History.searchTermGroupRemoveAll.testHasValue())
     }
 
     @Test

--- a/app/src/test/java/org/mozilla/fenix/components/metrics/MetricControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/metrics/MetricControllerTest.kt
@@ -337,6 +337,9 @@ class MetricControllerTest {
         every { marketingService1.shouldTrack(Event.HistoryAllItemsRemoved) } returns true
         every { marketingService1.shouldTrack(Event.HistoryRecentSearchesTapped("2")) } returns true
         every { marketingService1.shouldTrack(Event.HistorySearchTermGroupTapped) } returns true
+        every { marketingService1.shouldTrack(Event.HistorySearchTermGroupOpenTab) } returns true
+        every { marketingService1.shouldTrack(Event.HistorySearchTermGroupRemoveTab) } returns true
+        every { marketingService1.shouldTrack(Event.HistorySearchTermGroupRemoveAll) } returns true
 
         controller.start(MetricServiceType.Marketing)
 
@@ -348,6 +351,9 @@ class MetricControllerTest {
         controller.track(Event.HistoryAllItemsRemoved)
         controller.track(Event.HistoryRecentSearchesTapped("2"))
         controller.track(Event.HistorySearchTermGroupTapped)
+        controller.track(Event.HistorySearchTermGroupOpenTab)
+        controller.track(Event.HistorySearchTermGroupRemoveTab)
+        controller.track(Event.HistorySearchTermGroupRemoveAll)
 
         verify { marketingService1.track(Event.HistoryOpenedInNewTab) }
         verify { marketingService1.track(Event.HistoryOpenedInNewTabs) }
@@ -357,6 +363,9 @@ class MetricControllerTest {
         verify { marketingService1.track(Event.HistoryAllItemsRemoved) }
         verify { marketingService1.track(Event.HistoryRecentSearchesTapped("2")) }
         verify { marketingService1.track(Event.HistorySearchTermGroupTapped) }
+        verify { marketingService1.track(Event.HistorySearchTermGroupOpenTab) }
+        verify { marketingService1.track(Event.HistorySearchTermGroupRemoveTab) }
+        verify { marketingService1.track(Event.HistorySearchTermGroupRemoveAll) }
     }
 
     @Test

--- a/app/src/test/java/org/mozilla/fenix/library/historymetadata/controller/HistoryMetadataGroupControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/historymetadata/controller/HistoryMetadataGroupControllerTest.kt
@@ -25,6 +25,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.BrowserDirection
 import org.mozilla.fenix.HomeActivity
+import org.mozilla.fenix.components.metrics.Event
+import org.mozilla.fenix.components.metrics.MetricController
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.directionsEq
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
@@ -44,6 +46,7 @@ class HistoryMetadataGroupControllerTest {
 
     private val activity: HomeActivity = mockk(relaxed = true)
     private val store: HistoryMetadataGroupFragmentStore = mockk(relaxed = true)
+    private val metrics: MetricController = mockk(relaxed = true)
     private val navController: NavController = mockk(relaxed = true)
     private val historyStorage: PlacesHistoryStorage = mockk(relaxed = true)
 
@@ -73,6 +76,7 @@ class HistoryMetadataGroupControllerTest {
         controller = DefaultHistoryMetadataGroupController(
             activity = activity,
             store = store,
+            metrics = metrics,
             navController = navController,
             scope = scope,
             searchTerm = "mozilla"
@@ -97,6 +101,7 @@ class HistoryMetadataGroupControllerTest {
                 from = BrowserDirection.FromHistoryMetadataGroup,
                 historyMetadata = mozillaHistoryMetadataItem.historyMetadataKey
             )
+            metrics.track(Event.HistorySearchTermGroupOpenTab)
         }
     }
 
@@ -160,6 +165,7 @@ class HistoryMetadataGroupControllerTest {
             store.dispatch(HistoryMetadataGroupFragmentAction.Delete(firefoxHistoryMetadataItem))
             historyStorage.deleteHistoryMetadata(mozillaHistoryMetadataItem.historyMetadataKey)
             historyStorage.deleteHistoryMetadata(firefoxHistoryMetadataItem.historyMetadataKey)
+            metrics.track(Event.HistorySearchTermGroupRemoveTab)
         }
     }
 
@@ -170,6 +176,7 @@ class HistoryMetadataGroupControllerTest {
         coVerify {
             store.dispatch(HistoryMetadataGroupFragmentAction.DeleteAll)
             historyStorage.deleteHistoryMetadata(searchTerm)
+            metrics.track(Event.HistorySearchTermGroupRemoveAll)
         }
     }
 }


### PR DESCRIPTION
3 new events added for when the user opens a tab, closes one or closes all from a search group.
Kimmy to confirm if the current https://dictionary.telemetry.mozilla.org/apps/fenix/metrics/history_search_term_group_tapped is okay to be considered the 4th we needed.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
