### PR TITLE
Update minidump-stackwalk artifact name

### DIFF
--- a/taskcluster/ci/toolchain/gecko-derived.yml
+++ b/taskcluster/ci/toolchain/gecko-derived.yml
@@ -35,7 +35,7 @@ linux64-geckodriver:
 
 linux64-minidump-stackwalk:
     attributes:
-        toolchain-artifact: public/build/minidump_stackwalk.tar.zst
+        toolchain-artifact: public/build/minidump-stackwalk.tar.zst
     description: "minidump-stackwalk toolchain"
     run:
         index-search:


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1758939, all perf jobs are broken at the moment