### PR TITLE
For #24969 - Display address autofill prompt

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -76,6 +76,7 @@ import mozilla.components.feature.session.PictureInPictureFeature
 import mozilla.components.feature.session.SessionFeature
 import mozilla.components.feature.session.SwipeRefreshFeature
 import mozilla.components.concept.engine.permission.SitePermissions
+import mozilla.components.feature.prompts.address.AddressDelegate
 import mozilla.components.feature.session.ScreenOrientationFeature
 import mozilla.components.feature.sitepermissions.SitePermissionsFeature
 import mozilla.components.lib.state.ext.consumeFlow
@@ -636,6 +637,14 @@ abstract class BaseBrowserFragment :
                 },
                 onSelectCreditCard = {
                     showBiometricPrompt(context)
+                },
+                addressDelegate = object : AddressDelegate {
+                    override val addressPickerView
+                        get() = binding.addressSelectBar
+                    override val onManageAddresses = {
+                        val directions = NavGraphDirections.actionGlobalAutofillSettingFragment()
+                        findNavController().navigate(directions)
+                    }
                 }
             ),
             owner = this,

--- a/app/src/main/res/layout/fragment_browser.xml
+++ b/app/src/main/res/layout/fragment_browser.xml
@@ -18,7 +18,7 @@
             android:id="@+id/browserLayout"
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            app:layout_constraintBottom_toTopOf="@+id/creditCardSelectBar"
+            app:layout_constraintBottom_toTopOf="@+id/addressSelectBar"
             app:layout_constraintTop_toTopOf="parent"
             tools:context="browser.BrowserFragment">
 
@@ -68,13 +68,21 @@
 
         </androidx.coordinatorlayout.widget.CoordinatorLayout>
 
+        <mozilla.components.feature.prompts.address.AddressSelectBar
+            android:visibility="gone"
+            android:id="@+id/addressSelectBar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintBottom_toTopOf="@id/creditCardSelectBar"
+            app:layout_constraintTop_toBottomOf="@id/browserLayout" />
+
         <mozilla.components.feature.prompts.creditcard.CreditCardSelectBar
             android:visibility="gone"
             android:id="@+id/creditCardSelectBar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:layout_constraintBottom_toTopOf="@id/loginSelectBar"
-            app:layout_constraintTop_toBottomOf="@id/browserLayout" />
+            app:layout_constraintTop_toBottomOf="@id/addressSelectBar" />
 
         <mozilla.components.feature.prompts.login.LoginSelectBar
             android:visibility="gone"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -30,6 +30,7 @@
             tools:ignore="UnusedResources">@color/fx_mobile_text_color_warning</item>
         <item name="mozacLoginSelectHeaderTextStyle" tools:ignore="UnusedResources">@style/SelectPromptHeaderTextStyle</item>
         <item name="mozacSelectCreditCardHeaderTextStyle" tools:ignore="UnusedResources">@style/SelectPromptHeaderTextStyle</item>
+        <item name="mozacSelectAddressHeaderTextStyle" tools:ignore="UnusedResources">@style/SelectPromptHeaderTextStyle</item>
 
         <!-- Design system color attributes -->
 
@@ -227,6 +228,7 @@
             tools:ignore="UnusedResources">@color/fx_mobile_private_text_color_warning</item>
         <item name="mozacLoginSelectHeaderTextStyle" tools:ignore="UnusedResources">@style/SelectPromptHeaderTextStyle</item>
         <item name="mozacSelectCreditCardHeaderTextStyle" tools:ignore="UnusedResources">@style/SelectPromptHeaderTextStyle</item>
+        <item name="mozacSelectAddressHeaderTextStyle" tools:ignore="UnusedResources">@style/SelectPromptHeaderTextStyle</item>
 
         <!-- Design system color attributes -->
 


### PR DESCRIPTION
Display address autofill prompt.
Depends on [12061](https://github.com/mozilla-mobile/android-components/issues/12061).

Because there have been some [issues](https://bugzilla.mozilla.org/show_bug.cgi?id=1769014) with the `onAddressSelect` callback being triggered when the user interacts with an address form, please consider dispatching the `PromptRequest` from the Fenix code for testing.

Collapsed screenshot:
![Screenshot_20220513_144850](https://user-images.githubusercontent.com/35462038/168277227-934396ae-4fad-4006-9aa2-323af043bcfe.png)

Expanded screenshot:
![Screenshot_20220513_142727](https://user-images.githubusercontent.com/35462038/168275668-8d137db9-71d7-4e70-99e4-23e27bfeebd4.png)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
