### PR TITLE
For #23248 - Replace @color/menu_item_button_normal_theme with @color/fx_mobile_text_color_accent

### DIFF
--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -129,7 +129,6 @@
     <color name="prompt_login_edit_text_cursor_color_normal_theme">@color/photonViolet50</color>
     <color name="search_suggestion_indicator_icon_color_normal_theme">@color/photonGreen60</color>
     <color name="search_suggestion_indicator_icon_bookmark_color_normal_theme">@color/photonBlue40</color>
-    <color name="menu_item_button_normal_theme">@color/photonViolet40</color>
     <color name="recently_used_share_theme">@color/photonDarkGrey10</color>
 
     <color name="mozac_widget_favicon_background_normal_theme">@color/photonDarkGrey50</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -209,7 +209,6 @@
     <color name="search_suggestion_indicator_icon_bookmark_color_normal_theme">@color/photonBlue50</color>
     <color name="mozac_widget_favicon_background_normal_theme">@color/photonWhite</color>
     <color name="mozac_widget_favicon_border_normal_theme">@color/photonLightGrey30</color>
-    <color name="menu_item_button_normal_theme">@color/photonViolet70</color>
     <color name="recently_used_share_theme">@color/photonLightGrey30</color>
 
     <!-- Tab tray -->

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -82,7 +82,7 @@
         <item name="awesomeBarIndicatorBookmarkColor">@color/search_suggestion_indicator_icon_bookmark_color_normal_theme</item>
         <item name="preferenceSectionHeader">@color/fx_mobile_text_color_accent</item>
         <item name="selectPromptHeaderTextColor">@color/fx_mobile_text_color_accent</item>
-        <item name="menuItemButtonTintColor">@color/menu_item_button_normal_theme</item>
+        <item name="menuItemButtonTintColor">@color/fx_mobile_text_color_accent</item>
         <item name="recentlyUsedShareMenu">@color/recently_used_share_theme</item>
 
         <!-- Shared widget colors -->


### PR DESCRIPTION
Fixes #23248. @color/menu_item_button_normal_theme and @color/fx_mobile_text_color_accent are equivalent.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
