### PR TITLE
For #23563: Address time out crash when downloading wallpaper

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/wallpapers/WallpaperDownloader.kt
+++ b/app/src/main/java/org/mozilla/fenix/wallpapers/WallpaperDownloader.kt
@@ -44,14 +44,13 @@ class WallpaperDownloader(
                 method = Request.Method.GET
             )
             Result.runCatching {
-                client.fetch(request)
-            }.onSuccess {
-                if (!it.isSuccess) {
-                    logger.error("Download response failure code: ${it.status}")
+                val response = client.fetch(request)
+                if (!response.isSuccess) {
+                    logger.error("Download response failure code: ${response.status}")
                     return@withContext
                 }
                 File(localFile.path.substringBeforeLast("/")).mkdirs()
-                it.body.useStream { input ->
+                response.body.useStream { input ->
                     input.copyTo(localFile.outputStream())
                 }
             }.onFailure {


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
