### PR TITLE
For #23570 - Increase tap area for 'Show all' links

### DIFF
--- a/app/src/main/res/layout/recent_bookmarks_header.xml
+++ b/app/src/main/res/layout/recent_bookmarks_header.xml
@@ -8,8 +8,8 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_marginHorizontal="@dimen/home_item_horizontal_margin"
-    android:layout_marginTop="40dp"
-    android:layout_marginBottom="16dp">
+    android:layout_marginTop="32dp"
+    android:layout_marginBottom="8dp">
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/header"
@@ -20,7 +20,8 @@
         android:maxLines="2"
         android:text="@string/recent_bookmarks_title"
         android:gravity="top"
-        android:paddingTop="1dp"
+        android:paddingTop="8dp"
+        android:paddingBottom="8dp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toStartOf="@id/showAllBookmarksButton"
         app:layout_constraintTop_toTopOf="parent" />
@@ -35,6 +36,7 @@
         android:insetTop="0dp"
         android:paddingStart="16dp"
         android:paddingEnd="0dp"
+        android:paddingVertical="8dp"
         android:maxLines="1"
         android:nestedScrollingEnabled="false"
         android:text="@string/recently_saved_show_all"

--- a/app/src/main/res/layout/recent_tabs_header.xml
+++ b/app/src/main/res/layout/recent_tabs_header.xml
@@ -7,8 +7,8 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_marginHorizontal="@dimen/home_item_horizontal_margin"
-    android:layout_marginTop="40dp"
-    android:layout_marginBottom="16dp">
+    android:layout_marginTop="32dp"
+    android:layout_marginBottom="8dp">
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/header"
@@ -18,7 +18,8 @@
         android:maxLines="2"
         android:text="@string/recent_tabs_header"
         android:gravity="top"
-        android:paddingTop="1dp"
+        android:paddingTop="8dp"
+        android:paddingBottom="8dp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toStartOf="@id/show_all_button"
         app:layout_constraintTop_toTopOf="parent" />
@@ -34,6 +35,7 @@
         android:paddingStart="16dp"
         android:paddingEnd="0dp"
         android:maxLines="1"
+        android:paddingVertical="8dp"
         android:nestedScrollingEnabled="false"
         android:text="@string/recent_tabs_show_all"
         android:textColor="@color/fx_mobile_text_color_accent"

--- a/app/src/main/res/layout/recent_visits_header.xml
+++ b/app/src/main/res/layout/recent_visits_header.xml
@@ -8,8 +8,8 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_marginHorizontal="@dimen/home_item_horizontal_margin"
-    android:layout_marginTop="40dp"
-    android:layout_marginBottom="16dp">
+    android:layout_marginTop="32dp"
+    android:layout_marginBottom="8dp">
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/header"
@@ -19,7 +19,8 @@
         android:maxLines="2"
         android:text="@string/history_metadata_header_2"
         android:gravity="top"
-        android:paddingTop="1dp"
+        android:paddingTop="8dp"
+        android:paddingBottom="8dp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toStartOf="@id/show_all_button"
         app:layout_constraintTop_toTopOf="parent" />
@@ -35,6 +36,7 @@
         android:paddingStart="16dp"
         android:paddingEnd="0dp"
         android:maxLines="1"
+        android:paddingVertical="8dp"
         android:nestedScrollingEnabled="false"
         android:text="@string/recent_tabs_show_all"
         android:textColor="@color/fx_mobile_text_color_accent"


### PR DESCRIPTION
Increased the height of the `Show all` buttons from the home fragment headers. Using `TouchDelegate` and `View.increaseTapArea()` was limited because the `Show all` buttons are inside small `ConstraintLayouts`. I considered increasing the vertical padding of the buttons by `8dp` and `16dp`.

![before](https://user-images.githubusercontent.com/35462038/152553701-d56fb7fe-7bca-4d64-b89e-2addb8270255.jpeg)

![8dp](https://user-images.githubusercontent.com/35462038/152553784-b1995812-0bed-45c6-8ed4-1534c7f80cb2.jpeg)

![16dp](https://user-images.githubusercontent.com/35462038/152553802-3094ea54-972a-4368-b1ed-7fc14f7e2c5f.jpeg)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
