### PR TITLE
[UI smoke test] New browser functionalities in custom tabs UI tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/CustomTabsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/CustomTabsTest.kt
@@ -1,0 +1,137 @@
+package org.mozilla.fenix.ui
+
+import androidx.core.net.toUri
+import androidx.test.rule.ActivityTestRule
+import androidx.test.rule.GrantPermissionRule
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mozilla.fenix.IntentReceiverActivity
+import org.mozilla.fenix.customannotations.SmokeTest
+import org.mozilla.fenix.helpers.AndroidAssetDispatcher
+import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
+import org.mozilla.fenix.helpers.TestAssetHelper
+import org.mozilla.fenix.helpers.TestHelper.createCustomTabIntent
+import org.mozilla.fenix.helpers.TestHelper.openAppFromExternalLink
+import org.mozilla.fenix.ui.robots.browserScreen
+import org.mozilla.fenix.ui.robots.customTabScreen
+import org.mozilla.fenix.ui.robots.mDevice
+import org.mozilla.fenix.ui.robots.navigationToolbar
+import org.mozilla.fenix.ui.robots.notificationShade
+import org.mozilla.fenix.ui.robots.openEditURLView
+import org.mozilla.fenix.ui.robots.searchScreen
+
+class CustomTabsTest {
+    private lateinit var mockWebServer: MockWebServer
+    private val customMenuItem = "TestMenuItem"
+
+    @get:Rule
+    val activityTestRule = HomeActivityIntentTestRule()
+
+    @get: Rule
+    val intentReceiverActivityTestRule = ActivityTestRule(
+        IntentReceiverActivity::class.java, true, false
+    )
+
+    @get:Rule
+    var mGrantPermissions = GrantPermissionRule.grant(
+        android.Manifest.permission.WRITE_EXTERNAL_STORAGE
+    )
+
+    @Before
+    fun setUp() {
+        mockWebServer = MockWebServer().apply {
+            dispatcher = AndroidAssetDispatcher()
+            start()
+        }
+    }
+
+    @After
+    fun tearDown() {
+        mockWebServer.shutdown()
+    }
+
+    @SmokeTest
+    @Test
+    fun customTabCopyToolbarUrlTest() {
+        val customTabPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        intentReceiverActivityTestRule.launchActivity(
+            createCustomTabIntent(
+                customTabPage.url.toString(),
+                customMenuItem
+            )
+        )
+
+        customTabScreen {
+            longCLickAndCopyToolbarUrl()
+        }
+
+        openAppFromExternalLink(customTabPage.url.toString())
+
+        navigationToolbar {
+            openEditURLView()
+        }
+
+        searchScreen {
+            clickClearButton()
+            longClickToolbar()
+            clickPasteText()
+            verifyPastedToolbarText(customTabPage.url.toString())
+        }
+    }
+
+    @SmokeTest
+    @Test
+    fun customTabShareTextTest() {
+        val customTabPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        intentReceiverActivityTestRule.launchActivity(
+            createCustomTabIntent(
+                customTabPage.url.toString(),
+                customMenuItem
+            )
+        )
+
+        customTabScreen {
+            waitForPageToLoad()
+        }
+
+        browserScreen {
+            longClickMatchingText("content")
+        }.clickShareSelectedText {
+            verifyAndroidShareLayout()
+        }
+    }
+
+    @SmokeTest
+    @Test
+    fun customTabDownloadTest() {
+        val customTabPage = "https://storage.googleapis.com/mobile_test_assets/test_app/downloads.html"
+        val downloadFile = "web_icon.png"
+
+        intentReceiverActivityTestRule.launchActivity(
+            createCustomTabIntent(
+                customTabPage.toUri().toString(),
+                customMenuItem
+            )
+        )
+
+        customTabScreen {
+            waitForPageToLoad()
+        }
+
+        browserScreen {
+        }.clickDownloadLink(downloadFile) {
+            verifyDownloadPrompt(downloadFile)
+        }.clickDownload {
+            verifyDownloadNotificationPopup()
+        }
+        mDevice.openNotification()
+        notificationShade {
+            verifySystemNotificationExists("Download completed")
+        }
+    }
+}

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/CustomTabRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/CustomTabRobot.kt
@@ -10,9 +10,11 @@ import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiSelector
 import junit.framework.TestCase.assertTrue
 import org.mozilla.fenix.R
+import org.mozilla.fenix.helpers.Constants.LONG_CLICK_DURATION
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.TestHelper.appName
 import org.mozilla.fenix.helpers.TestHelper.packageName
@@ -74,6 +76,16 @@ class CustomTabRobot {
         )
     }
 
+    fun longCLickAndCopyToolbarUrl() {
+        mDevice.waitForObjects(mDevice.findObject(UiSelector().resourceId("$packageName:id/toolbar")))
+        customTabToolbar().click(LONG_CLICK_DURATION)
+        mDevice.findObject(UiSelector().textContains("Copy")).waitForExists(waitingTime)
+        val copyText = mDevice.findObject(By.textContains("Copy"))
+        copyText.click()
+    }
+
+    fun waitForPageToLoad() = progressBar.waitUntilGone(waitingTime)
+
     class Transition {
         fun openMainMenu(interact: CustomTabRobot.() -> Unit): Transition {
             mainMenuButton().waitForExists(waitingTime)
@@ -112,3 +124,10 @@ private fun forwardButton() = mDevice.findObject(UiSelector().description("Forwa
 private fun backButton() = mDevice.findObject(UiSelector().description("Back"))
 
 private fun closeButton() = onView(withContentDescription("Return to previous app"))
+
+private fun customTabToolbar() = mDevice.findObject(By.res("$packageName:id/toolbar"))
+
+private val progressBar =
+    mDevice.findObject(
+        UiSelector().resourceId("$packageName:id/mozac_browser_toolbar_progress")
+    )


### PR DESCRIPTION
New browser functionality in custom tab UI smoke tests.
• `customTabCopyToolbarUrlTest` ✅  Successfully passed 50x on Firebase
• `customTabShareTextTest` ✅  Successfully passed 50x on Firebase
• `customTabDownloadTest` ✅  Successfully passed 50x on Firebase

<details>

<summary> 📈 Results (dropdown)</summary>

matrix | result | logs | details
-- | -- | -- | --
matrix-y72yzd7jljzma | success | logs | 2 test cases passed
matrix-1mf7wv1uwpeol | success | logs | 2 test cases passed
matrix-mfz93zv7a6opa | success | logs | 2 test cases passed
matrix-1wjx2kle0pykc | success | logs | 2 test cases passed
matrix-11uh1jq4t2o5d | success | logs | 2 test cases passed
matrix-qd22lxzyv9zaa | success | logs | 2 test cases passed
matrix-29dxxihekei9d | success | logs | 2 test cases passed
matrix-vvoan7lxfy31a | success | logs | 2 test cases passed
matrix-2ezun8ifz6fsw | success | logs | 2 test cases passed
matrix-3frbqwlodwlvz | success | logs | 2 test cases passed
matrix-etwxg0xm33v7a | success | logs | 2 test cases passed
matrix-3f6zek17uktfq | success | logs | 2 test cases passed
matrix-2qj3jjfvimw0h | success | logs | 2 test cases passed
matrix-2rut31h9nu2hr | success | logs | 2 test cases passed
matrix-2pdim8r0b5y11 | success | logs | 2 test cases passed
matrix-1ne7a5r6ecejo | success | logs | 2 test cases passed
matrix-aagq75dpfkj3a | success | logs | 2 test cases passed
matrix-krmjmysxbv1va | success | logs | 2 test cases passed
matrix-3maj0b3lpbaqu | success | logs | 2 test cases passed
matrix-39vlkm886bjl7 | success | logs | 2 test cases passed
matrix-2cr6srzctz6ci | success | logs | 2 test cases passed
matrix-3i9zsxwpoz7fn | success | logs | 2 test cases passed
matrix-20b9ar4yial3h | success | logs | 2 test cases passed
matrix-1e0zkvxv8cgi8 | success | logs | 2 test cases passed
matrix-5pjjxzedaxroa | success | logs | 2 test cases passed
matrix-1vivvy8c6hadp | success | logs | 2 test cases passed
matrix-1v2ovxwq2fq6k | success | logs | 2 test cases passed
matrix-3fwtj8tgo0s2h | success | logs | 2 test cases passed
matrix-2225qg5rffztl | success | logs | 2 test cases passed
matrix-37gixrcvnioyk | success | logs | 2 test cases passed
matrix-q2xmw3b6pu6xa | success | logs | 2 test cases passed
matrix-2pvipxl1j571g | success | logs | 2 test cases passed
matrix-11z0ar4y1v258 | success | logs | 2 test cases passed
matrix-2av4n3z8lhq6d | success | logs | 2 test cases passed
matrix-2hp5u3ya6izqm | success | logs | 2 test cases passed
matrix-17qdc0r8m8j2z | success | logs | 2 test cases passed
matrix-2q41i4b7nrpzv | success | logs | 2 test cases passed
matrix-slujs5p7tlpca | success | logs | 2 test cases passed
matrix-2vpfrapalbma2 | success | logs | 2 test cases passed
matrix-3p63scd6ss5bl | success | logs | 2 test cases passed
matrix-3294h2pd2rzro | success | logs | 2 test cases passed
matrix-3mjx7z9y5khry | success | logs | 2 test cases passed
matrix-3pmixiwqasewq | success | logs | 2 test cases passed
matrix-1seii3mgd83zm | success | logs | 2 test cases passed
matrix-3j2wfnvv08wvk | success | logs | 2 test cases passed
matrix-5f7oc275g10oa | success | logs | 2 test cases passed
matrix-7sihppf9baija | success | logs | 2 test cases passed
matrix-3hmbhm7bphjl2 | success | logs | 2 test cases passed
matrix-3sn6gkaaig5xo | success | logs | 2 test cases passed
matrix-erj1w0bybrtfa | success | logs | 2 test cases passed
matrix-1mjzlvycexoby | success | logs | 1 test cases passed
matrix-mkwpfts79xjta | success | logs | 1 test cases passed
matrix-neat9n90ec9ba | success | logs | 1 test cases passed
matrix-2tx8se4inewr9 | success | logs | 1 test cases passed
matrix-mx6o6jcp8wina | success | logs | 1 test cases passed
matrix-2mw26vb70kzex | success | logs | 1 test cases passed
matrix-2fvgcsv2sff51 | success | logs | 1 test cases passed
matrix-lnjamr9ozntha | success | logs | 1 test cases passed
matrix-xlprg7mtkyaoa | success | logs | 1 test cases passed
matrix-3klgnak7uh42l | success | logs | 1 test cases passed
matrix-ak7ecikytokpa | success | logs | 1 test cases passed
matrix-3nvlnvlieredg | success | logs | 1 test cases passed
matrix-3h1cacxq0vfaj | success | logs | 1 test cases passed
matrix-3dnyaootemk6y | success | logs | 1 test cases passed
matrix-2t1jedkanzsdh | success | logs | 1 test cases passed
matrix-1vxc4y6ys7o9r | success | logs | 1 test cases passed
matrix-a2j0fvtpl2paa | success | logs | 1 test cases passed
matrix-3pcgmr3eki18v | success | logs | 1 test cases passed
matrix-3bf9lsd3pvpms | success | logs | 1 test cases passed
matrix-2nagqlk3y5din | success | logs | 1 test cases passed
matrix-3a1lx7l559f1f | success | logs | 1 test cases passed
matrix-2qm2ci4egwpjb | success | logs | 1 test cases passed
matrix-do7udivzxalda | success | logs | 1 test cases passed
matrix-9xmmplh3zoo6a | success | logs | 1 test cases passed
matrix-h9zl4j3m5g9la | success | logs | 1 test cases passed
matrix-2whbkm5qqilwz | success | logs | 1 test cases passed
matrix-7zzn6qg0p6ima | success | logs | 1 test cases passed
matrix-2030au8naktse | success | logs | 1 test cases passed
matrix-3oczwrxn3zfvn | success | logs | 1 test cases passed
matrix-30lqgfnox7ex9 | success | logs | 1 test cases passed
matrix-1xig658kz2un9 | success | logs | 1 test cases passed
matrix-37o80jah8qweu | success | logs | 1 test cases passed
matrix-lx6ifwoqc9y6a | success | logs | 1 test cases passed
matrix-3mtzmf8kn92p9 | success | logs | 1 test cases passed
matrix-o79jdcsmf8c1a | success | logs | 1 test cases passed
matrix-2edaxne20emoo | success | logs | 1 test cases passed
matrix-2d8si98ax0xut | success | logs | 1 test cases passed
matrix-35yt66u5hyoql | success | logs | 1 test cases passed
matrix-2s0h30stb2srv | success | logs | 1 test cases passed
matrix-nhn4xyci7w1za | success | logs | 1 test cases passed
matrix-3k0rinozgs486 | success | logs | 1 test cases passed
matrix-3oh3koa7r2s7s | success | logs | 1 test cases passed
matrix-3fhqg488jgpkf | success | logs | 1 test cases passed
matrix-1dmaxuqir2wem | success | logs | 1 test cases passed
matrix-1rwaufhctqp3a | success | logs | 1 test cases passed
matrix-3qshx5nrf6efu | success | logs | 1 test cases passed
matrix-1ldbfm68ymuln | success | logs | 1 test cases passed
matrix-3lpy2wbqini8t | success | logs | 1 test cases passed
matrix-1wpvsytbnwk46 | success | logs | 1 test cases passed
matrix-1vvl192rfux3e | success | logs | 1 test cases passed

</details>

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
