### PR TITLE
For #23399: Add tabs tray multi-select telemetry.

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -3821,6 +3821,106 @@ tabs_tray:
     notification_emails:
       - android-probes@mozilla.com
     expires: 107
+  enter_multiselect_mode:
+    type: event
+    description: |
+      User has entered multiselect mode.
+    bugs:
+      - https://github.com/mozilla-mobile/fenix/issues/23399
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/23964#issuecomment-1051128057
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: 107
+    metadata:
+      tags:
+        - Tabs
+    extra_keys:
+      tab_selected:
+        description: If a tab was selected when entering multi select.
+        type: boolean
+  share_selected_tabs:
+    type: event
+    description: |
+      User has chosen to share selected tabs.
+    bugs:
+      - https://github.com/mozilla-mobile/fenix/issues/23399
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/23964#issuecomment-1051128057
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: 107
+    metadata:
+      tags:
+        - Tabs
+    extra_keys:
+      tab_count:
+        description: The number of selected tabs shared.
+        type: quantity
+  bookmark_selected_tabs:
+    type: event
+    description: |
+      User has chosen to bookmark selected tabs.
+    bugs:
+      - https://github.com/mozilla-mobile/fenix/issues/23399
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/23964#issuecomment-1051128057
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: 107
+    metadata:
+      tags:
+        - Tabs
+    extra_keys:
+      tab_count:
+        description: The number of selected tabs bookmarked.
+        type: quantity
+  close_selected_tabs:
+    type: event
+    description: |
+      User has chosen to close selected tabs.
+    bugs:
+      - https://github.com/mozilla-mobile/fenix/issues/23399
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/23964#issuecomment-1051128057
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: 107
+    metadata:
+      tags:
+        - Tabs
+    extra_keys:
+      tab_count:
+        description: The number of selected tabs closed.
+        type: quantity
+  selected_tabs_to_collection:
+    type: event
+    description: |
+      User has chosen to save selected tabs to a collection.
+    bugs:
+      - https://github.com/mozilla-mobile/fenix/issues/23399
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/23964#issuecomment-1051128057
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: 107
+    metadata:
+      tags:
+        - Tabs
+    extra_keys:
+      tab_count:
+        description: The number of selected tabs added to colelction.
+        type: quantity
 
 collections:
   renamed:

--- a/app/src/main/java/org/mozilla/fenix/tabstray/NavigationInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/NavigationInteractor.kt
@@ -16,6 +16,7 @@ import mozilla.components.browser.storage.sync.Tab as SyncTab
 import mozilla.components.concept.engine.prompt.ShareData
 import mozilla.components.service.fxa.manager.FxaAccountManager
 import org.mozilla.fenix.BrowserDirection
+import org.mozilla.fenix.GleanMetrics.TabsTray
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.collections.CollectionsDialog
 import org.mozilla.fenix.collections.show
@@ -146,6 +147,8 @@ class DefaultNavigationInteractor(
     }
 
     override fun onShareTabs(tabs: Collection<TabSessionState>) {
+        TabsTray.shareSelectedTabs.record(TabsTray.ShareSelectedTabsExtra(tabCount = tabs.size))
+
         val data = tabs.map {
             ShareData(url = it.content.url, title = it.content.title)
         }
@@ -194,6 +197,8 @@ class DefaultNavigationInteractor(
     }
 
     override fun onSaveToCollections(tabs: Collection<TabSessionState>) {
+        TabsTray.selectedTabsToCollection.record(TabsTray.SelectedTabsToCollectionExtra(tabCount = tabs.size))
+
         metrics.track(Event.TabsTraySaveToCollectionPressed)
         tabsTrayStore.dispatch(TabsTrayAction.ExitSelectMode)
 
@@ -219,6 +224,8 @@ class DefaultNavigationInteractor(
     }
 
     override fun onSaveToBookmarks(tabs: Collection<TabSessionState>) {
+        TabsTray.bookmarkSelectedTabs.record(TabsTray.BookmarkSelectedTabsExtra(tabCount = tabs.size))
+
         tabs.forEach { tab ->
             // We don't combine the context with lifecycleScope so that our jobs are not cancelled
             // if we leave the fragment, i.e. we still want the bookmarks to be added if the

--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayController.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayController.kt
@@ -15,6 +15,7 @@ import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.concept.base.profiler.Profiler
 import mozilla.components.feature.tabs.TabsUseCases
 import mozilla.components.lib.state.DelicateAction
+import org.mozilla.fenix.GleanMetrics.TabsTray
 import org.mozilla.fenix.R
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.browser.browsingmode.BrowsingModeManager
@@ -200,6 +201,8 @@ class DefaultTabsTrayController(
      * This method has no effect for tabs that do not exist.
      */
     override fun handleMultipleTabsDeletion(tabs: Collection<TabSessionState>) {
+        TabsTray.closeSelectedTabs.record(TabsTray.CloseSelectedTabsExtra(tabCount = tabs.size))
+
         val isPrivate = tabs.any { it.content.private }
 
         // If user closes all the tabs from selected tabs page dismiss tray and navigate home.

--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayMiddleware.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayMiddleware.kt
@@ -7,6 +7,7 @@ package org.mozilla.fenix.tabstray
 import androidx.annotation.VisibleForTesting
 import mozilla.components.lib.state.Middleware
 import mozilla.components.lib.state.MiddlewareContext
+import org.mozilla.fenix.GleanMetrics.TabsTray
 import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.components.metrics.MetricController
 
@@ -53,6 +54,15 @@ class TabsTrayMiddleware(
                         metrics.track(Event.SearchTermGroupSizeDistribution(tabGroupSizeMapping))
                     }
                 }
+            }
+            is TabsTrayAction.EnterSelectMode -> {
+                TabsTray.enterMultiselectMode.record(TabsTray.EnterMultiselectModeExtra(false))
+            }
+            is TabsTrayAction.AddSelectTab -> {
+                TabsTray.enterMultiselectMode.record(TabsTray.EnterMultiselectModeExtra(true))
+            }
+            else -> {
+                // no-op
             }
         }
     }


### PR DESCRIPTION
Note: As no other pointer was given, I chose the expiry version as 107, in line with the other existing metrics for the tab tray.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
