### PR TITLE
Perform case-insensitive searches for saved logins

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/logins/LoginsFragmentStore.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/LoginsFragmentStore.kt
@@ -163,14 +163,18 @@ private fun filterItems(
             filteredItems = sortingStrategy(state.loginList)
         )
     } else {
+        val searchedForTextLC = searchedForText.lowercase()
         state.copy(
             isLoading = false,
             sortingStrategy = sortingStrategy,
             highlightedItem = sortingStrategyToMenuItem(sortingStrategy),
             searchedForText = searchedForText,
             filteredItems = sortingStrategy(state.loginList).filter {
-                it.origin.contains(
-                    searchedForText
+                it.origin.lowercase().contains(
+                    searchedForTextLC
+                ) ||
+                it.username.lowercase().contains(
+                    searchedForTextLC
                 )
             }
         )


### PR DESCRIPTION
Also extend the search to usernames in addition to origins

Note this change is untested locally as I don't have a dev env set up.