### PR TITLE
Revert "For #14321 - Dismiss search dialog buttons on edit cancel"

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/search/SearchDialogController.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchDialogController.kt
@@ -122,7 +122,6 @@ class SearchDialogController(
 
     override fun handleEditingCancelled() {
         clearToolbarFocus()
-        dismissDialog()
     }
 
     override fun handleTextChanged(text: String) {


### PR DESCRIPTION
Closes #23735.

This causes the regression described in #23735 which is definitely a bigger issue than #14321. We can work in an improved fix and land again.