### PR TITLE
For #24993 and #25085 fix flaky testStrictVisitProtectionSheet and testStrictVisitSheetDetails UI tests.

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/EnhancedTrackingProtectionRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/EnhancedTrackingProtectionRobot.kt
@@ -10,9 +10,7 @@ import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.RootMatchers
 import androidx.test.espresso.matcher.ViewMatchers
-import androidx.test.espresso.matcher.ViewMatchers.isCompletelyDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
-import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.platform.app.InstrumentationRegistry
@@ -25,6 +23,7 @@ import org.hamcrest.Matchers.containsString
 import org.hamcrest.Matchers.not
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
+import org.mozilla.fenix.helpers.TestHelper.getStringResource
 import org.mozilla.fenix.helpers.TestHelper.packageName
 import org.mozilla.fenix.helpers.click
 import org.mozilla.fenix.helpers.ext.waitNotNull
@@ -192,8 +191,11 @@ private fun assertTrackingContentBlocked() {
 private fun trackingContentBlockListButton() = onView(withId(R.id.tracking_content))
 
 private fun assertSecuritySheetIsCompletelyDisplayed() {
-    mDevice.findObject(UiSelector().description("Quick settings sheet"))
+    mDevice.findObject(UiSelector().description(getStringResource(R.string.quick_settings_sheet)))
         .waitForExists(waitingTime)
-    onView(withContentDescription("Quick settings sheet"))
-        .check(matches(isCompletelyDisplayed()))
+    assertTrue(
+        mDevice.findObject(
+            UiSelector().resourceId("$packageName:id/quick_action_sheet")
+        ).waitForExists(waitingTime)
+    )
 }


### PR DESCRIPTION
For #24993 and #25085 fix flaky `testStrictVisitProtectionSheet` and `testStrictVisitSheetDetails` UI tests.
✅  Successfully passed **100x** on Firebase

<details>

<summary> 📈 Results (dropdown)</summary>

matrix | result | logs | details
-- | -- | -- | --
matrix-qfox9ugpwsrta | success | logs | 2 test cases passed
matrix-4g8f0fgktn7pa | success | logs | 2 test cases passed
matrix-2faa1gatxsp1n | success | logs | 2 test cases passed
matrix-2r5tsmx942l9h | success | logs | 2 test cases passed
matrix-2jn99csnz41qw | success | logs | 2 test cases passed
matrix-1s891vigiarq5 | success | logs | 2 test cases passed
matrix-nopi94xcrpjoa | success | logs | 2 test cases passed
matrix-v3pwwttei81na | success | logs | 2 test cases passed
matrix-3j4fe7g4svlod | success | logs | 2 test cases passed
matrix-886b1nqxz0mca | success | logs | 2 test cases passed
matrix-37on3k3cddvwb | success | logs | 2 test cases passed
matrix-39colktapv4vk | success | logs | 2 test cases passed
matrix-49tu86t314ica | success | logs | 2 test cases passed
matrix-1lxal4v11pvco | success | logs | 2 test cases passed
matrix-2fdixiouquoka | success | logs | 2 test cases passed
matrix-2l1qkfl7869u3 | success | logs | 2 test cases passed
matrix-266wihivhdnd5 | success | logs | 2 test cases passed
matrix-3u2offgoy2tj1 | success | logs | 2 test cases passed
matrix-3fq89p6i6fg1p | success | logs | 2 test cases passed
matrix-19sm0r0j8v8u9 | success | logs | 2 test cases passed
matrix-1nq168nfv0p2w | success | logs | 2 test cases passed
matrix-bd9pdig7f0g1a | success | logs | 2 test cases passed
matrix-3jufk150oy8rk | success | logs | 2 test cases passed
matrix-2eqkc2mnu118o | success | logs | 2 test cases passed
matrix-3pcqgcnwenle9 | success | logs | 2 test cases passed
matrix-uqn4dm2k9hvma | success | logs | 2 test cases passed
matrix-33lddiro4q4ro | success | logs | 2 test cases passed
matrix-3dglvzquh4mof | success | logs | 2 test cases passed
matrix-33kmv3u9gs1f1 | success | logs | 2 test cases passed
matrix-3l8u9mpbdbmvm | success | logs | 2 test cases passed
matrix-286swgswh84ff | success | logs | 2 test cases passed
matrix-2ssm30osvvnhe | success | logs | 2 test cases passed
matrix-1w0wppo3f5ywf | success | logs | 2 test cases passed
matrix-2r376ub9yy6j5 | success | logs | 2 test cases passed
matrix-jl4afgi2ziyva | success | logs | 2 test cases passed
matrix-2m9tp0d697uag | success | logs | 2 test cases passed
matrix-gw5y91q73ufca | success | logs | 2 test cases passed
matrix-2ns7yx2xr9cey | success | logs | 2 test cases passed
matrix-3mdhdzwn5izij | success | logs | 2 test cases passed
matrix-2hdhai9ru7oy5 | success | logs | 2 test cases passed
matrix-2s7q7qqg02dun | success | logs | 2 test cases passed
matrix-1f04agxjh25z8 | success | logs | 2 test cases passed
matrix-1z5de9gtpba2w | success | logs | 2 test cases passed
matrix-rxvsy4u11441a | success | logs | 2 test cases passed
matrix-nu4g2zl3wwdxa | success | logs | 2 test cases passed
matrix-10keh7qa3rflc | success | logs | 2 test cases passed
matrix-26oak0zj0zepx | success | logs | 2 test cases passed
matrix-3nmhm6q89h6bt | success | logs | 2 test cases passed
matrix-hpfm6h5t3cwha | success | logs | 2 test cases passed
matrix-3o4y6nqmknvs1 | success | logs | 2 test cases passed
matrix-gn9xv7xemdyva | success | logs | 2 test cases passed
matrix-29s9msh8y3h61 | success | logs | 2 test cases passed
matrix-1fglzt4j1hbj8 | success | logs | 2 test cases passed
matrix-hocumt68ww3ea | success | logs | 2 test cases passed
matrix-3subde0erjd60 | success | logs | 2 test cases passed
matrix-2w10kyq8j3uw3 | success | logs | 2 test cases passed
matrix-30st6be1fe9r0 | success | logs | 2 test cases passed
matrix-1p4x0irgf7mjw | success | logs | 2 test cases passed
matrix-1mfvpebqzciin | success | logs | 2 test cases passed
matrix-jvhmpfhcys6ta | success | logs | 2 test cases passed
matrix-dx5d5jsrfpdxa | success | logs | 2 test cases passed
matrix-29jao69nu7jx8 | success | logs | 2 test cases passed
matrix-2b4ow2h8n8fnt | success | logs | 2 test cases passed
matrix-2oc7irr41263q | success | logs | 2 test cases passed
matrix-k6jyutt5f486a | success | logs | 2 test cases passed
matrix-z8y7v2e4s9nia | success | logs | 2 test cases passed
matrix-3nat0olfxwri8 | success | logs | 2 test cases passed
matrix-8ffm0zsjo7r9a | success | logs | 2 test cases passed
matrix-2c7z3hfrxuizt | success | logs | 2 test cases passed
matrix-x7nkiwd6prj5a | success | logs | 2 test cases passed
matrix-3qwyw7qy668lj | success | logs | 2 test cases passed
matrix-36bvfil22zevm | success | logs | 2 test cases passed
matrix-39uxnox358e6t | success | logs | 2 test cases passed
matrix-3f4r4js7mm7yn | success | logs | 2 test cases passed
matrix-xi4sxdp331kwa | success | logs | 2 test cases passed
matrix-k9h7nahs0yvka | success | logs | 2 test cases passed
matrix-1j4cz30q8kwkz | success | logs | 2 test cases passed
matrix-3p7vkfnfth33h | success | logs | 2 test cases passed
matrix-24br6tufznjrf | success | logs | 2 test cases passed
matrix-1khmbv5tdjf16 | success | logs | 2 test cases passed
matrix-1nk5gf3d03mze | success | logs | 2 test cases passed
matrix-p5cx0i95qgzca | success | logs | 2 test cases passed
matrix-79f44wrec2bla | success | logs | 2 test cases passed
matrix-y3a6fbazf47qa | success | logs | 2 test cases passed
matrix-2r7sl9cweuqfj | success | logs | 2 test cases passed
matrix-17e8kw6o8bibr | success | logs | 2 test cases passed
matrix-rvobq91w1wpaa | success | logs | 2 test cases passed
matrix-hh14bbxt4skea | success | logs | 2 test cases passed
matrix-16kji9oy7vqsv | success | logs | 2 test cases passed
matrix-8sap3v38uxc1a | success | logs | 2 test cases passed
matrix-3w4k4nwrovqkp | success | logs | 2 test cases passed
matrix-3aer7ue8c3e4r | success | logs | 2 test cases passed
matrix-2mv4l8qaykjnf | success | logs | 2 test cases passed
matrix-2u3es6b3xoo3g | success | logs | 2 test cases passed
matrix-1yxzm58bp4vra | success | logs | 2 test cases passed
matrix-1nt5uadl5ipoi | success | logs | 2 test cases passed
matrix-1rqyo4cbcuvsc | success | logs | 2 test cases passed
matrix-1r4ydb6jnru3h | success | logs | 2 test cases passed
matrix-3tulv07kcwkbt | success | logs | 2 test cases passed
matrix-3ij33s2vr1utb | success | logs | 2 test cases passed

</details>

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
