### PR TITLE
closes #22831: add wallpaper settings screen 

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/StoreProvider.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/StoreProvider.kt
@@ -38,7 +38,7 @@ class StoreProviderFactory<T : Store<*, *>>(
 ) : ViewModelProvider.Factory {
 
     @Suppress("UNCHECKED_CAST")
-    override fun <VM : ViewModel?> create(modelClass: Class<VM>): VM {
+    override fun <VM : ViewModel> create(modelClass: Class<VM>): VM {
         return StoreProvider(createStore()) as VM
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/BreadcrumbsRecorder.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/BreadcrumbsRecorder.kt
@@ -5,9 +5,9 @@
 package org.mozilla.fenix.components.metrics
 
 import android.os.Bundle
-import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleObserver
-import androidx.lifecycle.OnLifecycleEvent
+import androidx.lifecycle.LifecycleOwner
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination
 import mozilla.components.concept.base.crash.Breadcrumb
@@ -23,15 +23,13 @@ class BreadcrumbsRecorder(
     private val crashReporter: CrashReporter,
     private val navController: NavController,
     private val getBreadcrumbMessage: (NavDestination) -> String
-) : NavController.OnDestinationChangedListener, LifecycleObserver {
+) : NavController.OnDestinationChangedListener, DefaultLifecycleObserver {
 
-    @OnLifecycleEvent(Lifecycle.Event.ON_CREATE)
-    fun onCreate() {
+    override fun onCreate(owner: LifecycleOwner) {
         navController.addOnDestinationChangedListener(this)
     }
 
-    @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
-    fun onDestroy() {
+    override fun onDestroy(owner: LifecycleOwner) {
         navController.removeOnDestinationChangedListener(this)
     }
 

--- a/app/src/main/java/org/mozilla/fenix/customtabs/PoweredByNotification.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/PoweredByNotification.kt
@@ -15,9 +15,8 @@ import androidx.core.app.NotificationCompat.BADGE_ICON_NONE
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleObserver
-import androidx.lifecycle.OnLifecycleEvent
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import mozilla.components.browser.state.selector.findCustomTab
 import mozilla.components.browser.state.state.ExternalAppType
 import mozilla.components.browser.state.store.BrowserStore
@@ -32,18 +31,16 @@ class PoweredByNotification(
     private val applicationContext: Context,
     private val store: BrowserStore,
     private val customTabId: String
-) : LifecycleObserver {
+) : DefaultLifecycleObserver {
 
-    @OnLifecycleEvent(Lifecycle.Event.ON_RESUME)
-    fun onResume() {
+    override fun onResume(owner: LifecycleOwner) {
         if (store.state.findCustomTab(customTabId)?.config?.externalAppType === ExternalAppType.TRUSTED_WEB_ACTIVITY) {
             NotificationManagerCompat.from(applicationContext)
                 .notify(applicationContext, NOTIFICATION_TAG, buildNotification())
         }
     }
 
-    @OnLifecycleEvent(Lifecycle.Event.ON_PAUSE)
-    fun onPause() {
+    override fun onPause(owner: LifecycleOwner) {
         NotificationManagerCompat.from(applicationContext)
             .cancel(applicationContext, NOTIFICATION_TAG)
     }

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkDeselectNavigationListener.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkDeselectNavigationListener.kt
@@ -5,9 +5,8 @@
 package org.mozilla.fenix.library.bookmarks
 
 import android.os.Bundle
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleObserver
-import androidx.lifecycle.OnLifecycleEvent
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination
 import org.mozilla.fenix.R
@@ -16,15 +15,13 @@ class BookmarkDeselectNavigationListener(
     private val navController: NavController,
     private val viewModel: BookmarksSharedViewModel,
     private val bookmarkInteractor: BookmarkViewInteractor
-) : NavController.OnDestinationChangedListener, LifecycleObserver {
+) : NavController.OnDestinationChangedListener, DefaultLifecycleObserver {
 
-    @OnLifecycleEvent(Lifecycle.Event.ON_RESUME)
-    fun onResume() {
+    override fun onResume(owner: LifecycleOwner) {
         navController.addOnDestinationChangedListener(this)
     }
 
-    @OnLifecycleEvent(Lifecycle.Event.ON_PAUSE)
-    fun onDestroy() {
+    override fun onDestroy(owner: LifecycleOwner) {
         navController.removeOnDestinationChangedListener(this)
     }
 

--- a/app/src/main/java/org/mozilla/fenix/settings/HomeSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/HomeSettingsFragment.kt
@@ -5,6 +5,7 @@
 package org.mozilla.fenix.settings
 
 import android.os.Bundle
+import androidx.navigation.findNavController
 import androidx.preference.Preference
 import androidx.preference.PreferenceCategory
 import androidx.preference.PreferenceFragmentCompat
@@ -60,6 +61,16 @@ class HomeSettingsFragment : PreferenceFragmentCompat() {
             isVisible = FeatureFlags.historyMetadataUIFeature
             isChecked = context.settings().historyMetadataUIFeature
             onPreferenceChangeListener = CustomizeHomeMetricsUpdater()
+        }
+
+        requirePreference<Preference>(R.string.pref_key_wallpapers).apply {
+            setOnPreferenceClickListener {
+                view?.findNavController()?.navigate(
+                    HomeSettingsFragmentDirections.actionHomeSettingsFragmentToWallpaperSettingsFragment()
+                )
+                true
+            }
+            isVisible = FeatureFlags.showWallpapers
         }
 
         val openingScreenRadioHomepage =

--- a/app/src/main/java/org/mozilla/fenix/settings/OnSharedPreferenceChangeListener.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/OnSharedPreferenceChangeListener.kt
@@ -5,24 +5,19 @@
 package org.mozilla.fenix.settings
 
 import android.content.SharedPreferences
-import androidx.lifecycle.Lifecycle.Event.ON_CREATE
-import androidx.lifecycle.Lifecycle.Event.ON_DESTROY
-import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.OnLifecycleEvent
 
 class OnSharedPreferenceChangeListener(
     private val sharedPreferences: SharedPreferences,
     private val listener: (SharedPreferences, String) -> Unit
-) : SharedPreferences.OnSharedPreferenceChangeListener, LifecycleObserver {
+) : SharedPreferences.OnSharedPreferenceChangeListener, DefaultLifecycleObserver {
 
-    @OnLifecycleEvent(ON_CREATE)
-    fun onCreate() {
+    override fun onCreate(owner: LifecycleOwner) {
         sharedPreferences.registerOnSharedPreferenceChangeListener(this)
     }
 
-    @OnLifecycleEvent(ON_DESTROY)
-    fun onDestroy() {
+    override fun onDestroy(owner: LifecycleOwner) {
         sharedPreferences.unregisterOnSharedPreferenceChangeListener(this)
     }
 

--- a/app/src/main/java/org/mozilla/fenix/settings/about/SecretDebugMenuTrigger.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/about/SecretDebugMenuTrigger.kt
@@ -6,9 +6,8 @@ package org.mozilla.fenix.settings.about
 
 import android.view.View
 import android.widget.Toast
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleObserver
-import androidx.lifecycle.OnLifecycleEvent
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import org.mozilla.fenix.R
 import org.mozilla.fenix.utils.Settings
 
@@ -18,7 +17,7 @@ import org.mozilla.fenix.utils.Settings
 class SecretDebugMenuTrigger(
     logoView: View,
     private val settings: Settings
-) : View.OnClickListener, LifecycleObserver {
+) : View.OnClickListener, DefaultLifecycleObserver {
 
     private var secretDebugMenuClicks = 0
     private var lastDebugMenuToast: Toast? = null
@@ -32,8 +31,7 @@ class SecretDebugMenuTrigger(
     /**
      * Reset the [secretDebugMenuClicks] counter.
      */
-    @OnLifecycleEvent(Lifecycle.Event.ON_RESUME)
-    fun clearClickCounter() {
+    override fun onResume(owner: LifecycleOwner) {
         secretDebugMenuClicks = 0
     }
 

--- a/app/src/main/java/org/mozilla/fenix/settings/wallpaper/WallpaperSettings.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/wallpaper/WallpaperSettings.kt
@@ -1,0 +1,162 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.settings.wallpaper
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.GridCells
+import androidx.compose.foundation.lazy.LazyVerticalGrid
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import org.mozilla.fenix.R
+import org.mozilla.fenix.theme.FirefoxTheme
+import org.mozilla.fenix.wallpapers.Wallpaper
+import org.mozilla.fenix.wallpapers.WallpaperManager
+
+/**
+ * A screen for various settings related to wallpapers.
+ *
+ * @param wallpaperManager Manager for retrieving and updating current wallpaper.
+ */
+@Composable
+fun WallpaperSettings(
+    wallpaperManager: WallpaperManager
+) {
+    val selectedWallpaper = wallpaperManager.currentWallpaper.collectAsState()
+    Surface(color = FirefoxTheme.colors.layer2) {
+        WallpaperThumbnails(
+            wallpapers = wallpaperManager.wallpapers.toList(),
+            selectedWallpaper = selectedWallpaper.value,
+            onSelectionChanged = { wallpaperManager.updateWallpaperSelection(it) }
+        )
+    }
+}
+
+/**
+ * A grid of selectable wallpaper thumbnails.
+ *
+ * @param wallpapers Wallpapers to add to grid
+ * @param selectedWallpaper The currently selected wallpaper
+ * @param numColumns The number of columns that will occupy the grid.
+ * @param onSelectionChanged Action to take when a new wallpaper is selected.
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun WallpaperThumbnails(
+    wallpapers: List<Wallpaper>,
+    selectedWallpaper: Wallpaper,
+    numColumns: Int = 3,
+    onSelectionChanged: (Wallpaper) -> Unit,
+) {
+    LazyVerticalGrid(
+        cells = GridCells.Fixed(numColumns),
+        modifier = Modifier.padding(vertical = 30.dp, horizontal = 20.dp)
+    ) {
+        items(wallpapers) { wallpaper ->
+            WallpaperThumbnailItem(
+                wallpaper = wallpaper,
+                isSelected = selectedWallpaper == wallpaper,
+                onSelectionChanged = onSelectionChanged
+            )
+        }
+    }
+}
+
+/**
+ * A single wallpaper thumbnail.
+ *
+ * @param wallpaper The wallpaper to display.
+ * @param isSelected Whether the wallpaper is currently selected.
+ * @param aspectRatio The ratio of height to width of the thumbnail
+ * @param onSelectionChanged Action to take when wallpaper is selected.
+ */
+@Composable
+private fun WallpaperThumbnailItem(
+    wallpaper: Wallpaper,
+    isSelected: Boolean,
+    aspectRatio: Float = 1.1f,
+    onSelectionChanged: (Wallpaper) -> Unit
+) {
+    val thumbnailShape = RoundedCornerShape(8.dp)
+    val border = if (isSelected) {
+        Modifier.border(
+            BorderStroke(width = 2.dp, color = FirefoxTheme.colors.borderAccent),
+            thumbnailShape
+        )
+    } else {
+        Modifier.border(
+            BorderStroke(width = 1.dp, color = FirefoxTheme.colors.borderDefault),
+            thumbnailShape
+        )
+    }
+    val background = if (wallpaper == Wallpaper.NONE) {
+        Modifier.background(color = FirefoxTheme.colors.layer1)
+    } else {
+        Modifier
+    }
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .aspectRatio(aspectRatio)
+            .padding(4.dp)
+            .clip(thumbnailShape)
+            .then(background)
+            .then(border)
+            .clickable { onSelectionChanged(wallpaper) }
+    ) {
+        if (wallpaper != Wallpaper.NONE) {
+            WallpaperImageThumbnail(
+                wallpaper = wallpaper,
+            )
+        }
+    }
+}
+
+/**
+ * A image of a drawable wallpaper.
+ *
+ * @param wallpaper The wallpaper to use.
+ */
+@Composable
+private fun WallpaperImageThumbnail(wallpaper: Wallpaper) {
+    val contentDescription = stringResource(
+        R.string.content_description_wallpaper_name, wallpaper.name
+    )
+    Image(
+        painterResource(id = wallpaper.resource),
+        contentScale = ContentScale.FillBounds,
+        contentDescription = contentDescription,
+        modifier = Modifier.fillMaxSize()
+    )
+}
+
+@Preview
+@Composable
+private fun WallpaperThumbnailsPreview() {
+    WallpaperThumbnails(
+        wallpapers = Wallpaper.values().toList(),
+        onSelectionChanged = {},
+        selectedWallpaper = Wallpaper.NONE
+    )
+}

--- a/app/src/main/java/org/mozilla/fenix/settings/wallpaper/WallpaperSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/wallpaper/WallpaperSettingsFragment.kt
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.settings.wallpaper
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.Fragment
+import org.mozilla.fenix.databinding.FragmentWallpaperSettingsBinding
+import org.mozilla.fenix.ext.requireComponents
+import org.mozilla.fenix.theme.FirefoxTheme
+
+class WallpaperSettingsFragment : Fragment() {
+    private var _binding: FragmentWallpaperSettingsBinding? = null
+    private val binding get() = _binding!!
+
+    private val wallpaperManager by lazy {
+        requireComponents.wallpaperManager
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        _binding = FragmentWallpaperSettingsBinding.inflate(inflater, container, false)
+        binding.composeView.apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                FirefoxTheme {
+                    WallpaperSettings(wallpaperManager)
+                }
+            }
+        }
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/telemetry/TelemetryLifecycleObserver.kt
+++ b/app/src/main/java/org/mozilla/fenix/telemetry/TelemetryLifecycleObserver.kt
@@ -4,9 +4,9 @@
 
 package org.mozilla.fenix.telemetry
 
-import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleObserver
-import androidx.lifecycle.OnLifecycleEvent
+import androidx.lifecycle.LifecycleOwner
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.support.base.android.Clock
 import org.mozilla.fenix.GleanMetrics.EngineTab as EngineMetrics
@@ -22,16 +22,14 @@ import org.mozilla.fenix.GleanMetrics.EngineTab.foregroundMetricsKeys as Metrics
  */
 class TelemetryLifecycleObserver(
     private val store: BrowserStore
-) : LifecycleObserver {
+) : DefaultLifecycleObserver {
     private var pausedState: TabState? = null
 
-    @OnLifecycleEvent(Lifecycle.Event.ON_PAUSE)
-    fun onPause() {
+    override fun onPause(owner: LifecycleOwner) {
         pausedState = createTabState()
     }
 
-    @OnLifecycleEvent(Lifecycle.Event.ON_RESUME)
-    fun onResume() {
+    override fun onResume(owner: LifecycleOwner) {
         val lastState = pausedState ?: return
         val currentState = createTabState()
 

--- a/app/src/main/java/org/mozilla/fenix/wallpapers/Wallpaper.kt
+++ b/app/src/main/java/org/mozilla/fenix/wallpapers/Wallpaper.kt
@@ -9,8 +9,8 @@ import org.mozilla.fenix.R
 /**
  * A enum that represents the available wallpapers and their states.
  */
-enum class Wallpaper(val drawable: Int, val isDark: Boolean) {
-    FIRST(drawable = R.drawable.wallpaper_1, isDark = true),
-    SECOND(drawable = R.drawable.wallpaper_2, isDark = false),
-    NONE(drawable = R.attr.homeBackground, isDark = false);
+enum class Wallpaper(val resource: Int, val isDark: Boolean) {
+    NONE(resource = R.attr.homeBackground, isDark = false),
+    FIRST(resource = R.drawable.wallpaper_1, isDark = true),
+    SECOND(resource = R.drawable.wallpaper_2, isDark = false);
 }

--- a/app/src/main/java/org/mozilla/fenix/wallpapers/WallpaperManager.kt
+++ b/app/src/main/java/org/mozilla/fenix/wallpapers/WallpaperManager.kt
@@ -9,37 +9,61 @@ import android.view.View
 import androidx.appcompat.app.AppCompatDelegate
 import mozilla.components.support.ktx.android.content.getColorFromAttr
 import org.mozilla.fenix.ext.asActivity
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import org.mozilla.fenix.utils.Settings
 
 /**
  * Provides access to available wallpapers and manages their states.
  */
 class WallpaperManager(private val settings: Settings) {
+    val wallpapers = Wallpaper.values()
 
-    var currentWallpaper: Wallpaper = getCurrentWallpaperFromSettings()
-        set(value) {
-            settings.currentWallpaper = value.name
-            field = value
+    private var _currentWallpaper = MutableStateFlow(Wallpaper.valueOf(settings.currentWallpaper))
+    var currentWallpaper: StateFlow<Wallpaper> = _currentWallpaper
+
+    /**
+     * Switch the selected wallpaper. This change will be persisted to disk.
+     *
+     * @param wallpaper The wallpaper to switch to.
+     */
+    fun updateWallpaperSelection(wallpaper: Wallpaper) {
+        settings.currentWallpaper = wallpaper.name
+        _currentWallpaper.value = wallpaper
+    }
+
+    /**
+     * Update the selected wallpaper to be the next wallpaper, as enumerated by [Wallpaper].
+     * This change will be persisted to disk.
+     */
+    fun switchToNextWallpaper() {
+        val current = _currentWallpaper.value
+        val wallpapers = Wallpaper.values()
+        val nextIndex = wallpapers.indexOf(current) + 1
+        val nextWallpaper = if (nextIndex >= wallpapers.size) {
+            wallpapers.first()
+        } else {
+            wallpapers[nextIndex]
         }
+        updateWallpaperSelection(nextWallpaper)
+    }
 
     /**
      * Apply the [newWallpaper] into the [wallpaperContainer] and update the [currentWallpaper].
      */
-    fun updateWallpaper(wallpaperContainer: View, newWallpaper: Wallpaper) {
+    fun applyToView(wallpaperContainer: View, newWallpaper: Wallpaper) {
         if (newWallpaper == Wallpaper.NONE) {
             val context = wallpaperContainer.context
-            wallpaperContainer.setBackgroundColor(context.getColorFromAttr(newWallpaper.drawable))
+            wallpaperContainer.setBackgroundColor(context.getColorFromAttr(newWallpaper.resource))
         } else {
-            wallpaperContainer.setBackgroundResource(newWallpaper.drawable)
+            wallpaperContainer.setBackgroundResource(newWallpaper.resource)
         }
-        currentWallpaper = newWallpaper
 
-        adjustTheme(wallpaperContainer.context)
+        adjustTheme(wallpaperContainer.context, newWallpaper)
     }
-
-    private fun adjustTheme(context: Context) {
-        val mode = if (currentWallpaper != Wallpaper.NONE) {
-            if (currentWallpaper.isDark) {
+    private fun adjustTheme(context: Context, newWallpaper: Wallpaper) {
+        val mode = if (newWallpaper != Wallpaper.NONE) {
+            if (newWallpaper.isDark) {
                 updateThemePreference(useDarkTheme = true)
                 AppCompatDelegate.MODE_NIGHT_YES
             } else {
@@ -65,29 +89,5 @@ class WallpaperManager(private val settings: Settings) {
         settings.shouldUseDarkTheme = useDarkTheme
         settings.shouldUseLightTheme = useLightTheme
         settings.shouldFollowDeviceTheme = followDeviceTheme
-    }
-
-    /**
-     * Returns the next available [Wallpaper], the [currentWallpaper] is the last one then
-     * the first available [Wallpaper] will be returned.
-     */
-    fun switchToNextWallpaper(): Wallpaper {
-        val values = Wallpaper.values()
-        val index = values.indexOf(currentWallpaper) + 1
-
-        return if (index >= values.size) {
-            values.first()
-        } else {
-            values[index]
-        }
-    }
-
-    private fun getCurrentWallpaperFromSettings(): Wallpaper {
-        val currentWallpaper = settings.currentWallpaper
-        return if (currentWallpaper.isEmpty()) {
-            Wallpaper.NONE
-        } else {
-            Wallpaper.valueOf(currentWallpaper)
-        }
     }
 }

--- a/app/src/main/res/layout/fragment_wallpaper_settings.xml
+++ b/app/src/main/res/layout/fragment_wallpaper_settings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+    - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/compose_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+</LinearLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -620,7 +620,20 @@
     <fragment
         android:id="@+id/homeSettingsFragment"
         android:name="org.mozilla.fenix.settings.HomeSettingsFragment"
-        android:label="@string/preferences_home_2" />
+        android:label="@string/preferences_home_2">
+        <action
+            android:id="@+id/action_homeSettingsFragment_to_wallpaperSettingsFragment"
+            app:destination="@id/wallpaperSettingsFragment"
+            app:enterAnim="@anim/slide_in_right"
+            app:exitAnim="@anim/slide_out_left"
+            app:popEnterAnim="@anim/slide_in_left"
+            app:popExitAnim="@anim/slide_out_right" />
+    </fragment>
+    <fragment
+        android:id="@+id/wallpaperSettingsFragment"
+        android:name="org.mozilla.fenix.settings.wallpaper.WallpaperSettingsFragment"
+        android:label="@string/customize_wallpapers"/>
+
     <fragment
         android:id="@+id/dataChoicesFragment"
         android:name="org.mozilla.fenix.settings.DataChoicesFragment"

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -187,10 +187,11 @@
     <string name="pref_key_adjust_adgroup" translatable="false">pref_key_adjust_adgroup</string>
     <string name="pref_key_adjust_creative" translatable="false">pref_key_adjust_creative</string>
 
-    <!-- Wallpaper Settings -->
-    <string name="pref_key_current_wallpaper" translatable="false">pref_key_current_wallpaper</string>
-
     <string name="pref_key_encryption_key_generated" translatable="false">pref_key_encryption_key_generated</string>
+
+    <!-- Wallpaper Settings -->
+    <string name="pref_key_wallpapers" translatable="false">pref_key_wallpapers</string>
+    <string name="pref_key_current_wallpaper" translatable="false">pref_key_current_wallpaper</string>
 
     <!-- Top Sites -->
     <string name="default_top_sites_added" translatable="false">pref_key_pocket_top_site_added</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -461,6 +461,12 @@
     <!-- Title for the customize home screen section with Pocket. -->
     <string name="customize_toggle_pocket">Pocket</string>
 
+    <!-- Wallpapers -->
+    <!-- Title for preference to open wallpapers -->
+    <string name="customize_wallpapers">Wallpapers</string>
+    <!-- Content description for various wallpapers -->
+    <string name="content_description_wallpaper_name">Wallpaper Item: %1$s</string>
+
     <!-- Add-on Installation from AMO-->
     <!-- Error displayed when user attempts to install an add-on from AMO (addons.mozilla.org) that is not supported -->
     <string name="addon_not_supported_error">Add-on is not supported</string>

--- a/app/src/main/res/xml/home_preferences.xml
+++ b/app/src/main/res/xml/home_preferences.xml
@@ -29,6 +29,11 @@
         android:title="@string/customize_toggle_pocket"
         app:isPreferenceVisible="false" />
 
+    <androidx.preference.Preference
+        android:key="@string/pref_key_wallpapers"
+        android:title="@string/customize_wallpapers"
+        app:isPreferenceVisible="true" />
+
     <androidx.preference.PreferenceCategory
         android:layout="@layout/preference_cat_style"
         android:title="@string/preferences_opening_screen"

--- a/app/src/test/java/org/mozilla/fenix/customtabs/PoweredByNotificationTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/customtabs/PoweredByNotificationTest.kt
@@ -30,7 +30,7 @@ class PoweredByNotificationTest {
         )
 
         val feature = PoweredByNotification(testContext, store, "session-id")
-        feature.onResume()
+        feature.onResume(mockk())
     }
 
     @Test
@@ -45,12 +45,12 @@ class PoweredByNotificationTest {
         )
 
         val feature = PoweredByNotification(testContext, store, "session-id")
-        feature.onResume()
+        feature.onResume(mockk())
     }
 
     @Test
     fun `unregister receiver on pause`() {
         val feature = PoweredByNotification(testContext, mockk(), "session-id")
-        feature.onPause()
+        feature.onPause(mockk())
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkDeselectNavigationListenerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkDeselectNavigationListenerTest.kt
@@ -36,10 +36,10 @@ class BookmarkDeselectNavigationListenerTest {
         val navController: NavController = mockk(relaxed = true)
         val listener = BookmarkDeselectNavigationListener(navController, mockk(), mockk())
 
-        listener.onResume()
+        listener.onResume(mockk())
         verify { navController.addOnDestinationChangedListener(listener) }
 
-        listener.onDestroy()
+        listener.onDestroy(mockk())
         verify { navController.removeOnDestinationChangedListener(listener) }
     }
 

--- a/app/src/test/java/org/mozilla/fenix/settings/about/SecretDebugMenuTriggerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/about/SecretDebugMenuTriggerTest.kt
@@ -13,6 +13,7 @@ import io.mockk.Runs
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.just
+import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.unmockkStatic
@@ -78,7 +79,7 @@ class SecretDebugMenuTriggerTest {
         val trigger = SecretDebugMenuTrigger(logoView, settings)
 
         clickListener.captured.onClick(logoView)
-        trigger.clearClickCounter()
+        trigger.onResume(mockk())
 
         clickListener.captured.onClick(logoView)
 

--- a/app/src/test/java/org/mozilla/fenix/telemetry/TelemetryLifecycleObserverTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/telemetry/TelemetryLifecycleObserverTest.kt
@@ -47,7 +47,7 @@ class TelemetryLifecycleObserverTest {
     fun `resume without a pause does not record any metrics`() {
         val store = BrowserStore()
         val observer = TelemetryLifecycleObserver(store)
-        observer.onResume()
+        observer.onResume(mockk())
 
         assertFalse(EngineMetrics.foregroundMetrics.testHasValue())
     }
@@ -57,11 +57,11 @@ class TelemetryLifecycleObserverTest {
         val store = BrowserStore()
         val observer = TelemetryLifecycleObserver(store)
 
-        observer.onPause()
+        observer.onPause(mockk())
 
         clock.elapsedTime = 550
 
-        observer.onResume()
+        observer.onResume(mockk())
 
         assertTrue(EngineMetrics.foregroundMetrics.testHasValue())
 
@@ -92,7 +92,7 @@ class TelemetryLifecycleObserverTest {
 
         clock.elapsedTime = 120
 
-        observer.onPause()
+        observer.onPause(mockk())
 
         store.dispatch(
             EngineAction.KillEngineSessionAction("theverge")
@@ -104,7 +104,7 @@ class TelemetryLifecycleObserverTest {
 
         clock.elapsedTime = 10340
 
-        observer.onResume()
+        observer.onResume(mockk())
 
         assertTrue(EngineMetrics.foregroundMetrics.testHasValue())
 

--- a/app/src/test/java/org/mozilla/fenix/wallpapers/WallpaperManagerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/wallpapers/WallpaperManagerTest.kt
@@ -1,0 +1,76 @@
+package org.mozilla.fenix.wallpapers
+
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mozilla.fenix.utils.Settings
+
+class WallpaperManagerTest {
+
+    private val mockSettings: Settings = mockk()
+
+    @Test
+    fun `WHEN manager created THEN current wallpaper delegated by settings`() = runBlockingTest {
+        val expectedWallpaper = Wallpaper.FIRST
+        every { mockSettings.currentWallpaper } returns expectedWallpaper.name
+
+        val manager = WallpaperManager(mockSettings)
+
+        val result = manager.currentWallpaper.first()
+        assertEquals(expectedWallpaper, result)
+    }
+
+    @Test
+    fun `WHEN wallpaper edited THEN settings receive update and new value emitted`() = runBlockingTest {
+        val currentWallpaper = Wallpaper.NONE
+        every { mockSettings.currentWallpaper } returns currentWallpaper.name
+        val wallpaperSlot = slot<String>()
+        every { mockSettings.currentWallpaper = capture(wallpaperSlot) } just runs
+
+        val newWallpaper = Wallpaper.FIRST
+        val manager = WallpaperManager(mockSettings)
+        manager.updateWallpaperSelection(newWallpaper)
+
+        val result = manager.currentWallpaper.first()
+        assertEquals(newWallpaper, result)
+        assertEquals(newWallpaper.name, wallpaperSlot.captured)
+    }
+
+    @Test
+    fun `WHEN wallpaper switched to next THEN settings receive update and new value emitted`() = runBlockingTest {
+        val currentWallpaper = Wallpaper.values()[0]
+        every { mockSettings.currentWallpaper } returns currentWallpaper.name
+        val wallpaperSlot = slot<String>()
+        every { mockSettings.currentWallpaper = capture(wallpaperSlot) } just runs
+
+        val manager = WallpaperManager(mockSettings)
+        manager.switchToNextWallpaper()
+
+        val newWallpaper = Wallpaper.values()[1]
+        val result = manager.currentWallpaper.first()
+        assertEquals(newWallpaper, result)
+        assertEquals(newWallpaper.name, wallpaperSlot.captured)
+    }
+
+    @Test
+    fun `GIVEN current wallpaper is last WHEN wallpaper switched to next THEN first value is used`() = runBlockingTest {
+        val currentWallpaper = Wallpaper.values().last()
+        every { mockSettings.currentWallpaper } returns currentWallpaper.name
+        val wallpaperSlot = slot<String>()
+        every { mockSettings.currentWallpaper = capture(wallpaperSlot) } just runs
+
+        val manager = WallpaperManager(mockSettings)
+        manager.switchToNextWallpaper()
+
+        val newWallpaper = Wallpaper.values().first()
+        val result = manager.currentWallpaper.first()
+        assertEquals(newWallpaper, result)
+        assertEquals(newWallpaper.name, wallpaperSlot.captured)
+    }
+}

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -30,7 +30,7 @@ object Versions {
     const val androidx_preference = "1.1.1"
     const val androidx_legacy = "1.0.0"
     const val androidx_annotation = "1.1.0"
-    const val androidx_lifecycle = "2.2.0"
+    const val androidx_lifecycle = "2.4.0"
     const val androidx_fragment = "1.3.4"
     const val androidx_navigation = "2.3.3"
     const val androidx_recyclerview = "1.2.1"


### PR DESCRIPTION
Depends on #22944, which will reduce the scope of the PR to exclude the `androidx.lifecycle` update.

@jonalmeida and I briefly talked that the wallpaper state might better belong in the `HomeFragmentStore`, so this PR could serve as a good forum for discussion about that. Having that state accessible through the store could have additional benefits, such as easier access for text components to update their color like is being working on in #22941. It looks like there was already some discussion about this in #22851, actually.

<img width="625" alt="image" src="https://user-images.githubusercontent.com/10427470/147138891-e566338b-a00b-466f-9e61-b6d7627b32bb.png">

<img width="622" alt="image" src="https://user-images.githubusercontent.com/10427470/147138827-9146eb6f-cf39-4504-8280-0e6119aa60b5.png">

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: Adds some tests around the 
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
