### PR TITLE
For #23700 - HistoryFragment: Exit edit mode when tabs are opened or shared.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragment.kt
@@ -212,7 +212,7 @@ class HistoryFragment : LibraryPageFragment<History>(), UserInteractionHandler {
             }
 
             share(shareTabs)
-
+            historyStore.dispatch(HistoryFragmentAction.ExitEditMode)
             true
         }
         R.id.delete_history_multi_select -> {
@@ -227,6 +227,7 @@ class HistoryFragment : LibraryPageFragment<History>(), UserInteractionHandler {
             }
 
             showTabTray()
+            historyStore.dispatch(HistoryFragmentAction.ExitEditMode)
             true
         }
         R.id.open_history_in_private_tabs_multi_select -> {
@@ -241,6 +242,7 @@ class HistoryFragment : LibraryPageFragment<History>(), UserInteractionHandler {
             }
 
             showTabTray()
+            historyStore.dispatch(HistoryFragmentAction.ExitEditMode)
             true
         }
         R.id.history_search -> {


### PR DESCRIPTION
This mirrors behavior currently in Bookmarks library with the same actions.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

Current behavior
https://user-images.githubusercontent.com/59484634/153894271-c301156d-0f58-44cf-b410-b53469478489.mp4

Updated behavior
https://user-images.githubusercontent.com/59484634/153894326-626f157c-474d-4d59-8254-ca43269d6726.mp4


