### PR TITLE
For #24596 - Only restore Pocket categories selections once

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/PocketUpdatesMiddleware.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/PocketUpdatesMiddleware.kt
@@ -8,7 +8,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.datastore.core.DataStore
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import mozilla.components.lib.state.Action
 import mozilla.components.lib.state.Middleware
@@ -155,18 +155,17 @@ internal fun restoreSelectedCategories(
     selectedPocketCategoriesDataStore: DataStore<SelectedPocketStoriesCategories>
 ) {
     coroutineScope.launch {
-        selectedPocketCategoriesDataStore.data.collect { persistedSelectedCategories ->
-            store.dispatch(
-                AppAction.PocketStoriesCategoriesSelectionsChange(
-                    currentCategories,
-                    persistedSelectedCategories.valuesList.map {
+        store.dispatch(
+            AppAction.PocketStoriesCategoriesSelectionsChange(
+                currentCategories,
+                selectedPocketCategoriesDataStore.data.first()
+                    .valuesList.map {
                         PocketRecommendedStoriesSelectedCategory(
                             name = it.name,
                             selectionTimestamp = it.selectionTimestamp
                         )
                     }
-                )
             )
-        }
+        )
     }
 }


### PR DESCRIPTION
This fixes a regression from migrating from HomeStore to Appstore but
indirectly by ensuring that previous categories selections are only restored
once, not everytime user selects a new category and that change is persisted.

Speculative fix since I still don't know why this regressed - bisecting the code shows https://github.com/mozilla-mobile/fenix/commit/d7a9e304fb86e8464ba2a0b569b7bfa2f5276bc3 and indeed if marking the `appStore` as lateinit and initializing it in `HomeFragment` - as just before that commit - the issue dissapears but I tested this locally to fix the issue. And this also removes unneeded restorings since we already had that data in memory.

Confirmed with the reporter that the issue was reproducing only for the first run of a fresh install.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
