### PR TITLE
For mozilla-mobile#24461 increase touch target for scan, search engine & voice search button

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt
@@ -66,10 +66,12 @@ import org.mozilla.fenix.components.toolbar.ToolbarPosition
 import org.mozilla.fenix.databinding.FragmentSearchDialogBinding
 import org.mozilla.fenix.databinding.SearchSuggestionsHintBinding
 import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.increaseTapArea
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.search.awesomebar.AwesomeBarView
 import org.mozilla.fenix.search.awesomebar.toSearchProviderState
+import org.mozilla.fenix.search.toolbar.IncreaseDpsAction
 import org.mozilla.fenix.search.toolbar.ToolbarView
 import org.mozilla.fenix.settings.SupportUtils
 import org.mozilla.fenix.widget.VoiceSearchActivity
@@ -252,8 +254,11 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
             else -> {}
         }
 
-        binding.searchEnginesShortcutButton.setOnClickListener {
-            interactor.onSearchShortcutsButtonClicked()
+        binding.searchEnginesShortcutButton.apply {
+            increaseTapArea(TAP_INCREASE_DPS)
+            setOnClickListener {
+                interactor.onSearchShortcutsButtonClicked()
+            }
         }
 
         qrFeature.set(
@@ -263,6 +268,7 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
         )
 
         binding.qrScanButton.visibility = if (context?.hasCamera() == true) View.VISIBLE else View.GONE
+        binding.qrScanButton.increaseTapArea(TAP_INCREASE_DPS)
 
         binding.qrScanButton.setOnClickListener {
             if (!requireContext().hasCamera()) { return@setOnClickListener }
@@ -636,14 +642,16 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
                 requireContext().settings().shouldShowVoiceSearch
 
         if (isVisible) {
-            toolbarView.view.addEditActionEnd(
-                BrowserToolbar.Button(
-                    AppCompatResources.getDrawable(requireContext(), R.drawable.ic_microphone)!!,
-                    requireContext().getString(R.string.voice_search_content_description),
-                    visible = { true },
-                    listener = ::launchVoiceSearch
-                )
+            val voiceSearchAction = BrowserToolbar.Button(
+                AppCompatResources.getDrawable(requireContext(), R.drawable.ic_microphone)!!,
+                requireContext().getString(R.string.voice_search_content_description),
+                visible = { true },
+                listener = ::launchVoiceSearch
             )
+            toolbarView.view.run {
+                addEditActionEnd(IncreaseDpsAction(voiceSearchAction))
+                invalidateActions()
+            }
             voiceSearchButtonAlreadyAdded = true
         }
     }
@@ -719,6 +727,7 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
     }
 
     companion object {
+        private const val TAP_INCREASE_DPS = 8
         private const val QR_FRAGMENT_TAG = "MOZAC_QR_FRAGMENT"
         private const val REQUEST_CODE_CAMERA_PERMISSIONS = 1
     }

--- a/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt
@@ -71,7 +71,7 @@ import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.search.awesomebar.AwesomeBarView
 import org.mozilla.fenix.search.awesomebar.toSearchProviderState
-import org.mozilla.fenix.search.toolbar.IncreaseDpsAction
+import org.mozilla.fenix.search.toolbar.IncreasedTapAreaActionDecorator
 import org.mozilla.fenix.search.toolbar.ToolbarView
 import org.mozilla.fenix.settings.SupportUtils
 import org.mozilla.fenix.widget.VoiceSearchActivity
@@ -254,11 +254,9 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
             else -> {}
         }
 
-        binding.searchEnginesShortcutButton.apply {
-            increaseTapArea(TAP_INCREASE_DPS)
-            setOnClickListener {
-                interactor.onSearchShortcutsButtonClicked()
-            }
+        binding.searchEnginesShortcutButton.increaseTapArea(TAP_INCREASE_DPS)
+        binding.searchEnginesShortcutButton.setOnClickListener {
+            interactor.onSearchShortcutsButtonClicked()
         }
 
         qrFeature.set(
@@ -649,7 +647,7 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
                 listener = ::launchVoiceSearch
             )
             toolbarView.view.run {
-                addEditActionEnd(IncreaseDpsAction(voiceSearchAction))
+                addEditActionEnd(IncreasedTapAreaActionDecorator(voiceSearchAction))
                 invalidateActions()
             }
             voiceSearchButtonAlreadyAdded = true

--- a/app/src/main/java/org/mozilla/fenix/search/toolbar/IncreaseDpsAction.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/toolbar/IncreaseDpsAction.kt
@@ -1,0 +1,20 @@
+package org.mozilla.fenix.search.toolbar
+
+import android.view.View
+import mozilla.components.concept.toolbar.Toolbar
+import org.mozilla.fenix.ext.increaseTapArea
+
+class IncreaseDpsAction(
+    private val action: Toolbar.Action
+) : Toolbar.Action by action {
+
+    override fun bind(view: View) {
+        action.bind(view)
+        view.increaseTapArea(TAP_INCREASE_DPS)
+    }
+
+    companion object {
+        private const val TAP_INCREASE_DPS = 8
+    }
+
+}

--- a/app/src/main/java/org/mozilla/fenix/search/toolbar/IncreasedTapAreaActionDecorator.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/toolbar/IncreasedTapAreaActionDecorator.kt
@@ -1,10 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.search.toolbar
 
 import android.view.View
 import mozilla.components.concept.toolbar.Toolbar
 import org.mozilla.fenix.ext.increaseTapArea
 
-class IncreaseDpsAction(
+/**
+ * A Decorator that accepts a [Toolbar.Action] and increases its tap area.
+ */
+class IncreasedTapAreaActionDecorator(
     private val action: Toolbar.Action
 ) : Toolbar.Action by action {
 
@@ -16,5 +23,4 @@ class IncreaseDpsAction(
     companion object {
         private const val TAP_INCREASE_DPS = 8
     }
-
 }

--- a/app/src/main/java/org/mozilla/fenix/search/toolbar/IncreasedTapAreaActionDecorator.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/toolbar/IncreasedTapAreaActionDecorator.kt
@@ -5,6 +5,7 @@
 package org.mozilla.fenix.search.toolbar
 
 import android.view.View
+import androidx.annotation.VisibleForTesting
 import mozilla.components.concept.toolbar.Toolbar
 import org.mozilla.fenix.ext.increaseTapArea
 
@@ -21,6 +22,7 @@ class IncreasedTapAreaActionDecorator(
     }
 
     companion object {
-        private const val TAP_INCREASE_DPS = 8
+        @VisibleForTesting
+        const val TAP_INCREASE_DPS = 8
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/search/toolbar/IncreasedTapAreaActionDecoratorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/search/toolbar/IncreasedTapAreaActionDecoratorTest.kt
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.search.toolbar
+
+import android.view.View
+import io.mockk.MockKAnnotations
+import io.mockk.impl.annotations.MockK
+import io.mockk.justRun
+import io.mockk.mockkStatic
+import io.mockk.verify
+import mozilla.components.concept.toolbar.Toolbar
+import org.junit.Before
+import org.junit.Test
+import org.mozilla.fenix.ext.increaseTapArea
+
+class IncreasedTapAreaActionDecoratorTest {
+
+    @MockK lateinit var action: Toolbar.Action
+    @MockK lateinit var view: View
+
+    private lateinit var increasedTapAreaActionDecorator: IncreasedTapAreaActionDecorator
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+        increasedTapAreaActionDecorator = IncreasedTapAreaActionDecorator(action)
+        justRun { action.bind(view) }
+        mockkStatic(View::increaseTapArea)
+        justRun { view.increaseTapArea(IncreasedTapAreaActionDecorator.TAP_INCREASE_DPS) }
+    }
+
+    @Test
+    fun `increased tap area of view on bind`() {
+        increasedTapAreaActionDecorator.bind(view)
+
+        verify { view.increaseTapArea(IncreasedTapAreaActionDecorator.TAP_INCREASE_DPS) }
+    }
+
+    @Test
+    fun `should invoke provided action bind`() {
+        increasedTapAreaActionDecorator.bind(view)
+
+        verify { action.bind(view) }
+    }
+}


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

**After updating Search engine tap area**
![1_updated_search_engine](https://user-images.githubusercontent.com/12934264/160526043-9406d1fd-0b80-4f1d-9b1c-81b97d36c582.jpg)

**After updating Scan tap area**
I have updated search engine tap area first. ASA i updated scan tap area it started showing border for search engine. i think thats a false positive(or possibly cause by colliding tap area rect of scan).

![2_updated_scan](https://user-images.githubusercontent.com/12934264/160526048-b500ee7f-05ff-4187-817d-4f2fc6aa35cc.jpg)

**After updating voice search tap area**
![updated_micro_phone](https://user-images.githubusercontent.com/12934264/160526421-8eb80ecc-5524-4cad-a088-71d3ae869fb9.jpg)

The close button does not seems to be in this project. Its in browser-toolbar dependency. so could not access it.