### PR TITLE
For #24495 fix and re-enable settingsPrivacyItemsTest UI test.

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsPrivacyTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsPrivacyTest.kt
@@ -10,7 +10,6 @@ import androidx.test.uiautomator.UiDevice
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.customannotations.SmokeTest
@@ -59,10 +58,6 @@ class SettingsPrivacyTest {
     }
 
     @Test
-    @Ignore(
-        "New https-only setting was added. Test needs refactoring. " +
-            "See https://github.com/mozilla-mobile/fenix/issues/24495"
-    )
     // Walks through settings privacy menu and sub-menus to ensure all items are present
     fun settingsPrivacyItemsTest() {
         homeScreen {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsPrivacyTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsPrivacyTest.kt
@@ -71,6 +71,9 @@ class SettingsPrivacyTest {
         }.openPrivateBrowsingSubMenu {
             verifyNavigationToolBarHeader()
         }.goBack {
+            // HTTPS-Only Mode
+            verifyHTTPSOnlyModeButton()
+            verifyHTTPSOnlyModeState("Off")
 
             // ENHANCED TRACKING PROTECTION
             verifyEnhancedTrackingProtectionButton()

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsPrivacyTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsPrivacyTest.kt
@@ -77,7 +77,7 @@ class SettingsPrivacyTest {
 
             // ENHANCED TRACKING PROTECTION
             verifyEnhancedTrackingProtectionButton()
-            verifyEnhancedTrackingProtectionValue("On")
+            verifyEnhancedTrackingProtectionState("On")
         }.openEnhancedTrackingProtectionSubMenu {
             verifyNavigationToolBarHeader()
             verifyEnhancedTrackingProtectionProtectionSubMenuItems()
@@ -150,7 +150,7 @@ class SettingsPrivacyTest {
 
             // DELETE BROWSING DATA ON QUIT
             verifyDeleteBrowsingDataOnQuitButton()
-            verifyDeleteBrowsingDataOnQuitValue("Off")
+            verifyDeleteBrowsingDataOnQuitState("Off")
         }.openSettingsSubMenuDeleteBrowsingDataOnQuit {
             verifyNavigationToolBarHeader()
             verifyDeleteBrowsingDataOnQuitSubMenuItems()

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/StrictEnhancedTrackingProtectionTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/StrictEnhancedTrackingProtectionTest.kt
@@ -61,7 +61,7 @@ class StrictEnhancedTrackingProtectionTest {
         }.openThreeDotMenu {
         }.openSettings {
             verifyEnhancedTrackingProtectionButton()
-            verifyEnhancedTrackingProtectionValue("On")
+            verifyEnhancedTrackingProtectionState("On")
         }.openEnhancedTrackingProtectionSubMenu {
             verifyEnhancedTrackingProtectionHeader()
             verifyEnhancedTrackingProtectionOptionsEnabled()

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
@@ -18,6 +18,7 @@ import androidx.test.espresso.intent.matcher.IntentMatchers.toPackage
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.Visibility
 import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
+import androidx.test.espresso.matcher.ViewMatchers.hasSibling
 import androidx.test.espresso.matcher.ViewMatchers.isChecked
 import androidx.test.espresso.matcher.ViewMatchers.isCompletelyDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
@@ -429,8 +430,12 @@ private fun assertDeleteBrowsingDataOnQuitButton() {
 }
 
 private fun assertDeleteBrowsingDataValue(state: String) {
-    mDevice.wait(Until.findObject(By.text("Delete browsing data on quit")), waitingTime)
-    onView(withText(state)).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+    onView(
+        allOf(
+            withText(R.string.preferences_delete_browsing_data_on_quit),
+            hasSibling(withText(state))
+        )
+    ).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 }
 
 private fun assertNotificationsButton() {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
@@ -79,14 +79,14 @@ class SettingsRobot {
     fun verifyHTTPSOnlyModeState(state: String) = assertHTTPSOnlyModeState(state)
     fun verifyEnhancedTrackingProtectionButton() = assertEnhancedTrackingProtectionButton()
     fun verifyLoginsAndPasswordsButton() = assertLoginsAndPasswordsButton()
-    fun verifyEnhancedTrackingProtectionValue(state: String) =
-        assertEnhancedTrackingProtectionValue(state)
+    fun verifyEnhancedTrackingProtectionState(state: String) =
+        assertEnhancedTrackingProtectionState(state)
     fun verifyPrivateBrowsingButton() = assertPrivateBrowsingButton()
     fun verifySitePermissionsButton() = assertSitePermissionsButton()
     fun verifyDeleteBrowsingDataButton() = assertDeleteBrowsingDataButton()
     fun verifyDeleteBrowsingDataOnQuitButton() = assertDeleteBrowsingDataOnQuitButton()
-    fun verifyDeleteBrowsingDataOnQuitValue(state: String) =
-        assertDeleteBrowsingDataValue(state)
+    fun verifyDeleteBrowsingDataOnQuitState(state: String) =
+        assertDeleteBrowsingDataState(state)
     fun verifyNotificationsButton() = assertNotificationsButton()
     fun verifyDataCollectionButton() = assertDataCollectionButton()
     fun verifyOpenLinksInAppsButton() = assertOpenLinksInAppsButton()
@@ -412,7 +412,7 @@ private fun assertEnhancedTrackingProtectionButton() {
     ).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 }
 
-private fun assertEnhancedTrackingProtectionValue(state: String) {
+private fun assertEnhancedTrackingProtectionState(state: String) {
     mDevice.wait(Until.findObject(By.text("Enhanced Tracking Protection")), waitingTime)
     onView(withText(state)).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 }
@@ -448,7 +448,7 @@ private fun assertDeleteBrowsingDataOnQuitButton() {
         .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 }
 
-private fun assertDeleteBrowsingDataValue(state: String) {
+private fun assertDeleteBrowsingDataState(state: String) {
     onView(
         allOf(
             withText(R.string.preferences_delete_browsing_data_on_quit),

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
@@ -43,6 +43,7 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.Constants.PackageName.GOOGLE_PLAY_SERVICES
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.TestHelper.appName
+import org.mozilla.fenix.helpers.TestHelper.getStringResource
 import org.mozilla.fenix.helpers.TestHelper.hasCousin
 import org.mozilla.fenix.helpers.TestHelper.isPackageInstalled
 import org.mozilla.fenix.helpers.TestHelper.packageName
@@ -74,6 +75,8 @@ class SettingsRobot {
     // PRIVACY SECTION
     fun verifyPrivacyHeading() = assertPrivacyHeading()
 
+    fun verifyHTTPSOnlyModeButton() = assertHTTPSOnlyModeButton()
+    fun verifyHTTPSOnlyModeState(state: String) = assertHTTPSOnlyModeState(state)
     fun verifyEnhancedTrackingProtectionButton() = assertEnhancedTrackingProtectionButton()
     fun verifyLoginsAndPasswordsButton() = assertLoginsAndPasswordsButton()
     fun verifyEnhancedTrackingProtectionValue(state: String) =
@@ -382,6 +385,22 @@ private fun assertPrivacyHeading() {
     scrollToElementByText("Privacy and security")
     onView(withText("Privacy and security"))
         .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+}
+
+private fun assertHTTPSOnlyModeButton() {
+    scrollToElementByText(getStringResource(R.string.preferences_https_only_title))
+    onView(
+        withText(R.string.preferences_https_only_title)
+    ).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+}
+
+private fun assertHTTPSOnlyModeState(state: String) {
+    onView(
+        allOf(
+            withText(R.string.preferences_https_only_title),
+            hasSibling(withText(state))
+        )
+    ).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 }
 
 private fun assertEnhancedTrackingProtectionButton() {


### PR DESCRIPTION
For #24495 fix and re-enable `settingsPrivacyItemsTest` UI test ✅  successfully passed 40x on Firebase

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
