### PR TITLE
For #20811 - Fix synced tabs error button width

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabstray/syncedtabs/SyncedTabs.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/syncedtabs/SyncedTabs.kt
@@ -281,7 +281,9 @@ fun SyncedTabsErrorButton(
 ) {
     Button(
         onClick = onClick,
-        modifier = Modifier.clip(RoundedCornerShape(size = 4.dp)),
+        modifier = Modifier
+            .clip(RoundedCornerShape(size = 4.dp))
+            .fillMaxWidth(),
         elevation = ButtonDefaults.elevation(defaultElevation = 0.dp, pressedElevation = 0.dp),
         colors = ButtonDefaults.outlinedButtonColors(backgroundColor = FirefoxTheme.colors.actionPrimary),
     ) {


### PR DESCRIPTION
Closes #20811 

![Screenshot_20220414_120123](https://user-images.githubusercontent.com/87384386/163459357-7a28bc4d-5409-448f-a7e5-a2bef44d0c08.png)
![Screen Shot 2022-04-14 at 12 01 53 PM](https://user-images.githubusercontent.com/87384386/163459364-7e5e408b-8913-4f06-a067-341090dce3dc.png)


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
