### PR TITLE
android-components RemoteTabsStorage now requires a Context param

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -311,7 +311,7 @@ class Core(
     /**
      * The storage component to sync and persist tabs in a Firefox Sync account.
      */
-    val lazyRemoteTabsStorage = lazyMonitored { RemoteTabsStorage() }
+    val lazyRemoteTabsStorage = lazyMonitored { RemoteTabsStorage(context) }
 
     val recentlyClosedTabsStorage = lazyMonitored { RecentlyClosedTabsStorage(context, engine, crashReporter) }
 


### PR DESCRIPTION
companion to https://github.com/mozilla-mobile/android-components/pull/11799, but draft while we wait for a new app-services release. @jonalmeida 