### PR TITLE
For #24760 - Remove Event.wrapper for suggestions telemetry

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/metrics/Event.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/Event.kt
@@ -16,14 +16,6 @@ sealed class Event {
     object HistorySearchGroupOpened : Event()
     object SearchWidgetInstalled : Event()
 
-    object SyncedTabSuggestionClicked : Event()
-    object BookmarkSuggestionClicked : Event()
-    object ClipboardSuggestionClicked : Event()
-    object HistorySuggestionClicked : Event()
-    object SearchActionClicked : Event()
-    object SearchSuggestionClicked : Event()
-    object OpenedTabSuggestionClicked : Event()
-
     // Interaction events with extras
 
     data class SearchWithAds(val providerName: String) : Event() {

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
@@ -8,11 +8,9 @@ import android.content.Context
 import mozilla.components.service.glean.Glean
 import mozilla.components.service.glean.private.NoExtraKeys
 import mozilla.components.support.base.log.logger.Logger
-import org.mozilla.fenix.GleanMetrics.Awesomebar
 import org.mozilla.fenix.GleanMetrics.BrowserSearch
 import org.mozilla.fenix.GleanMetrics.Pings
 import org.mozilla.fenix.GleanMetrics.RecentlyVisitedHomepage
-import org.mozilla.fenix.GleanMetrics.SyncedTabs
 import org.mozilla.fenix.GleanMetrics.Messaging
 import org.mozilla.fenix.ext.components
 
@@ -73,29 +71,6 @@ private val Event.wrapper: EventWrapper<*>?
             {
                 BrowserSearch.inContent[label].add(1)
             }
-        )
-
-        is Event.SyncedTabSuggestionClicked -> EventWrapper<NoExtraKeys>(
-            { SyncedTabs.syncedTabsSuggestionClicked.record(it) }
-        )
-
-        is Event.BookmarkSuggestionClicked -> EventWrapper<NoExtraKeys>(
-            { Awesomebar.bookmarkSuggestionClicked.record(it) }
-        )
-        is Event.ClipboardSuggestionClicked -> EventWrapper<NoExtraKeys>(
-            { Awesomebar.clipboardSuggestionClicked.record(it) }
-        )
-        is Event.HistorySuggestionClicked -> EventWrapper<NoExtraKeys>(
-            { Awesomebar.historySuggestionClicked.record(it) }
-        )
-        is Event.SearchActionClicked -> EventWrapper<NoExtraKeys>(
-            { Awesomebar.searchActionClicked.record(it) }
-        )
-        is Event.SearchSuggestionClicked -> EventWrapper<NoExtraKeys>(
-            { Awesomebar.searchSuggestionClicked.record(it) }
-        )
-        is Event.OpenedTabSuggestionClicked -> EventWrapper<NoExtraKeys>(
-            { Awesomebar.openedTabSuggestionClicked.record(it) }
         )
 
         is Event.Messaging.MessageShown -> EventWrapper<NoExtraKeys>(

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
@@ -38,6 +38,7 @@ import org.mozilla.fenix.BuildConfig
 import org.mozilla.fenix.GleanMetrics.Addons
 import org.mozilla.fenix.GleanMetrics.ContextMenu
 import org.mozilla.fenix.GleanMetrics.AndroidAutofill
+import org.mozilla.fenix.GleanMetrics.Awesomebar
 import org.mozilla.fenix.GleanMetrics.ContextualMenu
 import org.mozilla.fenix.GleanMetrics.CreditCards
 import org.mozilla.fenix.GleanMetrics.CustomTab
@@ -47,6 +48,7 @@ import org.mozilla.fenix.GleanMetrics.MediaNotification
 import org.mozilla.fenix.GleanMetrics.MediaState
 import org.mozilla.fenix.GleanMetrics.PerfAwesomebar
 import org.mozilla.fenix.GleanMetrics.ProgressiveWebApp
+import org.mozilla.fenix.GleanMetrics.SyncedTabs
 import org.mozilla.fenix.search.awesomebar.ShortcutsSuggestionProvider
 import org.mozilla.fenix.utils.Settings
 
@@ -206,6 +208,27 @@ internal class ReleaseMetricController(
                 AndroidAutofill.unlockCancelled.record(NoExtras())
             }
         }
+        Component.FEATURE_SYNCEDTABS to SyncedTabsFacts.Items.SYNCED_TABS_SUGGESTION_CLICKED -> {
+            SyncedTabs.syncedTabsSuggestionClicked.record(NoExtras())
+        }
+        Component.FEATURE_AWESOMEBAR to AwesomeBarFacts.Items.BOOKMARK_SUGGESTION_CLICKED -> {
+            Awesomebar.bookmarkSuggestionClicked.record(NoExtras())
+        }
+        Component.FEATURE_AWESOMEBAR to AwesomeBarFacts.Items.CLIPBOARD_SUGGESTION_CLICKED -> {
+            Awesomebar.clipboardSuggestionClicked.record(NoExtras())
+        }
+        Component.FEATURE_AWESOMEBAR to AwesomeBarFacts.Items.HISTORY_SUGGESTION_CLICKED -> {
+            Awesomebar.historySuggestionClicked.record(NoExtras())
+        }
+        Component.FEATURE_AWESOMEBAR to AwesomeBarFacts.Items.SEARCH_ACTION_CLICKED -> {
+            Awesomebar.searchActionClicked.record(NoExtras())
+        }
+        Component.FEATURE_AWESOMEBAR to AwesomeBarFacts.Items.SEARCH_SUGGESTION_CLICKED -> {
+            Awesomebar.searchSuggestionClicked.record(NoExtras())
+        }
+        Component.FEATURE_AWESOMEBAR to AwesomeBarFacts.Items.OPENED_TAB_SUGGESTION_CLICKED -> {
+            Awesomebar.openedTabSuggestionClicked.record(NoExtras())
+        }
         Component.FEATURE_CONTEXTMENU to ContextMenuFacts.Items.TEXT_SELECTION_OPTION -> {
             when (metadata?.get("textSelectionOption")?.toString()) {
                 CONTEXT_MENU_COPY -> ContextualMenu.copyTapped.record(NoExtras())
@@ -339,27 +362,6 @@ internal class ReleaseMetricController(
                 settings.topSitesSize = count
             }
             null
-        }
-        Component.FEATURE_SYNCEDTABS == component && SyncedTabsFacts.Items.SYNCED_TABS_SUGGESTION_CLICKED == item -> {
-            Event.SyncedTabSuggestionClicked
-        }
-        Component.FEATURE_AWESOMEBAR == component && AwesomeBarFacts.Items.BOOKMARK_SUGGESTION_CLICKED == item -> {
-            Event.BookmarkSuggestionClicked
-        }
-        Component.FEATURE_AWESOMEBAR == component && AwesomeBarFacts.Items.CLIPBOARD_SUGGESTION_CLICKED == item -> {
-            Event.ClipboardSuggestionClicked
-        }
-        Component.FEATURE_AWESOMEBAR == component && AwesomeBarFacts.Items.HISTORY_SUGGESTION_CLICKED == item -> {
-            Event.HistorySuggestionClicked
-        }
-        Component.FEATURE_AWESOMEBAR == component && AwesomeBarFacts.Items.SEARCH_ACTION_CLICKED == item -> {
-            Event.SearchActionClicked
-        }
-        Component.FEATURE_AWESOMEBAR == component && AwesomeBarFacts.Items.SEARCH_SUGGESTION_CLICKED == item -> {
-            Event.SearchSuggestionClicked
-        }
-        Component.FEATURE_AWESOMEBAR == component && AwesomeBarFacts.Items.OPENED_TAB_SUGGESTION_CLICKED == item -> {
-            Event.OpenedTabSuggestionClicked
         }
         Component.FEATURE_SEARCH == component && AdsTelemetry.SERP_ADD_CLICKED == item -> {
             Event.SearchAdClicked(value!!)

--- a/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt
@@ -65,6 +65,7 @@ import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifAnyChanged
 import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
 import mozilla.components.ui.autocomplete.InlineAutocompleteEditText
 import org.mozilla.fenix.BrowserDirection
+import org.mozilla.fenix.GleanMetrics.Awesomebar
 import org.mozilla.fenix.GleanMetrics.VoiceSearch
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
@@ -319,7 +320,7 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
         }
 
         binding.fillLinkFromClipboard.setOnClickListener {
-            requireComponents.analytics.metrics.track(Event.ClipboardSuggestionClicked)
+            Awesomebar.clipboardSuggestionClicked.record(NoExtras())
             val clipboardUrl = requireContext().components.clipboardHandler.extractURL() ?: ""
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {

--- a/app/src/test/java/org/mozilla/fenix/components/metrics/GleanMetricsServiceTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/metrics/GleanMetricsServiceTest.kt
@@ -12,9 +12,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mozilla.fenix.GleanMetrics.Awesomebar
 import org.mozilla.fenix.GleanMetrics.RecentlyVisitedHomepage
-import org.mozilla.fenix.GleanMetrics.SyncedTabs
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
 @RunWith(FenixRobolectricTestRunner::class)
@@ -27,40 +25,6 @@ class GleanMetricsServiceTest {
     @Before
     fun setup() {
         gleanService = GleanMetricsService(testContext)
-    }
-
-    @Test
-    fun `synced tab event is correctly recorded`() {
-        assertFalse(SyncedTabs.syncedTabsSuggestionClicked.testHasValue())
-        gleanService.track(Event.SyncedTabSuggestionClicked)
-        assertTrue(SyncedTabs.syncedTabsSuggestionClicked.testHasValue())
-    }
-
-    @Test
-    fun `awesomebar events are correctly recorded`() {
-        assertFalse(Awesomebar.bookmarkSuggestionClicked.testHasValue())
-        gleanService.track(Event.BookmarkSuggestionClicked)
-        assertTrue(Awesomebar.bookmarkSuggestionClicked.testHasValue())
-
-        assertFalse(Awesomebar.clipboardSuggestionClicked.testHasValue())
-        gleanService.track(Event.ClipboardSuggestionClicked)
-        assertTrue(Awesomebar.clipboardSuggestionClicked.testHasValue())
-
-        assertFalse(Awesomebar.historySuggestionClicked.testHasValue())
-        gleanService.track(Event.HistorySuggestionClicked)
-        assertTrue(Awesomebar.historySuggestionClicked.testHasValue())
-
-        assertFalse(Awesomebar.searchActionClicked.testHasValue())
-        gleanService.track(Event.SearchActionClicked)
-        assertTrue(Awesomebar.searchActionClicked.testHasValue())
-
-        assertFalse(Awesomebar.searchSuggestionClicked.testHasValue())
-        gleanService.track(Event.SearchSuggestionClicked)
-        assertTrue(Awesomebar.searchSuggestionClicked.testHasValue())
-
-        assertFalse(Awesomebar.openedTabSuggestionClicked.testHasValue())
-        gleanService.track(Event.OpenedTabSuggestionClicked)
-        assertTrue(Awesomebar.openedTabSuggestionClicked.testHasValue())
     }
 
     @Test


### PR DESCRIPTION
Removed `Event.wrapper` for suggestions telemetry.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
