### PR TITLE
For #22795: Make logins search/sorting fast

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/ext/String.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/String.kt
@@ -16,9 +16,7 @@ import kotlinx.coroutines.withContext
 import mozilla.components.concept.fetch.Client
 import mozilla.components.concept.fetch.Request
 import mozilla.components.lib.publicsuffixlist.PublicSuffixList
-import mozilla.components.lib.publicsuffixlist.ext.urlToTrimmedHost
 import mozilla.components.support.ktx.android.net.hostWithoutCommonPrefixes
-import org.mozilla.fenix.perf.runBlockingIncrement
 import java.io.IOException
 import java.net.IDN
 import java.util.Locale
@@ -90,14 +88,6 @@ private fun Uri.isIpv6(): Boolean {
     val host = this.host ?: return false
     return host.isNotEmpty() && host.contains(":")
 }
-
-/**
- * Trim a host's prefix and suffix
- */
-fun String.urlToTrimmedHost(publicSuffixList: PublicSuffixList): String =
-    runBlockingIncrement {
-        urlToTrimmedHost(publicSuffixList).await()
-    }
 
 /**
  * Trims a URL string of its scheme and common prefixes.

--- a/app/src/main/java/org/mozilla/fenix/settings/logins/SavedLoginsSortingStrategyMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/SavedLoginsSortingStrategyMenu.kt
@@ -12,7 +12,6 @@ import mozilla.components.concept.menu.candidate.TextMenuCandidate
 import mozilla.components.concept.menu.candidate.TextStyle
 import mozilla.components.support.ktx.android.content.getColorFromAttr
 import org.mozilla.fenix.R
-import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.settings.logins.interactor.SavedLoginsInteractor
 
 class SavedLoginsSortingStrategyMenu(
@@ -51,7 +50,7 @@ class SavedLoginsSortingStrategyMenu(
                 effect = if (itemToHighlight == Item.AlphabeticallySort) highlight else null
             ) {
                 savedLoginsInteractor.onSortingStrategyChanged(
-                    SortingStrategy.Alphabetically(context.components.publicSuffixList)
+                    SortingStrategy.Alphabetically
                 )
             },
             TextMenuCandidate(

--- a/app/src/main/java/org/mozilla/fenix/settings/logins/SortingStrategy.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/SortingStrategy.kt
@@ -4,15 +4,12 @@
 
 package org.mozilla.fenix.settings.logins
 
-import mozilla.components.lib.publicsuffixlist.PublicSuffixList
-import org.mozilla.fenix.ext.urlToTrimmedHost
-
 sealed class SortingStrategy {
     abstract operator fun invoke(logins: List<SavedLogin>): List<SavedLogin>
 
-    data class Alphabetically(private val publicSuffixList: PublicSuffixList) : SortingStrategy() {
+    object Alphabetically : SortingStrategy() {
         override fun invoke(logins: List<SavedLogin>): List<SavedLogin> {
-            return logins.sortedBy { it.origin.urlToTrimmedHost(publicSuffixList) }
+            return logins.sortedBy { it.origin }
         }
     }
 

--- a/app/src/main/java/org/mozilla/fenix/settings/logins/view/LoginsAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/view/LoginsAdapter.kt
@@ -31,9 +31,9 @@ class LoginsAdapter(
 
     private object DiffCallback : DiffUtil.ItemCallback<SavedLogin>() {
         override fun areItemsTheSame(oldItem: SavedLogin, newItem: SavedLogin) =
-            oldItem.origin == newItem.origin
+            oldItem.guid == newItem.guid
 
         override fun areContentsTheSame(oldItem: SavedLogin, newItem: SavedLogin) =
-            oldItem == newItem
+            oldItem.origin == newItem.origin && oldItem.username == newItem.username
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/settings/logins/view/SavedLoginsListView.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/view/SavedLoginsListView.kt
@@ -62,6 +62,9 @@ class SavedLoginsListView(
             binding.savedLoginsList.isVisible = state.loginList.isNotEmpty()
             binding.savedPasswordsEmptyView.isVisible = state.loginList.isEmpty()
         }
-        loginsAdapter.submitList(state.filteredItems)
+        loginsAdapter.submitList(state.filteredItems) {
+            // Reset scroll position to the first item after submitted list was committed.
+            binding.savedLoginsList.scrollToPosition(0)
+        }
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -1153,8 +1153,7 @@ class Settings(private val appContext: Context) : PreferencesHolder {
     var savedLoginsSortingStrategy: SortingStrategy
         get() {
             return when (savedLoginsMenuHighlightedItem) {
-                SavedLoginsSortingStrategyMenu.Item.AlphabeticallySort ->
-                    SortingStrategy.Alphabetically(appContext.components.publicSuffixList)
+                SavedLoginsSortingStrategyMenu.Item.AlphabeticallySort -> SortingStrategy.Alphabetically
                 SavedLoginsSortingStrategyMenu.Item.LastUsedSort -> SortingStrategy.LastUsed
             }
         }

--- a/app/src/test/java/org/mozilla/fenix/ext/StringTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/ext/StringTest.kt
@@ -23,13 +23,6 @@ class StringTest {
     private val publicSuffixList = PublicSuffixList(testContext)
 
     @Test
-    fun `Url To Trimmed Host`() {
-        val urlTest = "http://www.example.com:1080/docs/resource1.html"
-        val new = urlTest.urlToTrimmedHost(publicSuffixList)
-        assertEquals(new, "example")
-    }
-
-    @Test
     fun `Simplified Url`() {
         val urlTest = "https://www.amazon.com"
         val new = urlTest.simplifiedUrl()

--- a/app/src/test/java/org/mozilla/fenix/settings/logins/LoginsFragmentStoreTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/logins/LoginsFragmentStoreTest.kt
@@ -117,7 +117,7 @@ class LoginsFragmentStoreTest {
             baseState.copy(
                 isLoading = true,
                 searchedForText = null,
-                sortingStrategy = SortingStrategy.Alphabetically(mockk()),
+                sortingStrategy = SortingStrategy.Alphabetically,
                 highlightedItem = SavedLoginsSortingStrategyMenu.Item.AlphabeticallySort,
                 loginList = loginList
             )
@@ -139,7 +139,7 @@ class LoginsFragmentStoreTest {
             baseState.copy(
                 isLoading = true,
                 searchedForText = "example",
-                sortingStrategy = SortingStrategy.Alphabetically(mockk()),
+                sortingStrategy = SortingStrategy.Alphabetically,
                 highlightedItem = SavedLoginsSortingStrategyMenu.Item.AlphabeticallySort,
                 loginList = loginList
             )

--- a/app/src/test/java/org/mozilla/fenix/settings/logins/LoginsListControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/logins/LoginsListControllerTest.kt
@@ -7,8 +7,6 @@ package org.mozilla.fenix.settings.logins
 import androidx.navigation.NavController
 import io.mockk.mockk
 import io.mockk.verifyAll
-import mozilla.components.lib.publicsuffixlist.PublicSuffixList
-import mozilla.components.support.test.robolectric.testContext
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.BrowserDirection
@@ -24,8 +22,7 @@ import org.mozilla.fenix.utils.Settings
 class LoginsListControllerTest {
     private val store: LoginsFragmentStore = mockk(relaxed = true)
     private val settings: Settings = mockk(relaxed = true)
-    private val publicSuffixList = PublicSuffixList(testContext)
-    private val sortingStrategy: SortingStrategy = SortingStrategy.Alphabetically(publicSuffixList)
+    private val sortingStrategy: SortingStrategy = SortingStrategy.Alphabetically
     private val navController: NavController = mockk(relaxed = true)
     private val browserNavigator: (String, Boolean, BrowserDirection) -> Unit = mockk(relaxed = true)
     private val metrics: MetricController = mockk(relaxed = true)
@@ -43,11 +40,7 @@ class LoginsListControllerTest {
         controller.handleSort(sortingStrategy)
 
         verifyAll {
-            store.dispatch(
-                LoginsAction.SortLogins(
-                    SortingStrategy.Alphabetically(publicSuffixList)
-                )
-            )
+            store.dispatch(LoginsAction.SortLogins(SortingStrategy.Alphabetically))
             settings.savedLoginsSortingStrategy = sortingStrategy
         }
     }

--- a/app/src/test/java/org/mozilla/fenix/settings/logins/SavedLoginsInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/logins/SavedLoginsInteractorTest.kt
@@ -43,12 +43,10 @@ class SavedLoginsInteractorTest {
     @Test
     fun `GIVEN a change in sorting strategy, WHEN the interactor is called for it, THEN it should just delegate the controller`() {
         every { testContext.components.publicSuffixList } returns PublicSuffixList(testContext)
-        val sortingStrategy = SortingStrategy.Alphabetically(testContext.components.publicSuffixList)
-
-        interactor.onSortingStrategyChanged(sortingStrategy)
+        interactor.onSortingStrategyChanged(SortingStrategy.Alphabetically)
 
         verifyAll {
-            listController.handleSort(sortingStrategy)
+            listController.handleSort(SortingStrategy.Alphabetically)
         }
     }
 

--- a/app/src/test/java/org/mozilla/fenix/settings/logins/SavedLoginsSortingStrategyMenuTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/logins/SavedLoginsSortingStrategyMenuTest.kt
@@ -12,7 +12,6 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 import mozilla.components.concept.menu.candidate.HighPriorityHighlightEffect
-import mozilla.components.lib.publicsuffixlist.PublicSuffixList
 import mozilla.components.support.ktx.android.content.getColorFromAttr
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
@@ -21,7 +20,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.R
-import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.settings.logins.SavedLoginsSortingStrategyMenu.Item
 import org.mozilla.fenix.settings.logins.interactor.SavedLoginsInteractor
@@ -69,16 +67,12 @@ class SavedLoginsSortingStrategyMenuTest {
 
     @Test
     fun `candidates call interactor on click`() {
-        val publicSuffixList = PublicSuffixList(testContext)
-        every { testContext.components.publicSuffixList } returns publicSuffixList
         val (name, lastUsed) = menu.menuItems(Item.AlphabeticallySort)
         every { interactor.onSortingStrategyChanged(any()) } just Runs
 
         name.onClick()
         verify {
-            interactor.onSortingStrategyChanged(
-                SortingStrategy.Alphabetically(publicSuffixList)
-            )
+            interactor.onSortingStrategyChanged(SortingStrategy.Alphabetically)
         }
 
         lastUsed.onClick()


### PR DESCRIPTION
The change that actually makes this work well is removing `urlToTrimmedHost` (see commit message).

Additionally, I'm also now resetting scroll position to top of the screen after logins list changes - this makes for a much nicer experience, resetting the UI back to its original state (first item in the list displayed on top of the screen) when:
- user changes search terms in a way that changes the results (e.g. erasing them entirely is a nice example)
- user changes sorting type

The rest is cleanup: removing unused code.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
