### PR TITLE
[UI Smoke test] Use app while tab crashed UI tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/CrashReportingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/CrashReportingTest.kt
@@ -47,10 +47,8 @@ class CrashReportingTest {
         featureSettingsHelper.resetAllFeatureFlags()
     }
 
-    @SmokeTest
     @Test
     fun closeTabCrashedReporterTest() {
-
         homeScreen {
         }.openNavigationToolbar {
         }.openTabCrashReporter {
@@ -61,7 +59,6 @@ class CrashReportingTest {
     }
 
     @Ignore("Test failure caused by: https://github.com/mozilla-mobile/fenix/issues/19964")
-    @SmokeTest
     @Test
     fun restoreTabCrashedReporterTest() {
         val website = TestAssetHelper.getGenericAsset(mockWebServer, 1)

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/CrashReportingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/CrashReportingTest.kt
@@ -1,0 +1,75 @@
+package org.mozilla.fenix.ui
+
+import androidx.compose.ui.test.junit4.AndroidComposeTestRule
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Before
+import org.junit.Ignore
+import org.junit.Rule
+import org.junit.Test
+import org.mozilla.fenix.customannotations.SmokeTest
+import org.mozilla.fenix.helpers.AndroidAssetDispatcher
+import org.mozilla.fenix.helpers.FeatureSettingsHelper
+import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
+import org.mozilla.fenix.helpers.TestAssetHelper
+import org.mozilla.fenix.ui.robots.homeScreen
+import org.mozilla.fenix.ui.robots.navigationToolbar
+
+class CrashReportingTest {
+
+    private lateinit var mockWebServer: MockWebServer
+    private val featureSettingsHelper = FeatureSettingsHelper()
+
+    @get:Rule
+    val activityTestRule = AndroidComposeTestRule(
+        HomeActivityIntentTestRule(),
+        { it.activity }
+    )
+
+    @Before
+    fun setUp() {
+        featureSettingsHelper.setJumpBackCFREnabled(false)
+        featureSettingsHelper.setPocketEnabled(false)
+
+        mockWebServer = MockWebServer().apply {
+            dispatcher = AndroidAssetDispatcher()
+            start()
+        }
+    }
+
+    @After
+    fun tearDown() {
+        mockWebServer.shutdown()
+        featureSettingsHelper.resetAllFeatureFlags()
+    }
+
+    @SmokeTest
+    @Test
+    fun closeTabCrashedReporterTest() {
+
+        homeScreen {
+        }.openNavigationToolbar {
+        }.openTabCrashReporter {
+        }.clickTabCrashedCloseButton {
+        }.openTabDrawer {
+            verifyNoOpenTabsInNormalBrowsing()
+        }
+    }
+
+    @Ignore("Test failure caused by: https://github.com/mozilla-mobile/fenix/issues/19964")
+    @SmokeTest
+    @Test
+    fun restoreTabCrashedReporterTest() {
+        val website = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        homeScreen {
+        }.openNavigationToolbar {
+        }.enterURLAndEnterToBrowser(website.url) {}
+
+        navigationToolbar {
+        }.openTabCrashReporter {
+            clickTabCrashedRestoreButton()
+            verifyPageContent(website.content)
+        }
+    }
+}

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/CrashReportingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/CrashReportingTest.kt
@@ -7,18 +7,22 @@ import org.junit.Before
 import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
+import org.mozilla.fenix.R
 import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.FeatureSettingsHelper
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
+import org.mozilla.fenix.helpers.TestHelper.getStringResource
 import org.mozilla.fenix.ui.robots.homeScreen
+import org.mozilla.fenix.ui.robots.mDevice
 import org.mozilla.fenix.ui.robots.navigationToolbar
 
 class CrashReportingTest {
 
     private lateinit var mockWebServer: MockWebServer
     private val featureSettingsHelper = FeatureSettingsHelper()
+    private val tabCrashMessage = getStringResource(R.string.tab_crash_title_2)
 
     @get:Rule
     val activityTestRule = AndroidComposeTestRule(
@@ -70,6 +74,68 @@ class CrashReportingTest {
         }.openTabCrashReporter {
             clickTabCrashedRestoreButton()
             verifyPageContent(website.content)
+        }
+    }
+
+    @SmokeTest
+    @Test
+    fun useAppWhileTabIsCrashedTest() {
+        val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+        val secondWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 2)
+
+        homeScreen {
+        }.openNavigationToolbar {
+        }.enterURLAndEnterToBrowser(firstWebPage.url) {
+            mDevice.waitForIdle()
+        }.openTabDrawer {
+        }.openNewTab {
+        }.submitQuery(secondWebPage.url.toString()) {
+            waitForPageToLoad()
+        }
+
+        navigationToolbar {
+        }.openTabCrashReporter {
+            verifyPageContent(tabCrashMessage)
+        }.openTabDrawer {
+            verifyExistingOpenTabs(firstWebPage.title)
+            verifyExistingOpenTabs(secondWebPage.title)
+        }.closeTabDrawer {
+        }.goToHomescreen {
+            verifyExistingTopSitesList()
+        }.openThreeDotMenu {
+            verifySettingsButton()
+        }
+    }
+
+    @SmokeTest
+    @Test
+    fun privateBrowsingUseAppWhileTabIsCrashedTest() {
+        val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+        val secondWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 2)
+
+        homeScreen {
+            togglePrivateBrowsingModeOnOff()
+        }.openNavigationToolbar {
+        }.enterURLAndEnterToBrowser(firstWebPage.url) {
+            mDevice.waitForIdle()
+        }.openTabDrawer {
+        }.openNewTab {
+        }.submitQuery(secondWebPage.url.toString()) {
+            waitForPageToLoad()
+            verifyPageContent("Page content: 2")
+        }
+
+        navigationToolbar {
+        }.openTabCrashReporter {
+            verifyPageContent(tabCrashMessage)
+        }.openTabDrawer {
+            verifyExistingOpenTabs(firstWebPage.title)
+            verifyExistingOpenTabs(secondWebPage.title)
+        }.closeTabDrawer {
+        }.goToHomescreen {
+            verifyPrivateSessionMessage()
+        }.openThreeDotMenu {
+            verifySettingsButton()
         }
     }
 }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -17,7 +17,6 @@ import mozilla.components.concept.engine.mediasession.MediaSession
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.IntentReceiverActivity
@@ -1020,34 +1019,6 @@ class SmokeTest {
             verifyAppearanceColorDark(true)
             verifyAppearanceColorLight(true)
             verifyAppearanceColorSepia(true)
-        }
-    }
-
-    @Test
-    fun closeTabCrashedReporterTest() {
-
-        homeScreen {
-        }.openNavigationToolbar {
-        }.openTabCrashReporter {
-        }.clickTabCrashedCloseButton {
-        }.openTabDrawer {
-            verifyNoOpenTabsInNormalBrowsing()
-        }
-    }
-
-    @Ignore("Test failure caused by: https://github.com/mozilla-mobile/fenix/issues/19964")
-    @Test
-    fun restoreTabCrashedReporterTest() {
-        val website = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-
-        homeScreen {
-        }.openNavigationToolbar {
-        }.enterURLAndEnterToBrowser(website.url) {}
-
-        navigationToolbar {
-        }.openTabCrashReporter {
-            clickTabCrashedRestoreButton()
-            verifyPageContent(website.content)
         }
     }
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -750,6 +750,8 @@ class BrowserRobot {
             val tabCrashedCloseButton = mDevice.findObject(text("Close tab"))
             tabCrashedCloseButton.click()
 
+            mDevice.waitForIdle()
+
             HomeScreenRobot().interact()
             return HomeScreenRobot.Transition()
         }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
@@ -222,14 +222,12 @@ class HomeScreenRobot {
         val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
 
         fun openTabDrawer(interact: TabDrawerRobot.() -> Unit): TabDrawerRobot.Transition {
-            mDevice.waitForIdle()
+            mDevice.findObject(
+                UiSelector().descriptionContains("open tab. Tap to switch tabs.")
+            ).waitForExists(waitingTime)
 
             tabsCounter().click()
-
-            mDevice.waitNotNull(
-                Until.findObject(By.res("$packageName:id/tab_layout")),
-                waitingTime
-            )
+            mDevice.waitNotNull(Until.findObject(By.res("$packageName:id/tab_layout")))
 
             TabDrawerRobot().interact()
             return TabDrawerRobot.Transition()


### PR DESCRIPTION
• Created a new CrashReportTest class and moved the related tests from the SmokeTest class

• Other refactoring work

• New "use app while tab crashed:" UI tests:
- `useAppWhileTabIsCrashedTest` ✅ Successfully passed 50x on Firebase
- `privateBrowsingUseAppWhileTabIsCrashedTest` ✅ Successfully passed 50x on Firebase

• Remove `@ SmokeTest` annotation for `closeTabCrashedReporterTest` and `restoreTabCrashedReporterTest`

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
