### PR TITLE
Fixup needed for breaking changes for Application Services v89.0.0

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/experiments/NimbusSetup.kt
+++ b/app/src/main/java/org/mozilla/fenix/experiments/NimbusSetup.kt
@@ -99,7 +99,7 @@ fun createNimbus(context: Context, url: String?): NimbusApi {
         // Something went wrong. We'd like not to, but stability of the app is more important than
         // failing fast here.
         errorReporter("Failed to initialize Nimbus", e)
-        NimbusDisabled()
+        NimbusDisabled(context)
     }
 }
 


### PR DESCRIPTION
This is for when a not-yet-released version of Android Components that ships v89.0.0 of Application Services.

The only change is NimbusDisabled now requires a Context, which allows the generated FML code to work even if Nimbus is disabled.

Relates to https://github.com/mozilla/application-services/pull/4784, https://github.com/mozilla/application-services/pull/4788 and https://github.com/mozilla-mobile/android-components/pull/11587

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
