### PR TITLE
Revert #24894: settings should not be used to cache previous auth state

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/BackgroundServices.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/BackgroundServices.kt
@@ -124,8 +124,6 @@ class BackgroundServices(
         }
     }
 
-    private val accountAuthenticationObserver = AccountAuthenticationObserver(context.settings())
-
     private val telemetryAccountObserver = TelemetryAccountObserver(
         context.settings(),
     )
@@ -165,9 +163,6 @@ class BackgroundServices(
         ),
         crashReporter
     ).also { accountManager ->
-        // Register an authentication account observer to cache status
-        accountManager.register(accountAuthenticationObserver)
-
         // Register a telemetry account observer to keep track of FxA auth metrics.
         accountManager.register(telemetryAccountObserver)
 
@@ -198,16 +193,6 @@ class BackgroundServices(
      */
     private val notificationManager by lazyMonitored {
         NotificationManager(context)
-    }
-}
-
-private class AccountAuthenticationObserver(private val settings: Settings) : AccountObserver {
-    override fun onAuthenticated(account: OAuthAccount, authType: AuthType) {
-        settings.hasFxaAuthenticated = true
-    }
-
-    override fun onLoggedOut() {
-        settings.hasFxaAuthenticated = false
     }
 }
 

--- a/app/src/main/java/org/mozilla/fenix/components/Components.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Components.kt
@@ -38,7 +38,6 @@ import org.mozilla.fenix.ext.sort
 import org.mozilla.fenix.home.PocketUpdatesMiddleware
 import org.mozilla.fenix.home.blocklist.BlocklistHandler
 import org.mozilla.fenix.home.blocklist.BlocklistMiddleware
-import org.mozilla.fenix.home.recentsyncedtabs.RecentSyncedTabState
 import org.mozilla.fenix.perf.AppStartReasonProvider
 import org.mozilla.fenix.perf.StartupActivityLog
 import org.mozilla.fenix.perf.StartupStateProvider
@@ -220,11 +219,6 @@ class Components(private val context: Context) {
                     core.store.state.asRecentTabs()
                 } else {
                     emptyList()
-                },
-                recentSyncedTabState = if (settings.hasFxaAuthenticated) {
-                    RecentSyncedTabState.Loading
-                } else {
-                    RecentSyncedTabState.None
                 },
                 recentHistory = emptyList()
             ).run { filterState(blocklistHandler) },

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -1012,11 +1012,6 @@ class Settings(private val appContext: Context) : PreferencesHolder {
         default = true
     )
 
-    var hasFxaAuthenticated by booleanPreference(
-        appContext.getPreferenceKey(R.string.pref_key_fxa_has_authenticated),
-        default = false
-    )
-
     var lastPlacesStorageMaintenance by longPreference(
         appContext.getPreferenceKey(R.string.pref_key_last_maintenance),
         default = 0

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -85,7 +85,6 @@
     <string name="pref_key_sign_out" translatable="false">pref_key_sign_out</string>
     <string name="pref_key_sync_sign_in" translatable="false">pref_key_sync_sign_in</string>
     <string name="pref_key_push_project_id" translatable="false">project_id</string>
-    <string name="pref_key_fxa_has_authenticated" translatable="false">pref_key_fxa_has_authenticated</string>
     <string name="pref_key_search_widget_installed" translatable="false">pref_key_search_widget_installed</string>
     <string name="pref_key_saved_logins_sorting_strategy" translatable="false">pref_key_saved_logins_sorting_strategy</string>
     <!-- Key for credit cards sync preference in the account settings fragment -->


### PR DESCRIPTION
This reverts an unnecessary change that was caching previous auth state in settings.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
