### PR TITLE
For #22710 - Disable run-ui in build-contributor-pr workflow

### DIFF
--- a/.github/workflows/build-contributor-pr.yml
+++ b/.github/workflows/build-contributor-pr.yml
@@ -107,7 +107,7 @@ jobs:
 
   run-ui:
     runs-on: macos-11
-    if: github.event.pull_request.head.repo.full_name != github.repository && github.actor != 'MickeyMoz'
+    if: ${{ false }} # disable for now due to INSTALL_FAILED_INSUFFICIENT_STORAGE error
 
     timeout-minutes: 60
     strategy:

--- a/.github/workflows/build-contributor-pr.yml
+++ b/.github/workflows/build-contributor-pr.yml
@@ -107,7 +107,7 @@ jobs:
 
   run-ui:
     runs-on: macos-11
-    if: ${{ false }} # disable for now due to INSTALL_FAILED_INSUFFICIENT_STORAGE error
+    if: ${{ false }}
 
     timeout-minutes: 60
     strategy:


### PR DESCRIPTION
Fixes #22710 

Unfortunately the problem with INSTALL_FAILED_INSUFFICIENT_STORAGE is still showcasing itself on v2.21.0 – I'm not aware of any workaround at this moment in time, so I'm disabling this step of the workflow again.