### PR TITLE
For #16952 - Add a new preference for enabling Https-only mode

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -25,6 +25,7 @@ import mozilla.components.browser.thumbnails.storage.ThumbnailStorage
 import mozilla.components.concept.base.crash.CrashReporting
 import mozilla.components.concept.engine.DefaultSettings
 import mozilla.components.concept.engine.Engine
+import mozilla.components.concept.engine.Engine.HttpsOnlyMode
 import mozilla.components.concept.engine.mediaquery.PreferredColorScheme
 import mozilla.components.concept.fetch.Client
 import mozilla.components.feature.customtabs.store.CustomTabsServiceStore
@@ -119,7 +120,8 @@ class Core(
             clearColor = ContextCompat.getColor(
                 context,
                 R.color.fx_mobile_layer_color_1
-            )
+            ),
+            httpsOnlyMode = getHttpsOnlyMode()
         )
 
         GeckoEngine(
@@ -446,6 +448,27 @@ class Core(
             context.settings().shouldUseLightTheme -> PreferredColorScheme.Light
             inDark -> PreferredColorScheme.Dark
             else -> PreferredColorScheme.Light
+        }
+    }
+
+    /**
+     * Get the current HttpsOnlyMode based on user preferences.
+     *
+     * @param enabled Optional [Boolean] overriding the current user preference for whether https-only mode
+     * is enabled or not, used when computing the result.
+     * @param mode Optional [String] overriding the current user preference for the mode in https-only mode
+     * is enabled (for all tabs / just for private tabs), used when computing the result.
+     */
+    fun getHttpsOnlyMode(
+        enabled: Boolean = context.settings().shouldUseHttpOnly,
+        mode: String = context.settings().shouldUseHttpOnlyMode
+    ): HttpsOnlyMode {
+        return if (!enabled) {
+            HttpsOnlyMode.DISABLED
+        } else if (mode == context.getString(R.string.all)) {
+            HttpsOnlyMode.ENABLED
+        } else {
+            HttpsOnlyMode.ENABLED_PRIVATE_ONLY
         }
     }
 

--- a/app/src/main/java/org/mozilla/fenix/settings/DropDownListPreference.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/DropDownListPreference.kt
@@ -16,10 +16,6 @@ class DropDownListPreference @JvmOverloads constructor(
     attrs: AttributeSet? = null
 ) : DropDownPreference(context, attrs) {
 
-    init {
-        layoutResource = R.layout.dropdown_preference_etp
-    }
-
     override fun createAdapter(): ArrayAdapter<Any> {
         return ArrayAdapter(context, R.layout.etp_dropdown_item)
     }

--- a/app/src/main/java/org/mozilla/fenix/settings/LearnMoreSwitchPreference.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/LearnMoreSwitchPreference.kt
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.settings
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.preference.PreferenceViewHolder
+import androidx.preference.SwitchPreference
+import org.mozilla.fenix.R
+import org.mozilla.fenix.utils.LinkTextView
+
+/**
+ * Switch preference showing a "Learn More" text below the summary and informing through a callback
+ * when this text is clicked by the user.
+ */
+class LearnMoreSwitchPreference @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null
+) : SwitchPreference(context, attrs) {
+
+    /**
+     * Lazy callback for when the "Learn more" text is clicked by the user.
+     */
+    var onLearnMoreClicked = { }
+
+    init {
+        layoutResource = R.layout.preference_switch_learn_more
+    }
+
+    override fun onBindViewHolder(holder: PreferenceViewHolder) {
+        super.onBindViewHolder(holder)
+
+        (holder.findViewById(R.id.learn_more) as LinkTextView).setOnClickListener {
+            onLearnMoreClicked()
+        }
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -506,6 +506,22 @@ class Settings(private val appContext: Context) : PreferencesHolder {
     )
 
     /**
+     * Whether "Https-only mode" is enabled or not.
+     */
+    var shouldUseHttpOnly by booleanPreference(
+        appContext.getPreferenceKey(R.string.pref_key_https_only_enabled),
+        default = false
+    )
+
+    /**
+     * The tabs for which the "Https-only mode" is enabled - for all tabs or just the private ones.
+     */
+    var shouldUseHttpOnlyMode by stringPreference(
+        appContext.getPreferenceKey(R.string.pref_key_https_only_enabled_mode),
+        default = appContext.getString(R.string.all)
+    )
+
+    /**
      * Declared as a function for performance purposes. This could be declared as a variable using
      * booleanPreference like other members of this class. However, doing so will make it so it will
      * be initialized once Settings.kt is first called, which in turn will call `isDefaultBrowserBlocking()`.

--- a/app/src/main/res/layout/dropdown_preference.xml
+++ b/app/src/main/res/layout/dropdown_preference.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginStart="?android:attr/listPreferredItemPaddingStart"
+    android:layout_marginEnd="?android:attr/listPreferredItemPaddingEnd"
+    android:background="@drawable/rounded_grey_corners_transparent_center"
+    android:clickable="true"
+    android:focusable="true"
+    android:gravity="center_vertical">
+
+    <androidx.appcompat.widget.AppCompatSpinner
+        android:id="@+id/spinner"
+        android:layout_width="match_parent"
+        android:layout_height="48dp"
+        android:popupBackground="?above"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/preference_switch_learn_more.xml
+++ b/app/src/main/res/layout/preference_switch_learn_more.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?android:selectableItemBackground"
+    android:clickable="true"
+    android:focusable="true"
+    android:gravity="center_vertical"
+    android:minHeight="48dp"
+    android:paddingStart="?android:attr/listPreferredItemPaddingStart"
+    android:paddingEnd="?android:attr/listPreferredItemPaddingEnd">
+
+    <TextView
+        android:id="@android:id/title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="@string/preference_https_only_title"
+        android:textAlignment="viewStart"
+        android:textColor="@color/state_list_text_color"
+        android:textSize="16sp"
+        app:layout_constraintBottom_toTopOf="@android:id/summary"
+        app:layout_constraintEnd_toStartOf="@android:id/widget_frame"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_chainStyle="packed"
+        tools:text="Setting title" />
+
+    <TextView
+        android:id="@android:id/summary"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="@string/preference_https_only_summary"
+        android:textAlignment="viewStart"
+        android:textColor="@color/secondary_state_list_text_color"
+        app:layout_constraintBottom_toTopOf="@id/learn_more"
+        app:layout_constraintEnd_toEndOf="@android:id/title"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@android:id/title"
+        app:layout_constraintVertical_chainStyle="packed"
+        tools:text="Settings summary" />
+
+    <org.mozilla.fenix.utils.LinkTextView
+        android:id="@+id/learn_more"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:minHeight="48.dp"
+        android:text="@string/preference_http_only_learn_more"
+        android:textColor="?accent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="@android:id/title"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@android:id/summary"
+        app:layout_constraintVertical_chainStyle="packed" />
+
+    <LinearLayout
+        android:id="@android:id/widget_frame"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
+        android:gravity="end|center_vertical"
+        android:minWidth="58dp"
+        android:orientation="vertical"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@android:id/title"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.5" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -31,6 +31,16 @@
         <item>@string/private_string</item>
     </string-array>
 
+    <string-array name="https_only_options_entries">
+        <item>@string/preference_https_only_content_1</item>
+        <item>@string/preference_https_only_content_2</item>
+    </string-array>
+
+    <string-array name="https_only_options_entry_values">
+        <item>@string/all</item>
+        <item>@string/private_string</item>
+    </string-array>
+
     <string name="resource_scheme">"resource://"</string>
     <string name="chrome_scheme">"chrome://</string>
     <string name="about_scheme">"about:"</string>

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -156,6 +156,10 @@
     <string name="pref_key_tracking_protection_custom_fingerprinters" translatable="false">pref_key_tracking_protection_custom_fingerprinters</string>
     <string name="pref_key_tracking_protection_redirect_trackers" translatable="false">pref_key_tracking_protection_redirect_trackers</string>
 
+    <!-- Https only Settings -->
+    <string name="pref_key_https_only_enabled" translatable="false">pref_key_https_only</string>
+    <string name="pref_key_https_only_enabled_mode" translatable="false">pref_key_https_only_enabled_mode</string>
+
     <!-- Logins Settings -->
     <string name="pref_key_save_logins_settings" translatable="false">pref_key_save_logins_settings</string>
     <string name="pref_key_save_logins" translatable="false">pref_key_save_logins</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -424,6 +424,16 @@
     <string name="preferences_addons">Add-ons</string>
     <!-- Preference for notifications -->
     <string name="preferences_notifications">Notifications</string>
+    <!-- Title of the preference to enable "HTTPS-Only" mode -->
+    <string name="preference_https_only_title">HTTPS-Only Mode</string>
+    <!-- Description of the preference to enable "HTTPS-Only" mode. %1$s will get replaced with the name of the app. -->
+    <string name="preference_https_only_summary">HTTPS provides a secure, encrypted connection between %1$s and the websites you visit. Most websites support HTTPS, and if HTTPS-Only Mode is enabled, then %1$s will upgrade all connections to HTTPS.</string>
+    <!-- Text displayed that links to website about "HTTP-Only" Mode -->
+    <string name="preference_http_only_learn_more">Learn more</string>
+    <!-- Option for for the https only setting-->
+    <string name="preference_https_only_content_1">In all tabs</string>
+    <!-- Option for for the https only setting-->
+    <string name="preference_https_only_content_2">Only in Private tabs</string>
 
     <!-- Add-on Preferences -->
     <!-- Preference to customize the configured AMO (addons.mozilla.org) collection -->

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -110,6 +110,20 @@
             app:iconSpaceReserved="false"
             android:title="@string/preference_enhanced_tracking_protection" />
 
+        <org.mozilla.fenix.settings.LearnMoreSwitchPreference
+            android:key="@string/pref_key_https_only_enabled"
+            android:title="@string/preference_https_only_title"
+            app:iconSpaceReserved="false" />
+
+        <org.mozilla.fenix.settings.DropDownListPreference
+            android:defaultValue="@string/all"
+            android:dependency="@string/pref_key_https_only_enabled"
+            android:entries="@array/https_only_options_entries"
+            android:entryValues="@array/https_only_options_entry_values"
+            android:key="@string/pref_key_https_only_enabled_mode"
+            android:layout="@layout/dropdown_preference"
+            app:useSimpleSummaryProvider="true" />
+
         <androidx.preference.Preference
             android:key="@string/pref_key_site_permissions"
             app:iconSpaceReserved="false"

--- a/app/src/main/res/xml/tracking_protection_preferences.xml
+++ b/app/src/main/res/xml/tracking_protection_preferences.xml
@@ -44,6 +44,7 @@
         android:entries="@array/cookies_options_entries"
         android:entryValues="@array/cookies_options_entry_values"
         android:key="@string/pref_key_tracking_protection_custom_cookies_select"
+        android:layout="@layout/dropdown_preference_etp"
         app:useSimpleSummaryProvider="true" />
     <CheckBoxPreference
         android:defaultValue="true"
@@ -57,6 +58,7 @@
         android:entries="@array/tracking_content_options_entries"
         android:entryValues="@array/tracking_content_options_entry_values"
         android:key="@string/pref_key_tracking_protection_custom_tracking_content_select"
+        android:layout="@layout/dropdown_preference_etp"
         app:useSimpleSummaryProvider="true" />
     <CheckBoxPreference
         android:defaultValue="true"

--- a/app/src/test/java/org/mozilla/fenix/components/CoreTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/CoreTest.kt
@@ -1,0 +1,134 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.components
+
+import android.content.Context
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import mozilla.components.concept.engine.Engine.HttpsOnlyMode
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.utils.Settings
+
+private const val HTTPS_ONLY_ALL_TABS_MODE = "all"
+private const val HTTPS_ONLY_PRIVATE_TABS_MODE = "private"
+
+class CoreTest {
+    @Test
+    fun `GIVEN Https-only mode is disabled WHEN getHttpsOnlyMode is called THEN return HttpsOnlyMode#DISABLED`() {
+        val settings: Settings = mockk(relaxed = true) {
+            every { shouldUseHttpOnly } returns false
+        }
+        mockkStatic("org.mozilla.fenix.ext.ContextKt") {
+            every { any<Context>().settings() } returns settings
+            val core = Core(mockk(relaxed = true), mockk(), mockk())
+
+            val result = core.getHttpsOnlyMode()
+
+            assertEquals(HttpsOnlyMode.DISABLED, result)
+        }
+    }
+
+    @Test
+    fun `GIVEN Https-only mode is enabled WHEN getHttpsOnlyMode is called THEN return by default HttpsOnlyMode#ENABLED`() {
+        val settings: Settings = mockk(relaxed = true) {
+            every { shouldUseHttpOnly } returns true
+        }
+        mockkStatic("org.mozilla.fenix.ext.ContextKt") {
+            every { any<Context>().settings() } returns settings
+            val core = Core(mockk(relaxed = true), mockk(), mockk())
+
+            val result = core.getHttpsOnlyMode()
+
+            assertEquals(HttpsOnlyMode.ENABLED, result)
+        }
+    }
+
+    @Test
+    fun `GIVEN Https-only mode is enabled for all tabs WHEN getHttpsOnlyMode is called THEN return HttpsOnlyMode#ENABLED`() {
+        val context: Context = mockk(relaxed = true)
+        val settings: Settings = mockk(relaxed = true) {
+            every { shouldUseHttpOnly } returns true
+            every { shouldUseHttpOnlyMode } returns HTTPS_ONLY_ALL_TABS_MODE
+        }
+        mockkStatic("org.mozilla.fenix.ext.ContextKt") {
+            every { any<Context>().settings() } returns settings
+            every { context.getString(any()) } returns HTTPS_ONLY_ALL_TABS_MODE
+            val core = Core(context, mockk(), mockk())
+
+            val result = core.getHttpsOnlyMode()
+
+            assertEquals(HttpsOnlyMode.ENABLED, result)
+        }
+    }
+
+    @Test
+    fun `GIVEN Https-only mode is enabled for only private tabs WHEN getHttpsOnlyMode is called THEN return HttpsOnlyMode#ENABLED_PRIVATE_ONLY`() {
+        val context: Context = mockk(relaxed = true)
+        val settings: Settings = mockk(relaxed = true) {
+            every { shouldUseHttpOnly } returns true
+            every { shouldUseHttpOnlyMode } returns HTTPS_ONLY_PRIVATE_TABS_MODE
+        }
+        mockkStatic("org.mozilla.fenix.ext.ContextKt") {
+            every { any<Context>().settings() } returns settings
+            every { context.getString(any()) } returns HTTPS_ONLY_ALL_TABS_MODE
+            val core = Core(context, mockk(), mockk())
+
+            val result = core.getHttpsOnlyMode()
+
+            assertEquals(HttpsOnlyMode.ENABLED_PRIVATE_ONLY, result)
+        }
+    }
+
+    @Test
+    fun `GIVEN Https-only mode is enabled WHEN getHttpsOnlyMode is called specifying the mode to be disabled THEN return HttpsOnlyMode#DISABLED`() {
+        val settings: Settings = mockk(relaxed = true) {
+            every { shouldUseHttpOnly } returns true
+        }
+        mockkStatic("org.mozilla.fenix.ext.ContextKt") {
+            every { any<Context>().settings() } returns settings
+            val core = Core(mockk(relaxed = true), mockk(), mockk())
+
+            val result = core.getHttpsOnlyMode(enabled = false)
+
+            assertEquals(HttpsOnlyMode.DISABLED, result)
+        }
+    }
+
+    @Test
+    fun `GIVEN Https-only mode is disabled WHEN getHttpsOnlyMode is called specifying the mode to be enabled THEN return by default HttpsOnlyMode#ENABLED`() {
+        val settings: Settings = mockk(relaxed = true) {
+            every { shouldUseHttpOnly } returns false
+        }
+        mockkStatic("org.mozilla.fenix.ext.ContextKt") {
+            every { any<Context>().settings() } returns settings
+            val core = Core(mockk(relaxed = true), mockk(), mockk())
+
+            val result = core.getHttpsOnlyMode(enabled = true)
+
+            assertEquals(HttpsOnlyMode.ENABLED, result)
+        }
+    }
+
+    @Test
+    fun `GIVEN Https-only mode is disabled WHEN getHttpsOnlyMode is called specifying the mode to be enabled for private tabs THEN return by default HttpsOnlyMode#ENABLED_PRIVATE_ONLY`() {
+        val context: Context = mockk(relaxed = true)
+        val settings: Settings = mockk(relaxed = true) {
+            every { shouldUseHttpOnly } returns false
+            every { shouldUseHttpOnlyMode } returns HTTPS_ONLY_ALL_TABS_MODE
+        }
+        mockkStatic("org.mozilla.fenix.ext.ContextKt") {
+            every { any<Context>().settings() } returns settings
+            every { context.getString(any()) } returns HTTPS_ONLY_ALL_TABS_MODE
+            val core = Core(mockk(relaxed = true), mockk(), mockk())
+
+            val result = core.getHttpsOnlyMode(enabled = true, mode = HTTPS_ONLY_PRIVATE_TABS_MODE)
+
+            assertEquals(HttpsOnlyMode.ENABLED_PRIVATE_ONLY, result)
+        }
+    }
+}

--- a/app/src/test/java/org/mozilla/fenix/settings/LearnMoreSwitchPreferenceTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/LearnMoreSwitchPreferenceTest.kt
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.settings
+
+import android.widget.FrameLayout
+import androidx.preference.PreferenceViewHolder
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.fenix.R
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+import org.mozilla.fenix.utils.LinkTextView
+
+@RunWith(FenixRobolectricTestRunner::class)
+class LearnMoreSwitchPreferenceTest {
+    @Test
+    fun `WHEN the preference is created THEN it sets a default layout resource`() {
+        val preference = LearnMoreSwitchPreference(testContext)
+
+        assertEquals(R.layout.preference_switch_learn_more, preference.layoutResource)
+    }
+
+    @Test
+    fun `WHEN the learn_more text is clicked THEN inform the onLearnMoreClicked callback`() {
+        val preference = LearnMoreSwitchPreference(testContext)
+        val learnMore = LinkTextView(testContext).apply { id = R.id.learn_more }
+        val layout = FrameLayout(testContext).apply { addView(learnMore) }
+        val viewHolder = PreferenceViewHolder.createInstanceForTests(layout)
+        var wasLearnMoreClicked = false
+        preference.onLearnMoreClicked = {
+            wasLearnMoreClicked = true
+        }
+        preference.onBindViewHolder(viewHolder)
+
+        learnMore.callOnClick()
+
+        assertTrue(wasLearnMoreClicked)
+    }
+}

--- a/app/src/test/java/org/mozilla/fenix/utils/SettingsTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/utils/SettingsTest.kt
@@ -18,6 +18,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.settings.PhoneFeature
 import org.mozilla.fenix.settings.deletebrowsingdata.DeleteBrowsingDataOnQuitType
@@ -799,5 +800,17 @@ class SettingsTest {
         every { settings.hasInactiveTabsAutoCloseDialogBeenDismissed } returns false
 
         assertTrue(settings.shouldShowInactiveTabsAutoCloseDialog(20))
+    }
+
+    @Test
+    fun `WHEN shouldUseHttpOnly is called THEN return false as the default`() {
+        assertFalse(settings.shouldUseHttpOnly)
+    }
+
+    @Test
+    fun `WHEN shouldUseHttpOnlyMode is called THEN return all as the default`() {
+        val result = settings.shouldUseHttpOnlyMode
+
+        assertEquals(testContext.getString(R.string.all), result)
     }
 }


### PR DESCRIPTION
Adds a new preference in the "Privacy and security" settings section with a
checkbox for disabling or enabling this and a dropdown for selecting to which
kind of tabs (all / just private) does "Https-only mode" applies when enabled.

An updated error page is to be added in a separate ticket.




### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
