### PR TITLE
For #18160: Show a prompt when trying to leave private browsing with active downloads

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabstray/CancelDownloadFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/CancelDownloadFragment.kt
@@ -1,0 +1,104 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabstray
+
+import android.app.Dialog
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.appcompat.app.AppCompatDialogFragment
+import androidx.fragment.app.setFragmentResult
+import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetDialog
+import org.mozilla.fenix.R
+import org.mozilla.fenix.databinding.FragmentCancelDownloadBinding
+import org.mozilla.fenix.ext.runIfFragmentIsAttached
+
+class CancelDownloadFragment : AppCompatDialogFragment() {
+
+    private var _binding: FragmentCancelDownloadBinding? = null
+    private val binding get() = _binding!!
+    private val args by navArgs<CancelDownloadFragmentArgs>()
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog =
+        BottomSheetDialog(requireContext(), this.theme).apply {
+            setOnShowListener {
+                val bottomSheet =
+                    findViewById<View>(com.google.android.material.R.id.design_bottom_sheet) as FrameLayout
+                val behavior = BottomSheetBehavior.from(bottomSheet)
+                behavior.state = BottomSheetBehavior.STATE_EXPANDED
+            }
+        }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentCancelDownloadBinding.inflate(inflater, container, false)
+
+        binding.cancelDownloadMessage.text = String.format(
+            binding.root.context.getString(
+                R.string.cancel_active_download_warning_content_description
+            ),
+            args.downloadCount
+        )
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.cancelDownloadAccept.setOnClickListener {
+            setFragmentResult(
+                RESULT_KEY,
+                Bundle().apply {
+                    putBoolean(ACCEPT_KEY, true)
+                    args.tabId?.let { putString(TAB_KEY, it) }
+                    args.source?.let { putString(SOURCE_KEY, it) }
+                    putBoolean(PRIVATE_KEY, args.private)
+                }
+            )
+            runIfFragmentIsAttached {
+                if (this.isVisible) {
+                    dismiss()
+                }
+                findNavController().popBackStack()
+            }
+        }
+
+        binding.cancelDownloadDeny.setOnClickListener {
+            dismiss()
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    companion object {
+        const val RESULT_KEY = "cancelDownloadFragmentResultKey"
+        const val ACCEPT_KEY = "cancelDownloadFragmentAcceptKey"
+        const val TAB_KEY = "cancelDownloadFragmentTabKey"
+        const val SOURCE_KEY = "cancelDownloadFragmentSourceKey"
+        const val PRIVATE_KEY = "cancelDownloadFragmentPrivateKey"
+    }
+}
+
+data class CancelDownloadFragmentArguments(
+    val downloadCount: Int,
+    val trigger: Trigger,
+    val tabId: String? = null,
+    val source: String? = null,
+    val private: Boolean = true
+)
+
+enum class Trigger {
+    SINGLE_TAB, CLOSE_ALL
+}

--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayInteractor.kt
@@ -22,8 +22,10 @@ interface TabsTrayInteractor {
 
     /**
      * Invoked when a tab is removed from the tabs tray with the given [tabId].
+     * @param source app feature from which the [TabSessionState] with [tabId] was closed.
+     * @param cancelPrivateDownloadsAccepted user confirmed private downloads cancellation
      */
-    fun onDeleteTab(tabId: String)
+    fun onDeleteTab(tabId: String, source: String? = null, cancelPrivateDownloadsAccepted: Boolean = false)
 
     /**
      * Invoked when [TabSessionState]s need to be deleted.
@@ -57,8 +59,8 @@ class DefaultTabsTrayInteractor(
         controller.handleNavigateToBrowser()
     }
 
-    override fun onDeleteTab(tabId: String) {
-        controller.handleTabDeletion(tabId)
+    override fun onDeleteTab(tabId: String, source: String?, cancelPrivateDownloadsAccepted: Boolean) {
+        controller.handleTabDeletion(tabId, source, cancelPrivateDownloadsAccepted)
     }
 
     override fun onDeleteTabs(tabs: Collection<TabSessionState>) {

--- a/app/src/main/java/org/mozilla/fenix/tabstray/browser/BrowserTrayInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/browser/BrowserTrayInteractor.kt
@@ -35,8 +35,9 @@ interface BrowserTrayInteractor : SelectionInteractor<TabSessionState>, UserInte
      *
      * @param tab [TabSessionState] to close.
      * @param source app feature from which the [tab] was closed.
+     * @param cancelPrivateDownloadsAccepted user confirmed private downloads cancellation
      */
-    fun close(tab: TabSessionState, source: String? = null)
+    fun close(tab: TabSessionState, source: String? = null, cancelPrivateDownloadsAccepted: Boolean = false)
 
     /**
      * TabTray's Floating Action Button clicked.
@@ -67,13 +68,6 @@ class DefaultBrowserTrayInteractor(
         }
     }
 
-    private val removeTabWrapper by lazy {
-        RemoveTabUseCaseWrapper(metrics) {
-            // Handle removal from the interactor where we can also handle "undo" visuals.
-            trayInteractor.onDeleteTab(it)
-        }
-    }
-
     /**
      * See [SelectionInteractor.open]
      */
@@ -91,8 +85,8 @@ class DefaultBrowserTrayInteractor(
     /**
      * See [BrowserTrayInteractor.close].
      */
-    override fun close(tab: TabSessionState, source: String?) {
-        closeTab(tab, source)
+    override fun close(tab: TabSessionState, source: String?, cancelPrivateDownloadsAccepted: Boolean) {
+        closeTab(tab, source, cancelPrivateDownloadsAccepted)
     }
 
     /**
@@ -148,7 +142,7 @@ class DefaultBrowserTrayInteractor(
         selectTabWrapper.invoke(tab.id, source)
     }
 
-    private fun closeTab(tab: TabSessionState, source: String? = null) {
-        removeTabWrapper.invoke(tab.id, source)
+    private fun closeTab(tab: TabSessionState, source: String?, cancelPrivateDownloadsAccepted: Boolean = false) {
+        trayInteractor.onDeleteTab(tab.id, source, cancelPrivateDownloadsAccepted)
     }
 }

--- a/app/src/main/res/layout/fragment_cancel_download.xml
+++ b/app/src/main/res/layout/fragment_cancel_download.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/cancel_download_fragment"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?foundation"
+    android:padding="8dp">
+
+    <TextView
+        android:id="@+id/cancel_download_message"
+        style="@style/QuickSettingsText.Icon"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:text="@string/cancel_active_download_warning_content_description"
+        android:textSize="16sp"
+        app:drawableStartCompat="@drawable/ic_info"
+        android:drawablePadding="16dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/cancel_download_deny"
+        style="@style/Widget.MaterialComponents.Button.TextButton"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:letterSpacing="0"
+        android:padding="10dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="16dp"
+        android:scrollbars="none"
+        android:text="@string/cancel_active_download_accept"
+        android:textAllCaps="false"
+        android:textColor="?primaryText"
+        android:textStyle="bold"
+        app:fontFamily="@font/metropolis_semibold"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/cancel_download_accept"
+        app:layout_constraintTop_toBottomOf="@id/cancel_download_message" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/cancel_download_accept"
+        style="@style/PositiveButton"
+        android:layout_width="wrap_content"
+        android:paddingStart="12dp"
+        android:paddingEnd="12dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
+        android:text="@string/cancel_active_download_deny"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/cancel_download_message" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -155,6 +155,35 @@
             app:nullable="true"
             android:defaultValue="@null"
             app:argType="string" />
+        <action
+            android:id="@+id/action_tabsTrayFragment_to_cancelDownloadFragment"
+            app:destination="@id/cancelDownloadFragment" />
+    </dialog>
+
+    <dialog
+        android:id="@+id/cancelDownloadFragment"
+        android:name="org.mozilla.fenix.tabstray.CancelDownloadFragment"
+        tools:layout="@layout/fragment_cancel_download">
+        <argument
+            android:name="downloadCount"
+            android:defaultValue="-1"
+            app:argType="integer" />
+        <argument
+            android:name="trigger"
+            app:argType="org.mozilla.fenix.tabstray.Trigger" />
+        <argument
+            android:name="tabId"
+            app:argType="string"
+            android:defaultValue="@null"
+            app:nullable="true" />
+        <argument
+            android:name="source"
+            android:defaultValue="@null"
+            app:argType="string"
+            app:nullable="true" />
+        <argument
+            android:name="private"
+            app:argType="boolean"/>
     </dialog>
 
     <fragment

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,6 +46,12 @@
     <string name="tab_tray_enter_multiselect_content_description">Entered multiselect mode, select tabs to save to a collection</string>
     <!-- Content description on checkmark while tab is selected in multiselect mode in tab tray -->
     <string name="tab_tray_multiselect_selected_content_description">Selected</string>
+    <!-- Text shown in confirmation dialog when closing tabs leads to cancelled downloads -->
+    <string name="cancel_active_download_warning_content_description">If you close all Private Browsing windows now, %1$s download will be canceled. Are you sure you want to leave Private Browsing?</string>
+    <!-- Option to, while closing private tab or tabs, cancel active private downloads -->
+    <string name="cancel_active_download_accept">Stay in private browsing</string>
+    <!-- Option to keep private downloads, cancelling tab or tabs closure -->
+    <string name="cancel_active_download_deny">Cancel downloads</string>
 
     <!-- Home - Recently saved bookmarks -->
     <!-- Title for the home screen section with recently saved bookmarks. -->


### PR DESCRIPTION
Relates to [...fenix/issue/18160](https://github.com/mozilla-mobile/fenix/issues/18160)

It appears that we have three scenarios when all tabs are being closing by the user.
1) manually closing the tabs individually
2) closing all tabs from drop down menu
3) taping the private notification with action "close all"

For the first two options I have added a simple DialogFragment, that requests user to confirm that she or he is okay with canceling the active downloads. The third scenario is a bit different, it might be triggered while app is in background mode, so I didn't tackle that case.

I also moved analytics from interactor layer to controller, since not every request to close the tab actually results with the tab being closed. So then controller, after actually closing the tab, will fire an analytics event.

I am not sure if I should write UI tests for it.

<img width="604" alt="image" src="https://user-images.githubusercontent.com/92760693/144115454-f005a0ad-94fd-42ce-aba6-9e907bcc621b.png">
