### PR TITLE
For #23817 fix and re-enable toggleSearchSuggestionsTest UI test

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SearchTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SearchTest.kt
@@ -100,7 +100,7 @@ class SearchTest {
             verifySearchBarEmpty()
             clickSearchEngineButton(activityTestRule, "DuckDuckGo")
             typeSearch("mozilla")
-            verifySearchEngineResults(activityTestRule, "mozilla firefox", "DuckDuckGo")
+            verifySearchEngineResults(activityTestRule, "mozilla firefox")
             clickSearchEngineResult(activityTestRule, "mozilla firefox")
             verifySearchEngineURL("DuckDuckGo")
         }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsSearchTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsSearchTest.kt
@@ -4,7 +4,6 @@ import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.customannotations.SmokeTest
@@ -98,8 +97,8 @@ class SettingsSearchTest {
         }.openSearch {
             typeSearch("test")
             expandSearchSuggestionsList()
-            verifySearchEngineSuggestionResults(activityTestRule, "Test_Page_1")
-            verifySearchEngineSuggestionResults(activityTestRule, "Test_Page_2")
+            verifyBookmarksAndHistorySuggestionResults(activityTestRule, "Test_Page_1")
+            verifyBookmarksAndHistorySuggestionResults(activityTestRule, "Test_Page_2")
         }.dismissSearchBar {
         }.openThreeDotMenu {
         }.openSettings {
@@ -182,7 +181,6 @@ class SettingsSearchTest {
         }
     }
 
-    @Ignore("Failing, see: https://github.com/mozilla-mobile/fenix/issues/23817")
     @SmokeTest
     @Test
     // Test running on beta/release builds in CI:
@@ -193,7 +191,7 @@ class SettingsSearchTest {
         homeScreen {
         }.openSearch {
             typeSearch("mozilla")
-            verifySearchEngineSuggestionResults(activityTestRule, "mozilla firefox")
+            verifyDefaultSearchEngineSuggestionResults(activityTestRule, "mozilla firefox", "mozilla")
         }.dismissSearchBar {
         }.openThreeDotMenu {
         }.openSettings {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SearchRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SearchRobot.kt
@@ -341,6 +341,8 @@ private fun assertDefaultSearchEngineSuggestionResults(rule: ComposeTestRule, se
             }
         }
     }
+    rule.waitUntil(waitingTime, waitForSearchSuggestions(rule, searchSuggestion))
+    rule.onNodeWithText(searchSuggestion).assertIsDisplayed()
 }
 
 private fun assertBookmarksAndHistorySuggestionResults(rule: ComposeTestRule, searchResult: String) {

--- a/automation/taskcluster/androidTest/flank-x86.yml
+++ b/automation/taskcluster/androidTest/flank-x86.yml
@@ -40,6 +40,7 @@ gcloud:
   test-targets:
    - notPackage org.mozilla.fenix.screenshots
    - notPackage org.mozilla.fenix.syncintegration
+   - class org.mozilla.fenix.ui.SettingsSearchTest#toggleSearchSuggestionsTest
 
   device:
    - model: Pixel2
@@ -53,7 +54,7 @@ flank:
   max-test-shards: -1
   # num-test-runs: the amount of times to run the tests.
   # 1 runs the tests once. 10 runs all the tests 10x
-  num-test-runs: 1
+  num-test-runs: 50
   ### Output Style flag
   ## Output style of execution status. May be one of [verbose, multi, single, compact].
   ## For runs with only one test execution the default value is 'verbose', in other cases


### PR DESCRIPTION
For #23817 fix and re-enable toggleSearchSuggestionsTest UI test. ✅  successfully ran 100x on Firebase.

❗ Made the test work, but #23864 is still a real bug in our app.

<details>

<summary> 📈 Results (dropdown)</summary>

matrix | result | logs | details
-- | -- | -- | --
matrix-3svbf12lcy9xk | success | logs | 1 test cases passed
matrix-c2tc4b0rdge8a | success | logs | 1 test cases passed
matrix-1emcfwv2ku4m2 | success | logs | 1 test cases passed
matrix-rizn95sq0zs3a | success | logs | 1 test cases passed
matrix-2q3de34erum2y | success | logs | 1 test cases passed
matrix-2081wjz5ta4f5 | success | logs | 1 test cases passed
matrix-1sebg16ijpeh2 | success | logs | 1 test cases passed
matrix-1wfrurhpsea7j | success | logs | 1 test cases passed
matrix-16jkkx143rme2 | success | logs | 1 test cases passed
matrix-3u819oi1gdhac | success | logs | 1 test cases passed
matrix-zgdmq7nss0zxa | success | logs | 1 test cases passed
matrix-6v06aovfvxqva | success | logs | 1 test cases passed
matrix-1tla99537lrc4 | success | logs | 1 test cases passed
matrix-1nhm343ttccuf | success | logs | 1 test cases passed
matrix-3svguvron0km7 | success | logs | 1 test cases passed
matrix-1j9epgkxcqqpl | success | logs | 1 test cases passed
matrix-dp3u0bmughupa | success | logs | 1 test cases passed
matrix-3i0b6l3bws1hu | success | logs | 1 test cases passed
matrix-3golhwbatw6at | success | logs | 1 test cases passed
matrix-2ia90r395d91b | success | logs | 1 test cases passed
matrix-1mstbp2i9e0r9 | success | logs | 1 test cases passed
matrix-1zy7chhuzk04x | success | logs | 1 test cases passed
matrix-1fa7f7oa4sm30 | success | logs | 1 test cases passed
matrix-8dxuzeu87y4ha | success | logs | 1 test cases passed
matrix-3v14zld9zvwt1 | success | logs | 1 test cases passed
matrix-2a399cgye4d27 | success | logs | 1 test cases passed
matrix-3nrifudlz3zj5 | success | logs | 1 test cases passed
matrix-aa6oj1ww5xb8a | success | logs | 1 test cases passed
matrix-3g2yayhrgoz7j | success | logs | 1 test cases passed
matrix-eds226gdeqy3a | success | logs | 1 test cases passed
matrix-2mknsqd9o595l | success | logs | 1 test cases passed
matrix-1sv8ykaj763mq | success | logs | 1 test cases passed
matrix-3adei5cmlgmd8 | success | logs | 1 test cases passed
matrix-2xyhzenzxd75n | success | logs | 1 test cases passed
matrix-144obuzm7d6ov | success | logs | 1 test cases passed
matrix-2sgglpks6q36p | success | logs | 1 test cases passed
matrix-1150qn4tdidz8 | success | logs | 1 test cases passed
matrix-32f618mv0l0a2 | success | logs | 1 test cases passed
matrix-1vs5oicb8kh2a | success | logs | 1 test cases passed
matrix-33xijei1hdt2p | success | logs | 1 test cases passed
matrix-1dtfthosknl88 | success | logs | 1 test cases passed
matrix-483429jsef8ea | success | logs | 1 test cases passed
matrix-1kma8jdku9s5h | success | logs | 1 test cases passed
matrix-2lxy5t8rxr1gh | success | logs | 1 test cases passed
matrix-2lpvs5dcvewca | success | logs | 1 test cases passed
matrix-1q8z7aupgjffi | success | logs | 1 test cases passed
matrix-njgngmazf5jma | success | logs | 1 test cases passed
matrix-2iaceq0vqzegc | success | logs | 1 test cases passed
matrix-1b6f1m70lndg3 | success | logs | 1 test cases passed
matrix-3oitg750tsdd9 | success | logs | 1 test cases passed
matrix-1wjbbwqz1rdac | success | logs | 1 test cases passed
matrix-36gv9zk99pmm6 | success | logs | 1 test cases passed
matrix-30xji4u4nth1w | success | logs | 1 test cases passed
matrix-1j7svh0ghithf | success | logs | 1 test cases passed
matrix-26urdnb354jjv | success | logs | 1 test cases passed
matrix-2cg347t4wtc4z | success | logs | 1 test cases passed
matrix-2hjwv00jtqeqa | success | logs | 1 test cases passed
matrix-16vdo229yi166 | success | logs | 1 test cases passed
matrix-2qgi061ppr0f6 | success | logs | 1 test cases passed
matrix-23912r7iek4x3 | success | logs | 1 test cases passed
matrix-m053hlcvcocha | success | logs | 1 test cases passed
matrix-2z3rba9rlgex3 | success | logs | 1 test cases passed
matrix-wycfcs92atmma | success | logs | 1 test cases passed
matrix-1w5har0pp4je1 | success | logs | 1 test cases passed
matrix-33b14yrmr2leo | success | logs | 1 test cases passed
matrix-2vbqhlpeekw0s | success | logs | 1 test cases passed
matrix-4znztssx0ji3a | success | logs | 1 test cases passed
matrix-2jix48i00i8qt | success | logs | 1 test cases passed
matrix-3qgn012lkyybt | success | logs | 1 test cases passed
matrix-4osq4rqb2ex2a | success | logs | 1 test cases passed
matrix-33kpwol5o4drt | success | logs | 1 test cases passed
matrix-11u4hqjqdhf85 | success | logs | 1 test cases passed
matrix-12hr120mn83qb | success | logs | 1 test cases passed
matrix-2innxse712ujg | success | logs | 1 test cases passed
matrix-3riibjr41q3lr | success | logs | 1 test cases passed
matrix-1srjh7z489v87 | success | logs | 1 test cases passed
matrix-12yfarxzoqz5t | success | logs | 1 test cases passed
matrix-zza9mab9to6na | success | logs | 1 test cases passed
matrix-2m578fahx03io | success | logs | 1 test cases passed
matrix-an8h98okawmia | success | logs | 1 test cases passed
matrix-1s1dq2d6z0fdx | success | logs | 1 test cases passed
matrix-33wqcxr1c8z9f | success | logs | 1 test cases passed
matrix-129vwvnv19kxt | success | logs | 1 test cases passed
matrix-2udnp03wfyxr9 | success | logs | 1 test cases passed
matrix-jjtn6aofnon5a | success | logs | 1 test cases passed
matrix-35eitprc32dcf | success | logs | 1 test cases passed
matrix-39n66lae57qve | success | logs | 1 test cases passed
matrix-2zytmy7zj04bx | success | logs | 1 test cases passed
matrix-4cd70zbkqt7ka | success | logs | 1 test cases passed
matrix-3ut9621sk67ap | success | logs | 1 test cases passed
matrix-2gy6kd13n9v2a | success | logs | 1 test cases passed
matrix-z2brrqgehapea | success | logs | 1 test cases passed
matrix-idbmxdi50b6la | success | logs | 1 test cases passed
matrix-9854yh3s0tpba | success | logs | 1 test cases passed
matrix-brp6zdfqznlva | success | logs | 1 test cases passed
matrix-3f2ila3mj55uu | success | logs | 1 test cases passed
matrix-2lk2a4dbzkgia | success | logs | 1 test cases passed
matrix-lmzhbojpebnma | success | logs | 1 test cases passed
matrix-9s9iyoks151la | success | logs | 1 test cases passed
matrix-2d2spn35r9gax | success | logs | 1 test cases passed

</details>

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
