### PR TITLE
For #24701 - Remove Event.wrapper for Pocket related telemetry

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -5377,9 +5377,11 @@ pocket:
       User tapped a Pocket recommended story to be opened.
     extra_keys:
       times_shown:
+        type: string
         description: |
           How many times was this story shown, including current.
       position:
+        type: string
         description: |
           Position of the clicked story in the list shown.
           Uses the [row x column] matrix notation.
@@ -5398,12 +5400,15 @@ pocket:
       User tapped a Pocket stories category to filter stories.
     extra_keys:
       category_name:
+        type: string
         description: |
           Pocket set topic name representing the just clicked category.
       selected_total:
+        type: string
         description: |
           How many categories were selected before this being tapped.
       new_state:
+        type: string
         description: |
           Category's new state after being tapped.
           Possible values: [selected], [deselected].

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/Event.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/Event.kt
@@ -8,7 +8,6 @@ import mozilla.components.browser.state.search.SearchEngine
 import org.mozilla.fenix.GleanMetrics.Autoplay
 import org.mozilla.fenix.GleanMetrics.ContextMenu
 import org.mozilla.fenix.GleanMetrics.Events
-import org.mozilla.fenix.GleanMetrics.Pocket
 import org.mozilla.fenix.GleanMetrics.SearchTerms
 import java.util.Locale
 
@@ -22,37 +21,6 @@ sealed class Event {
     object AddBookmark : Event()
     object HistoryHighlightOpened : Event()
     object HistorySearchGroupOpened : Event()
-    object PocketTopSiteClicked : Event()
-    object PocketTopSiteRemoved : Event()
-    object PocketHomeRecsShown : Event()
-    object PocketHomeRecsDiscoverMoreClicked : Event()
-    object PocketHomeRecsLearnMoreClicked : Event()
-    data class PocketHomeRecsStoryClicked(
-        val timesShown: Long,
-        val storyPosition: Pair<Int, Int>,
-    ) : Event() {
-        override val extras: Map<Pocket.homeRecsStoryClickedKeys, String>
-            get() = mapOf(
-                Pocket.homeRecsStoryClickedKeys.timesShown to timesShown.toString(),
-                Pocket.homeRecsStoryClickedKeys.position to "${storyPosition.first}x${storyPosition.second}"
-            )
-    }
-
-    data class PocketHomeRecsCategoryClicked(
-        val categoryname: String,
-        val previousSelectedCategoriesTotal: Int,
-        val isSelectedNextState: Boolean
-    ) : Event() {
-        override val extras: Map<Pocket.homeRecsCategoryClickedKeys, String>
-            get() = mapOf(
-                Pocket.homeRecsCategoryClickedKeys.categoryName to categoryname,
-                Pocket.homeRecsCategoryClickedKeys.selectedTotal to previousSelectedCategoriesTotal.toString(),
-                Pocket.homeRecsCategoryClickedKeys.newState to when (isSelectedNextState) {
-                    true -> "selected"
-                    false -> "deselected"
-                }
-            )
-    }
     object SearchWidgetInstalled : Event()
 
     object ProgressiveWebAppOpenFromHomescreenTap : Event()

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
@@ -20,7 +20,6 @@ import org.mozilla.fenix.GleanMetrics.HomeMenu
 import org.mozilla.fenix.GleanMetrics.HomeScreen
 import org.mozilla.fenix.GleanMetrics.Metrics
 import org.mozilla.fenix.GleanMetrics.Pings
-import org.mozilla.fenix.GleanMetrics.Pocket
 import org.mozilla.fenix.GleanMetrics.ProgressiveWebApp
 import org.mozilla.fenix.GleanMetrics.RecentBookmarks
 import org.mozilla.fenix.GleanMetrics.RecentSearches
@@ -103,29 +102,6 @@ private val Event.wrapper: EventWrapper<*>?
             { ContextMenu.itemTappedKeys.valueOf(it) }
         )
 
-        is Event.PocketTopSiteClicked -> EventWrapper<NoExtraKeys>(
-            { Pocket.pocketTopSiteClicked.record(it) }
-        )
-        is Event.PocketTopSiteRemoved -> EventWrapper<NoExtraKeys>(
-            { Pocket.pocketTopSiteRemoved.record(it) }
-        )
-        is Event.PocketHomeRecsShown -> EventWrapper<NoExtraKeys>(
-            { Pocket.homeRecsShown.record(it) }
-        )
-        is Event.PocketHomeRecsLearnMoreClicked -> EventWrapper<NoExtraKeys>(
-            { Pocket.homeRecsLearnMoreClicked.record(it) }
-        )
-        is Event.PocketHomeRecsDiscoverMoreClicked -> EventWrapper<NoExtraKeys>(
-            { Pocket.homeRecsDiscoverClicked.record(it) }
-        )
-        is Event.PocketHomeRecsStoryClicked -> EventWrapper(
-            { Pocket.homeRecsStoryClicked.record(it) },
-            { Pocket.homeRecsStoryClickedKeys.valueOf(it) }
-        )
-        is Event.PocketHomeRecsCategoryClicked -> EventWrapper(
-            { Pocket.homeRecsCategoryClicked.record(it) },
-            { Pocket.homeRecsCategoryClickedKeys.valueOf(it) }
-        )
         is Event.AutoPlaySettingVisited -> EventWrapper<NoExtraKeys>(
             { Autoplay.visitedSetting.record(it) }
         )

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -386,7 +386,6 @@ class HomeFragment : Fragment() {
                 homeActivity = activity,
                 appStore = components.appStore,
                 navController = findNavController(),
-                metrics = requireComponents.analytics.metrics
             )
         )
 

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
@@ -33,6 +33,7 @@ import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.GleanMetrics.Collections
 import org.mozilla.fenix.GleanMetrics.Events
 import org.mozilla.fenix.GleanMetrics.Pings
+import org.mozilla.fenix.GleanMetrics.Pocket
 import org.mozilla.fenix.GleanMetrics.TopSites
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
@@ -376,7 +377,7 @@ class DefaultSessionControlController(
     override fun handleRemoveTopSiteClicked(topSite: TopSite) {
         TopSites.remove.record(NoExtras())
         when (topSite.url) {
-            SupportUtils.POCKET_TRENDING_URL -> metrics.track(Event.PocketTopSiteRemoved)
+            SupportUtils.POCKET_TRENDING_URL -> Pocket.pocketTopSiteRemoved.record(NoExtras())
             SupportUtils.GOOGLE_URL -> TopSites.googleTopSiteRemoved.record(NoExtras())
             SupportUtils.BAIDU_URL -> TopSites.baiduTopSiteRemoved.record(NoExtras())
         }
@@ -413,7 +414,7 @@ class DefaultSessionControlController(
         when (topSite.url) {
             SupportUtils.GOOGLE_URL -> TopSites.openGoogleSearchAttribution.record(NoExtras())
             SupportUtils.BAIDU_URL -> TopSites.openBaiduSearchAttribution.record(NoExtras())
-            SupportUtils.POCKET_TRENDING_URL -> metrics.track(Event.PocketTopSiteClicked)
+            SupportUtils.POCKET_TRENDING_URL -> Pocket.pocketTopSiteClicked.record(NoExtras())
         }
 
         val availableEngines = getAvailableSearchEngines()


### PR DESCRIPTION
Removed `Event.wrapper` for `Pocket` metrics.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
