### PR TITLE
For #22640 re-enable verifyUndoSnackBarTest UI test

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/RetryTestRule.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/RetryTestRule.kt
@@ -4,10 +4,11 @@
 
 package org.mozilla.fenix.helpers
 
+import androidx.test.uiautomator.UiObjectNotFoundException
+import junit.framework.AssertionFailedError
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
-import java.lang.AssertionError
 
 class RetryTestRule(private val retryCount: Int = 5) : TestRule {
 
@@ -18,6 +19,14 @@ class RetryTestRule(private val retryCount: Int = 5) : TestRule {
                     base.evaluate()
                     break
                 } catch (t: AssertionError) {
+                    if (i == retryCount) {
+                        throw t
+                    }
+                } catch (t: AssertionFailedError) {
+                    if (i == retryCount) {
+                        throw t
+                    }
+                } catch (t: UiObjectNotFoundException) {
                     if (i == retryCount) {
                         throw t
                     }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
@@ -10,12 +10,12 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.FeatureSettingsHelper
 import org.mozilla.fenix.helpers.HomeActivityTestRule
+import org.mozilla.fenix.helpers.RetryTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.ui.robots.browserScreen
 import org.mozilla.fenix.ui.robots.homeScreen
@@ -47,6 +47,10 @@ class TabbedBrowsingTest {
     /* ktlint-disable no-blank-line-before-rbrace */ // This imposes unreadable grouping.
     @get:Rule
     val activityTestRule = HomeActivityTestRule()
+
+    @Rule
+    @JvmField
+    val retryTestRule = RetryTestRule(3)
 
     @Before
     fun setUp() {
@@ -172,7 +176,6 @@ class TabbedBrowsingTest {
         }
     }
 
-    @Ignore("Currently failing, will need some investigation, see https://github.com/mozilla-mobile/fenix/issues/22640")
     @Test
     fun verifyUndoSnackBarTest() {
         // disabling these features because they interfere with the snackbar visibility


### PR DESCRIPTION
For #22640 re-enable `verifyUndoSnackBarTest` UI test, add and update `RetryTestRule`
✅  Successfully passed **100x** on Firebase

<details>

<summary> 📈 Results (dropdown)</summary>

<h1 dir="auto" style="box-sizing: border-box; font-size: 2em; margin: 24px 0px 16px; font-weight: 600; line-height: 1.25; padding-bottom: 0.3em; border-bottom: 1px solid var(--color-border-muted); color: rgb(201, 209, 217); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Results</h1>

matrix | result | logs | details
-- | -- | -- | --
matrix-21nsgrkl3cnd4 | success | logs | 1 test cases passed
matrix-2hoixxz8yxvnr | success | logs | 1 test cases passed
matrix-2t91dnvb5z5t7 | success | logs | 1 test cases passed
matrix-13or34tbs28j8 | success | logs | 1 test cases passed
matrix-ennod26qzvtia | success | logs | 1 test cases passed
matrix-13youc7xxclit | success | logs | 1 test cases passed
matrix-xe19l0fsej8ka | success | logs | 1 test cases passed
matrix-3n21ceqys50w2 | success | logs | 1 test cases passed
matrix-2nnish27k0y0r | success | logs | 1 test cases passed
matrix-1kq2fkec0hojm | success | logs | 1 test cases passed
matrix-2qpzc45r6ig8y | success | logs | 1 test cases passed
matrix-2gprq615vdt2n | success | logs | 1 test cases passed
matrix-a936r75bvgdda | success | logs | 1 test cases passed
matrix-38k2s8rs5x8p1 | success | logs | 1 test cases passed
matrix-30blbnzp6udzq | success | logs | 1 test cases passed
matrix-3anlqks4hqn67 | success | logs | 1 test cases passed
matrix-staj2zwx0nc1a | success | logs | 1 test cases passed
matrix-amufok26mzupa | success | logs | 1 test cases passed
matrix-3mg7twe2ng08i | success | logs | 1 test cases passed
matrix-2m9komiccyxxc | success | logs | 1 test cases passed
matrix-20h7h1enov8uf | success | logs | 1 test cases passed
matrix-37ntrjx61scgp | success | logs | 1 test cases passed
matrix-1gezmzcx5woig | success | logs | 1 test cases passed
matrix-1io6h47kzclzm | success | logs | 1 test cases passed
matrix-5aow85sv1umra | success | logs | 1 test cases passed
matrix-2lb0dlzgv36wx | success | logs | 1 test cases passed
matrix-31fcnapx9yv1u | success | logs | 1 test cases passed
matrix-2j6t37nqcryca | success | logs | 1 test cases passed
matrix-22oam1ye8k37f | success | logs | 1 test cases passed
matrix-9uhrfbw5kepza | success | logs | 1 test cases passed
matrix-3au7pgzydvqqa | success | logs | 1 test cases passed
matrix-1alufg50xllk3 | success | logs | 1 test cases passed
matrix-8a3bcbj72eoga | success | logs | 1 test cases passed
matrix-4vcadgnj0rg8a | success | logs | 1 test cases passed
matrix-2ydb1pxlyl23f | success | logs | 1 test cases passed
matrix-159l2u1h2lpo7 | success | logs | 1 test cases passed
matrix-h0w9dazdmnp4a | success | logs | 1 test cases passed
matrix-s6f9gypv830ha | success | logs | 1 test cases passed
matrix-2ursa4yaq05nz | success | logs | 1 test cases passed
matrix-2n6e3tyajejdd | success | logs | 1 test cases passed
matrix-4o04m40dgvpua | success | logs | 1 test cases passed
matrix-1av0rk9w745o4 | success | logs | 1 test cases passed
matrix-3u4jjwsxf5ld9 | success | logs | 1 test cases passed
matrix-1fbwynqtn9jzl | success | logs | 1 test cases passed
matrix-y7znkgzc30sva | success | logs | 1 test cases passed
matrix-hjvakv2giq9fa | success | logs | 1 test cases passed
matrix-3fhggpl57jmg7 | success | logs | 1 test cases passed
matrix-3q6qwsjd4mlj5 | success | logs | 1 test cases passed
matrix-1trbv7e2u45id | success | logs | 1 test cases passed
matrix-1n6oapdx2ybj3 | success | logs | 1 test cases passed
matrix-276r9h4ts9dp6 | success | logs | 1 test cases passed
matrix-121wo44v4qz98 | success | logs | 1 test cases passed
matrix-30aek3qar5w7x | success | logs | 1 test cases passed
matrix-2bzbxzililgh6 | success | logs | 1 test cases passed
matrix-2edot6hhnr1qr | success | logs | 1 test cases passed
matrix-2qxtfzgbquo00 | success | logs | 1 test cases passed
matrix-2c9e5h4fbk66t | success | logs | 1 test cases passed
matrix-3rhqls1i4z05y | success | logs | 1 test cases passed
matrix-1kk389txoncfc | success | logs | 1 test cases passed
matrix-1lhl80a7zkg95 | success | logs | 1 test cases passed
matrix-2ljs8oy2v0d54 | success | logs | 1 test cases passed
matrix-nzhuawo95m5ga | success | logs | 1 test cases passed
matrix-2r53c36w6i543 | success | logs | 1 test cases passed
matrix-duih6ax0yngfa | success | logs | 1 test cases passed
matrix-1gwzh60qyf5vf | success | logs | 1 test cases passed
matrix-1nm03j3m9bdtl | success | logs | 1 test cases passed
matrix-jbxu8rmnd010a | success | logs | 1 test cases passed
matrix-2bcos58emkz0d | success | logs | 1 test cases passed
matrix-10j23x0sn8ny1 | success | logs | 1 test cases passed
matrix-1cegysul188bj | success | logs | 1 test cases passed
matrix-2vwfwgfot53a0 | success | logs | 1 test cases passed
matrix-3b136ahknjid8 | success | logs | 1 test cases passed
matrix-em0eqvlf9eu5a | success | logs | 1 test cases passed
matrix-2bccy9cd78jpn | success | logs | 1 test cases passed
matrix-3vgrcbdkz9gf4 | success | logs | 1 test cases passed
matrix-3kgrda0v98iva | success | logs | 1 test cases passed
matrix-3kb1gcqbwokeu | success | logs | 1 test cases passed
matrix-ju33kt8yhyn9a | success | logs | 1 test cases passed
matrix-2ad7p0uacq3hu | success | logs | 1 test cases passed
matrix-l7tgdlrt3uy6a | success | logs | 1 test cases passed
matrix-ajaq1bhpx290a | success | logs | 1 test cases passed
matrix-2p96ezp0e9uc5 | success | logs | 1 test cases passed
matrix-3a3d430mfk7jc | success | logs | 1 test cases passed
matrix-3v5yzt7qdtbbl | success | logs | 1 test cases passed
matrix-3kzg1dhx6w50t | success | logs | 1 test cases passed
matrix-dk89cze6tdl9a | success | logs | 1 test cases passed
matrix-1opvpmchzljw4 | success | logs | 1 test cases passed
matrix-1q1rzmr9378zj | success | logs | 1 test cases passed
matrix-1pwc083br0eed | success | logs | 1 test cases passed
matrix-3ibqho2arfx9j | success | logs | 1 test cases passed
matrix-1n8klntjbn3gd | success | logs | 1 test cases passed
matrix-3ejak4jhceir3 | success | logs | 1 test cases passed
matrix-3rooos9thidj9 | success | logs | 1 test cases passed
matrix-qa7wo2ji3hraa | success | logs | 1 test cases passed
matrix-39upefm8tua63 | success | logs | 1 test cases passed
matrix-1yxq5hozyt2n5 | success | logs | 1 test cases passed
matrix-1ktpw5qsk8tg8 | success | logs | 1 test cases passed
matrix-1v4w8apqm8xjd | success | logs | 1 test cases passed
matrix-12rkgmetebuhm | success | logs | 1 test cases passed
matrix-z26nreo3u24ea | success | logs | 1 test cases passed

</details>

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
