### PR TITLE
Update detekt and it's configuration

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/customannotations/SmokeTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/customannotations/SmokeTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.customannotations
 
 /**

--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/Constants.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/Constants.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.helpers
 
 object Constants {

--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/FeatureSettingsHelper.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/FeatureSettingsHelper.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.helpers
 
 import android.content.Context

--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/IdlingResourceHelper.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/IdlingResourceHelper.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.helpers
 
 import androidx.test.espresso.IdlingRegistry

--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/RecyclerViewIdlingResource.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/RecyclerViewIdlingResource.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.helpers
 
 import androidx.test.espresso.IdlingResource

--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/RetryTestRule.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/RetryTestRule.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.helpers
 
 import org.junit.rules.TestRule

--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/ViewVisibilityIdlingResource.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/ViewVisibilityIdlingResource.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.helpers
 
 import android.view.View

--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/idlingresource/AddonsInstallingIdlingResource.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/idlingresource/AddonsInstallingIdlingResource.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.helpers.idlingresource
 
 import androidx.fragment.app.FragmentManager

--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/idlingresource/AddonsLoadingIdlingResource.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/idlingresource/AddonsLoadingIdlingResource.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.helpers.idlingresource
 
 import android.view.View

--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/matchers/BitmapDrawableMatcher.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/matchers/BitmapDrawableMatcher.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.helpers.matchers
 
 import android.graphics.Bitmap

--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/matchers/RecyclerViewItemMatcher.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/matchers/RecyclerViewItemMatcher.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.helpers.matchers
 
 import android.view.View

--- a/app/src/androidTest/java/org/mozilla/fenix/perf/SampleBenchmark.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/perf/SampleBenchmark.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.perf
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAddonsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAddonsTest.kt
@@ -1,8 +1,8 @@
-package org.mozilla.fenix.ui
-
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.ui
 
 import android.view.View
 import androidx.test.espresso.IdlingRegistry
@@ -66,7 +66,10 @@ class SettingsAddonsTest {
             verifyAddons()
         }.openAddonsManagerMenu {
             addonsListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.add_ons_list), 1)
+                RecyclerViewIdlingResource(
+                    activityTestRule.activity.findViewById(R.id.add_ons_list),
+                    1
+                )
             IdlingRegistry.getInstance().register(addonsListIdlingResource!!)
             verifyAddonsItems()
         }
@@ -110,7 +113,10 @@ class SettingsAddonsTest {
             verifyAddons()
         }.openAddonsManagerMenu {
             addonsListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.add_ons_list), 1)
+                RecyclerViewIdlingResource(
+                    activityTestRule.activity.findViewById(R.id.add_ons_list),
+                    1
+                )
             IdlingRegistry.getInstance().register(addonsListIdlingResource!!)
             clickInstallAddon(addonName)
             acceptInstallAddon()

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/AccountSettingsRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/AccountSettingsRobot.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.ui.robots
 
 import androidx.test.espresso.Espresso

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/CollectionRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/CollectionRobot.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.ui.robots
 
 import androidx.test.espresso.Espresso.onView

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NotificationRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NotificationRobot.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.ui.robots
 
 import androidx.test.uiautomator.By.text

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAddonsManagerAddonDetailedMenuRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAddonsManagerAddonDetailedMenuRobot.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.ui.robots
 
 import androidx.test.espresso.Espresso.onView

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAddonsManagerRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAddonsManagerRobot.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.ui.robots
 
 import android.widget.RelativeLayout

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuHomepageRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuHomepageRobot.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.ui.robots
 
 import androidx.test.espresso.Espresso.onView

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ShareOverlayRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ShareOverlayRobot.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.ui.robots
 
 import android.content.Intent

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SyncSignInRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SyncSignInRobot.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-* License, v. 2.0. If a copy of the MPL was not distributed with this
-* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.ui.robots
 

--- a/app/src/test/java/org/mozilla/fenix/FenixLogSinkTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/FenixLogSinkTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix
 
 import android.util.Log

--- a/app/src/test/java/org/mozilla/fenix/components/InflationAwareFeatureTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/InflationAwareFeatureTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.components
 
 import android.view.View

--- a/app/src/test/java/org/mozilla/fenix/components/TrackingProtectionPolicyFactoryTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/TrackingProtectionPolicyFactoryTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.components
 
 import io.mockk.every

--- a/app/src/test/java/org/mozilla/fenix/components/metrics/MetricsUtilsTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/metrics/MetricsUtilsTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.components.metrics
 
 import android.content.Context

--- a/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarInteractorTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.components.toolbar
 
 import io.mockk.MockKAnnotations

--- a/app/src/test/java/org/mozilla/fenix/exceptions/login/LoginExceptionFragmentStoreTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/exceptions/login/LoginExceptionFragmentStoreTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.exceptions.login
 

--- a/app/src/test/java/org/mozilla/fenix/exceptions/login/LoginExceptionsAdapterTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/exceptions/login/LoginExceptionsAdapterTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.exceptions.login
 

--- a/app/src/test/java/org/mozilla/fenix/exceptions/login/LoginExceptionsInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/exceptions/login/LoginExceptionsInteractorTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.exceptions.login
 

--- a/app/src/test/java/org/mozilla/fenix/exceptions/trackingprotection/TrackingProtectionExceptionsFragmentStoreTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/exceptions/trackingprotection/TrackingProtectionExceptionsFragmentStoreTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.exceptions.trackingprotection
 

--- a/app/src/test/java/org/mozilla/fenix/exceptions/trackingprotection/TrackingProtectionExceptionsInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/exceptions/trackingprotection/TrackingProtectionExceptionsInteractorTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.exceptions.trackingprotection
 

--- a/app/src/test/java/org/mozilla/fenix/ext/MockKMatcherScope.kt
+++ b/app/src/test/java/org/mozilla/fenix/ext/MockKMatcherScope.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.ext
 
 import android.content.Intent

--- a/app/src/test/java/org/mozilla/fenix/helpers/MockkRetryTestRule.kt
+++ b/app/src/test/java/org/mozilla/fenix/helpers/MockkRetryTestRule.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.helpers
 
 import io.mockk.MockKException

--- a/app/src/test/java/org/mozilla/fenix/library/downloads/DownloadControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/downloads/DownloadControllerTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.library.downloads
 

--- a/app/src/test/java/org/mozilla/fenix/library/downloads/DownloadFragmentTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/downloads/DownloadFragmentTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.library.downloads
 

--- a/app/src/test/java/org/mozilla/fenix/library/downloads/DownloadInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/downloads/DownloadInteractorTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.library.downloads
 

--- a/app/src/test/java/org/mozilla/fenix/library/history/HistoryAdapterTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/history/HistoryAdapterTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.library.history
 

--- a/app/src/test/java/org/mozilla/fenix/library/history/HistoryControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/history/HistoryControllerTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.library.history
 

--- a/app/src/test/java/org/mozilla/fenix/library/history/HistoryInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/history/HistoryInteractorTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.library.history
 

--- a/app/src/test/java/org/mozilla/fenix/search/SearchDialogControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/search/SearchDialogControllerTest.kt
@@ -1,6 +1,6 @@
-/*  This Source Code Form is subject to the terms of the Mozilla Public
- *  License, v. 2.0. If a copy of the MPL was not distributed with this
- *  file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.search
 

--- a/app/src/test/java/org/mozilla/fenix/settings/account/AccountSettingsFragmentStoreTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/account/AccountSettingsFragmentStoreTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.settings.account
 

--- a/app/src/test/java/org/mozilla/fenix/settings/account/AccountSettingsInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/account/AccountSettingsInteractorTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.settings.account
 

--- a/app/src/test/java/org/mozilla/fenix/settings/account/DefaultSyncControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/account/DefaultSyncControllerTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.settings.account
 

--- a/app/src/test/java/org/mozilla/fenix/settings/account/DefaultSyncInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/account/DefaultSyncInteractorTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.settings.account
 

--- a/app/src/test/java/org/mozilla/fenix/settings/advanced/LocaleManagerExtensionTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/advanced/LocaleManagerExtensionTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-* License, v. 2.0. If a copy of the MPL was not distributed with this
-* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.settings.advanced
 

--- a/app/src/test/java/org/mozilla/fenix/settings/deletebrowsingdata/DefaultDeleteBrowsingDataControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/deletebrowsingdata/DefaultDeleteBrowsingDataControllerTest.kt
@@ -1,6 +1,6 @@
-/*  This Source Code Form is subject to the terms of the Mozilla Public
- *  License, v. 2.0. If a copy of the MPL was not distributed with this
- *  file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.settings.deletebrowsingdata
 

--- a/app/src/test/java/org/mozilla/fenix/settings/logins/LoginsListControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/logins/LoginsListControllerTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.settings.logins
 

--- a/app/src/test/java/org/mozilla/fenix/settings/logins/SavedLoginsInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/logins/SavedLoginsInteractorTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.settings.logins
 

--- a/app/src/test/java/org/mozilla/fenix/settings/logins/SavedLoginsStorageControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/logins/SavedLoginsStorageControllerTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.settings.logins
 

--- a/app/src/test/java/org/mozilla/fenix/settings/logins/SyncPreferenceViewTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/logins/SyncPreferenceViewTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.settings.logins
 
 import android.content.Context

--- a/app/src/test/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsSheetDialogFragmentTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsSheetDialogFragmentTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.settings.quicksettings
 

--- a/app/src/test/java/org/mozilla/fenix/sync/ext/ErrorTypeKtTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/sync/ext/ErrorTypeKtTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.sync.ext
 
 import org.junit.Test

--- a/app/src/test/java/org/mozilla/fenix/tabhistory/TabHistoryViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabhistory/TabHistoryViewHolderTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.tabhistory
 
 import android.view.View

--- a/app/src/test/java/org/mozilla/fenix/tabstray/browser/PrivateTabsBindingTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/browser/PrivateTabsBindingTest.kt
@@ -1,9 +1,6 @@
-/*
- * This Source Code Form is subject to the terms of the Mozilla Public
+/* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
- *
- */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.tabstray.browser
 

--- a/app/src/test/java/org/mozilla/fenix/tabstray/ext/LongKtTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/ext/LongKtTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.tabstray.ext
 
 import org.junit.Assert.assertEquals

--- a/app/src/test/java/org/mozilla/fenix/trackingprotection/TrackingProtectionPanelDialogFragmentTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/trackingprotection/TrackingProtectionPanelDialogFragmentTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.trackingprotection
 

--- a/app/src/test/java/org/mozilla/fenix/trackingprotection/TrackingProtectionPanelViewTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/trackingprotection/TrackingProtectionPanelViewTest.kt
@@ -1,6 +1,6 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
-   License, v. 2.0. If a copy of the MPL was not distributed with this
-   file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.fenix.trackingprotection
 

--- a/app/src/test/java/org/mozilla/fenix/whatsnew/WhatsNewTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/whatsnew/WhatsNewTest.kt
@@ -1,8 +1,8 @@
-package org.mozilla.fenix.whatsnew
-
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.whatsnew
 
 import androidx.preference.PreferenceManager
 import io.mockk.every

--- a/app/src/test/java/org/mozilla/fenix/whatsnew/WhatsNewVersionTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/whatsnew/WhatsNewVersionTest.kt
@@ -1,8 +1,8 @@
-package org.mozilla.fenix.whatsnew
-
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.whatsnew
 
 import org.junit.Assert.assertEquals
 import org.junit.Test

--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ buildscript {
 }
 
 plugins {
-    id("io.gitlab.arturbosch.detekt").version("1.17.1")
+    id("io.gitlab.arturbosch.detekt").version("1.19.0")
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -153,8 +153,6 @@ tasks.register('clean', Delete) {
 }
 
 detekt {
-    // The version number is duplicated, please refer to plugins block for more details
-    version = "1.17.1"
     input = files("$projectDir/app/src")
     config = files("$projectDir/config/detekt.yml")
 

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -17,7 +17,7 @@ object Versions {
     const val sentry = "1.7.10"
     const val leakcanary = "2.4"
     const val osslicenses_plugin = "0.10.4"
-    const val detekt = "1.17.1"
+    const val detekt = "1.19.0"
     const val jna = "5.6.0"
 
     const val androidx_activity_compose = "1.4.0"

--- a/config/detekt.yml
+++ b/config/detekt.yml
@@ -26,7 +26,7 @@ console-reports:
 
 comments:
   active: true
-  excludes: "**/*Test.kt, **/*Spec.kt, **/test/**, **/androidTest/**"
+  excludes: ['**/*Test.kt', '**/*Spec.kt', '**/test/**', '**/androidTest/**']
   AbsentOrWrongFileLicense:
     active: true
   CommentOverPrivateFunction:
@@ -62,19 +62,19 @@ complexity:
     active: false
   LargeClass:
     active: true
-    excludes: "**/*Test.kt, **/*Spec.kt, **/test/**, **/androidTest/**"
+    excludes: ['**/*Test.kt', '**/*Spec.kt', '**/test/**', '**/androidTest/**']
     # Had to increase the threshold as RC13 started counting lines of code
     # https://github.com/mozilla-mobile/fenix/issues/4861
     threshold: 200
   LongMethod:
     active: true
-    excludes: "**/*Test.kt, **/*Spec.kt, **/test/**, **/androidTest/**"
+    excludes: ['**/*Test.kt', '**/*Spec.kt', '**/test/**', '**/androidTest/**']
     # Had to increase the threshold as RC13 started counting lines of code
     # https://github.com/mozilla-mobile/fenix/issues/4861
     threshold: 75
   LongParameterList:
     active: true
-    excludes: "**/*Controller.kt, **/*Integration.kt"
+    excludes: ['**/*Controller.kt', '**/*Integration.kt']
     functionThreshold: 6
     constructorThreshold: 7
     ignoreDefaultParameters: false
@@ -87,14 +87,14 @@ complexity:
     threshold: 4
   StringLiteralDuplication:
     active: false
-    excludes: "**/*Test.kt, **/*Spec.kt, **/test/**, **/androidTest/**"
+    excludes: ['**/*Test.kt', '**/*Spec.kt', '**/test/**', '**/androidTest/**']
     threshold: 3
     ignoreAnnotation: true
     excludeStringsWithLessThan5Characters: true
     ignoreStringsRegex: '$^'
   TooManyFunctions:
     active: true
-    excludes: "**/*Test.kt, **/*Spec.kt, **/test/**, **/androidTest/**"
+    excludes: ['**/*Test.kt', '**/*Spec.kt', '**/test/**', '**/androidTest/**']
     thresholdInFiles: 11
     thresholdInClasses: 11
     thresholdInInterfaces: 11
@@ -111,12 +111,12 @@ mozilla-detekt-rules:
     bannedProperties: "BuildConfig.DEBUG"
   MozillaStrictModeSuppression:
     active: true
-    excludes: "**/*Test.kt, **/*Spec.kt, **/test/**, **/androidTest/**"
+    excludes: ['**/*Test.kt', '**/*Spec.kt', '**/test/**', '**/androidTest/**']
   MozillaCorrectUnitTestRunner:
     active: true
   MozillaRunBlockingCheck:
     active: true
-    excludes: "**/*Test.kt, **/*Spec.kt, **/test/**, **/androidTest/**"
+    excludes: ['**/*Test.kt', '**/*Spec.kt', '**/test/**', '**/androidTest/**']
   MozillaUseLazyMonitored:
     active: true
 
@@ -139,7 +139,7 @@ empty-blocks:
     active: true
   EmptyFunctionBlock:
     active: true
-    excludes: "**/*Test.kt, **/*Spec.kt, **/test/**, **/androidTest/**"
+    excludes: ['**/*Test.kt', '**/*Spec.kt', '**/test/**', '**/androidTest/**']
   EmptyIfBlock:
     active: true
   EmptyInitBlock:
@@ -157,7 +157,7 @@ exceptions:
   active: true
   ExceptionRaisedInUnexpectedLocation:
     active: false
-    methodNames: 'toString,hashCode,equals,finalize'
+    methodNames: [toString, hashCode, equals, finalize]
   InstanceOfCheckForException:
     active: false
   NotImplementedDeclaration:
@@ -176,7 +176,10 @@ exceptions:
     active: false
   ThrowingExceptionsWithoutMessageOrCause:
     active: false
-    exceptions: 'IllegalArgumentException,IllegalStateException,IOException'
+    exceptions:
+     - IllegalArgumentException
+     - IllegalStateException
+     - IOException
   ThrowingNewInstanceOfSameException:
     active: false
   TooGenericExceptionCaught:
@@ -211,7 +214,7 @@ naming:
     enumEntryPattern: '^[A-Z][_a-zA-Z0-9]*'
   ForbiddenClassName:
     active: false
-    forbiddenName: ''
+    forbiddenName: []
   FunctionMaxLength:
     active: false
     maximumFunctionNameLength: 30
@@ -220,7 +223,7 @@ naming:
     minimumFunctionNameLength: 3
   FunctionNaming:
     active: true
-    excludes: "**/*Test.kt, **/*Spec.kt, **/test/**, **/androidTest/**"
+    excludes: ['**/*Test.kt', '**/*Spec.kt', '**/test/**', '**/androidTest/**']
     functionPattern: '^([a-z$][a-zA-Z$0-9]*)|(`.*`)$'
     excludeClassPattern: '$^'
   MatchingDeclarationName:
@@ -257,7 +260,7 @@ performance:
     active: true
   SpreadOperator:
     active: true
-    excludes: "**/*Test.kt, **/*Spec.kt, **/test/**, **/androidTest/**"
+    excludes: ['**/*Test.kt', '**/*Spec.kt', '**/test/**', '**/androidTest/**']
   UnnecessaryTemporaryInstantiation:
     active: true
 
@@ -279,8 +282,8 @@ potential-bugs:
     active: false
   LateinitUsage:
     active: false
-    excludes: "**/*Test.kt, **/*Spec.kt, **/test/**, **/androidTest/**"
-    excludeAnnotatedProperties: ""
+    excludes: ['**/*Test.kt', '**/*Spec.kt', '**/test/**', '**/androidTest/**']
+    excludeAnnotatedProperties: []
     ignoreOnClassesPattern: ""
   UnconditionalJumpStatementInLoop:
     active: false
@@ -308,10 +311,10 @@ style:
     active: false
   ForbiddenComment:
     active: true
-    values: 'TODO:,FIXME:,STOPSHIP:'
+    values: ['TODO:', 'FIXME:', 'STOPSHIP:']
   ForbiddenImport:
     active: false
-    imports: ''
+    imports: []
   FunctionOnlyReturningConstant:
     active: false
     ignoreOverridableFunction: true
@@ -321,8 +324,8 @@ style:
     maxJumpCount: 1
   MagicNumber:
     active: true
-    excludes: "**/*Test.kt, **/*Spec.kt, **/test/**, **/androidTest/**"
-    ignoreNumbers: '-1,0,1,2'
+    excludes: ['**/*Test.kt', '**/*Spec.kt', '**/test/**', '**/androidTest/**']
+    ignoreNumbers: ['-1', '0', '1', '2']
     ignoreHashCodeFunction: false
     ignorePropertyDeclaration: false
     ignoreConstantDeclaration: true
@@ -332,7 +335,7 @@ style:
     ignoreEnums: false
   MaxLineLength:
     active: true
-    excludes: "**/*Test.kt, **/*Spec.kt, **/test/**, **/androidTest/**"
+    excludes: ['**/*Test.kt', '**/*Spec.kt', '**/test/**', '**/androidTest/**']
     maxLineLength: 120
     excludePackageStatements: false
     excludeImportStatements: false
@@ -385,10 +388,10 @@ style:
     active: false
   UseDataClass:
     active: false
-    excludeAnnotatedClasses: ""
+    excludeAnnotatedClasses: []
   UtilityClassWithPublicConstructor:
     active: false
   WildcardImport:
     active: true
-    excludes: "**/*Test.kt, **/*Spec.kt, **/test/**, **/androidTest/**"
-    excludeImports: 'java.util.*'
+    excludes: ['**/*Test.kt', '**/*Spec.kt', '**/test/**', '**/androidTest/**']
+    excludeImports: ['java.util.*']

--- a/config/detekt.yml
+++ b/config/detekt.yml
@@ -9,11 +9,11 @@ build:
 processors:
   active: true
   exclude:
+  # - 'KtFileCountProcessor'
+  # - 'PackageCountProcessor'
+  # - 'ClassCountProcessor'
   # - 'FunctionCountProcessor'
   # - 'PropertyCountProcessor'
-  # - 'ClassCountProcessor'
-  # - 'PackageCountProcessor'
-  # - 'KtFileCountProcessor'
 
 console-reports:
   active: true

--- a/config/detekt.yml
+++ b/config/detekt.yml
@@ -251,7 +251,7 @@ naming:
     active: true
     classPattern: '[A-Z$][a-zA-Z0-9$]*'
   ConstructorParameterNaming:
-    active: true
+    active: false
     parameterPattern: '[a-z][A-Za-z0-9]*'
     privateParameterPattern: '[a-z][A-Za-z0-9]*'
     excludeClassPattern: '$^'
@@ -276,7 +276,7 @@ naming:
     ignoreOverridden: true
     ignoreAnnotated: ['Composable']
   FunctionParameterNaming:
-    active: true
+    active: false
     parameterPattern: '[a-z][A-Za-z0-9]*'
     excludeClassPattern: '$^'
     ignoreOverridden: true
@@ -359,7 +359,7 @@ potential-bugs:
     restrictToAnnotatedMethods: true
     returnValueAnnotations: ['*.CheckReturnValue', '*.CheckResult']
   ImplicitDefaultLocale:
-    active: true
+    active: false
   ImplicitUnitReturnType:
     active: false
     allowExplicitReturnType: true
@@ -592,7 +592,7 @@ style:
   UtilityClassWithPublicConstructor:
     active: false
   VarCouldBeVal:
-    active: true
+    active: false
   WildcardImport:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']

--- a/config/detekt.yml
+++ b/config/detekt.yml
@@ -29,9 +29,13 @@ comments:
   excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
   AbsentOrWrongFileLicense:
     active: true
+    licenseTemplateFile: 'license.template'
+    licenseTemplateIsRegex: false
   CommentOverPrivateFunction:
     active: false
   CommentOverPrivateProperty:
+    active: false
+  DeprecatedBlockTag:
     active: false
   EndOfSentenceFormat:
     active: false
@@ -44,6 +48,8 @@ comments:
     searchInInnerInterface: true
   UndocumentedPublicFunction:
     active: false
+  UndocumentedPublicProperty:
+    active: false
 
 complexity:
   active: true
@@ -54,12 +60,17 @@ complexity:
     active: false
     threshold: 10
     includeStaticDeclarations: false
+    includePrivateDeclarations: false
   ComplexMethod:
     active: true
     threshold: 15
     ignoreSingleWhenExpression: true
+    ignoreSimpleWhenEntries: false
+    ignoreNestingFunctions: false
+    nestingFunctions: ['run', 'let', 'apply', 'with', 'also', 'use', 'forEach', 'isNotNull', 'ifNull']
   LabeledExpression:
     active: false
+    ignoredLabels: []
   LargeClass:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
@@ -82,9 +93,14 @@ complexity:
   MethodOverloading:
     active: false
     threshold: 6
+  NamedArguments:
+    active: false
+    threshold: 3
   NestedBlockDepth:
     active: true
     threshold: 4
+  ReplaceSafeCallChainWithRun:
+    active: false
   StringLiteralDuplication:
     active: false
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
@@ -100,6 +116,20 @@ complexity:
     thresholdInInterfaces: 11
     thresholdInObjects: 11
     thresholdInEnums: 11
+    ignoreDeprecated: false
+    ignorePrivate: false
+    ignoreOverridden: false
+
+coroutines:
+  active: true
+  GlobalCoroutineUsage:
+    active: false
+  RedundantSuspendModifier:
+    active: false
+  SleepInsteadOfDelay:
+    active: false
+  SuspendFunWithFlowReturnType:
+    active: false
 
 mozilla-detekt-rules:
   active: true
@@ -140,6 +170,7 @@ empty-blocks:
   EmptyFunctionBlock:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
+    ignoreOverridden: false
   EmptyIfBlock:
     active: true
   EmptyInitBlock:
@@ -147,6 +178,8 @@ empty-blocks:
   EmptyKtFile:
     active: true
   EmptySecondaryConstructor:
+    active: true
+  EmptyTryBlock:
     active: true
   EmptyWhenBlock:
     active: true
@@ -162,20 +195,30 @@ exceptions:
     active: false
   NotImplementedDeclaration:
     active: false
+  ObjectExtendsThrowable:
+    active: false
   PrintStackTrace:
     active: false
   RethrowCaughtException:
     active: false
   ReturnFromFinally:
     active: false
+    ignoreLabeled: false
   SwallowedException:
     active: false
+    ignoredExceptionTypes:
+     - InterruptedException
+     - NumberFormatException
+     - ParseException
+     - MalformedURLException
+    allowedExceptionNameRegex: '_|(ignore|expected).*'
   ThrowingExceptionFromFinally:
     active: false
   ThrowingExceptionInMain:
     active: false
   ThrowingExceptionsWithoutMessageOrCause:
     active: false
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     exceptions:
      - IllegalArgumentException
      - IllegalStateException
@@ -193,6 +236,7 @@ exceptions:
      - IndexOutOfBoundsException
      - RuntimeException
      - Throwable
+    allowedExceptionNameRegex: '_|(ignore|expected).*'
   TooGenericExceptionThrown:
     active: true
     exceptionNames:
@@ -206,6 +250,12 @@ naming:
   ClassNaming:
     active: true
     classPattern: '[A-Z$][a-zA-Z0-9$]*'
+  ConstructorParameterNaming:
+    active: true
+    parameterPattern: '[a-z][A-Za-z0-9]*'
+    privateParameterPattern: '[a-z][A-Za-z0-9]*'
+    excludeClassPattern: '$^'
+    ignoreOverridden: true
   EnumNaming:
     active: true
     enumEntryPattern: '^[A-Z][_a-zA-Z0-9]*'
@@ -223,14 +273,32 @@ naming:
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     functionPattern: '^([a-z$][a-zA-Z$0-9]*)|(`.*`)$'
     excludeClassPattern: '$^'
+    ignoreOverridden: true
+    ignoreAnnotated: ['Composable']
+  FunctionParameterNaming:
+    active: true
+    parameterPattern: '[a-z][A-Za-z0-9]*'
+    excludeClassPattern: '$^'
+    ignoreOverridden: true
+  InvalidPackageDeclaration:
+    active: false
+    excludes: ['*.kts']
+    rootPackage: ''
   MatchingDeclarationName:
     active: true
+    mustBeFirst: true
   MemberNameEqualsClassName:
     active: false
     ignoreOverridden: true
+  NoNameShadowing:
+    active: false
+  NonBooleanPropertyPrefixedWithIs:
+    active: false
   ObjectPropertyNaming:
     active: true
+    constantPattern: '[A-Za-z][_A-Za-z0-9]*'
     propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
+    privatePropertyPattern: '(_)?[A-Za-z][_A-Za-z0-9]*'
   PackageNaming:
     active: true
     packagePattern: '^[a-z]+(\.[a-z][a-z0-9]*)*$'
@@ -250,9 +318,12 @@ naming:
     variablePattern: '[a-z][A-Za-z0-9]*'
     privateVariablePattern: '(_)?[a-z][A-Za-z0-9]*'
     excludeClassPattern: '$^'
+    ignoreOverridden: true
 
 performance:
   active: true
+  ArrayPrimitive:
+    active: true
   ForEachOnRange:
     active: true
   SpreadOperator:
@@ -263,14 +334,35 @@ performance:
 
 potential-bugs:
   active: true
+  CastToNullableType:
+    active: false
+  Deprecation:
+    active: false
+  DontDowncastCollectionTypes:
+    active: false
+  DoubleMutabilityForCollection:
+    active: false
   DuplicateCaseInWhenExpression:
     active: true
   EqualsAlwaysReturnsTrueOrFalse:
     active: false
   EqualsWithHashCodeExist:
     active: true
+  ExitOutsideMain:
+    active: false
   ExplicitGarbageCollectionCall:
     active: true
+  HasPlatformType:
+    active: false
+  IgnoredReturnValue:
+    active: false
+    restrictToAnnotatedMethods: true
+    returnValueAnnotations: ['*.CheckReturnValue', '*.CheckResult']
+  ImplicitDefaultLocale:
+    active: true
+  ImplicitUnitReturnType:
+    active: false
+    allowExplicitReturnType: true
   InvalidRange:
     active: false
   IteratorHasNextCallsNextMethod:
@@ -282,13 +374,30 @@ potential-bugs:
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     excludeAnnotatedProperties: []
     ignoreOnClassesPattern: ''
+  MapGetWithNotNullAssertionOperator:
+    active: false
+  MissingWhenCase:
+    active: true
+    allowElseExpression: true
+  NullableToStringCall:
+    active: false
+  RedundantElseInWhen:
+    active: true
   UnconditionalJumpStatementInLoop:
+    active: false
+  UnnecessaryNotNullOperator:
+    active: true
+  UnnecessarySafeCall:
+    active: true
+  UnreachableCatchBlock:
     active: false
   UnreachableCode:
     active: true
   UnsafeCallOnNullableType:
     active: false
   UnsafeCast:
+    active: false
+  UnusedUnaryOperator:
     active: false
   UselessPostfixExpression:
     active: false
@@ -297,25 +406,60 @@ potential-bugs:
 
 style:
   active: true
+  ClassOrdering:
+    active: false
   CollapsibleIfStatements:
     active: true
   DataClassContainsFunctions:
     active: false
     conversionFunctionPrefix: 'to'
+  DataClassShouldBeImmutable:
+    active: false
+  DestructuringDeclarationWithTooManyEntries:
+    active: false
+    maxDestructuringEntries: 3
   EqualsNullCall:
+    active: false
+  EqualsOnSignatureLine:
+    active: false
+  ExplicitCollectionElementAccessMethod:
+    active: false
+  ExplicitItLambdaParameter:
     active: false
   ExpressionBodySyntax:
     active: false
+    includeLineWrapping: false
   ForbiddenComment:
     active: true
     values: ['TODO:', 'FIXME:', 'STOPSHIP:']
+    allowedPatterns: ''
   ForbiddenImport:
     active: false
     imports: []
+    forbiddenPatterns: ''
+  ForbiddenMethodCall:
+    active: false
+    methods: ['kotlin.io.println', 'kotlin.io.print']
+  ForbiddenPublicDataClass:
+    active: true
+    excludes: ['**']
+    ignorePackages: ['*.internal', '*.internal.*']
+  ForbiddenVoid:
+    active: false
+    ignoreOverridden: false
+    ignoreUsageInGenerics: false
   FunctionOnlyReturningConstant:
     active: false
     ignoreOverridableFunction: true
+    ignoreActualFunction: true
     excludedFunctions: 'describeContents'
+    excludeAnnotatedFunction: ['dagger.Provides']
+  LibraryCodeMustSpecifyReturnType:
+    active: true
+    excludes: ['**']
+  LibraryEntitiesShouldNotBePublic:
+    active: true
+    excludes: ['**']
   LoopWithTooManyJumpStatements:
     active: false
     maxJumpCount: 1
@@ -325,34 +469,52 @@ style:
     ignoreNumbers: ['-1', '0', '1', '2']
     ignoreHashCodeFunction: false
     ignorePropertyDeclaration: false
+    ignoreLocalVariableDeclaration: false
     ignoreConstantDeclaration: true
     ignoreCompanionObjectPropertyDeclaration: true
     ignoreAnnotation: false
     ignoreNamedArgument: true
     ignoreEnums: false
+    ignoreRanges: false
+    ignoreExtensionFunctions: true
+  MandatoryBracesIfStatements:
+    active: false
+  MandatoryBracesLoops:
+    active: false
   MaxLineLength:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     maxLineLength: 120
     excludePackageStatements: false
     excludeImportStatements: false
+    excludeCommentStatements: false
   MayBeConst:
     active: true
   ModifierOrder:
     active: true
+  MultilineLambdaItParameter:
+    active: false
   NestedClassesVisibility:
     active: false
   NewLineAtEndOfFile:
     active: true
   NoTabs:
     active: true
+  ObjectLiteralToLambda:
+    active: false
   OptionalAbstractKeyword:
     active: true
   OptionalUnit:
     active: false
   OptionalWhenBraces:
     active: false
+  PreferToOverPairSyntax:
+    active: false
   ProtectedMemberInFinalClass:
+    active: false
+  RedundantExplicitType:
+    active: false
+  RedundantHigherOrderMapUsage:
     active: false
   RedundantVisibilityModifierRule:
     active: false
@@ -360,6 +522,9 @@ style:
     active: true
     max: 3
     excludedFunctions: 'equals'
+    excludeLabeled: false
+    excludeReturnFromLambda: true
+    excludeGuardClauses: false
   SafeCast:
     active: true
   SerialVersionUIDInSerializableClass:
@@ -371,9 +536,21 @@ style:
     max: 2
   TrailingWhitespace:
     active: false
+  UnderscoresInNumericLiterals:
+    active: false
+    acceptableDecimalLength: 5
   UnnecessaryAbstractClass:
     active: true
+    excludeAnnotatedClasses: ['dagger.Module']
+  UnnecessaryAnnotationUseSiteTarget:
+    active: false
+  UnnecessaryApply:
+    active: true
+  UnnecessaryFilter:
+    active: false
   UnnecessaryInheritance:
+    active: true
+  UnnecessaryLet:
     active: false
   UnnecessaryParentheses:
     active: false
@@ -381,13 +558,41 @@ style:
     active: false
   UnusedImports:
     active: false
+  UnusedPrivateClass:
+    active: true
   UnusedPrivateMember:
+    active: false
+    allowedNames: '(_|ignored|expected|serialVersionUID)'
+  UseArrayLiteralsInAnnotations:
+    active: false
+  UseCheckNotNull:
+    active: false
+  UseCheckOrError:
     active: false
   UseDataClass:
     active: false
     excludeAnnotatedClasses: []
+    allowVars: false
+  UseEmptyCounterpart:
+    active: false
+  UseIfEmptyOrIfBlank:
+    active: false
+  UseIfInsteadOfWhen:
+    active: false
+  UseIsNullOrEmpty:
+    active: false
+  UseOrEmpty:
+    active: false
+  UseRequire:
+    active: false
+  UseRequireNotNull:
+    active: false
+  UselessCallOnNotNull:
+    active: true
   UtilityClassWithPublicConstructor:
     active: false
+  VarCouldBeVal:
+    active: true
   WildcardImport:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']

--- a/config/detekt.yml
+++ b/config/detekt.yml
@@ -22,6 +22,7 @@ console-reports:
   #  - 'ComplexityReport'
   #  - 'NotificationReport'
   #  - 'FindingsReport'
+  #  - 'FileBasedFindingsReport'
 
 comments:
   active: true

--- a/config/detekt.yml
+++ b/config/detekt.yml
@@ -23,10 +23,10 @@ console-reports:
   #  - 'NotificationReport'
   #  - 'FindingsReport'
   #  - 'FileBasedFindingsReport'
+    - 'LiteFindingsReport'
 
 comments:
   active: true
-  excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
   AbsentOrWrongFileLicense:
     active: true
     licenseTemplateFile: 'license.template'
@@ -40,16 +40,23 @@ comments:
   EndOfSentenceFormat:
     active: false
     endOfSentenceFormat: '([.?!][ \t\n\r\f<])|([.?!]$)'
+  OutdatedDocumentation:
+    active: false
+    matchTypeParameters: true
+    matchDeclarationsOrder: true
   UndocumentedPublicClass:
     active: false
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     searchInNestedClass: true
     searchInInnerClass: true
     searchInInnerObject: true
     searchInInnerInterface: true
   UndocumentedPublicFunction:
     active: false
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
   UndocumentedPublicProperty:
     active: false
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
 
 complexity:
   active: true
@@ -90,6 +97,7 @@ complexity:
     constructorThreshold: 7
     ignoreDefaultParameters: false
     ignoreDataClasses: true
+    ignoreAnnotatedParameter: []
   MethodOverloading:
     active: false
     threshold: 6
@@ -124,6 +132,12 @@ coroutines:
   active: true
   GlobalCoroutineUsage:
     active: false
+  InjectDispatcher:
+    active: false
+    dispatcherNames:
+      - 'IO'
+      - 'Default'
+      - 'Unconfined'
   RedundantSuspendModifier:
     active: false
   SleepInsteadOfDelay:
@@ -207,10 +221,10 @@ exceptions:
   SwallowedException:
     active: false
     ignoredExceptionTypes:
-     - InterruptedException
-     - NumberFormatException
-     - ParseException
-     - MalformedURLException
+      - 'InterruptedException'
+      - 'MalformedURLException'
+      - 'NumberFormatException'
+      - 'ParseException'
     allowedExceptionNameRegex: '_|(ignore|expected).*'
   ThrowingExceptionFromFinally:
     active: false
@@ -220,33 +234,43 @@ exceptions:
     active: false
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     exceptions:
-     - IllegalArgumentException
-     - IllegalStateException
-     - IOException
+      - 'ArrayIndexOutOfBoundsException'
+      - 'Exception'
+      - 'IllegalArgumentException'
+      - 'IllegalMonitorStateException'
+      - 'IllegalStateException'
+      - 'IndexOutOfBoundsException'
+      - 'NullPointerException'
+      - 'RuntimeException'
+      - 'Throwable'
   ThrowingNewInstanceOfSameException:
     active: false
   TooGenericExceptionCaught:
     active: true
     exceptionNames:
-     - ArrayIndexOutOfBoundsException
-     - Error
-     - Exception
-     - IllegalMonitorStateException
-     - NullPointerException
-     - IndexOutOfBoundsException
-     - RuntimeException
-     - Throwable
+      - 'ArrayIndexOutOfBoundsException'
+      - 'Error'
+      - 'Exception'
+      - 'IllegalMonitorStateException'
+      - 'IndexOutOfBoundsException'
+      - 'NullPointerException'
+      - 'RuntimeException'
+      - 'Throwable'
     allowedExceptionNameRegex: '_|(ignore|expected).*'
   TooGenericExceptionThrown:
     active: true
     exceptionNames:
-     - Error
-     - Exception
-     - Throwable
-     - RuntimeException
+      - 'Error'
+      - 'Exception'
+      - 'RuntimeException'
+      - 'Throwable'
 
 naming:
   active: true
+  BooleanPropertyNaming:
+    active: false
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
+    allowedPattern: '^(is|has|are)'
   ClassNaming:
     active: true
     classPattern: '[A-Z$][a-zA-Z0-9$]*'
@@ -282,8 +306,11 @@ naming:
     ignoreOverridden: true
   InvalidPackageDeclaration:
     active: false
-    excludes: ['*.kts']
     rootPackage: ''
+  LambdaParameterNaming:
+    active: false
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
+    parameterPattern: '[a-z][A-Za-z0-9]*|_'
   MatchingDeclarationName:
     active: true
     mustBeFirst: true
@@ -334,6 +361,10 @@ performance:
 
 potential-bugs:
   active: true
+  AvoidReferentialEquality:
+    active: false
+    forbiddenTypePatterns:
+      - 'kotlin.String'
   CastToNullableType:
     active: false
   Deprecation:
@@ -357,7 +388,11 @@ potential-bugs:
   IgnoredReturnValue:
     active: false
     restrictToAnnotatedMethods: true
-    returnValueAnnotations: ['*.CheckReturnValue', '*.CheckResult']
+    returnValueAnnotations:
+      - '*.CheckResult'
+      - '*.CheckReturnValue'
+    ignoreReturnValueAnnotations:
+      - '*.CanIgnoreReturnValue'
   ImplicitDefaultLocale:
     active: false
   ImplicitUnitReturnType:
@@ -372,10 +407,12 @@ potential-bugs:
   LateinitUsage:
     active: false
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
-    excludeAnnotatedProperties: []
     ignoreOnClassesPattern: ''
   MapGetWithNotNullAssertionOperator:
     active: false
+  MissingPackageDeclaration:
+    active: false
+    excludes: ['**/*.kts']
   MissingWhenCase:
     active: true
     allowElseExpression: true
@@ -395,6 +432,7 @@ potential-bugs:
     active: true
   UnsafeCallOnNullableType:
     active: false
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
   UnsafeCast:
     active: false
   UnusedUnaryOperator:
@@ -433,17 +471,22 @@ style:
     active: true
     values: ['TODO:', 'FIXME:', 'STOPSHIP:']
     allowedPatterns: ''
+    customMessage: ''
   ForbiddenImport:
     active: false
     imports: []
     forbiddenPatterns: ''
   ForbiddenMethodCall:
     active: false
-    methods: ['kotlin.io.println', 'kotlin.io.print']
+    methods:
+      - 'kotlin.io.print'
+      - 'kotlin.io.println'
   ForbiddenPublicDataClass:
     active: true
     excludes: ['**']
-    ignorePackages: ['*.internal', '*.internal.*']
+    ignorePackages:
+      - '*.internal'
+      - '*.internal.*'
   ForbiddenVoid:
     active: false
     ignoreOverridden: false
@@ -452,8 +495,7 @@ style:
     active: false
     ignoreOverridableFunction: true
     ignoreActualFunction: true
-    excludedFunctions: 'describeContents'
-    excludeAnnotatedFunction: ['dagger.Provides']
+    excludedFunctions: ''
   LibraryCodeMustSpecifyReturnType:
     active: true
     excludes: ['**']
@@ -534,14 +576,14 @@ style:
   ThrowsCount:
     active: true
     max: 2
+    excludeGuardClauses: false
   TrailingWhitespace:
     active: false
   UnderscoresInNumericLiterals:
     active: false
-    acceptableDecimalLength: 5
+    acceptableLength: 4
   UnnecessaryAbstractClass:
     active: true
-    excludeAnnotatedClasses: ['dagger.Module']
   UnnecessaryAnnotationUseSiteTarget:
     active: false
   UnnecessaryApply:
@@ -563,6 +605,8 @@ style:
   UnusedPrivateMember:
     active: false
     allowedNames: '(_|ignored|expected|serialVersionUID)'
+  UseAnyOrNoneInsteadOfFind:
+    active: false
   UseArrayLiteralsInAnnotations:
     active: false
   UseCheckNotNull:
@@ -571,7 +615,6 @@ style:
     active: false
   UseDataClass:
     active: false
-    excludeAnnotatedClasses: []
     allowVars: false
   UseEmptyCounterpart:
     active: false
@@ -596,4 +639,5 @@ style:
   WildcardImport:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
-    excludeImports: ['java.util.*']
+    excludeImports:
+      - 'java.util.*'

--- a/config/detekt.yml
+++ b/config/detekt.yml
@@ -23,9 +23,6 @@ console-reports:
   #  - 'NotificationReport'
   #  - 'FindingsReport'
   #  - 'BuildFailureReport'
-  #  - 'HtmlOutputReport'
-    - 'PlainOutputReport'
-    - 'XmlOutputReport'
 
 comments:
   active: true

--- a/config/detekt.yml
+++ b/config/detekt.yml
@@ -108,7 +108,7 @@ mozilla-detekt-rules:
     # BuildConfig.Debug: This property tests whether the application was built
     # with the debuggable flag or not. Use a check for different build variants,
     # instead.
-    bannedProperties: "BuildConfig.DEBUG"
+    bannedProperties: 'BuildConfig.DEBUG'
   MozillaStrictModeSuppression:
     active: true
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
@@ -124,7 +124,7 @@ empty-blocks:
   active: true
   EmptyCatchBlock:
     active: true
-    allowedExceptionNameRegex: "^(ignore|expected).*"
+    allowedExceptionNameRegex: '^(ignore|expected).*'
   EmptyClassBlock:
     active: true
   EmptyDefaultConstructor:
@@ -281,7 +281,7 @@ potential-bugs:
     active: false
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     excludeAnnotatedProperties: []
-    ignoreOnClassesPattern: ""
+    ignoreOnClassesPattern: ''
   UnconditionalJumpStatementInLoop:
     active: false
   UnreachableCode:
@@ -359,7 +359,7 @@ style:
   ReturnCount:
     active: true
     max: 3
-    excludedFunctions: "equals"
+    excludedFunctions: 'equals'
   SafeCast:
     active: true
   SerialVersionUIDInSerializableClass:

--- a/config/detekt.yml
+++ b/config/detekt.yml
@@ -22,7 +22,6 @@ console-reports:
   #  - 'ComplexityReport'
   #  - 'NotificationReport'
   #  - 'FindingsReport'
-  #  - 'BuildFailureReport'
 
 comments:
   active: true

--- a/config/detekt.yml
+++ b/config/detekt.yml
@@ -35,7 +35,7 @@ comments:
     active: false
   EndOfSentenceFormat:
     active: false
-    endOfSentenceFormat: ([.?!][ \t\n\r\f<])|([.?!]$)
+    endOfSentenceFormat: '([.?!][ \t\n\r\f<])|([.?!]$)'
   UndocumentedPublicClass:
     active: false
     searchInNestedClass: true

--- a/config/detekt.yml
+++ b/config/detekt.yml
@@ -201,9 +201,6 @@ exceptions:
      - Throwable
      - RuntimeException
 
-formatting:
-  autoCorrect: true
-
 naming:
   active: true
   ClassNaming:

--- a/config/detekt.yml
+++ b/config/detekt.yml
@@ -26,7 +26,7 @@ console-reports:
 
 comments:
   active: true
-  excludes: ['**/*Test.kt', '**/*Spec.kt', '**/test/**', '**/androidTest/**']
+  excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
   AbsentOrWrongFileLicense:
     active: true
   CommentOverPrivateFunction:
@@ -62,13 +62,13 @@ complexity:
     active: false
   LargeClass:
     active: true
-    excludes: ['**/*Test.kt', '**/*Spec.kt', '**/test/**', '**/androidTest/**']
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     # Had to increase the threshold as RC13 started counting lines of code
     # https://github.com/mozilla-mobile/fenix/issues/4861
     threshold: 200
   LongMethod:
     active: true
-    excludes: ['**/*Test.kt', '**/*Spec.kt', '**/test/**', '**/androidTest/**']
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     # Had to increase the threshold as RC13 started counting lines of code
     # https://github.com/mozilla-mobile/fenix/issues/4861
     threshold: 75
@@ -87,14 +87,14 @@ complexity:
     threshold: 4
   StringLiteralDuplication:
     active: false
-    excludes: ['**/*Test.kt', '**/*Spec.kt', '**/test/**', '**/androidTest/**']
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     threshold: 3
     ignoreAnnotation: true
     excludeStringsWithLessThan5Characters: true
     ignoreStringsRegex: '$^'
   TooManyFunctions:
     active: true
-    excludes: ['**/*Test.kt', '**/*Spec.kt', '**/test/**', '**/androidTest/**']
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     thresholdInFiles: 11
     thresholdInClasses: 11
     thresholdInInterfaces: 11
@@ -111,12 +111,12 @@ mozilla-detekt-rules:
     bannedProperties: "BuildConfig.DEBUG"
   MozillaStrictModeSuppression:
     active: true
-    excludes: ['**/*Test.kt', '**/*Spec.kt', '**/test/**', '**/androidTest/**']
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
   MozillaCorrectUnitTestRunner:
     active: true
   MozillaRunBlockingCheck:
     active: true
-    excludes: ['**/*Test.kt', '**/*Spec.kt', '**/test/**', '**/androidTest/**']
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
   MozillaUseLazyMonitored:
     active: true
 
@@ -139,7 +139,7 @@ empty-blocks:
     active: true
   EmptyFunctionBlock:
     active: true
-    excludes: ['**/*Test.kt', '**/*Spec.kt', '**/test/**', '**/androidTest/**']
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
   EmptyIfBlock:
     active: true
   EmptyInitBlock:
@@ -220,7 +220,7 @@ naming:
     minimumFunctionNameLength: 3
   FunctionNaming:
     active: true
-    excludes: ['**/*Test.kt', '**/*Spec.kt', '**/test/**', '**/androidTest/**']
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     functionPattern: '^([a-z$][a-zA-Z$0-9]*)|(`.*`)$'
     excludeClassPattern: '$^'
   MatchingDeclarationName:
@@ -257,7 +257,7 @@ performance:
     active: true
   SpreadOperator:
     active: true
-    excludes: ['**/*Test.kt', '**/*Spec.kt', '**/test/**', '**/androidTest/**']
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
   UnnecessaryTemporaryInstantiation:
     active: true
 
@@ -279,7 +279,7 @@ potential-bugs:
     active: false
   LateinitUsage:
     active: false
-    excludes: ['**/*Test.kt', '**/*Spec.kt', '**/test/**', '**/androidTest/**']
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     excludeAnnotatedProperties: []
     ignoreOnClassesPattern: ""
   UnconditionalJumpStatementInLoop:
@@ -321,7 +321,7 @@ style:
     maxJumpCount: 1
   MagicNumber:
     active: true
-    excludes: ['**/*Test.kt', '**/*Spec.kt', '**/test/**', '**/androidTest/**']
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     ignoreNumbers: ['-1', '0', '1', '2']
     ignoreHashCodeFunction: false
     ignorePropertyDeclaration: false
@@ -332,7 +332,7 @@ style:
     ignoreEnums: false
   MaxLineLength:
     active: true
-    excludes: ['**/*Test.kt', '**/*Spec.kt', '**/test/**', '**/androidTest/**']
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     maxLineLength: 120
     excludePackageStatements: false
     excludeImportStatements: false
@@ -390,5 +390,5 @@ style:
     active: false
   WildcardImport:
     active: true
-    excludes: ['**/*Test.kt', '**/*Spec.kt', '**/test/**', '**/androidTest/**']
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/jsTest/**', '**/iosTest/**']
     excludeImports: ['java.util.*']


### PR DESCRIPTION
The first commit of this PR is already committed here #23122. I'll wait for it to be merged and then rebase this one but I need those changes to make detekt happy.

This PR contains lots of small commits that just update the current configuration that Fenix have to one that is more similar to the default one of detekt. It seems that the configuration was created in the RC times of detekt. And detekt changed a lot since them so those should be just a cleanup. They shouldn't change anything in how detekt works.

The big ones are:
- e59450decd580b9bec7dab44557fa7a121f35ee7 this one syncs the current configuration with the default configuration of detekt. It only adds things keeping the current configuration as it is.
- fcdac9183638907bce9bf9fdd70e637644a8672d this one is easier. Now that the configuration of fenix is similar to the default one I used these commands to update the configuration: https://github.com/detekt/detekt/discussions/3558#discussioncomment-483027 and then fix the conflicts.

Note: I saw #23112. I'm OK fixing the conflicts that it could generate and creating this same PR to the Android Component Repo if you think it's valuable.