### PR TITLE
For #22155 - Store inactive tabs count telemetry when user opens tabs tray

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -1255,9 +1255,9 @@ metrics:
     expires: "2022-02-01"
   inactive_tabs_count:
     type: quantity
-    lifetime: application
     description: |
-      How many inactive tabs does the user have.
+      How many inactive tabs does the user have, checked when the user opens
+      the tabs tray.
       Value will be 0 if the feature is disabled.
     send_in_pings:
       - metrics

--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -80,7 +80,6 @@ import org.mozilla.fenix.components.Core
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.components.metrics.MozillaProductDetector
 import org.mozilla.fenix.components.toolbar.ToolbarPosition
-import org.mozilla.fenix.ext.actualInactiveTabs
 import org.mozilla.fenix.perf.MarkersActivityLifecycleCallbacks
 import org.mozilla.fenix.utils.Settings
 
@@ -627,8 +626,6 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
 
             tabViewSetting.set(settings.getTabViewPingString())
             closeTabSetting.set(settings.getTabTimeoutPingString())
-
-            inactiveTabsCount.set(browserStore.state.actualInactiveTabs(settings).size.toLong())
 
             val installSourcePackage = if (SDK_INT >= Build.VERSION_CODES.R) {
                 packageManager.getInstallSourceInfo(packageName).installingPackageName

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/Event.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/Event.kt
@@ -224,6 +224,7 @@ sealed class Event {
         override val extras: Map<Preferences.turnOffInactiveTabsSurveyKeys, String>
             get() = mapOf(Preferences.turnOffInactiveTabsSurveyKeys.feedback to feedback.lowercase(Locale.ROOT))
     }
+    data class InactiveTabsCountUpdate(val count: Int) : Event()
 
     object ProgressiveWebAppOpenFromHomescreenTap : Event()
     object ProgressiveWebAppInstallAsShortcut : Event()

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
@@ -652,6 +652,9 @@ private val Event.wrapper: EventWrapper<*>?
             { Preferences.turnOffInactiveTabsSurvey.record(it) },
             { Preferences.turnOffInactiveTabsSurveyKeys.valueOf(it) }
         )
+        is Event.InactiveTabsCountUpdate -> EventWrapper<NoExtraKeys>(
+            { Metrics.inactiveTabsCount.set(this.count.toLong()) },
+        )
         is Event.TabsTrayInactiveTabsCFRGotoSettings -> EventWrapper<NoExtraKeys>(
             { TabsTray.inactiveTabsCfrSettings.record(it) }
         )

--- a/app/src/main/java/org/mozilla/fenix/tabstray/browser/TabSorter.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/browser/TabSorter.kt
@@ -57,6 +57,8 @@ class TabSorter(
         if (shouldReportMetrics) {
             shouldReportMetrics = false
 
+            metrics.track(Event.InactiveTabsCountUpdate(inactiveTabs.size))
+
             if (settings.inactiveTabsAreEnabled) {
                 metrics.track(Event.TabsTrayHasInactiveTabs(inactiveTabs.size))
             }

--- a/app/src/test/java/org/mozilla/fenix/FenixApplicationTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/FenixApplicationTest.kt
@@ -11,7 +11,6 @@ import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
-import io.mockk.mockkStatic
 import io.mockk.spyk
 import io.mockk.verify
 import mozilla.components.browser.state.store.BrowserStore
@@ -32,7 +31,6 @@ import org.mozilla.fenix.GleanMetrics.Preferences
 import org.mozilla.fenix.GleanMetrics.SearchDefaultEngine
 import org.mozilla.fenix.components.metrics.MozillaProductDetector
 import org.mozilla.fenix.components.toolbar.ToolbarPosition
-import org.mozilla.fenix.ext.actualInactiveTabs
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.utils.BrowsersCache
 import org.mozilla.fenix.utils.Settings
@@ -143,13 +141,8 @@ class FenixApplicationTest {
         every { settings.searchTermTabGroupsAreEnabled } returns true
         every { application.reportHomeScreenMetrics(settings) } just Runs
         every { settings.inactiveTabsAreEnabled } returns true
-        mockkStatic("org.mozilla.fenix.ext.BrowserStateKt") {
-            every { browserStore.state.actualInactiveTabs(any()) } returns listOf(mockk(), mockk())
 
-            application.setStartupMetrics(browserStore, settings, browsersCache, mozillaProductDetector)
-
-            assertEquals(2, Metrics.inactiveTabsCount.testGetValue())
-        }
+        application.setStartupMetrics(browserStore, settings, browsersCache, mozillaProductDetector)
 
         // Verify that browser defaults metrics are set.
         assertEquals("Mozilla", Metrics.distributionId.testGetValue())

--- a/app/src/test/java/org/mozilla/fenix/tabstray/browser/TabSorterTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/browser/TabSorterTest.kt
@@ -6,11 +6,13 @@ package org.mozilla.fenix.tabstray.browser
 
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import mozilla.components.browser.state.state.createTab
 import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
+import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.components.metrics.MetricController
 import org.mozilla.fenix.tabstray.TabsTrayStore
 import org.mozilla.fenix.utils.Settings
@@ -283,5 +285,38 @@ class TabSorterTest {
         assertEquals(tabsTrayStore.state.inactiveTabs.size, 0)
         assertEquals(tabsTrayStore.state.searchTermGroups.size, 1)
         assertEquals(tabsTrayStore.state.normalTabs.size, 0)
+    }
+
+    @Test
+    fun `GIVEN the inactive tabs feature is enabled WHEN the tray is opened THEN we report the number of inactive tabs`() {
+        val tabSorter = TabSorter(settings, metrics, tabsTrayStore)
+
+        tabSorter.updateTabs(
+            listOf(
+                createTab(url = "url", id = "tab1", createdAt = inactiveTimestamp),
+                createTab(url = "url", id = "tab2", createdAt = inactiveTimestamp),
+            ),
+            selectedTabId = "tab2"
+        )
+        tabsTrayStore.waitUntilIdle()
+
+        verify { metrics.track(Event.InactiveTabsCountUpdate(2)) }
+    }
+
+    @Test
+    fun `GIVEN the inactive tabs feature is disabled WHEN the tray is opened THEN we report 0 for the number of inactive tabs`() {
+        val tabSorter = TabSorter(settings, metrics, tabsTrayStore)
+        every { settings.inactiveTabsAreEnabled }.answers { false }
+
+        tabSorter.updateTabs(
+            listOf(
+                createTab(url = "url", id = "tab1", createdAt = inactiveTimestamp),
+                createTab(url = "url", id = "tab2", createdAt = inactiveTimestamp),
+            ),
+            selectedTabId = "tab2"
+        )
+        tabsTrayStore.waitUntilIdle()
+
+        verify { metrics.track(Event.InactiveTabsCountUpdate(0)) }
     }
 }


### PR DESCRIPTION
Setting this value in FenixApplication.onCreate was buggy because of a race
with restoring BrowserState.
Setting it here would ensure a better granularity of the events and so to more
accurate reporting.

Checking now the metrics ping shows the expected value - [Glean dashboard](https://debug-ping-preview.firebaseapp.com/pings/petruInactiveTabs7)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
