### PR TITLE
For #24331 - Support for opening new tabs when requested by service workers

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -504,8 +504,9 @@ dependencies {
     implementation Deps.mozilla_feature_webcompat
     implementation Deps.mozilla_feature_webnotifications
     implementation Deps.mozilla_feature_webcompat_reporter
-    implementation Deps.mozilla_service_pocket
+    implementation Deps.mozilla_feature_serviceworker
 
+    implementation Deps.mozilla_service_pocket
     implementation Deps.mozilla_service_contile
     implementation Deps.mozilla_service_digitalassetlinks
     implementation Deps.mozilla_service_sync_autofill

--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -36,6 +36,7 @@ import mozilla.components.feature.addons.update.GlobalAddonDependencyProvider
 import mozilla.components.feature.autofill.AutofillUseCases
 import mozilla.components.feature.search.ext.buildSearchUrl
 import mozilla.components.feature.search.ext.waitForSelectedOrDefaultSearchEngine
+import mozilla.components.feature.serviceworker.ServiceWorkerSupport
 import mozilla.components.feature.top.sites.TopSitesProviderConfig
 import mozilla.components.lib.crash.CrashReporter
 import mozilla.components.service.fxa.manager.SyncEnginesStorage
@@ -200,6 +201,10 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
 
         setupLeakCanary()
         startMetricsIfEnabled()
+        ServiceWorkerSupport.install(
+            components.core.engine,
+            components.useCases.tabsUseCases.addTab
+        )
         setupPush()
 
         visibilityLifecycleCallback = VisibilityLifecycleCallback(getSystemService())

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -135,8 +135,9 @@ object Deps {
     const val mozilla_feature_webcompat = "org.mozilla.components:feature-webcompat:${Versions.mozilla_android_components}"
     const val mozilla_feature_webnotifications = "org.mozilla.components:feature-webnotifications:${Versions.mozilla_android_components}"
     const val mozilla_feature_webcompat_reporter = "org.mozilla.components:feature-webcompat-reporter:${Versions.mozilla_android_components}"
-    const val mozilla_service_pocket = "org.mozilla.components:service-pocket:${Versions.mozilla_android_components}"
+    const val mozilla_feature_serviceworker = "org.mozilla.components:feature-serviceworker:${Versions.mozilla_android_components}"
 
+    const val mozilla_service_pocket = "org.mozilla.components:service-pocket:${Versions.mozilla_android_components}"
     const val mozilla_service_contile =
         "org.mozilla.components:service-contile:${Versions.mozilla_android_components}"
     const val mozilla_service_digitalassetlinks =


### PR DESCRIPTION
Use the new `ServiceWorkerSupport` AC components for this.
Had to be installed in `FenixApplication` since there is a circular dependency
between the initialization of the required engine the `tabsUseCases` arguments.

Same patch as on https://github.com/mozilla-mobile/fenix/pull/24332
[x] Tested on https://cleverpush.com/en/test-notifications/ with a hardcoded notifications click after 5 seconds.
[x] Will test again the patch after the recent GeckoView change from https://bugzilla.mozilla.org/show_bug.cgi?id=1759588

https://user-images.githubusercontent.com/11428869/159000243-cd9bf5c1-702e-4f39-8fc8-a7facdcbdd0c.mp4

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
