### PR TITLE
For #24935: Dismiss keyboard on add address fragment stop.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/address/AddressEditorFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/address/AddressEditorFragment.kt
@@ -8,6 +8,7 @@ import android.os.Bundle
 import android.view.View
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
+import mozilla.components.support.ktx.android.view.hideKeyboard
 import org.mozilla.fenix.R
 import org.mozilla.fenix.SecureFragment
 import org.mozilla.fenix.databinding.FragmentAddressEditorBinding
@@ -48,5 +49,10 @@ class AddressEditorFragment : SecureFragment(R.layout.fragment_address_editor) {
     override fun onResume() {
         super.onResume()
         showToolbar(getString(R.string.addresses_add_address))
+    }
+
+    override fun onStop() {
+        super.onStop()
+        this.view?.hideKeyboard()
     }
 }


### PR DESCRIPTION
Fixes #24935

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
