### PR TITLE
For #24708 - Remove Event.wrapper for DarkThemeSelected telemetry

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -5289,6 +5289,7 @@ app_theme:
       A user selected Dark Theme
     extra_keys:
       source:
+        type: string
         description: |
           The source from where dark theme was selected. The source can be
           'SETTINGS' or 'ONBOARDING'

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/Event.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/Event.kt
@@ -7,7 +7,6 @@ package org.mozilla.fenix.components.metrics
 import mozilla.components.browser.state.search.SearchEngine
 import mozilla.components.feature.top.sites.TopSite
 import org.mozilla.fenix.GleanMetrics.Addons
-import org.mozilla.fenix.GleanMetrics.AppTheme
 import org.mozilla.fenix.GleanMetrics.Autoplay
 import org.mozilla.fenix.GleanMetrics.ContextMenu
 import org.mozilla.fenix.GleanMetrics.Events
@@ -244,13 +243,6 @@ sealed class Event {
 
         override val extras: Map<Events.performedSearchKeys, String>?
             get() = mapOf(Events.performedSearchKeys.source to eventSource.sourceLabel)
-    }
-
-    data class DarkThemeSelected(val source: Source) : Event() {
-        enum class Source { SETTINGS }
-
-        override val extras: Map<AppTheme.darkThemeSelectedKeys, String>?
-            get() = mapOf(AppTheme.darkThemeSelectedKeys.source to source.name)
     }
 
     data class SearchWithAds(val providerName: String) : Event() {

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
@@ -10,7 +10,6 @@ import mozilla.components.service.glean.private.NoExtraKeys
 import mozilla.components.support.base.log.logger.Logger
 import org.mozilla.fenix.GleanMetrics.Addons
 import org.mozilla.fenix.GleanMetrics.AndroidAutofill
-import org.mozilla.fenix.GleanMetrics.AppTheme
 import org.mozilla.fenix.GleanMetrics.Autoplay
 import org.mozilla.fenix.GleanMetrics.Awesomebar
 import org.mozilla.fenix.GleanMetrics.BrowserSearch
@@ -219,10 +218,6 @@ private val Event.wrapper: EventWrapper<*>?
         is Event.PocketHomeRecsCategoryClicked -> EventWrapper(
             { Pocket.homeRecsCategoryClicked.record(it) },
             { Pocket.homeRecsCategoryClickedKeys.valueOf(it) }
-        )
-        is Event.DarkThemeSelected -> EventWrapper(
-            { AppTheme.darkThemeSelected.record(it) },
-            { AppTheme.darkThemeSelectedKeys.valueOf(it) }
         )
         is Event.AddonsOpenInSettings -> EventWrapper<NoExtraKeys>(
             { Addons.openAddonsInSettings.record(it) }

--- a/app/src/main/java/org/mozilla/fenix/settings/CustomizationFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/CustomizationFragment.kt
@@ -12,11 +12,10 @@ import androidx.appcompat.app.AppCompatDelegate
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreference
 import org.mozilla.fenix.FeatureFlags
+import org.mozilla.fenix.GleanMetrics.AppTheme
 import org.mozilla.fenix.GleanMetrics.ToolbarSettings
 import org.mozilla.fenix.R
-import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.components.toolbar.ToolbarPosition
-import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.showToolbar
@@ -85,9 +84,9 @@ class CustomizationFragment : PreferenceFragmentCompat() {
     private fun bindDarkTheme() {
         radioDarkTheme = requirePreference(R.string.pref_key_dark_theme)
         radioDarkTheme.onClickListener {
-            requireContext().components.analytics.metrics.track(
-                Event.DarkThemeSelected(
-                    Event.DarkThemeSelected.Source.SETTINGS
+            AppTheme.darkThemeSelected.record(
+                AppTheme.DarkThemeSelectedExtra(
+                    "SETTINGS"
                 )
             )
             setNewTheme(AppCompatDelegate.MODE_NIGHT_YES)


### PR DESCRIPTION
Removed `Event.wrapper` for `DarkThemeSelected` metric.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
