### PR TITLE
For #23817 fix and re-enable deleteNonEmptyBookmarkFolderTest UI test

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -784,7 +784,6 @@ class SmokeTest {
         }
     }
 
-    @Ignore("Failing: https://github.com/mozilla-mobile/fenix/issues/24994")
     @Test
     // Verifies that deleting a Bookmarks folder also removes the item from inside it.
     fun deleteNonEmptyBookmarkFolderTest() {
@@ -794,13 +793,9 @@ class SmokeTest {
             createBookmark(website.url)
         }.openThreeDotMenu {
         }.openBookmarks {
-            bookmarksListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 1)
-            IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
             verifyBookmarkTitle("Test_Page_1")
             createFolder("My Folder")
             verifyFolderTitle("My Folder")
-            IdlingRegistry.getInstance().unregister(bookmarksListIdlingResource!!)
         }.openThreeDotMenu("Test_Page_1") {
         }.clickEdit {
             clickParentFolderSelector()
@@ -808,11 +803,7 @@ class SmokeTest {
             navigateUp()
             saveEditBookmark()
             createFolder("My Folder 2")
-            bookmarksListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 1)
-            IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
             verifyFolderTitle("My Folder 2")
-            IdlingRegistry.getInstance().unregister(bookmarksListIdlingResource!!)
         }.openThreeDotMenu("My Folder 2") {
         }.clickEdit {
             clickParentFolderSelector()


### PR DESCRIPTION
For #24994 fix and re-enable `deleteNonEmptyBookmarkFolderTest` UI test ✅  successfully ran 75x on Firebase.

Summary:

It looked like due to the retry test rule the same bookmark or sometimes bookmark folders were created multiple times resulting in failures caused by `AmbiguousViewMatcherException`.

Decided to run the test a couple of times without the Retry Rule and constantly failed with a `NullPointerException` due to the idling resource.
```
java.lang.NullPointerException: activityTestRule.activit…wById(R.id.bookmark_list) must not be null
at org.mozilla.fenix.ui.SmokeTest$deleteNonEmptyBookmarkFolderTest$5.invoke(SmokeTest.kt:806)
at org.mozilla.fenix.ui.SmokeTest$deleteNonEmptyBookmarkFolderTest$5.invoke(SmokeTest.kt:799)
at org.mozilla.fenix.ui.robots.ThreeDotMenuBookmarksRobot$Transition.clickEdit(ThreeDotMenuBookmarksRobot.kt:23)
at org.mozilla.fenix.ui.SmokeTest.deleteNonEmptyBookmarkFolderTest(SmokeTest.kt:799)
```

Removed the idling resource and added back the retry rule and everything seems to be in order.

<details>

<summary> 📈 Results (dropdown)</summary>

matrix | result | logs | details
-- | -- | -- | --
matrix-ji9g8igtrhvca | success | logs | 1 test cases passed
matrix-1slp0c6r287uo | success | logs | 1 test cases passed
matrix-vm5r4g9i859ha | success | logs | 1 test cases passed
matrix-1ohjrekfawdi0 | success | logs | 1 test cases passed
matrix-8zq4451pvcnua | success | logs | 1 test cases passed
matrix-2hikaesieehhj | success | logs | 1 test cases passed
matrix-2ruf3j3wawy10 | success | logs | 1 test cases passed
matrix-3256aqefnhm8x | success | logs | 1 test cases passed
matrix-2qdjv8pfmh4xp | success | logs | 1 test cases passed
matrix-2al4v7ajhtmok | success | logs | 1 test cases passed
matrix-168a5fbpvujgl | success | logs | 1 test cases passed
matrix-yyk598n1hwnba | success | logs | 1 test cases passed
matrix-2y78bwuedykta | success | logs | 1 test cases passed
matrix-29dlzpnsdvf72 | success | logs | 1 test cases passed
matrix-21xz1n1b7yrsp | success | logs | 1 test cases passed
matrix-2fvj9fiaovb6s | success | logs | 1 test cases passed
matrix-1kpw9644hp7cr | success | logs | 1 test cases passed
matrix-c4dlj4elm36la | success | logs | 1 test cases passed
matrix-oao7qkjx4hl4a | success | logs | 1 test cases passed
matrix-sbwso1nu30vla | success | logs | 1 test cases passed
matrix-31lqlacp7m42h | success | logs | 1 test cases passed
matrix-21atqflqaetjz | success | logs | 1 test cases passed
matrix-1x9jluq3sdk4f | success | logs | 1 test cases passed
matrix-6g7fkm5dodx0a | success | logs | 1 test cases passed
matrix-20vylscnrqn76 | success | logs | 1 test cases passed
matrix-2g9ru90ntkuw1 | success | logs | 1 test cases passed
matrix-3an5qwthcg6w7 | success | logs | 1 test cases passed
matrix-1j0l2tdpx6n22 | success | logs | 1 test cases passed
matrix-3oq7ouk89wr05 | success | logs | 1 test cases passed
matrix-39uuzyiug1v6k | success | logs | 1 test cases passed
matrix-db1xqx5pb9iza | success | logs | 1 test cases passed
matrix-14asca89w1bq6 | success | logs | 1 test cases passed
matrix-3u9vw4op8t9hg | success | logs | 1 test cases passed
matrix-11b9fklsbrpfg | success | logs | 1 test cases passed
matrix-1i42jwzu68q0e | success | logs | 1 test cases passed
matrix-3bcwrov6isle9 | success | logs | 1 test cases passed
matrix-umbvxsa77fmza | success | logs | 1 test cases passed
matrix-py9mgnkw4cnqa | success | logs | 1 test cases passed
matrix-zxmkli6u0ww8a | success | logs | 1 test cases passed
matrix-35pxmsphnbp6t | success | logs | 1 test cases passed
matrix-17g2armhdi4t0 | success | logs | 1 test cases passed
matrix-3f2rwtwyhqjsw | success | logs | 1 test cases passed
matrix-dtqf25jbmix0a | success | logs | 1 test cases passed
matrix-1rjm8z6p80nec | success | logs | 1 test cases passed
matrix-2do5s93vb5k6a | success | logs | 1 test cases passed
matrix-3sbdngy5absr0 | success | logs | 1 test cases passed
matrix-37pqf56bulnm0 | success | logs | 1 test cases passed
matrix-3i3ggppfw7eg2 | success | logs | 1 test cases passed
matrix-vexpj12vjb5ma | success | logs | 1 test cases passed
matrix-l0spe5tvyzoaa | success | logs | 1 test cases passed
matrix-2rnro186138sa | success | logs | 1 test cases passed
matrix-14svbjygfucrc | success | logs | 1 test cases passed
matrix-28mffoiwuyvps | success | logs | 1 test cases passed
matrix-2dabgnpceo9gs | success | logs | 1 test cases passed
matrix-1qrgcq0ymlub8 | success | logs | 1 test cases passed
matrix-1x9kri1633j5x | success | logs | 1 test cases passed
matrix-3asv1z8njx1gk | success | logs | 1 test cases passed
matrix-2vl5yl4dxnlwm | success | logs | 1 test cases passed
matrix-cjzmeola8y94a | success | logs | 1 test cases passed
matrix-203pwp7pm9xzk | success | logs | 1 test cases passed
matrix-2tc1hocef28te | success | logs | 1 test cases passed
matrix-10tsch4wd964p | success | logs | 1 test cases passed
matrix-3op5c237a602v | success | logs | 1 test cases passed
matrix-28yug2fhege92 | success | logs | 1 test cases passed
matrix-22p1df3knnw2k | success | logs | 1 test cases passed
matrix-35hgglh98tin4 | success | logs | 1 test cases passed
matrix-1sxx1c5wrx0tc | success | logs | 1 test cases passed
matrix-3v0kx4ykwetj2 | success | logs | 1 test cases passed
matrix-1mjx6vtv0baxb | success | logs | 1 test cases passed
matrix-3mxlkeulczuht | success | logs | 1 test cases passed
matrix-29sasags1sgf0 | success | logs | 1 test cases passed
matrix-2jikx729pouqx | success | logs | 1 test cases passed
matrix-7ybjyjre7qwca | success | logs | 1 test cases passed
matrix-3qe4338lnv2xk | success | logs | 1 test cases passed
matrix-3nkor73q2jyea | success | logs | 1 test cases passed

</details>

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
