### PR TITLE
fixes #23619: use well-defined name for fetching remote wallpaper assets

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/wallpapers/Wallpaper.kt
+++ b/app/src/main/java/org/mozilla/fenix/wallpapers/Wallpaper.kt
@@ -23,6 +23,13 @@ sealed class Wallpaper {
     }
 
     /**
+     * If a user had previously selected a wallpaper, they are allowed to retain it even if
+     * the wallpaper is otherwise expired. This type exists as a wrapper around that current
+     * wallpaper.
+     */
+    data class Expired(override val name: String) : Wallpaper()
+
+    /**
      * Wallpapers that are included directly in the shipped APK.
      *
      * @property drawableId The drawable bitmap used as the background.
@@ -39,15 +46,9 @@ sealed class Wallpaper {
      */
     sealed class Remote : Wallpaper() {
         abstract val expirationDate: Date?
-        data class Focus(override val name: String, override val expirationDate: Date? = null) : Remote()
-
-        /**
-         * If a user had previously selected a wallpaper, they are allowed to retain it even if
-         * the wallpaper is otherwise expired. This type exists as a wrapper around that current
-         * wallpaper.
-         */
-        data class Expired(override val name: String) : Remote() {
-            override val expirationDate: Date? = null
+        abstract val remoteParentDirName: String
+        data class Focus(override val name: String, override val expirationDate: Date? = null) : Remote() {
+            override val remoteParentDirName: String = "focus"
         }
     }
 

--- a/app/src/main/java/org/mozilla/fenix/wallpapers/WallpaperDownloader.kt
+++ b/app/src/main/java/org/mozilla/fenix/wallpapers/WallpaperDownloader.kt
@@ -73,9 +73,12 @@ class WallpaperDownloader(
     private fun Wallpaper.Remote.toMetadata(context: Context): List<WallpaperMetadata> =
         listOf("landscape", "portrait").flatMap { orientation ->
             listOf("light", "dark").map { theme ->
-                val remoteParent = this::class.simpleName!!.lowercase()
                 val localPath = "wallpapers/$orientation/$theme/$name.png"
-                val remotePath = "${context.resolutionSegment()}/$orientation/$theme/$remoteParent/$name.png"
+                val remotePath = "${context.resolutionSegment()}/" +
+                    "$orientation/" +
+                    "$theme/" +
+                    "$remoteParentDirName/" +
+                    "$name.png"
                 WallpaperMetadata(remotePath, localPath)
             }
         }

--- a/app/src/main/java/org/mozilla/fenix/wallpapers/WallpaperFileManager.kt
+++ b/app/src/main/java/org/mozilla/fenix/wallpapers/WallpaperFileManager.kt
@@ -23,9 +23,9 @@ class WallpaperFileManager(
      * files for each of the following orientation and theme combinations:
      * light/portrait - light/landscape - dark/portrait - dark/landscape
      */
-    fun lookupExpiredWallpaper(name: String): Wallpaper.Remote.Expired? {
+    fun lookupExpiredWallpaper(name: String): Wallpaper.Expired? {
         return if (getAllLocalWallpaperPaths(name).all { File(rootDirectory, it).exists() }) {
-            Wallpaper.Remote.Expired(name)
+            Wallpaper.Expired(name)
         } else null
     }
 

--- a/app/src/test/java/org/mozilla/fenix/wallpapers/WallpaperFileManagerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/wallpapers/WallpaperFileManagerTest.kt
@@ -43,7 +43,7 @@ class WallpaperFileManagerTest {
         val wallpaperName = "name"
         createAllFiles(wallpaperName)
 
-        val expected = Wallpaper.Remote.Expired(name = wallpaperName)
+        val expected = Wallpaper.Expired(name = wallpaperName)
         assertEquals(expected, fileManager.lookupExpiredWallpaper(wallpaperName))
     }
 
@@ -59,7 +59,7 @@ class WallpaperFileManagerTest {
     @Test
     fun `WHEN cleaned THEN current wallpaper and available wallpapers kept`() {
         val currentName = "current"
-        val currentWallpaper = Wallpaper.Remote.Expired(currentName)
+        val currentWallpaper = Wallpaper.Expired(currentName)
         val availableName = "available"
         val available = Wallpaper.Remote.Focus(name = availableName)
         val unavailableName = "unavailable"

--- a/app/src/test/java/org/mozilla/fenix/wallpapers/WallpaperManagerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/wallpapers/WallpaperManagerTest.kt
@@ -91,7 +91,7 @@ class WallpaperManagerTest {
         val currentExpiredWallpaper = makeFakeRemoteWallpaper(TimeRelation.BEFORE, name = currentWallpaperName)
         every { mockSettings.currentWallpaper } returns currentWallpaperName
         val expiredRemoteWallpaper = makeFakeRemoteWallpaper(TimeRelation.BEFORE, "expired")
-        val expected = Wallpaper.Remote.Expired(currentWallpaperName)
+        val expected = Wallpaper.Expired(currentWallpaperName)
         every { mockFileManager.lookupExpiredWallpaper(currentWallpaperName) } returns expected
 
         val wallpaperManager = WallpaperManager(
@@ -111,7 +111,7 @@ class WallpaperManagerTest {
     fun `GIVEN current wallpaper is expired THEN it is available even if not listed in initial parameter`() {
         val currentWallpaperName = "named"
         every { mockSettings.currentWallpaper } returns currentWallpaperName
-        val expected = Wallpaper.Remote.Expired(currentWallpaperName)
+        val expected = Wallpaper.Expired(currentWallpaperName)
         every { mockFileManager.lookupExpiredWallpaper(currentWallpaperName) } returns expected
 
         val wallpaperManager = WallpaperManager(


### PR DESCRIPTION
### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
