### PR TITLE
For #24006 - Return a null change payload if the new top sites list is larger than the old

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlAdapter.kt
@@ -21,10 +21,10 @@ import org.mozilla.fenix.components.tips.Tip
 import org.mozilla.fenix.home.BottomSpacerViewHolder
 import org.mozilla.fenix.home.HomeFragmentStore
 import org.mozilla.fenix.home.TopPlaceholderViewHolder
-import org.mozilla.fenix.home.pocket.PocketStoriesViewHolder
-import org.mozilla.fenix.home.recentbookmarks.view.RecentBookmarksHeaderViewHolder
 import org.mozilla.fenix.home.pocket.PocketCategoriesViewHolder
 import org.mozilla.fenix.home.pocket.PocketRecommendationsHeaderViewHolder
+import org.mozilla.fenix.home.pocket.PocketStoriesViewHolder
+import org.mozilla.fenix.home.recentbookmarks.view.RecentBookmarksHeaderViewHolder
 import org.mozilla.fenix.home.recentbookmarks.view.RecentBookmarksViewHolder
 import org.mozilla.fenix.home.recenttabs.view.RecentTabViewHolder
 import org.mozilla.fenix.home.recenttabs.view.RecentTabsHeaderViewHolder
@@ -84,11 +84,13 @@ sealed class AdapterItem(@LayoutRes val viewType: Int) {
          *
          * See https://github.com/mozilla-mobile/fenix/pull/20189#issuecomment-877124730
          */
+        @Suppress("ComplexCondition")
         override fun getChangePayload(newItem: AdapterItem): Any? {
             val newTopSites = (newItem as? TopSitePager)
             val oldTopSites = (this as? TopSitePager)
 
             if (newTopSites == null || oldTopSites == null ||
+                newTopSites.topSites.size > oldTopSites.topSites.size ||
                 (newTopSites.topSites.size > TopSitePagerViewHolder.TOP_SITES_PER_PAGE)
                 != (oldTopSites.topSites.size > TopSitePagerViewHolder.TOP_SITES_PER_PAGE)
             ) {

--- a/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/SessionControlAdapterTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/SessionControlAdapterTest.kt
@@ -50,6 +50,18 @@ class SessionControlAdapterTest {
     }
 
     @Test
+    fun `GIVEN topSitePager with 3 topSites WHEN getChangePayload with 5 items THEN return null`() {
+        val newItem = TopSitePager(mockk(relaxed = true))
+        val topSitePager = TopSitePager(mockk(relaxed = true))
+        every { topSitePager.topSites.size } returns 3
+        every { newItem.topSites.size } returns 5
+
+        val result = topSitePager.getChangePayload(newItem)
+
+        assertNull(result)
+    }
+
+    @Test
     fun `GIVEN two topSites WHEN getChangePayload called with one changed item THEN return TopSitePagerPayload with changes`() {
         val topSite0 = TopSite.Frecent(-1, "topSite0", "", 0)
         val topSite1 = TopSite.Frecent(-1, "topSite1", "", 0)


### PR DESCRIPTION
Fixes #24006, realistically just gonna convert top sites to compose after this.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
