### PR TITLE
For #23272 - AddLoginFragment use showKeyboard from Components

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/AddLoginFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/AddLoginFragment.kt
@@ -4,7 +4,6 @@
 
 package org.mozilla.fenix.settings.logins.fragment
 
-import android.content.Context
 import android.content.res.ColorStateList
 import android.os.Bundle
 import android.text.Editable
@@ -14,7 +13,6 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
-import android.view.inputmethod.InputMethodManager
 import android.webkit.URLUtil
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
@@ -23,6 +21,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import mozilla.components.lib.state.ext.consumeFrom
 import mozilla.components.support.ktx.android.view.hideKeyboard
+import mozilla.components.support.ktx.android.view.showKeyboard
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.StoreProvider
 import org.mozilla.fenix.databinding.FragmentAddLoginBinding
@@ -108,9 +107,7 @@ class AddLoginFragment : Fragment(R.layout.fragment_add_login) {
 
     private fun setUpClickListeners() {
         binding.hostnameText.requestFocus()
-        val imm =
-            requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-        imm.showSoftInput(binding.hostnameText, InputMethodManager.SHOW_IMPLICIT)
+        binding.hostnameText.showKeyboard()
 
         binding.clearHostnameTextButton.setOnClickListener {
             binding.hostnameText.text?.clear()


### PR DESCRIPTION
Made `hostnameText` from `AddLoginFragment` use the `showKeyboard` method from AC. After testing multiple methods to call `showSoftInput`, the delay seems to be the most important difference between the previous method of showing the keyboard and `showKeyboard`. 

https://user-images.githubusercontent.com/35462038/150145611-959fe01e-f455-45d7-8ea1-af1059d913d9.mp4

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
