### PR TITLE
Home page tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsBasicsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsBasicsTest.kt
@@ -207,6 +207,26 @@ class SettingsBasicsTest {
 
     @SmokeTest
     @Test
+    fun recentBookmarksOptionTest() {
+        val genericURL = getGenericAsset(mockWebServer, 1)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(genericURL.url) {
+            mDevice.waitForIdle()
+        }.openThreeDotMenu {
+        }.bookmarkPage {
+        }.goToHomescreen {
+            verifyRecentBookmarksSectionIsDisplayed()
+        }.openThreeDotMenu {
+        }.openCustomizeHome {
+            clickRecentBookmarksButton()
+        }.goBack {
+            verifyRecentBookmarksSectionIsNotDisplayed()
+        }
+    }
+
+    @SmokeTest
+    @Test
     fun startOnHomepageTest() {
         val genericURL = getGenericAsset(mockWebServer, 1)
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsBasicsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsBasicsTest.kt
@@ -13,6 +13,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.FenixApplication
+import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.FeatureSettingsHelper
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
@@ -186,6 +187,7 @@ class SettingsBasicsTest {
         }
     }
 
+    @SmokeTest
     @Test
     fun startOnHomepageTest() {
         val genericURL = getGenericAsset(mockWebServer, 1)

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsBasicsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsBasicsTest.kt
@@ -20,6 +20,7 @@ import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper.getGenericAsset
 import org.mozilla.fenix.helpers.TestAssetHelper.getLoremIpsumAsset
 import org.mozilla.fenix.helpers.TestHelper.restartApp
+import org.mozilla.fenix.ui.robots.browserScreen
 import org.mozilla.fenix.ui.robots.checkTextSizeOnWebsite
 import org.mozilla.fenix.ui.robots.homeScreen
 import org.mozilla.fenix.ui.robots.navigationToolbar
@@ -243,6 +244,40 @@ class SettingsBasicsTest {
 
         homeScreen {
             verifyHomeScreen()
+        }
+    }
+
+    @SmokeTest
+    @Test
+    fun startOnLastTabTest() {
+        val firstWebPage = getGenericAsset(mockWebServer, 1)
+
+        homeScreen {
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openHomepageSubMenu {
+            clickStartOnHomepageButton()
+        }
+
+        restartApp(activityIntentTestRule)
+
+        homeScreen {
+            verifyHomeScreen()
+        }
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(firstWebPage.url) {
+            mDevice.waitForIdle()
+        }.goToHomescreen {
+        }.openThreeDotMenu {
+        }.openCustomizeHome {
+            clickStartOnLastTabButton()
+        }
+
+        restartApp(activityIntentTestRule)
+
+        browserScreen {
+            verifyUrl(firstWebPage.url.toString())
         }
     }
 }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsBasicsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsBasicsTest.kt
@@ -189,6 +189,24 @@ class SettingsBasicsTest {
 
     @SmokeTest
     @Test
+    fun jumpBackInOptionTest() {
+        val genericURL = getGenericAsset(mockWebServer, 1)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(genericURL.url) {
+            mDevice.waitForIdle()
+        }.goToHomescreen {
+            verifyJumpBackInSectionIsDisplayed()
+        }.openThreeDotMenu {
+        }.openCustomizeHome {
+            clickJumpBackInButton()
+        }.goBack {
+            verifyJumpBackInSectionIsNotDisplayed()
+        }
+    }
+
+    @SmokeTest
+    @Test
     fun startOnHomepageTest() {
         val genericURL = getGenericAsset(mockWebServer, 1)
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -38,7 +38,6 @@ import org.mozilla.fenix.helpers.TestHelper.assertExternalAppOpens
 import org.mozilla.fenix.helpers.TestHelper.createCustomTabIntent
 import org.mozilla.fenix.helpers.TestHelper.deleteDownloadFromStorage
 import org.mozilla.fenix.helpers.TestHelper.isPackageInstalled
-import org.mozilla.fenix.helpers.TestHelper.restartApp
 import org.mozilla.fenix.helpers.TestHelper.returnToBrowser
 import org.mozilla.fenix.helpers.TestHelper.scrollToElementByText
 import org.mozilla.fenix.helpers.ViewVisibilityIdlingResource
@@ -1422,26 +1421,6 @@ class SmokeTest {
             verifyTabViewOptions()
             verifyCloseTabsOptions()
             verifyMoveOldTabsToInactiveOptions()
-        }
-    }
-
-    @Test
-    fun startOnHomepageTest() {
-        val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-
-        navigationToolbar {
-        }.enterURLAndEnterToBrowser(genericURL.url) {
-            mDevice.waitForIdle()
-        }.openThreeDotMenu {
-        }.openSettings {
-        }.openHomepageSubMenu {
-            clickStartOnHomepageButton()
-        }
-
-        restartApp(activityTestRule.activityRule)
-
-        homeScreen {
-            verifyHomeScreen()
         }
     }
 }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
@@ -13,11 +13,13 @@ import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.NoMatchingViewException
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions.actionOnItem
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.Visibility
 import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
+import androidx.test.espresso.matcher.ViewMatchers.hasSibling
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.espresso.matcher.ViewMatchers.withHint
@@ -115,6 +117,9 @@ class HomeScreenRobot {
     fun verifyNotExistingTopSitesList(title: String) = assertNotExistingTopSitesList(title)
     fun verifyExistingTopSitesTabs(title: String) = assertExistingTopSitesTabs(title)
     fun verifyTopSiteContextMenuItems() = assertTopSiteContextMenuItems()
+
+    fun verifyJumpBackInSectionIsDisplayed() = assertJumpBackInSectionIsDisplayed()
+    fun verifyJumpBackInSectionIsNotDisplayed() = assertJumpBackInSectionIsNotDisplayed()
 
     // Collections elements
     fun verifyCollectionIsDisplayed(title: String, collectionExists: Boolean = true) {
@@ -584,11 +589,23 @@ private fun assertShareTabsOverlay() {
     onView(withId(R.id.share_tab_url)).check(matches(isDisplayed()))
 }
 
+private fun assertJumpBackInSectionIsDisplayed() = jumpBackInSection().check(matches(isDisplayed()))
+
+private fun assertJumpBackInSectionIsNotDisplayed() = jumpBackInSection().check(doesNotExist())
+
 private fun privateBrowsingButton() = onView(withId(R.id.privateBrowsingButton))
 
 private fun saveTabsToCollectionButton() = onView(withId(R.id.add_tabs_to_collections_button))
 
 private fun tabsCounter() = onView(withId(R.id.tab_button))
+
+private fun jumpBackInSection() =
+    onView(
+        allOf(
+            withText(R.string.recent_tabs_header),
+            hasSibling(withText(R.string.recent_tabs_show_all))
+        )
+    )
 
 private fun startBrowsingButton(): UiObject {
     val startBrowsingButton = mDevice.findObject(UiSelector().resourceId("$packageName:id/finish_button"))

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
@@ -120,6 +120,8 @@ class HomeScreenRobot {
 
     fun verifyJumpBackInSectionIsDisplayed() = assertJumpBackInSectionIsDisplayed()
     fun verifyJumpBackInSectionIsNotDisplayed() = assertJumpBackInSectionIsNotDisplayed()
+    fun verifyRecentBookmarksSectionIsDisplayed() = assertRecentBookmarksSectionIsDisplayed()
+    fun verifyRecentBookmarksSectionIsNotDisplayed() = assertRecentBookmarksSectionIsNotDisplayed()
 
     // Collections elements
     fun verifyCollectionIsDisplayed(title: String, collectionExists: Boolean = true) {
@@ -593,6 +595,12 @@ private fun assertJumpBackInSectionIsDisplayed() = jumpBackInSection().check(mat
 
 private fun assertJumpBackInSectionIsNotDisplayed() = jumpBackInSection().check(doesNotExist())
 
+private fun assertRecentBookmarksSectionIsDisplayed() =
+    recentBookmarksSection().check(matches(isDisplayed()))
+
+private fun assertRecentBookmarksSectionIsNotDisplayed() =
+    recentBookmarksSection().check(doesNotExist())
+
 private fun privateBrowsingButton() = onView(withId(R.id.privateBrowsingButton))
 
 private fun saveTabsToCollectionButton() = onView(withId(R.id.add_tabs_to_collections_button))
@@ -604,6 +612,14 @@ private fun jumpBackInSection() =
         allOf(
             withText(R.string.recent_tabs_header),
             hasSibling(withText(R.string.recent_tabs_show_all))
+        )
+    )
+
+private fun recentBookmarksSection() =
+    onView(
+        allOf(
+            withText(R.string.recent_bookmarks_title),
+            hasSibling(withText(R.string.recently_saved_show_all))
         )
     )
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuHomepageRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuHomepageRobot.kt
@@ -30,6 +30,7 @@ class SettingsSubMenuHomepageRobot {
     }
 
     fun clickJumpBackInButton() = jumpBackInButton().click()
+    fun clickRecentBookmarksButton() = recentBookmarksButton().click()
     fun clickStartOnHomepageButton() = homepageButton().click()
 
     class Transition {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuHomepageRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuHomepageRobot.kt
@@ -32,6 +32,7 @@ class SettingsSubMenuHomepageRobot {
     fun clickJumpBackInButton() = jumpBackInButton().click()
     fun clickRecentBookmarksButton() = recentBookmarksButton().click()
     fun clickStartOnHomepageButton() = homepageButton().click()
+    fun clickStartOnLastTabButton() = lastTabButton().click()
 
     class Transition {
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuHomepageRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuHomepageRobot.kt
@@ -29,6 +29,7 @@ class SettingsSubMenuHomepageRobot {
         assertHomepageAfterFourHoursButton()
     }
 
+    fun clickJumpBackInButton() = jumpBackInButton().click()
     fun clickStartOnHomepageButton() = homepageButton().click()
 
     class Transition {


### PR DESCRIPTION
• `startOnHomepageTest` refactoring work - To avoid the test being duplicated, I removed the test from the `SmokeTest` class and added the `@ SmokeTest` annotation in the `SettingsBasicsTest` class

• Created a new `jumpBackInOption` UI smoke test ✅ Successfully passed 50x on Firebase

• Created a new `recentBookmarksOption` UI smoke test ✅ Successfully passed 50x on Firebase

• Created a new `startOnLastTab` UI smoke test ✅ Successfully passed 50x on Firebase

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
