### PR TITLE
For #11753 - Update compose to 1.1.1 and Kotlin to 1.6.10

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SearchTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SearchTest.kt
@@ -88,6 +88,7 @@ class SearchTest {
     }
 
     @Test
+    @Ignore("Flaky. See https://github.com/mozilla-mobile/fenix/issues/20973")
     fun shortcutButtonTest() {
         homeScreen {
         }.openThreeDotMenu {

--- a/app/src/main/java/org/mozilla/fenix/gleanplumb/state/MessagingMiddleware.kt
+++ b/app/src/main/java/org/mozilla/fenix/gleanplumb/state/MessagingMiddleware.kt
@@ -57,6 +57,10 @@ class MessagingMiddleware(
             is MessageDismissed -> onMessageDismissed(context, action.message)
 
             is MessageDisplayed -> onMessagedDisplayed(action.message, context)
+
+            else -> {
+                // no-op
+            }
         }
         next(action)
     }

--- a/app/src/main/java/org/mozilla/fenix/historymetadata/HistoryMetadataMiddleware.kt
+++ b/app/src/main/java/org/mozilla/fenix/historymetadata/HistoryMetadataMiddleware.kt
@@ -98,6 +98,9 @@ class HistoryMetadataMiddleware(
             is EngineAction.OptimizedLoadUrlTriggeredAction -> {
                 directLoadTriggeredSet.add(action.tabId)
             }
+            else -> {
+                // no-op
+            }
         }
 
         next(action)
@@ -125,6 +128,9 @@ class HistoryMetadataMiddleware(
                 context.state.findNormalTab(action.tabId)?.let { tab ->
                     createHistoryMetadata(context, tab)
                 }
+            }
+            else -> {
+                // no-op
             }
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkFragment.kt
@@ -197,6 +197,9 @@ class BookmarkFragment : LibraryPageFragment<BookmarkNode>(), UserInteractionHan
                         }
                 }
             }
+            else -> {
+                // no-op
+            }
         }
     }
 

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkView.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/BookmarkView.kt
@@ -154,6 +154,9 @@ class BookmarkView(
                     )
                 )
             }
+            else -> {
+                // no-op
+            }
         }
         binding.bookmarksProgressBar.isVisible = state.isLoading
         binding.swipeRefresh.isEnabled =

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryView.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryView.kt
@@ -108,6 +108,9 @@ class HistoryView(
                     context.getString(R.string.history_multi_select_title, mode.selectedItems.size)
                 )
             }
+            else -> {
+                // no-op
+            }
         }
     }
 

--- a/app/src/main/java/org/mozilla/fenix/tabstray/SearchTermTabGroupMiddleware.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/SearchTermTabGroupMiddleware.kt
@@ -52,6 +52,9 @@ class SearchTermTabGroupMiddleware : Middleware<BrowserState, BrowserAction> {
                     }
                 }
             }
+            else -> {
+                // no-op
+            }
         }
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/tabstray/syncedtabs/SyncedTabs.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/syncedtabs/SyncedTabs.kt
@@ -64,6 +64,7 @@ private const val EXPANDED_BY_DEFAULT = true
  * @param taskContinuityEnabled Indicates whether the Task Continuity enhancements should be visible for users.
  * @param onTabClick The lambda for handling clicks on synced tabs.
  */
+@SuppressWarnings("LongMethod")
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun SyncedTabsList(
@@ -118,6 +119,9 @@ fun SyncedTabsList(
                             )
                         }
                     }
+                    else -> {
+                        // no-op
+                    }
                 }
             }
         } else {
@@ -136,6 +140,9 @@ fun SyncedTabsList(
                         ) {
                             onTabClick(syncedTabItem.tab)
                         }
+                    }
+                    else -> {
+                        // no-op
                     }
                 }
             }

--- a/app/src/main/java/org/mozilla/fenix/telemetry/TelemetryMiddleware.kt
+++ b/app/src/main/java/org/mozilla/fenix/telemetry/TelemetryMiddleware.kt
@@ -61,6 +61,9 @@ class TelemetryMiddleware(
                 val tab = context.state.findTabOrCustomTab(action.tabId)
                 onEngineSessionKilled(context.state, tab)
             }
+            else -> {
+                // no-op
+            }
         }
 
         next(action)
@@ -80,6 +83,9 @@ class TelemetryMiddleware(
                 } else {
                     Metrics.hasOpenTabs.set(false)
                 }
+            }
+            else -> {
+                // no-op
             }
         }
     }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -6,7 +6,7 @@
 // FORCE REBUILD 2021-11-24
 
 object Versions {
-    const val kotlin = "1.5.31"
+    const val kotlin = "1.6.10"
     const val coroutines = "1.5.2"
 
     // These versions are linked: lint should be X+23.Y.Z of gradle_plugin version, according to:
@@ -20,8 +20,7 @@ object Versions {
     const val detekt = "1.19.0"
     const val jna = "5.8.0"
 
-    const val androidx_activity_compose = "1.4.0"
-    const val androidx_compose = "1.0.5"
+    const val androidx_compose = "1.1.1"
     const val androidx_appcompat = "1.3.0"
     const val androidx_benchmark = "1.0.0"
     const val androidx_biometric = "1.1.0"


### PR DESCRIPTION
Needs https://github.com/mozilla-mobile/android-components/pull/12000
Stress testing the awesomebar suggestions didn't show the crash from https://github.com/mozilla-mobile/fenix/issues/23989 anymore.

--------
The needed changes are around supporting exhaustive whens for sealed classes
as a new kotlin feature - https://kotlinlang.org/docs/whatsnew1530.html#exhaustive-when-statements-for-sealed-and-boolean-subjects

androidx_activity_compose was removed as a dependency since it isn't used.

Used 1.6.10 for Kotlin although 1.6.20 is available to prevent any issues with
Compose 1.1.1 reported as an error at compile time:
"e: This version (1.1.1) of the Compose Compiler requires Kotlin version 1.6.10
but you appear to be using Kotlin version 1.6.20 which is not known to be
compatible. Please fix your configuration (or
`suppressKotlinVersionCompatibilityCheck` but don't say I didn't warn you!)."



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
