### PR TITLE
For #23614 - Add default values for Fenix specific parameters

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -8,7 +8,7 @@ tasks:
     - $let:
           taskgraph:
               branch: taskgraph
-              revision: d85f4e4213706ec7737c7257f681977fdf20eb60
+              revision: b6890b6736403f053b731cbd4aabe43819a14acf
           trustDomain: mobile
       in:
           $let:

--- a/taskcluster/fenix_taskgraph/parameters.py
+++ b/taskcluster/fenix_taskgraph/parameters.py
@@ -14,13 +14,24 @@ from voluptuous import All, Any, Optional, Range, Required
 
 from .release_promotion import read_version_file
 
+
+def get_defaults(repo_root):
+    return {
+        "pull_request_number": None,
+        "release_type": "",
+        "shipping_phase": None,
+        "next_version": "",
+        "version": "",
+    }
+
+
 extend_parameters_schema({
     Required("pull_request_number"): Any(All(int, Range(min=1)), None),
     Required("release_type"): text_type,
     Optional("shipping_phase"): Any('build', 'ship', None),
     Required("version"): text_type,
     Required("next_version"): Any(None, text_type),
-})
+}, defaults_fn=get_defaults)
 
 
 def get_decision_parameters(graph_config, parameters):


### PR DESCRIPTION
Currently an exception will be raised if values for these parameters are not supplied. This will be the case when running with the default set of Parameters (e.g via `taskgraph full` without an explicit parameters file).

This PR adds defaults to these parameters (which also requires updating to the latest taskgraph).