### PR TITLE
For #23173 - CheckChanged use a single variable instead of two for checked status

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/collections/CollectionCreationTabListAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/collections/CollectionCreationTabListAdapter.kt
@@ -43,10 +43,7 @@ class CollectionCreationTabListAdapter(
             when (payloads[0]) {
                 is CheckChanged -> {
                     val checkChanged = payloads[0] as CheckChanged
-                    if (checkChanged.shouldBeChecked || checkChanged.shouldBeUnchecked) {
-                        holder.changeCheckBoxState(checkChanged.shouldBeChecked)
-                    }
-                    binding.tabSelectedCheckbox.isGone = checkChanged.shouldHideCheckBox
+                    holder.updateCheckbox(checkChanged)
                 }
             }
         }
@@ -111,9 +108,11 @@ class TabViewHolder(private val binding: CollectionTabListRowBinding) : ViewHold
 
     /**
      * Method used to change the tabSelectedCheckbox state
+     * @param checkChanged [CheckChanged] class containing the required checkbox updates
      */
-    fun changeCheckBoxState(shouldBeChecked: Boolean) {
-        binding.tabSelectedCheckbox.isChecked = shouldBeChecked
+    fun updateCheckbox(checkChanged: CheckChanged) {
+        binding.tabSelectedCheckbox.isChecked = checkChanged.shouldBeChecked
+        binding.tabSelectedCheckbox.isGone = checkChanged.shouldHideCheckBox
     }
 
     companion object {

--- a/app/src/main/java/org/mozilla/fenix/collections/TabDiffUtil.kt
+++ b/app/src/main/java/org/mozilla/fenix/collections/TabDiffUtil.kt
@@ -38,9 +38,8 @@ internal class TabDiffUtil(
      * Returns a change payload indication if the item is now/no longer selected.
      */
     override fun getChangePayload(oldItemPosition: Int, newItemPosition: Int): Any? {
-        val shouldBeChecked = newItemSelected(newItemPosition) && !oldItemSelected(oldItemPosition)
-        val shouldBeUnchecked = !newItemSelected(newItemPosition) && oldItemSelected(oldItemPosition)
-        return CheckChanged(shouldBeChecked, shouldBeUnchecked, newHideCheckboxes)
+        val shouldBeChecked = newItemSelected(newItemPosition)
+        return CheckChanged(shouldBeChecked, newHideCheckboxes)
     }
 
     override fun getOldListSize(): Int = old.size
@@ -51,12 +50,10 @@ internal class TabDiffUtil(
 }
 
 /**
- * @property shouldBeChecked Item was previously unchecked and should be checked.
- * @property shouldBeUnchecked Item was previously checked and should be unchecked.
+ * @property shouldBeChecked Item should be checked.
  * @property shouldHideCheckBox Checkbox should be visible.
  */
 data class CheckChanged(
     val shouldBeChecked: Boolean,
-    val shouldBeUnchecked: Boolean,
     val shouldHideCheckBox: Boolean
 )

--- a/app/src/test/java/org/mozilla/fenix/collections/TabDiffUtilTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/collections/TabDiffUtilTest.kt
@@ -96,8 +96,7 @@ class TabDiffUtilTest {
 
         assertEquals(
             CheckChanged(
-                shouldBeChecked = false,
-                shouldBeUnchecked = false,
+                shouldBeChecked = true,
                 shouldHideCheckBox = false
             ),
             payload
@@ -119,7 +118,6 @@ class TabDiffUtilTest {
         assertEquals(
             CheckChanged(
                 shouldBeChecked = true,
-                shouldBeUnchecked = false,
                 shouldHideCheckBox = false
             ),
             payload
@@ -141,7 +139,6 @@ class TabDiffUtilTest {
         assertEquals(
             CheckChanged(
                 shouldBeChecked = false,
-                shouldBeUnchecked = true,
                 shouldHideCheckBox = true
             ),
             payload


### PR DESCRIPTION
Removed shouldBeUnchecked property of class CheckChanged. CheckChanged.shouldBeChecked now holds the state of selected/not selected for the updated item, thus making the payload info easier to use.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
