### PR TITLE
For #24515 - Remove Event.wrapper for performed_search event

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -100,6 +100,7 @@ events:
       A user performed a search
     extra_keys:
       source:
+        type: string
         description: |
           A string that tells us how the user performed the search. Possible
           values are:

--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -169,8 +169,8 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
     private val externalSourceIntentProcessors by lazy {
         listOf(
             HomeDeepLinkIntentProcessor(this),
-            SpeechProcessingIntentProcessor(this, components.core.store, components.analytics.metrics),
-            StartSearchIntentProcessor(components.analytics.metrics),
+            SpeechProcessingIntentProcessor(this, components.core.store),
+            StartSearchIntentProcessor(),
             OpenBrowserIntentProcessor(this, ::getIntentSessionId),
             OpenSpecificTabIntentProcessor(this),
             DefaultBrowserIntentProcessor(this)

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/Event.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/Event.kt
@@ -4,13 +4,11 @@
 
 package org.mozilla.fenix.components.metrics
 
-import mozilla.components.browser.state.search.SearchEngine
 import mozilla.components.feature.top.sites.TopSite
 import org.mozilla.fenix.GleanMetrics.Addons
 import org.mozilla.fenix.GleanMetrics.AppTheme
 import org.mozilla.fenix.GleanMetrics.Autoplay
 import org.mozilla.fenix.GleanMetrics.ContextMenu
-import org.mozilla.fenix.GleanMetrics.Events
 import org.mozilla.fenix.GleanMetrics.Logins
 import org.mozilla.fenix.GleanMetrics.Pocket
 import org.mozilla.fenix.GleanMetrics.SearchTerms
@@ -207,70 +205,6 @@ sealed class Event {
 
         override val extras: Map<Logins.saveLoginsSettingChangedKeys, String>?
             get() = hashMapOf(Logins.saveLoginsSettingChangedKeys.setting to setting.name)
-    }
-
-    data class PerformedSearch(val eventSource: EventSource) : Event() {
-        sealed class EngineSource {
-            abstract val engine: SearchEngine
-            abstract val isCustom: Boolean
-
-            data class Default(override val engine: SearchEngine, override val isCustom: Boolean) :
-                EngineSource()
-
-            data class Shortcut(override val engine: SearchEngine, override val isCustom: Boolean) :
-                EngineSource()
-
-            // https://github.com/mozilla-mobile/fenix/issues/1607
-            // Sanitize identifiers for custom search engines.
-            val identifier: String
-                get() = if (isCustom) "custom" else engine.id
-
-            val searchEngine: SearchEngine
-                get() = when (this) {
-                    is Default -> engine
-                    is Shortcut -> engine
-                }
-
-            val descriptor: String
-                get() = when (this) {
-                    is Default -> "default"
-                    is Shortcut -> "shortcut"
-                }
-        }
-
-        sealed class EventSource(open val engineSource: EngineSource) {
-            data class Suggestion(override val engineSource: EngineSource) :
-                EventSource(engineSource)
-
-            data class Action(override val engineSource: EngineSource) : EventSource(engineSource)
-            data class Widget(override val engineSource: EngineSource) : EventSource(engineSource)
-            data class Shortcut(override val engineSource: EngineSource) : EventSource(engineSource)
-            data class TopSite(override val engineSource: EngineSource) : EventSource(engineSource)
-            data class Other(override val engineSource: EngineSource) : EventSource(engineSource)
-
-            private val label: String
-                get() = when (this) {
-                    is Suggestion -> "suggestion"
-                    is Action -> "action"
-                    is Widget -> "widget"
-                    is Shortcut -> "shortcut"
-                    is TopSite -> "topsite"
-                    is Other -> "other"
-                }
-
-            val countLabel: String
-                get() = "${engineSource.identifier.lowercase(Locale.getDefault())}.$label"
-
-            val sourceLabel: String
-                get() = "${engineSource.descriptor}.$label"
-        }
-
-        enum class SearchAccessPoint {
-            SUGGESTION, ACTION, WIDGET, SHORTCUT, TOPSITE, NONE
-        }
-
-        override val extras: Map<Events.performedSearchKeys, String>?
-            get() = mapOf(Events.performedSearchKeys.source to eventSource.sourceLabel)
     }
 
     data class DarkThemeSelected(val source: Source) : Event() {

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
@@ -18,7 +18,6 @@ import org.mozilla.fenix.GleanMetrics.ContextMenu
 import org.mozilla.fenix.GleanMetrics.ContextualMenu
 import org.mozilla.fenix.GleanMetrics.CreditCards
 import org.mozilla.fenix.GleanMetrics.CustomTab
-import org.mozilla.fenix.GleanMetrics.Events
 import org.mozilla.fenix.GleanMetrics.ExperimentsDefaultBrowser
 import org.mozilla.fenix.GleanMetrics.HomeMenu
 import org.mozilla.fenix.GleanMetrics.HomeScreen
@@ -88,13 +87,6 @@ private class EventWrapper<T : Enum<T>>(
 // FIXME(#19967): Migrate to non-deprecated API.
 private val Event.wrapper: EventWrapper<*>?
     get() = when (this) {
-        is Event.PerformedSearch -> EventWrapper(
-            {
-                Metrics.searchCount[this.eventSource.countLabel].add(1)
-                Events.performedSearch.record(it)
-            },
-            { Events.performedSearchKeys.valueOf(it) }
-        )
         is Event.SearchWithAds -> EventWrapper<NoExtraKeys>(
             {
                 BrowserSearch.withAds[label].add(1)

--- a/app/src/main/java/org/mozilla/fenix/home/intent/SpeechProcessingIntentProcessor.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/intent/SpeechProcessingIntentProcessor.kt
@@ -12,8 +12,6 @@ import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.feature.search.ext.waitForSelectedOrDefaultSearchEngine
 import org.mozilla.fenix.BrowserDirection
 import org.mozilla.fenix.HomeActivity
-import org.mozilla.fenix.components.metrics.Event
-import org.mozilla.fenix.components.metrics.MetricController
 import org.mozilla.fenix.components.metrics.MetricsUtils
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.widget.VoiceSearchActivity.Companion.SPEECH_PROCESSING
@@ -25,7 +23,6 @@ import org.mozilla.fenix.widget.VoiceSearchActivity.Companion.SPEECH_PROCESSING
 class SpeechProcessingIntentProcessor(
     private val activity: HomeActivity,
     private val store: BrowserStore,
-    private val metrics: MetricController
 ) : HomeIntentProcessor {
 
     override fun process(intent: Intent, navController: NavController, out: Intent): Boolean {
@@ -52,12 +49,11 @@ class SpeechProcessingIntentProcessor(
 
     private fun launchToBrowser(searchEngine: SearchEngine, text: String) {
         activity.components.strictMode.resetAfter(StrictMode.allowThreadDiskReads()) {
-            val searchEvent = MetricsUtils.createSearchEvent(
+            MetricsUtils.recordSearchEvent(
                 searchEngine,
                 store,
-                Event.PerformedSearch.SearchAccessPoint.WIDGET
+                MetricsUtils.SearchAccessPoint.WIDGET
             )
-            searchEvent?.let { metrics.track(it) }
         }
 
         activity.openToBrowserAndLoad(

--- a/app/src/main/java/org/mozilla/fenix/home/intent/StartSearchIntentProcessor.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/intent/StartSearchIntentProcessor.kt
@@ -12,17 +12,14 @@ import org.mozilla.fenix.GleanMetrics.SearchWidget
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.NavGraphDirections
 import org.mozilla.fenix.R
-import org.mozilla.fenix.components.metrics.Event
-import org.mozilla.fenix.components.metrics.MetricController
+import org.mozilla.fenix.components.metrics.MetricsUtils
 import org.mozilla.fenix.ext.nav
 
 /**
  * When the search widget is tapped, Fenix should open to the search fragment.
  * Tapping the private browsing mode launcher icon should also open to the search fragment.
  */
-class StartSearchIntentProcessor(
-    private val metrics: MetricController
-) : HomeIntentProcessor {
+class StartSearchIntentProcessor : HomeIntentProcessor {
 
     override fun process(intent: Intent, navController: NavController, out: Intent): Boolean {
         val event = intent.extras?.getString(HomeActivity.OPEN_TO_SEARCH)
@@ -30,12 +27,12 @@ class StartSearchIntentProcessor(
             val source = when (event) {
                 SEARCH_WIDGET -> {
                     SearchWidget.newTabButton.record(NoExtras())
-                    Event.PerformedSearch.SearchAccessPoint.WIDGET
+                    MetricsUtils.SearchAccessPoint.WIDGET
                 }
                 STATIC_SHORTCUT_NEW_TAB,
                 STATIC_SHORTCUT_NEW_PRIVATE_TAB,
                 PRIVATE_BROWSING_PINNED_SHORTCUT -> {
-                    Event.PerformedSearch.SearchAccessPoint.SHORTCUT
+                    MetricsUtils.SearchAccessPoint.SHORTCUT
                 }
                 else -> null
             }

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
@@ -421,16 +421,14 @@ class DefaultSessionControlController(
         }
 
         val availableEngines = getAvailableSearchEngines()
-        val searchAccessPoint = Event.PerformedSearch.SearchAccessPoint.TOPSITE
-        val event =
-            availableEngines.firstOrNull { engine ->
-                engine.resultUrls.firstOrNull { it.contains(topSite.url) } != null
-            }?.let { searchEngine ->
-                searchAccessPoint.let { sap ->
-                    MetricsUtils.createSearchEvent(searchEngine, store, sap)
-                }
+        val searchAccessPoint = MetricsUtils.SearchAccessPoint.TOPSITE
+        availableEngines.firstOrNull { engine ->
+            engine.resultUrls.firstOrNull { it.contains(topSite.url) } != null
+        }?.let { searchEngine ->
+            searchAccessPoint.let { sap ->
+                MetricsUtils.recordSearchEvent(searchEngine, store, sap)
             }
-        event?.let { activity.metrics.track(it) }
+        }
 
         val tabId = addTabUseCase.invoke(
             url = appendSearchAttributionToUrlIfNeeded(topSite.url),
@@ -596,15 +594,14 @@ class DefaultSessionControlController(
         if (clipboardText.isUrl() || searchEngine == null) {
             Events.enteredUrl.record(Events.EnteredUrlExtra(autocomplete = false))
         } else {
-            val searchAccessPoint = Event.PerformedSearch.SearchAccessPoint.ACTION
-            val event = searchAccessPoint.let { sap ->
-                MetricsUtils.createSearchEvent(
+            val searchAccessPoint = MetricsUtils.SearchAccessPoint.ACTION
+            searchAccessPoint.let { sap ->
+                MetricsUtils.recordSearchEvent(
                     searchEngine,
                     store,
                     sap
                 )
             }
-            event?.let { activity.metrics.track(it) }
         }
     }
 

--- a/app/src/main/java/org/mozilla/fenix/search/SearchDialogController.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchDialogController.kt
@@ -22,7 +22,6 @@ import org.mozilla.fenix.GleanMetrics.Events
 import org.mozilla.fenix.GleanMetrics.SearchShortcuts
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
-import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.components.metrics.MetricController
 import org.mozilla.fenix.components.metrics.MetricsUtils
 import org.mozilla.fenix.crashes.CrashListActivity
@@ -106,19 +105,16 @@ class SearchDialogController(
             Events.enteredUrl.record(Events.EnteredUrlExtra(autocomplete = false))
         } else {
             val searchAccessPoint = when (fragmentStore.state.searchAccessPoint) {
-                Event.PerformedSearch.SearchAccessPoint.NONE -> Event.PerformedSearch.SearchAccessPoint.ACTION
+                MetricsUtils.SearchAccessPoint.NONE -> MetricsUtils.SearchAccessPoint.ACTION
                 else -> fragmentStore.state.searchAccessPoint
             }
 
-            val event = searchAccessPoint?.let { sap ->
-                MetricsUtils.createSearchEvent(
+            searchAccessPoint?.let { sap ->
+                MetricsUtils.recordSearchEvent(
                     searchEngine,
                     store,
                     sap
                 )
-            }
-            event?.let {
-                metrics.track(it)
             }
         }
     }
@@ -176,17 +172,17 @@ class SearchDialogController(
         )
 
         val searchAccessPoint = when (fragmentStore.state.searchAccessPoint) {
-            Event.PerformedSearch.SearchAccessPoint.NONE -> Event.PerformedSearch.SearchAccessPoint.SUGGESTION
+            MetricsUtils.SearchAccessPoint.NONE -> MetricsUtils.SearchAccessPoint.SUGGESTION
             else -> fragmentStore.state.searchAccessPoint
         }
 
-        if (searchAccessPoint != null && searchEngine != null) {
-            MetricsUtils.createSearchEvent(
-                searchEngine,
-                store,
-                searchAccessPoint
-            )?.apply {
-                metrics.track(this)
+        searchAccessPoint?.let { sap ->
+            searchEngine?.let { engine ->
+                MetricsUtils.recordSearchEvent(
+                    engine,
+                    store,
+                    sap
+                )
             }
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/search/SearchFragmentStore.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchFragmentStore.kt
@@ -15,7 +15,7 @@ import mozilla.components.lib.state.Store
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.components.Components
-import org.mozilla.fenix.components.metrics.Event
+import org.mozilla.fenix.components.metrics.MetricsUtils
 
 /**
  * The [Store] for holding the [SearchFragmentState] and applying [SearchFragmentAction]s.
@@ -80,16 +80,25 @@ data class SearchFragmentState(
     val showSyncedTabsSuggestions: Boolean,
     val tabId: String?,
     val pastedText: String? = null,
-    val searchAccessPoint: Event.PerformedSearch.SearchAccessPoint?,
+    val searchAccessPoint: MetricsUtils.SearchAccessPoint?,
     val clipboardHasUrl: Boolean = false
 ) : State
 
+/**
+ * Method used to create initial SearchFragment state
+ *
+ * @param activity Activity context of the state.
+ * @param components Reference to all components.
+ * @param tabId Id of the current tab.
+ * @param pastedText Text pasted from the toolbar menu.
+ * @param searchAccessPoint Search access point used to collect data about the search.
+ */
 fun createInitialSearchFragmentState(
     activity: HomeActivity,
     components: Components,
     tabId: String?,
     pastedText: String?,
-    searchAccessPoint: Event.PerformedSearch.SearchAccessPoint
+    searchAccessPoint: MetricsUtils.SearchAccessPoint
 ): SearchFragmentState {
     val settings = components.settings
     val tab = tabId?.let { components.core.store.state.findTab(it) }

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -208,7 +208,7 @@
         <argument
             android:name="search_access_point"
             android:defaultValue="NONE"
-            app:argType="org.mozilla.fenix.components.metrics.Event$PerformedSearch$SearchAccessPoint" />
+            app:argType="org.mozilla.fenix.components.metrics.MetricsUtils$SearchAccessPoint" />
     </dialog>
 
     <fragment

--- a/app/src/test/java/org/mozilla/fenix/components/metrics/MetricsUtilsTestRoboelectric.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/metrics/MetricsUtilsTestRoboelectric.kt
@@ -8,53 +8,81 @@ import io.mockk.every
 import io.mockk.mockk
 import mozilla.components.browser.state.search.SearchEngine
 import mozilla.components.browser.state.store.BrowserStore
-import org.junit.Assert
+import mozilla.components.support.test.robolectric.testContext
+import mozilla.telemetry.glean.testing.GleanTestRule
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.fenix.GleanMetrics.Events
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
 /**
  * Just the Roboelectric tests for MetricsUtil. Splitting these files out means our other tests will run more quickly.
  * FenixRobolectricTestRunner also breaks our ability to use mockkStatic on Base64.
  */
+@RunWith(FenixRobolectricTestRunner::class)
 class MetricsUtilsTestRoboelectric {
 
+    @get:Rule
+    val gleanTestRule = GleanTestRule(testContext)
+
     @Test
-    fun createSearchEvent() {
+    fun `WHEN recordSearchEvent is called THEN the right event is recorded`() {
         val store = BrowserStore()
         val engine: SearchEngine = mockk(relaxed = true)
 
         every { engine.id } returns MetricsUtilsTest.ENGINE_SOURCE_IDENTIFIER
+        assertFalse(Events.performedSearch.testHasValue())
 
-        Assert.assertEquals(
-            "${MetricsUtilsTest.ENGINE_SOURCE_IDENTIFIER}.suggestion",
-            MetricsUtils.createSearchEvent(
-                engine,
-                store,
-                Event.PerformedSearch.SearchAccessPoint.SUGGESTION
-            )?.eventSource?.countLabel
+        MetricsUtils.recordSearchEvent(
+            engine,
+            store,
+            MetricsUtils.SearchAccessPoint.SUGGESTION
         )
-        Assert.assertEquals(
-            "${MetricsUtilsTest.ENGINE_SOURCE_IDENTIFIER}.action",
-            MetricsUtils.createSearchEvent(
-                engine,
-                store,
-                Event.PerformedSearch.SearchAccessPoint.ACTION
-            )?.eventSource?.countLabel
+
+        assertTrue(Events.performedSearch.testHasValue())
+        assertEquals(
+            "shortcut.suggestion",
+            Events.performedSearch.testGetValue().last().extra?.get("source")
         )
-        Assert.assertEquals(
-            "${MetricsUtilsTest.ENGINE_SOURCE_IDENTIFIER}.widget",
-            MetricsUtils.createSearchEvent(
-                engine,
-                store,
-                Event.PerformedSearch.SearchAccessPoint.WIDGET
-            )?.eventSource?.countLabel
+
+        MetricsUtils.recordSearchEvent(
+            engine,
+            store,
+            MetricsUtils.SearchAccessPoint.ACTION
         )
-        Assert.assertEquals(
-            "${MetricsUtilsTest.ENGINE_SOURCE_IDENTIFIER}.shortcut",
-            MetricsUtils.createSearchEvent(
-                engine,
-                store,
-                Event.PerformedSearch.SearchAccessPoint.SHORTCUT
-            )?.eventSource?.countLabel
+
+        assertTrue(Events.performedSearch.testHasValue())
+        assertEquals(
+            "shortcut.action",
+            Events.performedSearch.testGetValue().last().extra?.get("source")
+        )
+
+        MetricsUtils.recordSearchEvent(
+            engine,
+            store,
+            MetricsUtils.SearchAccessPoint.WIDGET
+        )
+
+        assertTrue(Events.performedSearch.testHasValue())
+        assertEquals(
+            "shortcut.widget",
+            Events.performedSearch.testGetValue().last().extra?.get("source")
+        )
+
+        MetricsUtils.recordSearchEvent(
+            engine,
+            store,
+            MetricsUtils.SearchAccessPoint.SHORTCUT
+        )
+
+        assertTrue(Events.performedSearch.testHasValue())
+        assertEquals(
+            "shortcut.shortcut",
+            Events.performedSearch.testGetValue().last().extra?.get("source")
         )
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/home/intent/StartSearchIntentProcessorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/intent/StartSearchIntentProcessorTest.kt
@@ -13,6 +13,7 @@ import io.mockk.verify
 import mozilla.components.service.glean.testing.GleanTestRule
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -21,8 +22,7 @@ import org.mozilla.fenix.GleanMetrics.SearchWidget
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.NavGraphDirections
 import org.mozilla.fenix.R
-import org.mozilla.fenix.components.metrics.Event
-import org.mozilla.fenix.components.metrics.MetricController
+import org.mozilla.fenix.components.metrics.MetricsUtils
 import org.mozilla.fenix.ext.nav
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
@@ -32,15 +32,14 @@ class StartSearchIntentProcessorTest {
     @get:Rule
     val gleanTestRule = GleanTestRule(testContext)
 
-    private val metrics: MetricController = mockk(relaxed = true)
     private val navController: NavController = mockk(relaxed = true)
     private val out: Intent = mockk(relaxed = true)
 
     @Test
     fun `do not process blank intents`() {
-        StartSearchIntentProcessor(metrics).process(Intent(), navController, out)
+        StartSearchIntentProcessor().process(Intent(), navController, out)
 
-        verify { metrics wasNot Called }
+        assertFalse(SearchWidget.newTabButton.testHasValue())
         verify { navController wasNot Called }
         verify { out wasNot Called }
     }
@@ -50,9 +49,9 @@ class StartSearchIntentProcessorTest {
         val intent = Intent().apply {
             removeExtra(HomeActivity.OPEN_TO_SEARCH)
         }
-        StartSearchIntentProcessor(metrics).process(intent, navController, out)
+        StartSearchIntentProcessor().process(intent, navController, out)
 
-        verify { metrics wasNot Called }
+        assertFalse(SearchWidget.newTabButton.testHasValue())
         verify { navController wasNot Called }
         verify { out wasNot Called }
     }
@@ -62,7 +61,7 @@ class StartSearchIntentProcessorTest {
         val intent = Intent().apply {
             putExtra(HomeActivity.OPEN_TO_SEARCH, StartSearchIntentProcessor.SEARCH_WIDGET)
         }
-        StartSearchIntentProcessor(metrics).process(intent, navController, out)
+        StartSearchIntentProcessor().process(intent, navController, out)
         val options = navOptions {
             popUpTo = R.id.homeFragment
         }
@@ -77,7 +76,7 @@ class StartSearchIntentProcessorTest {
                 null,
                 NavGraphDirections.actionGlobalSearchDialog(
                     sessionId = null,
-                    searchAccessPoint = Event.PerformedSearch.SearchAccessPoint.WIDGET
+                    searchAccessPoint = MetricsUtils.SearchAccessPoint.WIDGET
                 ),
                 options
             )

--- a/app/src/test/java/org/mozilla/fenix/search/SearchDialogControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/search/SearchDialogControllerTest.kt
@@ -8,8 +8,10 @@ import androidx.appcompat.app.AlertDialog
 import androidx.navigation.NavController
 import androidx.navigation.NavDirections
 import io.mockk.MockKAnnotations
+import io.mockk.Runs
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.spyk
@@ -78,7 +80,7 @@ class SearchDialogControllerTest {
         every { navController.currentDestination } returns mockk {
             every { id } returns R.id.searchDialogFragment
         }
-        every { MetricsUtils.createSearchEvent(searchEngine, browserStore, any()) } returns null
+        every { MetricsUtils.recordSearchEvent(searchEngine, browserStore, any()) } just Runs
     }
 
     @After
@@ -135,6 +137,7 @@ class SearchDialogControllerTest {
                 from = BrowserDirection.FromSearchDialog,
                 engine = searchEngine
             )
+            MetricsUtils.recordSearchEvent(searchEngine, browserStore, any())
         }
     }
 

--- a/app/src/test/java/org/mozilla/fenix/search/SearchFragmentStoreTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/search/SearchFragmentStoreTest.kt
@@ -28,7 +28,7 @@ import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.browser.browsingmode.BrowsingModeManager
 import org.mozilla.fenix.components.Components
-import org.mozilla.fenix.components.metrics.Event.PerformedSearch.SearchAccessPoint
+import org.mozilla.fenix.components.metrics.MetricsUtils
 import org.mozilla.fenix.utils.Settings
 
 class SearchFragmentStoreTest {
@@ -70,7 +70,7 @@ class SearchFragmentStoreTest {
             showSyncedTabsSuggestions = false,
             tabId = null,
             pastedText = "pastedText",
-            searchAccessPoint = SearchAccessPoint.ACTION
+            searchAccessPoint = MetricsUtils.SearchAccessPoint.ACTION
         )
 
         assertEquals(
@@ -80,7 +80,7 @@ class SearchFragmentStoreTest {
                 components,
                 tabId = null,
                 pastedText = "pastedText",
-                searchAccessPoint = SearchAccessPoint.ACTION
+                searchAccessPoint = MetricsUtils.SearchAccessPoint.ACTION
             )
         )
         assertEquals(
@@ -90,7 +90,7 @@ class SearchFragmentStoreTest {
                 components,
                 tabId = "tabId",
                 pastedText = "pastedText",
-                searchAccessPoint = SearchAccessPoint.ACTION
+                searchAccessPoint = MetricsUtils.SearchAccessPoint.ACTION
             )
         )
     }
@@ -128,14 +128,14 @@ class SearchFragmentStoreTest {
                 showSyncedTabsSuggestions = false,
                 tabId = "tabId",
                 pastedText = "",
-                searchAccessPoint = SearchAccessPoint.SHORTCUT
+                searchAccessPoint = MetricsUtils.SearchAccessPoint.SHORTCUT
             ),
             createInitialSearchFragmentState(
                 activity,
                 components,
                 tabId = "tabId",
                 pastedText = "",
-                searchAccessPoint = SearchAccessPoint.SHORTCUT
+                searchAccessPoint = MetricsUtils.SearchAccessPoint.SHORTCUT
             )
         )
     }
@@ -347,6 +347,6 @@ class SearchFragmentStoreTest {
         showHistorySuggestions = false,
         showBookmarkSuggestions = false,
         showSyncedTabsSuggestions = false,
-        searchAccessPoint = SearchAccessPoint.NONE
+        searchAccessPoint = MetricsUtils.SearchAccessPoint.NONE
     )
 }

--- a/app/src/test/java/org/mozilla/fenix/search/toolbar/ToolbarViewTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/search/toolbar/ToolbarViewTest.kt
@@ -24,7 +24,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.R
-import org.mozilla.fenix.components.metrics.Event
+import org.mozilla.fenix.components.metrics.MetricsUtils
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.search.SearchEngineSource
 import org.mozilla.fenix.search.SearchFragmentState
@@ -57,7 +57,7 @@ class ToolbarViewTest {
         showHistorySuggestions = false,
         showBookmarkSuggestions = false,
         showSyncedTabsSuggestions = false,
-        searchAccessPoint = Event.PerformedSearch.SearchAccessPoint.NONE
+        searchAccessPoint = MetricsUtils.SearchAccessPoint.NONE
     )
 
     @Before


### PR DESCRIPTION
Remove `Event.wrapper` for `performed_search` event

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
