### PR TITLE
For #23266 - Update the tabs tray multi-select background color to @color/fx_mobile_layer_color_accent

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabstray/browser/SelectionBannerBinding.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/browser/SelectionBannerBinding.kt
@@ -121,7 +121,7 @@ class SelectionBannerBinding(
         // memoize to avoid setting the background unnecessarily.
         if (isPreviousModeSelect != isSelectMode) {
             val colorResource = if (isSelectMode) {
-                R.color.accent_normal_theme
+                R.color.fx_mobile_layer_color_accent
             } else {
                 R.color.fx_mobile_layer_color_1
             }

--- a/app/src/main/java/org/mozilla/fenix/tabstray/browser/SelectionHandleBinding.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/browser/SelectionHandleBinding.kt
@@ -80,7 +80,7 @@ class SelectionHandleBinding(
 
     private fun updateBackgroundColor(handle: View, multiselect: Boolean) {
         val colorResource = if (multiselect) {
-            R.color.accent_normal_theme
+            R.color.fx_mobile_layer_color_accent
         } else {
             R.color.secondary_text_normal_theme
         }

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -13,7 +13,7 @@
     <!-- App Bar Top, App Bar Bottom, Frontlayer header -->
     <color name="fx_mobile_layer_color_3" tools:ignore="UnusedResources">@color/photonDarkGrey60</color>
     <!-- App Bar Top (edit), Header (edit) -->
-    <color name="fx_mobile_layer_color_accent" tools:ignore="UnusedResources">@color/photonViolet40</color>
+    <color name="fx_mobile_layer_color_accent">@color/photonViolet40</color>
     <!-- Selected tab -->
     <color name="fx_mobile_layer_color_accent_nonopaque">@color/photonViolet50A32</color>
     <color name="fx_mobile_layer_color_scrim" tools:ignore="UnusedResources">@color/photonDarkGrey05A45</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -13,7 +13,7 @@
     <!-- App Bar Top, App Bar Bottom, Frontlayer header -->
     <color name="fx_mobile_layer_color_3" tools:ignore="UnusedResources">@color/photonLightGrey10</color>
     <!-- App Bar Top (edit), Header (edit) -->
-    <color name="fx_mobile_layer_color_accent" tools:ignore="UnusedResources">@color/photonInk20</color>
+    <color name="fx_mobile_layer_color_accent">@color/photonInk20</color>
     <!-- Selected tab -->
     <color name="fx_mobile_layer_color_accent_nonopaque">@color/photonViolet70A12</color>
     <color name="fx_mobile_layer_color_scrim" tools:ignore="UnusedResources">@color/photonDarkGrey05A45</color>


### PR DESCRIPTION
Fixes #23266. See https://www.figma.com/file/YcQC7rU1SQJx49kIAXZhcI/Component-and-Color-Usage-Examples?node-id=78%3A16582 for the design token usage.

Light Mode:
Old|New
---|---
<img width="441" alt="Screen Shot 2022-01-18 at 4 32 14 PM" src="https://user-images.githubusercontent.com/1190888/150022072-54ca658f-f470-4bc4-981b-faf146e086ff.png">|<img width="441" alt="Screen Shot 2022-01-18 at 4 22 52 PM" src="https://user-images.githubusercontent.com/1190888/150021960-83a271f9-2f0f-4692-b6ca-3fff90b7bcff.png">

Dark Mode:
Old|New
---|---
<img width="441" alt="Screen Shot 2022-01-18 at 4 33 11 PM" src="https://user-images.githubusercontent.com/1190888/150022178-c1d528aa-a7ce-46e1-9ea7-5220af972f60.png">|<img width="441" alt="Screen Shot 2022-01-18 at 4 23 43 PM" src="https://user-images.githubusercontent.com/1190888/150021972-f8ad5560-5e4e-4cf4-9dda-9a94bc147787.png">

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
