### PR TITLE
[UI smoke test] For #21002: Ads UI test for browsing error pages

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/TestHelper.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/TestHelper.kt
@@ -38,6 +38,7 @@ import androidx.test.uiautomator.UiObject
 import androidx.test.uiautomator.UiScrollable
 import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
+import java.io.File
 import kotlinx.coroutines.runBlocking
 import mozilla.components.support.ktx.android.content.appName
 import org.hamcrest.CoreMatchers
@@ -51,7 +52,6 @@ import org.mozilla.fenix.helpers.idlingresource.NetworkConnectionIdlingResource
 import org.mozilla.fenix.ui.robots.BrowserRobot
 import org.mozilla.fenix.ui.robots.mDevice
 import org.mozilla.fenix.utils.IntentUtils
-import java.io.File
 
 object TestHelper {
 
@@ -250,4 +250,6 @@ object TestHelper {
             )
         )
     }
+
+    fun getStringResource(id: Int) = appContext.resources.getString(id, appName)
 }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/BrowsingErrorPagesTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/BrowsingErrorPagesTest.kt
@@ -1,0 +1,92 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.ui
+
+import androidx.core.net.toUri
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mozilla.fenix.R
+import org.mozilla.fenix.customannotations.SmokeTest
+import org.mozilla.fenix.helpers.FeatureSettingsHelper
+import org.mozilla.fenix.helpers.HomeActivityTestRule
+import org.mozilla.fenix.helpers.RetryTestRule
+import org.mozilla.fenix.helpers.TestHelper.getStringResource
+import org.mozilla.fenix.ui.robots.navigationToolbar
+
+/**
+ * Tests that verify errors encountered while browsing websites: unsafe pages, connection errors, etc
+ */
+class BrowsingErrorPagesTest {
+    private val malwareWarning = getStringResource(R.string.mozac_browser_errorpages_safe_browsing_malware_uri_title)
+    private val phishingWarning = getStringResource(R.string.mozac_browser_errorpages_safe_phishing_uri_title)
+    private val unwantedSoftwareWarning =
+        getStringResource(R.string.mozac_browser_errorpages_safe_browsing_unwanted_uri_title)
+    private val harmfulSiteWarning = getStringResource(R.string.mozac_browser_errorpages_safe_harmful_uri_title)
+    private val featureSettingsHelper = FeatureSettingsHelper()
+
+    @get: Rule
+    val mActivityTestRule = HomeActivityTestRule()
+
+    @Rule
+    @JvmField
+    val retryTestRule = RetryTestRule(3)
+
+    @Before
+    fun setUp() {
+        // disabling the jump-back-in pop-up that interferes with the tests.
+        featureSettingsHelper.setJumpBackCFREnabled(false)
+    }
+
+    @After
+    fun tearDown() {
+        featureSettingsHelper.resetAllFeatureFlags()
+    }
+
+    @SmokeTest
+    @Test
+    fun blockMalwarePageTest() {
+        val malwareURl = "http://itisatrap.org/firefox/its-an-attack.html"
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(malwareURl.toUri()) {
+            verifyPageContent(malwareWarning)
+        }
+    }
+
+    @SmokeTest
+    @Test
+    fun blockPhishingPageTest() {
+        val phishingURl = "http://itisatrap.org/firefox/its-a-trap.html"
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(phishingURl.toUri()) {
+            verifyPageContent(phishingWarning)
+        }
+    }
+
+    @SmokeTest
+    @Test
+    fun blockUnwantedSoftwarePageTest() {
+        val unwantedURl = "http://itisatrap.org/firefox/unwanted.html"
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(unwantedURl.toUri()) {
+            verifyPageContent(unwantedSoftwareWarning)
+        }
+    }
+
+    @SmokeTest
+    @Test
+    fun blockHarmfulPageTest() {
+        val harmfulURl = "https://itisatrap.org/firefox/harmful.html"
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(harmfulURl.toUri()) {
+            verifyPageContent(harmfulSiteWarning)
+        }
+    }
+}

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -98,7 +98,10 @@ class BrowserRobot {
         )
 
         runWithIdleRes(sessionLoadedIdlingResource) {
-            assertTrue(mDevice.findObject(UiSelector().textContains(expectedText)).waitForExists(waitingTime))
+            assertTrue(
+                "Page didn't load or doesn't contain the expected text",
+                mDevice.findObject(UiSelector().textContains(expectedText)).waitForExists(waitingTime)
+            )
         }
     }
 


### PR DESCRIPTION
Note: the tests use a live website mocking dangerous pages, which need to be in Google's database to get blocked. So that removes the option of having static pages. This increases the risk of tests failing if the website has issues.
@AaronMT any suggestion to handle this risk? I think the website is a Mozilla website but still has some risks.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
