### PR TITLE
For #23665 - Dismiss undo snackbar on fragment pause

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragment.kt
@@ -67,6 +67,7 @@ class BookmarkFragment : LibraryPageFragment<BookmarkNode>(), UserInteractionHan
     private val sharedViewModel: BookmarksSharedViewModel by activityViewModels()
     private val desktopFolders by lazy { DesktopFolders(requireContext(), showMobileRoot = false) }
 
+    private var snackbar: FenixSnackbar? = null
     private var pendingBookmarkDeletionJob: (suspend () -> Unit)? = null
     private var pendingBookmarksToDelete: MutableSet<BookmarkNode> = mutableSetOf()
 
@@ -283,6 +284,7 @@ class BookmarkFragment : LibraryPageFragment<BookmarkNode>(), UserInteractionHan
 
     override fun onPause() {
         invokePendingDeletion()
+        snackbar?.dismiss()
         super.onPause()
     }
 
@@ -321,7 +323,7 @@ class BookmarkFragment : LibraryPageFragment<BookmarkNode>(), UserInteractionHan
             else -> throw IllegalStateException("Illegal event type in onDeleteSome")
         }
 
-        viewLifecycleOwner.lifecycleScope.allowUndo(
+        snackbar = viewLifecycleOwner.lifecycleScope.allowUndo(
             requireView(), message,
             getString(R.string.bookmark_undo_deletion),
             {
@@ -379,7 +381,7 @@ class BookmarkFragment : LibraryPageFragment<BookmarkNode>(), UserInteractionHan
                     dialog.dismiss()
                     val snackbarMessage = getRemoveBookmarksSnackBarMessage(selected, containsFolders = true)
                     // Use fragment's lifecycle; the view may be gone by the time dialog is interacted with.
-                    lifecycleScope.allowUndo(
+                    snackbar = lifecycleScope.allowUndo(
                         requireView(),
                         snackbarMessage,
                         getString(R.string.bookmark_undo_deletion),

--- a/app/src/main/java/org/mozilla/fenix/library/downloads/DownloadFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/downloads/DownloadFragment.kt
@@ -26,6 +26,7 @@ import mozilla.components.support.base.feature.UserInteractionHandler
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
+import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.components.StoreProvider
 import org.mozilla.fenix.databinding.FragmentDownloadsBinding
 import org.mozilla.fenix.ext.components
@@ -44,6 +45,7 @@ class DownloadFragment : LibraryPageFragment<DownloadItem>(), UserInteractionHan
     private var undoScope: CoroutineScope? = null
     private var pendingDownloadDeletionJob: (suspend () -> Unit)? = null
     private lateinit var downloadsUseCases: DownloadsUseCases
+    private var snackbar: FenixSnackbar? = null
 
     private var _binding: FragmentDownloadsBinding? = null
     private val binding get() = _binding!!
@@ -129,7 +131,7 @@ class DownloadFragment : LibraryPageFragment<DownloadItem>(), UserInteractionHan
     private fun deleteDownloadItems(items: Set<DownloadItem>) {
         updatePendingDownloadToDelete(items)
         undoScope = CoroutineScope(IO)
-        undoScope?.allowUndo(
+        snackbar = undoScope?.allowUndo(
             requireView(),
             getMultiSelectSnackBarMessage(items),
             getString(R.string.bookmark_undo_deletion),
@@ -205,6 +207,7 @@ class DownloadFragment : LibraryPageFragment<DownloadItem>(), UserInteractionHan
 
     override fun onPause() {
         invokePendingDeletion()
+        snackbar?.dismiss()
         super.onPause()
     }
 

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragment.kt
@@ -36,6 +36,7 @@ import org.mozilla.fenix.NavHostActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.addons.showSnackBar
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
+import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.components.StoreProvider
 import org.mozilla.fenix.components.history.DefaultPagedHistoryProvider
 import org.mozilla.fenix.components.metrics.Event
@@ -57,6 +58,7 @@ class HistoryFragment : LibraryPageFragment<History>(), UserInteractionHandler {
 
     private var undoScope: CoroutineScope? = null
     private var pendingHistoryDeletionJob: (suspend () -> Unit)? = null
+    private var snackbar: FenixSnackbar? = null
 
     private var _historyView: HistoryView? = null
     private val historyView: HistoryView
@@ -132,7 +134,7 @@ class HistoryFragment : LibraryPageFragment<History>(), UserInteractionHandler {
     private fun deleteHistoryItems(items: Set<History>) {
         updatePendingHistoryToDelete(items)
         undoScope = CoroutineScope(IO)
-        undoScope?.allowUndo(
+        snackbar = undoScope?.allowUndo(
             requireView(),
             getMultiSelectSnackBarMessage(items),
             getString(R.string.bookmark_undo_deletion),
@@ -281,6 +283,7 @@ class HistoryFragment : LibraryPageFragment<History>(), UserInteractionHandler {
 
     override fun onPause() {
         invokePendingDeletion()
+        snackbar?.dismiss()
         super.onPause()
     }
 

--- a/app/src/main/java/org/mozilla/fenix/utils/Undo.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Undo.kt
@@ -44,6 +44,8 @@ fun Context.getUndoDelay(): Long {
  * @param onCancel A suspend block to execute in case of cancellation.
  * @param operation A suspend block to execute if user doesn't cancel via the displayed [FenixSnackbar].
  * @param anchorView A [View] to which [FenixSnackbar] should be anchored.
+ *
+ * @return The [FenixSnackbar] created, used to dismiss it before the delay
  */
 @Suppress("LongParameterList")
 fun CoroutineScope.allowUndo(
@@ -55,13 +57,13 @@ fun CoroutineScope.allowUndo(
     anchorView: View? = null,
     elevation: Float? = null,
     paddedForBottomToolbar: Boolean = false
-) {
+): FenixSnackbar {
     // By using an AtomicBoolean, we achieve memory effects of reading and
     // writing a volatile variable.
     val requestedUndo = AtomicBoolean(false)
 
     @Suppress("ComplexCondition")
-    fun showUndoSnackbar() {
+    fun showUndoSnackbar(): FenixSnackbar {
         val snackbar = FenixSnackbar
             .make(
                 view = view,
@@ -114,7 +116,8 @@ fun CoroutineScope.allowUndo(
                 operation.invoke()
             }
         }
+        return snackbar
     }
 
-    showUndoSnackbar()
+    return showUndoSnackbar()
 }

--- a/app/src/test/java/org/mozilla/fenix/tabstray/TabsTrayFragmentTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/TabsTrayFragmentTest.kt
@@ -41,6 +41,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.NavGraphDirections
 import org.mozilla.fenix.R
+import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.components.metrics.MetricController
 import org.mozilla.fenix.databinding.ComponentTabstray2Binding
@@ -93,7 +94,7 @@ class TabsTrayFragmentTest {
             every { any<LifecycleOwner>().lifecycleScope } returns lifecycleScope
             fabButtonBinding.newTabButton.isVisible = true
             every { fragment.context } returns testContext // needed for getString()
-            every { any<CoroutineScope>().allowUndo(any(), any(), any(), any(), any(), any(), any(), any()) } just Runs
+            every { any<CoroutineScope>().allowUndo(any(), any(), any(), any(), any(), any(), any(), any()) } returns mockk()
 
             fragment.showUndoSnackbarForTab(true)
 
@@ -123,7 +124,7 @@ class TabsTrayFragmentTest {
             val lifecycleScope: LifecycleCoroutineScope = mockk(relaxed = true)
             every { any<LifecycleOwner>().lifecycleScope } returns lifecycleScope
             every { fragment.context } returns testContext // needed for getString()
-            every { any<CoroutineScope>().allowUndo(any(), any(), any(), any(), any(), any(), any(), any()) } just Runs
+            every { any<CoroutineScope>().allowUndo(any(), any(), any(), any(), any(), any(), any(), any()) } returns mockk()
 
             fragment.showUndoSnackbarForTab(true)
 
@@ -154,7 +155,7 @@ class TabsTrayFragmentTest {
             every { any<LifecycleOwner>().lifecycleScope } returns lifecycleScope
             fabButtonBinding.newTabButton.isVisible = true
             every { fragment.context } returns testContext // needed for getString()
-            every { any<CoroutineScope>().allowUndo(any(), any(), any(), any(), any(), any(), any(), any()) } just Runs
+            every { any<CoroutineScope>().allowUndo(any(), any(), any(), any(), any(), any(), any(), any()) } returns mockk()
 
             fragment.showUndoSnackbarForTab(false)
 
@@ -182,9 +183,10 @@ class TabsTrayFragmentTest {
             mockkStatic("org.mozilla.fenix.utils.UndoKt")
             mockkStatic("androidx.lifecycle.LifecycleOwnerKt")
             val lifecycleScope: LifecycleCoroutineScope = mockk(relaxed = true)
+            val snackbar: FenixSnackbar = mockk(relaxed = true)
             every { any<LifecycleOwner>().lifecycleScope } returns lifecycleScope
             every { fragment.context } returns testContext // needed for getString()
-            every { any<CoroutineScope>().allowUndo(any(), any(), any(), any(), any(), any(), any(), any()) } just Runs
+            every { any<CoroutineScope>().allowUndo(any(), any(), any(), any(), any(), any(), any(), any()) } returns snackbar
 
             fragment.showUndoSnackbarForTab(false)
 


### PR DESCRIPTION
Changed the behavior of the `Undo` snackbar to be dismissed inside the `onPause` of the history, bookmark and download fragments.

https://user-images.githubusercontent.com/35462038/154079582-69fc4a53-ccde-4900-8073-6aa504862419.mp4

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
