### PR TITLE
Fix and re-enable jumpBackInOptionTest and recentBookmarksOptionTest UI tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsHomepageTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsHomepageTest.kt
@@ -7,13 +7,13 @@ package org.mozilla.fenix.ui
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.FeatureSettingsHelper
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
+import org.mozilla.fenix.helpers.RetryTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper.getGenericAsset
 import org.mozilla.fenix.helpers.TestHelper.restartApp
 import org.mozilla.fenix.ui.robots.browserScreen
@@ -29,7 +29,11 @@ class SettingsHomepageTest {
     private val featureSettingsHelper = FeatureSettingsHelper()
 
     @get:Rule
-    val activityIntentTestRule = HomeActivityIntentTestRule()
+    val activityIntentTestRule = HomeActivityIntentTestRule(skipOnboarding = true)
+
+    @Rule
+    @JvmField
+    val retryTestRule = RetryTestRule(3)
 
     @Before
     fun setUp() {
@@ -48,7 +52,6 @@ class SettingsHomepageTest {
         featureSettingsHelper.resetAllFeatureFlags()
     }
 
-    @Ignore("Failing, see: https://github.com/mozilla-mobile/fenix/issues/24375")
     @SmokeTest
     @Test
     fun jumpBackInOptionTest() {
@@ -66,7 +69,6 @@ class SettingsHomepageTest {
         }
     }
 
-    @Ignore("Failing, see: https://github.com/mozilla-mobile/fenix/issues/24384")
     @SmokeTest
     @Test
     fun recentBookmarksOptionTest() {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
@@ -12,14 +12,12 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.action.ViewActions.click
-import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.contrib.RecyclerViewActions.actionOnItem
 import androidx.test.espresso.matcher.RootMatchers
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.Visibility
 import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
-import androidx.test.espresso.matcher.ViewMatchers.hasSibling
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.espresso.matcher.ViewMatchers.withHint
@@ -674,15 +672,15 @@ private fun assertTopSiteContextMenuItems() {
     )
 }
 
-private fun assertJumpBackInSectionIsDisplayed() = jumpBackInSection().check(matches(isDisplayed()))
+private fun assertJumpBackInSectionIsDisplayed() = assertTrue(jumpBackInSection().waitForExists(waitingTime))
 
-private fun assertJumpBackInSectionIsNotDisplayed() = jumpBackInSection().check(doesNotExist())
+private fun assertJumpBackInSectionIsNotDisplayed() = assertFalse(jumpBackInSection().waitForExists(waitingTimeShort))
 
 private fun assertRecentBookmarksSectionIsDisplayed() =
-    recentBookmarksSection().check(matches(isDisplayed()))
+    assertTrue(recentBookmarksSection().waitForExists(waitingTime))
 
 private fun assertRecentBookmarksSectionIsNotDisplayed() =
-    recentBookmarksSection().check(doesNotExist())
+    assertFalse(recentBookmarksSection().waitForExists(waitingTimeShort))
 
 private fun privateBrowsingButton() = onView(withId(R.id.privateBrowsingButton))
 
@@ -691,20 +689,10 @@ private fun saveTabsToCollectionButton() = onView(withId(R.id.add_tabs_to_collec
 private fun tabsCounter() = onView(withId(R.id.tab_button))
 
 private fun jumpBackInSection() =
-    onView(
-        allOf(
-            withText(R.string.recent_tabs_header),
-            hasSibling(withText(R.string.recent_tabs_show_all))
-        )
-    )
+    mDevice.findObject(UiSelector().textContains(getStringResource(R.string.recent_tabs_header)))
 
 private fun recentBookmarksSection() =
-    onView(
-        allOf(
-            withText(R.string.recent_bookmarks_title),
-            hasSibling(withText(R.string.recently_saved_show_all))
-        )
-    )
+    mDevice.findObject(UiSelector().textContains(getStringResource(R.string.recent_bookmarks_title)))
 
 private fun startBrowsingButton(): UiObject {
     val startBrowsingButton = mDevice.findObject(UiSelector().resourceId("$packageName:id/finish_button"))

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,7 +41,7 @@
     <!-- Content description for the recently saved bookmarks section on the home screen. -->
     <string moz:removedIn="100" name="recently_saved_bookmarks_content_description" tools:ignore="UnusedResources">Recently saved bookmarks</string>
     <!-- Title for the button which navigates the user to show all of their saved bookmarks. -->
-    <string name="recently_saved_show_all">Show all</string>
+    <string name="recently_saved_show_all" moz:removedIn="101" tools:ignore="UnusedResources">Show all</string>
     <!-- Content description for the button which navigates the user to show all of their saved bookmarks. -->
     <string name="recently_saved_show_all_content_description_2">Show all saved bookmarks</string>
     <!-- Text for the menu button to remove a recently saved bookmark from the user's home screen -->


### PR DESCRIPTION
• Fix and re-enable `jumpBackInOptionTest` and `recentBookmarksOptionTest` ✅  successfully ran 50x on Firebase 
• Ignore and remove `recently_saved_show_all` unused resource that [causes lint to fail](https://github.com/mozilla-mobile/fenix/runs/5817347446?check_suite_focus=true#step:4:1375) (@Mugurell please review and share your thoughts ☺️ )

Just to be safe, I'll add the `pr:do-not-land` label because i'll need to change `moz:removedIn` to 101 in case the PR doesn't get merged until the version bump scheduled for today. 


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
