### PR TITLE
For #24593 - Initialize Glean on all builds. Avoid Fennec check.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/Config.kt
+++ b/app/src/main/java/org/mozilla/fenix/Config.kt
@@ -42,18 +42,6 @@ enum class ReleaseChannel {
         get() = this == Debug || this == Nightly
 
     /**
-     * Is this a build for a release channel that we used to ship Fennec on?
-     */
-    val isFennec: Boolean
-        get() = this in fennecChannels
-
-    /**
-     * Is this build for a "pure" Fenix channel that we never shipped Fennec on?
-     */
-    val isFenix: Boolean
-        get() = !isFennec
-
-    /**
      * Is this a "Mozilla Online" build of Fenix? "Mozilla Online" is the Chinese branch of Mozilla
      * and this flag will be `true` for builds shipping to Chinese app stores.
      */
@@ -72,8 +60,3 @@ object Config {
         }
     }
 }
-
-private val fennecChannels: List<ReleaseChannel> = listOf(
-    ReleaseChannel.Beta,
-    ReleaseChannel.Release
-)

--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -123,13 +123,8 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
             return
         }
 
-        if (Config.channel.isFenix) {
-            // We need to always initialize Glean and do it early here.
-            // Note that we are only initializing Glean here for "fenix" builds. "fennec" builds
-            // will initialize in MigratingFenixApplication because we first need to migrate the
-            // user's choice from Fennec.
-            initializeGlean()
-        }
+        // We need to always initialize Glean and do it early here.
+        initializeGlean()
 
         setupInMainProcessOnly()
 
@@ -142,7 +137,7 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
     protected open fun initializeGlean() {
         val telemetryEnabled = settings().isTelemetryEnabled
 
-        logger.debug("Initializing Glean (uploadEnabled=$telemetryEnabled, isFennec=${Config.channel.isFennec})")
+        logger.debug("Initializing Glean (uploadEnabled=$telemetryEnabled})")
 
         Glean.initialize(
             applicationContext = this,


### PR DESCRIPTION
This completes the work for removing the Fennec migration support.
Before that, for Fenix release and beta, apps to which users might update to
from old Fennec builds the Glean initialization was done separately in
MigratingFenixApplication to allow time to first migrate user's telemetry
setting.
With the removal of the migration support it is now safe to initialize Glean in
the same way for all builds and remove that Fennec check.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
