### PR TITLE
For #22415: Remove element type from content descriptions.

### DIFF
--- a/app/src/main/res/layout/recent_bookmarks_header.xml
+++ b/app/src/main/res/layout/recent_bookmarks_header.xml
@@ -31,7 +31,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:background="?android:attr/selectableItemBackground"
-        android:contentDescription="@string/recently_saved_show_all_content_description"
+        android:contentDescription="@string/recently_saved_show_all_content_description_2"
         android:insetTop="0dp"
         android:paddingStart="16dp"
         android:paddingEnd="0dp"

--- a/app/src/main/res/layout/recent_tabs_header.xml
+++ b/app/src/main/res/layout/recent_tabs_header.xml
@@ -29,7 +29,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:background="?android:attr/selectableItemBackground"
-        android:contentDescription="@string/recent_tabs_show_all_content_description"
+        android:contentDescription="@string/recent_tabs_show_all_content_description_2"
         android:insetTop="0dp"
         android:paddingStart="16dp"
         android:paddingEnd="0dp"

--- a/app/src/main/res/layout/recent_visits_header.xml
+++ b/app/src/main/res/layout/recent_visits_header.xml
@@ -30,7 +30,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:background="?android:attr/selectableItemBackground"
-        android:contentDescription="@string/past_explorations_show_all_content_description"
+        android:contentDescription="@string/past_explorations_show_all_content_description_2"
         android:insetTop="0dp"
         android:paddingStart="16dp"
         android:paddingEnd="0dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -55,7 +55,9 @@
     <!-- Title for the button which navigates the user to show all of their saved bookmarks. -->
     <string name="recently_saved_show_all">Show all</string>
     <!-- Content description for the button which navigates the user to show all of their saved bookmarks. -->
-    <string name="recently_saved_show_all_content_description">Show all saved bookmarks button</string>
+    <string name="recently_saved_show_all_content_description_2">Show all saved bookmarks</string>
+    <!-- Content description for the button which navigates the user to show all of their saved bookmarks. -->
+    <string name="recently_saved_show_all_content_description" moz:removedIn="97" tools:ignore="UnusedResources">Show all saved bookmarks button</string>
 
     <!-- About content. The first parameter is the name of the application. (For example: Fenix) -->
     <string name="about_content">%1$s is produced by Mozilla.</string>
@@ -133,7 +135,9 @@
     <!-- Button text for showing all the tabs in the tabs tray -->
     <string name="recent_tabs_show_all">Show all</string>
     <!-- Content description for the button which navigates the user to show all recent tabs in the tabs tray. -->
-    <string name="recent_tabs_show_all_content_description">Show all recent tabs button</string>
+    <string name="recent_tabs_show_all_content_description_2">Show all recent tabs button</string>
+    <!-- Content description for the button which navigates the user to show all recent tabs in the tabs tray. -->
+    <string name="recent_tabs_show_all_content_description2" moz:removedIn="97" tools:ignore="UnusedResources">Show all recent tabs</string>
     <!-- Title for showing a group item in the 'Jump back in' section of the new tab
         The first parameter is the search term that the user used. (for example: your search for "cat")-->
     <string name="recent_tabs_search_term">Your search for \"%1$s\"</string>
@@ -155,7 +159,9 @@
          in the Recently visited section -->
     <string name="recently_visited_menu_item_remove">Remove</string>
     <!-- Content description for the button which navigates the user to show all of their history. -->
-    <string name="past_explorations_show_all_content_description">Show all past explorations button</string>
+    <string name="past_explorations_show_all_content_description_2">Show all past explorations</string>
+    <!-- Content description for the button which navigates the user to show all of their history. -->
+    <string name="past_explorations_show_all_content_description" moz:removedIn="97" tools:ignore="UnusedResources">Show all past explorations button</string>
 
     <!-- Browser Fragment -->
     <!-- Content description (not visible, for screen readers etc.): Navigate to open tabs -->


### PR DESCRIPTION
Adding the type to content description is not advised according to a11y guidelines.
See https://support.google.com/accessibility/android/answer/7158690?hl=en.

See also more on the [issue](https://github.com/mozilla-mobile/fenix/issues/22415#issuecomment-998920691).
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
