### PR TITLE
For #25002 #25184 and #23417 fix testDownloadCompleteNotification testDownloadPrompt and testCloseDownloadPrompt

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/DownloadTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/DownloadTest.kt
@@ -94,7 +94,6 @@ class DownloadTest {
         }
     }
 
-    @Ignore("Failing, see: https://github.com/mozilla-mobile/fenix/issues/25002")
     @Test
     fun testDownloadCompleteNotification() {
         downloadFile = "smallZip.zip"

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/DownloadRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/DownloadRobot.kt
@@ -7,6 +7,7 @@
 package org.mozilla.fenix.ui.robots
 
 import android.content.Intent
+import android.util.Log
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.intent.Intents
@@ -133,16 +134,29 @@ fun downloadRobot(interact: DownloadRobot.() -> Unit): DownloadRobot.Transition 
 }
 
 private fun assertDownloadPrompt(fileName: String) {
-    assertTrue(
-        "Download prompt button not visible",
-        mDevice.findObject(UiSelector().resourceId("$packageName:id/download_button"))
-            .waitForExists(waitingTime)
-    )
-    assertTrue(
-        "$fileName title doesn't match",
-        mDevice.findObject(UiSelector().text(fileName))
-            .waitForExists(waitingTime)
-    )
+    var currentTries = 0
+    while (currentTries++ < 3) {
+        try {
+            assertTrue(
+                "Download prompt button not visible",
+                mDevice.findObject(UiSelector().resourceId("$packageName:id/download_button"))
+                    .waitForExists(waitingTime)
+            )
+            assertTrue(
+                "$fileName title doesn't match",
+                mDevice.findObject(UiSelector().text(fileName))
+                    .waitForExists(waitingTime)
+            )
+
+            break
+        } catch (e: AssertionError) {
+            Log.e("DOWNLOAD_ROBOT", "Failed to find locator: ${e.localizedMessage}")
+
+            browserScreen {
+            }.clickDownloadLink(fileName) {
+            }
+        }
+    }
 }
 
 private fun assertDownloadNotificationPopup() {


### PR DESCRIPTION
### Description
For #25184 and #23417 fix flaky `testDownloadPrompt` and `testCloseDownloadPrompt` ✅  successfully passed 100x on Firebase.

### Summary
Both test were flaky because after performing the click on the desired file link the prompt wasn't always displayed.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
