### PR TITLE
fixes #22889: add bottom spacer to onboarding adapter

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/perf/StartupExcessiveResourceUseTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/perf/StartupExcessiveResourceUseTest.kt
@@ -25,7 +25,7 @@ private const val EXPECTED_SUPPRESSION_COUNT = 19
 @Suppress("TopLevelPropertyNaming") // it's silly this would have a different naming convention b/c no const
 private val EXPECTED_RUNBLOCKING_RANGE = 0..1 // CI has +1 counts compared to local runs: increment these together
 private const val EXPECTED_RECYCLER_VIEW_CONSTRAINT_LAYOUT_CHILDREN = 4
-private const val EXPECTED_NUMBER_OF_INFLATION = 13
+private const val EXPECTED_NUMBER_OF_INFLATION = 14
 
 private val failureMsgStrictMode = getErrorMessage(
     shortName = "StrictMode suppression",

--- a/app/src/main/java/org/mozilla/fenix/home/BottomSpacerViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/BottomSpacerViewHolder.kt
@@ -5,24 +5,13 @@
 package org.mozilla.fenix.home
 
 import android.view.View
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.unit.dp
 import androidx.recyclerview.widget.RecyclerView
-import org.mozilla.fenix.theme.FirefoxTheme
+import org.mozilla.fenix.R
 
-class BottomSpacerViewHolder(val composeView: ComposeView) : RecyclerView.ViewHolder(composeView) {
-    init {
-        composeView.setContent {
-            FirefoxTheme {
-                Spacer(modifier = Modifier.height(88.dp))
-            }
-        }
-    }
-
+class BottomSpacerViewHolder(
+    view: View,
+) : RecyclerView.ViewHolder(view) {
     companion object {
-        val LAYOUT_ID = View.generateViewId()
+        val LAYOUT_ID = R.layout.bottom_spacer
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlAdapter.kt
@@ -235,9 +235,6 @@ class SessionControlAdapter(
                 interactor = interactor,
                 metrics = components.analytics.metrics
             )
-            BottomSpacerViewHolder.LAYOUT_ID -> return BottomSpacerViewHolder(
-                composeView = ComposeView(parent.context)
-            )
         }
 
         val view = LayoutInflater.from(parent.context).inflate(viewType, parent, false)
@@ -284,6 +281,7 @@ class SessionControlAdapter(
                 view,
                 interactor
             )
+            BottomSpacerViewHolder.LAYOUT_ID -> BottomSpacerViewHolder(view)
             else -> throw IllegalStateException()
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlView.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlView.kt
@@ -142,7 +142,8 @@ private fun onboardingAdapterItems(onboardingState: OnboardingState): List<Adapt
     items.addAll(
         listOf(
             AdapterItem.OnboardingPrivacyNotice,
-            AdapterItem.OnboardingFinish
+            AdapterItem.OnboardingFinish,
+            AdapterItem.BottomSpacer
         )
     )
 

--- a/app/src/main/res/layout/bottom_spacer.xml
+++ b/app/src/main/res/layout/bottom_spacer.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<View xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="88dp" />


### PR DESCRIPTION
Fixes #22889

Noticed some serious scroll lag on the first draw of the bottom spacer when I added it to the onboarding screen. Switching it to a regular view instead of Compose addresses that.

<img width="622" alt="image" src="https://user-images.githubusercontent.com/10427470/146452469-5877c099-9c1b-463d-ae16-0549f1cdf827.png">


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: N/A
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: N/A

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
