### PR TITLE
For #23841: Credit cards: Hide keyboard when selecting month or year

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/creditcards/CreditCardEditorFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/creditcards/CreditCardEditorFragment.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.fenix.settings.creditcards
 
+import android.annotation.SuppressLint
 import android.content.DialogInterface
 import android.os.Bundle
 import android.view.Menu
@@ -56,6 +57,7 @@ class CreditCardEditorFragment :
 
     private lateinit var interactor: CreditCardEditorInteractor
 
+    @SuppressLint("ClickableViewAccessibility")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
@@ -81,10 +83,20 @@ class CreditCardEditorFragment :
             creditCardEditorView = CreditCardEditorView(binding, interactor)
             creditCardEditorView.bind(creditCardEditorState)
 
-            binding.cardNumberInput.apply {
-                requestFocus()
-                placeCursorAtEnd()
-                showKeyboard()
+            binding.apply {
+                cardNumberInput.apply {
+                    requestFocus()
+                    placeCursorAtEnd()
+                    showKeyboard()
+                }
+                expiryMonthDropDown.setOnTouchListener { view, _ ->
+                    view?.hideKeyboard()
+                    false
+                }
+                expiryYearDropDown.setOnTouchListener { view, _ ->
+                    view?.hideKeyboard()
+                    false
+                }
             }
         }
     }


### PR DESCRIPTION


https://user-images.githubusercontent.com/36289013/155844318-21f32ecc-ee20-47d0-87d2-ee8375980f81.mp4



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

Fixes #23841
Fixes #23841
Fixes #23841