### PR TITLE
Add webrender flag for the  extra option.

### DIFF
--- a/taskcluster/ci/browsertime/kind.yml
+++ b/taskcluster/ci/browsertime/kind.yml
@@ -92,6 +92,7 @@ job-defaults:
             - '--browsertime-ffmpeg=$MOZ_FETCHES_DIR/ffmpeg-4.1.4-i686-static/bin/ffmpeg'
             - '--browsertime-browsertimejs=$MOZ_FETCHES_DIR/browsertime/node_modules/browsertime/bin/browsertime.js'
             - '--conditioned-profile=settled'
+            - '--enable-webrender'
     fetches:
         toolchain:
             - browsertime


### PR DESCRIPTION
This patch adds a no-op --enable-webrender flag to get the `webrender` extra option added to the perfherder data.