### PR TITLE
For #13336: Open bookmarks in current tab

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkController.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkController.kt
@@ -77,7 +77,7 @@ class DefaultBookmarkController(
         val flags = EngineSession.LoadUrlFlags.select(EngineSession.LoadUrlFlags.ALLOW_JAVASCRIPT_URL)
         openInNewTabAndShow(
             item.url!!,
-            true,
+            false,
             BrowserDirection.FromBookmarks,
             activity.browsingModeManager.mode,
             flags

--- a/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkControllerTest.kt
@@ -110,7 +110,7 @@ class BookmarkControllerTest {
     }
 
     @Test
-    fun `handleBookmarkTapped should load the bookmark in a new tab`() {
+    fun `handleBookmarkTapped should load the bookmark in the current tab`() {
         var invokePendingDeletionInvoked = false
         val flags = EngineSession.LoadUrlFlags.select(EngineSession.LoadUrlFlags.ALLOW_JAVASCRIPT_URL)
 

--- a/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkControllerTest.kt
@@ -124,7 +124,7 @@ class BookmarkControllerTest {
         verify {
             homeActivity.openToBrowserAndLoad(
                 item.url!!,
-                true,
+                false,
                 BrowserDirection.FromBookmarks,
                 flags = flags
             )
@@ -290,7 +290,7 @@ class BookmarkControllerTest {
         verify {
             homeActivity.openToBrowserAndLoad(
                 item.url!!,
-                true,
+                false,
                 BrowserDirection.FromBookmarks,
                 flags = flags
             )


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

Hi there
These are my fixes to #13336, to open bookmarks in the current tab. I am not sure whether this change is approved, but as the issue is still open, I am submitting a draft PR.
May I ask the Fenix UX team for their approval on this change, or is the bookmarks opening in a new tab as intended? I can work on it to add other things if needed.
Thank you!

Here are the videos of the proposed change:

https://user-images.githubusercontent.com/58442255/149168581-54cbf4ab-b79b-4532-9fbb-9881cc96c4cc.mp4

Bookmarklets also work:

https://user-images.githubusercontent.com/58442255/149168733-c9d7f058-a252-4337-8000-aa88877e1d5d.mp4




