### PR TITLE
No issue: Remove unused code from TrackingProtectionPolicyFactory

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/TrackingProtectionPolicyFactory.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/TrackingProtectionPolicyFactory.kt
@@ -42,9 +42,9 @@ class TrackingProtectionPolicyFactory(
             }
 
         return when {
-            normalMode && privateMode -> trackingProtectionPolicy.adaptPolicyToChannel()
-            normalMode && !privateMode -> trackingProtectionPolicy.adaptPolicyToChannel().forRegularSessionsOnly()
-            !normalMode && privateMode -> trackingProtectionPolicy.adaptPolicyToChannel().forPrivateSessionsOnly()
+            normalMode && privateMode -> trackingProtectionPolicy
+            normalMode && !privateMode -> trackingProtectionPolicy.forRegularSessionsOnly()
+            !normalMode && privateMode -> trackingProtectionPolicy.forPrivateSessionsOnly()
             else -> TrackingProtectionPolicy.none()
         }
     }

--- a/app/src/test/java/org/mozilla/fenix/components/TrackingProtectionPolicyFactoryTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/TrackingProtectionPolicyFactoryTest.kt
@@ -133,25 +133,6 @@ class TrackingProtectionPolicyFactoryTest {
     }
 
     @Test
-    fun `adaptPolicyToChannel MUST only update properties that have changed per given channel`() {
-        mockkObject(Config)
-
-        val policies = arrayOf(
-            TrackingProtectionPolicy.strict(), TrackingProtectionPolicy.recommended(),
-            TrackingProtectionPolicy.select()
-        )
-
-        for (channel in ReleaseChannel.values()) {
-            every { Config.channel } returns channel
-
-            for (policy in policies) {
-                val adaptedPolicy = policy.adaptPolicyToChannel()
-                policy.assertPolicyEquals(adaptedPolicy, checkPrivacy = false)
-            }
-        }
-    }
-
-    @Test
     fun `GIVEN custom policy WHEN cookie policy social THEN tracking policy should have cookie policy allow non-trackers`() {
         val expected = TrackingProtectionPolicy.select(
             cookiePolicy = TrackingProtectionPolicy.CookiePolicy.ACCEPT_NON_TRACKERS,


### PR DESCRIPTION
To make sure we are getting the right values from the tracking protection `TrackingProtectionPolicy.strict()` `createCustomTrackingProtectionPolicy()` and  `TrackingProtectionPolicy.recommended()`, we need to remove this unused code that it's altering the value of `cookiePolicyPrivateMode` related https://github.com/mozilla-mobile/android-components/pull/11481
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
