### PR TITLE
Add Operating System and Arch to CI log

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -368,6 +368,15 @@ android.applicationVariants.all { variant ->
     }
 
 // -------------------------------------------------------------------------------------------------
+// CI Build environment
+// -------------------------------------------------------------------------------------------------
+    println("Build environment")
+
+    println("os.name         ${System.getProperty('os.name')}")
+    println("os.arch         ${System.getProperty('os.arch')}")
+    println("os.version      ${System.getProperty('os.version')}")
+
+// -------------------------------------------------------------------------------------------------
 // BuildConfig: Set flag for official builds; similar to MOZILLA_OFFICIAL in mozilla-central.
 // -------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR is to explore the build environment on the CI server.

It could land, but doesn't need to.

The System properties exposed are: `os.name` `os.arch` and `os.version`.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
