### PR TITLE
For #22271 Improve URL accessing from the clipboard for Android 12 and above.

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NavigationToolbarRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NavigationToolbarRobot.kt
@@ -7,6 +7,7 @@
 package org.mozilla.fenix.ui.robots
 
 import android.net.Uri
+import android.os.Build
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.IdlingRegistry
@@ -162,10 +163,15 @@ class NavigationToolbarRobot {
                 waitingTime
             )
 
-            mDevice.waitNotNull(
-                Until.findObject(By.res("org.mozilla.fenix.debug:id/clipboard_url")),
-                waitingTime
-            )
+            // On Android 12 or above we don't SHOW the URL unless the user requests to do so.
+            // See for mor information https://github.com/mozilla-mobile/fenix/issues/22271
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+                mDevice.waitNotNull(
+                    Until.findObject(By.res("org.mozilla.fenix.debug:id/clipboard_url")),
+                    waitingTime
+                )
+            }
+
             fillLinkButton().click()
 
             BrowserRobot().interact()

--- a/app/src/main/java/org/mozilla/fenix/search/SearchFragmentStore.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchFragmentStore.kt
@@ -61,7 +61,7 @@ sealed class SearchEngineSource {
  * @property showHistorySuggestions Whether or not to show history suggestions in the AwesomeBar
  * @property showBookmarkSuggestions Whether or not to show the bookmark suggestion in the AwesomeBar
  * @property pastedText The text pasted from the long press toolbar menu
- * @property clipboardUrl The URL in the clipboard of the user - if there's any; otherwise `null`.
+ * @property clipboardHasUrl Indicates if the clipboard contains an URL.
  */
 data class SearchFragmentState(
     val query: String,
@@ -81,7 +81,7 @@ data class SearchFragmentState(
     val tabId: String?,
     val pastedText: String? = null,
     val searchAccessPoint: Event.PerformedSearch.SearchAccessPoint?,
-    val clipboardUrl: String? = null
+    val clipboardHasUrl: Boolean = false
 ) : State
 
 fun createInitialSearchFragmentState(
@@ -131,7 +131,7 @@ sealed class SearchFragmentAction : Action {
     data class ShowSearchShortcutEnginePicker(val show: Boolean) : SearchFragmentAction()
     data class AllowSearchSuggestionsInPrivateModePrompt(val show: Boolean) : SearchFragmentAction()
     data class UpdateQuery(val query: String) : SearchFragmentAction()
-    data class UpdateClipboardUrl(val url: String?) : SearchFragmentAction()
+    data class UpdateClipboardHasUrl(val hasUrl: Boolean) : SearchFragmentAction()
 
     /**
      * Updates the local `SearchFragmentState` from the global `SearchState` in `BrowserStore`.
@@ -172,9 +172,9 @@ private fun searchStateReducer(state: SearchFragmentState, action: SearchFragmen
                 }
             )
         }
-        is SearchFragmentAction.UpdateClipboardUrl -> {
+        is SearchFragmentAction.UpdateClipboardHasUrl -> {
             state.copy(
-                clipboardUrl = action.url
+                clipboardHasUrl = action.hasUrl
             )
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/utils/ClipboardHandler.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/ClipboardHandler.kt
@@ -7,6 +7,8 @@ package org.mozilla.fenix.utils
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
+import android.os.Build
+import android.view.textclassifier.TextClassifier
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.getSystemService
 import mozilla.components.support.utils.SafeUrl
@@ -21,6 +23,13 @@ private const val MIME_TYPE_TEXT_HTML = "text/html"
 class ClipboardHandler(val context: Context) {
     private val clipboard = context.getSystemService<ClipboardManager>()!!
 
+    /**
+     * Provides access to the current content of the clipboard, be aware this is a sensitive
+     * API as from Android 12 and above, accessing it will trigger a notification letting the user
+     * know the app has accessed the clipboard, make sure when you call this API that users are
+     * completely aware that we are accessing the clipboard.
+     * See for more details https://github.com/mozilla-mobile/fenix/issues/22271.
+     */
     var text: String?
         get() {
             if (!clipboard.isPrimaryClipEmpty() &&
@@ -37,13 +46,36 @@ class ClipboardHandler(val context: Context) {
             clipboard.setPrimaryClip(ClipData.newPlainText("Text", value))
         }
 
-    val url: String?
-        get() {
-            return text?.let {
-                val finder = WebURLFinder(it)
-                finder.bestWebURL()
-            }
+    /**
+     * Returns a possible URL from the actual content of the clipboard, be aware this is a sensitive
+     * API as from Android 12 and above, accessing it will trigger a notification letting the user
+     * know the app has accessed the clipboard, make sure when you call this API that users are
+     * completely aware that we are accessing the clipboard.
+     * See for more details https://github.com/mozilla-mobile/fenix/issues/22271.
+     */
+    fun extractURL(): String? {
+        return text?.let {
+            val finder = WebURLFinder(it)
+            finder.bestWebURL()
         }
+    }
+
+    @Suppress("MagicNumber")
+    internal fun containsURL(): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val description = clipboard.primaryClipDescription
+            // An IllegalStateException is thrown if the url is too long.
+            val score =
+                try {
+                    description?.getConfidenceScore(TextClassifier.TYPE_URL) ?: 0F
+                } catch (e: IllegalStateException) {
+                    0F
+                }
+            score >= 0.7F
+        } else {
+            !extractURL().isNullOrEmpty()
+        }
+    }
 
     private fun ClipboardManager.isPrimaryClipPlainText() =
         primaryClipDescription?.hasMimeType(MIME_TYPE_TEXT_PLAIN) ?: false

--- a/app/src/main/java/org/mozilla/fenix/utils/ToolbarPopupWindow.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/ToolbarPopupWindow.kt
@@ -34,7 +34,7 @@ object ToolbarPopupWindow {
     ) {
         val context = view.get()?.context ?: return
         val clipboard = context.components.clipboardHandler
-        if (!copyVisible && clipboard.text.isNullOrEmpty()) return
+        if (!copyVisible && !clipboard.containsURL()) return
 
         val isCustomTabSession = customTabId != null
 
@@ -54,9 +54,9 @@ object ToolbarPopupWindow {
 
         binding.copy.isVisible = copyVisible
 
-        binding.paste.isVisible = !clipboard.text.isNullOrEmpty() && !isCustomTabSession
+        binding.paste.isVisible = clipboard.containsURL() && !isCustomTabSession
         binding.pasteAndGo.isVisible =
-            !clipboard.text.isNullOrEmpty() && !isCustomTabSession
+            clipboard.containsURL() && !isCustomTabSession
 
         binding.copy.setOnClickListener {
             popupWindow.dismiss()

--- a/app/src/main/res/values-v31/dimens.xml
+++ b/app/src/main/res/values-v31/dimens.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <dimen name="search_fragment_clipboard_item_height">49dp</dimen>
+</resources>

--- a/app/src/test/java/org/mozilla/fenix/search/SearchFragmentStoreTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/search/SearchFragmentStoreTest.kt
@@ -203,16 +203,13 @@ class SearchFragmentStoreTest {
         val initialState = emptyDefaultState()
         val store = SearchFragmentStore(initialState)
 
-        assertNull(store.state.clipboardUrl)
+        assertFalse(store.state.clipboardHasUrl)
 
         store.dispatch(
-            SearchFragmentAction.UpdateClipboardUrl("https://www.mozilla.org")
+            SearchFragmentAction.UpdateClipboardHasUrl(true)
         ).joinBlocking()
 
-        assertEquals(
-            "https://www.mozilla.org",
-            store.state.clipboardUrl
-        )
+        assertTrue(store.state.clipboardHasUrl)
     }
 
     @Test

--- a/app/src/test/java/org/mozilla/fenix/utils/ClipboardHandlerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/utils/ClipboardHandlerTest.kt
@@ -52,18 +52,18 @@ class ClipboardHandlerTest {
 
     @Test
     fun getUrl() {
-        assertEquals(null, clipboardHandler.url)
+        assertEquals(null, clipboardHandler.extractURL())
 
         clipboard.setPrimaryClip(ClipData.newPlainText("Text", clipboardUrl))
-        assertEquals(clipboardUrl, clipboardHandler.url)
+        assertEquals(clipboardUrl, clipboardHandler.extractURL())
     }
 
     @Test
     fun getUrlfromTextUrlMIME() {
-        assertEquals(null, clipboardHandler.url)
+        assertEquals(null, clipboardHandler.extractURL())
 
         clipboard.setPrimaryClip(ClipData.newHtmlText("Html", clipboardUrl, clipboardUrl))
-        assertEquals(clipboardUrl, clipboardHandler.url)
+        assertEquals(clipboardUrl, clipboardHandler.extractURL())
     }
 
     @Test


### PR DESCRIPTION
As accessing the clipboard is sensitive action, on Android 12 and above we changed the UI to not show (access the clipboard) the URL unless the user request to do so.

### Behavior on Android 12 and above

We show the **"Fill link from clipboard"** item (but not the URL item)  when the user clicks it, we fill the toolbar with its content.

![Demo](https://user-images.githubusercontent.com/773158/141153264-35d4b935-417b-45cb-a9a1-09d64fee20d5.mp4)

### Behavior pre Android 12 and above

Same as before show the **"Fill link from clipboard"** item and the URL item, when the user clicks it, we navigate to the site.

![clipboard_pre_android_12](https://user-images.githubusercontent.com/773158/141154796-78314e3a-c797-41cd-97ae-921efbcb068f.gif)


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
