### PR TITLE
For #24080 - Use layer accent non opaque for the tabs tray and history selected background color

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabhistory/TabHistoryViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabhistory/TabHistoryViewHolder.kt
@@ -32,7 +32,7 @@ class TabHistoryViewHolder(
 
         if (item.isSelected) {
             view.setBackgroundColor(
-                view.context.getColorFromAttr(R.attr.tabHistoryItemSelectedBackground)
+                view.context.getColorFromAttr(R.attr.layerNonOpaque)
             )
         } else {
             view.background = null

--- a/app/src/main/java/org/mozilla/fenix/tabstray/browser/BrowserTabViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/browser/BrowserTabViewHolder.kt
@@ -16,9 +16,9 @@ import mozilla.components.concept.base.images.ImageLoader
 import org.mozilla.fenix.R
 import org.mozilla.fenix.databinding.TabTrayGridItemBinding
 import org.mozilla.fenix.ext.increaseTapArea
-import kotlin.math.max
 import org.mozilla.fenix.selection.SelectionHolder
 import org.mozilla.fenix.tabstray.TabsTrayStore
+import kotlin.math.max
 
 sealed class BrowserTabViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
     /**
@@ -102,7 +102,7 @@ sealed class BrowserTabViewHolder(itemView: View) : RecyclerView.ViewHolder(item
 
         override fun updateSelectedTabIndicator(showAsSelected: Boolean) {
             val color = if (showAsSelected) {
-                R.color.tab_tray_item_selected_background_normal_theme
+                R.color.fx_mobile_layer_color_accent_nonopaque
             } else {
                 R.color.tab_tray_item_background_normal_theme
             }

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -140,12 +140,8 @@
 
     <!-- Tab tray -->
     <color name="tab_tray_item_background_normal_theme">@color/photonDarkGrey80</color>
-    <color name="tab_tray_item_selected_background_normal_theme">@color/tab_tray_item_selected_background_dark_theme</color>
     <color name="tab_tray_item_thumbnail_background_normal_theme">@color/photonDarkGrey50</color>
     <color name="tab_tray_item_thumbnail_icon_normal_theme">@color/photonDarkGrey05</color>
-
-    <!-- Tab History -->
-    <color name="tab_history_item_selected_background_normal_theme">@color/tab_tray_item_selected_background_dark_theme</color>
 
     <!-- Reader View colors -->
     <color name="mozac_feature_readerview_text_color">@color/fx_mobile_text_color_primary</color>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -8,6 +8,8 @@
     <!-- Layers -->
     <!-- Search -->
     <attr name="layer3" format="reference" />
+    <!-- Selected tab -->
+    <attr name="layerNonOpaque" format="reference" />
     <attr name="scrim" format="reference" />
 
     <!-- Action -->
@@ -75,9 +77,6 @@
     <!-- Tab tray -->
     <attr name="tabTrayThumbnailItemBackground" format="reference" />
     <attr name="tabTrayThumbnailIcon" format="reference" />
-
-    <!-- Tab History -->
-    <attr name="tabHistoryItemSelectedBackground" format="reference" />
 
     <declare-styleable name="TrackingProtectionCategory">
         <attr name="categoryItemTitle" format="reference" />

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -138,7 +138,7 @@
     <!-- App Bar Top (edit), Text Cursor, Selected Tab Check -->
     <color name="fx_mobile_private_layer_color_accent" tools:ignore="UnusedResources">@color/photonViolet40</color>
     <!-- Selected tab -->
-    <color name="fx_mobile_private_layer_color_accent_nonopaque" tools:ignore="UnusedResources">@color/photonViolet50A32</color>
+    <color name="fx_mobile_private_layer_color_accent_nonopaque">@color/photonViolet50A32</color>
     <color name="fx_mobile_private_layer_color_scrim">@color/photonDarkGrey90A95</color>
     <!-- Tooltip -->
     <color name="fx_mobile_private_layer_color_gradient_start" tools:ignore="UnusedResources">@color/photonViolet70</color>
@@ -248,9 +248,6 @@
     <color name="dark_grey_90_gradient_start">@color/photonDarkGrey90</color>
     <color name="dark_grey_90_gradient_end">#0015141A</color>
 
-    <!-- Tab Tray -->
-    <color name="tab_tray_item_selected_background_dark_theme">#412E69</color>
-
     <!-- Private theme color palette -->
     <color name="accent_private_theme">@color/photonViolet50</color>
     <color name="accent_high_contrast_private_theme">#AA71FF</color>
@@ -280,12 +277,8 @@
 
     <!-- Tab tray -->
     <color name="tab_tray_item_background_normal_theme">@color/photonLightGrey10</color>
-    <color name="tab_tray_item_selected_background_normal_theme">#E5DFF4</color>
     <color name="tab_tray_item_thumbnail_background_normal_theme">@color/photonLightGrey10</color>
     <color name="tab_tray_item_thumbnail_icon_normal_theme">@color/photonLightGrey60</color>
-
-    <!-- Tab History -->
-    <color name="tab_history_item_selected_background_normal_theme">@color/tab_tray_item_selected_background_normal_theme</color>
 
     <!-- Bookmark buttons -->
     <color name="bookmark_favicon_background">#DFDFE3</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -36,6 +36,8 @@
         <!-- Layers -->
         <!-- Search -->
         <item name="layer3">@color/fx_mobile_layer_color_3</item>
+        <!-- Selected tab -->
+        <item name="layerNonOpaque">@color/fx_mobile_layer_color_accent_nonopaque</item>
         <item name="scrim">@color/fx_mobile_layer_color_scrim</item>
 
         <!-- Action -->
@@ -108,9 +110,6 @@
 
         <item name="tabTrayThumbnailItemBackground">@color/tab_tray_item_thumbnail_background_normal_theme</item>
         <item name="tabTrayThumbnailIcon">@color/tab_tray_item_thumbnail_icon_normal_theme</item>
-
-        <!-- Tab History -->
-        <item name="tabHistoryItemSelectedBackground">@color/tab_history_item_selected_background_normal_theme</item>
 
         <!-- Drawables -->
         <item name="fenixLogo">@drawable/ic_logo_wordmark_normal</item>
@@ -229,6 +228,8 @@
         <!-- Layers -->
         <!-- Search -->
         <item name="layer3">@color/fx_mobile_private_layer_color_3</item>
+        <!-- Selected tab -->
+        <item name="layerNonOpaque">@color/fx_mobile_private_layer_color_accent_nonopaque</item>
         <item name="scrim">@color/fx_mobile_private_layer_color_scrim</item>
 
         <!-- Action -->
@@ -300,9 +301,6 @@
         <!-- Tab Tray -->
         <item name="tabTrayThumbnailItemBackground">@color/tab_tray_item_thumbnail_background_normal_theme</item>
         <item name="tabTrayThumbnailIcon">@color/tab_tray_item_thumbnail_icon_normal_theme</item>
-
-        <!-- Tab History -->
-        <item name="tabHistoryItemSelectedBackground">@color/tab_tray_item_selected_background_dark_theme</item>
 
         <!-- Drawables -->
         <item name="fenixLogo">@drawable/ic_logo_wordmark_private</item>


### PR DESCRIPTION
Fixes #24080

Light Mode:
Old|New
---|---
<img width="441" alt="Screen Shot 2022-03-03 at 1 15 04 PM" src="https://user-images.githubusercontent.com/1190888/156627881-206e603c-cd6c-461b-a656-d1d1414cf2a4.png">|<img width="441" alt="Screen Shot 2022-03-03 at 1 22 26 PM" src="https://user-images.githubusercontent.com/1190888/156627964-a995a2ab-df52-4456-9747-4baff52bf025.png">
<img width="441" alt="Screen Shot 2022-03-03 at 1 16 04 PM" src="https://user-images.githubusercontent.com/1190888/156628052-091a7255-7a6f-4dac-a77f-d5b4dfcf125d.png">|<img width="441" alt="Screen Shot 2022-03-03 at 1 22 33 PM" src="https://user-images.githubusercontent.com/1190888/156628065-b00e76ec-269e-46f4-9fbf-1547a784d916.png">

Dark Mode:
Old|New
---|---
<img width="441" alt="Screen Shot 2022-03-03 at 1 15 17 PM" src="https://user-images.githubusercontent.com/1190888/156628133-79085fc8-ee46-4e35-90ff-ba367014fa68.png">|<img width="441" alt="Screen Shot 2022-03-03 at 1 21 48 PM" src="https://user-images.githubusercontent.com/1190888/156628155-a2dc506b-675d-40f3-867a-c3b46276e2df.png">
<img width="441" alt="Screen Shot 2022-03-03 at 1 15 41 PM" src="https://user-images.githubusercontent.com/1190888/156628185-95d33692-5298-4790-b30e-321c84284618.png">|<img width="441" alt="Screen Shot 2022-03-03 at 1 22 13 PM" src="https://user-images.githubusercontent.com/1190888/156628214-1fc28ae1-d8bb-4ea4-8a88-3cce1db810c4.png">


Private Mode:
Old|New
---|---
<img width="441" alt="Screen Shot 2022-03-03 at 1 16 43 PM" src="https://user-images.githubusercontent.com/1190888/156628356-f49332b8-2503-4627-a9b9-75ca6524bd1b.png">|<img width="441" alt="Screen Shot 2022-03-03 at 1 22 56 PM" src="https://user-images.githubusercontent.com/1190888/156628386-998dbcf3-7e25-4eab-98ed-ab91a32f60fe.png">


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
