### PR TITLE
[UI Smoke test] Custom tabs external links and save login UI tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/CustomTabsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/CustomTabsTest.kt
@@ -26,6 +26,8 @@ import org.mozilla.fenix.ui.robots.searchScreen
 class CustomTabsTest {
     private lateinit var mockWebServer: MockWebServer
     private val customMenuItem = "TestMenuItem"
+    private val externalLinksPWAPage = "https://mozilla-mobile.github.io/testapp/externalLinks.html"
+    private val loginPage = "https://mozilla-mobile.github.io/testapp/loginForm"
 
     @get:Rule
     val activityTestRule = HomeActivityIntentTestRule()
@@ -51,6 +53,59 @@ class CustomTabsTest {
     @After
     fun tearDown() {
         mockWebServer.shutdown()
+    }
+
+    @SmokeTest
+    @Test
+    fun customTabsOpenExternalLinkTest() {
+
+        intentReceiverActivityTestRule.launchActivity(
+            createCustomTabIntent(
+                externalLinksPWAPage.toUri().toString(),
+                customMenuItem
+            )
+        )
+
+        customTabScreen {
+            waitForPageToLoad()
+            clickLinkMatchingText("External link")
+            waitForPageToLoad()
+            verifyCustomTabToolbarTitle("Google")
+        }
+    }
+
+    @SmokeTest
+    @Test
+    fun customTabsSaveLoginTest() {
+
+        intentReceiverActivityTestRule.launchActivity(
+            createCustomTabIntent(
+                loginPage.toUri().toString(),
+                customMenuItem
+            )
+        )
+
+        customTabScreen {
+            waitForPageToLoad()
+            fillAndSubmitLoginCredentials("mozilla", "firefox")
+        }
+
+        browserScreen {
+            verifySaveLoginPromptIsDisplayed()
+            saveLoginFromPrompt("Save")
+        }
+
+        openAppFromExternalLink(loginPage)
+
+        browserScreen {
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openLoginsAndPasswordSubMenu {
+        }.openSavedLogins {
+            verifySecurityPromptForLogins()
+            tapSetupLater()
+            verifySavedLoginFromPrompt("mozilla")
+        }
     }
 
     @SmokeTest

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/CustomTabRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/CustomTabRobot.kt
@@ -11,6 +11,7 @@ import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.uiautomator.By
+import androidx.test.uiautomator.UiObjectNotFoundException
 import androidx.test.uiautomator.UiSelector
 import junit.framework.TestCase.assertTrue
 import org.mozilla.fenix.R
@@ -84,6 +85,48 @@ class CustomTabRobot {
         copyText.click()
     }
 
+    fun fillAndSubmitLoginCredentials(userName: String, password: String) {
+        var currentTries = 0
+        while (currentTries++ < 3) {
+            try {
+                mDevice.waitForIdle(waitingTime)
+                userNameTextBox.setText(userName)
+                passwordTextBox.setText(password)
+                submitLoginButton.click()
+                mDevice.waitForObjects(mDevice.findObject(UiSelector().resourceId("$packageName:id/save_confirm")))
+                break
+            } catch (e: UiObjectNotFoundException) {
+                customTabScreen {
+                }.openMainMenu {
+                    refreshButton().click()
+                    waitForPageToLoad()
+                }
+            }
+        }
+    }
+
+    fun clickLinkMatchingText(expectedText: String) {
+        var currentTries = 0
+        while (currentTries++ < 3) {
+            try {
+                mDevice.findObject(UiSelector().resourceId("$packageName:id/engineView"))
+                    .waitForExists(waitingTime)
+                mDevice.findObject(UiSelector().textContains(expectedText))
+                    .waitForExists(waitingTime)
+
+                val element = mDevice.findObject(UiSelector().textContains(expectedText))
+                element.click()
+                break
+            } catch (e: UiObjectNotFoundException) {
+                customTabScreen {
+                }.openMainMenu {
+                    refreshButton().click()
+                    waitForPageToLoad()
+                }
+            }
+        }
+    }
+
     fun waitForPageToLoad() = progressBar.waitUntilGone(waitingTime)
 
     class Transition {
@@ -130,4 +173,14 @@ private fun customTabToolbar() = mDevice.findObject(By.res("$packageName:id/tool
 private val progressBar =
     mDevice.findObject(
         UiSelector().resourceId("$packageName:id/mozac_browser_toolbar_progress")
+    )
+
+private val submitLoginButton =
+    mDevice.findObject(
+        UiSelector()
+            .index(2)
+            .resourceId("submit")
+            .textContains("Submit Query")
+            .className("android.widget.Button")
+            .packageName("$packageName")
     )


### PR DESCRIPTION
New Custom Tabs UI smoke tests:
`customTabsOpenExternalLinkTest` ✅ Successfully passed 50x on Firebase
`customTabsSaveLoginTest` ✅ Successfully passed 50x on Firebase

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
