### PR TITLE
For #16152 - Add a dark theme for the tabs tray grid view

### DIFF
--- a/app/src/main/res/drawable/tab_tray_grid_item_selected_border.xml
+++ b/app/src/main/res/drawable/tab_tray_grid_item_selected_border.xml
@@ -17,7 +17,7 @@
 
             <stroke
                 android:width="4dp"
-                android:color="@color/photonViolet70" />
+                android:color="@color/fx_mobile_border_color_accent" />
 
             <corners android:radius="@dimen/tab_tray_grid_item_outer_border_radius" />
         </shape>

--- a/app/src/main/res/layout/tab_tray_grid_item.xml
+++ b/app/src/main/res/layout/tab_tray_grid_item.xml
@@ -25,10 +25,10 @@ A FrameLayout here is an efficient way of having a views stack while allowing:
         android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:importantForAccessibility="yes"
-        app:cardBackgroundColor="@color/photonWhite"
+        app:cardBackgroundColor="@color/fx_mobile_layer_color_2"
         app:cardCornerRadius="@dimen/tab_tray_grid_item_border_radius"
         app:cardElevation="0dp"
-        app:strokeColor="@color/photonLightGrey30"
+        app:strokeColor="@color/tab_tray_item_divider_normal_theme"
         app:strokeWidth="1dp">
 
         <androidx.constraintlayout.widget.ConstraintLayout
@@ -60,7 +60,7 @@ A FrameLayout here is an efficient way of having a views stack while allowing:
                 android:paddingVertical="5dp"
                 android:requiresFadingEdge="horizontal"
                 android:singleLine="true"
-                android:textColor="@color/photonInk80"
+                android:textColor="@color/tab_tray_item_text_normal_theme"
                 android:textSize="14sp"
                 android:visibility="visible"
                 app:layout_constraintEnd_toStartOf="@id/mozac_browser_tabstray_close"
@@ -78,7 +78,7 @@ A FrameLayout here is an efficient way of having a views stack while allowing:
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
                 app:srcCompat="@drawable/ic_close"
-                app:tint="@color/photonInk80" />
+                app:tint="@color/tab_tray_item_text_normal_theme" />
 
             <View
                 android:id="@+id/horizonatal_divider"

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -92,7 +92,7 @@
     <!-- Form parts -->
     <color name="fx_mobile_border_color_form_default" tools:ignore="UnusedResources">@color/photonLightGrey05</color>
     <!-- Active tab (Nav), Selected tab, Active form -->
-    <color name="fx_mobile_border_color_accent" tools:ignore="UnusedResources">@color/photonViolet40</color>
+    <color name="fx_mobile_border_color_accent">@color/photonViolet40</color>
     <!-- Form parts -->
     <color name="fx_mobile_border_color_disabled" tools:ignore="UnusedResources">@color/photonLightGrey70</color>
     <!-- Form parts -->
@@ -145,7 +145,7 @@
     <color name="mozac_widget_favicon_border_normal_theme">@color/photonDarkGrey10</color>
 
     <!-- Tab tray -->
-    <color name="tab_tray_item_text_normal_theme">@color/photonLightGrey05</color>
+    <color name="tab_tray_item_text_normal_theme">@color/primary_text_normal_theme</color>
     <color name="tab_tray_item_url_normal_theme">@color/photonLightGrey60</color>
     <color name="tab_tray_item_background_normal_theme">@color/photonDarkGrey80</color>
     <color name="tab_tray_item_selected_background_normal_theme">@color/tab_tray_item_selected_background_dark_theme</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -92,7 +92,7 @@
     <!-- Form parts -->
     <color name="fx_mobile_border_color_form_default" tools:ignore="UnusedResources">@color/photonDarkGrey90</color>
     <!-- Active tab (Nav), Selected tab, Active form -->
-    <color name="fx_mobile_border_color_accent" tools:ignore="UnusedResources">@color/photonInk20</color>
+    <color name="fx_mobile_border_color_accent">@color/photonInk20</color>
     <!-- Form parts -->
     <color name="fx_mobile_border_color_disabled" tools:ignore="UnusedResources">@color/photonLightGrey70</color>
     <!-- Form parts -->
@@ -234,7 +234,7 @@
     <color name="recently_used_share_theme">@color/photonLightGrey30</color>
 
     <!-- Tab tray -->
-    <color name="tab_tray_item_text_normal_theme">@color/photonInk80</color>
+    <color name="tab_tray_item_text_normal_theme">@color/primary_text_normal_theme</color>
     <color name="tab_tray_item_url_normal_theme">@color/photonDarkGrey05</color>
     <color name="tab_tray_item_background_normal_theme">@color/photonLightGrey10</color>
     <color name="tab_tray_item_selected_background_normal_theme">#E5DFF4</color>


### PR DESCRIPTION
Fixes #16152. We also updated the light theme selected border color to align with the design system.

Light Mode:
Old|New
---|---
<img width="441" alt="Screen Shot 2022-01-13 at 12 26 06 PM" src="https://user-images.githubusercontent.com/1190888/149379712-b19be18d-02d0-494f-9f7d-1bd66fe7ee86.png">|<img width="441" alt="Screen Shot 2022-01-13 at 12 25 20 PM" src="https://user-images.githubusercontent.com/1190888/149380131-675d23a8-f981-45ce-a4db-4005645a4dde.png">


Dark Mode:
Old|New
---|---
<img width="441" alt="Screen Shot 2022-01-13 at 12 26 17 PM" src="https://user-images.githubusercontent.com/1190888/149379907-28d821cc-aec8-4c03-b862-73421fa34103.png">|<img width="441" alt="Screen Shot 2022-01-13 at 12 25 08 PM" src="https://user-images.githubusercontent.com/1190888/149379969-72b8cfdf-9e61-47dc-9f48-ddeceb01aeee.png">


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
