### PR TITLE
Issue #12731: Disable TrimMemoryMiddleware on all channels

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -219,12 +219,14 @@ class Core(
         BrowserStore(
             middleware = middlewareList + EngineMiddleware.create(
                 engine,
-                // We are disabling automatic suspending of engine sessions under memory pressure
-                // in Nightly as a test. Instead we solely rely on GeckoView and the Android system
-                // to reclaim memory when needed.
+                // We are disabling automatic suspending of engine sessions under memory pressure.
+                // Instead we solely rely on GeckoView and the Android system to reclaim memory
+                // when needed. For details, see:
+                // https://bugzilla.mozilla.org/show_bug.cgi?id=1752594
                 // https://github.com/mozilla-mobile/fenix/issues/12731
                 // https://github.com/mozilla-mobile/android-components/issues/11300
-                trimMemoryAutomatically = Config.channel.isReleaseOrBeta
+                // https://github.com/mozilla-mobile/android-components/issues/11653
+                trimMemoryAutomatically = false
             )
         ).apply {
             // Install the "icons" WebExtension to automatically load icons for every visited website.


### PR DESCRIPTION
This was already disabled in Nightly over two months ago and seems to work much better combined with latest fixes in GV (see links inline for details.)