### PR TITLE
For #24703 - Replace Mockito mocks with Mockk mocks

### DIFF
--- a/app/src/test/java/org/mozilla/fenix/ext/SearchEngineTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/ext/SearchEngineTest.kt
@@ -4,8 +4,8 @@
 
 package org.mozilla.fenix.ext
 
+import io.mockk.mockk
 import mozilla.components.browser.state.search.SearchEngine
-import mozilla.components.support.test.mock
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -18,7 +18,7 @@ class SearchEngineTest {
         val searchEngine = SearchEngine(
             id = UUID.randomUUID().toString(),
             name = "Not custom",
-            icon = mock(),
+            icon = mockk(),
             type = SearchEngine.Type.BUNDLED,
             resultUrls = listOf(
                 "https://www.startpage.com/sp/search?q={searchTerms}"
@@ -28,7 +28,7 @@ class SearchEngineTest {
         val customSearchEngine = SearchEngine(
             id = UUID.randomUUID().toString(),
             name = "Custom",
-            icon = mock(),
+            icon = mockk(),
             type = SearchEngine.Type.CUSTOM,
             resultUrls = listOf(
                 "https://www.startpage.com/sp/search?q={searchTerms}"
@@ -44,7 +44,7 @@ class SearchEngineTest {
         val searchEngine = SearchEngine(
             id = UUID.randomUUID().toString(),
             name = "Not well known",
-            icon = mock(),
+            icon = mockk(),
             type = SearchEngine.Type.BUNDLED,
             resultUrls = listOf(
                 "https://www.random.com/sp/search?q={searchTerms}"
@@ -54,7 +54,7 @@ class SearchEngineTest {
         val wellKnownSearchEngine = SearchEngine(
             id = UUID.randomUUID().toString(),
             name = "Well known",
-            icon = mock(),
+            icon = mockk(),
             type = SearchEngine.Type.CUSTOM,
             resultUrls = listOf(
                 "https://www.startpage.com/sp/search?q={searchTerms}"

--- a/app/src/test/java/org/mozilla/fenix/settings/quicksettings/AutoplayValueTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/quicksettings/AutoplayValueTest.kt
@@ -7,12 +7,12 @@ package org.mozilla.fenix.settings.quicksettings
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
 import mozilla.components.concept.engine.permission.SitePermissions
 import mozilla.components.concept.engine.permission.SitePermissions.AutoplayStatus
 import mozilla.components.feature.sitepermissions.SitePermissionsRules
 import mozilla.components.feature.sitepermissions.SitePermissionsRules.AutoplayAction
 import mozilla.components.feature.sitepermissions.SitePermissionsRules.Action
-import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertFalse
@@ -292,7 +292,7 @@ class AutoplayValueTest {
 
         val value = AutoplayValue.AllowAll(
             label = "label",
-            rules = mock(),
+            rules = mockk(),
             sitePermission = null
         )
 
@@ -319,7 +319,7 @@ class AutoplayValueTest {
 
         val value = AutoplayValue.BlockAll(
             label = "label",
-            rules = mock(),
+            rules = mockk(),
             sitePermission = null
         )
 
@@ -346,7 +346,7 @@ class AutoplayValueTest {
 
         val value = AutoplayValue.BlockAudible(
             label = "label",
-            rules = mock(),
+            rules = mockk(),
             sitePermission = null
         )
 

--- a/app/src/test/java/org/mozilla/fenix/settings/quicksettings/DefaultQuickSettingsControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/quicksettings/DefaultQuickSettingsControllerTest.kt
@@ -27,7 +27,6 @@ import mozilla.components.concept.engine.permission.SitePermissions.Status.NO_DE
 import mozilla.components.feature.session.SessionUseCases
 import mozilla.components.feature.session.TrackingProtectionUseCases
 import mozilla.components.service.glean.testing.GleanTestRule
-import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.After
 import org.junit.Assert.assertArrayEquals
@@ -231,7 +230,7 @@ class DefaultQuickSettingsControllerTest {
         every { store.dispatch(any()) } returns mockk()
         every { controller.handleAutoplayAdd(any()) } returns Unit
         every { controller.handlePermissionsChange(any()) } returns Unit
-        every { autoplayValue.updateSitePermissions(any()) } returns mock()
+        every { autoplayValue.updateSitePermissions(any()) } returns mockk()
 
         controller.handleAutoplayChanged(autoplayValue)
 

--- a/app/src/test/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsFragmentStoreTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/quicksettings/QuickSettingsFragmentStoreTest.kt
@@ -20,7 +20,6 @@ import mozilla.components.concept.engine.permission.SitePermissions
 import mozilla.components.feature.sitepermissions.SitePermissionsRules
 import mozilla.components.feature.sitepermissions.SitePermissionsRules.Action
 import mozilla.components.feature.sitepermissions.SitePermissionsRules.AutoplayAction
-import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -284,7 +283,7 @@ class QuickSettingsFragmentStoreTest {
             val initialState = QuickSettingsFragmentState(
                 webInfoState = websiteInfoState,
                 websitePermissionsState = initialWebsitePermissionsState,
-                trackingProtectionState = mock()
+                trackingProtectionState = mockk()
             )
             val store = QuickSettingsFragmentStore(initialState)
 

--- a/app/src/test/java/org/mozilla/fenix/settings/quicksettings/WebsitePermissionViewTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/quicksettings/WebsitePermissionViewTest.kt
@@ -13,10 +13,10 @@ import io.mockk.spyk
 import io.mockk.MockKAnnotations
 import io.mockk.verify
 import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
 import junit.framework.TestCase.assertEquals
-import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Before
 import org.junit.Test
@@ -157,17 +157,17 @@ class WebsitePermissionViewTest {
         val options = listOf(
             AutoplayValue.BlockAll(
                 label = "BlockAll",
-                rules = mock(),
+                rules = mockk(),
                 sitePermission = null
             ),
             AutoplayValue.AllowAll(
                 label = "AllowAll",
-                rules = mock(),
+                rules = mockk(),
                 sitePermission = null
             ),
             AutoplayValue.BlockAudible(
                 label = "BlockAudible",
-                rules = mock(),
+                rules = mockk(),
                 sitePermission = null
             )
         )
@@ -189,7 +189,7 @@ class WebsitePermissionViewTest {
         assertEquals(permission.autoplayValue, permissionView.status.selectedItem)
 
         permissionView.status.onItemSelectedListener!!.onItemSelected(
-            mock(),
+            mockk(),
             permissionView.status,
             1,
             0L
@@ -200,7 +200,7 @@ class WebsitePermissionViewTest {
 
         permissionView.status.setSelection(2)
         permissionView.status.onItemSelectedListener!!.onItemSelected(
-            mock(),
+            mockk(),
             permissionView.status,
             2,
             0L

--- a/app/src/test/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsManageExceptionsPhoneFeatureFragmentTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/sitepermissions/SitePermissionsManageExceptionsPhoneFeatureFragmentTest.kt
@@ -19,7 +19,6 @@ import mozilla.components.concept.engine.permission.SitePermissions.AutoplayStat
 import mozilla.components.feature.sitepermissions.SitePermissionsRules
 import mozilla.components.feature.sitepermissions.SitePermissionsRules.AutoplayAction
 import mozilla.components.feature.sitepermissions.SitePermissionsRules.Action
-import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertFalse
@@ -448,7 +447,7 @@ class SitePermissionsManageExceptionsPhoneFeatureFragmentTest {
 
         val value = AutoplayValue.AllowAll(
             label = "label",
-            rules = mock(),
+            rules = mockk(),
             sitePermission = null
         )
 
@@ -476,7 +475,7 @@ class SitePermissionsManageExceptionsPhoneFeatureFragmentTest {
 
         val value = AutoplayValue.BlockAll(
             label = "label",
-            rules = mock(),
+            rules = mockk(),
             sitePermission = null
         )
 
@@ -504,7 +503,7 @@ class SitePermissionsManageExceptionsPhoneFeatureFragmentTest {
 
         val value = AutoplayValue.BlockAudible(
             label = "label",
-            rules = mock(),
+            rules = mockk(),
             sitePermission = null
         )
 

--- a/app/src/test/java/org/mozilla/fenix/wifi/WifiConnectionMonitorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/wifi/WifiConnectionMonitorTest.kt
@@ -9,7 +9,6 @@ import android.net.ConnectivityManager
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
-import mozilla.components.support.test.mock
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertFalse
@@ -142,7 +141,7 @@ class WifiConnectionMonitorTest {
         val callback: (Boolean) -> Unit = { wasNotified = it }
 
         wifiConnectionMonitor.addOnWifiConnectedChangedListener(callback)
-        wifiConnectionMonitor.frameworkListener.onLost(mock())
+        wifiConnectionMonitor.frameworkListener.onLost(mockk())
 
         assertFalse(wasNotified!!)
     }
@@ -154,7 +153,7 @@ class WifiConnectionMonitorTest {
         val callback: (Boolean) -> Unit = { wasNotified = it }
 
         wifiConnectionMonitor.addOnWifiConnectedChangedListener(callback)
-        wifiConnectionMonitor.frameworkListener.onAvailable(mock())
+        wifiConnectionMonitor.frameworkListener.onAvailable(mockk())
 
         assertTrue(wasNotified!!)
     }


### PR DESCRIPTION
Replaced `mock()` calls inside tests with `mockk()` to avoid intermittent test failures.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
