### PR TITLE
For #23240 - Replace @color/contrast_text_private_theme with @color/fx_mobile_private_text_color_primary

### DIFF
--- a/app/src/main/res/layout/search_suggestions_hint.xml
+++ b/app/src/main/res/layout/search_suggestions_hint.xml
@@ -32,7 +32,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             app:srcCompat="@drawable/ic_info"
-            tools:tint="@color/contrast_text_private_theme" />
+            tools:tint="@color/fx_mobile_private_text_color_primary" />
 
         <TextView
             android:id="@+id/title"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -145,7 +145,6 @@
 
     <!-- Private theme color palette -->
     <color name="secondary_text_private_theme">#A7A2B7</color>
-    <color name="contrast_text_private_theme">@color/photonLightGrey05</color>
     <color name="caption_text_private_theme">@color/photonLightGrey70</color>
     <color name="foundation_private_theme">#261E4B</color>
     <color name="inset_private_theme">@color/photonInk50</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -230,7 +230,7 @@
         <!-- Updated color attributes -->
         <item name="primaryText">@color/fx_mobile_private_text_color_primary</item>
         <item name="secondaryText">@color/secondary_text_private_theme</item>
-        <item name="contrastText">@color/contrast_text_private_theme</item>
+        <item name="contrastText">@color/fx_mobile_private_text_color_primary</item>
         <item name="accent">@color/accent_private_theme</item>
         <item name="accentBright">@color/accent_bright_private_theme</item>
         <item name="accentHighContrast">@color/accent_high_contrast_private_theme</item>


### PR DESCRIPTION
@color/contrast_text_private_theme and @color/fx_mobile_private_text_color_primary are the same color

Fixes #23240

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
