### PR TITLE
Revert to Android Components 100.0.20220321143410

### DIFF
--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "100.0.20220323143118"
+    const val VERSION = "100.0.20220321143410"
 }


### PR DESCRIPTION
Reverting to last known/stable version of A-C.

See: https://bugzilla.mozilla.org/show_bug.cgi?id=1760880