### PR TITLE
for #23144: only recreate activity when logo is clicked

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -765,6 +765,7 @@ class HomeFragment : Fragment() {
                     wallpaperContainer = binding.homeLayout,
                     newWallpaper = manager.switchToNextWallpaper()
                 )
+                requireActivity().recreate()
             }
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/wallpapers/WallpaperManager.kt
+++ b/app/src/main/java/org/mozilla/fenix/wallpapers/WallpaperManager.kt
@@ -8,7 +8,6 @@ import android.content.Context
 import android.view.View
 import androidx.appcompat.app.AppCompatDelegate
 import mozilla.components.support.ktx.android.content.getColorFromAttr
-import org.mozilla.fenix.ext.asActivity
 import org.mozilla.fenix.utils.Settings
 
 /**
@@ -34,10 +33,10 @@ class WallpaperManager(private val settings: Settings) {
         }
         currentWallpaper = newWallpaper
 
-        adjustTheme(wallpaperContainer.context)
+        adjustTheme()
     }
 
-    private fun adjustTheme(context: Context) {
+    private fun adjustTheme() {
         val mode = if (currentWallpaper != Wallpaper.NONE) {
             if (currentWallpaper.isDark) {
                 updateThemePreference(useDarkTheme = true)
@@ -55,7 +54,6 @@ class WallpaperManager(private val settings: Settings) {
 
         if (AppCompatDelegate.getDefaultNightMode() != mode) {
             AppCompatDelegate.setDefaultNightMode(mode)
-            context.asActivity()?.recreate()
         }
     }
 


### PR DESCRIPTION
By only adjusting the theme when the logo is clicked we should be able to avoid perf regressions on start and still update the theme with newly selected wallpapers. 