### PR TITLE
For #24709 - Remove Event.wrapper for Wallpapers telemetry

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/metrics/Event.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/Event.kt
@@ -275,11 +275,6 @@ sealed class Event {
 
     sealed class Search
 
-    object WallpaperSettingsOpened : Event()
-    data class WallpaperSelected(val wallpaper: org.mozilla.fenix.wallpapers.Wallpaper) : Event()
-    data class WallpaperSwitched(val wallpaper: org.mozilla.fenix.wallpapers.Wallpaper) : Event()
-    data class ChangeWallpaperWithLogoToggled(val checked: Boolean) : Event()
-
     sealed class Messaging(open val messageId: String) : Event() {
         data class MessageShown(override val messageId: String) : Messaging(messageId)
         data class MessageDismissed(override val messageId: String) : Messaging(messageId)

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
@@ -33,7 +33,6 @@ import org.mozilla.fenix.GleanMetrics.SearchTerms
 import org.mozilla.fenix.GleanMetrics.StartOnHome
 import org.mozilla.fenix.GleanMetrics.SyncedTabs
 import org.mozilla.fenix.GleanMetrics.Tabs
-import org.mozilla.fenix.GleanMetrics.Wallpapers
 import org.mozilla.fenix.GleanMetrics.Messaging
 import org.mozilla.fenix.ext.components
 
@@ -389,38 +388,6 @@ private val Event.wrapper: EventWrapper<*>?
                     Messaging.MessageExpiredExtra(
                         messageKey = this.messageId
                     )
-                )
-            }
-        )
-        is Event.WallpaperSettingsOpened -> EventWrapper<NoExtraKeys>(
-            { Wallpapers.wallpaperSettingsOpened.record() }
-        )
-        is Event.WallpaperSelected -> EventWrapper<NoExtraKeys>(
-            {
-                Wallpapers.wallpaperSelected.record(
-                    Wallpapers.WallpaperSelectedExtra(
-                        name = this.wallpaper.name,
-                        themeCollection = this.wallpaper::class.simpleName,
-                    ),
-                )
-            }
-        )
-        is Event.WallpaperSwitched -> EventWrapper<NoExtraKeys>(
-            {
-                Wallpapers.wallpaperSwitched.record(
-                    Wallpapers.WallpaperSwitchedExtra(
-                        name = this.wallpaper.name,
-                        themeCollection = this.wallpaper::class.simpleName,
-                    ),
-                )
-            }
-        )
-        is Event.ChangeWallpaperWithLogoToggled -> EventWrapper<NoExtraKeys>(
-            {
-                Wallpapers.changeWallpaperLogoToggled.record(
-                    Wallpapers.ChangeWallpaperLogoToggledExtra(
-                        checked = this.checked,
-                    ),
                 )
             }
         )

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -78,6 +78,7 @@ import org.mozilla.fenix.BrowserDirection
 import org.mozilla.fenix.Config
 import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.GleanMetrics.Events
+import org.mozilla.fenix.GleanMetrics.Wallpapers
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.browser.BrowserAnimator.Companion.getToolbarNavOptions
@@ -747,7 +748,12 @@ class HomeFragment : Fragment() {
             binding.wordmark.setOnClickListener {
                 val manager = requireComponents.wallpaperManager
                 val newWallpaper = manager.switchToNextWallpaper()
-                requireComponents.analytics.metrics.track(Event.WallpaperSwitched(newWallpaper))
+                Wallpapers.wallpaperSwitched.record(
+                    Wallpapers.WallpaperSwitchedExtra(
+                        name = newWallpaper.name,
+                        themeCollection = newWallpaper::class.simpleName
+                    )
+                )
                 manager.updateWallpaper(
                     wallpaperContainer = binding.wallpaperImageView,
                     newWallpaper = newWallpaper

--- a/app/src/main/java/org/mozilla/fenix/settings/wallpaper/WallpaperSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/wallpaper/WallpaperSettingsFragment.kt
@@ -16,8 +16,9 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
+import mozilla.components.service.glean.private.NoExtras
+import org.mozilla.fenix.GleanMetrics.Wallpapers
 import org.mozilla.fenix.R
-import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.showToolbar
 import org.mozilla.fenix.theme.FirefoxTheme
@@ -33,16 +34,12 @@ class WallpaperSettingsFragment : Fragment() {
         requireComponents.settings
     }
 
-    private val metrics by lazy {
-        requireComponents.analytics.metrics
-    }
-
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        metrics.track(Event.WallpaperSettingsOpened)
+        Wallpapers.wallpaperSettingsOpened.record(NoExtras())
         return ComposeView(requireContext()).apply {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
@@ -59,14 +56,23 @@ class WallpaperSettingsFragment : Fragment() {
                         onSelectWallpaper = { selectedWallpaper: Wallpaper ->
                             currentWallpaper = selectedWallpaper
                             wallpaperManager.currentWallpaper = selectedWallpaper
-                            metrics.track(Event.WallpaperSelected(selectedWallpaper))
+                            Wallpapers.wallpaperSelected.record(
+                                Wallpapers.WallpaperSelectedExtra(
+                                    name = selectedWallpaper.name,
+                                    themeCollection = selectedWallpaper::class.simpleName
+                                )
+                            )
                         },
                         onViewWallpaper = { findNavController().navigate(R.id.homeFragment) },
                         tapLogoSwitchChecked = wallpapersSwitchedByLogo,
                         onTapLogoSwitchCheckedChange = {
                             settings.wallpapersSwitchedByLogoTap = it
                             wallpapersSwitchedByLogo = it
-                            metrics.track(Event.ChangeWallpaperWithLogoToggled(it))
+                            Wallpapers.changeWallpaperLogoToggled.record(
+                                Wallpapers.ChangeWallpaperLogoToggledExtra(
+                                    checked = it
+                                )
+                            )
                         }
                     )
                 }


### PR DESCRIPTION
Removed `Event.wrapper` for `Wallpapers` metrics. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
