### PR TITLE
For #24303 ⁃ Refactor Onboarding into its own fragment

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -241,7 +241,8 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
         // Unless the activity is recreated, navigate to home first (without rendering it)
         // to add it to the back stack.
         if (savedInstanceState == null) {
-            navigateToHome()
+//            navigateToHome()
+            navHost.navController.navigate(NavGraphDirections.actionStartupOnboarding())
         }
 
         if (!shouldStartOnHome() && shouldNavigateToBrowserOnColdStart(savedInstanceState)) {

--- a/app/src/main/java/org/mozilla/fenix/home/Mode.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/Mode.kt
@@ -4,15 +4,7 @@
 
 package org.mozilla.fenix.home
 
-import android.content.Context
-import mozilla.components.concept.sync.AccountObserver
-import mozilla.components.concept.sync.AuthType
-import mozilla.components.concept.sync.OAuthAccount
-import mozilla.components.concept.sync.Profile
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
-import org.mozilla.fenix.browser.browsingmode.BrowsingModeManager
-import org.mozilla.fenix.ext.components
-import org.mozilla.fenix.onboarding.FenixOnboarding
 
 /**
  * Describes various states of the home fragment UI.
@@ -20,7 +12,6 @@ import org.mozilla.fenix.onboarding.FenixOnboarding
 sealed class Mode {
     object Normal : Mode()
     object Private : Mode()
-    data class Onboarding(val state: OnboardingState) : Mode()
 
     companion object {
         fun fromBrowsingMode(browsingMode: BrowsingMode) = when (browsingMode) {
@@ -28,44 +19,4 @@ sealed class Mode {
             BrowsingMode.Private -> Private
         }
     }
-}
-
-/**
- * Describes various onboarding states.
- */
-sealed class OnboardingState {
-    // Signed out, without an option to auto-login using a shared FxA account.
-    object SignedOutNoAutoSignIn : OnboardingState()
-    // Signed in.
-    object SignedIn : OnboardingState()
-}
-
-class CurrentMode(
-    private val context: Context,
-    private val onboarding: FenixOnboarding,
-    private val browsingModeManager: BrowsingModeManager,
-    private val dispatchModeChanges: (mode: Mode) -> Unit
-) : AccountObserver {
-
-    private val accountManager by lazy { context.components.backgroundServices.accountManager }
-
-    fun getCurrentMode() = if (onboarding.userHasBeenOnboarded()) {
-        Mode.fromBrowsingMode(browsingModeManager.mode)
-    } else {
-        val account = accountManager.authenticatedAccount()
-        if (account != null) {
-            Mode.Onboarding(OnboardingState.SignedIn)
-        } else {
-            Mode.Onboarding(OnboardingState.SignedOutNoAutoSignIn)
-        }
-    }
-
-    fun emitModeChanges() {
-        dispatchModeChanges(getCurrentMode())
-    }
-
-    override fun onAuthenticated(account: OAuthAccount, authType: AuthType) = emitModeChanges()
-    override fun onAuthenticationProblems() = emitModeChanges()
-    override fun onLoggedOut() = emitModeChanges()
-    override fun onProfileUpdated(profile: Profile) = emitModeChanges()
 }

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlAdapter.kt
@@ -4,7 +4,6 @@
 
 package org.mozilla.fenix.home.sessioncontrol
 
-import android.content.Context
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
@@ -36,14 +35,6 @@ import org.mozilla.fenix.home.sessioncontrol.viewholders.NoCollectionsMessageVie
 import org.mozilla.fenix.home.sessioncontrol.viewholders.PrivateBrowsingDescriptionViewHolder
 import org.mozilla.fenix.home.sessioncontrol.viewholders.TabInCollectionViewHolder
 import org.mozilla.fenix.home.sessioncontrol.viewholders.onboarding.MessageCardViewHolder
-import org.mozilla.fenix.home.sessioncontrol.viewholders.onboarding.OnboardingFinishViewHolder
-import org.mozilla.fenix.home.sessioncontrol.viewholders.onboarding.OnboardingHeaderViewHolder
-import org.mozilla.fenix.home.sessioncontrol.viewholders.onboarding.OnboardingManualSignInViewHolder
-import org.mozilla.fenix.home.sessioncontrol.viewholders.onboarding.OnboardingPrivacyNoticeViewHolder
-import org.mozilla.fenix.home.sessioncontrol.viewholders.onboarding.OnboardingSectionHeaderViewHolder
-import org.mozilla.fenix.home.sessioncontrol.viewholders.onboarding.OnboardingThemePickerViewHolder
-import org.mozilla.fenix.home.sessioncontrol.viewholders.onboarding.OnboardingToolbarPositionPickerViewHolder
-import org.mozilla.fenix.home.sessioncontrol.viewholders.onboarding.OnboardingTrackingProtectionViewHolder
 import org.mozilla.fenix.home.topsites.TopSitePagerViewHolder
 import mozilla.components.feature.tab.collections.Tab as ComponentTab
 
@@ -132,31 +123,12 @@ sealed class AdapterItem(@LayoutRes val viewType: Int) {
             other is TabInCollectionItem && tab.id == other.tab.id
     }
 
-    object OnboardingHeader : AdapterItem(OnboardingHeaderViewHolder.LAYOUT_ID)
-    data class OnboardingSectionHeader(
-        val labelBuilder: (Context) -> String
-    ) : AdapterItem(OnboardingSectionHeaderViewHolder.LAYOUT_ID) {
-        override fun sameAs(other: AdapterItem) =
-            other is OnboardingSectionHeader && labelBuilder == other.labelBuilder
-    }
-
-    object OnboardingManualSignIn : AdapterItem(OnboardingManualSignInViewHolder.LAYOUT_ID)
-
     data class NimbusMessageCard(
         val message: Message
     ) : AdapterItem(MessageCardViewHolder.LAYOUT_ID) {
         override fun sameAs(other: AdapterItem) =
             other is NimbusMessageCard && message.id == other.message.id
     }
-
-    object OnboardingThemePicker : AdapterItem(OnboardingThemePickerViewHolder.LAYOUT_ID)
-    object OnboardingTrackingProtection :
-        AdapterItem(OnboardingTrackingProtectionViewHolder.LAYOUT_ID)
-
-    object OnboardingPrivacyNotice : AdapterItem(OnboardingPrivacyNoticeViewHolder.LAYOUT_ID)
-    object OnboardingFinish : AdapterItem(OnboardingFinishViewHolder.LAYOUT_ID)
-    object OnboardingToolbarPositionPicker :
-        AdapterItem(OnboardingToolbarPositionPickerViewHolder.LAYOUT_ID)
 
     object CustomizeHomeButton : AdapterItem(CustomizeHomeButtonViewHolder.LAYOUT_ID)
 
@@ -290,21 +262,6 @@ class SessionControlAdapter(
                 view as WidgetSiteItemView,
                 interactor
             )
-            OnboardingHeaderViewHolder.LAYOUT_ID -> OnboardingHeaderViewHolder(view)
-            OnboardingSectionHeaderViewHolder.LAYOUT_ID -> OnboardingSectionHeaderViewHolder(view)
-            OnboardingManualSignInViewHolder.LAYOUT_ID -> OnboardingManualSignInViewHolder(view)
-            OnboardingThemePickerViewHolder.LAYOUT_ID -> OnboardingThemePickerViewHolder(view)
-            OnboardingTrackingProtectionViewHolder.LAYOUT_ID -> OnboardingTrackingProtectionViewHolder(
-                view
-            )
-            OnboardingPrivacyNoticeViewHolder.LAYOUT_ID -> OnboardingPrivacyNoticeViewHolder(
-                view,
-                interactor
-            )
-            OnboardingFinishViewHolder.LAYOUT_ID -> OnboardingFinishViewHolder(view, interactor)
-            OnboardingToolbarPositionPickerViewHolder.LAYOUT_ID -> OnboardingToolbarPositionPickerViewHolder(
-                view
-            )
             MessageCardViewHolder.LAYOUT_ID -> MessageCardViewHolder(view, interactor)
             BottomSpacerViewHolder.LAYOUT_ID -> BottomSpacerViewHolder(view)
             else -> throw IllegalStateException()
@@ -377,10 +334,6 @@ class SessionControlAdapter(
                 val (collection, tab, isLastTab) = item as AdapterItem.TabInCollectionItem
                 holder.bindSession(collection, tab, isLastTab)
             }
-            is OnboardingSectionHeaderViewHolder -> holder.bind(
-                (item as AdapterItem.OnboardingSectionHeader).labelBuilder
-            )
-            is OnboardingManualSignInViewHolder -> holder.bind()
             is RecentlyVisitedViewHolder,
             is RecentBookmarksViewHolder,
             is RecentTabViewHolder,

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
@@ -139,11 +139,6 @@ interface SessionControlController {
     fun handleSponsorPrivacyClicked()
 
     /**
-     * @see [OnboardingInteractor.onStartBrowsingClicked]
-     */
-    fun handleStartBrowsingClicked()
-
-    /**
      * @see [OnboardingInteractor.onReadPrivacyNoticeClicked]
      */
     fun handleReadPrivacyNoticeClicked()
@@ -229,7 +224,6 @@ class DefaultSessionControlController(
     private val appStore: AppStore,
     private val navController: NavController,
     private val viewLifecycleScope: CoroutineScope,
-    private val hideOnboarding: () -> Unit,
     private val registerCollectionStorageObserver: () -> Unit,
     private val removeCollectionWithUndo: (tabCollection: TabCollection) -> Unit,
     private val showTabTray: () -> Unit
@@ -500,10 +494,6 @@ class DefaultSessionControlController(
         if (navController.currentDestination?.id == R.id.searchDialogFragment) {
             navController.navigateUp()
         }
-    }
-
-    override fun handleStartBrowsingClicked() {
-        hideOnboarding()
     }
 
     override fun handleCustomizeHomeTapped() {

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlInteractor.kt
@@ -152,12 +152,7 @@ interface ToolbarInteractor {
 /**
  * Interface for onboarding related actions in the [SessionControlInteractor].
  */
-interface OnboardingInteractor {
-    /**
-     * Hides the onboarding and navigates to Search. Called when a user clicks on the "Start Browsing" button.
-     */
-    fun onStartBrowsingClicked()
-
+interface HomeOnboardingInteractor {
     /**
      * Opens a custom tab to privacy notice url. Called when a user clicks on the "read our privacy notice" button.
      */
@@ -261,7 +256,7 @@ class SessionControlInteractor(
     private val recentVisitsController: RecentVisitsController,
     private val pocketStoriesController: PocketStoriesController
 ) : CollectionInteractor,
-    OnboardingInteractor,
+    HomeOnboardingInteractor,
     TopSiteInteractor,
     TabSessionInteractor,
     ToolbarInteractor,
@@ -323,10 +318,6 @@ class SessionControlInteractor(
 
     override fun onSponsorPrivacyClicked() {
         controller.handleSponsorPrivacyClicked()
-    }
-
-    override fun onStartBrowsingClicked() {
-        controller.handleStartBrowsingClicked()
     }
 
     override fun onReadPrivacyNoticeClicked() {

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlView.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlView.kt
@@ -18,7 +18,6 @@ import org.mozilla.fenix.gleanplumb.Message
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.home.Mode
-import org.mozilla.fenix.home.OnboardingState
 import org.mozilla.fenix.home.recentbookmarks.RecentBookmark
 import org.mozilla.fenix.home.recenttabs.RecentTab
 import org.mozilla.fenix.home.recentvisits.RecentlyVisitedItem
@@ -116,39 +115,6 @@ private fun showCollections(
 
 private fun privateModeAdapterItems() = listOf(AdapterItem.PrivateBrowsingDescription)
 
-private fun onboardingAdapterItems(onboardingState: OnboardingState): List<AdapterItem> {
-    val items: MutableList<AdapterItem> = mutableListOf(AdapterItem.OnboardingHeader)
-
-    items.addAll(
-        listOf(
-            AdapterItem.OnboardingThemePicker,
-            AdapterItem.OnboardingToolbarPositionPicker,
-            AdapterItem.OnboardingTrackingProtection
-        )
-    )
-    // Customize FxA items based on where we are with the account state:
-    items.addAll(
-        when (onboardingState) {
-            OnboardingState.SignedOutNoAutoSignIn -> {
-                listOf(
-                    AdapterItem.OnboardingManualSignIn
-                )
-            }
-            OnboardingState.SignedIn -> listOf()
-        }
-    )
-
-    items.addAll(
-        listOf(
-            AdapterItem.OnboardingPrivacyNotice,
-            AdapterItem.OnboardingFinish,
-            AdapterItem.BottomSpacer
-        )
-    )
-
-    return items
-}
-
 private fun AppState.toAdapterList(settings: Settings): List<AdapterItem> = when (mode) {
     is Mode.Normal -> normalModeAdapterItems(
         settings,
@@ -163,7 +129,6 @@ private fun AppState.toAdapterList(settings: Settings): List<AdapterItem> = when
         pocketStories
     )
     is Mode.Private -> privateModeAdapterItems()
-    is Mode.Onboarding -> onboardingAdapterItems(mode.state)
 }
 
 @VisibleForTesting

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingFinishViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingFinishViewHolder.kt
@@ -10,7 +10,7 @@ import mozilla.components.service.glean.private.NoExtras
 import org.mozilla.fenix.GleanMetrics.Onboarding
 import org.mozilla.fenix.R
 import org.mozilla.fenix.databinding.OnboardingFinishBinding
-import org.mozilla.fenix.home.sessioncontrol.OnboardingInteractor
+import org.mozilla.fenix.onboarding.interactor.OnboardingInteractor
 
 class OnboardingFinishViewHolder(
     view: View,

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingPrivacyNoticeViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingPrivacyNoticeViewHolder.kt
@@ -10,7 +10,7 @@ import mozilla.components.service.glean.private.NoExtras
 import org.mozilla.fenix.GleanMetrics.Onboarding
 import org.mozilla.fenix.R
 import org.mozilla.fenix.databinding.OnboardingPrivacyNoticeBinding
-import org.mozilla.fenix.home.sessioncontrol.OnboardingInteractor
+import org.mozilla.fenix.onboarding.interactor.OnboardingInteractor
 
 class OnboardingPrivacyNoticeViewHolder(
     view: View,

--- a/app/src/main/java/org/mozilla/fenix/onboarding/OnboardingAccountObserver.kt
+++ b/app/src/main/java/org/mozilla/fenix/onboarding/OnboardingAccountObserver.kt
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.onboarding
+
+import android.content.Context
+import mozilla.components.concept.sync.AccountObserver
+import mozilla.components.concept.sync.AuthType
+import mozilla.components.concept.sync.OAuthAccount
+import mozilla.components.concept.sync.Profile
+import org.mozilla.fenix.ext.components
+
+class OnboardingAccountObserver(
+    private val context: Context,
+    private val dispatchChanges: (state: OnboardingState) -> Unit,
+) : AccountObserver {
+
+    private val accountManager by lazy { context.components.backgroundServices.accountManager }
+
+    override fun onAuthenticated(account: OAuthAccount, authType: AuthType) =
+        dispatchChanges(getOnboardingState())
+
+    override fun onAuthenticationProblems() = dispatchChanges(getOnboardingState())
+
+    override fun onLoggedOut() = dispatchChanges(getOnboardingState())
+
+    override fun onProfileUpdated(profile: Profile) = dispatchChanges(getOnboardingState())
+
+    fun getOnboardingState(): OnboardingState {
+        val account = accountManager.authenticatedAccount()
+
+        return if (account != null) {
+            OnboardingState.SignedIn
+        } else {
+            OnboardingState.SignedOutNoAutoSignIn
+        }
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/onboarding/OnboardingFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/onboarding/OnboardingFragment.kt
@@ -1,0 +1,191 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.onboarding
+
+import android.graphics.drawable.BitmapDrawable
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.map
+import mozilla.components.browser.state.state.selectedOrDefaultSearchEngine
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.lib.state.ext.consumeFlow
+import mozilla.components.lib.state.ext.consumeFrom
+import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
+import mozilla.components.ui.tabcounter.TabCounterMenu
+import org.mozilla.fenix.HomeActivity
+import org.mozilla.fenix.R
+import org.mozilla.fenix.browser.BrowserAnimator
+import org.mozilla.fenix.browser.browsingmode.BrowsingMode
+import org.mozilla.fenix.components.StoreProvider
+import org.mozilla.fenix.components.toolbar.FenixTabCounterMenu
+import org.mozilla.fenix.databinding.FragmentHomeBinding
+import org.mozilla.fenix.ext.nav
+import org.mozilla.fenix.ext.requireComponents
+import org.mozilla.fenix.home.HomeFragmentDirections
+import org.mozilla.fenix.onboarding.interactor.DefaultOnboardingInteractor
+import org.mozilla.fenix.onboarding.interactor.OnboardingInteractor
+import org.mozilla.fenix.onboarding.view.OnboardingView
+import org.mozilla.fenix.theme.ThemeManager
+import java.lang.ref.WeakReference
+
+/**
+ * TODO
+ */
+class OnboardingFragment : Fragment() {
+
+    private var _binding: FragmentHomeBinding? = null
+    private val binding get() = _binding!!
+
+    private lateinit var onboardingStore: OnboardingStore
+    private lateinit var interactor: OnboardingInteractor
+    private lateinit var onboardingAccountObserver: OnboardingAccountObserver
+    private lateinit var onboardingView: OnboardingView
+
+    private val store: BrowserStore
+        get() = requireComponents.core.store
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        _binding = FragmentHomeBinding.inflate(inflater, container, false)
+
+        onboardingStore = StoreProvider.get(this) {
+            OnboardingStore()
+        }
+
+        onboardingAccountObserver = OnboardingAccountObserver(
+            context = requireContext(),
+            dispatchChanges = { mode ->
+                if (mode != onboardingStore.state.state) {
+                    onboardingStore.dispatch(OnboardingFragmentAction.UpdateState(mode))
+                }
+            }
+        )
+
+        interactor = DefaultOnboardingInteractor()
+
+        onboardingView = OnboardingView(
+            containerView = binding.sessionControlRecyclerView,
+            interactor = interactor
+        )
+
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        observeSearchEngineChanges()
+        createHomeMenu(requireContext(), WeakReference(binding.menuButton))
+        createTabCounterMenu()
+
+        binding.menuButton.setColorFilter(
+            ContextCompat.getColor(
+                requireContext(),
+                ThemeManager.resolveAttribute(R.attr.textPrimary, requireContext())
+            )
+        )
+
+        binding.toolbar.compoundDrawablePadding =
+            view.resources.getDimensionPixelSize(R.dimen.search_bar_search_engine_icon_padding)
+        binding.toolbarWrapper.setOnClickListener {
+            navigateToSearch()
+        }
+
+        binding.tabButton.setOnClickListener {
+            openTabsTray()
+        }
+
+        consumeFrom(onboardingStore) { state ->
+            onboardingView.update(state)
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+
+        _binding = null
+    }
+
+    private fun observeSearchEngineChanges() {
+        consumeFlow(store) { flow ->
+            flow.map { state -> state.search.selectedOrDefaultSearchEngine }
+                .ifChanged()
+                .collect { searchEngine ->
+                    if (searchEngine != null) {
+                        val iconSize =
+                            requireContext().resources.getDimensionPixelSize(R.dimen.preference_icon_drawable_size)
+                        val searchIcon =
+                            BitmapDrawable(requireContext().resources, searchEngine.icon)
+                        searchIcon.setBounds(0, 0, iconSize, iconSize)
+                        binding.searchEngineIcon.setImageDrawable(searchIcon)
+                    } else {
+                        binding.searchEngineIcon.setImageDrawable(null)
+                    }
+                }
+        }
+    }
+
+    private fun navigateToSearch() {
+        val directions =
+            OnboardingFragmentDirections.actionGlobalSearchDialog(
+                sessionId = null
+            )
+
+        nav(R.id.homeFragment, directions, BrowserAnimator.getToolbarNavOptions(requireContext()))
+    }
+
+    private fun createTabCounterMenu() {
+        val browsingModeManager = (activity as HomeActivity).browsingModeManager
+        val mode = browsingModeManager.mode
+
+        val onItemTapped: (TabCounterMenu.Item) -> Unit = {
+            if (it is TabCounterMenu.Item.NewTab) {
+                browsingModeManager.mode = BrowsingMode.Normal
+            } else if (it is TabCounterMenu.Item.NewPrivateTab) {
+                browsingModeManager.mode = BrowsingMode.Private
+            }
+        }
+
+        val tabCounterMenu = FenixTabCounterMenu(
+            requireContext(),
+            onItemTapped,
+            iconColor = if (mode == BrowsingMode.Private) {
+                ContextCompat.getColor(
+                    requireContext(),
+                    R.color.fx_mobile_private_text_color_primary
+                )
+            } else {
+                null
+            }
+        )
+
+        val inverseBrowsingMode = when (mode) {
+            BrowsingMode.Normal -> BrowsingMode.Private
+            BrowsingMode.Private -> BrowsingMode.Normal
+        }
+
+        tabCounterMenu.updateMenu(showOnly = inverseBrowsingMode)
+        binding.tabButton.setOnLongClickListener {
+            tabCounterMenu.menuController.show(anchor = it)
+            true
+        }
+    }
+
+    private fun openTabsTray() {
+        findNavController().nav(
+            R.id.homeFragment,
+            HomeFragmentDirections.actionGlobalTabsTrayFragment()
+        )
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/onboarding/OnboardingState.kt
+++ b/app/src/main/java/org/mozilla/fenix/onboarding/OnboardingState.kt
@@ -1,0 +1,52 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.onboarding
+
+import org.mozilla.fenix.onboarding.view.OnboardingAdapterItem
+
+/**
+ * Describes various onboarding states.
+ */
+sealed class OnboardingState {
+    // Signed out, without an option to auto-login using a shared FxA account.
+    object SignedOutNoAutoSignIn : OnboardingState()
+    // Signed in.
+    object SignedIn : OnboardingState()
+}
+
+fun OnboardingState.toOnboardingItems(): List<OnboardingAdapterItem> {
+    val items: MutableList<OnboardingAdapterItem> =
+        mutableListOf(OnboardingAdapterItem.OnboardingHeader)
+
+    items.addAll(
+        listOf(
+            OnboardingAdapterItem.OnboardingThemePicker,
+            OnboardingAdapterItem.OnboardingToolbarPositionPicker,
+            OnboardingAdapterItem.OnboardingTrackingProtection
+        )
+    )
+
+    // Customize FxA items based on where we are with the account state:
+    items.addAll(
+        when (this) {
+            OnboardingState.SignedOutNoAutoSignIn -> {
+                listOf(
+                    OnboardingAdapterItem.OnboardingManualSignIn
+                )
+            }
+            OnboardingState.SignedIn -> listOf()
+        }
+    )
+
+    items.addAll(
+        listOf(
+            OnboardingAdapterItem.OnboardingPrivacyNotice,
+            OnboardingAdapterItem.OnboardingFinish,
+            OnboardingAdapterItem.BottomSpacer
+        )
+    )
+
+    return items
+}

--- a/app/src/main/java/org/mozilla/fenix/onboarding/OnboardingStore.kt
+++ b/app/src/main/java/org/mozilla/fenix/onboarding/OnboardingStore.kt
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.onboarding
+
+import mozilla.components.lib.state.Action
+import mozilla.components.lib.state.State
+import mozilla.components.lib.state.Store
+
+class OnboardingStore(
+    initialState: OnboardingFragmentState = OnboardingFragmentState(),
+) : Store<OnboardingFragmentState, OnboardingFragmentAction>(
+    initialState = initialState,
+    reducer = ::onboardingFragmentStateReducer
+)
+
+/**
+ * The state for [OnboardingFragment].
+ *
+ * @property state
+ */
+data class OnboardingFragmentState(
+    val state: OnboardingState = OnboardingState.SignedOutNoAutoSignIn,
+) : State
+
+/**
+ * TODO
+ */
+sealed class OnboardingFragmentAction : Action {
+    /**
+     * TODO
+     */
+    data class UpdateState(val state: OnboardingState) : OnboardingFragmentAction()
+}
+
+/**
+ * TODO
+ */
+private fun onboardingFragmentStateReducer(
+    state: OnboardingFragmentState,
+    action: OnboardingFragmentAction,
+): OnboardingFragmentState {
+    return when (action) {
+        is OnboardingFragmentAction.UpdateState -> state.copy(state = action.state)
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/onboarding/controller/OnboardingController.kt
+++ b/app/src/main/java/org/mozilla/fenix/onboarding/controller/OnboardingController.kt
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.onboarding.controller
+
+interface OnboardingController {
+    /**
+     * @see [OnboardingInteractor.onStartBrowsingClicked]
+     */
+    fun handleStartBrowsingClicked()
+
+    /**
+     * @see [OnboardingInteractor.onReadPrivacyNoticeClicked]
+     */
+    fun handleReadPrivacyNoticeClicked()
+
+    /**
+     * @see [OnboardingInteractor.showOnboardingDialog]
+     */
+    fun handleShowOnboardingDialog()
+}
+
+class DefaultOnboardingController(
+
+) : OnboardingController {
+
+    override fun handleStartBrowsingClicked() {
+        TODO("Not yet implemented")
+    }
+
+    override fun handleReadPrivacyNoticeClicked() {
+        TODO("Not yet implemented")
+    }
+
+    override fun handleShowOnboardingDialog() {
+        TODO("Not yet implemented")
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/onboarding/interactor/OnboardingInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/onboarding/interactor/OnboardingInteractor.kt
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.onboarding.interactor
+
+interface OnboardingInteractor {
+    /**
+     * Hides the onboarding and navigates to Search. Called when a user clicks on the "Start Browsing" button.
+     */
+    fun onStartBrowsingClicked()
+
+    /**
+     * Opens a custom tab to privacy notice url. Called when a user clicks on the "read our privacy notice" button.
+     */
+    fun onReadPrivacyNoticeClicked()
+
+    /**
+     * Show the onboarding dialog to onboard users about recentTabs,recentBookmarks,
+     * historyMetadata and pocketArticles sections.
+     */
+    fun showOnboardingDialog()
+}
+
+class DefaultOnboardingInteractor(
+
+) : OnboardingInteractor {
+
+    override fun onStartBrowsingClicked() {
+        TODO("Not yet implemented")
+    }
+
+    override fun onReadPrivacyNoticeClicked() {
+        TODO("Not yet implemented")
+    }
+
+    override fun showOnboardingDialog() {
+        TODO("Not yet implemented")
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/onboarding/view/OnboardingAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/onboarding/view/OnboardingAdapter.kt
@@ -1,0 +1,109 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.onboarding.view
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.annotation.LayoutRes
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import org.mozilla.fenix.home.BottomSpacerViewHolder
+import org.mozilla.fenix.home.sessioncontrol.viewholders.onboarding.OnboardingFinishViewHolder
+import org.mozilla.fenix.home.sessioncontrol.viewholders.onboarding.OnboardingHeaderViewHolder
+import org.mozilla.fenix.home.sessioncontrol.viewholders.onboarding.OnboardingManualSignInViewHolder
+import org.mozilla.fenix.home.sessioncontrol.viewholders.onboarding.OnboardingPrivacyNoticeViewHolder
+import org.mozilla.fenix.home.sessioncontrol.viewholders.onboarding.OnboardingSectionHeaderViewHolder
+import org.mozilla.fenix.home.sessioncontrol.viewholders.onboarding.OnboardingThemePickerViewHolder
+import org.mozilla.fenix.home.sessioncontrol.viewholders.onboarding.OnboardingToolbarPositionPickerViewHolder
+import org.mozilla.fenix.home.sessioncontrol.viewholders.onboarding.OnboardingTrackingProtectionViewHolder
+import org.mozilla.fenix.onboarding.interactor.OnboardingInteractor
+
+class OnboardingAdapter(
+    private val interactor: OnboardingInteractor,
+) : ListAdapter<OnboardingAdapterItem, RecyclerView.ViewHolder>(OnboardingAdapterItemDiffCallback()) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        val view = LayoutInflater.from(parent.context).inflate(viewType, parent, false)
+
+        return when (viewType) {
+            OnboardingHeaderViewHolder.LAYOUT_ID -> OnboardingHeaderViewHolder(view)
+            OnboardingSectionHeaderViewHolder.LAYOUT_ID -> OnboardingSectionHeaderViewHolder(view)
+            OnboardingManualSignInViewHolder.LAYOUT_ID -> OnboardingManualSignInViewHolder(view)
+            OnboardingThemePickerViewHolder.LAYOUT_ID -> OnboardingThemePickerViewHolder(view)
+            OnboardingTrackingProtectionViewHolder.LAYOUT_ID -> OnboardingTrackingProtectionViewHolder(
+                view
+            )
+            OnboardingPrivacyNoticeViewHolder.LAYOUT_ID -> OnboardingPrivacyNoticeViewHolder(
+                view,
+                interactor
+            )
+            OnboardingFinishViewHolder.LAYOUT_ID -> OnboardingFinishViewHolder(view, interactor)
+            OnboardingToolbarPositionPickerViewHolder.LAYOUT_ID -> OnboardingToolbarPositionPickerViewHolder(
+                view)
+            BottomSpacerViewHolder.LAYOUT_ID -> BottomSpacerViewHolder(view)
+            else -> throw IllegalStateException("ViewType $viewType does not match a ViewHolder")
+        }
+    }
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        val item = getItem(position)
+
+        when (holder) {
+            is OnboardingSectionHeaderViewHolder -> holder.bind(
+                (item as OnboardingAdapterItem.OnboardingSectionHeader).labelBuilder
+            )
+            is OnboardingManualSignInViewHolder -> holder.bind()
+        }
+    }
+
+    override fun getItemViewType(position: Int) = getItem(position).viewType
+}
+
+sealed class OnboardingAdapterItem(@LayoutRes val viewType: Int) {
+    object OnboardingHeader : OnboardingAdapterItem(OnboardingHeaderViewHolder.LAYOUT_ID)
+
+    data class OnboardingSectionHeader(
+        val labelBuilder: (Context) -> String,
+    ) : OnboardingAdapterItem(OnboardingSectionHeaderViewHolder.LAYOUT_ID) {
+        override fun sameAs(other: OnboardingAdapterItem) =
+            other is OnboardingSectionHeader && labelBuilder == other.labelBuilder
+    }
+
+    object OnboardingManualSignIn :
+        OnboardingAdapterItem(OnboardingManualSignInViewHolder.LAYOUT_ID)
+
+    object OnboardingThemePicker : OnboardingAdapterItem(OnboardingThemePickerViewHolder.LAYOUT_ID)
+    object OnboardingTrackingProtection :
+        OnboardingAdapterItem(OnboardingTrackingProtectionViewHolder.LAYOUT_ID)
+
+    object OnboardingPrivacyNotice :
+        OnboardingAdapterItem(OnboardingPrivacyNoticeViewHolder.LAYOUT_ID)
+
+    object OnboardingFinish : OnboardingAdapterItem(OnboardingFinishViewHolder.LAYOUT_ID)
+    object OnboardingToolbarPositionPicker :
+        OnboardingAdapterItem(OnboardingToolbarPositionPickerViewHolder.LAYOUT_ID)
+
+    object BottomSpacer : OnboardingAdapterItem(BottomSpacerViewHolder.LAYOUT_ID)
+
+    /**
+     * True if this item represents the same value as other.
+     */
+    open fun sameAs(other: OnboardingAdapterItem) = this::class == other::class
+
+    open fun contentsSameAs(other: OnboardingAdapterItem) = this::class == other::class
+}
+
+class OnboardingAdapterItemDiffCallback : DiffUtil.ItemCallback<OnboardingAdapterItem>() {
+    override fun areItemsTheSame(oldItem: OnboardingAdapterItem, newItem: OnboardingAdapterItem) =
+        oldItem.sameAs(newItem)
+
+    @Suppress("DiffUtilEquals")
+    override fun areContentsTheSame(
+        oldItem: OnboardingAdapterItem,
+        newItem: OnboardingAdapterItem,
+    ) = oldItem.contentsSameAs(newItem)
+}

--- a/app/src/main/java/org/mozilla/fenix/onboarding/view/OnboardingView.kt
+++ b/app/src/main/java/org/mozilla/fenix/onboarding/view/OnboardingView.kt
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.onboarding.view
+
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import org.mozilla.fenix.onboarding.OnboardingFragmentState
+import org.mozilla.fenix.onboarding.interactor.OnboardingInteractor
+import org.mozilla.fenix.onboarding.toOnboardingItems
+
+class OnboardingView(
+    val containerView: RecyclerView,
+    val interactor: OnboardingInteractor,
+) {
+
+    private val onboardingAdapter = OnboardingAdapter(interactor)
+
+    init {
+        containerView.apply {
+            adapter = onboardingAdapter
+            layoutManager = LinearLayoutManager(containerView.context)
+        }
+    }
+
+    fun update(onboardingState: OnboardingFragmentState) {
+        onboardingAdapter.submitList(onboardingState.state.toOnboardingItems())
+    }
+}

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -12,6 +12,12 @@
         app:popUpToInclusive="true" />
 
     <action
+        android:id="@+id/action_startup_onboarding"
+        app:destination="@id/onboardingFragment"
+        app:popUpTo="@id/startupFragment"
+        app:popUpToInclusive="true" />
+
+    <action
         android:id="@+id/action_global_home"
         app:destination="@id/homeFragment"
         app:popUpTo="@id/homeFragment"
@@ -190,6 +196,13 @@
             android:defaultValue="-1L"
             app:argType="long" />
     </fragment>
+
+    <fragment
+        android:id="@+id/onboardingFragment"
+        android:name="org.mozilla.fenix.onboarding.OnboardingFragment"
+        tools:layout="@layout/fragment_onboarding">
+    </fragment>
+
     <dialog
         android:id="@+id/homeOnboardingDialogFragment"
         android:name="org.mozilla.fenix.onboarding.HomeOnboardingDialogFragment"


### PR DESCRIPTION
Fixes #24303

🚧🚧🚧🚧 **This is a proof-of-concept - please review strictly for feasibility of whether or not we should continue with this pathway.**

This currently removes all of the onboarding items from the `HomeFragment` into their own `OnboardingFragment`. This allows us to decouple handling of whether or not the user has been onboarded state out of the `HomeFragment` and reduces one mode that needs to be managed in the `HomeFragment`. It also saves us a bit of time with the Compose refactoring of the Home screen with not having to refactor around 8 ViewHolders so this could be 2-4 weeks of time saving, but not a total dealbreaker if we decide to just convert them to Compose if this is not the solution we want to go with. Some future benefit might be that this will be an easier way to navigate back to Onboarding / Customization instead of making this first run only.

The problem I am seeing is that we have to duplicate a lot of code from the `HomeFragment` to implement the function of the Toolbar, Tab Counter, and Home Menu. There will probably be features missing from this current prototype such as whether or not we allow for toggling of the new wallpaper feature by tapping on the Firefox logo. Prior suggestions of base fragment to contain some of these shared code seems unfavourable based on experiences with the `BaseBrowserFragment`.

I would like to evaluate whether or not we should continue down this route or turn back and just convert the Onboarding to Compose for the time being and re-evaluate splitting Onboarding out in the future.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
