### PR TITLE
Refactor: Move historymetadata classes in separate package

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -74,9 +74,9 @@ import org.mozilla.fenix.downloads.DownloadService
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.gecko.GeckoProvider
-import org.mozilla.fenix.home.recentvisits.DefaultHistoryMetadataService
-import org.mozilla.fenix.home.recentvisits.HistoryMetadataMiddleware
-import org.mozilla.fenix.home.recentvisits.HistoryMetadataService
+import org.mozilla.fenix.historymetadata.DefaultHistoryMetadataService
+import org.mozilla.fenix.historymetadata.HistoryMetadataMiddleware
+import org.mozilla.fenix.historymetadata.HistoryMetadataService
 import org.mozilla.fenix.media.MediaSessionService
 import org.mozilla.fenix.perf.StrictModeManager
 import org.mozilla.fenix.perf.lazyMonitored

--- a/app/src/main/java/org/mozilla/fenix/historymetadata/HistoryMetadataMiddleware.kt
+++ b/app/src/main/java/org/mozilla/fenix/historymetadata/HistoryMetadataMiddleware.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.fenix.home.recentvisits
+package org.mozilla.fenix.historymetadata
 
 import mozilla.components.browser.state.action.BrowserAction
 import mozilla.components.browser.state.action.ContentAction

--- a/app/src/main/java/org/mozilla/fenix/historymetadata/HistoryMetadataService.kt
+++ b/app/src/main/java/org/mozilla/fenix/historymetadata/HistoryMetadataService.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.fenix.home.recentvisits
+package org.mozilla.fenix.historymetadata
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.asCoroutineDispatcher

--- a/app/src/test/java/org/mozilla/fenix/home/recentvisits/HistoryMetadataMiddlewareTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/recentvisits/HistoryMetadataMiddlewareTest.kt
@@ -32,6 +32,8 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+import org.mozilla.fenix.historymetadata.HistoryMetadataMiddleware
+import org.mozilla.fenix.historymetadata.HistoryMetadataService
 
 @RunWith(FenixRobolectricTestRunner::class)
 class HistoryMetadataMiddlewareTest {

--- a/app/src/test/java/org/mozilla/fenix/home/recentvisits/HistoryMetadataServiceTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/recentvisits/HistoryMetadataServiceTest.kt
@@ -19,6 +19,8 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.mozilla.fenix.historymetadata.DefaultHistoryMetadataService
+import org.mozilla.fenix.historymetadata.HistoryMetadataService
 
 class HistoryMetadataServiceTest {
 


### PR DESCRIPTION
With recent refactoring they ended up in the `recentVists` package and under `home`, but should be independent. Looks like this happened in https://github.com/mozilla-mobile/fenix/commit/5c3fedd707bc4b8ebb6367338477a575d5338eed#diff-9b96b5577338e5c5fda33eab2440a81f68293cc3fef9e9cf61304ddcf7b9c51d by mistake.