### PR TITLE
for #24718: add two remote firefox wallpapers

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/wallpapers/Wallpaper.kt
+++ b/app/src/main/java/org/mozilla/fenix/wallpapers/Wallpaper.kt
@@ -58,6 +58,16 @@ sealed class Wallpaper {
         ) : Remote() {
             override val remoteParentDirName: String = "house"
         }
+
+        /**
+         * Wallpapers that are original Firefox creations.
+         */
+        data class Firefox(
+            override val name: String,
+        ) : Remote() {
+            override val expirationDate: Date? = null
+            override val remoteParentDirName: String = "firefox"
+        }
     }
 
     companion object {

--- a/app/src/main/java/org/mozilla/fenix/wallpapers/WallpaperManager.kt
+++ b/app/src/main/java/org/mozilla/fenix/wallpapers/WallpaperManager.kt
@@ -243,6 +243,12 @@ class WallpaperManager(
             Wallpaper.Remote.House(
                 "mei",
             ),
+            Wallpaper.Remote.Firefox(
+                "twilight-hills"
+            ),
+            Wallpaper.Remote.Firefox(
+                "beach-vibe"
+            ),
         )
         private val availableWallpapers = listOf(defaultWallpaper) + localWallpapers + remoteWallpapers
         private const val ANIMATION_DELAY_MS = 1500L


### PR DESCRIPTION
for #24718

<img width="393" alt="image" src="https://user-images.githubusercontent.com/10427470/162851054-54085cdc-8e06-45c8-ac82-b41645dec36d.png">

<img width="400" alt="image" src="https://user-images.githubusercontent.com/10427470/162851074-edaea5ba-cb10-40d0-acec-605a99d31018.png">

<img width="393" alt="image" src="https://user-images.githubusercontent.com/10427470/162851093-fdf54abf-df05-40c8-bc1b-7f480ec3e6df.png">

<img width="393" alt="image" src="https://user-images.githubusercontent.com/10427470/162851109-9633d569-40c0-472a-aff7-8797ee6026d5.png">

<img width="390" alt="image" src="https://user-images.githubusercontent.com/10427470/162851129-3c0f6c35-5711-471a-962e-eedd756e1f44.png">

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
