### PR TITLE
For #24897 - Move clickable handling to the parent in ExpandableListHeader

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/compose/list/ExpandableListHeader.kt
+++ b/app/src/main/java/org/mozilla/fenix/compose/list/ExpandableListHeader.kt
@@ -46,16 +46,21 @@ fun ExpandableListHeader(
     expanded: Boolean? = null,
     expandActionContentDescription: String? = null,
     collapseActionContentDescription: String? = null,
-    onClick: () -> Unit = {},
+    onClick: (() -> Unit)? = null,
     actions: @Composable () -> Unit = {},
 ) {
     Row(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = when (onClick != null) {
+            true -> Modifier.clickable { onClick() }
+            false -> Modifier
+        }.then(
+            Modifier.fillMaxWidth()
+        ),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         Row(
             modifier = Modifier
                 .weight(1f)
-                .clickable(onClick = onClick)
                 .padding(horizontal = 16.dp, vertical = 8.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {


### PR DESCRIPTION
Fixes #24897

ExpandableListHeader provides a consistent UX for similar usecases.

Needed to update it to allow clicks to be handled by a parent and it not
stealing the click or shown an improper Indication.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
