### PR TITLE
For #24971 - Split full name from Address editor into first, middle and last name

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/address/view/AddressEditorView.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/address/view/AddressEditorView.kt
@@ -23,7 +23,7 @@ class AddressEditorView(
      * Binds the view.
      */
     fun bind() {
-        binding.fullNameInput.apply {
+        binding.firstNameInput.apply {
             requestFocus()
             placeCursorAtEnd()
             showKeyboard()
@@ -43,9 +43,9 @@ class AddressEditorView(
 
         interactor.onSaveAddress(
             UpdatableAddressFields(
-                givenName = binding.fullNameInput.text.toString(),
-                additionalName = "",
-                familyName = "",
+                givenName = binding.firstNameInput.text.toString(),
+                additionalName = binding.middleNameInput.text.toString(),
+                familyName = binding.lastNameInput.text.toString(),
                 organization = "",
                 streetAddress = binding.streetAddressInput.text.toString(),
                 addressLevel3 = "",

--- a/app/src/main/res/layout/fragment_address_editor.xml
+++ b/app/src/main/res/layout/fragment_address_editor.xml
@@ -14,25 +14,25 @@
         android:layout_height="wrap_content"
         android:layout_margin="16dp">
 
-        <!-- Full Name -->
+        <!-- First Name -->
         <TextView
-            android:id="@+id/full_name_title"
+            android:id="@+id/first_name_title"
             android:layout_width="wrap_content"
             android:layout_height="16dp"
             android:gravity="center_vertical"
+            android:labelFor="@id/first_name_input"
             android:letterSpacing="0.05"
             android:paddingStart="3dp"
             android:paddingEnd="0dp"
-            android:text="@string/addresses_full_name"
+            android:text="@string/addresses_first_name"
             android:textColor="?attr/textPrimary"
             android:textSize="12sp"
-            android:labelFor="@id/card_number_input"
             app:fontFamily="@font/metropolis_semibold"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
         <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/full_name_layout"
+            android:id="@+id/first_name_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:textColor="?attr/textPrimary"
@@ -40,10 +40,98 @@
             app:hintEnabled="false"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/full_name_title">
+            app:layout_constraintTop_toBottomOf="@+id/first_name_title">
 
             <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/full_name_input"
+                android:id="@+id/first_name_input"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:ellipsize="end"
+                android:fontFamily="sans-serif"
+                android:imeOptions="flagNoExtractUi"
+                android:letterSpacing="0.01"
+                android:lineSpacingExtra="8sp"
+                android:maxLines="1"
+                android:singleLine="true"
+                android:textColor="?attr/textPrimary"
+                android:textSize="16sp" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <!-- Middle Name -->
+        <TextView
+            android:id="@+id/middle_name_title"
+            android:layout_width="wrap_content"
+            android:layout_height="16dp"
+            android:gravity="center_vertical"
+            android:labelFor="@id/middle_name_input"
+            android:letterSpacing="0.05"
+            android:paddingStart="3dp"
+            android:paddingEnd="0dp"
+            android:text="@string/addresses_middle_name"
+            android:textColor="?attr/textPrimary"
+            android:textSize="12sp"
+            app:fontFamily="@font/metropolis_semibold"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/first_name_layout" />
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/middle_name_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textColor="?attr/textPrimary"
+            app:errorEnabled="true"
+            app:hintEnabled="false"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/middle_name_title">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/middle_name_input"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:ellipsize="end"
+                android:fontFamily="sans-serif"
+                android:imeOptions="flagNoExtractUi"
+                android:letterSpacing="0.01"
+                android:lineSpacingExtra="8sp"
+                android:maxLines="1"
+                android:singleLine="true"
+                android:textColor="?attr/textPrimary"
+                android:textSize="16sp" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <!-- Last Name -->
+        <TextView
+            android:id="@+id/last_name_title"
+            android:layout_width="wrap_content"
+            android:layout_height="16dp"
+            android:gravity="center_vertical"
+            android:labelFor="@id/last_name_input"
+            android:letterSpacing="0.05"
+            android:paddingStart="3dp"
+            android:paddingEnd="0dp"
+            android:text="@string/addresses_last_name"
+            android:textColor="?attr/textPrimary"
+            android:textSize="12sp"
+            app:fontFamily="@font/metropolis_semibold"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/middle_name_layout" />
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/last_name_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textColor="?attr/textPrimary"
+            app:errorEnabled="true"
+            app:hintEnabled="false"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/last_name_title">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/last_name_input"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:ellipsize="end"
@@ -74,7 +162,7 @@
             android:labelFor="@id/street_address_input"
             app:fontFamily="@font/metropolis_semibold"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/full_name_layout" />
+            app:layout_constraintTop_toBottomOf="@+id/last_name_layout" />
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/street_address_layout"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1549,7 +1549,13 @@
     <!-- Title of the "Manage addresses" screen -->
     <string name="addresses_manage_addresses">Manage addresses</string>
     <!-- The header for the full name of an address -->
-    <string name="addresses_full_name">Full Name</string>
+    <string name="addresses_full_name" moz:removedIn="102" tools:ignore="UnusedResources">Full Name</string>
+    <!-- The header for the first name of an address -->
+    <string name="addresses_first_name">First Name</string>
+    <!-- The header for the middle name of an address -->
+    <string name="addresses_middle_name">Middle Name</string>
+    <!-- The header for the last name of an address -->
+    <string name="addresses_last_name">Last Name</string>
     <!-- The header for the street address of an address -->
     <string name="addresses_street_address">Street Address</string>
     <!-- The header for the city of an address -->


### PR DESCRIPTION
Fixes #24971

Address editor screen now uses first, middle and last name:

![Screenshot_20220428_180758](https://user-images.githubusercontent.com/35462038/165784361-00e91841-4ec8-447f-842f-e5cc495a164c.png)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
