### PR TITLE
For #23317 - Update tab tray icon to match design system colors

### DIFF
--- a/app/src/main/res/color/tab_icon.xml
+++ b/app/src/main/res/color/tab_icon.xml
@@ -4,5 +4,5 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:color="@color/fx_mobile_icon_color_active" android:state_selected="true" />
-    <item android:color="@color/tab_tray_heading_icon_inactive_normal_theme" />
+    <item android:color="@color/fx_mobile_icon_color_primary_inactive" />
 </selector>

--- a/app/src/main/res/color/tab_icon.xml
+++ b/app/src/main/res/color/tab_icon.xml
@@ -3,6 +3,6 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:color="@color/accent_normal_theme" android:state_selected="true" />
+    <item android:color="@color/fx_mobile_icon_color_active" android:state_selected="true" />
     <item android:color="@color/tab_tray_heading_icon_inactive_normal_theme" />
 </selector>

--- a/app/src/main/res/layout/component_tabstray2.xml
+++ b/app/src/main/res/layout/component_tabstray2.xml
@@ -121,7 +121,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="@id/tab_layout"
         app:srcCompat="@drawable/ic_menu"
-        app:tint="@color/tab_tray_heading_icon_menu_normal_theme" />
+        app:tint="@color/fx_mobile_icon_color_primary" />
 
     <View
         android:id="@+id/divider"

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -62,7 +62,7 @@
 
     <!-- Icon -->
     <!-- Primary icon -->
-    <color name="fx_mobile_icon_color_primary" tools:ignore="UnusedResources">@color/photonLightGrey05</color>
+    <color name="fx_mobile_icon_color_primary">@color/photonLightGrey05</color>
     <!-- Inactive tab -->
     <color name="fx_mobile_icon_color_primary_inactive">@color/photonLightGrey05A60</color>
     <!-- Secondary icon -->
@@ -135,7 +135,6 @@
     <!-- Tab tray -->
     <color name="tab_tray_item_background_normal_theme">@color/photonDarkGrey80</color>
     <color name="tab_tray_item_selected_background_normal_theme">@color/tab_tray_item_selected_background_dark_theme</color>
-    <color name="tab_tray_heading_icon_menu_normal_theme">@color/photonLightGrey05</color>
     <color name="tab_tray_item_thumbnail_background_normal_theme">@color/photonDarkGrey50</color>
     <color name="tab_tray_item_thumbnail_icon_normal_theme">@color/photonDarkGrey05</color>
 

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -64,7 +64,7 @@
     <!-- Primary icon -->
     <color name="fx_mobile_icon_color_primary" tools:ignore="UnusedResources">@color/photonLightGrey05</color>
     <!-- Inactive tab -->
-    <color name="fx_mobile_icon_color_primary_inactive" tools:ignore="UnusedResources">@color/photonLightGrey05A60</color>
+    <color name="fx_mobile_icon_color_primary_inactive">@color/photonLightGrey05A60</color>
     <!-- Secondary icon -->
     <color name="fx_mobile_icon_color_secondary" tools:ignore="UnusedResources">@color/photonLightGrey40</color>
     <!-- Active tab -->
@@ -135,7 +135,6 @@
     <!-- Tab tray -->
     <color name="tab_tray_item_background_normal_theme">@color/photonDarkGrey80</color>
     <color name="tab_tray_item_selected_background_normal_theme">@color/tab_tray_item_selected_background_dark_theme</color>
-    <color name="tab_tray_heading_icon_inactive_normal_theme">@color/photonLightGrey05</color>
     <color name="tab_tray_heading_icon_menu_normal_theme">@color/photonLightGrey05</color>
     <color name="tab_tray_item_thumbnail_background_normal_theme">@color/photonDarkGrey50</color>
     <color name="tab_tray_item_thumbnail_icon_normal_theme">@color/photonDarkGrey05</color>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -68,7 +68,7 @@
     <!-- Secondary icon -->
     <color name="fx_mobile_icon_color_secondary" tools:ignore="UnusedResources">@color/photonLightGrey40</color>
     <!-- Active tab -->
-    <color name="fx_mobile_icon_color_active" tools:ignore="UnusedResources">@color/photonViolet40</color>
+    <color name="fx_mobile_icon_color_active">@color/photonViolet40</color>
     <!-- Disabled icon -->
     <color name="fx_mobile_icon_color_disabled" tools:ignore="UnusedResources">@color/photonLightGrey70</color>
     <!-- Icon inverted (on color) -->

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -68,7 +68,7 @@
     <!-- Secondary icon -->
     <color name="fx_mobile_icon_color_secondary" tools:ignore="UnusedResources">@color/photonDarkGrey05</color>
     <!-- Active tab -->
-    <color name="fx_mobile_icon_color_active" tools:ignore="UnusedResources">@color/photonInk20</color>
+    <color name="fx_mobile_icon_color_active">@color/photonInk20</color>
     <!-- Disabled icon -->
     <color name="fx_mobile_icon_color_disabled" tools:ignore="UnusedResources">@color/photonLightGrey70</color>
     <!-- Icon inverted (on color) -->

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -64,7 +64,7 @@
     <!-- Primary icon -->
     <color name="fx_mobile_icon_color_primary" tools:ignore="UnusedResources">@color/photonDarkGrey90</color>
     <!-- Inactive tab -->
-    <color name="fx_mobile_icon_color_primary_inactive" tools:ignore="UnusedResources">@color/photonDarkGrey90A60</color>
+    <color name="fx_mobile_icon_color_primary_inactive">@color/photonDarkGrey90A60</color>
     <!-- Secondary icon -->
     <color name="fx_mobile_icon_color_secondary" tools:ignore="UnusedResources">@color/photonDarkGrey05</color>
     <!-- Active tab -->
@@ -202,7 +202,6 @@
     <!-- Tab tray -->
     <color name="tab_tray_item_background_normal_theme">@color/photonLightGrey10</color>
     <color name="tab_tray_item_selected_background_normal_theme">#E5DFF4</color>
-    <color name="tab_tray_heading_icon_inactive_normal_theme">@color/photonInk20A48</color>
     <color name="tab_tray_heading_icon_menu_normal_theme">@color/accent_normal_theme</color>
     <color name="tab_tray_item_thumbnail_background_normal_theme">@color/photonLightGrey10</color>
     <color name="tab_tray_item_thumbnail_icon_normal_theme">@color/photonLightGrey60</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -62,7 +62,7 @@
 
     <!-- Icon -->
     <!-- Primary icon -->
-    <color name="fx_mobile_icon_color_primary" tools:ignore="UnusedResources">@color/photonDarkGrey90</color>
+    <color name="fx_mobile_icon_color_primary">@color/photonDarkGrey90</color>
     <!-- Inactive tab -->
     <color name="fx_mobile_icon_color_primary_inactive">@color/photonDarkGrey90A60</color>
     <!-- Secondary icon -->
@@ -202,7 +202,6 @@
     <!-- Tab tray -->
     <color name="tab_tray_item_background_normal_theme">@color/photonLightGrey10</color>
     <color name="tab_tray_item_selected_background_normal_theme">#E5DFF4</color>
-    <color name="tab_tray_heading_icon_menu_normal_theme">@color/accent_normal_theme</color>
     <color name="tab_tray_item_thumbnail_background_normal_theme">@color/photonLightGrey10</color>
     <color name="tab_tray_item_thumbnail_icon_normal_theme">@color/photonLightGrey60</color>
 


### PR DESCRIPTION
Fixes #23317

Light Mode:
Old|New
---|---
<img width="441" alt="Screen Shot 2022-01-20 at 1 59 59 PM" src="https://user-images.githubusercontent.com/1190888/150404710-ae81b8f6-9af7-4c80-a21c-0760ccc17e77.png">|<img width="441" alt="Screen Shot 2022-01-20 at 1 58 53 PM" src="https://user-images.githubusercontent.com/1190888/150404718-3c644cf3-f52c-4d17-b224-86a8dc793270.png">


Dark Mode:
Old|New
---|---
<img width="441" alt="Screen Shot 2022-01-20 at 2 00 14 PM" src="https://user-images.githubusercontent.com/1190888/150404674-48a036d0-5a24-4063-949b-9bdb6dbd94f0.png">|<img width="441" alt="Screen Shot 2022-01-20 at 1 58 37 PM" src="https://user-images.githubusercontent.com/1190888/150404683-c5e86802-6eab-47ee-bab2-a1a00e40ef1e.png">


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
