### PR TITLE
closes #24289: wrap filesDir access in runBlockingIncrement

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/perf/StartupExcessiveResourceUseTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/perf/StartupExcessiveResourceUseTest.kt
@@ -21,7 +21,7 @@ import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.helpers.HomeActivityTestRule
 
 // BEFORE INCREASING THESE VALUES, PLEASE CONSULT WITH THE PERF TEAM.
-private const val EXPECTED_SUPPRESSION_COUNT = 19
+private const val EXPECTED_SUPPRESSION_COUNT = 20
 @Suppress("TopLevelPropertyNaming") // it's silly this would have a different naming convention b/c no const
 private val EXPECTED_RUNBLOCKING_RANGE = 0..1 // CI has +1 counts compared to local runs: increment these together
 private const val EXPECTED_RECYCLER_VIEW_CONSTRAINT_LAYOUT_CHILDREN = 4

--- a/app/src/main/java/org/mozilla/fenix/components/Components.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Components.kt
@@ -7,6 +7,7 @@ package org.mozilla.fenix.components
 import android.app.Application
 import android.content.Context
 import android.content.Intent
+import android.os.StrictMode
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.net.toUri
@@ -144,15 +145,6 @@ class Components(private val context: Context) {
         AddonManager(core.store, core.engine, addonCollectionProvider, addonUpdater)
     }
 
-    val wallpaperManager by lazyMonitored {
-        WallpaperManager(
-            settings,
-            WallpaperDownloader(context, core.client),
-            WallpaperFileManager(context.filesDir),
-            analytics.crashReporter,
-        )
-    }
-
     val analytics by lazyMonitored { Analytics(context) }
     val publicSuffixList by lazyMonitored { PublicSuffixList(context) }
     val clipboardHandler by lazyMonitored { ClipboardHandler(context) }
@@ -161,6 +153,17 @@ class Components(private val context: Context) {
     val push by lazyMonitored { Push(context, analytics.crashReporter) }
     val wifiConnectionMonitor by lazyMonitored { WifiConnectionMonitor(context as Application) }
     val strictMode by lazyMonitored { StrictModeManager(Config, this) }
+
+    val wallpaperManager by lazyMonitored {
+        strictMode.resetAfter(StrictMode.allowThreadDiskReads()) {
+            WallpaperManager(
+                settings,
+                WallpaperDownloader(context, core.client),
+                WallpaperFileManager(context.filesDir),
+                analytics.crashReporter,
+            )
+        }
+    }
 
     val settings by lazyMonitored { Settings(context) }
 


### PR DESCRIPTION
We should be able to avoid this synchronous behavior when we [uplift wallpapers](https://github.com/mozilla-mobile/android-components/issues/11679) into A-C, but this was the simplest solve for now. 

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
