### PR TITLE
No issue: Update debug app name to Fenix

### DIFF
--- a/app/src/main/res/values/static_strings.xml
+++ b/app/src/main/res/values/static_strings.xml
@@ -4,7 +4,7 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <resources>
     <!-- Name of the application -->
-    <string name="app_name" translatable="false">Firefox Preview</string>
+    <string name="app_name" translatable="false">Firefox Fenix</string>
 
     <!-- Preference for developers -->
     <string name="preference_leakcanary" translatable="false">LeakCanary</string>


### PR DESCRIPTION
We don't use the "Preview" naming any more and it's easier to find the app when "Fenix" is in the app name.

