### PR TITLE
Fix and re-enable home screen UI tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
@@ -14,6 +14,7 @@ import org.junit.Test
 import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.helpers.HomeActivityTestRule
+import org.mozilla.fenix.helpers.RetryTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.ext.waitNotNull
 import org.mozilla.fenix.ui.robots.homeScreen
@@ -32,6 +33,10 @@ class HomeScreenTest {
 
     @get:Rule
     val activityTestRule = HomeActivityTestRule()
+
+    @Rule
+    @JvmField
+    val retryTestRule = RetryTestRule(3)
 
     @Test
     fun homeScreenItemsTest() {
@@ -93,7 +98,6 @@ class HomeScreenTest {
         }
     }
 
-    @Ignore("Failing, see: https://github.com/mozilla-mobile/fenix/issues/24436")
     @Test
     fun dismissOnboardingUsingSettingsTest() {
         homeScreen {
@@ -106,7 +110,6 @@ class HomeScreenTest {
         }
     }
 
-    @Ignore("Failing, see: https://github.com/mozilla-mobile/fenix/issues/24436")
     @Test
     fun dismissOnboardingUsingBookmarksTest() {
         homeScreen {
@@ -121,7 +124,6 @@ class HomeScreenTest {
         }
     }
 
-    @Ignore("Failing, see: https://github.com/mozilla-mobile/fenix/issues/24436")
     @Test
     fun dismissOnboardingUsingHelpTest() {
         val settings = activityTestRule.activity.applicationContext.settings()
@@ -136,7 +138,6 @@ class HomeScreenTest {
         }
     }
 
-    @Ignore("Failing, see: https://github.com/mozilla-mobile/fenix/issues/24436")
     @Test
     fun toolbarTapDoesntDismissOnboardingTest() {
         homeScreen {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
@@ -48,6 +48,7 @@ import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeShort
 import org.mozilla.fenix.helpers.TestHelper.appContext
 import org.mozilla.fenix.helpers.TestHelper.appName
+import org.mozilla.fenix.helpers.TestHelper.getStringResource
 import org.mozilla.fenix.helpers.TestHelper.packageName
 import org.mozilla.fenix.helpers.TestHelper.scrollToElementByText
 import org.mozilla.fenix.helpers.click
@@ -505,8 +506,13 @@ private fun verifySearchEngineIcon(searchEngineName: String) {
 
 // First Run elements
 private fun assertWelcomeHeader() =
-    onView(allOf(withText("Welcome to $appName!")))
-        .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+    assertTrue(
+        mDevice.findObject(
+            UiSelector().textContains(
+                getStringResource(R.string.onboarding_header)
+            )
+        ).waitForExists(waitingTime)
+    )
 
 private fun assertStartSyncHeader() {
     scrollToElementByText(STRING_ONBOARDING_ACCOUNT_SIGN_IN_HEADER)


### PR DESCRIPTION
For #24436 fix and re-enable home screen UI tests.
• `dismissOnboardingUsingSettingsTest` ✅  successfully ran 50x on Firebase
• `dismissOnboardingUsingBookmarksTest` ✅  successfully ran 50x on Firebase
• `dismissOnboardingUsingHelpTest` ✅  successfully ran 50x on Firebase
• `toolbarTapDoesntDismissOnboardingTest` ✅  successfully ran 50x on Firebase

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
