### PR TITLE
Prevent default browser marketing from waking user

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/onboarding/DefaultBrowserNotificationWorker.kt
+++ b/app/src/main/java/org/mozilla/fenix/onboarding/DefaultBrowserNotificationWorker.kt
@@ -90,7 +90,7 @@ class DefaultBrowserNotificationWorker(
             val channel = NotificationChannel(
                 NOTIFICATION_CHANNEL_ID,
                 applicationContext.getString(R.string.notification_marketing_channel_name),
-                NotificationManager.IMPORTANCE_DEFAULT
+                NotificationManager.IMPORTANCE_LOW
             )
 
             notificationManager.createNotificationChannel(channel)


### PR DESCRIPTION
This will fix #20887.

`IMPORTANCE_DEFAULT` is documented to make an audible alert, and without any logic in here to restrict the time of day at which the notification is sent, that's not reasonable behavior. The audible alert has been observed in the wild to wake up users in the middle of the night and annoy them (see #20887).

This sets `IMPORTANCE_LOW` instead, which is as close as you can get to `IMPORTANCE_DEFAULT` without making sound. This should make sure the marketing message is more well-received.

I don't think this sort of configuration setting is really testable in the current test suite. There doesn't seem to be a test for the existing value.

No screenshot is needed because the rendered notification is the responsibility of the OS. Similarly, there's nothing here to scan for accessibility.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
