### PR TITLE
Bug 1809788 - Support text sharing via navigator.share()

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/share/ShareController.kt
+++ b/app/src/main/java/org/mozilla/fenix/share/ShareController.kt
@@ -212,7 +212,7 @@ class DefaultShareController(
     @VisibleForTesting
     fun getShareText() = shareData.joinToString("\n\n") { data ->
         val url = data.url.orEmpty()
-        if (url.isExtensionUrl()) {
+        val parsedUrl = if (url.isExtensionUrl()) {
             // Sharing moz-extension:// URLs is not practical in general, as
             // they will only work on the current device.
 
@@ -225,6 +225,7 @@ class DefaultShareController(
         } else {
             url
         }
+        listOfNotNull(data.text, parsedUrl).joinToString("\n")
     }
 
     @VisibleForTesting

--- a/app/src/test/java/org/mozilla/fenix/share/ShareControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/share/ShareControllerTest.kt
@@ -52,8 +52,8 @@ class ShareControllerTest {
     private val context: Context = spyk(testContext)
     private val shareSubject = "shareSubject"
     private val shareData = listOf(
-        ShareData(url = "url0", title = "title0"),
-        ShareData(url = "url1", title = "title1"),
+        ShareData(url = "url0", title = "title0", text = "text0"),
+        ShareData(url = "url1", title = "title1", text = "text1")
     )
 
     // Navigation between app fragments uses ShareTab as arguments. SendTabUseCases uses TabData.
@@ -61,7 +61,7 @@ class ShareControllerTest {
         TabData("title0", "url0"),
         TabData("title1", "url1"),
     )
-    private val textToShare = "${shareData[0].url}\n\n${shareData[1].url}"
+    private val textToShare = "${shareData[0].text}\n${shareData[0].url}\n\n${shareData[1].text}\n${shareData[1].url}"
     private val sendTabUseCases = mockk<SendTabUseCases>(relaxed = true)
     private val saveToPdfUseCase = mockk<SessionUseCases.SaveToPdfUseCase>(relaxed = true)
     private val snackbar = mockk<FenixSnackbar>(relaxed = true)


### PR DESCRIPTION
Fixes #11946

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.