### PR TITLE
For #22784: Prevent crashing when snackbar is triggered after the fragment has been detached.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
@@ -42,6 +42,7 @@ import org.mozilla.fenix.databinding.TabstrayMultiselectItemsBinding
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.metrics
 import org.mozilla.fenix.ext.requireComponents
+import org.mozilla.fenix.ext.runIfFragmentIsAttached
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.home.HomeScreenViewModel
 import org.mozilla.fenix.share.ShareFragment
@@ -485,18 +486,20 @@ class TabsTrayFragment : AppCompatDialogFragment() {
         isNewCollection: Boolean = false,
         collectionToSelect: Long?
     ) {
-        FenixSnackbar
-            .make(requireView())
-            .collectionMessage(tabSize, isNewCollection)
-            .anchorWithAction(getSnackbarAnchor()) {
-                findNavController().navigate(
-                    TabsTrayFragmentDirections.actionGlobalHome(
-                        focusOnAddressBar = false,
-                        focusOnCollection = collectionToSelect.orDefault()
+        runIfFragmentIsAttached {
+            FenixSnackbar
+                .make(requireView())
+                .collectionMessage(tabSize, isNewCollection)
+                .anchorWithAction(getSnackbarAnchor()) {
+                    findNavController().navigate(
+                        TabsTrayFragmentDirections.actionGlobalHome(
+                            focusOnAddressBar = false,
+                            focusOnCollection = collectionToSelect.orDefault()
+                        )
                     )
-                )
-                dismissTabsTray()
-            }.show()
+                    dismissTabsTray()
+                }.show()
+        }
     }
 
     @VisibleForTesting


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
