### PR TITLE
For #22561: Use color instead of color attribute for group titles.

### DIFF
--- a/app/src/main/res/layout/tab_group_item.xml
+++ b/app/src/main/res/layout/tab_group_item.xml
@@ -15,6 +15,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
+        android:tint="@color/tab_tray_group_title_normal_theme"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:srcCompat="@drawable/ic_search" />
@@ -28,6 +29,7 @@
         android:gravity="start"
         android:maxLines="1"
         android:textAppearance="@style/Header16TextStyle"
+        android:textColor="@color/tab_tray_group_title_normal_theme"
         app:layout_constraintBottom_toBottomOf="@id/group_icon"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"

--- a/app/src/main/res/layout/tab_tray_title_header_item.xml
+++ b/app/src/main/res/layout/tab_tray_title_header_item.xml
@@ -18,6 +18,7 @@
     android:gravity="start"
     android:maxLines="1"
     android:text="@string/tab_tray_header_title_1"
+    android:textColor="@color/tab_tray_group_title_normal_theme"
     android:textAppearance="@style/Header16TextStyle"
     app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -151,6 +151,7 @@
     <color name="tab_tray_item_thumbnail_background_normal_theme">@color/photonDarkGrey50</color>
     <color name="tab_tray_item_thumbnail_icon_normal_theme">@color/photonDarkGrey05</color>
     <color name="tab_tray_selected_mask_normal_theme">@color/photonViolet50A32</color>
+    <color name="tab_tray_group_title_normal_theme">@color/photonLightGrey05</color>
 
     <!-- Tab History -->
     <color name="tab_history_item_selected_background_normal_theme">@color/tab_tray_item_selected_background_dark_theme</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -253,6 +253,8 @@
     <color name="tab_tray_item_thumbnail_background_normal_theme">@color/photonLightGrey10</color>
     <color name="tab_tray_item_thumbnail_icon_normal_theme">@color/photonLightGrey60</color>
     <color name="tab_tray_selected_mask_normal_theme">@color/photonViolet70A12</color>
+    <color name="tab_tray_group_title_normal_theme">@color/photonInk80</color>
+
 
     <!-- Tab History -->
     <color name="tab_history_item_selected_background_normal_theme">@color/tab_tray_item_selected_background_normal_theme</color>


### PR DESCRIPTION
The new color uses the values for primary text, as originally intended.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
