### PR TITLE
For #12717 - Bookmark search

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkAdapter.kt
@@ -33,39 +33,7 @@ class BookmarkAdapter(private val emptyView: View, private val interactor: Bookm
     }
 
     fun updateData(tree: BookmarkNode?, mode: BookmarkFragmentState.Mode) {
-        val allNodes = tree?.children.orEmpty()
-        val folders: MutableList<BookmarkNode> = mutableListOf()
-        val notFolders: MutableList<BookmarkNode> = mutableListOf()
-        val separators: MutableList<BookmarkNode> = mutableListOf()
-        allNodes.forEach {
-            when (it.type) {
-                BookmarkNodeType.SEPARATOR -> separators.add(it)
-                BookmarkNodeType.FOLDER -> folders.add(it)
-                else -> notFolders.add(it)
-            }
-        }
-        // Display folders above all other bookmarks. Exclude separators.
-        // For separator removal, see discussion in https://github.com/mozilla-mobile/fenix/issues/15214
-        val newTree = folders + notFolders - separators
-
-        val diffUtil = DiffUtil.calculateDiff(
-            BookmarkDiffUtil(
-                this.tree,
-                newTree,
-                this.mode,
-                mode
-            )
-        )
-
-        this.tree = newTree
-
-        isFirstRun = if (isFirstRun) false else {
-            emptyView.isVisible = this.tree.isEmpty()
-            false
-        }
-        this.mode = mode
-
-        diffUtil.dispatchUpdatesTo(this)
+        updateData(tree?.children.orEmpty(), mode)
     }
 
     @VisibleForTesting

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragmentInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragmentInteractor.kt
@@ -120,4 +120,12 @@ class BookmarkFragmentInteractor(
     override fun onRequestSync() {
         bookmarksController.handleRequestSync()
     }
+
+    override fun onSearchEnded() {
+        bookmarksController.handleSearchEnded()
+    }
+
+    override fun onQueryText(previousQuery: String, newQuery: String) {
+        bookmarksController.handleQuery(previousQuery, newQuery)
+    }
 }

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkView.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkView.kt
@@ -97,6 +97,16 @@ interface BookmarkViewInteractor : SelectionInteractor<BookmarkNode> {
      *
      */
     fun onRequestSync()
+
+    /**
+     * Handles a new bookmark query.
+     */
+    fun onQueryText(previousQuery: String, newQuery: String)
+
+    /**
+     * Handles ending a bookmarks query.
+     */
+    fun onSearchEnded()
 }
 
 class BookmarkView(
@@ -135,7 +145,10 @@ class BookmarkView(
             }
         }
 
-        bookmarkAdapter.updateData(state.tree, mode)
+        when (mode) {
+            is BookmarkFragmentState.Mode.Searching -> bookmarkAdapter.updateData(state.queriedItems, mode)
+            else -> bookmarkAdapter.updateData(state.tree, mode)
+        }
 
         when (mode) {
             is BookmarkFragmentState.Mode.Normal -> {

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/Utils.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/Utils.kt
@@ -39,6 +39,10 @@ fun friendlyRootTitle(
 
 data class BookmarkNodeWithDepth(val depth: Int, val node: BookmarkNode, val parent: String?)
 
+/**
+ * Get a depth first flat list of all nodes of type [BookmarkNodeType.FOLDER] optionally excluding
+ * the node having [excludeSubtreeRoot] as `guid`.
+ */
 fun BookmarkNode.flatNodeList(excludeSubtreeRoot: String?, depth: Int = 0): List<BookmarkNodeWithDepth> {
     if (this.type != BookmarkNodeType.FOLDER || this.guid == excludeSubtreeRoot) {
         return emptyList()
@@ -48,4 +52,14 @@ fun BookmarkNode.flatNodeList(excludeSubtreeRoot: String?, depth: Int = 0): List
         ?.filter { it.type == BookmarkNodeType.FOLDER }
         ?.flatMap { it.flatNodeList(excludeSubtreeRoot = excludeSubtreeRoot, depth = depth + 1) }
         .orEmpty()
+}
+
+/**
+ * Get a depth first flat list of all nodes starting from the current one.
+ */
+fun BookmarkNode.flattenAllNodes(): List<BookmarkNode> {
+    val childrenTree = children
+        ?.flatMap { it.flattenAllNodes() }
+        .orEmpty()
+    return listOf(this) + childrenTree
 }

--- a/app/src/main/java/org/mozilla/fenix/settings/advanced/LocaleSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/advanced/LocaleSettingsFragment.kt
@@ -10,8 +10,6 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.inputmethod.EditorInfo
-import androidx.appcompat.widget.SearchView
 import androidx.fragment.app.Fragment
 import mozilla.components.lib.state.ext.consumeFrom
 import mozilla.components.support.ktx.android.view.hideKeyboard
@@ -20,6 +18,7 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.components.StoreProvider
 import org.mozilla.fenix.databinding.FragmentLocaleSettingsBinding
 import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.configureSearchViewInMenu
 import org.mozilla.fenix.ext.showToolbar
 
 class LocaleSettingsFragment : Fragment() {
@@ -65,22 +64,11 @@ class LocaleSettingsFragment : Fragment() {
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         inflater.inflate(R.menu.languages_list, menu)
-        val searchItem = menu.findItem(R.id.search)
-        val searchView: SearchView = searchItem.actionView as SearchView
-        searchView.imeOptions = EditorInfo.IME_ACTION_DONE
-        searchView.queryHint = getString(R.string.locale_search_hint)
-        searchView.maxWidth = Int.MAX_VALUE
-
-        searchView.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
-            override fun onQueryTextSubmit(query: String): Boolean {
-                return false
-            }
-
-            override fun onQueryTextChange(newText: String): Boolean {
-                interactor.onSearchQueryTyped(newText)
-                return false
-            }
-        })
+        configureSearchViewInMenu(
+            menu = menu,
+            queryHint = getString(R.string.locale_search_hint),
+            onQueryTextChange = { _, newQuery -> interactor.onSearchQueryTyped(newQuery) }
+        )
     }
 
     override fun onResume() {

--- a/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/SavedLoginsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/SavedLoginsFragment.kt
@@ -10,10 +10,8 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.inputmethod.EditorInfo
 import android.widget.FrameLayout
 import androidx.appcompat.app.AppCompatActivity
-import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.Toolbar
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.lifecycle.lifecycleScope
@@ -28,6 +26,7 @@ import org.mozilla.fenix.SecureFragment
 import org.mozilla.fenix.components.StoreProvider
 import org.mozilla.fenix.databinding.FragmentSavedLoginsBinding
 import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.configureSearchViewInMenu
 import org.mozilla.fenix.ext.redirectToReAuth
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.showToolbar
@@ -111,26 +110,11 @@ class SavedLoginsFragment : SecureFragment() {
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         inflater.inflate(R.menu.login_list, menu)
-        val searchItem = menu.findItem(R.id.search)
-        val searchView: SearchView = searchItem.actionView as SearchView
-        searchView.imeOptions = EditorInfo.IME_ACTION_DONE
-        searchView.queryHint = getString(R.string.preferences_passwords_saved_logins_search)
-        searchView.maxWidth = Int.MAX_VALUE
-
-        searchView.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
-            override fun onQueryTextSubmit(query: String?): Boolean {
-                return false
-            }
-
-            override fun onQueryTextChange(newText: String?): Boolean {
-                savedLoginsStore.dispatch(
-                    LoginsAction.FilterLogins(
-                        newText
-                    )
-                )
-                return false
-            }
-        })
+        configureSearchViewInMenu(
+            menu = menu,
+            queryHint = getString(R.string.preferences_passwords_saved_logins_search),
+            onQueryTextChange = { _, newQuery -> savedLoginsStore.dispatch(LoginsAction.FilterLogins(newQuery)) }
+        )
     }
 
     /**

--- a/app/src/main/res/menu/bookmarks_menu.xml
+++ b/app/src/main/res/menu/bookmarks_menu.xml
@@ -5,11 +5,20 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
+        android:id="@+id/search_bookmarks"
+        android:contentDescription="@string/locale_search_hint"
+        android:icon="@drawable/ic_search"
+        android:title="@string/bookmark_search_hint"
+        app:actionViewClass="androidx.appcompat.widget.SearchView"
+        app:iconTint="?primaryText"
+        app:showAsAction="ifRoom|collapseActionView" />
+
+    <item
         android:id="@+id/add_bookmark_folder"
         android:icon="@drawable/ic_folder_new"
         app:iconTint="?primaryText"
         android:title="@string/bookmark_add_folder"
-        app:showAsAction="ifRoom" />
+        app:showAsAction="ifRoom|collapseActionView" />
 
     <item
         android:id="@+id/close_bookmarks"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -907,6 +907,8 @@
     <string name="bookmark_delete_multiple_folders_confirmation_dialog">%s will delete the selected items.</string>
     <!-- Snackbar title shown after a folder has been deleted. This first parameter is the name of the deleted folder -->
     <string name="bookmark_delete_folder_snackbar" moz:removedIn="96" tools:ignore="UnusedResources">Deleted %1$s</string>
+    <!-- Placeholder text shown as a hint in the bookmarks search bar before the user enters text -->
+    <string name="bookmark_search_hint">Search bookmarks</string>
     <!-- Screen title for adding a bookmarks folder -->
     <string name="bookmark_add_folder">Add folder</string>
     <!-- Snackbar title shown after a bookmark has been created. -->

--- a/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkFragmentInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkFragmentInteractorTest.kt
@@ -206,4 +206,18 @@ class BookmarkFragmentInteractorTest {
             bookmarkController.handleRequestSync()
         }
     }
+
+    @Test
+    fun `GIVEN a BookmarkController WHEN onSearchEnded is called THEN delegate the controller`() {
+        interactor.onSearchEnded()
+
+        verify { bookmarkController.handleSearchEnded() }
+    }
+
+    @Test
+    fun `GIVEN a BookmarkController WHEN onQueryText is called THEN delegate the controller`() {
+        interactor.onQueryText("t", "test")
+
+        verify { bookmarkController.handleQuery("t", "test") }
+    }
 }

--- a/app/src/test/java/org/mozilla/fenix/library/bookmarks/UtilsKtTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/bookmarks/UtilsKtTest.kt
@@ -80,6 +80,18 @@ class UtilsKtTest {
             rootWithChildren.flatNodeList(excludeSubtreeRoot = "folder2")
         )
     }
+
+    @Test
+    fun `GIVEN a BookmarkNode WHEN flattenAllNodes is used THEN do a depth first traversal to flatten all nodes`() {
+        val nodeA11 = testBookmarkItem(parentGuid = "nodeA1", url = "nodeA1")
+        val nodeA1 = testFolder(parentGuid = "root", guid = "nodeA1", children = listOf(nodeA11))
+        val nodeB1 = testBookmarkItem(parentGuid = "root", url = "nodeB1")
+        val root = testFolder(guid = "root", parentGuid = null, children = listOf(nodeA1, nodeB1))
+
+        val result = root.flattenAllNodes()
+
+        assertEquals(listOf(root, nodeA1, nodeA11, nodeB1), result)
+    }
 }
 
 internal fun testBookmarkItem(parentGuid: String, url: String, title: String = "Item for $url") = BookmarkNode(


### PR DESCRIPTION
Allows for an in-memory search of all bookmarks flattened and then the default
folders (like Bookmarks Toolbar, etc) removed.
Search will only start and the current bookmarks list will be updated to
the queried results after the user first enters a valid query (not blank).
Search will end when the SearchView is closed. (Deleting all query characters
will not end the search mode).

https://user-images.githubusercontent.com/11428869/149887801-b1e3c30f-e3b4-41e8-bbb9-ccfb2d709c0a.mp4

cc @topotropic 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
