### PR TITLE
fixes #23404: add switch to wallpaper settings to disable tap-to-change

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -763,7 +763,7 @@ class HomeFragment : Fragment() {
             requireComponents.reviewPromptController.promptReview(requireActivity())
         }
 
-        if (shouldEnableWallpaper()) {
+        if (shouldEnableWallpaper() && context.settings().wallpapersSwitchedByLogoTap) {
             binding.wordmark.setOnClickListener {
                 val manager = requireComponents.wallpaperManager
                 manager.updateWallpaper(

--- a/app/src/main/java/org/mozilla/fenix/settings/wallpaper/WallpaperSettings.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/wallpaper/WallpaperSettings.kt
@@ -10,6 +10,9 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -24,6 +27,8 @@ import androidx.compose.material.Snackbar
 import androidx.compose.material.SnackbarDuration
 import androidx.compose.material.SnackbarHost
 import androidx.compose.material.Surface
+import androidx.compose.material.Switch
+import androidx.compose.material.SwitchDefaults
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
 import androidx.compose.material.rememberScaffoldState
@@ -57,6 +62,8 @@ import java.util.Locale
  * @param selectedWallpaper The currently selected wallpaper.
  * @param onSelectWallpaper Callback for when a new wallpaper is selected.
  * @param onViewWallpaper Callback for when the view action is clicked from snackbar.
+ * @param tapLogoSwitchChecked Enabled state for switch controlling taps to change wallpaper.
+ * @param onTapLogoSwitchCheckedChange Callback for when state of above switch is updated.
  */
 @Composable
 @Suppress("LongParameterList")
@@ -67,6 +74,8 @@ fun WallpaperSettings(
     selectedWallpaper: Wallpaper,
     onSelectWallpaper: (Wallpaper) -> Unit,
     onViewWallpaper: () -> Unit,
+    tapLogoSwitchChecked: Boolean,
+    onTapLogoSwitchCheckedChange: (Boolean) -> Unit
 ) {
     val coroutineScope = rememberCoroutineScope()
     val scaffoldState = rememberScaffoldState()
@@ -80,7 +89,7 @@ fun WallpaperSettings(
             }
         }
     ) {
-        Surface(color = FirefoxTheme.colors.layer2) {
+        Column {
             WallpaperThumbnails(
                 wallpapers = wallpapers,
                 defaultWallpaper = defaultWallpaper,
@@ -96,6 +105,7 @@ fun WallpaperSettings(
                     onSelectWallpaper(updatedWallpaper)
                 },
             )
+            WallpaperLogoSwitch(tapLogoSwitchChecked, onCheckedChange = onTapLogoSwitchCheckedChange)
         }
     }
 }
@@ -158,18 +168,20 @@ private fun WallpaperThumbnails(
     numColumns: Int = 3,
     onSelectWallpaper: (Wallpaper) -> Unit,
 ) {
-    LazyVerticalGrid(
-        cells = GridCells.Fixed(numColumns),
-        modifier = Modifier.padding(vertical = 30.dp, horizontal = 20.dp)
-    ) {
-        items(wallpapers) { wallpaper ->
-            WallpaperThumbnailItem(
-                wallpaper = wallpaper,
-                defaultWallpaper = defaultWallpaper,
-                loadWallpaperResource = loadWallpaperResource,
-                isSelected = selectedWallpaper == wallpaper,
-                onSelect = onSelectWallpaper
-            )
+    Surface(color = FirefoxTheme.colors.layer2) {
+        LazyVerticalGrid(
+            cells = GridCells.Fixed(numColumns),
+            modifier = Modifier.padding(vertical = 30.dp, horizontal = 20.dp)
+        ) {
+            items(wallpapers) { wallpaper ->
+                WallpaperThumbnailItem(
+                    wallpaper = wallpaper,
+                    defaultWallpaper = defaultWallpaper,
+                    loadWallpaperResource = loadWallpaperResource,
+                    isSelected = selectedWallpaper == wallpaper,
+                    onSelect = onSelectWallpaper
+                )
+            }
         }
     }
 }
@@ -227,6 +239,45 @@ private fun WallpaperThumbnailItem(
     }
 }
 
+@Composable
+private fun WallpaperLogoSwitch(
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit
+) {
+    Column(
+        modifier = Modifier.padding(horizontal = 12.dp, vertical = 16.dp),
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.SpaceBetween,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text(
+                text = stringResource(R.string.wallpaper_tap_to_change_switch_label),
+                color = FirefoxTheme.colors.textPrimary,
+                fontSize = 18.sp,
+                modifier = Modifier.padding(start = 4.dp)
+            )
+            Switch(
+                checked = checked,
+                onCheckedChange = onCheckedChange,
+                colors = SwitchDefaults.colors(
+                    checkedThumbColor = FirefoxTheme.colors.formSelected,
+                    checkedTrackColor = FirefoxTheme.colors.formSurface,
+                    uncheckedTrackColor = FirefoxTheme.colors.formSurface
+                )
+            )
+        }
+
+        Text(
+            text = stringResource(R.string.wallpaper_tap_to_change_switch_description),
+            color = FirefoxTheme.colors.textDisabled,
+            fontSize = 12.sp,
+            fontFamily = FontFamily(Font(R.font.metropolis_semibold)),
+            modifier = Modifier.padding(start = 8.dp, top = 16.dp)
+        )
+    }
+}
+
 @Preview
 @Composable
 private fun WallpaperThumbnailsPreview() {
@@ -243,6 +294,8 @@ private fun WallpaperThumbnailsPreview() {
             selectedWallpaper = wallpaperManager.currentWallpaper,
             onSelectWallpaper = {},
             onViewWallpaper = {},
+            tapLogoSwitchChecked = false,
+            onTapLogoSwitchCheckedChange = {}
         )
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/settings/wallpaper/WallpaperSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/wallpaper/WallpaperSettingsFragment.kt
@@ -27,6 +27,10 @@ class WallpaperSettingsFragment : Fragment() {
         requireComponents.wallpaperManager
     }
 
+    private val settings by lazy {
+        requireComponents.settings
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -37,6 +41,7 @@ class WallpaperSettingsFragment : Fragment() {
             setContent {
                 FirefoxTheme {
                     var currentWallpaper by remember { mutableStateOf(wallpaperManager.currentWallpaper) }
+                    var wallpapersSwitchedByLogo by remember { mutableStateOf(settings.wallpapersSwitchedByLogoTap) }
                     WallpaperSettings(
                         wallpapers = wallpaperManager.availableWallpapers,
                         defaultWallpaper = WallpaperManager.defaultWallpaper,
@@ -49,6 +54,11 @@ class WallpaperSettingsFragment : Fragment() {
                             wallpaperManager.currentWallpaper = selectedWallpaper
                         },
                         onViewWallpaper = { findNavController().navigate(R.id.homeFragment) },
+                        tapLogoSwitchChecked = wallpapersSwitchedByLogo,
+                        onTapLogoSwitchCheckedChange = {
+                            settings.wallpapersSwitchedByLogoTap = it
+                            wallpapersSwitchedByLogo = it
+                        }
                     )
                 }
             }

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -171,6 +171,11 @@ class Settings(private val appContext: Context) : PreferencesHolder {
         default = WallpaperManager.defaultWallpaper.name
     )
 
+    var wallpapersSwitchedByLogoTap by booleanPreference(
+        appContext.getPreferenceKey(R.string.pref_key_wallpapers_switched_by_logo_tap),
+        default = true
+    )
+
     var openLinksInAPrivateTab by booleanPreference(
         appContext.getPreferenceKey(R.string.pref_key_open_links_in_a_private_tab),
         default = false

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -190,6 +190,7 @@
     <!-- Wallpaper Settings -->
     <string name="pref_key_wallpapers" translatable="false">pref_key_wallpapers</string>
     <string name="pref_key_current_wallpaper" translatable="false">pref_key_current_wallpaper</string>
+    <string name="pref_key_wallpapers_switched_by_logo_tap">pref_key_wallpapers_switched_by_logo_tap</string>
 
     <string name="pref_key_encryption_key_generated" translatable="false">pref_key_encryption_key_generated</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -464,6 +464,10 @@
     <string name="wallpaper_updated_snackbar_message">Wallpaper updated!</string>
     <!-- Snackbar label for action to view selected wallpaper -->
     <string name="wallpaper_updated_snackbar_action">View</string>
+    <!-- Label for switch which toggles the "tap-to-switch" behavior on home screen logo -->
+    <string name="wallpaper_tap_to_change_switch_label">Tap logo to change wallpaper</string>
+    <!-- Description for switch which toggles the "tap-to-switch" behavior on home screen logo -->
+    <string name="wallpaper_tap_to_change_switch_description">Cycle through and update image without leaving the homepage.</string>
 
     <!-- Add-on Installation from AMO-->
     <!-- Error displayed when user attempts to install an add-on from AMO (addons.mozilla.org) that is not supported -->


### PR DESCRIPTION
<img width="628" alt="image" src="https://user-images.githubusercontent.com/10427470/151041461-5ec5d266-36c3-4073-bb77-9e0e0d14e086.png">

<img width="623" alt="image" src="https://user-images.githubusercontent.com/10427470/151041760-e833f240-3a69-4fd6-8010-9594ee7d283b.png">


### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
