### PR TITLE
Issue #22561: Fix tab group titles colour when in private mode

### DIFF
--- a/app/src/main/res/layout/tab_group_item.xml
+++ b/app/src/main/res/layout/tab_group_item.xml
@@ -17,6 +17,7 @@
         android:layout_marginStart="16dp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
+        app:tint="@color/primary_text_normal_theme"
         app:srcCompat="@drawable/ic_search" />
 
     <TextView
@@ -28,6 +29,7 @@
         android:gravity="start"
         android:maxLines="1"
         android:textAppearance="@style/Header16TextStyle"
+        android:textColor="@color/primary_text_normal_theme"
         app:layout_constraintBottom_toBottomOf="@id/group_icon"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"

--- a/app/src/main/res/layout/tab_tray_title_header_item.xml
+++ b/app/src/main/res/layout/tab_tray_title_header_item.xml
@@ -19,6 +19,7 @@
     android:maxLines="1"
     android:text="@string/tab_tray_header_title_1"
     android:textAppearance="@style/Header16TextStyle"
+    android:textColor="@color/primary_text_normal_theme"
     app:layout_constraintBottom_toBottomOf="parent"
     app:layout_constraintStart_toStartOf="parent"
     app:layout_constraintTop_toTopOf="parent" />


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
