### PR TITLE
fixes #20833: move home recycler bottom margin into standalone item

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/BottomSpacerViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/BottomSpacerViewHolder.kt
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.home
+
+import android.view.View
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.unit.dp
+import androidx.recyclerview.widget.RecyclerView
+import org.mozilla.fenix.theme.FirefoxTheme
+
+class BottomSpacerViewHolder(val composeView: ComposeView) : RecyclerView.ViewHolder(composeView) {
+    init {
+        composeView.setContent {
+            FirefoxTheme {
+                Spacer(modifier = Modifier.height(88.dp))
+            }
+        }
+    }
+
+    companion object {
+        val LAYOUT_ID = View.generateViewId()
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlAdapter.kt
@@ -44,6 +44,7 @@ import org.mozilla.fenix.home.sessioncontrol.viewholders.onboarding.OnboardingTh
 import org.mozilla.fenix.home.sessioncontrol.viewholders.onboarding.OnboardingToolbarPositionPickerViewHolder
 import org.mozilla.fenix.home.sessioncontrol.viewholders.onboarding.OnboardingTrackingProtectionViewHolder
 import org.mozilla.fenix.home.tips.ButtonTipViewHolder
+import org.mozilla.fenix.home.BottomSpacerViewHolder
 import org.mozilla.fenix.home.topsites.TopSitePagerViewHolder
 import mozilla.components.feature.tab.collections.Tab as ComponentTab
 
@@ -168,6 +169,8 @@ sealed class AdapterItem(@LayoutRes val viewType: Int) {
     object PocketStoriesItem :
         AdapterItem(PocketStoriesViewHolder.LAYOUT_ID)
 
+    object BottomSpacer : AdapterItem(BottomSpacerViewHolder.LAYOUT_ID)
+
     /**
      * True if this item represents the same value as other. Used by [AdapterItemDiffCallback].
      */
@@ -231,6 +234,9 @@ class SessionControlAdapter(
                 store = store,
                 interactor = interactor,
                 metrics = components.analytics.metrics
+            )
+            BottomSpacerViewHolder.LAYOUT_ID -> return BottomSpacerViewHolder(
+                composeView = ComposeView(parent.context)
             )
         }
 

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlView.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlView.kt
@@ -93,6 +93,8 @@ internal fun normalModeAdapterItems(
         items.add(AdapterItem.CustomizeHomeButton)
     }
 
+    items.add(AdapterItem.BottomSpacer)
+
     return items
 }
 

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -68,7 +68,6 @@
         android:layout_height="match_parent"
         android:clipChildren="false"
         android:clipToPadding="false"
-        android:layout_marginBottom="88dp"
         android:paddingVertical="16dp"
         android:scrollbars="none"
         android:transitionGroup="false"

--- a/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/SessionControlViewTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/SessionControlViewTest.kt
@@ -265,7 +265,7 @@ class SessionControlViewTest {
             historyMetadata,
             pocketArticles
         )
-        assertEquals(results.size, 1)
+        assertEquals(results.size, 2)
         assertTrue(results[0] is AdapterItem.TopPlaceholderItem)
     }
 


### PR DESCRIPTION
- No black box over pocket items

<img width="620" alt="image" src="https://user-images.githubusercontent.com/10427470/145882031-a7cecab7-5260-4e4a-bf90-254d360eab9d.png">

- `Customize homepage` still visible with required bottom spacing

<img width="624" alt="image" src="https://user-images.githubusercontent.com/10427470/145882134-ecde03f1-f5bf-4641-8934-15b8077c647d.png">

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: N/A
- [x] **Screenshots**: Included
- [x] **Accessibility**: N/A

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
