### PR TITLE
Closes #24407: Allow query parameters in AMO installation URLs

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/AppRequestInterceptor.kt
+++ b/app/src/main/java/org/mozilla/fenix/AppRequestInterceptor.kt
@@ -92,7 +92,7 @@ class AppRequestInterceptor(
         if (hasUserGesture && isSameDomain && uri.startsWith(AMO_BASE_URL)) {
 
             // Check if this is a request to install an add-on.
-            val matchResult = AMO_INSTALL_URL_REGEX.toRegex().matchEntire(uri)
+            val matchResult = AMO_INSTALL_URL_REGEX.toRegex().find(uri)
             if (matchResult != null) {
 
                 // Navigate and trigger add-on installation.

--- a/app/src/test/java/org/mozilla/fenix/AppRequestInterceptorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/AppRequestInterceptorTest.kt
@@ -65,6 +65,24 @@ class AppRequestInterceptorTest {
     }
 
     @Test
+    fun `GIVEN valid request to install add-on WHEN url is provided with query parameters THEN start add-on installation`() {
+        val addonId = "12345678"
+        val result = interceptor.onLoadRequest(
+            engineSession = mockk(),
+            uri = "https://addons.mozilla.org/android/downloads/file/$addonId/test.xpi?queryParam=test",
+            lastUri = "https://addons.mozilla.org/en-US/firefox/",
+            hasUserGesture = true,
+            isSameDomain = true,
+            isDirectNavigation = false,
+            isRedirect = false,
+            isSubframeRequest = false
+        )
+
+        verify { navigationController.navigate(NavGraphDirections.actionGlobalAddonsManagementFragment(addonId)) }
+        assertEquals(RequestInterceptor.InterceptionResponse.Deny, result)
+    }
+
+    @Test
     fun `GIVEN request to install add-on WHEN on a different domain THEN no add-on installation is started`() {
         every { testContext.components.services } returns Services(testContext, mockk(relaxed = true))
         val result = interceptor.onLoadRequest(


### PR DESCRIPTION
We could use the new `matchAt(uri, 0)` instead, but it's still marked as experimental and wouldn't buy us anything. We already have a `startsWith` check for performance and sec. reasons anyway.