### PR TITLE
For #23431 - Display the order of Contile Top Sites correctly

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -36,6 +36,7 @@ import mozilla.components.feature.addons.update.GlobalAddonDependencyProvider
 import mozilla.components.feature.autofill.AutofillUseCases
 import mozilla.components.feature.search.ext.buildSearchUrl
 import mozilla.components.feature.search.ext.waitForSelectedOrDefaultSearchEngine
+import mozilla.components.feature.top.sites.TopSitesProviderConfig
 import mozilla.components.lib.crash.CrashReporter
 import mozilla.components.service.fxa.manager.SyncEnginesStorage
 import mozilla.components.service.glean.Glean
@@ -82,6 +83,7 @@ import org.mozilla.fenix.session.VisibilityLifecycleCallback
 import org.mozilla.fenix.telemetry.TelemetryLifecycleObserver
 import org.mozilla.fenix.utils.BrowsersCache
 import org.mozilla.fenix.utils.Settings
+import org.mozilla.fenix.utils.Settings.Companion.TOP_SITES_PROVIDER_MAX_THRESHOLD
 import java.util.concurrent.TimeUnit
 
 /**
@@ -258,11 +260,14 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
                         // we can prevent with this.
                         components.core.topSitesStorage.getTopSites(
                             totalSites = components.settings.topSitesMaxLimit,
-                            fetchProvidedTopSites = components.settings.showContileFeature,
                             frecencyConfig = if (components.settings.showTopFrecentSites)
                                 FrecencyThresholdOption.SKIP_ONE_TIME_PAGES
                             else
-                                null
+                                null,
+                            providerConfig = TopSitesProviderConfig(
+                                showProviderTopSites = components.settings.showContileFeature,
+                                maxThreshold = TOP_SITES_PROVIDER_MAX_THRESHOLD
+                            )
                         )
 
                         // This service uses `historyStorage`, and so we can only touch it when we know

--- a/app/src/main/java/org/mozilla/fenix/ext/TopSite.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/TopSite.kt
@@ -5,6 +5,7 @@
 package org.mozilla.fenix.ext
 
 import mozilla.components.feature.top.sites.TopSite
+import org.mozilla.fenix.settings.SupportUtils
 
 /**
  * Returns the type name of the [TopSite].
@@ -14,4 +15,23 @@ fun TopSite.name(): String = when (this) {
     is TopSite.Frecent -> "FRECENT"
     is TopSite.Pinned -> "PINNED"
     is TopSite.Provided -> "PROVIDED"
+}
+
+/**
+ * Returns a sorted list of [TopSite] with the default Google top site always appearing
+ * as the first item.
+ */
+fun List<TopSite>.sort(): List<TopSite> {
+    val defaultGoogleTopSiteIndex = this.indexOfFirst {
+        it is TopSite.Default && it.url == SupportUtils.GOOGLE_URL
+    }
+
+    return if (defaultGoogleTopSiteIndex == -1) {
+        this
+    } else {
+        val result = this.toMutableList()
+        result.removeAt(defaultGoogleTopSiteIndex)
+        result.add(0, this[defaultGoogleTopSiteIndex])
+        result
+    }
 }

--- a/app/src/main/java/org/mozilla/fenix/home/topsites/DefaultTopSitesView.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/topsites/DefaultTopSitesView.kt
@@ -6,14 +6,25 @@ package org.mozilla.fenix.home.topsites
 
 import mozilla.components.feature.top.sites.TopSite
 import mozilla.components.feature.top.sites.view.TopSitesView
+import org.mozilla.fenix.ext.sort
 import org.mozilla.fenix.home.HomeFragmentAction
 import org.mozilla.fenix.home.HomeFragmentStore
+import org.mozilla.fenix.utils.Settings
 
 class DefaultTopSitesView(
-    val store: HomeFragmentStore
+    val store: HomeFragmentStore,
+    val settings: Settings
 ) : TopSitesView {
 
     override fun displayTopSites(topSites: List<TopSite>) {
-        store.dispatch(HomeFragmentAction.TopSitesChange(topSites))
+        store.dispatch(
+            HomeFragmentAction.TopSitesChange(
+                if (!settings.showContileFeature) {
+                    topSites
+                } else {
+                    topSites.sort()
+                }
+            )
+        )
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -18,6 +18,7 @@ import androidx.lifecycle.LifecycleOwner
 import mozilla.components.feature.sitepermissions.SitePermissionsRules
 import mozilla.components.feature.sitepermissions.SitePermissionsRules.Action
 import mozilla.components.feature.sitepermissions.SitePermissionsRules.AutoplayAction
+import mozilla.components.service.contile.ContileTopSitesProvider
 import mozilla.components.support.ktx.android.content.PreferencesHolder
 import mozilla.components.support.ktx.android.content.booleanPreference
 import mozilla.components.support.ktx.android.content.floatPreference
@@ -61,7 +62,6 @@ private const val AUTOPLAY_USER_SETTING = "AUTOPLAY_USER_SETTING"
 class Settings(private val appContext: Context) : PreferencesHolder {
 
     companion object {
-        const val topSitesMaxCount = 16
         const val FENIX_PREFERENCES = "fenix_preferences"
 
         private const val BLOCKED_INT = 0
@@ -83,6 +83,14 @@ class Settings(private val appContext: Context) : PreferencesHolder {
          * Filtering is applied depending on the [historyImprovementFeatures] flag value.
          */
         const val SEARCH_GROUP_MINIMUM_SITES: Int = 2
+
+        // The maximum number of top sites to display.
+        const val TOP_SITES_MAX_COUNT = 16
+        /**
+         * Only fetch top sites from the [ContileTopSitesProvider] when the number of default and
+         * pinned sites are below this maximum threshold.
+         */
+        const val TOP_SITES_PROVIDER_MAX_THRESHOLD = 8
 
         private fun Action.toInt() = when (this) {
             Action.BLOCKED -> BLOCKED_INT
@@ -1122,7 +1130,7 @@ class Settings(private val appContext: Context) : PreferencesHolder {
 
     val topSitesMaxLimit by intPreference(
         appContext.getPreferenceKey(R.string.pref_key_top_sites_max_limit),
-        default = topSitesMaxCount
+        default = TOP_SITES_MAX_COUNT
     )
 
     var openTabsCount by intPreference(

--- a/app/src/test/java/org/mozilla/fenix/ext/TopSiteTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/ext/TopSiteTest.kt
@@ -1,0 +1,117 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.ext
+
+import mozilla.components.feature.top.sites.TopSite
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+import org.mozilla.fenix.settings.SupportUtils
+
+@RunWith(FenixRobolectricTestRunner::class)
+class TopSiteTest {
+
+    val defaultGoogleTopSite = TopSite.Default(
+        id = 1L,
+        title = "Google",
+        url = SupportUtils.GOOGLE_URL,
+        createdAt = 0
+    )
+    val providedSite1 = TopSite.Provided(
+        id = 3,
+        title = "Mozilla",
+        url = "https://mozilla.com",
+        clickUrl = "https://mozilla.com/click",
+        imageUrl = "https://test.com/image2.jpg",
+        impressionUrl = "https://example.com",
+        createdAt = 3
+    )
+    val providedSite2 = TopSite.Provided(
+        id = 3,
+        title = "Firefox",
+        url = "https://firefox.com",
+        clickUrl = "https://firefox.com/click",
+        imageUrl = "https://test.com/image2.jpg",
+        impressionUrl = "https://example.com",
+        createdAt = 3
+    )
+    val pinnedSite1 = TopSite.Pinned(
+        id = 1L,
+        title = "DuckDuckGo",
+        url = "https://duckduckgo.com",
+        createdAt = 0
+    )
+    val pinnedSite2 = TopSite.Pinned(
+        id = 1L,
+        title = "Mozilla",
+        url = "mozilla.org",
+        createdAt = 0
+    )
+    val frecentSite = TopSite.Frecent(
+        id = 1L,
+        title = "Mozilla",
+        url = "mozilla.org",
+        createdAt = 0
+    )
+
+    @Test
+    fun `GIVEN the default Google top site is the first item WHEN the list of top sites is sorted THEN the order doesn't change`() {
+        val topSites = listOf(
+            defaultGoogleTopSite,
+            providedSite1,
+            providedSite2,
+            pinnedSite1,
+            pinnedSite2,
+            frecentSite
+        )
+
+        assertEquals(topSites.sort(), topSites)
+    }
+
+    @Test
+    fun `GIVEN the default Google top site is after the provided top sites WHEN the list of top sites is sorted THEN the default Google top site should be first`() {
+        val topSites = listOf(
+            providedSite1,
+            providedSite2,
+            defaultGoogleTopSite,
+            pinnedSite1,
+            pinnedSite2,
+            frecentSite
+        )
+        val expected = listOf(
+            defaultGoogleTopSite,
+            providedSite1,
+            providedSite2,
+            pinnedSite1,
+            pinnedSite2,
+            frecentSite
+        )
+
+        assertEquals(topSites.sort(), expected)
+    }
+
+    @Test
+    fun `GIVEN the default Google top site is the last item WHEN the list of top sites is sorted THEN the default Google top site should be first`() {
+        val topSites = listOf(
+            providedSite1,
+            providedSite2,
+            pinnedSite1,
+            pinnedSite2,
+            frecentSite,
+            defaultGoogleTopSite
+        )
+        val expected = listOf(
+            defaultGoogleTopSite,
+            providedSite1,
+            providedSite2,
+            pinnedSite1,
+            pinnedSite2,
+            frecentSite
+        )
+
+        assertEquals(topSites.sort(), expected)
+    }
+}

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "99.0.20220209143350"
+    const val VERSION = "99.0.20220209170927"
 }


### PR DESCRIPTION
Fixes #23431. This also fixes the breaking change introduced from https://github.com/mozilla-mobile/android-components/issues/11654.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
