### PR TITLE
For #22495 - Disable inactive tabs survey

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -872,7 +872,7 @@ class Settings(private val appContext: Context) : PreferencesHolder {
      */
     var shouldShowInactiveTabsTurnOffSurvey by booleanPreference(
         appContext.getPreferenceKey(R.string.pref_key_should_show_inactive_tabs_turn_off_survey),
-        default = true
+        default = false
     )
 
     fun getSitePermissionsPhoneFeatureAction(


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
Once we've collected enough data, we should turn off the inactive tabs survey, so that users aren't spending time filling out a survey that we don't need them to

Issue : https://github.com/mozilla-mobile/fenix/issues/22495
- [ ] **Tests**: This PR does not include tests since a small UI feature was supposed to be removed
- [ ] **Screenshots**: This PR does not include screenshots since nothing new added
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
