### PR TITLE
For #24603 - Remove forEach from MediaNotification telemetry test

### DIFF
--- a/app/src/test/java/org/mozilla/fenix/components/metrics/MetricControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/metrics/MetricControllerTest.kt
@@ -286,21 +286,29 @@ class MetricControllerTest {
     @Test
     fun `WHEN processing a FEATURE_MEDIA NOTIFICATION fact THEN the right metric is recorded`() {
         val controller = ReleaseMetricController(emptyList(), { true }, { true }, mockk())
-        val itemsToEvents = listOf(
-            Action.PLAY to MediaNotification.play,
-            Action.PAUSE to MediaNotification.pause,
-        )
+        // Verify the play action
+        var fact = Fact(Component.FEATURE_MEDIA, Action.PLAY, MediaFacts.Items.NOTIFICATION)
+        assertFalse(MediaNotification.play.testHasValue())
 
-        itemsToEvents.forEach { (action, event) ->
-            val fact = Fact(Component.FEATURE_MEDIA, action, MediaFacts.Items.NOTIFICATION)
-            controller.run {
-                fact.process()
-            }
-
-            assertEquals(true, event.testHasValue())
-            assertEquals(1, event.testGetValue().size)
-            assertEquals(null, event.testGetValue().single().extra)
+        controller.run {
+            fact.process()
         }
+
+        assertTrue(MediaNotification.play.testHasValue())
+        assertEquals(1, MediaNotification.play.testGetValue().size)
+        assertNull(MediaNotification.play.testGetValue().single().extra)
+
+        // Verify the pause action
+        fact = Fact(Component.FEATURE_MEDIA, Action.PAUSE, MediaFacts.Items.NOTIFICATION)
+        assertFalse(MediaNotification.pause.testHasValue())
+
+        controller.run {
+            fact.process()
+        }
+
+        assertTrue(MediaNotification.pause.testHasValue())
+        assertEquals(1, MediaNotification.pause.testGetValue().size)
+        assertNull(MediaNotification.pause.testGetValue().single().extra)
     }
 
     @Test


### PR DESCRIPTION
Removed the `forEach` from the `MediaNotification` telemetry test from `MetricControllerTest` to increase readability.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
