### PR TITLE
Android Autofill: Enable keyboard inline autofill suggestions

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -264,6 +264,9 @@
             <intent-filter>
                 <action android:name="android.service.autofill.AutofillService"/>
             </intent-filter>
+            <meta-data
+                android:name="android.autofill"
+                android:resource="@xml/autofill_configuration" />
         </service>
 
         <service android:name=".media.MediaSessionService"

--- a/app/src/main/res/xml/autofill_configuration.xml
+++ b/app/src/main/res/xml/autofill_configuration.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<autofill-service
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:supportsInlineSuggestions="true"
+    tools:targetApi="r" />


### PR DESCRIPTION
On Android 11+ autofill suggestions can be shown inline in the UI of the keyboard instead of as an overlay over the app UI. @VitalyVPinchuk implemented this in Android Components ([#11102](https://github.com/mozilla-mobile/android-components/pull/11102)) and adding this XML here, will enable this in Fenix on supported Android versions.