### PR TITLE
bug 1764109 - retry ui-tests on exit code 20.

### DIFF
--- a/taskcluster/ci/ui-test/kind.yml
+++ b/taskcluster/ci/ui-test/kind.yml
@@ -97,6 +97,7 @@ job-defaults:
             - name: public
               path: /builds/worker/artifacts
               type: directory
+        retry-exit-status: [20]
     worker-type: b-android
 
 jobs:


### PR DESCRIPTION
No screenshots or accessibility changes.
It looks like ui tests already have a retry exit status of 72: https://firefox-ci-tc.services.mozilla.com/tasks/Qq4UBdkkScqVnb7dc2yJxw
This patch adds `20` to the retry exit statuses per [bug 1764109](https://bugzilla.mozilla.org/show_bug.cgi?id=1764109).