### PR TITLE
For #23187 - Replace @color/notification_accent_color_normal_theme with @color/fx_mobile_text_color_accent

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/downloads/DownloadService.kt
+++ b/app/src/main/java/org/mozilla/fenix/downloads/DownloadService.kt
@@ -12,5 +12,5 @@ import org.mozilla.fenix.ext.components
 class DownloadService : AbstractFetchDownloadService() {
     override val httpClient by lazy { components.core.client }
     override val store: BrowserStore by lazy { components.core.store }
-    override val style: Style by lazy { Style(R.color.notification_accent_color_normal_theme) }
+    override val style: Style by lazy { Style(R.color.fx_mobile_text_color_accent) }
 }

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -135,7 +135,6 @@
     <color name="search_suggestion_indicator_icon_bookmark_color_normal_theme">@color/photonBlue40</color>
     <color name="select_login_header_normal_theme">@color/accent_high_contrast_dark_theme</color>
     <color name="select_credit_card_header_normal_theme">@color/accent_high_contrast_dark_theme</color>
-    <color name="notification_accent_color_normal_theme">@color/accent_high_contrast_dark_theme</color>
     <color name="menu_item_button_normal_theme">@color/accent_high_contrast_dark_theme</color>
     <color name="recently_used_share_theme">@color/photonDarkGrey10</color>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -227,7 +227,6 @@
     <color name="select_credit_card_header_normal_theme">@color/accent_bright_light_theme</color>
     <color name="mozac_widget_favicon_background_normal_theme">@color/photonWhite</color>
     <color name="mozac_widget_favicon_border_normal_theme">@color/photonLightGrey30</color>
-    <color name="notification_accent_color_normal_theme">@color/accent_bright_light_theme</color>
     <color name="menu_item_button_normal_theme">@color/accent_bright_light_theme</color>
     <color name="recently_used_share_theme">@color/photonLightGrey30</color>
 


### PR DESCRIPTION
Fixes #23187. @color/notification_accent_color_normal_theme and @color/fx_mobile_text_color_accent are equivalent.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
