### PR TITLE
For #22710 - Disable contributor UI test job due to INSTALL_FAILED_INSUFFICIENT_STORAGE in CI

### DIFF
--- a/.github/workflows/build-contributor-pr.yml
+++ b/.github/workflows/build-contributor-pr.yml
@@ -107,7 +107,7 @@ jobs:
 
   run-ui:
     runs-on: macos-11
-    if: github.event.pull_request.head.repo.full_name != github.repository && github.actor != 'MickeyMoz'
+    if: ${{ false }} # disable for now'
 
     timeout-minutes: 60
     strategy:
@@ -118,12 +118,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run subset of UI Tests
-        uses: reactivecircus/android-emulator-runner@v2.21.0
+        uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
           target: ${{ matrix.target }}
           arch: x86_64
-          profile: pixel_2
+          profile: pixel_3a
           script:
             "JAVA_HOME=$JAVA_HOME_11_X64 && ./gradlew connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=\
             org.mozilla.fenix.ui.NavigationToolbarTest#visitURLTest"


### PR DESCRIPTION
Fixes #22710

This reverts commit b83bddfb31494886f1f1070b67d059f82e2e085d https://github.com/mozilla-mobile/fenix/pull/22657.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
