### PR TITLE
No issue: Additional UI test disabling on API30

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/DownloadTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/DownloadTest.kt
@@ -9,6 +9,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.customannotations.SmokeTest
@@ -111,6 +112,7 @@ class DownloadTest {
         }
     }
 
+    @Ignore("Intermittent: https://github.com/mozilla-mobile/fenix/issues/23434")
     @SmokeTest
     @Test
     fun pauseResumeCancelDownloadTest() {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/NoNetworkAccessStartupTests.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/NoNetworkAccessStartupTests.kt
@@ -7,6 +7,7 @@ package org.mozilla.fenix.ui
 import androidx.core.net.toUri
 import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.After
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.R
@@ -87,6 +88,7 @@ class NoNetworkAccessStartupTests {
         }.refreshPage { }
     }
 
+    @Ignore("Failing with frequent ANR: https://bugzilla.mozilla.org/show_bug.cgi?id=1764605")
     @Test
     fun testSignInPageWithNoNetworkConnection() {
         setNetworkEnabled(false)

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsPrivacyTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsPrivacyTest.kt
@@ -361,6 +361,7 @@ class SettingsPrivacyTest {
         }
     }
 
+    @Ignore("Intermittent: https://github.com/mozilla-mobile/fenix/issues/22188")
     @Test
     fun launchPageShortcutInPrivateModeTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)


### PR DESCRIPTION
Adding to https://github.com/mozilla-mobile/fenix/issues/24978