### PR TITLE
Add distribution_id into first session ping

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -4370,6 +4370,23 @@ first_session:
       - android-probes@mozilla.com
       - erichards@mozilla.com
     expires: never
+  distribution_id:
+    type: string
+    description: |
+      A string containing the distribution identifier. This is currently used
+      to identify installs from Mozilla Online.
+    send_in_pings:
+      - first-session
+    bugs:
+      - https://github.com/mozilla-mobile/fenix/issues/20376
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/22543#issuecomment-977456848
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - android-probes@mozilla.com
+      - rxu@mozilla.com
+    expires: never
   timestamp:
     send_in_pings:
       - first-session

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/FirstSessionPing.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/FirstSessionPing.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import mozilla.components.support.base.log.logger.Logger
+import org.mozilla.fenix.Config
 import org.mozilla.fenix.GleanMetrics.FirstSession
 import org.mozilla.fenix.GleanMetrics.Pings
 import org.mozilla.fenix.ext.settings
@@ -60,6 +61,12 @@ class FirstSessionPing(private val context: Context) {
                 FirstSession.adgroup.set(it.adjustAdGroup)
                 FirstSession.creative.set(it.adjustCreative)
                 FirstSession.network.set(it.adjustNetwork)
+                FirstSession.distributionId.set(
+                    when (Config.channel.isMozillaOnline) {
+                        true -> "MozillaOnline"
+                        false -> "Mozilla"
+                    }
+                )
                 FirstSession.timestamp.set()
             }
 


### PR DESCRIPTION
_distribution_id_ have already been added to metrics ping (#16075)
We also want to add this field to other pings for convenience and reference.
This PR tries to add distribution_id to the first session ping.