### PR TITLE
For #24666 Changed trackingProtectionLayout's bottomToTop constraint …

### DIFF
--- a/app/src/main/res/layout/fragment_quick_settings_dialog_sheet.xml
+++ b/app/src/main/res/layout/fragment_quick_settings_dialog_sheet.xml
@@ -41,7 +41,7 @@
             android:id="@+id/trackingProtectionLayout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:layout_constraintBottom_toTopOf="@+id/clearSiteDataLayout" />
+            app:layout_constraintBottom_toTopOf="@+id/clearSiteDataDivider" />
 
         <View
             android:id="@+id/trackingProtectionDivider"


### PR DESCRIPTION
(…from clearSiteDataLayout to clearSiteDataDivider.) see #24666 
Before

![162282040-5885825f-aa0a-4eec-8216-560294bd2710](https://user-images.githubusercontent.com/39624400/165623264-d28af48c-4c95-448c-a845-e69c9bd4beac.jpg)
 
and  After:
![Screenshot_2022-04-27-23-09-58-333_org mozilla fenix debug](https://user-images.githubusercontent.com/39624400/165623316-4b49873f-b021-4f69-bff0-6c16de00ec55.jpg)


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
