### PR TITLE
No issue: remove 'mozilla-mobile/releng' as CODEOWNER of /automation …

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,9 +26,9 @@
 * @mozilla-mobile/ACT @mozilla-mobile/fenix
 /.cron.yml @mozilla-mobile/releng @mozilla-mobile/fenix
 /.taskcluster.yml @mozilla-mobile/releng @mozilla-mobile/fenix
-/automation/ @mozilla-mobile/releng @mozilla-mobile/fenix
+/automation/ @mozilla-mobile/fenix
 /taskcluster/ @mozilla-mobile/releng @mozilla-mobile/fenix
-/.github/ @mozilla-mobile/releng @mozilla-mobile/fenix
+/.github/ @mozilla-mobile/fenix
 
 # --- PERFORMANCE START --- #
 # The performance team would like to monitor some files to understand


### PR DESCRIPTION
…and /.github

These directories are specific to Fenix. After a quick scan and chat
with Releng, we don't have knowledge / motivation to be maintainers
here.

Releng will continue to be CODEOWNERS of core taskcluster files though.
