### PR TITLE
Issue #22757: Check the parent cast to AbstractBrowserTrayList first

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabstray/browser/AbstractBrowserTabViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/browser/AbstractBrowserTabViewHolder.kt
@@ -257,13 +257,16 @@ abstract class AbstractBrowserTabViewHolder(
                     touchStartPoint = null
                 }
                 MotionEvent.ACTION_MOVE -> {
-                    val parent = itemView.parent as AbstractBrowserTrayList
                     val touchStart = touchStartPoint
                     val selected = holder.selectedItems
                     val selectsOnlyThis = (selected.size == 1 && selected.contains(item))
                     val featureEnabled = FeatureFlags.tabReorderingFeature &&
-                        !parent.context.settings().searchTermTabGroupsAreEnabled
+                        !itemView.context.settings().searchTermTabGroupsAreEnabled
                     if (featureEnabled && selectsOnlyThis && touchStart != null) {
+                        // In a tab group, we do not use a AbstractBrowserTrayList as the parent,
+                        // so we should return early and mark the event as unhandled (return false).
+                        val parent = itemView.parent as? AbstractBrowserTrayList ?: return@setOnTouchListener false
+
                         // Prevent scrolling if the user tries to start drag vertically
                         parent.requestDisallowInterceptTouchEvent(true)
                         // Only start deselect+drag if the user drags far enough


### PR DESCRIPTION
We re-use the same ViewHolders in search term groups, so when we need to
cast to a AbstractBrowserTrayList for tab reordering, we need to check
our parent correctly first.

Not applicable for unit testing unfortunately.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
