### PR TITLE
For #23771 - Set correct destructive text color for card editor error messages

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/creditcards/view/CreditCardEditorView.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/creditcards/view/CreditCardEditorView.kt
@@ -61,9 +61,15 @@ class CreditCardEditorView(
         binding.nameOnCardInput.text = state.billingName.toEditable()
 
         binding.cardNumberLayout.setErrorTextColor(
-            ColorStateList.valueOf(binding.root.context.getColorFromAttr(R.attr.destructive)))
+            ColorStateList.valueOf(
+                binding.root.context.getColorFromAttr(R.attr.destructive)
+            )
+        )
         binding.nameOnCardLayout.setErrorTextColor(
-            ColorStateList.valueOf(binding.root.context.getColorFromAttr(R.attr.destructive)))
+            ColorStateList.valueOf(
+                binding.root.context.getColorFromAttr(R.attr.destructive)
+            )
+        )
 
         bindExpiryMonthDropDown(state.expiryMonth)
         bindExpiryYearDropDown(state.expiryYears)

--- a/app/src/main/java/org/mozilla/fenix/settings/creditcards/view/CreditCardEditorView.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/creditcards/view/CreditCardEditorView.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.fenix.settings.creditcards.view
 
+import android.content.res.ColorStateList
 import android.view.View
 import android.widget.ArrayAdapter
 import androidx.annotation.VisibleForTesting
@@ -58,6 +59,11 @@ class CreditCardEditorView(
 
         binding.cardNumberInput.text = state.cardNumber.toEditable()
         binding.nameOnCardInput.text = state.billingName.toEditable()
+
+        binding.cardNumberLayout.setErrorTextColor(
+            ColorStateList.valueOf(binding.root.context.getColorFromAttr(R.attr.destructive)))
+        binding.nameOnCardLayout.setErrorTextColor(
+            ColorStateList.valueOf(binding.root.context.getColorFromAttr(R.attr.destructive)))
 
         bindExpiryMonthDropDown(state.expiryMonth)
         bindExpiryYearDropDown(state.expiryYears)

--- a/app/src/test/java/org/mozilla/fenix/settings/creditcards/CreditCardEditorViewTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/creditcards/CreditCardEditorViewTest.kt
@@ -17,9 +17,13 @@ import mozilla.components.concept.storage.NewCreditCardFields
 import mozilla.components.concept.storage.UpdatableCreditCardFields
 import mozilla.components.service.sync.autofill.AutofillCreditCardsAddressesStorage
 import mozilla.components.service.sync.autofill.AutofillCrypto
+import mozilla.components.support.ktx.android.content.getColorFromAttr
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.utils.CreditCardNetworkType
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -160,6 +164,9 @@ class CreditCardEditorViewTest {
         }
 
         assertFalse(creditCardEditorView.validateForm())
+        assertNotNull(fragmentCreditCardEditorBinding.cardNumberLayout.error)
+        assertEquals(fragmentCreditCardEditorBinding.cardNumberLayout.errorCurrentTextColors,
+            fragmentCreditCardEditorBinding.root.context.getColorFromAttr(R.attr.destructive))
 
         verify(exactly = 0) {
             interactor.onSaveCreditCard(
@@ -180,6 +187,9 @@ class CreditCardEditorViewTest {
         fragmentCreditCardEditorBinding.saveButton.performClick()
 
         assertFalse(creditCardEditorView.validateForm())
+        assertNotNull(fragmentCreditCardEditorBinding.cardNumberLayout.error)
+        assertEquals(fragmentCreditCardEditorBinding.cardNumberLayout.errorCurrentTextColors,
+            fragmentCreditCardEditorBinding.root.context.getColorFromAttr(R.attr.destructive))
 
         verify(exactly = 0) {
             interactor.onSaveCreditCard(
@@ -217,6 +227,9 @@ class CreditCardEditorViewTest {
         }
 
         assertFalse(creditCardEditorView.validateForm())
+        assertNotNull(fragmentCreditCardEditorBinding.nameOnCardLayout.error)
+        assertEquals(fragmentCreditCardEditorBinding.nameOnCardLayout.errorCurrentTextColors,
+            fragmentCreditCardEditorBinding.root.context.getColorFromAttr(R.attr.destructive))
 
         verify(exactly = 0) {
             interactor.onSaveCreditCard(
@@ -288,49 +301,5 @@ class CreditCardEditorViewTest {
                 )
             )
         }
-    }
-
-    @Test
-    fun `GIVEN invalid name on card WHEN the save button is clicked THEN error message is displayed`() {
-        creditCardEditorView.bind(getInitialCreditCardEditorState())
-
-        val billingName = "       "
-        val cardNumber = "2221000000000000"
-        val expiryMonth = 5
-
-        fragmentCreditCardEditorBinding.cardNumberInput.text = cardNumber.toEditable()
-        fragmentCreditCardEditorBinding.nameOnCardInput.text = billingName.toEditable()
-        fragmentCreditCardEditorBinding.expiryMonthDropDown.setSelection(expiryMonth - 1)
-
-        fragmentCreditCardEditorBinding.saveButton.performClick()
-
-        verify {
-            creditCardEditorView.validateForm()
-        }
-
-        assertFalse(creditCardEditorView.validateForm())
-        assertNotNull(fragmentCreditCardEditorBinding.nameOnCardLayout.error)
-    }
-
-    @Test
-    fun `GIVEN invalid card number WHEN the save button is clicked THEN error message is displayed`() {
-        creditCardEditorView.bind(getInitialCreditCardEditorState())
-
-        val billingName = "Banana Apple"
-        val cardNumber = "0000"
-        val expiryMonth = 5
-
-        fragmentCreditCardEditorBinding.cardNumberInput.text = cardNumber.toEditable()
-        fragmentCreditCardEditorBinding.nameOnCardInput.text = billingName.toEditable()
-        fragmentCreditCardEditorBinding.expiryMonthDropDown.setSelection(expiryMonth - 1)
-
-        fragmentCreditCardEditorBinding.saveButton.performClick()
-
-        verify {
-            creditCardEditorView.validateForm()
-        }
-
-        assertFalse(creditCardEditorView.validateForm())
-        assertNotNull(fragmentCreditCardEditorBinding.cardNumberLayout.error)
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/settings/creditcards/CreditCardEditorViewTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/creditcards/CreditCardEditorViewTest.kt
@@ -165,8 +165,10 @@ class CreditCardEditorViewTest {
 
         assertFalse(creditCardEditorView.validateForm())
         assertNotNull(fragmentCreditCardEditorBinding.cardNumberLayout.error)
-        assertEquals(fragmentCreditCardEditorBinding.cardNumberLayout.errorCurrentTextColors,
-            fragmentCreditCardEditorBinding.root.context.getColorFromAttr(R.attr.destructive))
+        assertEquals(
+            fragmentCreditCardEditorBinding.cardNumberLayout.errorCurrentTextColors,
+            fragmentCreditCardEditorBinding.root.context.getColorFromAttr(R.attr.destructive)
+        )
 
         verify(exactly = 0) {
             interactor.onSaveCreditCard(
@@ -188,8 +190,10 @@ class CreditCardEditorViewTest {
 
         assertFalse(creditCardEditorView.validateForm())
         assertNotNull(fragmentCreditCardEditorBinding.cardNumberLayout.error)
-        assertEquals(fragmentCreditCardEditorBinding.cardNumberLayout.errorCurrentTextColors,
-            fragmentCreditCardEditorBinding.root.context.getColorFromAttr(R.attr.destructive))
+        assertEquals(
+            fragmentCreditCardEditorBinding.cardNumberLayout.errorCurrentTextColors,
+            fragmentCreditCardEditorBinding.root.context.getColorFromAttr(R.attr.destructive)
+        )
 
         verify(exactly = 0) {
             interactor.onSaveCreditCard(
@@ -228,8 +232,10 @@ class CreditCardEditorViewTest {
 
         assertFalse(creditCardEditorView.validateForm())
         assertNotNull(fragmentCreditCardEditorBinding.nameOnCardLayout.error)
-        assertEquals(fragmentCreditCardEditorBinding.nameOnCardLayout.errorCurrentTextColors,
-            fragmentCreditCardEditorBinding.root.context.getColorFromAttr(R.attr.destructive))
+        assertEquals(
+            fragmentCreditCardEditorBinding.nameOnCardLayout.errorCurrentTextColors,
+            fragmentCreditCardEditorBinding.root.context.getColorFromAttr(R.attr.destructive)
+        )
 
         verify(exactly = 0) {
             interactor.onSaveCreditCard(

--- a/app/src/test/java/org/mozilla/fenix/settings/creditcards/CreditCardEditorViewTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/creditcards/CreditCardEditorViewTest.kt
@@ -19,9 +19,7 @@ import mozilla.components.service.sync.autofill.AutofillCreditCardsAddressesStor
 import mozilla.components.service.sync.autofill.AutofillCrypto
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.utils.CreditCardNetworkType
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
+import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -290,5 +288,49 @@ class CreditCardEditorViewTest {
                 )
             )
         }
+    }
+
+    @Test
+    fun `GIVEN invalid name on card WHEN the save button is clicked THEN error message is displayed`() {
+        creditCardEditorView.bind(getInitialCreditCardEditorState())
+
+        val billingName = "       "
+        val cardNumber = "2221000000000000"
+        val expiryMonth = 5
+
+        fragmentCreditCardEditorBinding.cardNumberInput.text = cardNumber.toEditable()
+        fragmentCreditCardEditorBinding.nameOnCardInput.text = billingName.toEditable()
+        fragmentCreditCardEditorBinding.expiryMonthDropDown.setSelection(expiryMonth - 1)
+
+        fragmentCreditCardEditorBinding.saveButton.performClick()
+
+        verify {
+            creditCardEditorView.validateForm()
+        }
+
+        assertFalse(creditCardEditorView.validateForm())
+        assertNotNull(fragmentCreditCardEditorBinding.nameOnCardLayout.error)
+    }
+
+    @Test
+    fun `GIVEN invalid card number WHEN the save button is clicked THEN error message is displayed`() {
+        creditCardEditorView.bind(getInitialCreditCardEditorState())
+
+        val billingName = "Banana Apple"
+        val cardNumber = "0000"
+        val expiryMonth = 5
+
+        fragmentCreditCardEditorBinding.cardNumberInput.text = cardNumber.toEditable()
+        fragmentCreditCardEditorBinding.nameOnCardInput.text = billingName.toEditable()
+        fragmentCreditCardEditorBinding.expiryMonthDropDown.setSelection(expiryMonth - 1)
+
+        fragmentCreditCardEditorBinding.saveButton.performClick()
+
+        verify {
+            creditCardEditorView.validateForm()
+        }
+
+        assertFalse(creditCardEditorView.validateForm())
+        assertNotNull(fragmentCreditCardEditorBinding.cardNumberLayout.error)
     }
 }


### PR DESCRIPTION
https://github.com/mozilla-mobile/fenix/pull/23797

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
