### PR TITLE
Revert "For #22777 - Replace about_link_normal_theme with fx_mobile_text_color_action"

### DIFF
--- a/app/src/main/res/layout/fragment_add_on_details.xml
+++ b/app/src/main/res/layout/fragment_add_on_details.xml
@@ -22,7 +22,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:textColor="?primaryText"
-            android:textColorLink="@color/fx_mobile_text_color_action"
+            android:textColorLink="?aboutLink"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             tools:text="@tools:sample/lorem/random" />
@@ -134,7 +134,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="10dp"
             android:text="@string/mozac_feature_addons_home_page"
-            android:textColor="@color/fx_mobile_text_color_action"
+            android:textColor="?aboutLink"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/last_updated_divider" />
 

--- a/app/src/main/res/layout/fragment_add_on_permissions.xml
+++ b/app/src/main/res/layout/fragment_add_on_permissions.xml
@@ -28,6 +28,6 @@
             android:paddingEnd="16dp"
             android:text="@string/mozac_feature_addons_learn_more"
             style="@style/AboutHeaderContentText"
-            android:textColor="@color/fx_mobile_text_color_action"/>
+            android:textColor="?aboutLink"/>
     </RelativeLayout>
 </ScrollView>

--- a/app/src/main/res/layout/settings_studies.xml
+++ b/app/src/main/res/layout/settings_studies.xml
@@ -31,7 +31,7 @@
         android:importantForAccessibility="no"
         android:text="@string/preference_experiments_summary_2"
         android:textColor="?attr/secondaryText"
-        android:textColorLink="@color/fx_mobile_text_color_action"
+        android:textColorLink="?aboutLink"
         app:layout_constraintEnd_toEndOf="@id/studiesTitle"
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toStartOf="@id/studiesTitle"

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -102,6 +102,7 @@
     <color name="accent_normal_theme">@color/photonViolet50</color>
     <color name="accent_bright_normal_theme">@color/accent_bright_dark_theme</color>
     <color name="accent_high_contrast_normal_theme">@color/accent_high_contrast_dark_theme</color>
+    <color name="about_link_normal_theme">@color/photonViolet40</color>
     <color name="tab_ring_normal_theme">@color/accent_normal_theme</color>
     <color name="neutral_normal_theme">@color/photonGrey20</color>
     <color name="neutral_faded_normal_theme">#1FFBFBFE</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -134,6 +134,7 @@
     <color name="foundation_light_theme">@color/photonLightGrey20</color>
     <color name="accent_light_theme">@color/photonInk20</color>
     <color name="accent_bright_light_theme">@color/photonViolet70</color>
+    <color name="about_link_normal_theme">@color/photonViolet70</color>
     <color name="dark_grey_90_gradient_start">@color/photonDarkGrey90</color>
     <color name="dark_grey_90_gradient_end">#0015141A</color>
     <color name="preference_section_header_normal_theme">@color/accent_bright_light_theme</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -46,6 +46,7 @@
         <item name="contrastText">@color/contrast_text_normal_theme</item>
         <item name="accent">@color/accent_normal_theme</item>
         <item name="accentBright">@color/accent_bright_normal_theme</item>
+        <item name="aboutLink">@color/about_link_normal_theme</item>
         <item name="accentHighContrast">@color/accent_high_contrast_normal_theme</item>
         <item name="foundation">@color/foundation_normal_theme</item>
         <item name="above">@color/above_normal_theme</item>
@@ -538,7 +539,7 @@
     <style name="ShareDialogStyle" parent="DialogStyleBase"/>
 
     <style name="AboutItemText" parent="TextAppearance.MaterialComponents.Body2">
-        <item name="android:textColor">@color/fx_mobile_text_color_action</item>
+        <item name="android:textColor">?aboutLink</item>
         <item name="android:textSize">@dimen/about_items_text_size</item>
         <item name="android:paddingStart">@dimen/about_list_item_text_padding</item>
         <item name="android:paddingEnd">@dimen/about_list_item_text_padding</item>


### PR DESCRIPTION
Reverts mozilla-mobile/fenix#22778

I realized we still had a ?aboutLink for private theme so the original changes were because we didn't consider.