### PR TITLE
Update Android Components version; Fix breaking change in KeyProvider

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/creditcards/CreditCardEditorFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/creditcards/CreditCardEditorFragment.kt
@@ -12,6 +12,9 @@ import android.view.View
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.mozilla.fenix.R
 import org.mozilla.fenix.SecureFragment
 import org.mozilla.fenix.databinding.FragmentCreditCardEditorBinding
@@ -65,10 +68,14 @@ class CreditCardEditorFragment : SecureFragment(R.layout.fragment_credit_card_ed
 
         val binding = FragmentCreditCardEditorBinding.bind(view)
 
-        creditCardEditorState =
-            args.creditCard?.toCreditCardEditorState(storage) ?: getInitialCreditCardEditorState()
-        creditCardEditorView = CreditCardEditorView(binding, interactor)
-        creditCardEditorView.bind(creditCardEditorState)
+        lifecycleScope.launch(Dispatchers.Main) {
+            creditCardEditorState = withContext(Dispatchers.IO) {
+                args.creditCard?.toCreditCardEditorState(storage)
+                    ?: getInitialCreditCardEditorState()
+            }
+            creditCardEditorView = CreditCardEditorView(binding, interactor)
+            creditCardEditorView.bind(creditCardEditorState)
+        }
     }
 
     /**

--- a/app/src/main/java/org/mozilla/fenix/settings/creditcards/CreditCardEditorState.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/creditcards/CreditCardEditorState.kt
@@ -31,9 +31,9 @@ data class CreditCardEditorState(
 /**
  * Returns a [CreditCardEditorState] from the given [CreditCard].
  */
-fun CreditCard.toCreditCardEditorState(storage: AutofillCreditCardsAddressesStorage): CreditCardEditorState {
+suspend fun CreditCard.toCreditCardEditorState(storage: AutofillCreditCardsAddressesStorage): CreditCardEditorState {
     val crypto = storage.getCreditCardCrypto()
-    val key = crypto.key()
+    val key = crypto.getOrGenerateKey()
     val cardNumber = crypto.decrypt(key, encryptedCardNumber)?.number ?: ""
     val startYear = expiryYear.toInt()
     val endYear = startYear + NUMBER_OF_YEARS_TO_SHOW

--- a/app/src/test/java/org/mozilla/fenix/settings/creditcards/CreditCardEditorStateTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/creditcards/CreditCardEditorStateTest.kt
@@ -6,6 +6,7 @@ package org.mozilla.fenix.settings.creditcards
 
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
 import mozilla.components.concept.storage.CreditCard
 import mozilla.components.concept.storage.CreditCardNumber
 import mozilla.components.service.sync.autofill.AutofillCreditCardsAddressesStorage
@@ -36,7 +37,7 @@ class CreditCardEditorStateTest {
     )
 
     @Test
-    fun testToCreditCardEditorState() {
+    fun testToCreditCardEditorState() = runBlocking {
         val storage: AutofillCreditCardsAddressesStorage = mockk(relaxed = true)
         val crypto: AutofillCrypto = mockk(relaxed = true)
 

--- a/app/src/test/java/org/mozilla/fenix/settings/creditcards/CreditCardEditorViewTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/creditcards/CreditCardEditorViewTest.kt
@@ -10,6 +10,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
+import kotlinx.coroutines.runBlocking
 import mozilla.components.concept.storage.CreditCard
 import mozilla.components.concept.storage.CreditCardNumber
 import mozilla.components.concept.storage.NewCreditCardFields
@@ -99,7 +100,7 @@ class CreditCardEditorViewTest {
     }
 
     @Test
-    fun `GIVEN a credit card THEN credit card form inputs are displaying the provided credit card information`() {
+    fun `GIVEN a credit card THEN credit card form inputs are displaying the provided credit card information`() = runBlocking {
         creditCardEditorView.bind(creditCard.toCreditCardEditorState(storage))
 
         assertEquals(cardNumber, fragmentCreditCardEditorBinding.cardNumberInput.text.toString())
@@ -120,7 +121,7 @@ class CreditCardEditorViewTest {
     }
 
     @Test
-    fun `GIVEN a credit card WHEN the delete card button is clicked THEN interactor is called`() {
+    fun `GIVEN a credit card WHEN the delete card button is clicked THEN interactor is called`() = runBlocking {
         creditCardEditorView.bind(creditCard.toCreditCardEditorState(storage))
 
         assertEquals(View.VISIBLE, fragmentCreditCardEditorBinding.deleteButton.visibility)
@@ -271,7 +272,7 @@ class CreditCardEditorViewTest {
     }
 
     @Test
-    fun `GIVEN a valid credit card WHEN the save button is clicked THEN interactor is called`() {
+    fun `GIVEN a valid credit card WHEN the save button is clicked THEN interactor is called`() = runBlocking {
         creditCardEditorView.bind(creditCard.toCreditCardEditorState(storage))
 
         fragmentCreditCardEditorBinding.saveButton.performClick()

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "97.0.20211213190046"
+    const val VERSION = "97.0.20211215143138"
 }


### PR DESCRIPTION
`key` was renamed to `getOrGenerateKey` and is now a `suspend`.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
