### PR TITLE
No issue: Disable HomeScreen tests for recent failing

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
@@ -8,6 +8,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.Until
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.customannotations.SmokeTest
@@ -92,6 +93,7 @@ class HomeScreenTest {
     }
 
     @Test
+    @Ignore("Failing: https://github.com/mozilla-mobile/fenix/issues/24436")
     fun dismissOnboardingUsingSettingsTest() {
         homeScreen {
             verifyWelcomeHeader()
@@ -104,6 +106,7 @@ class HomeScreenTest {
     }
 
     @Test
+    @Ignore("Failing: https://github.com/mozilla-mobile/fenix/issues/24436")
     fun dismissOnboardingUsingBookmarksTest() {
         homeScreen {
             verifyWelcomeHeader()
@@ -132,6 +135,7 @@ class HomeScreenTest {
     }
 
     @Test
+    @Ignore("Failing: https://github.com/mozilla-mobile/fenix/issues/24436")
     fun toolbarTapDoesntDismissOnboardingTest() {
         homeScreen {
             verifyWelcomeHeader()


### PR DESCRIPTION
As per https://console.firebase.google.com/u/1/project/moz-fenix/testlab/histories/bh.66b7091e15d53d45/matrices/6119952028663171131/details?stepId=bs.40bbe80adaf5999e&testCaseId=1

Some recent change on the home-screen has regressed these tests which are merely checking the home screen for elements.. 