### PR TITLE
For #23719 - Replace preference framework strings with string resources

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/collections/CollectionsDialog.kt
+++ b/app/src/main/java/org/mozilla/fenix/collections/CollectionsDialog.kt
@@ -62,7 +62,7 @@ fun CollectionsDialog.show(
 
     val builder = AlertDialog.Builder(context).setTitle(R.string.tab_tray_select_collection)
         .setView(layout)
-        .setPositiveButton(android.R.string.ok) { dialog, _ ->
+        .setPositiveButton(R.string.create_collection_positive) { dialog, _ ->
             val selectedCollection =
                 (list.adapter as CollectionsListAdapter).getSelectedCollection()
             val collection = storage.cachedTabCollections[selectedCollection]
@@ -73,7 +73,7 @@ fun CollectionsDialog.show(
             }
 
             dialog.dismiss()
-        }.setNegativeButton(android.R.string.cancel) { dialog, _ ->
+        }.setNegativeButton(R.string.create_collection_negative) { dialog, _ ->
             onNegativeButtonClick.invoke()
 
             dialog.cancel()
@@ -110,7 +110,7 @@ internal fun CollectionsDialog.showAddNewDialog(
 
     AlertDialog.Builder(context)
         .setTitle(R.string.tab_tray_add_new_collection)
-        .setView(layout).setPositiveButton(android.R.string.ok) { dialog, _ ->
+        .setView(layout).setPositiveButton(R.string.create_collection_positive) { dialog, _ ->
 
             MainScope().launch {
                 val id = storage.createCollection(
@@ -122,7 +122,7 @@ internal fun CollectionsDialog.showAddNewDialog(
 
             dialog.dismiss()
         }
-        .setNegativeButton(android.R.string.cancel) { dialog, _ ->
+        .setNegativeButton(R.string.create_collection_negative) { dialog, _ ->
             onNegativeButtonClick.invoke()
             dialog.cancel()
         }

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/edit/EditBookmarkFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/edit/EditBookmarkFragment.kt
@@ -201,7 +201,7 @@ class EditBookmarkFragment : Fragment(R.layout.fragment_edit_bookmark) {
         activity?.let { activity ->
             AlertDialog.Builder(activity).apply {
                 setMessage(R.string.bookmark_deletion_confirmation)
-                setNegativeButton(android.R.string.cancel) { dialog: DialogInterface, _ ->
+                setNegativeButton(R.string.bookmark_delete_negative) { dialog: DialogInterface, _ ->
                     dialog.cancel()
                 }
                 setPositiveButton(R.string.tab_collection_dialog_positive) { dialog: DialogInterface, _ ->

--- a/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/LoginDetailFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/LoginDetailFragment.kt
@@ -195,7 +195,7 @@ class LoginDetailFragment : SecureFragment(R.layout.fragment_login_detail) {
         activity?.let { activity ->
             deleteDialog = AlertDialog.Builder(activity).apply {
                 setMessage(R.string.login_deletion_confirmation)
-                setNegativeButton(android.R.string.cancel) { dialog: DialogInterface, _ ->
+                setNegativeButton(R.string.dialog_delete_negative) { dialog: DialogInterface, _ ->
                     dialog.cancel()
                 }
                 setPositiveButton(R.string.dialog_delete_positive) { dialog: DialogInterface, _ ->

--- a/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsDetailsExceptionsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsDetailsExceptionsFragment.kt
@@ -133,11 +133,11 @@ class SitePermissionsDetailsExceptionsFragment : PreferenceFragmentCompat() {
             AlertDialog.Builder(requireContext()).apply {
                 setMessage(R.string.confirm_clear_permissions_site)
                 setTitle(R.string.clear_permissions)
-                setPositiveButton(android.R.string.ok) { dialog: DialogInterface, _ ->
+                setPositiveButton(R.string.clear_permissions_positive) { dialog: DialogInterface, _ ->
                     clearSitePermissions()
                     dialog.dismiss()
                 }
-                setNegativeButton(android.R.string.cancel) { dialog: DialogInterface, _ ->
+                setNegativeButton(R.string.clear_permissions_negative) { dialog: DialogInterface, _ ->
                     dialog.cancel()
                 }
             }.show()

--- a/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsExceptionsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsExceptionsFragment.kt
@@ -103,11 +103,11 @@ class SitePermissionsExceptionsFragment :
             AlertDialog.Builder(requireContext()).apply {
                 setMessage(R.string.confirm_clear_permissions_on_all_sites)
                 setTitle(R.string.clear_permissions)
-                setPositiveButton(android.R.string.ok) { dialog: DialogInterface, _ ->
+                setPositiveButton(R.string.clear_permissions_positive) { dialog: DialogInterface, _ ->
                     deleteAllSitePermissions()
                     dialog.dismiss()
                 }
-                setNegativeButton(android.R.string.cancel) { dialog: DialogInterface, _ ->
+                setNegativeButton(R.string.clear_permissions_negative) { dialog: DialogInterface, _ ->
                     dialog.cancel()
                 }
             }.show()

--- a/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsManageExceptionsPhoneFeatureFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsManageExceptionsPhoneFeatureFragment.kt
@@ -154,11 +154,11 @@ class SitePermissionsManageExceptionsPhoneFeatureFragment : Fragment() {
             AlertDialog.Builder(requireContext()).apply {
                 setMessage(R.string.confirm_clear_permission_site)
                 setTitle(R.string.clear_permission)
-                setPositiveButton(android.R.string.ok) { dialog: DialogInterface, _ ->
+                setPositiveButton(R.string.clear_permission_positive) { dialog: DialogInterface, _ ->
                     clearPermissions()
                     dialog.dismiss()
                 }
-                setNegativeButton(android.R.string.cancel) { dialog: DialogInterface, _ ->
+                setNegativeButton(R.string.clear_permission_negative) { dialog: DialogInterface, _ ->
                     dialog.cancel()
                 }
             }.show()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -774,6 +774,8 @@
     <string name="bookmark_delete_folder_confirmation_dialog">Are you sure you want to delete this folder?</string>
     <!-- Confirmation message for a dialog confirming if the user wants to delete multiple items including folders. Parameter will be replaced by app name. -->
     <string name="bookmark_delete_multiple_folders_confirmation_dialog">%s will delete the selected items.</string>
+    <!-- Text for the cancel button on delete bookmark dialog -->
+    <string name="bookmark_delete_negative">Cancel</string>
     <!-- Screen title for adding a bookmarks folder -->
     <string name="bookmark_add_folder">Add folder</string>
     <!-- Snackbar title shown after a bookmark has been created. -->
@@ -840,8 +842,16 @@
     <string name="phone_feature_recommended">Recommended</string>
     <!-- Button label for clearing all the information of site permissions-->
     <string name="clear_permissions">Clear permissions</string>
+    <!-- Text for the OK button on Clear permissions dialog -->
+    <string name="clear_permissions_positive">OK</string>
+    <!-- Text for the cancel button on Clear permissions dialog -->
+    <string name="clear_permissions_negative">Cancel</string>
     <!-- Button label for clearing a site permission-->
     <string name="clear_permission">Clear permission</string>
+    <!-- Text for the OK button on Clear permission dialog -->
+    <string name="clear_permission_positive">OK</string>
+    <!-- Text for the cancel button on Clear permission dialog -->
+    <string name="clear_permission_negative">Cancel</string>
     <!-- Button label for clearing all the information on all sites-->
     <string name="clear_permissions_on_all_sites">Clear permissions on all sites</string>
     <!-- Preference for altering video and audio autoplay for all websites -->
@@ -938,6 +948,10 @@
     <string name="create_collection_save">Save</string>
     <!-- Snackbar action to view the collection the user just created or updated -->
     <string name="create_collection_view">View</string>
+    <!-- Text for the OK button from collection dialogs -->
+    <string name="create_collection_positive">OK</string>
+    <!-- Text for the cancel button from collection dialogs -->
+    <string name="create_collection_negative">Cancel</string>
 
     <!-- Default name for a new collection in "name new collection" step of the collection creator. %d is a placeholder for the number of collections-->
     <string name="create_collection_default_name">Collection %d</string>
@@ -1594,6 +1608,8 @@
     <string name="login_deletion_confirmation">Are you sure you want to delete this login?</string>
     <!-- Positive action of a dialog asking to delete  -->
     <string name="dialog_delete_positive">Delete</string>
+    <!-- Negative action of a dialog asking to delete login -->
+    <string name="dialog_delete_negative">Cancel</string>
     <!--  The saved login options menu description. -->
     <string name="login_options_menu">Login options</string>
     <!--  The editable text field for a login's web address. -->


### PR DESCRIPTION
Replaced the `android.R.string` strings with string resources for better localization.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
