### PR TITLE
Fixes #24188 - Use app_name for InactiveTabAutoClose message

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabstray/browser/InactiveTabViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/browser/InactiveTabViewHolder.kt
@@ -79,6 +79,14 @@ sealed class InactiveTabViewHolder(itemView: View) : RecyclerView.ViewHolder(ite
 
         init {
             binding.root.context.metrics.track(Event.TabsTrayAutoCloseDialogSeen)
+
+            binding.message.text = with(binding.root.context) {
+                getString(
+                    R.string.tab_tray_inactive_auto_close_body_2,
+                    getString(R.string.app_name)
+                )
+            }
+
             binding.closeButton.setOnClickListener {
                 interactor.onCloseClicked()
             }


### PR DESCRIPTION
Used `app_name` for inactive tab auto close dialog message instead of placeholder

![inactive](https://user-images.githubusercontent.com/35462038/157860974-2febf302-a9f5-40af-8000-a085229bdd7a.png)


### Pull Request checklist!
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
