### PR TITLE
[UI Smoke Tests] New undoDeleteBookmarkFolderTest UI test and Improve coverage for deleteNonEmptyBookmarkFolderTest UI test

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
@@ -627,4 +627,30 @@ class BookmarksTest {
             verifyBookmarkIsDeleted("Test_Page_1")
         }
     }
+
+    @SmokeTest
+    @Test
+    fun undoDeleteBookmarkFolderTest() {
+
+        browserScreen {
+        }.openThreeDotMenu {
+        }.openBookmarks {
+            bookmarksListIdlingResource =
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 1)
+            IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
+            createFolder("My Folder")
+            verifyFolderTitle("My Folder")
+            IdlingRegistry.getInstance().unregister(bookmarksListIdlingResource!!)
+        }.openThreeDotMenu("My Folder") {
+        }.clickDelete {
+            cancelFolderDeletion()
+            verifyFolderTitle("My Folder")
+        }.openThreeDotMenu("My Folder") {
+        }.clickDelete {
+            confirmDeletion()
+            verifyDeleteSnackBarText()
+            clickUndoDeleteButton()
+            verifyFolderTitle("My Folder")
+        }
+    }
 }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -950,6 +950,18 @@ class SmokeTest {
             selectFolder("My Folder")
             navigateUp()
             saveEditBookmark()
+            createFolder("My Folder 2")
+            bookmarksListIdlingResource =
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 1)
+            IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
+            verifyFolderTitle("My Folder 2")
+            IdlingRegistry.getInstance().unregister(bookmarksListIdlingResource!!)
+        }.openThreeDotMenu("My Folder 2") {
+        }.clickEdit {
+            clickParentFolderSelector()
+            selectFolder("My Folder")
+            navigateUp()
+            saveEditBookmark()
         }.openThreeDotMenu("My Folder") {
         }.clickDelete {
             cancelFolderDeletion()
@@ -958,12 +970,15 @@ class SmokeTest {
         }.clickDelete {
             confirmDeletion()
             verifyDeleteSnackBarText()
+            verifyBookmarkIsDeleted("My Folder")
+            verifyBookmarkIsDeleted("My Folder 2")
+            verifyBookmarkIsDeleted("Test_Page_1")
             navigateUp()
         }
 
         browserScreen {
         }.openThreeDotMenu {
-            verifyBookmarksButton()
+            verifyAddBookmarkButton()
         }
     }
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BookmarksRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BookmarksRobot.kt
@@ -369,6 +369,7 @@ private fun assertBookmarkIsDeleted(expectedTitle: String) {
     assertFalse(
         mDevice.findObject(
             UiSelector()
+                .resourceId("$packageName:id/title")
                 .textContains(expectedTitle)
         ).waitForExists(waitingTime)
     )


### PR DESCRIPTION
• New `undoDeleteBookmarkFolderTest` UI smoke test ✅ Successfully passed 60x on Firebase
• Improve coverage for `deleteNonEmptyBookmarkFolderTest` UI smoke test ✅ Successfully passed 60x on Firebase


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
