### PR TITLE
For #22310 - Change tab holder's checkbox state when pressing "Select…

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/collections/CollectionCreationTabListAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/collections/CollectionCreationTabListAdapter.kt
@@ -43,10 +43,8 @@ class CollectionCreationTabListAdapter(
             when (payloads[0]) {
                 is CheckChanged -> {
                     val checkChanged = payloads[0] as CheckChanged
-                    if (checkChanged.shouldBeChecked) {
-                        binding.tabSelectedCheckbox.isChecked = true
-                    } else if (checkChanged.shouldBeUnchecked) {
-                        binding.tabSelectedCheckbox.isChecked = false
+                    if (checkChanged.shouldBeChecked || checkChanged.shouldBeUnchecked) {
+                        holder.changeCheckBoxState(checkChanged.shouldBeChecked)
                     }
                     binding.tabSelectedCheckbox.isGone = checkChanged.shouldHideCheckBox
                 }
@@ -109,6 +107,13 @@ class TabViewHolder(private val binding: CollectionTabListRowBinding) : ViewHold
         }
 
         itemView.context.components.core.icons.loadIntoView(binding.faviconImage, tab.url)
+    }
+
+    /**
+     * Method used to change the tabSelectedCheckbox state
+     */
+    fun changeCheckBoxState(shouldBeChecked: Boolean) {
+        binding.tabSelectedCheckbox.isChecked = shouldBeChecked
     }
 
     companion object {


### PR DESCRIPTION

Change tab holder's checkbox state when pressing "Select All"/"Deselect All".

### Pressed "Select All"
![Screenshot_20211114-163817_Firefox Preview](https://user-images.githubusercontent.com/62257305/141685936-1e4b6697-7409-4754-ae5a-97121b2a632f.jpg)
### Pressed "Deselect All"
![Screenshot_20211114-163824_Firefox Preview](https://user-images.githubusercontent.com/62257305/141685939-af275177-baa6-4712-8205-c39f90790603.jpg)


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
