### PR TITLE
For #23503: Respect studies and telemetry prefs when manually opting in to studies

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/nimbus/NimbusBranchesFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/nimbus/NimbusBranchesFragment.kt
@@ -47,6 +47,7 @@ class NimbusBranchesFragment : Fragment() {
         }
 
         controller = NimbusBranchesController(
+            context = requireContext(),
             nimbusBranchesStore = nimbusBranchesStore,
             experiments = requireContext().components.analytics.experiments,
             experimentId = args.experimentId

--- a/app/src/main/java/org/mozilla/fenix/nimbus/NimbusBranchesFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/nimbus/NimbusBranchesFragment.kt
@@ -10,6 +10,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -48,6 +49,7 @@ class NimbusBranchesFragment : Fragment() {
 
         controller = NimbusBranchesController(
             context = requireContext(),
+            navController = findNavController(),
             nimbusBranchesStore = nimbusBranchesStore,
             experiments = requireContext().components.analytics.experiments,
             experimentId = args.experimentId

--- a/app/src/main/java/org/mozilla/fenix/nimbus/controller/NimbusBranchesController.kt
+++ b/app/src/main/java/org/mozilla/fenix/nimbus/controller/NimbusBranchesController.kt
@@ -38,9 +38,9 @@ class NimbusBranchesController(
         val telemetryEnabled = context.settings().isTelemetryEnabled
         val experimentsEnabled = context.settings().isExperimentationEnabled
 
-        if (!telemetryEnabled && !experimentsEnabled) {
-            updateOptInState(branch)
+        updateOptInState(branch)
 
+        if (!telemetryEnabled && !experimentsEnabled) {
             val snackbarText = context.getString(R.string.experiments_snackbar)
             val buttonText = context.getString(R.string.experiments_snackbar_button)
             context.getRootView()?.let { v ->
@@ -58,8 +58,6 @@ class NimbusBranchesController(
                     }
                     .show()
             }
-        } else {
-            updateOptInState(branch)
         }
     }
 

--- a/app/src/main/java/org/mozilla/fenix/nimbus/controller/NimbusBranchesController.kt
+++ b/app/src/main/java/org/mozilla/fenix/nimbus/controller/NimbusBranchesController.kt
@@ -5,16 +5,16 @@
 package org.mozilla.fenix.nimbus.controller
 
 import android.content.Context
+import androidx.navigation.NavController
 import mozilla.components.service.nimbus.NimbusApi
 import mozilla.components.service.nimbus.ui.NimbusBranchesAdapterDelegate
 import org.mozilla.experiments.nimbus.Branch
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.FenixSnackbar
-import org.mozilla.fenix.components.metrics.MetricServiceType
-import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.getRootView
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.nimbus.NimbusBranchesAction
+import org.mozilla.fenix.nimbus.NimbusBranchesFragmentDirections
 import org.mozilla.fenix.nimbus.NimbusBranchesStore
 
 /**
@@ -28,6 +28,7 @@ import org.mozilla.fenix.nimbus.NimbusBranchesStore
  */
 class NimbusBranchesController(
     private val context: Context,
+    private val navController: NavController,
     private val nimbusBranchesStore: NimbusBranchesStore,
     private val experiments: NimbusApi,
     private val experimentId: String
@@ -39,9 +40,9 @@ class NimbusBranchesController(
 
         if (!telemetryEnabled && !experimentsEnabled) {
             updateOptInState(branch)
-            context.components.analytics.metrics.stop(MetricServiceType.Data)
 
             val snackbarText = context.getString(R.string.experiments_snackbar)
+            val buttonText = context.getString(R.string.experiments_snackbar_button)
             context.getRootView()?.let { v ->
                 FenixSnackbar.make(
                     view = v,
@@ -49,6 +50,12 @@ class NimbusBranchesController(
                     isDisplayedWithBrowserToolbar = false
                 )
                     .setText(snackbarText)
+                    .setAction(buttonText) {
+                        navController.navigate(
+                            NimbusBranchesFragmentDirections
+                                .actionNimbusBranchesFragmentToDataChoicesFragment()
+                        )
+                    }
                     .show()
             }
         } else {

--- a/app/src/main/java/org/mozilla/fenix/nimbus/controller/NimbusBranchesController.kt
+++ b/app/src/main/java/org/mozilla/fenix/nimbus/controller/NimbusBranchesController.kt
@@ -4,15 +4,22 @@
 
 package org.mozilla.fenix.nimbus.controller
 
+import android.content.Context
 import mozilla.components.service.nimbus.NimbusApi
 import mozilla.components.service.nimbus.ui.NimbusBranchesAdapterDelegate
 import org.mozilla.experiments.nimbus.Branch
+import org.mozilla.fenix.R
+import org.mozilla.fenix.components.FenixSnackbar
+import org.mozilla.fenix.components.metrics.MetricServiceType
+import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.getRootView
+import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.nimbus.NimbusBranchesAction
 import org.mozilla.fenix.nimbus.NimbusBranchesStore
 
 /**
  * [NimbusBranchesFragment] controller. This implements [NimbusBranchesAdapterDelegate] to handle
- * interactions with a Nimbus branch item.
+ * interactions with a Nimbus branch.
  *
  * @param nimbusBranchesStore An instance of [NimbusBranchesStore] for dispatching
  * [NimbusBranchesAction]s.
@@ -20,12 +27,36 @@ import org.mozilla.fenix.nimbus.NimbusBranchesStore
  * @param experimentId The string experiment-id or "slug" for a Nimbus experiment.
  */
 class NimbusBranchesController(
+    private val context: Context,
     private val nimbusBranchesStore: NimbusBranchesStore,
     private val experiments: NimbusApi,
     private val experimentId: String
 ) : NimbusBranchesAdapterDelegate {
 
     override fun onBranchItemClicked(branch: Branch) {
+        val telemetryEnabled = context.settings().isTelemetryEnabled
+        val experimentsEnabled = context.settings().isExperimentationEnabled
+
+        if (!telemetryEnabled && !experimentsEnabled) {
+            updateOptInState(branch)
+            context.components.analytics.metrics.stop(MetricServiceType.Data)
+
+            val snackbarText = context.getString(R.string.experiments_snackbar)
+            context.getRootView()?.let { v ->
+                FenixSnackbar.make(
+                    view = v,
+                    FenixSnackbar.LENGTH_LONG,
+                    isDisplayedWithBrowserToolbar = false
+                )
+                    .setText(snackbarText)
+                    .show()
+            }
+        } else {
+            updateOptInState(branch)
+        }
+    }
+
+    private fun updateOptInState(branch: Branch) {
         nimbusBranchesStore.dispatch(
             if (experiments.getExperimentBranch(experimentId) != branch.slug) {
                 experiments.optInWithBranch(experimentId, branch.slug)

--- a/app/src/main/java/org/mozilla/fenix/settings/DataChoicesFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/DataChoicesFragment.kt
@@ -18,33 +18,30 @@ import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.showToolbar
 
 /**
- * Settings screen that allows the user to configure their data collection and experimentation
- * preferences.
+ * Lets the user toggle telemetry on/off.
  */
 class DataChoicesFragment : PreferenceFragmentCompat() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val settings = requireContext().settings()
-        val analytics = requireContext().components.analytics
-
+        val context = requireContext()
         preferenceManager.sharedPreferences.registerOnSharedPreferenceChangeListener(this) { _, key ->
             if (key == getPreferenceKey(R.string.pref_key_telemetry)) {
-                if (settings.isTelemetryEnabled) {
-                    analytics.metrics.start(MetricServiceType.Data)
+                if (context.settings().isTelemetryEnabled) {
+                    context.components.analytics.metrics.start(MetricServiceType.Data)
                 } else {
-                    analytics.metrics.stop(MetricServiceType.Data)
+                    context.components.analytics.metrics.stop(MetricServiceType.Data)
                 }
                 // Reset experiment identifiers on both opt-in and opt-out; it's likely
                 // that in future we will need to pass in the new telemetry client_id
                 // to this method when the user opts back in.
-                analytics.experiments.resetTelemetryIdentifiers()
+                context.components.analytics.experiments.resetTelemetryIdentifiers()
             } else if (key == getPreferenceKey(R.string.pref_key_marketing_telemetry)) {
-                if (settings.isMarketingTelemetryEnabled) {
-                    analytics.metrics.start(MetricServiceType.Marketing)
+                if (context.settings().isMarketingTelemetryEnabled) {
+                    context.components.analytics.metrics.start(MetricServiceType.Marketing)
                 } else {
-                    analytics.metrics.stop(MetricServiceType.Marketing)
+                    context.components.analytics.metrics.stop(MetricServiceType.Marketing)
                 }
             }
         }

--- a/app/src/main/java/org/mozilla/fenix/settings/DataChoicesFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/DataChoicesFragment.kt
@@ -18,30 +18,33 @@ import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.showToolbar
 
 /**
- * Lets the user toggle telemetry on/off.
+ * Settings screen that allows the user to configure their data collection and experimentation
+ * preferences.
  */
 class DataChoicesFragment : PreferenceFragmentCompat() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val context = requireContext()
+        val settings = requireContext().settings()
+        val analytics = requireContext().components.analytics
+
         preferenceManager.sharedPreferences.registerOnSharedPreferenceChangeListener(this) { _, key ->
             if (key == getPreferenceKey(R.string.pref_key_telemetry)) {
-                if (context.settings().isTelemetryEnabled) {
-                    context.components.analytics.metrics.start(MetricServiceType.Data)
+                if (settings.isTelemetryEnabled) {
+                    analytics.metrics.start(MetricServiceType.Data)
                 } else {
-                    context.components.analytics.metrics.stop(MetricServiceType.Data)
+                    analytics.metrics.stop(MetricServiceType.Data)
                 }
                 // Reset experiment identifiers on both opt-in and opt-out; it's likely
                 // that in future we will need to pass in the new telemetry client_id
                 // to this method when the user opts back in.
-                context.components.analytics.experiments.resetTelemetryIdentifiers()
+                analytics.experiments.resetTelemetryIdentifiers()
             } else if (key == getPreferenceKey(R.string.pref_key_marketing_telemetry)) {
-                if (context.settings().isMarketingTelemetryEnabled) {
-                    context.components.analytics.metrics.start(MetricServiceType.Marketing)
+                if (settings.isMarketingTelemetryEnabled) {
+                    analytics.metrics.start(MetricServiceType.Marketing)
                 } else {
-                    context.components.analytics.metrics.stop(MetricServiceType.Marketing)
+                    analytics.metrics.stop(MetricServiceType.Marketing)
                 }
             }
         }

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -1160,6 +1160,14 @@
             <argument
                 android:name="experimentName"
                 app:argType="string" />
+            <action
+                android:id="@+id/action_nimbusBranchesFragment_to_dataChoicesFragment"
+                app:destination="@id/dataChoicesFragment"
+                app:enterAnim="@anim/slide_in_right"
+                app:exitAnim="@anim/slide_out_left"
+                app:popEnterAnim="@anim/slide_in_left"
+                app:popExitAnim="@anim/slide_out_right"
+                app:popUpTo="@id/settingsFragment" />
         </fragment>
     </navigation>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1765,5 +1765,7 @@
     <string name="pocket_stories_feature_learn_more">Learn more</string>
 
     <!-- Snackbar message for enrolling in a Nimbus experiment from the secret settings when Studies preference is Off.-->
-    <string name="experiments_snackbar">Study enrollment change successful, but no data will be sent. Enable Studies and telemetry to send data.</string>
+    <string name="experiments_snackbar">Enable telemetry to send data.</string>
+    <!-- Snackbar button text to navigate to telemetry settings.-->
+    <string name="experiments_snackbar_button">Go to settings</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1763,4 +1763,7 @@
     <string name="pocket_stories_feature_caption">Part of the Firefox family. %s</string>
     <!-- Clickable text for opening an external link for more information about Pocket. -->
     <string name="pocket_stories_feature_learn_more">Learn more</string>
+
+    <!-- Snackbar message for enrolling in a Nimbus experiment from the secret settings when Studies preference is Off.-->
+    <string name="experiments_snackbar">Study enrollment change successful, but no data will be sent. Enable Studies and telemetry to send data.</string>
 </resources>

--- a/app/src/test/java/org/mozilla/fenix/nimbus/NimbusBranchesControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/nimbus/NimbusBranchesControllerTest.kt
@@ -4,16 +4,35 @@
 
 package org.mozilla.fenix.nimbus
 
+import android.R
+import android.app.Activity
+import android.content.Context
+import android.view.View
+import android.view.ViewGroup
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
 import io.mockk.verify
+import io.mockk.verifyAll
 import mozilla.components.service.nimbus.NimbusApi
 import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.mozilla.experiments.nimbus.Branch
+import org.mozilla.fenix.components.Components
+import org.mozilla.fenix.components.FenixSnackbar
+import org.mozilla.fenix.components.metrics.MetricController
+import org.mozilla.fenix.components.metrics.MetricServiceType
+import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.getRootView
+import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.nimbus.controller.NimbusBranchesController
+import org.mozilla.fenix.utils.Settings
 
+@RunWith(FenixRobolectricTestRunner::class)
 class NimbusBranchesControllerTest {
 
     private val experiments: NimbusApi = mockk(relaxed = true)
@@ -21,15 +40,155 @@ class NimbusBranchesControllerTest {
 
     private lateinit var controller: NimbusBranchesController
     private lateinit var nimbusBranchesStore: NimbusBranchesStore
+    private lateinit var settings: Settings
+    private lateinit var activity: Context
+    private lateinit var components: Components
+    private lateinit var metrics: MetricController
+    private lateinit var snackbar: FenixSnackbar
+    private lateinit var rootView: View
 
     @Before
     fun setup() {
+        components = mockk(relaxed = true)
+        settings = mockk(relaxed = true)
+        metrics = mockk(relaxed = true)
+        snackbar = mockk(relaxed = true)
+
+        rootView = mockk<ViewGroup>(relaxed = true)
+        activity = mockk<Activity>(relaxed = true) {
+            every { findViewById<View>(R.id.content) } returns rootView
+            every { getRootView() } returns rootView
+        }
+
+        mockkObject(FenixSnackbar)
+        every { FenixSnackbar.make(any(), any(), any(), any()) } returns snackbar
+
+        every { activity.settings() } returns settings
+        every { activity.components.analytics.metrics } returns metrics
+
         nimbusBranchesStore = NimbusBranchesStore(NimbusBranchesState(emptyList()))
-        controller = NimbusBranchesController(nimbusBranchesStore, experiments, experimentId)
+        controller = NimbusBranchesController(
+            activity,
+            nimbusBranchesStore,
+            experiments,
+            experimentId
+        )
     }
 
     @Test
     fun `WHEN branch item is clicked THEN branch is opted into and selectedBranch state is updated`() {
+        every { settings.isTelemetryEnabled } returns true
+        every { settings.isExperimentationEnabled } returns true
+
+        val branch = Branch(
+            slug = "slug",
+            ratio = 1
+        )
+
+        controller.onBranchItemClicked(branch)
+
+        nimbusBranchesStore.waitUntilIdle()
+
+        verify {
+            experiments.optInWithBranch(experimentId, branch.slug)
+        }
+
+        assertEquals(branch.slug, nimbusBranchesStore.state.selectedBranch)
+    }
+
+    @Test
+    fun `WHEN branch item is clicked THEN branch is opted out and selectedBranch state is updated`() {
+        every { settings.isTelemetryEnabled } returns true
+        every { settings.isExperimentationEnabled } returns true
+        every { experiments.getExperimentBranch(experimentId) } returns "slug"
+
+        val branch = Branch(
+            slug = "slug",
+            ratio = 1
+        )
+
+        controller.onBranchItemClicked(branch)
+
+        nimbusBranchesStore.waitUntilIdle()
+
+        verify {
+            experiments.optOut(experimentId)
+        }
+    }
+
+    @Test
+    fun `WHEN studies and telemetry are ON and item is clicked THEN branch is opted in`() {
+        every { settings.isTelemetryEnabled } returns true
+        every { settings.isExperimentationEnabled } returns true
+
+        val branch = Branch(
+            slug = "slug",
+            ratio = 1
+        )
+
+        controller.onBranchItemClicked(branch)
+
+        nimbusBranchesStore.waitUntilIdle()
+
+        verify {
+            experiments.optInWithBranch(experimentId, branch.slug)
+        }
+
+        assertEquals(branch.slug, nimbusBranchesStore.state.selectedBranch)
+    }
+
+    @Test
+    fun `WHEN studies and telemetry are Off THEN branch is opted in AND data is not sent`() {
+        every { settings.isTelemetryEnabled } returns false
+        every { settings.isExperimentationEnabled } returns false
+        every { activity.getString(any()) } returns "hello"
+
+        val branch = Branch(
+            slug = "slug",
+            ratio = 1
+        )
+
+        controller.onBranchItemClicked(branch)
+
+        nimbusBranchesStore.waitUntilIdle()
+
+        verify(exactly = 1) { metrics.stop(MetricServiceType.Data) }
+
+        verifyAll {
+            experiments.getExperimentBranch(experimentId)
+            experiments.optInWithBranch(experimentId, branch.slug)
+            snackbar.setText("hello")
+        }
+
+        assertEquals(branch.slug, nimbusBranchesStore.state.selectedBranch)
+    }
+
+    @Test
+    fun `WHEN studies are ON and telemetry Off THEN branch is opted in`() {
+        every { settings.isExperimentationEnabled } returns true
+        every { settings.isTelemetryEnabled } returns false
+
+        val branch = Branch(
+            slug = "slug",
+            ratio = 1
+        )
+
+        controller.onBranchItemClicked(branch)
+
+        nimbusBranchesStore.waitUntilIdle()
+
+        verify {
+            experiments.optInWithBranch(experimentId, branch.slug)
+        }
+
+        assertEquals(branch.slug, nimbusBranchesStore.state.selectedBranch)
+    }
+
+    @Test
+    fun `WHEN studies are OFF and telemetry ON THEN branch is opted in`() {
+        every { settings.isExperimentationEnabled } returns false
+        every { settings.isTelemetryEnabled } returns true
+
         val branch = Branch(
             slug = "slug",
             ratio = 1

--- a/app/src/test/java/org/mozilla/fenix/nimbus/NimbusBranchesControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/nimbus/NimbusBranchesControllerTest.kt
@@ -9,6 +9,7 @@ import android.app.Activity
 import android.content.Context
 import android.view.View
 import android.view.ViewGroup
+import androidx.navigation.NavController
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -24,7 +25,6 @@ import org.mozilla.experiments.nimbus.Branch
 import org.mozilla.fenix.components.Components
 import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.components.metrics.MetricController
-import org.mozilla.fenix.components.metrics.MetricServiceType
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.getRootView
 import org.mozilla.fenix.ext.settings
@@ -39,6 +39,7 @@ class NimbusBranchesControllerTest {
     private val experimentId = "id"
 
     private lateinit var controller: NimbusBranchesController
+    private lateinit var navController: NavController
     private lateinit var nimbusBranchesStore: NimbusBranchesStore
     private lateinit var settings: Settings
     private lateinit var activity: Context
@@ -53,6 +54,7 @@ class NimbusBranchesControllerTest {
         settings = mockk(relaxed = true)
         metrics = mockk(relaxed = true)
         snackbar = mockk(relaxed = true)
+        navController = mockk(relaxed = true)
 
         rootView = mockk<ViewGroup>(relaxed = true)
         activity = mockk<Activity>(relaxed = true) {
@@ -66,9 +68,14 @@ class NimbusBranchesControllerTest {
         every { activity.settings() } returns settings
         every { activity.components.analytics.metrics } returns metrics
 
+        every { navController.currentDestination } returns mockk {
+            every { id } returns org.mozilla.fenix.R.id.nimbusBranchesFragment
+        }
+
         nimbusBranchesStore = NimbusBranchesStore(NimbusBranchesState(emptyList()))
         controller = NimbusBranchesController(
             activity,
+            navController,
             nimbusBranchesStore,
             experiments,
             experimentId
@@ -151,8 +158,6 @@ class NimbusBranchesControllerTest {
         controller.onBranchItemClicked(branch)
 
         nimbusBranchesStore.waitUntilIdle()
-
-        verify(exactly = 1) { metrics.stop(MetricServiceType.Data) }
 
         verifyAll {
             experiments.getExperimentBranch(experimentId)


### PR DESCRIPTION
For #23503 

For reviewer: 
* We want to make sure that the user's settings for data collection (telemetry) and experimentation (studies) are respected, even when they are using the [secret nimbus settings](https://github.com/mozilla-mobile/fenix/wiki/%22Secret-settings%22-debug-menu-instructions) to manually opt in and out of experiments
* This PR puts a little bit more logic around the manual opt in/out to check the user's settings before we change anything
* To test this: 
   * Change your data collection settings: Go to three dot menu -> Data collection -> toggle "usage and technical data" (telemetry) and "Studies" (experimentation/Nimbus)
   * Enable secret settings (see wiki link above)
   * Go to settings -> Nimbus Experiments (all the way at the bottom) -> select an experiment from the list -> select a branch from the list (**note** the color is messed up on this page so it's hard to see the ✅ when you select a branch. You can kinda see the white checkmark in my screenshot below)
   * When telemetry && experimentation are OFF, you will now see a snackbar telling you what's going on
   * In all other cases, you won't see the snackbar (see [cases](https://github.com/mozilla-mobile/fenix/issues/23503#issuecomment-1040860419))

<img width="397" alt="image" src="https://user-images.githubusercontent.com/43795363/155438410-8b5eb5ea-f7ec-4a76-b854-512d6e9cd6f6.png">  

<img width="400" alt="image" src="https://user-images.githubusercontent.com/43795363/155438447-26c17505-00a4-4713-b061-726ad3f604f7.png">

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
