### PR TITLE
Fix lincense in tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/customannotations/SmokeTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/customannotations/SmokeTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.customannotations
 
 /**

--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/Constants.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/Constants.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.helpers
 
 object Constants {

--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/FeatureSettingsHelper.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/FeatureSettingsHelper.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.helpers
 
 import android.content.Context

--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/IdlingResourceHelper.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/IdlingResourceHelper.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.helpers
 
 import androidx.test.espresso.IdlingRegistry

--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/RecyclerViewIdlingResource.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/RecyclerViewIdlingResource.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.helpers
 
 import androidx.test.espresso.IdlingResource

--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/RetryTestRule.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/RetryTestRule.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.helpers
 
 import org.junit.rules.TestRule

--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/ViewVisibilityIdlingResource.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/ViewVisibilityIdlingResource.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.helpers
 
 import android.view.View

--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/idlingresource/AddonsInstallingIdlingResource.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/idlingresource/AddonsInstallingIdlingResource.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.helpers.idlingresource
 
 import androidx.fragment.app.FragmentManager

--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/idlingresource/AddonsLoadingIdlingResource.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/idlingresource/AddonsLoadingIdlingResource.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.helpers.idlingresource
 
 import android.view.View

--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/matchers/BitmapDrawableMatcher.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/matchers/BitmapDrawableMatcher.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.helpers.matchers
 
 import android.graphics.Bitmap

--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/matchers/RecyclerViewItemMatcher.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/matchers/RecyclerViewItemMatcher.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.helpers.matchers
 
 import android.view.View

--- a/app/src/androidTest/java/org/mozilla/fenix/perf/SampleBenchmark.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/perf/SampleBenchmark.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.perf
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAddonsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAddonsTest.kt
@@ -1,8 +1,8 @@
-package org.mozilla.fenix.ui
-
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.ui
 
 import android.view.View
 import androidx.test.espresso.IdlingRegistry

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/AccountSettingsRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/AccountSettingsRobot.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.ui.robots
 
 import androidx.test.espresso.Espresso

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/CollectionRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/CollectionRobot.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.ui.robots
 
 import androidx.test.espresso.Espresso.onView

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NotificationRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NotificationRobot.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.ui.robots
 
 import androidx.test.uiautomator.By.text

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAddonsManagerAddonDetailedMenuRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAddonsManagerAddonDetailedMenuRobot.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.ui.robots
 
 import androidx.test.espresso.Espresso.onView

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAddonsManagerRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAddonsManagerRobot.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.ui.robots
 
 import android.widget.RelativeLayout

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuHomepageRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuHomepageRobot.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.ui.robots
 
 import androidx.test.espresso.Espresso.onView

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ShareOverlayRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ShareOverlayRobot.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.ui.robots
 
 import android.content.Intent

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SyncSignInRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SyncSignInRobot.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-* License, v. 2.0. If a copy of the MPL was not distributed with this
-* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.ui.robots
 

--- a/app/src/test/java/org/mozilla/fenix/FenixLogSinkTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/FenixLogSinkTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix
 
 import android.util.Log

--- a/app/src/test/java/org/mozilla/fenix/components/InflationAwareFeatureTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/InflationAwareFeatureTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.components
 
 import android.view.View

--- a/app/src/test/java/org/mozilla/fenix/components/TrackingProtectionPolicyFactoryTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/TrackingProtectionPolicyFactoryTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.components
 
 import io.mockk.every

--- a/app/src/test/java/org/mozilla/fenix/components/metrics/MetricsUtilsTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/metrics/MetricsUtilsTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.components.metrics
 
 import android.content.Context

--- a/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarInteractorTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.components.toolbar
 
 import io.mockk.MockKAnnotations

--- a/app/src/test/java/org/mozilla/fenix/exceptions/login/LoginExceptionFragmentStoreTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/exceptions/login/LoginExceptionFragmentStoreTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.exceptions.login
 

--- a/app/src/test/java/org/mozilla/fenix/exceptions/login/LoginExceptionsAdapterTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/exceptions/login/LoginExceptionsAdapterTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.exceptions.login
 

--- a/app/src/test/java/org/mozilla/fenix/exceptions/login/LoginExceptionsInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/exceptions/login/LoginExceptionsInteractorTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.exceptions.login
 

--- a/app/src/test/java/org/mozilla/fenix/exceptions/trackingprotection/TrackingProtectionExceptionsFragmentStoreTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/exceptions/trackingprotection/TrackingProtectionExceptionsFragmentStoreTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.exceptions.trackingprotection
 

--- a/app/src/test/java/org/mozilla/fenix/exceptions/trackingprotection/TrackingProtectionExceptionsInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/exceptions/trackingprotection/TrackingProtectionExceptionsInteractorTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.exceptions.trackingprotection
 

--- a/app/src/test/java/org/mozilla/fenix/ext/MockKMatcherScope.kt
+++ b/app/src/test/java/org/mozilla/fenix/ext/MockKMatcherScope.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.ext
 
 import android.content.Intent

--- a/app/src/test/java/org/mozilla/fenix/helpers/MockkRetryTestRule.kt
+++ b/app/src/test/java/org/mozilla/fenix/helpers/MockkRetryTestRule.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.helpers
 
 import io.mockk.MockKException

--- a/app/src/test/java/org/mozilla/fenix/library/downloads/DownloadControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/downloads/DownloadControllerTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.library.downloads
 

--- a/app/src/test/java/org/mozilla/fenix/library/downloads/DownloadFragmentTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/downloads/DownloadFragmentTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.library.downloads
 

--- a/app/src/test/java/org/mozilla/fenix/library/downloads/DownloadInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/downloads/DownloadInteractorTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.library.downloads
 

--- a/app/src/test/java/org/mozilla/fenix/library/history/HistoryAdapterTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/history/HistoryAdapterTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.library.history
 

--- a/app/src/test/java/org/mozilla/fenix/library/history/HistoryControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/history/HistoryControllerTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.library.history
 

--- a/app/src/test/java/org/mozilla/fenix/library/history/HistoryInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/history/HistoryInteractorTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.library.history
 

--- a/app/src/test/java/org/mozilla/fenix/search/SearchDialogControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/search/SearchDialogControllerTest.kt
@@ -1,6 +1,6 @@
-/*  This Source Code Form is subject to the terms of the Mozilla Public
- *  License, v. 2.0. If a copy of the MPL was not distributed with this
- *  file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.search
 

--- a/app/src/test/java/org/mozilla/fenix/settings/account/AccountSettingsFragmentStoreTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/account/AccountSettingsFragmentStoreTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.settings.account
 

--- a/app/src/test/java/org/mozilla/fenix/settings/account/AccountSettingsInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/account/AccountSettingsInteractorTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.settings.account
 

--- a/app/src/test/java/org/mozilla/fenix/settings/account/DefaultSyncControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/account/DefaultSyncControllerTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.settings.account
 

--- a/app/src/test/java/org/mozilla/fenix/settings/account/DefaultSyncInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/account/DefaultSyncInteractorTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.settings.account
 

--- a/app/src/test/java/org/mozilla/fenix/settings/advanced/LocaleManagerExtensionTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/advanced/LocaleManagerExtensionTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-* License, v. 2.0. If a copy of the MPL was not distributed with this
-* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.settings.advanced
 

--- a/app/src/test/java/org/mozilla/fenix/settings/deletebrowsingdata/DefaultDeleteBrowsingDataControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/deletebrowsingdata/DefaultDeleteBrowsingDataControllerTest.kt
@@ -1,6 +1,6 @@
-/*  This Source Code Form is subject to the terms of the Mozilla Public
- *  License, v. 2.0. If a copy of the MPL was not distributed with this
- *  file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.settings.deletebrowsingdata
 

--- a/app/src/test/java/org/mozilla/fenix/settings/logins/LoginsListControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/logins/LoginsListControllerTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.settings.logins
 

--- a/app/src/test/java/org/mozilla/fenix/settings/logins/SavedLoginsInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/logins/SavedLoginsInteractorTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.settings.logins
 

--- a/app/src/test/java/org/mozilla/fenix/settings/logins/SavedLoginsStorageControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/logins/SavedLoginsStorageControllerTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.settings.logins
 

--- a/app/src/test/java/org/mozilla/fenix/settings/logins/SyncPreferenceViewTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/logins/SyncPreferenceViewTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.settings.logins
 
 import android.content.Context

--- a/app/src/test/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsSheetDialogFragmentTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsSheetDialogFragmentTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.settings.quicksettings
 

--- a/app/src/test/java/org/mozilla/fenix/sync/ext/ErrorTypeKtTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/sync/ext/ErrorTypeKtTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.sync.ext
 
 import org.junit.Test

--- a/app/src/test/java/org/mozilla/fenix/tabhistory/TabHistoryViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabhistory/TabHistoryViewHolderTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.tabhistory
 
 import android.view.View

--- a/app/src/test/java/org/mozilla/fenix/tabstray/browser/PrivateTabsBindingTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/browser/PrivateTabsBindingTest.kt
@@ -1,9 +1,6 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
+/* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- *
- */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.tabstray.browser
 

--- a/app/src/test/java/org/mozilla/fenix/tabstray/ext/LongKtTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/ext/LongKtTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.tabstray.ext
 
 import org.junit.Assert.assertEquals

--- a/app/src/test/java/org/mozilla/fenix/trackingprotection/TrackingProtectionPanelDialogFragmentTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/trackingprotection/TrackingProtectionPanelDialogFragmentTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.trackingprotection
 

--- a/app/src/test/java/org/mozilla/fenix/trackingprotection/TrackingProtectionPanelViewTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/trackingprotection/TrackingProtectionPanelViewTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.trackingprotection
 

--- a/app/src/test/java/org/mozilla/fenix/whatsnew/WhatsNewTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/whatsnew/WhatsNewTest.kt
@@ -1,8 +1,8 @@
-package org.mozilla.fenix.whatsnew
-
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.whatsnew
 
 import androidx.preference.PreferenceManager
 import io.mockk.every

--- a/app/src/test/java/org/mozilla/fenix/whatsnew/WhatsNewVersionTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/whatsnew/WhatsNewVersionTest.kt
@@ -1,8 +1,8 @@
-package org.mozilla.fenix.whatsnew
-
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.whatsnew
 
 import org.junit.Assert.assertEquals
 import org.junit.Test


### PR DESCRIPTION
I'm creating a PR updating detekt from `1.17.1` to `1.19.0`. Updating it detekt found that there were some test without the license or with one that doesn't match the one defined on the detekt configuration. This PR fixes that (my next PR will update detekt to ensure that this doesn't happen again).