### PR TITLE
For #19918: Add option to hide the toolbar home button

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -101,4 +101,9 @@ object FeatureFlags {
      * Enables history improvement features.
      */
     val historyImprovementFeatures = Config.channel.isNightlyOrDebug
+
+    /**
+     * Enables turning on/off the home button of the toolbar.
+     */
+    val showHomeButtonToolbar = Config.channel.isNightlyOrDebug
 }

--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -71,17 +71,18 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
             )
         }
 
-        val homeAction = BrowserToolbar.Button(
-            imageDrawable = AppCompatResources.getDrawable(
-                context,
-                R.drawable.mozac_ic_home
-            )!!,
-            contentDescription = context.getString(R.string.browser_toolbar_home),
-            iconTintColorResource = ThemeManager.resolveAttribute(R.attr.primaryText, context),
-            listener = browserToolbarInteractor::onHomeButtonClicked
-        )
-
-        browserToolbarView.view.addNavigationAction(homeAction)
+        if (context.settings().isHomeButtonToolbarEnabled) {
+            val homeAction = BrowserToolbar.Button(
+                imageDrawable = AppCompatResources.getDrawable(
+                    context,
+                    R.drawable.mozac_ic_home
+                )!!,
+                contentDescription = context.getString(R.string.browser_toolbar_home),
+                iconTintColorResource = ThemeManager.resolveAttribute(R.attr.primaryText, context),
+                listener = browserToolbarInteractor::onHomeButtonClicked
+            )
+            browserToolbarView.view.addNavigationAction(homeAction)
+        }
 
         if (resources.getBoolean(R.bool.tablet)) {
             val enableTint = ThemeManager.resolveAttribute(R.attr.primaryText, context)

--- a/app/src/main/java/org/mozilla/fenix/settings/CustomizationFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/CustomizationFragment.kt
@@ -136,6 +136,12 @@ class CustomizationFragment : PreferenceFragmentCompat() {
         bottomPreference.setCheckedWithoutClickListener(toolbarPosition == ToolbarPosition.BOTTOM)
 
         addToRadioGroup(topPreference, bottomPreference)
+
+        requirePreference<SwitchPreference>(R.string.pref_key_toolbar_home_button).apply {
+            isVisible = FeatureFlags.showHomeButtonToolbar
+            isChecked = context.settings().isHomeButtonToolbarEnabled
+            onPreferenceChangeListener = SharedPreferenceUpdater()
+        }
     }
 
     private fun setupGesturesCategory() {

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -1166,6 +1166,11 @@ class Settings(private val appContext: Context) : PreferencesHolder {
             }
         }
 
+    var isHomeButtonToolbarEnabled by booleanPreference(
+        appContext.getPreferenceKey(R.string.pref_key_toolbar_home_button),
+        default = true
+    )
+
     var isPullToRefreshEnabledInBrowser by booleanPreference(
         appContext.getPreferenceKey(R.string.pref_key_website_pull_to_refresh),
         default = true

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -122,6 +122,7 @@
     <!-- Toolbar Settings -->
     <string name="pref_key_toolbar_top" translatable="false">pref_key_toolbar_top</string>
     <string name="pref_key_toolbar_bottom" translatable="false">pref_key_toolbar_bottom</string>
+    <string name="pref_key_toolbar_home_button" translatable="false">pref_key_toolbar_home_button</string>
 
     <!-- Privacy Pop Window -->
     <string name="pref_key_privacy_pop_window" translatable="false">pref_key_privacy_pop_window</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -587,6 +587,8 @@
     <string name="preference_top_toolbar">Top</string>
     <!-- Preference for using bottom toolbar -->
     <string name="preference_bottom_toolbar">Bottom</string>
+    <!-- Preference for home button on toolbar -->
+    <string name="preference_home_button_toolbar">Home Button</string>
 
     <!-- Theme Preferences -->
     <!-- Preference for using light theme -->

--- a/app/src/main/res/xml/customization_preferences.xml
+++ b/app/src/main/res/xml/customization_preferences.xml
@@ -41,6 +41,10 @@
         <org.mozilla.fenix.settings.RadioButtonPreference
             android:key="@string/pref_key_toolbar_bottom"
             android:title="@string/preference_bottom_toolbar" />
+        <androidx.preference.SwitchPreference
+            android:key="@string/pref_key_toolbar_home_button"
+            android:title="@string/preference_home_button_toolbar"
+            app:isPreferenceVisible="false"/>
     </androidx.preference.PreferenceCategory>
 
     <androidx.preference.PreferenceCategory


### PR DESCRIPTION
Fixes #19918 
Adds a simple option under the Customise menu which disables completely the home button from the toolbar.

https://user-images.githubusercontent.com/18355854/146061198-99f9ffa0-8e27-4690-9840-d0b9e9c327c5.mp4

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: N/A - let me know if any tests are required
- [x] **Screenshots**: Video included
- [x] **Accessibility**: Checked the additional menu entry with Accessibility scanner

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
