### PR TITLE
For #16152: Use dark background for tabs in grid view

### DIFF
--- a/app/src/main/res/drawable/tab_tray_grid_item_selected_border.xml
+++ b/app/src/main/res/drawable/tab_tray_grid_item_selected_border.xml
@@ -17,7 +17,7 @@
 
             <stroke
                 android:width="4dp"
-                android:color="@color/photonViolet70" />
+                android:color="@color/grid_view_tab_selected_outline_color" />
 
             <corners android:radius="@dimen/tab_tray_grid_item_outer_border_radius" />
         </shape>

--- a/app/src/main/res/layout/tab_tray_grid_item.xml
+++ b/app/src/main/res/layout/tab_tray_grid_item.xml
@@ -25,10 +25,10 @@ A FrameLayout here is an efficient way of having a views stack while allowing:
         android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:importantForAccessibility="yes"
-        app:cardBackgroundColor="@color/photonWhite"
+        app:cardBackgroundColor="@color/grid_view_tab_background_color"
         app:cardCornerRadius="@dimen/tab_tray_grid_item_border_radius"
         app:cardElevation="0dp"
-        app:strokeColor="@color/photonLightGrey30"
+        app:strokeColor="@color/grid_view_tab_outline_color"
         app:strokeWidth="1dp">
 
         <androidx.constraintlayout.widget.ConstraintLayout
@@ -60,7 +60,7 @@ A FrameLayout here is an efficient way of having a views stack while allowing:
                 android:paddingVertical="5dp"
                 android:requiresFadingEdge="horizontal"
                 android:singleLine="true"
-                android:textColor="@color/photonInk80"
+                android:textColor="@color/tab_tray_item_text_normal_theme"
                 android:textSize="14sp"
                 android:visibility="visible"
                 app:layout_constraintEnd_toStartOf="@id/mozac_browser_tabstray_close"
@@ -78,7 +78,7 @@ A FrameLayout here is an efficient way of having a views stack while allowing:
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
                 app:srcCompat="@drawable/ic_close"
-                app:tint="@color/photonInk80" />
+                app:tint="@color/tab_tray_item_text_normal_theme" />
 
             <View
                 android:id="@+id/horizonatal_divider"

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -157,6 +157,11 @@
     <color name="tab_tray_item_thumbnail_background_normal_theme">@color/photonDarkGrey50</color>
     <color name="tab_tray_item_thumbnail_icon_normal_theme">@color/photonDarkGrey05</color>
 
+    <!-- Grid View -->
+    <color name="grid_view_tab_background_color">@color/photonDarkGrey50</color>
+    <color name="grid_view_tab_outline_color">@color/photonDarkGrey10</color>
+    <color name="grid_view_tab_selected_outline_color">@color/photonViolet40</color>
+
     <!-- Tab History -->
     <color name="tab_history_item_selected_background_normal_theme">@color/tab_tray_item_selected_background_dark_theme</color>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -254,7 +254,12 @@
     <color name="tab_tray_heading_icon_menu_normal_theme">@color/accent_normal_theme</color>
     <color name="tab_tray_item_thumbnail_background_normal_theme">@color/photonLightGrey10</color>
     <color name="tab_tray_item_thumbnail_icon_normal_theme">@color/photonLightGrey60</color>
-
+    
+    <!-- Grid View -->
+    <color name="grid_view_tab_background_color">@color/photonWhite</color>
+    <color name="grid_view_tab_outline_color">@color/photonLightGrey30</color>
+    <color name="grid_view_tab_selected_outline_color">@color/photonViolet70</color>
+    
     <!-- Tab History -->
     <color name="tab_history_item_selected_background_normal_theme">@color/tab_tray_item_selected_background_normal_theme</color>
 


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture


Screenshots:
Light mode|Dark mode
---|---
![Screenshot_20220113-211826_Firefox Preview](https://user-images.githubusercontent.com/58442255/149337852-7d62c0db-22e6-44ce-86f3-8e81b47180f2.jpg) | ![Screenshot_20220113-211835_Firefox Preview](https://user-images.githubusercontent.com/58442255/149337859-17fcf2f9-58f6-4bfc-adbd-1b1da2fd3cdd.jpg)

Accessibility Scanner results:
Light mode|Dark mode
---|---
![A Screenshot_20220113-211758_Accessibility Scanner](https://user-images.githubusercontent.com/58442255/149338714-6f807cec-1791-47b7-8bb0-1e4d28398597.jpg)|![A Screenshot_20220113-211726_Accessibility Scanner](https://user-images.githubusercontent.com/58442255/149338726-8ed687da-3014-45f7-9366-ffb6d993a17b.jpg)

