### PR TITLE
Fixed the synced tab list size by increasing the padding

### DIFF
--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -166,7 +166,7 @@
     <dimen name="tab_tray_new_collection_padding_start">24dp</dimen>
     <dimen name="tab_tray_new_collection_drawable_padding">28dp</dimen>
     <!--  Keeps FAB and snackbar from covering last item in list -->
-    <dimen name="tab_tray_list_bottom_padding">190dp</dimen>
+    <dimen name="tab_tray_list_bottom_padding">230dp</dimen>
 
     <!-- Saved Logins Fragment -->
     <dimen name="saved_logins_sort_menu_dropdown_chevron_icon_margin_start">24dp</dimen>


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

Closes #23249 
The list of the synced tabs was supposed to scroll completely but it didn't scroll just the last item because the bottom padding was not enough to counter for overflow of list container. So, I increased the padding from 190dp to 230dp as the last item was about the size. Below are the screenshots for the synced tabs list in both compact and expanded view.
![device-2022-01-18-210602](https://user-images.githubusercontent.com/71327295/149969223-d923a687-a9e4-421b-a334-2f808995ba28.png)
![device-2022-01-18-210624](https://user-images.githubusercontent.com/71327295/149969248-b08823c2-8662-4182-9913-37cb968585cc.png)

