### PR TITLE
For #23378 - Fix search suggestion buttons not visible

### DIFF
--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -161,6 +161,9 @@
     <color name="search_widget_mic_fill_color">@color/photonLightGrey05</color>
     <color name="search_widget_text">@color/fx_mobile_text_color_primary</color>
 
+    <!-- Mozilla Android Component color variable overrides -->
+    <color name="mozac_ui_icons_fill" tools:ignore="UnusedResources">@color/fx_mobile_text_color_primary</color>
+
     <!-- Reader View colors -->
     <color name="mozac_feature_readerview_text_color">@color/fx_mobile_text_color_primary</color>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -279,10 +279,12 @@
     <color name="toolbar_menu_transparent">@android:color/transparent</color>
 
     <!-- Mozilla Android Component color variable overrides -->
-    <color name="mozac_ui_icons_fill" tools:ignore="UnusedResources">?primaryText</color>
+    <color name="mozac_ui_icons_fill" tools:ignore="UnusedResources">@color/primary_text_light_theme</color>
+
     <!-- Tab Counter colors -->
     <color name="mozac_ui_tabcounter_default_tint" tools:ignore="UnusedResources">@color/primary_text_light_theme</color>
     <color name="mozac_ui_tabcounter_default_text" tools:ignore="UnusedResources">@color/primary_text_light_theme</color>
+    
     <!-- Reader View colors -->
     <color name="mozac_feature_readerview_text_color" tools:ignore="UnusedResources">@color/primary_text_light_theme</color>
     <color name="mozac_feature_readerview_selected">@color/photonViolet40</color>


### PR DESCRIPTION
Fixes the problem with the non-visible suggestion button. (regressed by 12347c99999c340e7f7072ab2749cb13c5fd86c9 )
Removed the attribute ?primaryText and added the static color value to to both /colors.xml and night/colors.xml

![fx](https://user-images.githubusercontent.com/18355854/151434907-3aafd25b-b61c-4929-90cb-09d647b87d15.jpg)

CC: @gabrielluong who worked on the color changes

### Pull Request checklist
- [x] **Tests**: N/A
- [x] **Screenshots**
- [x] **Accessibility**: N/A

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
