### PR TITLE
For #24998 fix flaky deleteDeleteBrowsingHistoryDataTest UI test

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuDeleteBrowsingDataRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuDeleteBrowsingDataRobot.kt
@@ -134,7 +134,7 @@ private fun openTabsCheckBox() = onView(allOf(withId(R.id.checkbox), hasSibling(
 private fun browsingHistorySubsection() =
     onView(withText(R.string.preferences_delete_browsing_data_browsing_data_title))
 
-private fun browsingHistoryDescription(addresses: String) = onView(withText("$addresses addresses"))
+private fun browsingHistoryDescription(addresses: String) = mDevice.findObject(UiSelector().textContains("$addresses addresses"))
 
 private fun browsingHistoryCheckBox() =
     onView(allOf(withId(R.id.checkbox), hasSibling(withText("Browsing history and site data"))))
@@ -186,7 +186,7 @@ private fun assertAllOptionsAndCheckBoxes() {
     openTabsDescription("0").check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
     openTabsCheckBox().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
     browsingHistorySubsection().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-    browsingHistoryDescription("0").check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+    assertTrue(browsingHistoryDescription("0").waitForExists(waitingTime))
     browsingHistoryCheckBox().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
     cookiesSubsection().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
     cookiesDescription().check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
@@ -213,7 +213,7 @@ private fun assertOpenTabsDescription(tabNumber: String) =
     openTabsDescription(tabNumber).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
 private fun assertBrowsingHistoryDescription(addresses: String) =
-    browsingHistoryDescription(addresses).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+    assertTrue(browsingHistoryDescription(addresses).waitForExists(waitingTime))
 
 private fun assertDeleteBrowsingDataSnackbar() {
     assertTrue(


### PR DESCRIPTION
For #24998 fix flaky `deleteDeleteBrowsingHistoryDataTest` UI test ✅ successfully ran **100x** on Firebase.

<details>

<summary> 📈 Results (dropdown)</summary>

matrix | result | logs | details
-- | -- | -- | --
matrix-18fkzbexzz953 | success | logs | 1 test cases passed
matrix-2tf4dbo4yxuy2 | success | logs | 1 test cases passed
matrix-varctu8ftv03a | success | logs | 1 test cases passed
matrix-2cy3j4lyaky6g | success | logs | 1 test cases passed
matrix-3v1686bx2jm6d | success | logs | 1 test cases passed
matrix-3nyu74qqfpvfy | success | logs | 1 test cases passed
matrix-1ah1gw04tx836 | success | logs | 1 test cases passed
matrix-3ocagwhhygiyp | success | logs | 1 test cases passed
matrix-2ept1xztxxx8b | success | logs | 1 test cases passed
matrix-3rjvuvg2hpn17 | success | logs | 1 test cases passed
matrix-2b18kzgeykd5a | success | logs | 1 test cases passed
matrix-1fz21k33pcv1d | success | logs | 1 test cases passed
matrix-12ji0n5ki1vdn | success | logs | 1 test cases passed
matrix-3gy7xz203egii | success | logs | 1 test cases passed
matrix-2bayu26dnohzo | success | logs | 1 test cases passed
matrix-16ciycszof9za | success | logs | 1 test cases passed
matrix-3a1ta62ne7uqk | success | logs | 1 test cases passed
matrix-3uihhupomkip1 | success | logs | 1 test cases passed
matrix-1k5deo6txyntz | success | logs | 1 test cases passed
matrix-xefz6nfnfvjqa | success | logs | 1 test cases passed
matrix-309m481roehg5 | success | logs | 1 test cases passed
matrix-rmg81umpzzyva | success | logs | 1 test cases passed
matrix-21q5itej1n3vb | success | logs | 1 test cases passed
matrix-3tt8d9kwsjdpo | success | logs | 1 test cases passed
matrix-jsfa1pn2m3oua | success | logs | 1 test cases passed
matrix-1g9uwiuctdaau | success | logs | 1 test cases passed
matrix-3m2kd9357uama | success | logs | 1 test cases passed
matrix-3qydpdme3zn8l | success | logs | 1 test cases passed
matrix-wdb325d9jyyea | success | logs | 1 test cases passed
matrix-3h5ef4rfd25kf | success | logs | 1 test cases passed
matrix-wefbj1gwp0mha | success | logs | 1 test cases passed
matrix-bguxicq7v54la | success | logs | 1 test cases passed
matrix-3ch97tcv50xex | success | logs | 1 test cases passed
matrix-102uf2dtkgnoc | success | logs | 1 test cases passed
matrix-d08bpke2xvfpa | success | logs | 1 test cases passed
matrix-3bwc8b0mbluou | success | logs | 1 test cases passed
matrix-16udss7561vcx | success | logs | 1 test cases passed
matrix-21yilx40t389i | success | logs | 1 test cases passed
matrix-2fry4a3amk0fi | success | logs | 1 test cases passed
matrix-2vs7qbaen9dsv | success | logs | 1 test cases passed
matrix-2uombstymlv4v | success | logs | 1 test cases passed
matrix-yxm4xx55mazca | success | logs | 1 test cases passed
matrix-2gku21i47z78g | success | logs | 1 test cases passed
matrix-7il6c7mp2p7da | success | logs | 1 test cases passed
matrix-1plmoyplaviii | success | logs | 1 test cases passed
matrix-926wawjutaexa | success | logs | 1 test cases passed
matrix-makawduv89oca | success | logs | 1 test cases passed
matrix-25o880cd7ahuh | success | logs | 1 test cases passed
matrix-ekklcme9nmyga | success | logs | 1 test cases passed
matrix-34ybya597j9dk | success | logs | 1 test cases passed
matrix-2l8fj4olegdpv | success | logs | 1 test cases passed
matrix-3gxzvzu458z2w | success | logs | 1 test cases passed
matrix-2y96w0wslo0zd | success | logs | 1 test cases passed
matrix-6y3ga76bp9s5a | success | logs | 1 test cases passed
matrix-mzuklp6hopgta | success | logs | 1 test cases passed
matrix-3gk7y2q0kn4a3 | success | logs | 1 test cases passed
matrix-m1owuji782q4a | success | logs | 1 test cases passed
matrix-mk6devizcg7wa | success | logs | 1 test cases passed
matrix-1jyfg4bxx45hu | success | logs | 1 test cases passed
matrix-2drbp9p6tm12m | success | logs | 1 test cases passed
matrix-wvcd1zuys7pxa | success | logs | 1 test cases passed
matrix-mpxtskg6gsssa | success | logs | 1 test cases passed
matrix-rp6rg56fu92pa | success | logs | 1 test cases passed
matrix-1q2btje6050it | success | logs | 1 test cases passed
matrix-3gptvebv5q2ea | success | logs | 1 test cases passed
matrix-j1xdogmx09d7a | success | logs | 1 test cases passed
matrix-ecrrko3d9er5a | success | logs | 1 test cases passed
matrix-2j0dvuwd7oimb | success | logs | 1 test cases passed
matrix-vffqv9uv8p3sa | success | logs | 1 test cases passed
matrix-a5zyvpjxh4bda | success | logs | 1 test cases passed
matrix-2uqv5z03uqnjm | success | logs | 1 test cases passed
matrix-ko97kryyrqkua | success | logs | 1 test cases passed
matrix-18qck4shrfmzp | success | logs | 1 test cases passed
matrix-2nw3r9wgv37fi | success | logs | 1 test cases passed
matrix-28igv9lw0nebn | success | logs | 1 test cases passed
matrix-300xuzfxhbq8j | success | logs | 1 test cases passed
matrix-13zwj5ipuhl3m | success | logs | 1 test cases passed
matrix-15cqy1890su8b | success | logs | 1 test cases passed
matrix-2s5vfgtdkbvv0 | success | logs | 1 test cases passed
matrix-4b8wycor0l7ba | success | logs | 1 test cases passed
matrix-1rzaw1yg7j4j8 | success | logs | 1 test cases passed
matrix-wxm0bbfw60vea | success | logs | 1 test cases passed
matrix-2jbdoy7tpqwdq | success | logs | 1 test cases passed
matrix-22l6zoxcvmz1l | success | logs | 1 test cases passed
matrix-29p8br85cmjhk | success | logs | 1 test cases passed
matrix-1aqwkxevairxs | success | logs | 1 test cases passed
matrix-2jwia9jt4nb08 | success | logs | 1 test cases passed
matrix-1lwbyo3kgike0 | success | logs | 1 test cases passed
matrix-28p6b90yos1aq | success | logs | 1 test cases passed
matrix-1gvmu5lle7nq8 | success | logs | 1 test cases passed
matrix-c5qdanec1izqa | success | logs | 1 test cases passed
matrix-2c228s4xhorgc | success | logs | 1 test cases passed
matrix-279ec016km56k | success | logs | 1 test cases passed
matrix-1sgp7pkmh068a | success | logs | 1 test cases passed
matrix-3tbqj5cvbklxm | success | logs | 1 test cases passed
matrix-3hk1rrwp9qlxk | success | logs | 1 test cases passed
matrix-2w3du90ys65o9 | success | logs | 1 test cases passed
matrix-1keuwvkrywelz | success | logs | 1 test cases passed
matrix-3l1bnoqengw57 | success | logs | 1 test cases passed
matrix-1smeojag7r7ie | success | logs | 1 test cases passed
matrix-2phbbx6n4txxn | success | logs | 1 test cases passed

</details>

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
