### PR TITLE
For #24759 - Remove forEach from ContextualMenu telemetry test

### DIFF
--- a/app/src/test/java/org/mozilla/fenix/components/metrics/MetricControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/metrics/MetricControllerTest.kt
@@ -409,29 +409,74 @@ class MetricControllerTest {
     @Test
     fun `WHEN processing a ContextualMenu fact THEN the right metric is recorded`() {
         val controller = ReleaseMetricController(emptyList(), { true }, { true }, mockk())
-
-        val longPressItemsToEvents = listOf(
-            Companion.CONTEXT_MENU_COPY to ContextualMenu.copyTapped,
-            Companion.CONTEXT_MENU_SEARCH to ContextualMenu.searchTapped,
-            Companion.CONTEXT_MENU_SELECT_ALL to ContextualMenu.selectAllTapped,
-            Companion.CONTEXT_MENU_SHARE to ContextualMenu.shareTapped,
+        val action = mockk<Action>()
+        // Verify copy button interaction
+        var fact = Fact(
+            Component.FEATURE_CONTEXTMENU,
+            action,
+            ContextMenuFacts.Items.TEXT_SELECTION_OPTION,
+            metadata = mapOf("textSelectionOption" to Companion.CONTEXT_MENU_COPY)
         )
+        assertFalse(ContextualMenu.copyTapped.testHasValue())
 
-        longPressItemsToEvents.forEach { (item, event) ->
-            val fact = Fact(
-                Component.FEATURE_CONTEXTMENU,
-                mockk(),
-                ContextMenuFacts.Items.TEXT_SELECTION_OPTION,
-                metadata = mapOf("textSelectionOption" to item)
-            )
-            with(controller) {
-                fact.process()
-            }
-
-            assertEquals(true, event.testHasValue())
-            assertEquals(1, event.testGetValue().size)
-            assertEquals(null, event.testGetValue().single().extra)
+        with(controller) {
+            fact.process()
         }
+
+        assertTrue(ContextualMenu.copyTapped.testHasValue())
+        assertEquals(1, ContextualMenu.copyTapped.testGetValue().size)
+        assertNull(ContextualMenu.copyTapped.testGetValue().single().extra)
+
+        // Verify search button interaction
+        fact = Fact(
+            Component.FEATURE_CONTEXTMENU,
+            action,
+            ContextMenuFacts.Items.TEXT_SELECTION_OPTION,
+            metadata = mapOf("textSelectionOption" to Companion.CONTEXT_MENU_SEARCH)
+        )
+        assertFalse(ContextualMenu.searchTapped.testHasValue())
+
+        with(controller) {
+            fact.process()
+        }
+
+        assertTrue(ContextualMenu.searchTapped.testHasValue())
+        assertEquals(1, ContextualMenu.searchTapped.testGetValue().size)
+        assertNull(ContextualMenu.searchTapped.testGetValue().single().extra)
+
+        // Verify select all button interaction
+        fact = Fact(
+            Component.FEATURE_CONTEXTMENU,
+            action,
+            ContextMenuFacts.Items.TEXT_SELECTION_OPTION,
+            metadata = mapOf("textSelectionOption" to Companion.CONTEXT_MENU_SELECT_ALL)
+        )
+        assertFalse(ContextualMenu.selectAllTapped.testHasValue())
+
+        with(controller) {
+            fact.process()
+        }
+
+        assertTrue(ContextualMenu.selectAllTapped.testHasValue())
+        assertEquals(1, ContextualMenu.selectAllTapped.testGetValue().size)
+        assertNull(ContextualMenu.selectAllTapped.testGetValue().single().extra)
+
+        // Verify share button interaction
+        fact = Fact(
+            Component.FEATURE_CONTEXTMENU,
+            action,
+            ContextMenuFacts.Items.TEXT_SELECTION_OPTION,
+            metadata = mapOf("textSelectionOption" to Companion.CONTEXT_MENU_SHARE)
+        )
+        assertFalse(ContextualMenu.shareTapped.testHasValue())
+
+        with(controller) {
+            fact.process()
+        }
+
+        assertTrue(ContextualMenu.shareTapped.testHasValue())
+        assertEquals(1, ContextualMenu.shareTapped.testGetValue().size)
+        assertNull(ContextualMenu.shareTapped.testGetValue().single().extra)
     }
 
     @Test


### PR DESCRIPTION
Removed the `forEach` from the `ContextualMenu` telemetry test from `MetricControllerTest` to increase readability.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
