### PR TITLE
For #24786 - Remove Event.wrapper for SearchTerms telemetry

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -7297,6 +7297,7 @@ search_terms:
       Number of search term group when tabs tray is opened.
     extra_keys:
       count:
+        type: string
         description: |
           The number of tabs per search group
     bugs:
@@ -7314,6 +7315,7 @@ search_terms:
       Number of search term tabs per group when tabs tray is opened.
     extra_keys:
       count:
+        type: string
         description: |
           The average number of tabs per search group
     bugs:

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/Event.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/Event.kt
@@ -4,8 +4,6 @@
 
 package org.mozilla.fenix.components.metrics
 
-import org.mozilla.fenix.GleanMetrics.SearchTerms
-
 sealed class Event {
 
     // Interaction Events
@@ -60,20 +58,6 @@ sealed class Event {
         val label: String
             get() = keyName
     }
-
-    data class SearchTermGroupCount(val count: Int) : Event() {
-        override val extras: Map<SearchTerms.numberOfSearchTermGroupKeys, String>
-            get() = hashMapOf(SearchTerms.numberOfSearchTermGroupKeys.count to count.toString())
-    }
-
-    data class AverageTabsPerSearchTermGroup(val averageSize: Double) : Event() {
-        override val extras: Map<SearchTerms.averageTabsPerGroupKeys, String>
-            get() = hashMapOf(SearchTerms.averageTabsPerGroupKeys.count to averageSize.toString())
-    }
-
-    data class SearchTermGroupSizeDistribution(val groupSizes: List<Long>) : Event()
-
-    object JumpBackInGroupTapped : Event()
 
     sealed class Search
 

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
@@ -16,7 +16,6 @@ import org.mozilla.fenix.GleanMetrics.Pings
 import org.mozilla.fenix.GleanMetrics.ProgressiveWebApp
 import org.mozilla.fenix.GleanMetrics.RecentSearches
 import org.mozilla.fenix.GleanMetrics.RecentlyVisitedHomepage
-import org.mozilla.fenix.GleanMetrics.SearchTerms
 import org.mozilla.fenix.GleanMetrics.StartOnHome
 import org.mozilla.fenix.GleanMetrics.SyncedTabs
 import org.mozilla.fenix.GleanMetrics.Tabs
@@ -140,20 +139,6 @@ private val Event.wrapper: EventWrapper<*>?
             { RecentSearches.groupDeleted.record(it) }
         )
 
-        is Event.SearchTermGroupCount -> EventWrapper(
-            { SearchTerms.numberOfSearchTermGroup.record(it) },
-            { SearchTerms.numberOfSearchTermGroupKeys.valueOf(it) }
-        )
-        is Event.AverageTabsPerSearchTermGroup -> EventWrapper(
-            { SearchTerms.averageTabsPerGroup.record(it) },
-            { SearchTerms.averageTabsPerGroupKeys.valueOf(it) }
-        )
-        is Event.SearchTermGroupSizeDistribution -> EventWrapper<NoExtraKeys>(
-            { SearchTerms.groupSizeDistribution.accumulateSamples(this.groupSizes.toLongArray()) },
-        )
-        is Event.JumpBackInGroupTapped -> EventWrapper<NoExtraKeys>(
-            { SearchTerms.jumpBackInGroupTapped.record(it) }
-        )
         is Event.Messaging.MessageShown -> EventWrapper<NoExtraKeys>(
             {
                 Messaging.messageShown.record(

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -359,7 +359,6 @@ class HomeFragment : Fragment() {
             recentTabController = DefaultRecentTabsController(
                 selectTabUseCase = components.useCases.tabsUseCases.selectTab,
                 navController = findNavController(),
-                metrics = requireComponents.analytics.metrics,
                 store = components.core.store,
                 appStore = components.appStore,
             ),

--- a/app/src/main/java/org/mozilla/fenix/home/recenttabs/controller/RecentTabController.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recenttabs/controller/RecentTabController.kt
@@ -10,11 +10,10 @@ import androidx.navigation.NavController
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.feature.tabs.TabsUseCases.SelectTabUseCase
 import mozilla.components.service.glean.private.NoExtras
+import org.mozilla.fenix.GleanMetrics.SearchTerms
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.components.appstate.AppAction
-import org.mozilla.fenix.components.metrics.Event
-import org.mozilla.fenix.components.metrics.MetricController
 import org.mozilla.fenix.ext.inProgressMediaTab
 import org.mozilla.fenix.home.HomeFragmentDirections
 import org.mozilla.fenix.home.recenttabs.RecentTab
@@ -56,7 +55,6 @@ interface RecentTabController {
 class DefaultRecentTabsController(
     private val selectTabUseCase: SelectTabUseCase,
     private val navController: NavController,
-    private val metrics: MetricController,
     private val store: BrowserStore,
     private val appStore: AppStore,
 ) : RecentTabController {
@@ -79,7 +77,7 @@ class DefaultRecentTabsController(
     }
 
     override fun handleRecentSearchGroupClicked(tabId: String) {
-        metrics.track(Event.JumpBackInGroupTapped)
+        SearchTerms.jumpBackInGroupTapped.record(NoExtras())
         navController.navigate(
             HomeFragmentDirections.actionGlobalTabsTrayFragment(
                 focusGroupTabId = tabId

--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayMiddleware.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayMiddleware.kt
@@ -8,8 +8,8 @@ import androidx.annotation.VisibleForTesting
 import mozilla.components.lib.state.Middleware
 import mozilla.components.lib.state.MiddlewareContext
 import org.mozilla.fenix.GleanMetrics.Metrics
+import org.mozilla.fenix.GleanMetrics.SearchTerms
 import org.mozilla.fenix.GleanMetrics.TabsTray
-import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.components.metrics.MetricController
 
 /**
@@ -45,15 +45,23 @@ class TabsTrayMiddleware(
                     shouldReportSearchGroupMetrics = false
                     val tabGroups = action.tabPartition?.tabGroups ?: emptyList()
 
-                    metrics.track(Event.SearchTermGroupCount(tabGroups.size))
+                    SearchTerms.numberOfSearchTermGroup.record(
+                        SearchTerms.NumberOfSearchTermGroupExtra(
+                            tabGroups.size.toString()
+                        )
+                    )
 
                     if (tabGroups.isNotEmpty()) {
                         val tabsPerGroup = tabGroups.map { it.tabIds.size }
                         val averageTabsPerGroup = tabsPerGroup.average()
-                        metrics.track(Event.AverageTabsPerSearchTermGroup(averageTabsPerGroup))
+                        SearchTerms.averageTabsPerGroup.record(
+                            SearchTerms.AverageTabsPerGroupExtra(
+                                averageTabsPerGroup.toString()
+                            )
+                        )
 
                         val tabGroupSizeMapping = tabsPerGroup.map { generateTabGroupSizeMappedValue(it) }
-                        metrics.track(Event.SearchTermGroupSizeDistribution(tabGroupSizeMapping))
+                        SearchTerms.groupSizeDistribution.accumulateSamples(tabGroupSizeMapping.toLongArray())
                     }
                 }
             }

--- a/app/src/test/java/org/mozilla/fenix/components/metrics/MetricControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/metrics/MetricControllerTest.kt
@@ -382,29 +382,6 @@ class MetricControllerTest {
     }
 
     @Test
-    fun `search term group events should be sent to enabled service`() {
-        val controller = ReleaseMetricController(
-            listOf(dataService1),
-            isDataTelemetryEnabled = { true },
-            isMarketingDataTelemetryEnabled = { true },
-            mockk()
-        )
-        every { dataService1.shouldTrack(Event.SearchTermGroupCount(5)) } returns true
-        every { dataService1.shouldTrack(Event.AverageTabsPerSearchTermGroup(2.5)) } returns true
-        every { dataService1.shouldTrack(Event.JumpBackInGroupTapped) } returns true
-
-        controller.start(MetricServiceType.Data)
-
-        controller.track(Event.SearchTermGroupCount(5))
-        controller.track(Event.AverageTabsPerSearchTermGroup(2.5))
-        controller.track(Event.JumpBackInGroupTapped)
-
-        verify { dataService1.track(Event.SearchTermGroupCount(5)) }
-        verify { dataService1.track(Event.AverageTabsPerSearchTermGroup(2.5)) }
-        verify { dataService1.track(Event.JumpBackInGroupTapped) }
-    }
-
-    @Test
     fun `WHEN processing a FEATURE_AUTOFILL fact THEN the right metric is recorded`() {
         val controller = ReleaseMetricController(emptyList(), { true }, { true }, mockk())
         var fact = Fact(

--- a/app/src/test/java/org/mozilla/fenix/home/recenttabs/controller/RecentTabControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/recenttabs/controller/RecentTabControllerTest.kt
@@ -28,9 +28,9 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.GleanMetrics.RecentTabs
+import org.mozilla.fenix.GleanMetrics.SearchTerms
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.AppStore
-import org.mozilla.fenix.components.metrics.MetricController
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -45,7 +45,6 @@ class RecentTabControllerTest {
 
     private val navController: NavController = mockk(relaxed = true)
     private val selectTabUseCase: TabsUseCases = mockk(relaxed = true)
-    private val metrics: MetricController = mockk(relaxed = true)
     private val appStore: AppStore = mockk()
 
     private lateinit var store: BrowserStore
@@ -61,7 +60,6 @@ class RecentTabControllerTest {
             DefaultRecentTabsController(
                 selectTabUseCase = selectTabUseCase.selectTab,
                 navController = navController,
-                metrics = metrics,
                 store = store,
                 appStore = appStore,
             )
@@ -164,5 +162,22 @@ class RecentTabControllerTest {
         }
 
         assertTrue(RecentTabs.showAllClicked.testHasValue())
+    }
+
+    @Test
+    fun `WHEN handleRecentSearchGroupClicked is called THEN navigate to the tabsTrayFragment and record the correct metric`() {
+        assertFalse(SearchTerms.jumpBackInGroupTapped.testHasValue())
+
+        controller.handleRecentSearchGroupClicked("1")
+
+        verify {
+            navController.navigate(
+                match<NavDirections> {
+                    it.actionId == R.id.action_global_tabsTrayFragment &&
+                        it.arguments["focusGroupTabId"] == "1"
+                }
+            )
+        }
+        assertTrue(SearchTerms.jumpBackInGroupTapped.testHasValue())
     }
 }


### PR DESCRIPTION
Removed `Event.wrapper` for `SearchTerms` telemetry.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
