### PR TITLE
Application services 93.0.1

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -309,7 +309,7 @@ class Core(
     /**
      * The storage component to sync and persist tabs in a Firefox Sync account.
      */
-    val lazyRemoteTabsStorage = lazyMonitored { RemoteTabsStorage() }
+    val lazyRemoteTabsStorage = lazyMonitored { RemoteTabsStorage(context) }
 
     val recentlyClosedTabsStorage = lazyMonitored { RecentlyClosedTabsStorage(context, engine, crashReporter) }
 

--- a/app/src/main/java/org/mozilla/fenix/gleanplumb/NimbusMessagingStorage.kt
+++ b/app/src/main/java/org/mozilla/fenix/gleanplumb/NimbusMessagingStorage.kt
@@ -47,7 +47,7 @@ class NimbusMessagingStorage(
         val nimbusActions = nimbusFeature.actions
 
         val nimbusMessages = nimbusFeature.messages
-        val defaultStyle = StyleData(context)
+        val defaultStyle = StyleData()
         val storageMetadata = metadataStorage.getMetadata()
 
         return nimbusMessages.mapNotNull { (key, value) ->

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -444,7 +444,7 @@ class Settings(private val appContext: Context) : PreferencesHolder {
      */
     var searchTermTabGroupsAreEnabled by lazyFeatureFlagPreference(
         appContext.getPreferenceKey(R.string.pref_key_search_term_tab_groups),
-        default = { FxNimbus.features.searchTermGroups.value(appContext).enabled },
+        default = { FxNimbus.features.searchTermGroups.value().enabled },
         featureFlag = FeatureFlags.tabGroupFeature
     )
 
@@ -1203,7 +1203,7 @@ class Settings(private val appContext: Context) : PreferencesHolder {
     )
 
     private val homescreenSections: Map<HomeScreenSection, Boolean> by lazy {
-        FxNimbus.features.homescreen.value(appContext).sectionsEnabled
+        FxNimbus.features.homescreen.value().sectionsEnabled
     }
 
     var historyMetadataUIFeature by lazyFeatureFlagPreference(

--- a/app/src/test/java/org/mozilla/fenix/gleanplumb/DefaultMessageControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/gleanplumb/DefaultMessageControllerTest.kt
@@ -105,7 +105,7 @@ class DefaultMessageControllerTest {
 
     @Test
     fun `WHEN calling onMessageDisplayed THEN report to the messageManager`() {
-        val data = MessageData(_context = testContext)
+        val data = MessageData()
         val message = mockMessage(data)
         assertFalse(Messaging.messageExpired.testHasValue())
         assertFalse(Messaging.messageShown.testHasValue())
@@ -125,7 +125,7 @@ class DefaultMessageControllerTest {
         verify { store.dispatch(MessageDisplayed(message)) }
     }
 
-    private fun mockMessage(data: MessageData = MessageData(_context = testContext)) = Message(
+    private fun mockMessage(data: MessageData = MessageData()) = Message(
         id = "id",
         data = data,
         style = mockk(relaxed = true),

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "102.0.20220509143036"
+    const val VERSION = "102.0.20220509214046"
 }


### PR DESCRIPTION
AC update: mozilla-mobile/android-components#12044

Note that there's also an [AC PR](https://github.com/mozilla-mobile/android-components/pull/12029) to update to `v91.1.21`.  See the AC PRs for a comparisons of the two upgrades.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
