### PR TITLE
For #23636 - Unfocus keyboard on homepage touch

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/search/SearchFragmentStore.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchFragmentStore.kt
@@ -62,6 +62,7 @@ sealed class SearchEngineSource {
  * @property showBookmarkSuggestions Whether or not to show the bookmark suggestion in the AwesomeBar
  * @property pastedText The text pasted from the long press toolbar menu
  * @property clipboardHasUrl Indicates if the clipboard contains an URL.
+ * @property showPillButtons Whether or not to show qr and search engine pill buttons above the toolbar.
  */
 data class SearchFragmentState(
     val query: String,
@@ -81,7 +82,8 @@ data class SearchFragmentState(
     val tabId: String?,
     val pastedText: String? = null,
     val searchAccessPoint: Event.PerformedSearch.SearchAccessPoint?,
-    val clipboardHasUrl: Boolean = false
+    val clipboardHasUrl: Boolean = false,
+    val showPillButtons: Boolean = true
 ) : State
 
 fun createInitialSearchFragmentState(
@@ -132,6 +134,7 @@ sealed class SearchFragmentAction : Action {
     data class AllowSearchSuggestionsInPrivateModePrompt(val show: Boolean) : SearchFragmentAction()
     data class UpdateQuery(val query: String) : SearchFragmentAction()
     data class UpdateClipboardHasUrl(val hasUrl: Boolean) : SearchFragmentAction()
+    data class ShowPillButtons(val show: Boolean) : SearchFragmentAction()
 
     /**
      * Updates the local `SearchFragmentState` from the global `SearchState` in `BrowserStore`.
@@ -153,6 +156,8 @@ private fun searchStateReducer(state: SearchFragmentState, action: SearchFragmen
             state.copy(showSearchShortcuts = action.show && state.areShortcutsAvailable)
         is SearchFragmentAction.UpdateQuery ->
             state.copy(query = action.query)
+        is SearchFragmentAction.ShowPillButtons ->
+            state.copy(showPillButtons = action.show)
         is SearchFragmentAction.AllowSearchSuggestionsInPrivateModePrompt ->
             state.copy(showSearchSuggestionsHint = action.show)
         is SearchFragmentAction.SetShowSearchSuggestions ->


### PR DESCRIPTION
Added `showPillButtons` property to `SearchFragmentState`, to hold the hide/show state of the **QR scan** and **Search engine** buttons above the search bar. The buttons should hide on touch inside the `HomeFragment` and should be displayed when the toolbar regains focus.

https://user-images.githubusercontent.com/35462038/152982015-5bacd3db-1799-483a-91e6-8d5cedf7e7f0.mp4

https://user-images.githubusercontent.com/35462038/152982264-fcfd532f-8e65-40d2-9c71-80b7365ecf30.mp4

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
