### PR TITLE
Auto-publish & substitute local Glean package

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -804,6 +804,11 @@ if (gradle.hasProperty('localProperties.autoPublish.application-services.dir')) 
     apply from: "../${appServicesSrcDir}/build-scripts/substitute-local-appservices.gradle"
 }
 
+if (gradle.hasProperty('localProperties.autoPublish.glean.dir')) {
+    ext.gleanSrcDir = gradle."localProperties.autoPublish.glean.dir"
+    apply from: "../${gleanSrcDir}/build-scripts/substitute-local-glean.gradle"
+}
+
 // Define a reusable task for updating the versions of our built-in web extensions. We automate this
 // to make sure we never forget to update the version, either in local development or for releases.
 // In both cases, we want to make sure the latest version of all extensions (including their latest

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAddonsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAddonsTest.kt
@@ -9,6 +9,7 @@ import androidx.test.espresso.IdlingRegistry
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.R
@@ -103,6 +104,7 @@ class SettingsAddonsTest {
     }
 
     // Installs an addon, then uninstalls it
+    @Ignore("Intermittent failures, see: https://github.com/mozilla-mobile/fenix/issues/24843")
     @Test
     fun verifyAddonsCanBeUninstalled() {
         val addonName = "uBlock Origin"

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsPrivacyTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsPrivacyTest.kt
@@ -301,6 +301,7 @@ class SettingsPrivacyTest {
         }
     }
 
+    @Ignore("Intermittent failures, see: https://github.com/mozilla-mobile/fenix/issues/23816")
     @SmokeTest
     @Test
     fun verifyMultipleLoginsSelectionsTest() {

--- a/settings.gradle
+++ b/settings.gradle
@@ -27,6 +27,7 @@ def runCmd(cmd, workingDir, successMessage, captureStdout=true) {
 Properties localProperties = null
 String settingAppServicesPath = "autoPublish.application-services.dir"
 String settingAndroidComponentsPath = "autoPublish.android-components.dir"
+String settingGleanPath = "autoPublish.glean.dir"
 
 if (file('local.properties').canRead()) {
     localProperties = new Properties()
@@ -70,5 +71,20 @@ if (localProperties != null) {
         runCmd(publishAcCmd, androidComponentsLocalPath, "Published android-components for local development.", false)
     } else {
         log("Disabled auto-publication of android-components. Enable it by settings '$settingAndroidComponentsPath' in local.properties")
+    }
+
+    String gleanLocalPath = localProperties.getProperty(settingGleanPath)
+
+    if (gleanLocalPath != null) {
+        log("Enabling automatic publication of Glean from: $gleanLocalPath")
+        // As above, hacks to execute .py files on Windows.
+        def publishGleanCmd = [];
+        if (System.properties['os.name'].toLowerCase().contains('windows')) {
+            publishGleanCmd << "py";
+        }
+        publishGleanCmd << "./build-scripts/publish_to_maven_local_if_modified.py";
+        runCmd(publishGleanCmd, gleanLocalPath, "Published Glean for local development.", false)
+    } else {
+        log("Disabled auto-publication of Glean. Enable it by settings '$settingGleanPath' in local.properties")
     }
 }


### PR DESCRIPTION
I'm simplifying how to test out a local Glean dev version in a-c and Fenix.
See https://github.com/mozilla/glean/pull/2019.

These are the only Fenix changes needed.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
