### PR TITLE
fixes #23981: open download function and override for test

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -789,7 +789,7 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
     override fun getWorkManagerConfiguration() = Builder().setMinimumLoggingLevel(INFO).build()
 
     @OptIn(DelicateCoroutinesApi::class)
-    private fun downloadWallpapers() {
+    open fun downloadWallpapers() {
         if (FeatureFlags.showWallpapers) {
             GlobalScope.launch {
                 components.wallpaperManager.downloadAllRemoteWallpapers()

--- a/app/src/test/java/org/mozilla/fenix/helpers/FenixRobolectricTestApplication.kt
+++ b/app/src/test/java/org/mozilla/fenix/helpers/FenixRobolectricTestApplication.kt
@@ -29,6 +29,8 @@ class FenixRobolectricTestApplication : FenixApplication() {
 
     override fun setupInMainProcessOnly() = Unit
 
+    override fun downloadWallpapers() = Unit
+
     private fun setApplicationTheme() {
         // According to the Robolectric devs, the application context will not have the <application>'s
         // theme but will use the platform's default team so we set our theme here. We change it here


### PR DESCRIPTION
### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
