### PR TITLE
For #24707 - Remove Event.wrapper for CreditCards telemetry

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/metrics/Event.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/Event.kt
@@ -57,18 +57,6 @@ sealed class Event {
     // Recently visited/Recent searches
     object RecentSearchesGroupDeleted : Event()
 
-    // Credit cards
-    object CreditCardSaved : Event()
-    object CreditCardDeleted : Event()
-    object CreditCardModified : Event()
-    object CreditCardFormDetected : Event()
-    object CreditCardAutofilled : Event()
-    object CreditCardAutofillPromptShown : Event()
-    object CreditCardAutofillPromptExpanded : Event()
-    object CreditCardAutofillPromptDismissed : Event()
-    object CreditCardManagementAddTapped : Event()
-    object CreditCardManagementCardTapped : Event()
-
     // Interaction events with extras
 
     data class SearchWithAds(val providerName: String) : Event() {

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
@@ -12,7 +12,6 @@ import org.mozilla.fenix.GleanMetrics.Autoplay
 import org.mozilla.fenix.GleanMetrics.Awesomebar
 import org.mozilla.fenix.GleanMetrics.BrowserSearch
 import org.mozilla.fenix.GleanMetrics.ContextualMenu
-import org.mozilla.fenix.GleanMetrics.CreditCards
 import org.mozilla.fenix.GleanMetrics.HomeMenu
 import org.mozilla.fenix.GleanMetrics.HomeScreen
 import org.mozilla.fenix.GleanMetrics.Pings
@@ -177,36 +176,6 @@ private val Event.wrapper: EventWrapper<*>?
 
         is Event.RecentBookmarkCount -> EventWrapper<NoExtraKeys>(
             { RecentBookmarks.recentBookmarksCount.set(this.count.toLong()) },
-        )
-        is Event.CreditCardSaved -> EventWrapper<NoExtraKeys>(
-            { CreditCards.saved.add() }
-        )
-        is Event.CreditCardDeleted -> EventWrapper<NoExtraKeys>(
-            { CreditCards.deleted.add() }
-        )
-        is Event.CreditCardModified -> EventWrapper<NoExtraKeys>(
-            { CreditCards.modified.record(it) }
-        )
-        is Event.CreditCardFormDetected -> EventWrapper<NoExtraKeys>(
-            { CreditCards.formDetected.record(it) }
-        )
-        is Event.CreditCardAutofillPromptShown -> EventWrapper<NoExtraKeys>(
-            { CreditCards.autofillPromptShown.record(it) }
-        )
-        is Event.CreditCardAutofillPromptExpanded -> EventWrapper<NoExtraKeys>(
-            { CreditCards.autofillPromptExpanded.record(it) }
-        )
-        is Event.CreditCardAutofillPromptDismissed -> EventWrapper<NoExtraKeys>(
-            { CreditCards.autofillPromptDismissed.record(it) }
-        )
-        is Event.CreditCardAutofilled -> EventWrapper<NoExtraKeys>(
-            { CreditCards.autofilled.record(it) }
-        )
-        is Event.CreditCardManagementAddTapped -> EventWrapper<NoExtraKeys>(
-            { CreditCards.managementAddTapped.record(it) }
-        )
-        is Event.CreditCardManagementCardTapped -> EventWrapper<NoExtraKeys>(
-            { CreditCards.managementCardTapped.record(it) }
         )
         is Event.SearchTermGroupCount -> EventWrapper(
             { SearchTerms.numberOfSearchTermGroup.record(it) },

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
@@ -38,6 +38,7 @@ import org.mozilla.fenix.BuildConfig
 import org.mozilla.fenix.GleanMetrics.Addons
 import org.mozilla.fenix.GleanMetrics.ContextMenu
 import org.mozilla.fenix.GleanMetrics.AndroidAutofill
+import org.mozilla.fenix.GleanMetrics.CreditCards
 import org.mozilla.fenix.GleanMetrics.CustomTab
 import org.mozilla.fenix.GleanMetrics.Events
 import org.mozilla.fenix.GleanMetrics.LoginDialog
@@ -163,6 +164,16 @@ internal class ReleaseMetricController(
             }
             Unit
         }
+        Component.FEATURE_PROMPTS to CreditCardAutofillDialogFacts.Items.AUTOFILL_CREDIT_CARD_FORM_DETECTED ->
+            CreditCards.formDetected.record(NoExtras())
+        Component.FEATURE_PROMPTS to CreditCardAutofillDialogFacts.Items.AUTOFILL_CREDIT_CARD_SUCCESS ->
+            CreditCards.autofilled.record(NoExtras())
+        Component.FEATURE_PROMPTS to CreditCardAutofillDialogFacts.Items.AUTOFILL_CREDIT_CARD_PROMPT_SHOWN ->
+            CreditCards.autofillPromptShown.record(NoExtras())
+        Component.FEATURE_PROMPTS to CreditCardAutofillDialogFacts.Items.AUTOFILL_CREDIT_CARD_PROMPT_EXPANDED ->
+            CreditCards.autofillPromptExpanded.record(NoExtras())
+        Component.FEATURE_PROMPTS to CreditCardAutofillDialogFacts.Items.AUTOFILL_CREDIT_CARD_PROMPT_DISMISSED ->
+            CreditCards.autofillPromptDismissed.record(NoExtras())
 
         Component.FEATURE_AUTOFILL to AutofillFacts.Items.AUTOFILL_REQUEST -> {
             val hasMatchingLogins = metadata?.get(AutofillFacts.Metadata.HAS_MATCHING_LOGINS) as Boolean?
@@ -260,17 +271,6 @@ internal class ReleaseMetricController(
 
     @Suppress("LongMethod", "MaxLineLength")
     private fun Fact.toEvent(): Event? = when {
-        Component.FEATURE_PROMPTS == component && CreditCardAutofillDialogFacts.Items.AUTOFILL_CREDIT_CARD_FORM_DETECTED == item ->
-            Event.CreditCardFormDetected
-        Component.FEATURE_PROMPTS == component && CreditCardAutofillDialogFacts.Items.AUTOFILL_CREDIT_CARD_SUCCESS == item ->
-            Event.CreditCardAutofilled
-        Component.FEATURE_PROMPTS == component && CreditCardAutofillDialogFacts.Items.AUTOFILL_CREDIT_CARD_PROMPT_SHOWN == item ->
-            Event.CreditCardAutofillPromptShown
-        Component.FEATURE_PROMPTS == component && CreditCardAutofillDialogFacts.Items.AUTOFILL_CREDIT_CARD_PROMPT_EXPANDED == item ->
-            Event.CreditCardAutofillPromptExpanded
-        Component.FEATURE_PROMPTS == component && CreditCardAutofillDialogFacts.Items.AUTOFILL_CREDIT_CARD_PROMPT_DISMISSED == item ->
-            Event.CreditCardAutofillPromptDismissed
-
         Component.FEATURE_CONTEXTMENU == component && ContextMenuFacts.Items.TEXT_SELECTION_OPTION == item -> {
             when (metadata?.get("textSelectionOption")?.toString()) {
                 CONTEXT_MENU_COPY -> Event.ContextMenuCopyTapped

--- a/app/src/main/java/org/mozilla/fenix/settings/creditcards/CreditCardsManagementFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/creditcards/CreditCardsManagementFragment.kt
@@ -49,7 +49,6 @@ class CreditCardsManagementFragment : SecureFragment() {
             controller = DefaultCreditCardsManagementController(
                 navController = findNavController()
             ),
-            requireContext().components.analytics.metrics
         )
         val binding = ComponentCreditCardsBinding.bind(view)
 

--- a/app/src/main/java/org/mozilla/fenix/settings/creditcards/controller/CreditCardEditorController.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/creditcards/controller/CreditCardEditorController.kt
@@ -12,8 +12,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import mozilla.components.concept.storage.NewCreditCardFields
 import mozilla.components.concept.storage.UpdatableCreditCardFields
+import mozilla.components.service.glean.private.NoExtras
 import mozilla.components.service.sync.autofill.AutofillCreditCardsAddressesStorage
-import org.mozilla.fenix.components.metrics.Event
+import org.mozilla.fenix.GleanMetrics.CreditCards
 import org.mozilla.fenix.components.metrics.MetricController
 import org.mozilla.fenix.settings.creditcards.CreditCardEditorFragment
 import org.mozilla.fenix.settings.creditcards.interactor.CreditCardEditorInteractor
@@ -77,7 +78,7 @@ class DefaultCreditCardEditorController(
                 lifecycleScope.launch(Dispatchers.Main) {
                     navController.popBackStack()
                 }
-                metrics.track(Event.CreditCardDeleted)
+                CreditCards.deleted.add()
             }
             dialog.dismiss()
         }
@@ -90,7 +91,7 @@ class DefaultCreditCardEditorController(
             lifecycleScope.launch(Dispatchers.Main) {
                 navController.popBackStack()
             }
-            metrics.track(Event.CreditCardSaved)
+            CreditCards.saved.add()
         }
     }
 
@@ -101,7 +102,7 @@ class DefaultCreditCardEditorController(
             lifecycleScope.launch(Dispatchers.Main) {
                 navController.popBackStack()
             }
-            metrics.track(Event.CreditCardModified)
+            CreditCards.modified.record(NoExtras())
         }
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/settings/creditcards/interactor/CreditCardsManagementInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/creditcards/interactor/CreditCardsManagementInteractor.kt
@@ -5,8 +5,8 @@
 package org.mozilla.fenix.settings.creditcards.interactor
 
 import mozilla.components.concept.storage.CreditCard
-import org.mozilla.fenix.components.metrics.Event
-import org.mozilla.fenix.components.metrics.MetricController
+import mozilla.components.service.glean.private.NoExtras
+import org.mozilla.fenix.GleanMetrics.CreditCards
 import org.mozilla.fenix.settings.creditcards.controller.CreditCardsManagementController
 
 /**
@@ -37,16 +37,15 @@ interface CreditCardsManagementInteractor {
  */
 class DefaultCreditCardsManagementInteractor(
     private val controller: CreditCardsManagementController,
-    private val metrics: MetricController
 ) : CreditCardsManagementInteractor {
 
     override fun onSelectCreditCard(creditCard: CreditCard) {
         controller.handleCreditCardClicked(creditCard)
-        metrics.track(Event.CreditCardManagementCardTapped)
+        CreditCards.managementCardTapped.record(NoExtras())
     }
 
     override fun onAddCreditCardClick() {
         controller.handleAddCreditCardClicked()
-        metrics.track(Event.CreditCardManagementAddTapped)
+        CreditCards.managementAddTapped.record(NoExtras())
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/components/metrics/GleanMetricsServiceTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/metrics/GleanMetricsServiceTest.kt
@@ -13,7 +13,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.GleanMetrics.Awesomebar
-import org.mozilla.fenix.GleanMetrics.CreditCards
 import org.mozilla.fenix.GleanMetrics.RecentBookmarks
 import org.mozilla.fenix.GleanMetrics.RecentlyVisitedHomepage
 import org.mozilla.fenix.GleanMetrics.SyncedTabs
@@ -89,48 +88,5 @@ class GleanMetricsServiceTest {
         assertFalse(RecentlyVisitedHomepage.searchGroupOpened.testHasValue())
         gleanService.track(Event.HistorySearchGroupOpened)
         assertTrue(RecentlyVisitedHomepage.searchGroupOpened.testHasValue())
-    }
-
-    @Test
-    fun `credit card events are correctly recorded`() {
-        assertFalse(CreditCards.saved.testHasValue())
-        gleanService.track(Event.CreditCardSaved)
-        assertTrue(CreditCards.saved.testHasValue())
-
-        assertFalse(CreditCards.deleted.testHasValue())
-        gleanService.track(Event.CreditCardDeleted)
-        assertTrue(CreditCards.deleted.testHasValue())
-
-        assertFalse(CreditCards.modified.testHasValue())
-        gleanService.track(Event.CreditCardModified)
-        assertTrue(CreditCards.modified.testHasValue())
-
-        assertFalse(CreditCards.formDetected.testHasValue())
-        gleanService.track(Event.CreditCardFormDetected)
-        assertTrue(CreditCards.formDetected.testHasValue())
-
-        assertFalse(CreditCards.autofilled.testHasValue())
-        gleanService.track(Event.CreditCardAutofilled)
-        assertTrue(CreditCards.autofilled.testHasValue())
-
-        assertFalse(CreditCards.autofillPromptShown.testHasValue())
-        gleanService.track(Event.CreditCardAutofillPromptShown)
-        assertTrue(CreditCards.autofillPromptShown.testHasValue())
-
-        assertFalse(CreditCards.autofillPromptExpanded.testHasValue())
-        gleanService.track(Event.CreditCardAutofillPromptExpanded)
-        assertTrue(CreditCards.autofillPromptExpanded.testHasValue())
-
-        assertFalse(CreditCards.autofillPromptDismissed.testHasValue())
-        gleanService.track(Event.CreditCardAutofillPromptDismissed)
-        assertTrue(CreditCards.autofillPromptDismissed.testHasValue())
-
-        assertFalse(CreditCards.managementAddTapped.testHasValue())
-        gleanService.track(Event.CreditCardManagementAddTapped)
-        assertTrue(CreditCards.managementAddTapped.testHasValue())
-
-        assertFalse(CreditCards.managementCardTapped.testHasValue())
-        gleanService.track(Event.CreditCardManagementCardTapped)
-        assertTrue(CreditCards.managementCardTapped.testHasValue())
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/components/metrics/MetricControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/metrics/MetricControllerTest.kt
@@ -35,6 +35,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.GleanMetrics.AndroidAutofill
+import org.mozilla.fenix.GleanMetrics.CreditCards
 import org.mozilla.fenix.GleanMetrics.CustomTab
 import org.mozilla.fenix.GleanMetrics.LoginDialog
 import org.mozilla.fenix.GleanMetrics.MediaNotification
@@ -275,107 +276,6 @@ class MetricControllerTest {
     }
 
     @Test
-    fun `credit card fact should trigger event`() {
-        val enabled = true
-        val settings: Settings = mockk(relaxed = true)
-        val controller = ReleaseMetricController(
-            services = listOf(dataService1),
-            isDataTelemetryEnabled = { enabled },
-            isMarketingDataTelemetryEnabled = { enabled },
-            settings
-        )
-
-        var fact = Fact(
-            Component.FEATURE_PROMPTS,
-            Action.INTERACTION,
-            CreditCardAutofillDialogFacts.Items.AUTOFILL_CREDIT_CARD_FORM_DETECTED
-        )
-
-        var event = controller.factToEvent(fact)
-        assertEquals(event, Event.CreditCardFormDetected)
-
-        fact = Fact(
-            Component.FEATURE_PROMPTS,
-            Action.INTERACTION,
-            CreditCardAutofillDialogFacts.Items.AUTOFILL_CREDIT_CARD_SUCCESS
-        )
-
-        event = controller.factToEvent(fact)
-        assertEquals(event, Event.CreditCardAutofilled)
-
-        fact = Fact(
-            Component.FEATURE_PROMPTS,
-            Action.INTERACTION,
-            CreditCardAutofillDialogFacts.Items.AUTOFILL_CREDIT_CARD_PROMPT_SHOWN
-        )
-
-        event = controller.factToEvent(fact)
-        assertEquals(event, Event.CreditCardAutofillPromptShown)
-
-        fact = Fact(
-            Component.FEATURE_PROMPTS,
-            Action.INTERACTION,
-            CreditCardAutofillDialogFacts.Items.AUTOFILL_CREDIT_CARD_PROMPT_EXPANDED
-        )
-
-        event = controller.factToEvent(fact)
-        assertEquals(event, Event.CreditCardAutofillPromptExpanded)
-
-        fact = Fact(
-            Component.FEATURE_PROMPTS,
-            Action.INTERACTION,
-            CreditCardAutofillDialogFacts.Items.AUTOFILL_CREDIT_CARD_PROMPT_DISMISSED
-        )
-
-        event = controller.factToEvent(fact)
-        assertEquals(event, Event.CreditCardAutofillPromptDismissed)
-    }
-
-    @Test
-    fun `credit card events should be sent to enabled service`() {
-        val controller = ReleaseMetricController(
-            listOf(dataService1),
-            isDataTelemetryEnabled = { true },
-            isMarketingDataTelemetryEnabled = { true },
-            mockk()
-        )
-        every { dataService1.shouldTrack(Event.CreditCardSaved) } returns true
-        every { dataService1.shouldTrack(Event.CreditCardDeleted) } returns true
-        every { dataService1.shouldTrack(Event.CreditCardModified) } returns true
-        every { dataService1.shouldTrack(Event.CreditCardFormDetected) } returns true
-        every { dataService1.shouldTrack(Event.CreditCardAutofilled) } returns true
-        every { dataService1.shouldTrack(Event.CreditCardAutofillPromptShown) } returns true
-        every { dataService1.shouldTrack(Event.CreditCardAutofillPromptExpanded) } returns true
-        every { dataService1.shouldTrack(Event.CreditCardAutofillPromptDismissed) } returns true
-        every { dataService1.shouldTrack(Event.CreditCardManagementAddTapped) } returns true
-        every { dataService1.shouldTrack(Event.CreditCardManagementCardTapped) } returns true
-
-        controller.start(MetricServiceType.Data)
-
-        controller.track(Event.CreditCardSaved)
-        controller.track(Event.CreditCardDeleted)
-        controller.track(Event.CreditCardModified)
-        controller.track(Event.CreditCardFormDetected)
-        controller.track(Event.CreditCardAutofilled)
-        controller.track(Event.CreditCardAutofillPromptShown)
-        controller.track(Event.CreditCardAutofillPromptExpanded)
-        controller.track(Event.CreditCardAutofillPromptDismissed)
-        controller.track(Event.CreditCardManagementAddTapped)
-        controller.track(Event.CreditCardManagementCardTapped)
-
-        verify { dataService1.track(Event.CreditCardSaved) }
-        verify { dataService1.track(Event.CreditCardDeleted) }
-        verify { dataService1.track(Event.CreditCardModified) }
-        verify { dataService1.track(Event.CreditCardFormDetected) }
-        verify { dataService1.track(Event.CreditCardAutofilled) }
-        verify { dataService1.track(Event.CreditCardAutofillPromptShown) }
-        verify { dataService1.track(Event.CreditCardAutofillPromptExpanded) }
-        verify { dataService1.track(Event.CreditCardAutofillPromptDismissed) }
-        verify { dataService1.track(Event.CreditCardManagementAddTapped) }
-        verify { dataService1.track(Event.CreditCardManagementCardTapped) }
-    }
-
-    @Test
     fun `WHEN changing Fact(component, item) without additional vals to events THEN it returns the right event`() {
         // This naive test was added for a refactoring. It only covers the comparisons that were easy to add.
         val controller = ReleaseMetricController(emptyList(), { true }, { true }, mockk())
@@ -566,6 +466,30 @@ class MetricControllerTest {
             fact.process()
 
             assertTrue(AndroidAutofill.unlockCancelled.testHasValue())
+        }
+    }
+
+    @Test
+    fun `WHEN processing a CreditCardAutofillDialog fact THEN the right metric is recorded`() {
+        val controller = ReleaseMetricController(emptyList(), { true }, { true }, mockk())
+        val action = mockk<Action>(relaxed = true)
+        val itemsToEvents = listOf(
+            CreditCardAutofillDialogFacts.Items.AUTOFILL_CREDIT_CARD_FORM_DETECTED to CreditCards.formDetected,
+            CreditCardAutofillDialogFacts.Items.AUTOFILL_CREDIT_CARD_SUCCESS to CreditCards.autofilled,
+            CreditCardAutofillDialogFacts.Items.AUTOFILL_CREDIT_CARD_PROMPT_SHOWN to CreditCards.autofillPromptShown,
+            CreditCardAutofillDialogFacts.Items.AUTOFILL_CREDIT_CARD_PROMPT_EXPANDED to CreditCards.autofillPromptExpanded,
+            CreditCardAutofillDialogFacts.Items.AUTOFILL_CREDIT_CARD_PROMPT_DISMISSED to CreditCards.autofillPromptDismissed,
+        )
+
+        itemsToEvents.forEach { (item, event) ->
+            val fact = Fact(Component.FEATURE_PROMPTS, action, item)
+            controller.run {
+                fact.process()
+            }
+
+            assertEquals(true, event.testHasValue())
+            assertEquals(1, event.testGetValue().size)
+            assertEquals(null, event.testGetValue().single().extra)
         }
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/settings/creditcards/DefaultCreditCardsManagementInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/creditcards/DefaultCreditCardsManagementInteractorTest.kt
@@ -7,37 +7,50 @@ package org.mozilla.fenix.settings.creditcards
 import io.mockk.mockk
 import io.mockk.verify
 import mozilla.components.concept.storage.CreditCard
+import mozilla.components.support.test.robolectric.testContext
+import mozilla.telemetry.glean.testing.GleanTestRule
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
-import org.mozilla.fenix.components.metrics.Event
-import org.mozilla.fenix.components.metrics.MetricController
+import org.junit.runner.RunWith
+import org.mozilla.fenix.GleanMetrics.CreditCards
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.settings.creditcards.controller.CreditCardsManagementController
 import org.mozilla.fenix.settings.creditcards.interactor.DefaultCreditCardsManagementInteractor
 
+@RunWith(FenixRobolectricTestRunner::class)
 class DefaultCreditCardsManagementInteractorTest {
 
+    @get:Rule
+    val gleanTestRule = GleanTestRule(testContext)
+
     private val controller: CreditCardsManagementController = mockk(relaxed = true)
-    private val metrics: MetricController = mockk(relaxed = true)
 
     private lateinit var interactor: DefaultCreditCardsManagementInteractor
 
     @Before
     fun setup() {
-        interactor = DefaultCreditCardsManagementInteractor(controller, metrics)
+        interactor = DefaultCreditCardsManagementInteractor(controller)
     }
 
     @Test
     fun onSelectCreditCard() {
         val creditCard: CreditCard = mockk(relaxed = true)
+        assertFalse(CreditCards.managementCardTapped.testHasValue())
+
         interactor.onSelectCreditCard(creditCard)
         verify { controller.handleCreditCardClicked(creditCard) }
-        verify { metrics.track(Event.CreditCardManagementCardTapped) }
+        assertTrue(CreditCards.managementCardTapped.testHasValue())
     }
 
     @Test
     fun onClickAddCreditCard() {
+        assertFalse(CreditCards.managementAddTapped.testHasValue())
+
         interactor.onAddCreditCardClick()
         verify { controller.handleAddCreditCardClicked() }
-        verify { metrics.track(Event.CreditCardManagementAddTapped) }
+        assertTrue(CreditCards.managementAddTapped.testHasValue())
     }
 }


### PR DESCRIPTION
Removed `Event.wrapper` for `CreditCards` metrics.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
