### PR TITLE
Fixes #23492: Perf regression of calling isFirefoxDefault from main thread

### DIFF
--- a/.experimenter.json
+++ b/.experimenter.json
@@ -1,4 +1,15 @@
 {
+  "homescreen": {
+    "description": "The homescreen that the user goes to when they press home or new tab.",
+    "hasExposure": true,
+    "exposureDescription": "",
+    "variables": {
+      "sections-enabled": {
+        "description": "This property provides a lookup table of whether or not the given section should be enabled. If the section is enabled, it should be toggleable in the settings screen, and on by default.",
+        "type": "json"
+      }
+    }
+  },
   "default-browser-message": {
     "description": "A small feature allowing experiments on the placement of a default browser message.",
     "hasExposure": true,
@@ -37,17 +48,6 @@
       "settings-title": {
         "description": "The title of displayed in the Settings screen and app menu.",
         "type": "string"
-      }
-    }
-  },
-  "homescreen": {
-    "description": "The homescreen that the user goes to when they press home or new tab.",
-    "hasExposure": true,
-    "exposureDescription": "",
-    "variables": {
-      "sections-enabled": {
-        "description": "This property provides a lookup table of whether or not the given section should be enabled. If the section is enabled, it should be toggleable in the settings screen, and on by default.",
-        "type": "json"
       }
     }
   }

--- a/.experimenter.json
+++ b/.experimenter.json
@@ -1,4 +1,15 @@
 {
+  "default-browser-message": {
+    "description": "A small feature allowing experiments on the placement of a default browser message.",
+    "hasExposure": true,
+    "exposureDescription": "",
+    "variables": {
+      "message-location": {
+        "description": "Where is the message to be put.",
+        "type": "string"
+      }
+    }
+  },
   "search-term-groups": {
     "description": "A feature allowing the grouping of URLs around the search term that it came from.",
     "hasExposure": true,
@@ -7,22 +18,6 @@
       "enabled": {
         "description": "If true, the feature shows up on the homescreen and on the new tab screen.",
         "type": "boolean"
-      }
-    }
-  },
-  "default-browser-message": {
-    "description": "A small feature allowing experiments on the placement of a default browser message.",
-    "hasExposure": true,
-    "exposureDescription": "",
-    "variables": {
-      "message-location": {
-        "description": "Where is the message to be put.",
-        "enum": [
-          "homescreen-banner",
-          "settings",
-          "app-menu-item"
-        ],
-        "type": "string"
       }
     }
   },

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
@@ -446,10 +446,13 @@ open class DefaultToolbarMenu(
         }
     }
 
-    private fun getSetDefaultBrowserItem(): BrowserMenuImageText? =
-        if (BrowsersCache.all(context).isFirefoxDefaultBrowser) {
-            null
-        } else if (FxNimbus.features.defaultBrowserMessage.value().messageLocation == MessageSurfaceId.APP_MENU_ITEM) {
+    private fun getSetDefaultBrowserItem(): BrowserMenuImageText? {
+        val browsers = BrowsersCache.all(context)
+        val config = FxNimbus.features.defaultBrowserMessage.value()
+        return if (
+            config.messageLocation == MessageSurfaceId.APP_MENU_ITEM &&
+            !browsers.isFirefoxDefaultBrowser
+        ) {
             BrowserMenuImageText(
                 label = context.getString(R.string.preferences_set_as_default_browser),
                 imageResource = R.mipmap.ic_launcher
@@ -459,4 +462,5 @@ open class DefaultToolbarMenu(
         } else {
             null
         }
+    }
 }

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
@@ -447,11 +447,9 @@ open class DefaultToolbarMenu(
     }
 
     private fun getSetDefaultBrowserItem(): BrowserMenuImageText? {
-        val browsers = BrowsersCache.all(context)
-        val config = FxNimbus.features.defaultBrowserMessage.value()
+        val settings = context.components.settings
         return if (
-            config.messageLocation == MessageSurfaceId.APP_MENU_ITEM &&
-            !browsers.isFirefoxDefaultBrowser
+            settings.isDefaultBrowserMessageLocation(MessageSurfaceId.APP_MENU_ITEM)
         ) {
             BrowserMenuImageText(
                 label = context.getString(R.string.preferences_set_as_default_browser),

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
@@ -39,10 +39,8 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.components.accounts.FenixAccountManager
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.settings
-import org.mozilla.fenix.nimbus.FxNimbus
 import org.mozilla.fenix.nimbus.MessageSurfaceId
 import org.mozilla.fenix.theme.ThemeManager
-import org.mozilla.fenix.utils.BrowsersCache
 
 /**
  * Builds the toolbar object used with the 3-dot menu in the browser fragment.

--- a/app/src/main/java/org/mozilla/fenix/home/HomeMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeMenu.kt
@@ -175,14 +175,9 @@ class HomeMenu(
 
         // Use nimbus to set the icon and title.
         val nimbusValidation = FxNimbus.features.nimbusValidation.value()
-        val settingsIcon = context.resources.getIdentifier(
-            nimbusValidation.settingsIcon,
-            "drawable",
-            context.packageName
-        )
         val settingsItem = BrowserMenuImageText(
             nimbusValidation.settingsTitle,
-            settingsIcon,
+            R.drawable.mozac_ic_settings,
             primaryTextColor
         ) {
             onItemTapped.invoke(Item.Settings)

--- a/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
@@ -148,7 +148,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
      * Note: Changing Settings screen before experiment is over requires changing all layouts.
      */
     private fun getPreferenceLayoutId() =
-        if (isDefaultBrowserExperimentBranch() && !isFirefoxDefaultBrowser()) {
+        if (isDefaultBrowserExperimentBranch()) {
             R.xml.preferences_default_browser_experiment
         } else {
             R.xml.preferences
@@ -473,7 +473,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
      */
     private fun getClickListenerForMakeDefaultBrowser(): Preference.OnPreferenceClickListener {
         return Preference.OnPreferenceClickListener {
-            if (isDefaultBrowserExperimentBranch() && !isFirefoxDefaultBrowser()) {
+            if (isDefaultBrowserExperimentBranch()) {
                 requireContext().metrics.track(Event.SetDefaultBrowserSettingsScreenClicked)
             }
             activity?.openSetDefaultBrowserOption()
@@ -605,7 +605,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
     }
 
     private fun isDefaultBrowserExperimentBranch(): Boolean =
-        FxNimbus.features.defaultBrowserMessage.value().messageLocation == MessageSurfaceId.SETTINGS
+        requireContext().settings().isDefaultBrowserMessageLocation(MessageSurfaceId.SETTINGS)
 
     private fun isFirefoxDefaultBrowser(): Boolean {
         val browsers = BrowsersCache.all(requireContext())

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -466,7 +466,7 @@ class Settings(private val appContext: Context) : PreferencesHolder {
      */
     var searchTermTabGroupsAreEnabled by lazyFeatureFlagPreference(
         appContext.getPreferenceKey(R.string.pref_key_search_term_tab_groups),
-        default = { FxNimbus.features.searchTermGroups.value().enabled },
+        default = { FxNimbus.features.searchTermGroups.value(appContext).enabled },
         featureFlag = FeatureFlags.tabGroupFeature
     )
 

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -37,6 +37,7 @@ import org.mozilla.fenix.components.settings.lazyFeatureFlagPreference
 import org.mozilla.fenix.components.toolbar.ToolbarPosition
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.getPreferenceKey
+import org.mozilla.fenix.nimbus.DefaultBrowserMessage
 import org.mozilla.fenix.nimbus.FxNimbus
 import org.mozilla.fenix.nimbus.HomeScreenSection
 import org.mozilla.fenix.nimbus.MessageSurfaceId
@@ -326,14 +327,24 @@ class Settings(private val appContext: Context) : PreferencesHolder {
      * Shows if the set default browser experiment card should be shown on home screen.
      */
     fun shouldShowSetAsDefaultBrowserCard(): Boolean {
-        val browsers = BrowsersCache.all(appContext)
-        val feature = FxNimbus.features.defaultBrowserMessage.value()
-        val isExperimentBranch = feature.messageLocation == MessageSurfaceId.HOMESCREEN_BANNER
-        return isExperimentBranch &&
+        return isDefaultBrowserMessageLocation(MessageSurfaceId.HOMESCREEN_BANNER) &&
             !userDismissedExperimentCard &&
-            !browsers.isFirefoxDefaultBrowser &&
             numberOfAppLaunches > APP_LAUNCHES_TO_SHOW_DEFAULT_BROWSER_CARD
     }
+
+    private val defaultBrowserFeature: DefaultBrowserMessage by lazy {
+        FxNimbus.features.defaultBrowserMessage.value()
+    }
+
+    fun isDefaultBrowserMessageLocation(surfaceId: MessageSurfaceId): Boolean =
+        defaultBrowserFeature.messageLocation?.let { experimentalSurfaceId ->
+            if (experimentalSurfaceId == surfaceId) {
+                val browsers = BrowsersCache.all(appContext)
+                !browsers.isFirefoxDefaultBrowser
+            } else {
+                false
+            }
+        } ?: false
 
     var gridTabView by booleanPreference(
         appContext.getPreferenceKey(R.string.pref_key_tab_view_grid),
@@ -453,9 +464,9 @@ class Settings(private val appContext: Context) : PreferencesHolder {
     /**
      * Indicates if the user has enabled the search term tab groups feature.
      */
-    var searchTermTabGroupsAreEnabled by featureFlagPreference(
+    var searchTermTabGroupsAreEnabled by lazyFeatureFlagPreference(
         appContext.getPreferenceKey(R.string.pref_key_search_term_tab_groups),
-        default = FeatureFlags.tabGroupFeature,
+        default = { FxNimbus.features.searchTermGroups.value().enabled },
         featureFlag = FeatureFlags.tabGroupFeature
     )
 

--- a/nimbus.fml.yaml
+++ b/nimbus.fml.yaml
@@ -54,6 +54,13 @@ features:
         description: If true, the feature shows up on the homescreen and on the new tab screen.
         type: Boolean
         default: false
+    defaults:
+      - channel: nightly
+        value:
+          enabled: true
+      - channel: developer
+        value:
+          enabled: true
   default-browser-message:
     description: A small feature allowing experiments on the placement of a default browser message.
     variables:

--- a/nimbus.fml.yaml
+++ b/nimbus.fml.yaml
@@ -59,8 +59,8 @@ features:
     variables:
       message-location:
         description: Where is the message to be put.
-        type: MessageSurfaceId
-        default: homescreen-banner
+        type: Option<MessageSurfaceId>
+        default: null
 types:
   objects: {}
   enums:


### PR DESCRIPTION
Fixes #23492
Fixes #23618

Perf regression calling slow isFirefoxDefault from the main thread.

Prior #23400, the default browser message was only displayed when part of an experiment. The check that isFirefoxDefault was only done as a final check before the message is displayed.

#23400 changed the order of this, so the slow check was done each time the toolbar was created.

Fixes #23492; this PR does three things:

- it moves the check for isDefaultBrowser until _after_ the check to see which message surface to display on (as was prior to #23400 )
- it makes the default browser message be able to turn off.
- it changes the feature of showing the default browser message to be off by default (as was prior to #23400 )

Now, the default browser message is displayable when an experiment toggles it on.

The isFirefoxDefault _is_ done when the message is toggled on, but:

1. There are no plans to toggle this on in this release
2. The messaging system is being re-written to avoid these problems.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
