### PR TITLE
For #24706 - Remove Event.wrapper for Autofill related telemetry

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/metrics/Event.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/Event.kt
@@ -64,16 +64,6 @@ sealed class Event {
     // Recently visited/Recent searches
     object RecentSearchesGroupDeleted : Event()
 
-    // Android Autofill
-    object AndroidAutofillUnlockSuccessful : Event()
-    object AndroidAutofillUnlockCanceled : Event()
-    object AndroidAutofillSearchDisplayed : Event()
-    object AndroidAutofillSearchItemSelected : Event()
-    object AndroidAutofillConfirmationSuccessful : Event()
-    object AndroidAutofillConfirmationCanceled : Event()
-    object AndroidAutofillRequestWithLogins : Event()
-    object AndroidAutofillRequestWithoutLogins : Event()
-
     // Credit cards
     object CreditCardSaved : Event()
     object CreditCardDeleted : Event()

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
@@ -8,7 +8,6 @@ import android.content.Context
 import mozilla.components.service.glean.Glean
 import mozilla.components.service.glean.private.NoExtraKeys
 import mozilla.components.support.base.log.logger.Logger
-import org.mozilla.fenix.GleanMetrics.AndroidAutofill
 import org.mozilla.fenix.GleanMetrics.Autoplay
 import org.mozilla.fenix.GleanMetrics.Awesomebar
 import org.mozilla.fenix.GleanMetrics.BrowserSearch
@@ -199,31 +198,6 @@ private val Event.wrapper: EventWrapper<*>?
 
         is Event.RecentBookmarkCount -> EventWrapper<NoExtraKeys>(
             { RecentBookmarks.recentBookmarksCount.set(this.count.toLong()) },
-        )
-
-        is Event.AndroidAutofillRequestWithLogins -> EventWrapper<NoExtraKeys>(
-            { AndroidAutofill.requestMatchingLogins.record(it) }
-        )
-        is Event.AndroidAutofillRequestWithoutLogins -> EventWrapper<NoExtraKeys>(
-            { AndroidAutofill.requestNoMatchingLogins.record(it) }
-        )
-        is Event.AndroidAutofillSearchDisplayed -> EventWrapper<NoExtraKeys>(
-            { AndroidAutofill.searchDisplayed.record(it) }
-        )
-        is Event.AndroidAutofillSearchItemSelected -> EventWrapper<NoExtraKeys>(
-            { AndroidAutofill.searchItemSelected.record(it) }
-        )
-        is Event.AndroidAutofillUnlockCanceled -> EventWrapper<NoExtraKeys>(
-            { AndroidAutofill.unlockCancelled.record(it) }
-        )
-        is Event.AndroidAutofillUnlockSuccessful -> EventWrapper<NoExtraKeys>(
-            { AndroidAutofill.unlockSuccessful.record(it) }
-        )
-        is Event.AndroidAutofillConfirmationCanceled -> EventWrapper<NoExtraKeys>(
-            { AndroidAutofill.confirmCancelled.record(it) }
-        )
-        is Event.AndroidAutofillConfirmationSuccessful -> EventWrapper<NoExtraKeys>(
-            { AndroidAutofill.confirmSuccessful.record(it) }
         )
         is Event.CreditCardSaved -> EventWrapper<NoExtraKeys>(
             { CreditCards.saved.add() }

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
@@ -37,6 +37,7 @@ import mozilla.telemetry.glean.private.NoExtras
 import org.mozilla.fenix.BuildConfig
 import org.mozilla.fenix.GleanMetrics.Addons
 import org.mozilla.fenix.GleanMetrics.ContextMenu
+import org.mozilla.fenix.GleanMetrics.AndroidAutofill
 import org.mozilla.fenix.GleanMetrics.CustomTab
 import org.mozilla.fenix.GleanMetrics.Events
 import org.mozilla.fenix.GleanMetrics.LoginDialog
@@ -107,6 +108,7 @@ internal class ReleaseMetricController(
     }
 
     @VisibleForTesting
+    @Suppress("LongMethod")
     internal fun Fact.process(): Unit = when (component to item) {
         Component.FEATURE_PROMPTS to LoginDialogFacts.Items.DISPLAY -> {
             LoginDialog.displayed.record(NoExtras())
@@ -160,6 +162,36 @@ internal class ReleaseMetricController(
                 Addons.openAddonInToolbarMenu.record(Addons.OpenAddonInToolbarMenuExtra(it.toString()))
             }
             Unit
+        }
+
+        Component.FEATURE_AUTOFILL to AutofillFacts.Items.AUTOFILL_REQUEST -> {
+            val hasMatchingLogins = metadata?.get(AutofillFacts.Metadata.HAS_MATCHING_LOGINS) as Boolean?
+            if (hasMatchingLogins == true) {
+                AndroidAutofill.requestMatchingLogins.record(NoExtras())
+            } else {
+                AndroidAutofill.requestNoMatchingLogins.record(NoExtras())
+            }
+        }
+        Component.FEATURE_AUTOFILL to AutofillFacts.Items.AUTOFILL_SEARCH -> {
+            if (action == Action.SELECT) {
+                AndroidAutofill.searchItemSelected.record(NoExtras())
+            } else {
+                AndroidAutofill.searchDisplayed.record(NoExtras())
+            }
+        }
+        Component.FEATURE_AUTOFILL to AutofillFacts.Items.AUTOFILL_CONFIRMATION -> {
+            if (action == Action.CONFIRM) {
+                AndroidAutofill.confirmSuccessful.record(NoExtras())
+            } else {
+                AndroidAutofill.confirmCancelled.record(NoExtras())
+            }
+        }
+        Component.FEATURE_AUTOFILL to AutofillFacts.Items.AUTOFILL_LOCK -> {
+            if (action == Action.CONFIRM) {
+                AndroidAutofill.unlockSuccessful.record(NoExtras())
+            } else {
+                AndroidAutofill.unlockCancelled.record(NoExtras())
+            }
         }
 
         else -> {
@@ -333,35 +365,6 @@ internal class ReleaseMetricController(
         }
         Component.FEATURE_SEARCH == component && InContentTelemetry.IN_CONTENT_SEARCH == item -> {
             Event.SearchInContent(value!!)
-        }
-        Component.FEATURE_AUTOFILL == component && AutofillFacts.Items.AUTOFILL_REQUEST == item -> {
-            val hasMatchingLogins = metadata?.get(AutofillFacts.Metadata.HAS_MATCHING_LOGINS) as Boolean?
-            if (hasMatchingLogins == true) {
-                Event.AndroidAutofillRequestWithLogins
-            } else {
-                Event.AndroidAutofillRequestWithoutLogins
-            }
-        }
-        Component.FEATURE_AUTOFILL == component && AutofillFacts.Items.AUTOFILL_SEARCH == item -> {
-            if (action == Action.SELECT) {
-                Event.AndroidAutofillSearchItemSelected
-            } else {
-                Event.AndroidAutofillSearchDisplayed
-            }
-        }
-        Component.FEATURE_AUTOFILL == component && AutofillFacts.Items.AUTOFILL_LOCK == item -> {
-            if (action == Action.CONFIRM) {
-                Event.AndroidAutofillUnlockSuccessful
-            } else {
-                Event.AndroidAutofillUnlockCanceled
-            }
-        }
-        Component.FEATURE_AUTOFILL == component && AutofillFacts.Items.AUTOFILL_CONFIRMATION == item -> {
-            if (action == Action.CONFIRM) {
-                Event.AndroidAutofillConfirmationSuccessful
-            } else {
-                Event.AndroidAutofillConfirmationCanceled
-            }
         }
         else -> null
     }


### PR DESCRIPTION
Removed `Event.wrapper` for `AndroidAutofill` metrics.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
