### PR TITLE
[UI smoke test] Most viewed top sites UI test

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/TopSitesTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/TopSitesTest.kt
@@ -11,8 +11,8 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
+import org.mozilla.fenix.helpers.FeatureSettingsHelper
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.ui.robots.homeScreen
@@ -30,6 +30,7 @@ import org.mozilla.fenix.ui.robots.navigationToolbar
 class TopSitesTest {
     private val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
     private lateinit var mockWebServer: MockWebServer
+    private val featureSettingsHelper = FeatureSettingsHelper()
 
     @get:Rule
     val activityIntentTestRule = HomeActivityIntentTestRule()
@@ -40,17 +41,18 @@ class TopSitesTest {
             dispatcher = AndroidAssetDispatcher()
             start()
         }
+
+        featureSettingsHelper.setJumpBackCFREnabled(false)
     }
 
     @After
     fun tearDown() {
         mockWebServer.shutdown()
+        featureSettingsHelper.resetAllFeatureFlags()
     }
 
     @Test
     fun verifyAddToFirefoxHome() {
-        val settings = activityIntentTestRule.activity.applicationContext.settings()
-        settings.shouldShowJumpBackInCFR = false
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
         val defaultWebPageTitle = "Test_Page_1"
 
@@ -69,8 +71,6 @@ class TopSitesTest {
 
     @Test
     fun verifyOpenTopSiteNormalTab() {
-        val settings = activityIntentTestRule.activity.applicationContext.settings()
-        settings.shouldShowJumpBackInCFR = false
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
         val defaultWebPageTitle = "Test_Page_1"
 
@@ -99,8 +99,6 @@ class TopSitesTest {
 
     @Test
     fun verifyOpenTopSitePrivateTab() {
-        val settings = activityIntentTestRule.activity.applicationContext.settings()
-        settings.shouldShowJumpBackInCFR = false
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
         val defaultWebPageTitle = "Test_Page_1"
 
@@ -123,8 +121,6 @@ class TopSitesTest {
 
     @Test
     fun verifyRenameTopSite() {
-        val settings = activityIntentTestRule.activity.applicationContext.settings()
-        settings.shouldShowJumpBackInCFR = false
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
         val defaultWebPageTitle = "Test_Page_1"
         val defaultWebPageTitleNew = "Test_Page_2"
@@ -149,8 +145,6 @@ class TopSitesTest {
 
     @Test
     fun verifyRemoveTopSite() {
-        val settings = activityIntentTestRule.activity.applicationContext.settings()
-        settings.shouldShowJumpBackInCFR = false
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
         val defaultWebPageTitle = "Test_Page_1"
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/TopSitesTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/TopSitesTest.kt
@@ -11,10 +11,12 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.FeatureSettingsHelper
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
+import org.mozilla.fenix.ui.robots.browserScreen
 import org.mozilla.fenix.ui.robots.homeScreen
 import org.mozilla.fenix.ui.robots.navigationToolbar
 
@@ -181,6 +183,31 @@ class TopSitesTest {
             defaultTopSites.forEach { item ->
                 verifyExistingTopSitesTabs(item)
             }
+        }
+    }
+
+    @SmokeTest
+    @Test
+    fun addAndRemoveMostViewedTopSiteTest() {
+        val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        for (i in 0..1) {
+            navigationToolbar {
+            }.enterURLAndEnterToBrowser(defaultWebPage.url) {
+                mDevice.waitForIdle()
+                waitForPageToLoad()
+            }
+        }
+
+        browserScreen {
+        }.goToHomescreen {
+            verifyExistingTopSitesList()
+            verifyExistingTopSitesTabs(defaultWebPage.title)
+        }.openContextMenuOnTopSitesWithTitle(defaultWebPage.title) {
+        }.deleteTopSiteFromHistory {
+        }.openThreeDotMenu {
+        }.openHistory {
+            verifyEmptyHistoryView()
         }
     }
 }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
@@ -15,6 +15,7 @@ import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions.actionOnItem
+import androidx.test.espresso.matcher.RootMatchers
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.Visibility
 import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
@@ -297,6 +298,16 @@ class HomeScreenRobot {
             return Transition()
         }
 
+        fun deleteTopSiteFromHistory(interact: HomeScreenRobot.() -> Unit): Transition {
+            mDevice.findObject(
+                UiSelector().resourceId("$packageName:id/simple_text")
+            ).waitForExists(waitingTime)
+            deleteFromHistory.click()
+
+            HomeScreenRobot().interact()
+            return Transition()
+        }
+
         fun openTopSiteInPrivateTab(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
             onView(withText("Open in private tab"))
                 .check((matches(withEffectiveVisibility(Visibility.VISIBLE))))
@@ -561,10 +572,17 @@ private fun assertExistingTopSitesList() =
     onView(allOf(withId(R.id.top_sites_list)))
         .check((matches(withEffectiveVisibility(Visibility.VISIBLE))))
 
-private fun assertExistingTopSitesTabs(title: String) =
+private fun assertExistingTopSitesTabs(title: String) {
+    mDevice.findObject(
+        UiSelector()
+            .resourceId("$packageName:id/top_site_title")
+            .textContains(title)
+    ).waitForExists(waitingTime)
+
     onView(allOf(withId(R.id.top_sites_list)))
         .check(matches(hasDescendant(withText(title))))
         .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+}
 
 private fun assertNotExistingTopSitesList(title: String) =
     onView(allOf(withId(R.id.top_sites_list)))
@@ -623,3 +641,11 @@ private fun startBrowsingButton(): UiObject {
         .ensureFullyVisible(startBrowsingButton)
     return startBrowsingButton
 }
+
+val deleteFromHistory =
+    onView(
+        allOf(
+            withId(R.id.simple_text),
+            withText(R.string.delete_from_history)
+        )
+    ).inRoot(RootMatchers.isPlatformPopup())


### PR DESCRIPTION
• Small refactoring in the TopSitesTest class
• New `addAndRemoveMostViewedTopSiteTest` UI smoke test.
✅  Successfully passed 55x on Firebase

<details>

<summary> 📈 Results (dropdown)</summary>

matrix | result | logs | details
-- | -- | -- | --
matrix-2i2435ugv77b3 | success | logs | 1 test cases passed
matrix-abu6ovwkfh5va | success | logs | 1 test cases passed
matrix-1og1s56ojdau8 | success | logs | 1 test cases passed
matrix-22momt4pux4hh | success | logs | 1 test cases passed
matrix-qg0xx5fevqjxa | success | logs | 1 test cases passed
matrix-16u3gav0ji34o | success | logs | 1 test cases passed
matrix-otxv7ww1h60oa | success | logs | 1 test cases passed
matrix-3ds8y782mnbcf | success | logs | 1 test cases passed
matrix-2xiaox0kcdkgk | success | logs | 1 test cases passed
matrix-2uktc3cs8v9qd | success | logs | 1 test cases passed
matrix-rf3g7ricr1v0a | success | logs | 1 test cases passed
matrix-2p5urftxgnzc8 | success | logs | 1 test cases passed
matrix-3rv9yv3npylco | success | logs | 1 test cases passed
matrix-3gjei2izxtu8v | success | logs | 1 test cases passed
matrix-1ucl9h3knv5ra | success | logs | 1 test cases passed
matrix-ynw0mtqwnfq8a | success | logs | 1 test cases passed
matrix-m967d7x2dbzea | success | logs | 1 test cases passed
matrix-2g0jrx2fvherg | success | logs | 1 test cases passed
matrix-32q7wvpkk20s7 | success | logs | 1 test cases passed
matrix-rfayeo723tkva | success | logs | 1 test cases passed
matrix-3tg49n6q8fxka | success | logs | 1 test cases passed
matrix-2kfw7wy92p1r6 | success | logs | 1 test cases passed
matrix-255xli8nw5ort | success | logs | 1 test cases passed
matrix-25b6ics5emvmp | success | logs | 1 test cases passed
matrix-2h1rn8jzxz2e3 | success | logs | 1 test cases passed
matrix-276yo29hwj9ea | success | logs | 1 test cases passed
matrix-1rerpbts93pr6 | success | logs | 1 test cases passed
matrix-11ulv71dp1qnx | success | logs | 1 test cases passed
matrix-uddg9pftlaija | success | logs | 1 test cases passed
matrix-3ud4u64fjup4e | success | logs | 1 test cases passed
matrix-2t8tccz1xpbtc | success | logs | 1 test cases passed
matrix-1ibeq05xdeyny | success | logs | 1 test cases passed
matrix-39qivjxxd9drl | success | logs | 1 test cases passed
matrix-2ipctyqcdjuma | success | logs | 1 test cases passed
matrix-253dkjjo7ul8h | success | logs | 1 test cases passed
matrix-3b7sdxnmnnu3v | success | logs | 1 test cases passed
matrix-3tkdaypi0fgq2 | success | logs | 1 test cases passed
matrix-dkcvepvcdpnqa | success | logs | 1 test cases passed
matrix-3lrrbzyzwaq39 | success | logs | 1 test cases passed
matrix-1hm4s5bi4hf4l | success | logs | 1 test cases passed
matrix-uvw2hbgjm5zma | success | logs | 1 test cases passed
matrix-3ue552athtmid | success | logs | 1 test cases passed
matrix-2ojbpgqxiptyh | success | logs | 1 test cases passed
matrix-2o6j2l7w98ofr | success | logs | 1 test cases passed
matrix-k903en2fx2gva | success | logs | 1 test cases passed
matrix-3iiuzcldp32zk | success | logs | 1 test cases passed
matrix-1ih283qsjt6td | success | logs | 1 test cases passed
matrix-2i5hm6k4xktij | success | logs | 1 test cases passed
matrix-ioy1mwzbemewa | success | logs | 1 test cases passed
matrix-2ftu3f98dufya | success | logs | 1 test cases passed
matrix-wrgab0j6aigna | success | logs | 1 test cases passed
matrix-2pcw9xoi3tmkh | success | logs | 1 test cases passed
matrix-fft8r89svqeda | success | logs | 1 test cases passed
matrix-6khpznkib9vha | success | logs | 1 test cases passed
matrix-30h9j9go0ew5i | success | logs | 1 test cases passed

</details>


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
