### PR TITLE
For #24811 - Remove Event.wrapper for Messaging telemetry

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/Analytics.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Analytics.kt
@@ -17,11 +17,11 @@ import mozilla.components.lib.crash.sentry.SentryService
 import mozilla.components.service.nimbus.NimbusApi
 import org.mozilla.fenix.BuildConfig
 import org.mozilla.fenix.Config
+import org.mozilla.fenix.GleanMetrics.Messaging
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ReleaseChannel
 import org.mozilla.fenix.components.metrics.AdjustMetricsService
-import org.mozilla.fenix.components.metrics.Event
 import org.mozilla.fenix.components.metrics.GleanMetricsService
 import org.mozilla.fenix.components.metrics.MetricController
 import org.mozilla.fenix.experiments.createNimbus
@@ -135,7 +135,7 @@ class Analytics(
             metadataStorage = OnDiskMessageMetadataStorage(context),
             gleanPlumb = experiments,
             reportMalformedMessage = {
-                metrics.track(Event.Messaging.MessageMalformed(it))
+                Messaging.malformed.record(Messaging.MalformedExtra(it))
             },
             messagingFeature = FxNimbus.features.messaging,
             attributeProvider = CustomAttributeProvider,

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/Event.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/Event.kt
@@ -29,15 +29,6 @@ sealed class Event {
 
     sealed class Search
 
-    sealed class Messaging(open val messageId: String) : Event() {
-        data class MessageShown(override val messageId: String) : Messaging(messageId)
-        data class MessageDismissed(override val messageId: String) : Messaging(messageId)
-        data class MessageClicked(override val messageId: String, val uuid: String?) :
-            Messaging(messageId)
-        data class MessageMalformed(override val messageId: String) : Messaging(messageId)
-        data class MessageExpired(override val messageId: String) : Messaging(messageId)
-    }
-
     internal open val extras: Map<*, String>?
         get() = null
 }

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/GleanMetricsService.kt
@@ -11,7 +11,6 @@ import mozilla.components.support.base.log.logger.Logger
 import org.mozilla.fenix.GleanMetrics.BrowserSearch
 import org.mozilla.fenix.GleanMetrics.Pings
 import org.mozilla.fenix.GleanMetrics.RecentlyVisitedHomepage
-import org.mozilla.fenix.GleanMetrics.Messaging
 import org.mozilla.fenix.ext.components
 
 private class EventWrapper<T : Enum<T>>(
@@ -70,53 +69,6 @@ private val Event.wrapper: EventWrapper<*>?
         is Event.SearchInContent -> EventWrapper<NoExtraKeys>(
             {
                 BrowserSearch.inContent[label].add(1)
-            }
-        )
-
-        is Event.Messaging.MessageShown -> EventWrapper<NoExtraKeys>(
-            {
-                Messaging.messageShown.record(
-                    Messaging.MessageShownExtra(
-                        messageKey = this.messageId
-                    )
-                )
-            }
-        )
-        is Event.Messaging.MessageClicked -> EventWrapper<NoExtraKeys>(
-            {
-                Messaging.messageClicked.record(
-                    Messaging.MessageClickedExtra(
-                        messageKey = this.messageId,
-                        actionUuid = this.uuid
-                    )
-                )
-            }
-        )
-        is Event.Messaging.MessageDismissed -> EventWrapper<NoExtraKeys>(
-            {
-                Messaging.messageDismissed.record(
-                    Messaging.MessageDismissedExtra(
-                        messageKey = this.messageId
-                    )
-                )
-            }
-        )
-        is Event.Messaging.MessageMalformed -> EventWrapper<NoExtraKeys>(
-            {
-                Messaging.malformed.record(
-                    Messaging.MalformedExtra(
-                        messageKey = this.messageId
-                    )
-                )
-            }
-        )
-        is Event.Messaging.MessageExpired -> EventWrapper<NoExtraKeys>(
-            {
-                Messaging.messageExpired.record(
-                    Messaging.MessageExpiredExtra(
-                        messageKey = this.messageId
-                    )
-                )
             }
         )
 

--- a/app/src/main/java/org/mozilla/fenix/gleanplumb/DefaultMessageController.kt
+++ b/app/src/main/java/org/mozilla/fenix/gleanplumb/DefaultMessageController.kt
@@ -9,20 +9,18 @@ import android.net.Uri
 import androidx.annotation.VisibleForTesting
 import androidx.core.net.toUri
 import org.mozilla.fenix.BuildConfig
+import org.mozilla.fenix.GleanMetrics.Messaging
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.components.appstate.AppAction.MessagingAction.MessageClicked
 import org.mozilla.fenix.components.appstate.AppAction.MessagingAction.MessageDismissed
 import org.mozilla.fenix.components.appstate.AppAction.MessagingAction.MessageDisplayed
-import org.mozilla.fenix.components.metrics.Event
-import org.mozilla.fenix.components.metrics.MetricController
 
 /**
  * Handles default interactions with the ui of GleanPlumb messages.
  */
 class DefaultMessageController(
     private val appStore: AppStore,
-    private val metrics: MetricController,
     private val messagingStorage: NimbusMessagingStorage,
     private val homeActivity: HomeActivity
 ) : MessageController {
@@ -31,21 +29,26 @@ class DefaultMessageController(
         val result = messagingStorage.getMessageAction(message)
         val uuid = result.first
         val action = result.second
-        metrics.track(Event.Messaging.MessageClicked(message.id, uuid))
+        Messaging.messageClicked.record(
+            Messaging.MessageClickedExtra(
+                messageKey = message.id,
+                actionUuid = uuid
+            )
+        )
         handleAction(action)
         appStore.dispatch(MessageClicked(message))
     }
 
     override fun onMessageDismissed(message: Message) {
-        metrics.track(Event.Messaging.MessageDismissed(message.id))
+        Messaging.messageDismissed.record(Messaging.MessageDismissedExtra(message.id))
         appStore.dispatch(MessageDismissed(message))
     }
 
     override fun onMessageDisplayed(message: Message) {
         if (message.maxDisplayCount <= message.metadata.displayCount + 1) {
-            metrics.track(Event.Messaging.MessageExpired(message.id))
+            Messaging.messageExpired.record(Messaging.MessageExpiredExtra(message.id))
         }
-        metrics.track(Event.Messaging.MessageShown(message.id))
+        Messaging.messageShown.record(Messaging.MessageShownExtra(message.id))
         appStore.dispatch(MessageDisplayed(message))
     }
 

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -335,7 +335,6 @@ class HomeFragment : Fragment() {
                     appStore = components.appStore,
                     messagingStorage = components.analytics.messagingStorage,
                     homeActivity = activity,
-                    metrics = components.analytics.metrics
                 ),
                 store = store,
                 tabCollectionStorage = components.core.tabCollectionStorage,

--- a/app/src/test/java/org/mozilla/fenix/gleanplumb/DefaultMessageControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/gleanplumb/DefaultMessageControllerTest.kt
@@ -10,36 +10,39 @@ import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
 import mozilla.components.support.test.robolectric.testContext
+import mozilla.telemetry.glean.testing.GleanTestRule
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.BuildConfig
+import org.mozilla.fenix.GleanMetrics.Messaging
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.components.appstate.AppAction
 import org.mozilla.fenix.components.appstate.AppAction.MessagingAction.MessageClicked
 import org.mozilla.fenix.components.appstate.AppAction.MessagingAction.MessageDisplayed
-import org.mozilla.fenix.components.metrics.Event
-import org.mozilla.fenix.components.metrics.MetricController
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.nimbus.MessageData
 
 @RunWith(FenixRobolectricTestRunner::class)
 class DefaultMessageControllerTest {
 
+    @get:Rule
+    val gleanTestRule = GleanTestRule(testContext)
+
     private val activity: HomeActivity = mockk(relaxed = true)
     private val storageNimbus: NimbusMessagingStorage = mockk(relaxed = true)
     private lateinit var controller: DefaultMessageController
-    private lateinit var metrics: MetricController
     private val store: AppStore = mockk(relaxed = true)
 
     @Before
     fun setup() {
-        metrics = mockk(relaxed = true)
         controller = DefaultMessageController(
             messagingStorage = storageNimbus,
-            metrics = metrics,
             appStore = store,
             homeActivity = activity
         )
@@ -51,10 +54,15 @@ class DefaultMessageControllerTest {
         val message = mockMessage()
         every { customController.handleAction(any()) } returns mockk()
         every { storageNimbus.getMessageAction(message) } returns Pair("uuid", message.id)
+        assertFalse(Messaging.messageClicked.testHasValue())
 
         customController.onMessagePressed(message)
 
-        verify { metrics.track(Event.Messaging.MessageClicked(message.id, "uuid")) }
+        assertTrue(Messaging.messageClicked.testHasValue())
+        val event = Messaging.messageClicked.testGetValue()
+        assertEquals(1, event.size)
+        assertEquals(message.id, event.single().extra!!["message_key"])
+        assertEquals("uuid", event.single().extra!!["action_uuid"])
         verify { customController.handleAction(any()) }
         verify { store.dispatch(MessageClicked(message)) }
     }
@@ -84,10 +92,14 @@ class DefaultMessageControllerTest {
     @Test
     fun `WHEN calling onMessageDismissed THEN report to the messageManager`() {
         val message = mockMessage()
+        assertFalse(Messaging.messageDismissed.testHasValue())
 
         controller.onMessageDismissed(message)
 
-        verify { metrics.track(Event.Messaging.MessageDismissed(message.id)) }
+        assertTrue(Messaging.messageDismissed.testHasValue())
+        val event = Messaging.messageDismissed.testGetValue()
+        assertEquals(1, event.size)
+        assertEquals(message.id, event.single().extra!!["message_key"])
         verify { store.dispatch(AppAction.MessagingAction.MessageDismissed(message)) }
     }
 
@@ -95,11 +107,21 @@ class DefaultMessageControllerTest {
     fun `WHEN calling onMessageDisplayed THEN report to the messageManager`() {
         val data = MessageData(_context = testContext)
         val message = mockMessage(data)
+        assertFalse(Messaging.messageExpired.testHasValue())
+        assertFalse(Messaging.messageShown.testHasValue())
 
         controller.onMessageDisplayed(message)
 
-        verify { metrics.track(Event.Messaging.MessageExpired(message.id)) }
-        verify { metrics.track(Event.Messaging.MessageShown(message.id)) }
+        assertTrue(Messaging.messageExpired.testHasValue())
+        val messageExpiredEvent = Messaging.messageExpired.testGetValue()
+        assertEquals(1, messageExpiredEvent.size)
+        assertEquals(message.id, messageExpiredEvent.single().extra!!["message_key"])
+
+        assertTrue(Messaging.messageShown.testHasValue())
+        val event = Messaging.messageShown.testGetValue()
+        assertEquals(1, event.size)
+        assertEquals(message.id, event.single().extra!!["message_key"])
+
         verify { store.dispatch(MessageDisplayed(message)) }
     }
 


### PR DESCRIPTION
Removed Event.wrapper for Messaging metrics.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
