### PR TITLE
Closes #23073: Long press on security icon in navbar to open Site permissions

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -413,6 +413,10 @@ abstract class BaseBrowserFragment :
             showQuickSettingsDialog()
         }
 
+        browserToolbarView.view.display.setOnSiteSecurityLongClickListener {
+            navToSitePermissionsFragment()
+        }
+
         contextMenuFeature.set(
             feature = ContextMenuFeature(
                 fragmentManager = parentFragmentManager,
@@ -1165,6 +1169,8 @@ abstract class BaseBrowserFragment :
         tab: SessionState,
         sitePermissions: SitePermissions?
     )
+
+    protected abstract fun navToSitePermissionsFragment()
 
     /**
      * Returns the layout [android.view.Gravity] for the quick settings and ETP dialog.

--- a/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BrowserFragment.kt
@@ -319,6 +319,11 @@ class BrowserFragment : BaseBrowserFragment(), UserInteractionHandler {
         }
     }
 
+    override fun navToSitePermissionsFragment() {
+        val directions = BrowserFragmentDirections.actionBrowserFragmentToSitePermissionsFragment()
+        nav(R.id.browserFragment, directions)
+    }
+
     private val collectionStorageObserver = object : TabCollectionStorage.Observer {
         override fun onCollectionCreated(
             title: String,

--- a/app/src/main/java/org/mozilla/fenix/customtabs/ExternalAppBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/customtabs/ExternalAppBrowserFragment.kt
@@ -196,6 +196,11 @@ class ExternalAppBrowserFragment : BaseBrowserFragment(), UserInteractionHandler
         }
     }
 
+    override fun navToSitePermissionsFragment() {
+        val directions = ExternalAppBrowserFragmentDirections.actionGlobalSitePermissionsFragment()
+        nav(R.id.browserFragment, directions)
+    }
+
     override fun getContextMenuCandidates(
         context: Context,
         view: View

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -129,6 +129,9 @@
         android:id="@+id/action_global_quickSettingsSheetDialogFragment"
         app:destination="@id/quickSettingsSheetDialogFragment" />
     <action
+        android:id="@+id/action_global_sitePermissionsFragment"
+        app:destination="@id/sitePermissionsFragment" />
+    <action
         android:id="@+id/action_global_connectionDetailsDialogFragment"
         app:destination="@id/connectionPanelDialogFragment" />
     <action
@@ -240,6 +243,9 @@
         <action
             android:id="@+id/action_browserFragment_to_quickSettingsSheetDialogFragment"
             app:destination="@id/quickSettingsSheetDialogFragment" />
+        <action
+            android:id="@+id/action_browserFragment_to_sitePermissionsFragment"
+            app:destination="@id/sitePermissionsFragment" />
     </fragment>
 
     <fragment


### PR DESCRIPTION
Relates to [...issue/23073](https://github.com/mozilla-mobile/fenix/issues/23073)

Adding a long press support for the security icon, to quickly navigate to SitePermissions screen.
No tests included, similar functionality (clicking) isn't covered by tests.

Requires [this](https://github.com/mozilla-mobile/android-components/pull/11494) AC PR to be merged.

<img width="395" alt="Screen Shot 2022-01-05 at 3 03 35 PM" src="https://user-images.githubusercontent.com/92760693/148451215-874511f9-34e9-4b9d-8d02-44ef41aef0b4.png">
