### PR TITLE
For #24040 - App should not crash when the search widget is clicked while PIP mode is active

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -52,6 +52,7 @@ import mozilla.components.concept.storage.BookmarkNode
 import mozilla.components.concept.storage.BookmarkNodeType
 import mozilla.components.concept.storage.HistoryMetadataKey
 import mozilla.components.feature.contextmenu.DefaultSelectionActionDelegate
+import mozilla.components.feature.media.ext.findActiveMediaTab
 import mozilla.components.feature.privatemode.notification.PrivateNotificationFeature
 import mozilla.components.feature.search.BrowserStoreSearchAdapter
 import mozilla.components.service.fxa.sync.SyncReason
@@ -510,6 +511,11 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
                 "intent" to intent.action.toString()
             )
         )
+
+        val tab = components.core.store.state.findActiveMediaTab()
+        if (tab != null) {
+            components.useCases.sessionUseCases.exitFullscreen(tab.id)
+        }
 
         val intentProcessors =
             listOf(

--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -1321,7 +1321,7 @@ abstract class BaseBrowserFragment :
      * Exit fullscreen mode when exiting PIP mode
      */
     private fun pipModeChanged(session: SessionState) {
-        if (!session.content.pictureInPictureEnabled && session.content.fullScreen) {
+        if (!session.content.pictureInPictureEnabled && session.content.fullScreen && isAdded) {
             onBackPressed()
             fullScreenChanged(false)
         }


### PR DESCRIPTION
When the search event is from the search widget while PIP is active,  the search fragment opens after the screen is unlocked. This avoids the issue of the search page opening in landscape mode and also the app doesn't crash.


https://user-images.githubusercontent.com/12825812/165027626-74e22740-03a3-4268-ab28-030312fe3d90.mp4



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
