### PR TITLE
For #25187: Dismiss the default browser card after clicking.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
@@ -611,6 +611,7 @@ class DefaultSessionControlController(
     override fun handleSetDefaultBrowser() {
         settings.userDismissedExperimentCard = true
         activity.openSetDefaultBrowserOption()
+        appStore.dispatch(AppAction.RemoveSetDefaultBrowserCard)
     }
 
     override fun handleCloseExperimentCard() {


### PR DESCRIPTION
It looks like after some optimizations done to the home screen, we are not re-rendering items after opening the default browser prompt and now we need to explicitly dismiss the card after the user clicks the button. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
