### PR TITLE
CI for PR#20067

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarView.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarView.kt
@@ -155,7 +155,8 @@ class BrowserToolbarView(
                     lifecycleOwner = lifecycleOwner,
                     bookmarksStorage = bookmarkStorage,
                     pinnedSiteStorage = components.core.pinnedSiteStorage,
-                    isPinningSupported = isPinningSupported
+                    isPinningSupported = isPinningSupported,
+                    onMenuBuilderChanged = { view.display.menuBuilder = it }
                 )
                 view.display.setMenuDismissAction {
                     view.invalidateActions()

--- a/app/src/main/java/org/mozilla/fenix/home/HomeMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeMenu.kt
@@ -22,6 +22,7 @@ import mozilla.components.browser.menu.item.BrowserMenuImageText
 import mozilla.components.concept.sync.AccountObserver
 import mozilla.components.concept.sync.AuthType
 import mozilla.components.concept.sync.OAuthAccount
+import mozilla.components.concept.sync.Profile
 import mozilla.components.support.ktx.android.content.getColorFromAttr
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.accounts.AccountState
@@ -93,25 +94,25 @@ class HomeMenu(
     private fun getSyncItemTitle(): String =
         accountManager.accountProfileEmail ?: context.getString(R.string.sync_menu_sign_in)
 
-    private val syncSignInMenuItem = BrowserMenuImageText(
-        getSyncItemTitle(),
-        R.drawable.ic_synced_tabs,
-        primaryTextColor
-    ) {
-        onItemTapped.invoke(Item.SyncAccount(accountManager.accountState))
-    }
-
-    val desktopItem = BrowserMenuImageSwitch(
-        imageResource = R.drawable.ic_desktop,
-        label = context.getString(R.string.browser_menu_desktop_site),
-        initialState = { context.settings().openNextTabInDesktopMode }
-    ) { checked ->
-        onItemTapped.invoke(Item.DesktopMode(checked))
-    }
-
     @Suppress("ComplexMethod")
     private fun coreMenuItems(): List<BrowserMenuItem> {
         val settings = context.components.settings
+
+        val syncSignInMenuItem = BrowserMenuImageText(
+            getSyncItemTitle(),
+            R.drawable.ic_synced_tabs,
+            primaryTextColor
+        ) {
+            onItemTapped.invoke(Item.SyncAccount(accountManager.accountState))
+        }
+
+        val desktopItem = BrowserMenuImageSwitch(
+            imageResource = R.drawable.ic_desktop,
+            label = context.getString(R.string.browser_menu_desktop_site),
+            initialState = { context.settings().openNextTabInDesktopMode }
+        ) { checked ->
+            onItemTapped.invoke(Item.DesktopMode(checked))
+        }
 
         val bookmarksItem = BrowserMenuImageText(
             context.getString(R.string.library_bookmarks),
@@ -217,10 +218,8 @@ class HomeMenu(
     }
 
     init {
-        val menuItems = coreMenuItems()
-
         // Report initial state.
-        onMenuBuilderChanged(BrowserMenuBuilder(menuItems))
+        onMenuBuilderChanged(BrowserMenuBuilder(coreMenuItems()))
 
         // Observe account state changes, and update menu item builder with a new set of items.
         context.components.backgroundServices.accountManagerAvailableQueue.runIfReadyOrQueue {
@@ -228,13 +227,24 @@ class HomeMenu(
             if (lifecycleOwner.lifecycle.currentState == Lifecycle.State.DESTROYED) {
                 return@runIfReadyOrQueue
             }
+
             context.components.backgroundServices.accountManager.register(
                 object : AccountObserver {
                     override fun onAuthenticationProblems() {
                         lifecycleOwner.lifecycleScope.launch(Dispatchers.Main) {
                             onMenuBuilderChanged(
                                 BrowserMenuBuilder(
-                                    menuItems
+                                    coreMenuItems()
+                                )
+                            )
+                        }
+                    }
+
+                    override fun onProfileUpdated(profile: Profile) {
+                        lifecycleOwner.lifecycleScope.launch(Dispatchers.Main) {
+                            onMenuBuilderChanged(
+                                BrowserMenuBuilder(
+                                    coreMenuItems()
                                 )
                             )
                         }
@@ -244,7 +254,7 @@ class HomeMenu(
                         lifecycleOwner.lifecycleScope.launch(Dispatchers.Main) {
                             onMenuBuilderChanged(
                                 BrowserMenuBuilder(
-                                    menuItems
+                                    coreMenuItems()
                                 )
                             )
                         }
@@ -254,7 +264,7 @@ class HomeMenu(
                         lifecycleOwner.lifecycleScope.launch(Dispatchers.Main) {
                             onMenuBuilderChanged(
                                 BrowserMenuBuilder(
-                                    menuItems
+                                    coreMenuItems()
                                 )
                             )
                         }


### PR DESCRIPTION
CI for https://github.com/mozilla-mobile/fenix/pull/20067
(see [guide to merging contributor PRs](https://github.com/mozilla-mobile/fenix/wiki/Guide-to-merging-contributor-PRs))

For #19657: Using AccountObserver with context.components.backgroundServices.accountManager.register to monitor account state changes in DefaultToolbarMenu.kt to keep it similar to HomeMenu.kt



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
