### PR TITLE
For FNXV2-18419: Nimbus search term groups experiment

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuTabsRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuTabsRobot.kt
@@ -17,6 +17,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import org.hamcrest.CoreMatchers.allOf
 import org.mozilla.fenix.R
+import org.mozilla.fenix.ext.components
 
 /**
  * Implementation of Robot Pattern for the settings Tabs sub menu.
@@ -49,10 +50,14 @@ private fun assertTabViewOptions() {
         .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
     gridToggle()
         .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
-    searchTermTabGroupsToggle()
-        .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
-    searchGroupsDescription()
-        .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+    val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    if (context.components.settings.showSearchGroupsFeature) {
+        searchTermTabGroupsToggle()
+            .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+        searchGroupsDescription()
+            .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+    }
 }
 
 private fun assertCloseTabsOptions() {

--- a/app/src/debug/res/raw/initial_experiments.json
+++ b/app/src/debug/res/raw/initial_experiments.json
@@ -81,6 +81,54 @@
           "proposedEnrollment": 7,
           "userFacingDescription": "Experiment to test the home screen configurations",
           "last_modified": 1621443780172
+      },
+      {
+          "slug": "feature-search-term-groups-android",
+          "appId": "org.mozilla.fenix",
+          "appName": "fenix",
+          "channel": "nightly",
+          "branches": [
+              {
+                  "slug": "enabled",
+                  "ratio": 0,
+                  "feature": {
+                      "enabled": true,
+                      "featureId": "search-term-groups"
+                  }
+              },
+              {
+                  "slug": "disabled",
+                  "ratio": 100,
+                  "feature": {
+                      "enabled": false,
+                      "featureId": "search-term-groups"
+                  }
+              }
+          ],
+          "outcomes": [],
+          "arguments": {},
+          "probeSets": [],
+          "startDate": null,
+          "targeting": "true",
+          "featureIds": [
+              "search-term-groups"
+          ],
+          "application": "org.mozilla.firefox_beta",
+          "bucketConfig": {
+              "count": 0,
+              "start": 0,
+              "total": 10000,
+              "namespace": "nimbus-validation-2",
+              "randomizationUnit": "nimbus_id"
+          },
+          "schemaVersion": "1.5.0",
+          "userFacingName": "Search term groups test",
+          "referenceBranch": "control",
+          "proposedDuration": 14,
+          "isEnrollmentPaused": false,
+          "proposedEnrollment": 7,
+          "userFacingDescription": "Experiment to test the search term groups on tabs tray and homescreen.",
+          "last_modified": 1621443780172
       }
   ]
 }

--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -669,7 +669,7 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
             voiceSearchEnabled.set(settings.shouldShowVoiceSearch)
             openLinksInAppEnabled.set(settings.openLinksInExternalApp)
             signedInSync.set(settings.signedInFxaAccount)
-            searchTermGroupsEnabled.set(settings.searchTermTabGroupsAreEnabled)
+            searchTermGroupsEnabled.set(settings.showSearchGroupsFeature)
 
             val syncedItems = SyncEnginesStorage(applicationContext).getStatus().entries.filter {
                 it.value

--- a/app/src/main/java/org/mozilla/fenix/experiments/Experiments.kt
+++ b/app/src/main/java/org/mozilla/fenix/experiments/Experiments.kt
@@ -15,7 +15,8 @@ enum class FeatureId(val jsonName: String) {
     NIMBUS_VALIDATION("nimbus-validation"),
     ANDROID_KEYSTORE("fenix-android-keystore"),
     DEFAULT_BROWSER("fenix-default-browser"),
-    HOME_PAGE("homescreen")
+    HOME_PAGE("homescreen"),
+    SEARCH_TERM_GROUPS("search-term-groups")
 }
 
 /**

--- a/app/src/main/java/org/mozilla/fenix/experiments/NimbusFeatures.kt
+++ b/app/src/main/java/org/mozilla/fenix/experiments/NimbusFeatures.kt
@@ -6,7 +6,9 @@ package org.mozilla.fenix.experiments
 
 import android.content.Context
 import org.mozilla.experiments.nimbus.mapKeysAsEnums
+import org.mozilla.fenix.Config
 import org.mozilla.fenix.FeatureFlags
+import org.mozilla.fenix.ReleaseChannel
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.getVariables
 
@@ -20,6 +22,10 @@ class NimbusFeatures(private val context: Context) {
 
     val homeScreen: HomeScreenFeatures by lazy {
         HomeScreenFeatures(context)
+    }
+
+    val searchTermGroups: SearchTermGroupFeatures by lazy {
+        SearchTermGroupFeatures(context, false)
     }
 
     /**
@@ -114,6 +120,25 @@ class NimbusFeatures(private val context: Context) {
          */
         fun isTopSitesActive(): Boolean {
             return homeScreenFeatures[HomeScreenSection.topSites] == true
+        }
+    }
+
+    /**
+     * Component that indicates whether search term groups are active. This accompanies
+     * the `FeatureId.SEARCH_TERM_GROUPS` feature.
+     */
+    class SearchTermGroupFeatures(
+        private val context: Context,
+        val default: Boolean = false
+    ) {
+        /**
+         * Indicates if the search term groups feature is active.
+         */
+        fun isActive(): Boolean {
+            val experiments = context.components.analytics.experiments
+            val variables = experiments.getVariables(FeatureId.SEARCH_TERM_GROUPS, false)
+            return variables.getBool("enabled")
+                ?: (default || Config.channel == ReleaseChannel.Nightly)
         }
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/ext/Nimbus.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/Nimbus.kt
@@ -27,7 +27,7 @@ fun <T> NimbusApi.withExperiment(featureId: FeatureId, transform: (String?) -> T
 /**
  * The synonym for [getExperimentBranch] to complement [withExperiment(String, (String?) -> T))].
  *
- * Short-hand for ` org.mozilla.experiments.nimbus.NimbusApi.getExperimentBranch`.
+ * Short-hand for `org.mozilla.experiments.nimbus.NimbusApi.getExperimentBranch`.
  */
 @Suppress("TooGenericExceptionCaught")
 fun NimbusApi.withExperiment(featureId: FeatureId) =
@@ -49,7 +49,7 @@ fun NimbusApi.withExperiment(featureId: FeatureId) =
  *      event by calling the `sendExposureEvent` function at the time of the exposure to the
  *      feature.
  *
- * See [sendExposureEvent] for more information on manually recording the event.
+ * See [recordExposureEvent] for more information on manually recording the event.
  *
  * @return a [Variables] object used to configure the feature.
  */
@@ -103,7 +103,7 @@ fun <T> NimbusApi.withVariables(featureId: FeatureId, sendExposureEvent: Boolean
  * This function is safe to call even when there is no active experiment for the feature. The SDK
  * will ensure that an event is only recorded for active experiments.
  *
- *  @param featureId string representing the id of the feature for which to record the exposure
+ * @param featureId string representing the id of the feature for which to record the exposure
  *     event.
  */
 fun NimbusApi.recordExposureEvent(featureId: FeatureId) =

--- a/app/src/main/java/org/mozilla/fenix/home/recenttabs/view/RecentTabViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recenttabs/view/RecentTabViewHolder.kt
@@ -9,6 +9,9 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import mozilla.components.lib.state.ext.observeAsComposableState
 import org.mozilla.fenix.R
+import org.mozilla.fenix.components.components
+import org.mozilla.fenix.experiments.FeatureId
+import org.mozilla.fenix.ext.recordExposureEvent
 import org.mozilla.fenix.home.HomeFragmentStore
 import org.mozilla.fenix.home.recenttabs.interactor.RecentTabInteractor
 import org.mozilla.fenix.theme.FirefoxTheme
@@ -36,6 +39,10 @@ class RecentTabViewHolder(
         )
         composeView.setContent {
             val recentTabs = store.observeAsComposableState { state -> state.recentTabs }
+
+            if (!recentTabs.value.isNullOrEmpty()) {
+                components.analytics.experiments.recordExposureEvent(FeatureId.SEARCH_TERM_GROUPS)
+            }
 
             FirefoxTheme {
                 RecentTabs(

--- a/app/src/main/java/org/mozilla/fenix/home/recenttabs/view/RecentTabs.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recenttabs/view/RecentTabs.kt
@@ -82,7 +82,7 @@ fun RecentTabs(
                     )
                 }
                 is RecentTab.SearchGroup -> {
-                    if (components.settings.searchTermTabGroupsAreEnabled) {
+                    if (components.settings.showSearchGroupsFeature) {
                         RecentSearchGroupItem(
                             searchTerm = tab.searchTerm,
                             tabId = tab.tabId,

--- a/app/src/main/java/org/mozilla/fenix/settings/TabsSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/TabsSettingsFragment.kt
@@ -19,8 +19,10 @@ import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.components.metrics.Event.TabViewSettingChanged
 import org.mozilla.fenix.components.metrics.Event.TabViewSettingChanged.Type
 import org.mozilla.fenix.databinding.SurveyInactiveTabsDisableBinding
+import org.mozilla.fenix.experiments.FeatureId
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.metrics
+import org.mozilla.fenix.ext.recordExposureEvent
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.showToolbar
 import org.mozilla.fenix.utils.view.addToRadioGroup
@@ -69,9 +71,15 @@ class TabsSettingsFragment : PreferenceFragmentCompat() {
         listRadioButton = requirePreference(R.string.pref_key_tab_view_list_do_not_use)
         gridRadioButton = requirePreference(R.string.pref_key_tab_view_grid)
         searchTermTabGroups = requirePreference<SwitchPreference>(R.string.pref_key_search_term_tab_groups).also {
-            it.isVisible = FeatureFlags.tabGroupFeature
-            it.isChecked = it.context.settings().searchTermTabGroupsAreEnabled
+            it.isVisible = it.context.settings().showSearchGroupsFeature
+            it.isChecked = it.context.settings().showSearchGroupsFeature
             it.onPreferenceChangeListener = SharedPreferenceUpdater()
+
+            if (it.context.settings().showSearchGroupsFeature) {
+                requireContext().components.analytics.experiments.recordExposureEvent(
+                    FeatureId.SEARCH_TERM_GROUPS
+                )
+            }
         }
 
         radioManual = requirePreference(R.string.pref_key_close_tabs_manually)

--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
@@ -39,8 +39,10 @@ import org.mozilla.fenix.databinding.ComponentTabstrayFabBinding
 import org.mozilla.fenix.databinding.FragmentTabTrayDialogBinding
 import org.mozilla.fenix.databinding.TabsTrayTabCounter2Binding
 import org.mozilla.fenix.databinding.TabstrayMultiselectItemsBinding
+import org.mozilla.fenix.experiments.FeatureId
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.metrics
+import org.mozilla.fenix.ext.recordExposureEvent
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.home.HomeScreenViewModel
@@ -357,6 +359,12 @@ class TabsTrayFragment : AppCompatDialogFragment() {
 
         setFragmentResultListener(ShareFragment.RESULT_KEY) { _, _ ->
             dismissTabsTray()
+        }
+
+        if (requireComponents.settings.showSearchGroupsFeature) {
+            requireContext().components.analytics.experiments.recordExposureEvent(
+                FeatureId.SEARCH_TERM_GROUPS
+            )
         }
     }
 

--- a/app/src/main/java/org/mozilla/fenix/tabstray/browser/TabGroupViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/browser/TabGroupViewHolder.kt
@@ -35,9 +35,7 @@ class TabGroupViewHolder(
 
     private lateinit var groupListAdapter: TabGroupListAdapter
 
-    fun bind(
-        group: TabGroup,
-    ) {
+    fun bind(group: TabGroup) {
         val selectedTabId = itemView.context.components.core.store.state.selectedTabId
         val selectedIndex = group.tabs.indexOfFirst { it.id == selectedTabId }
 

--- a/app/src/main/java/org/mozilla/fenix/tabstray/browser/TabSorter.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/browser/TabSorter.kt
@@ -68,7 +68,7 @@ private fun List<TabSessionState>.getInactiveTabs(settings: Settings): List<TabS
  */
 private fun List<TabSessionState>.getSearchGroupTabs(settings: Settings): List<TabSessionState> {
     val inactiveTabsEnabled = settings.inactiveTabsAreEnabled
-    val tabGroupsEnabled = settings.searchTermTabGroupsAreEnabled
+    val tabGroupsEnabled = settings.showSearchGroupsFeature
     return when {
         tabGroupsEnabled && inactiveTabsEnabled ->
             filter { it.isNormalTabActiveWithSearchTerm(maxActiveTime) }

--- a/app/src/main/java/org/mozilla/fenix/tabstray/viewholders/NormalBrowserPageViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/viewholders/NormalBrowserPageViewHolder.kt
@@ -82,7 +82,7 @@ class NormalBrowserPageViewHolder(
         val inactiveTabAdapter = concatAdapter.inactiveTabsAdapter
         val tabGroupAdapter = concatAdapter.tabGroupAdapter
         val inactiveTabsAreEnabled = containerView.context.settings().inactiveTabsAreEnabled
-        val searchTermTabGroupsAreEnabled = containerView.context.settings().searchTermTabGroupsAreEnabled
+        val searchTermTabGroupsAreEnabled = containerView.context.settings().showSearchGroupsFeature
 
         val selectedTab = browserStore.state.selectedNormalTab ?: return
         // It's safe to read the state directly (i.e. won't cause bugs because of the store actions

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -426,11 +426,12 @@ class Settings(private val appContext: Context) : PreferencesHolder {
     )
 
     /**
-     * Indicates if the user has enabled the search term tab groups feature.
+     * Whether we should show search term groups in the tabs tray, homescreen, and
+     * settings.
      */
-    var searchTermTabGroupsAreEnabled by featureFlagPreference(
-        appContext.getPreferenceKey(R.string.pref_key_search_term_tab_groups),
-        default = FeatureFlags.tabGroupFeature,
+    var showSearchGroupsFeature by lazyFeatureFlagPreference(
+        appContext.getPreferenceKey(R.string.pref_key_history_metadata_feature),
+        default = { appContext.components.analytics.features.searchTermGroups.isActive() },
         featureFlag = FeatureFlags.tabGroupFeature
     )
 

--- a/app/src/test/java/org/mozilla/fenix/FenixApplicationTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/FenixApplicationTest.kt
@@ -138,7 +138,7 @@ class FenixApplicationTest {
         every { settings.historyMetadataUIFeature } returns true
         every { settings.showPocketRecommendationsFeature } returns true
         every { settings.showPocketRecommendationsFeature } returns true
-        every { settings.searchTermTabGroupsAreEnabled } returns true
+        every { settings.showSearchGroupsFeature } returns true
         every { application.reportHomeScreenMetrics(settings) } just Runs
         every { settings.inactiveTabsAreEnabled } returns true
 

--- a/app/src/test/java/org/mozilla/fenix/tabstray/browser/TabSorterTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/browser/TabSorterTest.kt
@@ -22,7 +22,7 @@ class TabSorterTest {
     @Before
     fun setUp() {
         every { settings.inactiveTabsAreEnabled }.answers { true }
-        every { settings.searchTermTabGroupsAreEnabled }.answers { true }
+        every { settings.showSearchGroupsFeature }.answers { true }
     }
 
     @Test
@@ -148,7 +148,7 @@ class TabSorterTest {
 
     @Test
     fun `WHEN search term tabs is off THEN adapter have no search term group`() {
-        every { settings.searchTermTabGroupsAreEnabled }.answers { false }
+        every { settings.showSearchGroupsFeature }.answers { false }
         val tabSorter = TabSorter(settings, tabsTrayStore)
 
         tabSorter.updateTabs(
@@ -186,7 +186,7 @@ class TabSorterTest {
     @Test
     fun `WHEN both inactive tabs and search term tabs are off THEN adapter have only normal tabs`() {
         every { settings.inactiveTabsAreEnabled }.answers { false }
-        every { settings.searchTermTabGroupsAreEnabled }.answers { false }
+        every { settings.showSearchGroupsFeature }.answers { false }
         val tabSorter = TabSorter(settings, tabsTrayStore)
 
         tabSorter.updateTabs(


### PR DESCRIPTION
For [FNXV2-18419](https://mozilla-hub.atlassian.net/browse/FNXV2-18419)

Creates a branch to control search term groups on home (jump back in), the tabs tray, and the setting (Settings -> Tabs -> "Search groups" toggle), and records exposure events for each.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
