### PR TITLE
For #23040 - Add hand curated parameters files to `taskgraph/test/params`

### DIFF
--- a/taskcluster/test/params/fork-cron-nightly.yml
+++ b/taskcluster/test/params/fork-cron-nightly.yml
@@ -1,0 +1,25 @@
+base_repository: https://github.com/JohanLorenzo/fenix
+build_date: 1570168853
+do_not_optimize: []
+existing_tasks: {}
+filters:
+- target_tasks_method
+head_ref: master
+head_repository: https://github.com/JohanLorenzo/fenix
+head_rev: 841b06b02fc3a887fcea2a8b42dfbb9142f0bc52
+head_tag: ''
+hg_branch: null
+level: '1'
+moz_build_date: '20191004060053'
+optimize_target_tasks: true
+owner: cron@noreply.mozilla.org
+project: fenix
+pull_request_number: null
+pushdate: 0
+pushlog_id: '0'
+release_type: ''
+version: ''
+next_version: ''
+repository_type: git
+target_tasks_method: nightly
+tasks_for: cron

--- a/taskcluster/test/params/fork-push.yml
+++ b/taskcluster/test/params/fork-push.yml
@@ -1,0 +1,25 @@
+base_repository: https://github.com/JohanLorenzo/fenix
+build_date: 1570138994
+do_not_optimize: []
+existing_tasks: {}
+filters:
+- target_tasks_method
+head_ref: refs/heads/master
+head_repository: https://github.com/JohanLorenzo/fenix
+head_rev: 841b06b02fc3a887fcea2a8b42dfbb9142f0bc52
+head_tag: ''
+hg_branch: null
+level: '1'
+moz_build_date: '20191003214314'
+optimize_target_tasks: true
+owner: sdblatz@gmail.com
+project: fenix
+pull_request_number: null
+pushdate: 0
+pushlog_id: '0'
+release_type: ''
+version: ''
+next_version: ''
+repository_type: git
+target_tasks_method: default
+tasks_for: github-push

--- a/taskcluster/test/params/fork-release-beta.yml
+++ b/taskcluster/test/params/fork-release-beta.yml
@@ -1,0 +1,25 @@
+base_repository: https://github.com/JohanLorenzo/fenix
+build_date: 1570115614
+do_not_optimize: []
+existing_tasks: {}
+filters:
+- target_tasks_method
+head_ref: master
+head_repository: https://github.com/JohanLorenzo/fenix
+head_rev: bc471ea59c09e6272b6bf6480b27ed7445180ed0
+head_tag: v2.1.0
+hg_branch: null
+level: '1'
+moz_build_date: '20191003151334'
+optimize_target_tasks: true
+owner: JohanLorenzo@users.noreply.github.com
+project: fenix
+pull_request_number: null
+pushdate: 0
+pushlog_id: '0'
+release_type: beta
+version: 2.1.0-beta.0
+next_version: '2.1.0-beta.1'
+repository_type: git
+target_tasks_method: release
+tasks_for: github-release

--- a/taskcluster/test/params/fork-release-production.yml
+++ b/taskcluster/test/params/fork-release-production.yml
@@ -1,0 +1,25 @@
+base_repository: https://github.com/JohanLorenzo/fenix
+build_date: 1570115614
+do_not_optimize: []
+existing_tasks: {}
+filters:
+- target_tasks_method
+head_ref: master
+head_repository: https://github.com/JohanLorenzo/fenix
+head_rev: bc471ea59c09e6272b6bf6480b27ed7445180ed0
+head_tag: v2.1.0
+hg_branch: null
+level: '1'
+moz_build_date: '20191003151334'
+optimize_target_tasks: true
+owner: JohanLorenzo@users.noreply.github.com
+project: fenix
+pull_request_number: null
+pushdate: 0
+pushlog_id: '0'
+release_type: production
+version: 2.1.0
+next_version: 2.2.0
+repository_type: git
+target_tasks_method: release
+tasks_for: github-release

--- a/taskcluster/test/params/main-repo-cron-nightly.yml
+++ b/taskcluster/test/params/main-repo-cron-nightly.yml
@@ -1,0 +1,24 @@
+base_repository: https://github.com/mozilla-mobile/fenix
+build_date: 1641186118
+do_not_optimize: []
+existing_tasks: {}
+filters:
+- target_tasks_method
+head_ref: main
+head_repository: https://github.com/mozilla-mobile/fenix
+head_rev: 9c10f7abb66354ff00e7c976078d0301efd60e80
+head_tag: ''
+level: '3'
+moz_build_date: '20220103050158'
+next_version: null
+optimize_target_tasks: true
+owner: cron@noreply.mozilla.org
+project: fenix
+pull_request_number: null
+pushdate: 0
+pushlog_id: '0'
+release_type: ''
+repository_type: git
+target_tasks_method: nightly
+tasks_for: cron
+version: ''

--- a/taskcluster/test/params/main-repo-pull-request.yml
+++ b/taskcluster/test/params/main-repo-pull-request.yml
@@ -1,0 +1,25 @@
+base_repository: https://github.com/mozilla-mobile/fenix
+build_date: 1570193209
+do_not_optimize: []
+existing_tasks: {}
+filters:
+- target_tasks_method
+head_ref: import-l10n
+head_repository: https://github.com/Pike/fenix
+head_rev: 3e6c558e8e74e04ebf60f853687c8b644c6c16da
+head_tag: ''
+hg_branch: null
+level: '1'
+moz_build_date: '20191004124649'
+optimize_target_tasks: true
+owner: Pike@users.noreply.github.com
+project: fenix
+pull_request_number: 5639
+pushdate: 0
+pushlog_id: '0'
+release_type: ''
+version: ''
+next_version: ''
+repository_type: git
+target_tasks_method: default
+tasks_for: github-pull-request

--- a/taskcluster/test/params/main-repo-push.yml
+++ b/taskcluster/test/params/main-repo-push.yml
@@ -1,0 +1,25 @@
+base_repository: https://github.com/mozilla-mobile/fenix
+build_date: 1570138994
+do_not_optimize: []
+existing_tasks: {}
+filters:
+- target_tasks_method
+head_ref: refs/heads/master
+head_repository: https://github.com/mozilla-mobile/fenix
+head_rev: 841b06b02fc3a887fcea2a8b42dfbb9142f0bc52
+head_tag: ''
+hg_branch: null
+level: '3'
+moz_build_date: '20191003214314'
+optimize_target_tasks: true
+owner: sdblatz@gmail.com
+project: fenix
+pull_request_number: null
+pushdate: 0
+pushlog_id: '0'
+release_type: ''
+version: ''
+next_version: ''
+repository_type: git
+target_tasks_method: default
+tasks_for: github-push

--- a/taskcluster/test/params/main-repo-release-beta.yml
+++ b/taskcluster/test/params/main-repo-release-beta.yml
@@ -1,0 +1,56 @@
+base_repository: https://github.com/mozilla-mobile/fenix
+build_date: 1640308990
+build_number: 1
+do_not_optimize: []
+existing_tasks:
+  build-android-test-beta: JcGAMJ92R6eYCGFRFf_c5A
+  build-android-test-debug: Yswb54wTShCK37S8aE1kLg
+  build-android-test-mozillaonline: MuicYM5XS66yd1DMqN_m7g
+  build-android-test-nightly: eYBy9EptRpuWCCOPVLtmBw
+  build-beta-firebase: ctkrmSACRfW-3wbUE6SMqA
+  build-debug: Z-w5JkIjTQCwbJJVaqyuoQ
+  build-docker-image-android-build: fDd4Ru8QTqWygbEDP8f2MQ
+  build-docker-image-base: VS0lztwQRraFi5kf_8NHww
+  build-docker-image-bump: Dtyz3Jx8Qoa-aOy81LeVTg
+  build-docker-image-ui-tests: GtzptMkwSHGSKMTrQW8xpg
+  build-docker-image-visual-metrics: LzG9cHbwQkWrWc9K_-1mww
+  build-nightly-firebase: ewGHJXPoRiKrlGAKluR7-A
+  build-nightly-simulation: Yw9U9iyWSHuYbi64i0De5g
+  fetch-android-sdk-3859397: MA30YXOCRKiLZ05rrXSeOQ
+  geckoview-nightly: TVzzL2lATEaK2T542lUi8g
+  lint-compare-locales: b5xz-COoRoS1ZgvTEgepKQ
+  lint-detekt: COLcAr2fQfWLfsbri1BrEA
+  lint-ktlint: ChXvD8RKQdWDOaJMCd28qw
+  lint-lint: XiIM2XFUR72qg5F39f0CfQ
+  signing-android-test-beta: Lx0M3F6fR3iOqqj8HEwYTg
+  signing-android-test-mozillaonline: ITnjsIbARGujUVjGBkO4cA
+  signing-android-test-nightly: ExRmq67nRTSlkAUhV3V_9Q
+  signing-beta-firebase: IxvD0ajDST-kO6ejtRE7PQ
+  signing-nightly-firebase: F2c1KMwMRpyL44yS-LeMxw
+  signing-nightly-simulation: AOzAFsYuRdmc_lgmR_0sFA
+  test-debug: R4GUJoc3TryBaSC7bsoN_g
+  toolchain-linux64-android-gradle-dependencies: JJyZAqa5QJ6KIXhyVq_91Q
+  toolchain-linux64-android-sdk-linux-repack: eeuRa0X3Q7i5MGe1dc-eBQ
+  ui-test-x86-beta: QHZGQaQBS8ak_C6yL_M6eg
+  ui-test-x86-nightly: YimVW6nmRiex8ng4ompZ_g
+filters:
+- target_tasks_method
+head_ref: refs/heads/releases_v96.0.0
+head_repository: https://github.com/mozilla-mobile/fenix
+head_rev: e20176743eb13c51bc7a055e2bf4c552f80a2f60
+head_tag: v96.0.0-beta.5
+level: '3'
+moz_build_date: '20211224012310'
+next_version: 96.0.0-beta.6
+optimize_target_tasks: true
+owner: 88508950+dsmithpadilla@users.noreply.github.com
+project: fenix
+pull_request_number: null
+pushdate: 0
+pushlog_id: '0'
+release_type: beta
+repository_type: git
+shipping_phase: ship
+target_tasks_method: release
+tasks_for: action
+version: 96.0.0-beta.5

--- a/taskcluster/test/params/main-repo-release-production.yml
+++ b/taskcluster/test/params/main-repo-release-production.yml
@@ -1,0 +1,56 @@
+base_repository: https://github.com/mozilla-mobile/fenix
+build_date: 1639626597
+build_number: 1
+do_not_optimize: []
+existing_tasks:
+  build-android-test-beta: B4vD3TngTLW9D35-ApYfKQ
+  build-android-test-debug: QjtVnyJqTJe6eEmIHY50ug
+  build-android-test-mozillaonline: CF4tcO1jTP2rPh_Xv1xHvw
+  build-android-test-nightly: bVmBLzC6TR62HYEvb56EoQ
+  build-beta-firebase: QkYQC1H8SyuRaNZ6TSMBqA
+  build-debug: aPka3rH1TaOfJi9rdbXr0A
+  build-docker-image-android-build: OYF1kt39Q4K9n04xAn0VhA
+  build-docker-image-base: C2JDRKUwQy2A2dyy_RBPmg
+  build-docker-image-bump: YM-8YRG8S26AP9jhlX2rVA
+  build-docker-image-ui-tests: VLtBlgncTuyEMd1sDPuUzg
+  build-docker-image-visual-metrics: QYro9_lnRlyojAMggegF_Q
+  build-nightly-firebase: Gs-zgJzJS12p3pfHoFA1VA
+  build-nightly-simulation: AAwPI-HBSGOn_qWGTgCRyA
+  fetch-android-sdk-3859397: MA30YXOCRKiLZ05rrXSeOQ
+  geckoview-nightly: C9oROmpESfWu2u0JE0vkAw
+  lint-compare-locales: TZKl9oDaTVGPqLm5ErpKgA
+  lint-detekt: AlPM1LCYSJWHBT_L8tNzbA
+  lint-ktlint: fYRhiE7dQDiNhS3rV3Z_kg
+  lint-lint: ViR0bDwFQHCH9ESikK82oQ
+  signing-android-test-beta: CGOoDIR-TSmsxjieMOlitg
+  signing-android-test-mozillaonline: b-Y5L_0zSmWvnw6ujqbPAw
+  signing-android-test-nightly: JLG-ztp3QLumczj96aOALA
+  signing-beta-firebase: CrApN9xIRPGgOAAdLLVXVA
+  signing-nightly-firebase: HTX6Yv7wTwShhdOlKW-Fhg
+  signing-nightly-simulation: FDthhipBSkW6v6ScdevaWw
+  test-debug: HrKX6aOlTAaFzOFMe6VHgQ
+  toolchain-linux64-android-gradle-dependencies: dRunSF1JRbKW5mNWqWQWOg
+  toolchain-linux64-android-sdk-linux-repack: eeuRa0X3Q7i5MGe1dc-eBQ
+  ui-test-x86-beta: SBiN3LFzSqO-W67DLpepMQ
+  ui-test-x86-nightly: OoeIZujaSpmk-VUUKw_nkg
+filters:
+- target_tasks_method
+head_ref: refs/heads/releases_v95.0.0
+head_repository: https://github.com/mozilla-mobile/fenix
+head_rev: 2742cd554c5b0d6b93bcb7e893808cbddb79c194
+head_tag: v95.2.0
+level: '3'
+moz_build_date: '20211216034957'
+next_version: 95.2.1
+optimize_target_tasks: true
+owner: 88508950+dsmithpadilla@users.noreply.github.com
+project: fenix
+pull_request_number: null
+pushdate: 0
+pushlog_id: '0'
+release_type: release
+repository_type: git
+shipping_phase: ship
+target_tasks_method: release
+tasks_for: action
+version: 95.2.0


### PR DESCRIPTION
Fixes #23040

These files can be used to test changes to the taskgraph locally, e.g via:

    $ taskgraph target -p taskcluster/test/params

They can also potentially be used by future theoretical tests that could validate our CI pipeline.