### PR TITLE
Re-enable top sites UI tests and other refactoring work

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -325,23 +325,6 @@ class SmokeTest {
         }
     }
 
-    @Ignore("Failing, see: https://github.com/mozilla-mobile/fenix/issues/24458")
-    @Test
-    // Verifies the Add to top sites option in a tab's 3 dot menu
-    fun openMainMenuAddTopSiteTest() {
-        val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-
-        navigationToolbar {
-        }.enterURLAndEnterToBrowser(defaultWebPage.url) {
-        }.openThreeDotMenu {
-            expandMenu()
-        }.addToFirefoxHome {
-            verifySnackBarText("Added to top sites!")
-        }.goToHomescreen {
-            verifyExistingTopSitesTabs(defaultWebPage.title)
-        }
-    }
-
     @Test
     // Verifies the Add to home screen option in a tab's 3 dot menu
     fun mainMenuAddToHomeScreenTest() {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/TopSitesTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/TopSitesTest.kt
@@ -36,7 +36,7 @@ class TopSitesTest {
     private val featureSettingsHelper = FeatureSettingsHelper()
 
     @get:Rule
-    val activityIntentTestRule = HomeActivityIntentTestRule()
+    val activityIntentTestRule = HomeActivityIntentTestRule(skipOnboarding = true)
 
     @Before
     fun setUp() {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/TopSitesTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/TopSitesTest.kt
@@ -55,6 +55,7 @@ class TopSitesTest {
     }
 
     @Ignore("Failing, see: https://github.com/mozilla-mobile/fenix/issues/24462")
+    @SmokeTest
     @Test
     fun verifyAddToFirefoxHome() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/TopSitesTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/TopSitesTest.kt
@@ -9,7 +9,6 @@ import androidx.test.uiautomator.UiDevice
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.customannotations.SmokeTest
@@ -54,7 +53,6 @@ class TopSitesTest {
         featureSettingsHelper.resetAllFeatureFlags()
     }
 
-    @Ignore("Failing, see: https://github.com/mozilla-mobile/fenix/issues/24462")
     @SmokeTest
     @Test
     fun verifyAddToFirefoxHome() {
@@ -102,7 +100,6 @@ class TopSitesTest {
         mDevice.pressBack()
     }
 
-    @Ignore("Failing, see: https://github.com/mozilla-mobile/fenix/issues/24376")
     @Test
     fun verifyOpenTopSitePrivateTab() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
@@ -125,7 +122,6 @@ class TopSitesTest {
         }
     }
 
-    @Ignore("Failing, see: https://github.com/mozilla-mobile/fenix/issues/24377")
     @Test
     fun verifyRenameTopSite() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
@@ -150,7 +146,6 @@ class TopSitesTest {
         }
     }
 
-    @Ignore("Failing, see: https://github.com/mozilla-mobile/fenix/issues/20418")
     @Test
     fun verifyRemoveTopSite() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)


### PR DESCRIPTION
• Remove duplicate `openMainMenuAddTopSiteTest` UI test in favour of `verifyAddToFirefoxHome` 
• Skip onboarding in TopSitesTest class
• Re-enable `verifyAddToFirefoxHome` `verifyOpenTopSitePrivateTab` `verifyRenameTopSite` `verifyRemoveTopSite` ✅  successfully ran 50x on Firebase

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
