### PR TITLE
Fix fenix crashing when trying to add an invalid bookmark

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -1262,7 +1262,19 @@ abstract class BaseBrowserFragment :
                     }
                 }
             } catch (e: PlacesException.UrlParseFailed) {
-                println("We should do something here")
+                withContext(Main) {
+                    requireComponents.analytics.metrics.track(Event.AddBookmark)
+
+                    view?.let {
+                        FenixSnackbar.make(
+                            view = binding.browserLayout,
+                            duration = FenixSnackbar.LENGTH_LONG,
+                            isDisplayedWithBrowserToolbar = true
+                        )
+                            .setText(getString(R.string.bookmark_invalid_url_error))
+                            .show()
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/components/bookmarks/BookmarksUseCase.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/bookmarks/BookmarksUseCase.kt
@@ -6,6 +6,7 @@ package org.mozilla.fenix.components.bookmarks
 
 import androidx.annotation.WorkerThread
 import mozilla.appservices.places.BookmarkRoot
+import mozilla.appservices.places.uniffi.PlacesException
 import mozilla.components.concept.storage.BookmarksStorage
 import mozilla.components.concept.storage.HistoryStorage
 import org.mozilla.fenix.home.recentbookmarks.RecentBookmark
@@ -29,18 +30,21 @@ class BookmarksUseCase(
          */
         @WorkerThread
         suspend operator fun invoke(url: String, title: String, position: UInt? = null): Boolean {
-            val canAdd = storage.getBookmarksWithUrl(url).firstOrNull { it.url == it.url } == null
+            try {
+                val canAdd = storage.getBookmarksWithUrl(url).firstOrNull { it.url == it.url } == null
 
-            if (canAdd) {
-                storage.addItem(
-                    BookmarkRoot.Mobile.id,
-                    url = url,
-                    title = title,
-                    position = position
-                )
+                if (canAdd) {
+                    storage.addItem(
+                        BookmarkRoot.Mobile.id,
+                        url = url,
+                        title = title,
+                        position = position
+                    )
+                }
+                return canAdd
+            } catch (e: PlacesException.UrlParseFailed) {
+                return false
             }
-
-            return canAdd
         }
     }
 


### PR DESCRIPTION
This fixes an existing issue where adding an invalid URL to bookmarks would crash the app. 
Note: This will not fix the crasher when navigating to an invalid url, that is fixed in https://github.com/mozilla-mobile/android-components/pull/11603


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
