### PR TITLE
Fix externalLinkPWATest UI test on Firebase

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/CustomTabsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/CustomTabsTest.kt
@@ -27,7 +27,10 @@ import org.mozilla.fenix.ui.robots.searchScreen
 class CustomTabsTest {
     private lateinit var mockWebServer: MockWebServer
     private val customMenuItem = "TestMenuItem"
-    private val externalLinksPWAPage = "https://mozilla-mobile.github.io/testapp/externalLinks.html"
+    /* Updated externalLinks.html to v2.0,
+       changed the hypertext reference to mozilla-mobile.github.io/testapp/downloads for "External link"
+     */
+    private val externalLinksPWAPage = "https://mozilla-mobile.github.io/testapp/v2.0/externalLinks.html"
     private val loginPage = "https://mozilla-mobile.github.io/testapp/loginForm"
 
     @get:Rule
@@ -54,6 +57,7 @@ class CustomTabsTest {
     @SmokeTest
     @Test
     fun customTabsOpenExternalLinkTest() {
+        val externalLinkURL = "https://mozilla-mobile.github.io/testapp/downloads"
 
         intentReceiverActivityTestRule.launchActivity(
             createCustomTabIntent(
@@ -66,7 +70,7 @@ class CustomTabsTest {
             waitForPageToLoad()
             clickLinkMatchingText("External link")
             waitForPageToLoad()
-            verifyCustomTabToolbarTitle("Google")
+            verifyCustomTabToolbarTitle(externalLinkURL)
         }
     }
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/PwaTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/PwaTest.kt
@@ -16,7 +16,10 @@ import org.mozilla.fenix.ui.robots.navigationToolbar
 
 class PwaTest {
     private val featureSettingsHelper = FeatureSettingsHelper()
-    private val externalLinksPWAPage = "https://mozilla-mobile.github.io/testapp/externalLinks.html"
+    /* Updated externalLinks.html to v2.0,
+       changed the hypertext reference to mozilla-mobile.github.io/testapp/downloads for "External link"
+     */
+    private val externalLinksPWAPage = "https://mozilla-mobile.github.io/testapp/v2.0/externalLinks.html"
     private val emailLink = "mailto://example@example.com"
     private val phoneLink = "tel://1234567890"
     private val shortcutTitle = "TEST_APP"
@@ -37,7 +40,7 @@ class PwaTest {
     @SmokeTest
     @Test
     fun externalLinkPWATest() {
-        val customTabTitle = "Google"
+        val externalLinkURL = "https://mozilla-mobile.github.io/testapp/downloads"
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(externalLinksPWAPage.toUri()) {
@@ -46,11 +49,10 @@ class PwaTest {
             clickAddAutomaticallyButton()
         }.openHomeScreenShortcut(shortcutTitle) {
             clickLinkMatchingText("External link")
-            fillAndSubmitGoogleSearchQuery("Mozilla")
         }
 
         customTabScreen {
-            verifyCustomTabToolbarTitle(customTabTitle)
+            verifyCustomTabToolbarTitle(externalLinkURL)
         }
     }
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -570,15 +570,6 @@ class BrowserRobot {
         tabCrashRestoreButton.click()
     }
 
-    fun fillAndSubmitGoogleSearchQuery(searchString: String) {
-        mDevice.findObject(
-            UiSelector().resourceId("$packageName:id/engineView")
-        ).waitForExists(waitingTime)
-        googleSearchBox.setText(searchString)
-        mDevice.pressEnter()
-        mDevice.waitForIdle(waitingTime)
-    }
-
     fun fillAndSubmitLoginCredentials(userName: String, password: String) {
         userNameTextBox.setText(userName)
         passwordTextBox.setText(password)
@@ -926,15 +917,6 @@ val passwordTextBox =
     mDevice.findObject(
         UiSelector()
             .resourceId("password")
-            .className("android.widget.EditText")
-            .packageName("$packageName")
-    )
-
-val googleSearchBox =
-    mDevice.findObject(
-        UiSelector()
-            .index(0)
-            .resourceId("mib")
             .className("android.widget.EditText")
             .packageName("$packageName")
     )

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/CustomTabRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/CustomTabRobot.kt
@@ -60,12 +60,17 @@ class CustomTabRobot {
     }
 
     fun verifyCustomTabToolbarTitle(title: String) {
+        waitForPageToLoad()
+
         mDevice.waitForObjects(
             mDevice.findObject(
                 UiSelector()
                     .resourceId("$packageName:id/mozac_browser_toolbar_title_view")
                     .textContains(title)
             )
+                .getFromParent(
+                    UiSelector().resourceId("$packageName:id/mozac_browser_toolbar_origin_view")
+                )
         )
 
         assertTrue(


### PR DESCRIPTION
Fix `externalLinkPWATest` ✅ successfully ran **100x** on Firebase.

There are 2 reasons to use another search provider:
• Google is sometimes blocking our requests, read an article that duckduckgo could be the solution to overcome the "unusual traffic" problem.
![image](https://user-images.githubusercontent.com/51314259/168761551-660962ea-f0f1-4e69-a0b2-bdff419aecca.png)

• When we run the UI tests locally for Beta or RC builds, we always need to manually dismiss Google's cookie consent 

<details>

<summary> 📈 Results (dropdown)</summary>

matrix | result | logs | details
-- | -- | -- | --
matrix-1x9kjquapvv44 | success | logs | 1 test cases passed
matrix-1s7xb4jqqu9jy | success | logs | 1 test cases passed
matrix-zr8fpsouu72na | success | logs | 1 test cases passed
matrix-jrka5kes26q3a | success | logs | 1 test cases passed
matrix-ec67b5vyx7kla | success | logs | 1 test cases passed
matrix-3fo6gptyax2g9 | success | logs | 1 test cases passed
matrix-197xwo9u9x5po | success | logs | 1 test cases passed
matrix-bj85y2dj2qqsa | success | logs | 1 test cases passed
matrix-183hy85kkw1bg | success | logs | 1 test cases passed
matrix-2aam9s9jjjphm | success | logs | 1 test cases passed
matrix-2i07oz74ajngg | success | logs | 1 test cases passed
matrix-2ingztwqxjruq | success | logs | 1 test cases passed
matrix-1hxlmjjgfaikc | success | logs | 1 test cases passed
matrix-3qdv1k5bsywkc | success | logs | 1 test cases passed
matrix-3tb0mp3zjfr6a | success | logs | 1 test cases passed
matrix-1j2ubilzcopiz | success | logs | 1 test cases passed
matrix-kr3hhfju08l8a | success | logs | 1 test cases passed
matrix-1ctqf3ywazy1e | success | logs | 1 test cases passed
matrix-10mm0i3c9cx2m | success | logs | 1 test cases passed
matrix-3ncuheyijgk7i | success | logs | 1 test cases passed
matrix-1332ghce3t57p | success | logs | 1 test cases passed
matrix-6ecgo9aj3ukxa | success | logs | 1 test cases passed
matrix-2cspryaqeg7ox | success | logs | 1 test cases passed
matrix-15e2wi2agjx8k | success | logs | 1 test cases passed
matrix-1r4qdf67qhe5t | success | logs | 1 test cases passed
matrix-3rx06ri9yj03z | success | logs | 1 test cases passed
matrix-wu1igpwrndn1a | success | logs | 1 test cases passed
matrix-277d9ory4k2ht | success | logs | 1 test cases passed
matrix-2rqxca7s5izsb | success | logs | 1 test cases passed
matrix-v37eq6ums799a | success | logs | 1 test cases passed
matrix-muc09m53p86ra | success | logs | 1 test cases passed
matrix-ubrz61u5h1l4a | success | logs | 1 test cases passed
matrix-3gapwd0vsbkt2 | success | logs | 1 test cases passed
matrix-1znfufq77lo5h | success | logs | 1 test cases passed
matrix-2zmugwz4oftr3 | success | logs | 1 test cases passed
matrix-nqhz8xbszy3ra | success | logs | 1 test cases passed
matrix-ohgvfqvv2a4aa | success | logs | 1 test cases passed
matrix-1g0zzh2niwiea | success | logs | 1 test cases passed
matrix-258amq9tot98x | success | logs | 1 test cases passed
matrix-2g9f1vsfoy87a | success | logs | 1 test cases passed
matrix-1fmkmk1t9on3o | success | logs | 1 test cases passed
matrix-3d27kc7ig9sui | success | logs | 1 test cases passed
matrix-2kyxugxlrhyar | success | logs | 1 test cases passed
matrix-382w1ehma54ew | success | logs | 1 test cases passed
matrix-2prylam56nhht | success | logs | 1 test cases passed
matrix-1refsssxw2tua | success | logs | 1 test cases passed
matrix-2p5a0g67t6e7e | success | logs | 1 test cases passed
matrix-2ca71ch0qofom | success | logs | 1 test cases passed
matrix-1egapy7pwn7rz | success | logs | 1 test cases passed
matrix-3qpmgbb2fnmse | success | logs | 1 test cases passed
matrix-3lq5yx2ip34xs | success | logs | 1 test cases passed
matrix-1vbobwv2rqqrz | success | logs | 1 test cases passed
matrix-d2kw5qmf0aspa | success | logs | 1 test cases passed
matrix-3kdwutdci8cne | success | logs | 1 test cases passed
matrix-1z6xibd9nguwb | success | logs | 1 test cases passed
matrix-2f0s2b2c8ah8o | success | logs | 1 test cases passed
matrix-3groemj63jowz | success | logs | 1 test cases passed
matrix-2sx7f0m95gg5n | success | logs | 1 test cases passed
matrix-2j8o35rpmhjvt | success | logs | 1 test cases passed
matrix-350oy1fhqdzak | success | logs | 1 test cases passed
matrix-34ggl4l6ccv5a | success | logs | 1 test cases passed
matrix-300dj5m404h43 | success | logs | 1 test cases passed
matrix-1zlow0xl2kckw | success | logs | 1 test cases passed
matrix-1txab8jof45zv | success | logs | 1 test cases passed
matrix-159xv3wmweywv | success | logs | 1 test cases passed
matrix-37z9n322dy941 | success | logs | 1 test cases passed
matrix-249n1q6pq7fp1 | success | logs | 1 test cases passed
matrix-3j2jv64ykb87l | success | logs | 1 test cases passed
matrix-h8olpn277xr9a | success | logs | 1 test cases passed
matrix-wqc4iq4c8m06a | success | logs | 1 test cases passed
matrix-3jbwr2zhzyw93 | success | logs | 1 test cases passed
matrix-s6d8cliioqlwa | success | logs | 1 test cases passed
matrix-3fg46wq8516zd | success | logs | 1 test cases passed
matrix-2zuwa4u45qpld | success | logs | 1 test cases passed
matrix-10rj2ofnim6yh | success | logs | 1 test cases passed
matrix-3ls6fxk7sgejk | success | logs | 1 test cases passed
matrix-162he8v2rd8sq | success | logs | 1 test cases passed
matrix-2utysmg0dmdjk | success | logs | 1 test cases passed
matrix-2paslazul06iy | success | logs | 1 test cases passed
matrix-3o7igz6vlzq6z | success | logs | 1 test cases passed
matrix-329crm4cpygas | success | logs | 1 test cases passed
matrix-qj80ozs6ku66a | success | logs | 1 test cases passed
matrix-13dfpa5mh6966 | success | logs | 1 test cases passed
matrix-uw7gx7oo7ywqa | success | logs | 1 test cases passed
matrix-3qnjk2bx1m7q1 | success | logs | 1 test cases passed
matrix-9roki4ftywyra | success | logs | 1 test cases passed
matrix-28r1sw9itp55d | success | logs | 1 test cases passed
matrix-pz6g3ju0ck6ca | success | logs | 1 test cases passed
matrix-bkil97mhgr3pa | success | logs | 1 test cases passed
matrix-1u5kqt3feowrf | success | logs | 1 test cases passed
matrix-3antel8c3omlr | success | logs | 1 test cases passed
matrix-2bfa4r9jkcqks | success | logs | 1 test cases passed
matrix-2wu731r8hxcwf | success | logs | 1 test cases passed
matrix-2aj8135jruff4 | success | logs | 1 test cases passed
matrix-16n01l41ocyuz | success | logs | 1 test cases passed
matrix-3rpjx6t9achwc | success | logs | 1 test cases passed
matrix-18ee204t1p1xw | success | logs | 1 test cases passed
matrix-3hys9ncszp6kl | success | logs | 1 test cases passed
matrix-2a2fcpzabzob1 | success | logs | 1 test cases passed
matrix-1kxm5z7u8m9r0 | success | logs | 1 test cases passed
matrix-1e9jwb1abe6hm | success | logs | 1 test cases passed

</details>


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
