### PR TITLE
Refactoring and coverage improvements for tabs tray UI tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsPrivacyTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsPrivacyTest.kt
@@ -480,7 +480,7 @@ class SettingsPrivacyTest {
         }.goBack {
         }.goBack {
         }.openTabDrawer {
-            verifyNoTabsOpened()
+            verifyNoOpenTabsInNormalBrowsing()
         }
     }
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -984,20 +984,16 @@ class SmokeTest {
 
     @Test
     fun emptyTabsTrayViewPrivateBrowsingTest() {
-        homeScreen {
-        }.dismissOnboarding()
-
-        homeScreen {
-        }.openTabDrawer {
+        navigationToolbar {
+        }.openTabTray {
         }.toggleToPrivateTabs() {
-            verifyPrivateModeSelected()
-            verifyNormalBrowsingButtonIsDisplayed()
-            verifyNoTabsOpened()
+            verifyNormalBrowsingButtonIsSelected(false)
+            verifyPrivateBrowsingButtonIsSelected(true)
+            verifySyncedTabsButtonIsSelected(false)
+            verifyNoOpenTabsInPrivateBrowsing()
+            verifyPrivateBrowsingNewTabButton()
             verifyTabTrayOverflowMenu(true)
-            verifyNewTabButton()
-        }.openTabsListThreeDotMenu {
-            verifyTabSettingsButton()
-            verifyRecentlyClosedTabsButton()
+            verifyEmptyTabsTrayMenuButtons()
         }
     }
 
@@ -1020,7 +1016,7 @@ class SmokeTest {
             verifyCloseTabsButton("Test_Page_1")
             verifyOpenedTabThumbnail()
             verifyTabTrayOverflowMenu(true)
-            verifyNewTabButton()
+            verifyPrivateBrowsingNewTabButton()
         }
     }
 
@@ -1128,7 +1124,7 @@ class SmokeTest {
         }.openTabCrashReporter {
         }.clickTabCrashedCloseButton {
         }.openTabDrawer {
-            verifyNoTabsOpened()
+            verifyNoOpenTabsInNormalBrowsing()
         }
     }
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -1009,14 +1009,19 @@ class SmokeTest {
         }.enterURLAndEnterToBrowser(website.url) {
             mDevice.waitForIdle()
         }.openTabDrawer {
-            verifyPrivateModeSelected()
-            verifyNormalBrowsingButtonIsDisplayed()
-            verifyExistingTabList()
-            verifyExistingOpenTabs("Test_Page_1")
-            verifyCloseTabsButton("Test_Page_1")
-            verifyOpenedTabThumbnail()
+            verifyNormalBrowsingButtonIsSelected(false)
+            verifyPrivateBrowsingButtonIsSelected(true)
+            verifySyncedTabsButtonIsSelected(false)
             verifyTabTrayOverflowMenu(true)
+            verifyTabsTrayCounter()
+            verifyExistingTabList()
+            verifyExistingOpenTabs(website.title)
+            verifyCloseTabsButton(website.title)
+            verifyOpenedTabThumbnail()
             verifyPrivateBrowsingNewTabButton()
+        }.openTab(website.title) {
+            verifyUrl(website.url.toString())
+            verifyTabCounter("1")
         }
     }
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
@@ -315,14 +315,19 @@ class TabbedBrowsingTest {
         navigationToolbar {
         }.enterURLAndEnterToBrowser(defaultWebPage.url) {
         }.openTabDrawer {
+            verifyNormalBrowsingButtonIsSelected(true)
+            verifyPrivateBrowsingButtonIsSelected(false)
+            verifySyncedTabsButtonIsSelected(false)
+            verifyTabTrayOverflowMenu(true)
+            verifyTabsTrayCounter()
             verifyExistingTabList()
             verifyNormalBrowsingNewTabButton()
-            verifyTabTrayOverflowMenu(true)
+            verifyOpenedTabThumbnail()
             verifyExistingOpenTabs(defaultWebPage.title)
             verifyCloseTabsButton(defaultWebPage.title)
-        }.openNewTab {
-            verifySearchBarEmpty()
-            verifyKeyboardVisibility()
+        }.openTab(defaultWebPage.title) {
+            verifyUrl(defaultWebPage.url.toString())
+            verifyTabCounter("1")
         }
     }
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
@@ -77,7 +77,7 @@ class TabbedBrowsingTest {
             verifyExistingOpenTabs("Test_Page_1")
             closeTab()
         }.openTabDrawer {
-            verifyNoTabsOpened()
+            verifyNoOpenTabsInNormalBrowsing()
         }.openNewTab {
         }.submitQuery(defaultWebPage.url.toString()) {
             mDevice.waitForIdle()
@@ -102,7 +102,7 @@ class TabbedBrowsingTest {
             verifyExistingTabList()
             verifyPrivateModeSelected()
         }.toggleToNormalTabs {
-            verifyNoTabsOpened()
+            verifyNoOpenTabsInNormalBrowsing()
         }.toggleToPrivateTabs {
             verifyExistingTabList()
         }
@@ -275,7 +275,7 @@ class TabbedBrowsingTest {
 
         navigationToolbar {
         }.openTabTray {
-            verifyNoTabsOpened()
+            verifyNoOpenTabsInNormalBrowsing()
             // With no tabs opened the state should be STATE_COLLAPSED.
             verifyBehaviorState(BottomSheetBehavior.STATE_COLLAPSED)
             // Need to ensure the halfExpandedRatio is very small so that when in STATE_HALF_EXPANDED
@@ -301,16 +301,10 @@ class TabbedBrowsingTest {
             verifyNormalBrowsingButtonIsSelected(true)
             verifyPrivateBrowsingButtonIsSelected(false)
             verifySyncedTabsButtonIsSelected(false)
-            verifyNoTabsOpened()
-            verifyNewTabButton()
+            verifyNoOpenTabsInNormalBrowsing()
+            verifyNormalBrowsingNewTabButton()
             verifyTabTrayOverflowMenu(true)
-        }.toggleToPrivateTabs {
-            verifyNormalBrowsingButtonIsSelected(false)
-            verifyPrivateBrowsingButtonIsSelected(true)
-            verifySyncedTabsButtonIsSelected(false)
-            verifyNoTabsOpened()
-            verifyNewTabButton()
-            verifyTabTrayOverflowMenu(true)
+            verifyEmptyTabsTrayMenuButtons()
         }
     }
 
@@ -322,7 +316,7 @@ class TabbedBrowsingTest {
         }.enterURLAndEnterToBrowser(defaultWebPage.url) {
         }.openTabDrawer {
             verifyExistingTabList()
-            verifyNewTabButton()
+            verifyNormalBrowsingNewTabButton()
             verifyTabTrayOverflowMenu(true)
             verifyExistingOpenTabs(defaultWebPage.title)
             verifyCloseTabsButton(defaultWebPage.title)

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/TabDrawerRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/TabDrawerRobot.kt
@@ -19,6 +19,7 @@ import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.longClick
 import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.RootMatchers
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
@@ -78,10 +79,13 @@ class TabDrawerRobot {
 
     fun verifyExistingTabList() = assertExistingTabList()
 
-    fun verifyNoTabsOpened() = assertNoTabsOpenedText()
+    fun verifyNoOpenTabsInNormalBrowsing() = assertNoOpenTabsInNormalBrowsing()
+    fun verifyNoOpenTabsInPrivateBrowsing() = assertNoOpenTabsInPrivateBrowsing()
     fun verifyPrivateModeSelected() = assertPrivateModeSelected()
     fun verifyNormalModeSelected() = assertNormalModeSelected()
-    fun verifyNewTabButton() = assertNewTabButton()
+    fun verifyNormalBrowsingNewTabButton() = assertNormalBrowsingNewTabButton()
+    fun verifyPrivateBrowsingNewTabButton() = assertPrivateBrowsingNewTabButton()
+    fun verifyEmptyTabsTrayMenuButtons() = assertEmptyTabsTrayMenuButtons()
     fun verifySelectTabsButton() = assertSelectTabsButton()
     fun verifyTabTrayOverflowMenu(visibility: Boolean) = assertTabTrayOverflowButton(visibility)
 
@@ -502,13 +506,37 @@ private fun assertExistingTabList() {
     )
 }
 
-private fun assertNoTabsOpenedText() =
-    onView(withId(R.id.tab_tray_empty_view))
-        .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+private fun assertNoOpenTabsInNormalBrowsing() =
+    onView(
+        allOf(
+            withId(R.id.tab_tray_empty_view),
+            withText(R.string.no_open_tabs_description)
+        )
+    ).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
-private fun assertNewTabButton() =
-    onView(withId(R.id.new_tab_button))
-        .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+private fun assertNoOpenTabsInPrivateBrowsing() =
+    onView(
+        allOf(
+            withId(R.id.tab_tray_empty_view),
+            withText(R.string.no_private_tabs_description)
+        )
+    ).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+
+private fun assertNormalBrowsingNewTabButton() =
+    onView(
+        allOf(
+            withId(R.id.new_tab_button),
+            withContentDescription(R.string.add_tab)
+        )
+    ).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+
+private fun assertPrivateBrowsingNewTabButton() =
+    onView(
+        allOf(
+            withId(R.id.new_tab_button),
+            withContentDescription(R.string.add_private_tab)
+        )
+    ).check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
 private fun assertSelectTabsButton() =
     onView(withText("Select tabs"))
@@ -525,6 +553,16 @@ private fun assertPrivateModeSelected() =
 private fun assertTabTrayOverflowButton(visible: Boolean) =
     onView(withId(R.id.tab_tray_overflow))
         .check(matches(withEffectiveVisibility(visibleOrGone(visible))))
+
+private fun assertEmptyTabsTrayMenuButtons() {
+    threeDotMenu().click()
+    tabsSettingsButton()
+        .inRoot(RootMatchers.isPlatformPopup())
+        .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+    recentlyClosedTabsButton()
+        .inRoot(RootMatchers.isPlatformPopup())
+        .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+}
 
 private fun assertTabTrayDoesExist() {
     onView(withId(R.id.tab_wrapper))
@@ -579,6 +617,22 @@ private fun tab(title: String) =
     )
 
 private fun tabsCounter() = onView(withId(R.id.tab_button))
+
+private fun tabsSettingsButton() =
+    onView(
+        allOf(
+            withId(R.id.simple_text),
+            withText(R.string.tab_tray_menu_tab_settings)
+        )
+    )
+
+private fun recentlyClosedTabsButton() =
+    onView(
+        allOf(
+            withId(R.id.simple_text),
+            withText(R.string.tab_tray_menu_recently_closed)
+        )
+    )
 
 private fun visibleOrGone(visibility: Boolean) =
     if (visibility) ViewMatchers.Visibility.VISIBLE else ViewMatchers.Visibility.GONE

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/TabDrawerRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/TabDrawerRobot.kt
@@ -88,6 +88,7 @@ class TabDrawerRobot {
     fun verifyEmptyTabsTrayMenuButtons() = assertEmptyTabsTrayMenuButtons()
     fun verifySelectTabsButton() = assertSelectTabsButton()
     fun verifyTabTrayOverflowMenu(visibility: Boolean) = assertTabTrayOverflowButton(visibility)
+    fun verifyTabsTrayCounter() = assertTabsTrayCounter()
 
     fun verifyTabTrayIsOpened() = assertTabTrayDoesExist()
     fun verifyTabTrayIsClosed() = assertTabTrayDoesNotExist()
@@ -554,6 +555,9 @@ private fun assertTabTrayOverflowButton(visible: Boolean) =
     onView(withId(R.id.tab_tray_overflow))
         .check(matches(withEffectiveVisibility(visibleOrGone(visible))))
 
+private fun assertTabsTrayCounter() =
+    tabsTrayCounterBox().check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+
 private fun assertEmptyTabsTrayMenuButtons() {
     threeDotMenu().click()
     tabsSettingsButton()
@@ -617,6 +621,8 @@ private fun tab(title: String) =
     )
 
 private fun tabsCounter() = onView(withId(R.id.tab_button))
+
+private fun tabsTrayCounterBox() = onView(withId(R.id.counter_box))
 
 private fun tabsSettingsButton() =
     onView(

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuMainRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuMainRobot.kt
@@ -44,8 +44,6 @@ import org.mozilla.fenix.share.ShareFragment
  */
 @Suppress("ForbiddenComment")
 class ThreeDotMenuMainRobot {
-    fun verifyTabSettingsButton() = assertTabSettingsButton()
-    fun verifyRecentlyClosedTabsButton() = assertRecentlyClosedTabsButton()
     fun verifyShareAllTabsButton() = assertShareAllTabsButton()
     fun clickShareAllTabsButton() = shareAllTabsButton().click()
     fun verifySettingsButton() = assertSettingsButton()
@@ -88,7 +86,7 @@ class ThreeDotMenuMainRobot {
     fun verifyDownloadsButton() = assertDownloadsButton()
     fun verifyShareTabsOverlay() = assertShareTabsOverlay()
     fun verifySignInToSyncButton() = assertSignInToSyncButton()
-    fun verifyNewTabButton() = assertNewTabButton()
+    fun verifyNewTabButton() = assertNormalBrowsingNewTabButton()
     fun verifyReportSiteIssueButton() = assertReportSiteIssueButton()
 
     fun verifyDesktopSiteModeEnabled(state: Boolean) {
@@ -555,26 +553,6 @@ private fun clickAddonsManagerButton() {
     addOnsButton().check(matches(isCompletelyDisplayed())).click()
 }
 
-private fun tabSettingsButton() =
-    onView(allOf(withText("Tab settings"))).inRoot(RootMatchers.isPlatformPopup())
-
-private fun assertTabSettingsButton() {
-    tabSettingsButton()
-        .check(
-            matches(isDisplayed())
-        )
-}
-
-private fun recentlyClosedTabsButton() =
-    onView(allOf(withText("Recently closed tabs"))).inRoot(RootMatchers.isPlatformPopup())
-
-private fun assertRecentlyClosedTabsButton() {
-    recentlyClosedTabsButton()
-        .check(
-            matches(isDisplayed())
-        )
-}
-
 private fun shareAllTabsButton() =
     onView(allOf(withText("Share all tabs"))).inRoot(RootMatchers.isPlatformPopup())
 
@@ -585,4 +563,4 @@ private fun assertShareAllTabsButton() {
         )
 }
 
-private fun assertNewTabButton() = onView(withText("New tab")).check(matches(isDisplayed()))
+private fun assertNormalBrowsingNewTabButton() = onView(withText("New tab")).check(matches(isDisplayed()))


### PR DESCRIPTION
• Refactor and improve coverage for `verifyEmptyTabTray` & `emptyTabsTrayViewPrivateBrowsingTest` UI tests

✅ Successfully passed 50x on Firebase

<details>

<summary> 📈 Results (dropdown)</summary>

matrix | result | logs | details
-- | -- | -- | --
matrix-1f4k3xii0w1tc | success | logs | 2 test cases passed
matrix-24v5kg7ephk0h | success | logs | 2 test cases passed
matrix-2daed1jj4musb | success | logs | 2 test cases passed
matrix-2bxkyxwbgnsdg | success | logs | 2 test cases passed
matrix-2ganhf5qe68gb | success | logs | 2 test cases passed
matrix-gleufaiv23aha | success | logs | 2 test cases passed
matrix-2x6crqk7ylm30 | success | logs | 2 test cases passed
matrix-2vthq5uothdiv | success | logs | 2 test cases passed
matrix-3v0chykp402za | success | logs | 2 test cases passed
matrix-1yjo4pochaf4l | success | logs | 2 test cases passed
matrix-2q9nycl95pvzq | success | logs | 2 test cases passed
matrix-3o5laajsa9zwa | success | logs | 2 test cases passed
matrix-l9pijmdwa2wla | success | logs | 2 test cases passed
matrix-vfgok0enc0tqa | success | logs | 2 test cases passed
matrix-24455jngdy9x5 | success | logs | 2 test cases passed
matrix-3ttdx6ntf12vg | success | logs | 2 test cases passed
matrix-3c1037fno937a | success | logs | 2 test cases passed
matrix-1tzh7jqzottof | success | logs | 2 test cases passed
matrix-3bwf2ufzz972x | success | logs | 2 test cases passed
matrix-355xq4w8mxy9m | success | logs | 2 test cases passed
matrix-pdzby2byy63ga | success | logs | 2 test cases passed
matrix-14ptbk5hmsv7r | success | logs | 2 test cases passed
matrix-whcwvo5xmkcfa | success | logs | 2 test cases passed
matrix-2qewcxhc3bm4n | success | logs | 2 test cases passed
matrix-10bbwj19e57u1 | success | logs | 2 test cases passed
matrix-2h0p1l6gbby8z | success | logs | 2 test cases passed
matrix-3sthsdz00ju6v | success | logs | 2 test cases passed
matrix-1lklhccxfohqh | success | logs | 2 test cases passed
matrix-2m6efpg6ws9lz | success | logs | 2 test cases passed
matrix-vb3w68jwc9bta | success | logs | 2 test cases passed
matrix-2wm1tca7667pr | success | logs | 2 test cases passed
matrix-uq637ycsfgjda | success | logs | 2 test cases passed
matrix-20v7gh9fyvmsa | success | logs | 2 test cases passed
matrix-sek5rs685e77a | success | logs | 2 test cases passed
matrix-4p3rmbc3a4eba | success | logs | 2 test cases passed
matrix-3qt3bicujg5nx | success | logs | 2 test cases passed
matrix-3nj8xoy8ap8f5 | success | logs | 2 test cases passed
matrix-7j6dticsfbuta | success | logs | 2 test cases passed
matrix-ob2ebncq2cava | success | logs | 2 test cases passed
matrix-2j0k9kk94zb0n | success | logs | 2 test cases passed
matrix-hlsbzvlyq5y9a | success | logs | 2 test cases passed
matrix-pxif86o463x1a | success | logs | 2 test cases passed
matrix-2lbubd6p5atxo | success | logs | 2 test cases passed
matrix-2hopar8kryg4b | success | logs | 2 test cases passed
matrix-2douww2crtqog | success | logs | 2 test cases passed
matrix-20yhcg72huw64 | success | logs | 2 test cases passed
matrix-1sc6lutca11iy | success | logs | 2 test cases passed
matrix-2hehbbsvj5gq0 | success | logs | 2 test cases passed
matrix-35u14rwdxyemx | success | logs | 2 test cases passed
matrix-2qa5aij8nzs9s | success | logs | 2 test cases passed

</details>


• Improve `verifyOpenTabDetails` and `privateTabsTrayWithOpenedTabTest` UI test coverage

✅  Both successfully passed 50x on Firebase

<details>

<summary> 📈 Results (dropdown)</summary>

matrix | result | logs | details
-- | -- | -- | --
matrix-33f6z5006qg4q | success | logs | 2 test cases passed
matrix-2tjz6i9834cji | success | logs | 2 test cases passed
matrix-2g2d9szkhh1s0 | success | logs | 2 test cases passed
matrix-995i5zyfhk6ea | success | logs | 2 test cases passed
matrix-3e5o9p2fmjcp8 | success | logs | 2 test cases passed
matrix-3ijv5xxt4195a | success | logs | 2 test cases passed
matrix-18lld04yhiks1 | success | logs | 2 test cases passed
matrix-2t17a49wu3wtu | success | logs | 2 test cases passed
matrix-2sm7yzksevpjk | success | logs | 2 test cases passed
matrix-19dt27hofncma | success | logs | 2 test cases passed
matrix-rpsr65f0z8caa | success | logs | 2 test cases passed
matrix-3ngh5a3usrh0o | success | logs | 2 test cases passed
matrix-1qfarbyhi5jvl | success | logs | 2 test cases passed
matrix-3tt0sstnd6346 | success | logs | 2 test cases passed
matrix-29yg0f0f81ywv | success | logs | 2 test cases passed
matrix-2111r1qh7ma1v | success | logs | 2 test cases passed
matrix-3d0hj8q7o8mrl | success | logs | 2 test cases passed
matrix-1zhx5885gpqlh | success | logs | 2 test cases passed
matrix-3on3i3e5ji6fh | success | logs | 2 test cases passed
matrix-4u3gv8iocrgta | success | logs | 2 test cases passed
matrix-1na1aysp2tcut | success | logs | 2 test cases passed
matrix-15sv7v66sg89e | success | logs | 2 test cases passed
matrix-3s90mvhsz2c76 | success | logs | 2 test cases passed
matrix-289fwo6lx6m0x | success | logs | 2 test cases passed
matrix-3fg0hd3q6rde1 | success | logs | 2 test cases passed
matrix-1cztgxchz2g91 | success | logs | 2 test cases passed
matrix-2rk1xy8hkcibl | success | logs | 2 test cases passed
matrix-149td2u029jl0 | success | logs | 2 test cases passed
matrix-2c6qqw5m9bvoc | success | logs | 2 test cases passed
matrix-ewmzii7t8j2qa | success | logs | 2 test cases passed
matrix-247oyf1mncudo | success | logs | 2 test cases passed
matrix-3fj89xo7883jv | success | logs | 2 test cases passed
matrix-1c0cdrkkko272 | success | logs | 2 test cases passed
matrix-1a06gb25lh54o | success | logs | 2 test cases passed
matrix-22388wmjigigs | success | logs | 2 test cases passed
matrix-3lx2rgt8xd8ik | success | logs | 2 test cases passed
matrix-1nd4wnzzwkhno | success | logs | 2 test cases passed
matrix-ocd9pdcxbejca | success | logs | 2 test cases passed
matrix-1zydad7wpbxps | success | logs | 2 test cases passed
matrix-779an1ep653ha | success | logs | 2 test cases passed
matrix-3ozdgswxwl7sx | success | logs | 2 test cases passed
matrix-9ny8hi4wtusfa | success | logs | 2 test cases passed
matrix-1pw1ufuldl891 | success | logs | 2 test cases passed
matrix-2eveiaf12g6r5 | success | logs | 2 test cases passed
matrix-1n9t9uepbshj2 | success | logs | 2 test cases passed
matrix-2c4ap2xlvxtsi | success | logs | 2 test cases passed
matrix-193hrj86prahz | success | logs | 2 test cases passed
matrix-1yap1kt6p9sth | success | logs | 2 test cases passed
matrix-1fw26z8vmc9h2 | success | logs | 2 test cases passed
matrix-3noom8wcitdvi | success | logs | 2 test cases passed

</details>

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
