### PR TITLE
for #24665: Show recent synced placeholders early

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/BackgroundServices.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/BackgroundServices.kt
@@ -124,6 +124,8 @@ class BackgroundServices(
         }
     }
 
+    private val accountAuthenticationObserver = AccountAuthenticationObserver(context.settings())
+
     private val telemetryAccountObserver = TelemetryAccountObserver(
         context.settings(),
     )
@@ -163,6 +165,9 @@ class BackgroundServices(
         ),
         crashReporter
     ).also { accountManager ->
+        // Register an authentication account observer to cache status
+        accountManager.register(accountAuthenticationObserver)
+
         // Register a telemetry account observer to keep track of FxA auth metrics.
         accountManager.register(telemetryAccountObserver)
 
@@ -193,6 +198,16 @@ class BackgroundServices(
      */
     private val notificationManager by lazyMonitored {
         NotificationManager(context)
+    }
+}
+
+private class AccountAuthenticationObserver(private val settings: Settings) : AccountObserver {
+    override fun onAuthenticated(account: OAuthAccount, authType: AuthType) {
+        settings.hasFxaAuthenticated = true
+    }
+
+    override fun onLoggedOut() {
+        settings.hasFxaAuthenticated = false
     }
 }
 

--- a/app/src/main/java/org/mozilla/fenix/components/BackgroundServices.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/BackgroundServices.kt
@@ -30,7 +30,6 @@ import mozilla.components.service.fxa.SyncEngine
 import mozilla.components.service.fxa.manager.FxaAccountManager
 import mozilla.components.service.fxa.manager.SCOPE_SESSION
 import mozilla.components.service.fxa.manager.SCOPE_SYNC
-import mozilla.components.service.fxa.manager.SyncEnginesStorage
 import mozilla.components.service.fxa.sync.GlobalSyncableStoreProvider
 import mozilla.components.service.glean.private.NoExtras
 import mozilla.components.service.sync.autofill.AutofillCreditCardsAddressesStorage
@@ -164,11 +163,6 @@ class BackgroundServices(
         ),
         crashReporter
     ).also { accountManager ->
-        // TODO this needs to change once we have a SyncManager
-        context.settings().fxaHasSyncedItems = accountManager.authenticatedAccount()?.let {
-            SyncEnginesStorage(context).getStatus().any { it.value }
-        } ?: false
-
         // Register a telemetry account observer to keep track of FxA auth metrics.
         accountManager.register(telemetryAccountObserver)
 

--- a/app/src/main/java/org/mozilla/fenix/components/Components.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Components.kt
@@ -37,6 +37,7 @@ import org.mozilla.fenix.ext.sort
 import org.mozilla.fenix.home.PocketUpdatesMiddleware
 import org.mozilla.fenix.home.blocklist.BlocklistHandler
 import org.mozilla.fenix.home.blocklist.BlocklistMiddleware
+import org.mozilla.fenix.home.recentsyncedtabs.RecentSyncedTabState
 import org.mozilla.fenix.perf.AppStartReasonProvider
 import org.mozilla.fenix.perf.StartupActivityLog
 import org.mozilla.fenix.perf.StartupStateProvider
@@ -213,6 +214,11 @@ class Components(private val context: Context) {
                     core.store.state.asRecentTabs()
                 } else {
                     emptyList()
+                },
+                recentSyncedTabState = if (settings.hasFxaAuthenticated) {
+                    RecentSyncedTabState.Loading
+                } else {
+                    RecentSyncedTabState.None
                 },
                 recentHistory = emptyList()
             ).run { filterState(blocklistHandler) },

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -1012,6 +1012,16 @@ class Settings(private val appContext: Context) : PreferencesHolder {
         default = true
     )
 
+    var hasFxaAuthenticated by booleanPreference(
+        appContext.getPreferenceKey(R.string.pref_key_fxa_has_authenticated),
+        default = false
+    )
+
+    var lastPlacesStorageMaintenance by longPreference(
+        appContext.getPreferenceKey(R.string.pref_key_last_maintenance),
+        default = 0
+    )
+
     fun addSearchWidgetInstalled(count: Int) {
         val key = appContext.getPreferenceKey(R.string.pref_key_search_widget_installed)
         val newValue = preferences.getInt(key, 0) + count

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -1012,16 +1012,6 @@ class Settings(private val appContext: Context) : PreferencesHolder {
         default = true
     )
 
-    var fxaHasSyncedItems by booleanPreference(
-        appContext.getPreferenceKey(R.string.pref_key_fxa_has_synced_items),
-        default = false
-    )
-
-    var lastPlacesStorageMaintenance by longPreference(
-        appContext.getPreferenceKey(R.string.pref_key_last_maintenance),
-        default = 0
-    )
-
     fun addSearchWidgetInstalled(count: Int) {
         val key = appContext.getPreferenceKey(R.string.pref_key_search_widget_installed)
         val newValue = preferences.getInt(key, 0) + count

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -85,6 +85,7 @@
     <string name="pref_key_sign_out" translatable="false">pref_key_sign_out</string>
     <string name="pref_key_sync_sign_in" translatable="false">pref_key_sync_sign_in</string>
     <string name="pref_key_push_project_id" translatable="false">project_id</string>
+    <string name="pref_key_fxa_has_authenticated" translatable="false">pref_key_fxa_has_authenticated</string>
     <string name="pref_key_search_widget_installed" translatable="false">pref_key_search_widget_installed</string>
     <string name="pref_key_saved_logins_sorting_strategy" translatable="false">pref_key_saved_logins_sorting_strategy</string>
     <!-- Key for credit cards sync preference in the account settings fragment -->

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -85,7 +85,6 @@
     <string name="pref_key_sign_out" translatable="false">pref_key_sign_out</string>
     <string name="pref_key_sync_sign_in" translatable="false">pref_key_sync_sign_in</string>
     <string name="pref_key_push_project_id" translatable="false">project_id</string>
-    <string name="pref_key_fxa_has_synced_items" translatable="false">pref_key_fxa_has_synced_items</string>
     <string name="pref_key_search_widget_installed" translatable="false">pref_key_search_widget_installed</string>
     <string name="pref_key_saved_logins_sorting_strategy" translatable="false">pref_key_saved_logins_sorting_strategy</string>
     <!-- Key for credit cards sync preference in the account settings fragment -->

--- a/app/src/test/java/org/mozilla/fenix/home/recentsyncedtabs/RecentSyncedTabFeatureTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/recentsyncedtabs/RecentSyncedTabFeatureTest.kt
@@ -176,13 +176,6 @@ class RecentSyncedTabFeatureTest {
     }
 
     @Test
-    fun `WHEN error is received THEN action dispatched with empty synced state`() {
-        feature.onError(SyncedTabsView.ErrorType.NO_TABS_AVAILABLE)
-
-        verify { store.dispatch(AppAction.RecentSyncedTabStateChange(RecentSyncedTabState.None)) }
-    }
-
-    @Test
     fun `WHEN synced tab displayed THEN labeled counter metric recorded with device type`() {
         val tab = SyncedDeviceTabs(deviceAccessed1, listOf(createActiveTab()))
 
@@ -220,6 +213,26 @@ class RecentSyncedTabFeatureTest {
         feature.displaySyncedTabs(listOf(tab2))
 
         assertFalse(RecentSyncedTabs.latestSyncedTabIsStale.testHasValue())
+    }
+
+    @Test
+    fun `GIVEN that feature is not loading WHEN no tabs error received THEN dispatches NONE state`() {
+        every { store.state } returns mockk {
+            every { recentSyncedTabState } returns RecentSyncedTabState.None
+        }
+        feature.onError(SyncedTabsView.ErrorType.NO_TABS_AVAILABLE)
+
+        verify { store.dispatch(AppAction.RecentSyncedTabStateChange(RecentSyncedTabState.None)) }
+    }
+
+    @Test
+    fun `GIVEN that feature is loading WHEN fatal error received THEN dispatches NONE state`() {
+        every { store.state } returns mockk {
+            every { recentSyncedTabState } returns RecentSyncedTabState.Loading
+        }
+        feature.onError(SyncedTabsView.ErrorType.MULTIPLE_DEVICES_UNAVAILABLE)
+
+        verify { store.dispatch(AppAction.RecentSyncedTabStateChange(RecentSyncedTabState.None)) }
     }
 
     private fun createActiveTab(


### PR DESCRIPTION
for #24665

Separate commits since the first is technically unrelated, in case we want to file it for a different issue. I could also squash these if a single commit makes sense. During investigation I thought to maybe reuse `fxaHasSyncedItems`, but then I noticed that it was actually unused. 

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
