### PR TITLE
Revert "Change FxNimbus initialization sequence (#25089)"

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -72,7 +72,6 @@ import org.mozilla.fenix.components.toolbar.ToolbarPosition
 import org.mozilla.fenix.ext.isCustomEngine
 import org.mozilla.fenix.ext.isKnownSearchDomain
 import org.mozilla.fenix.ext.settings
-import org.mozilla.fenix.nimbus.FxNimbus
 import org.mozilla.fenix.perf.MarkersActivityLifecycleCallbacks
 import org.mozilla.fenix.perf.ProfilerMarkerFactProcessor
 import org.mozilla.fenix.perf.StartupTimeline
@@ -394,8 +393,7 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
     private fun setupMegazord(): Deferred<Unit> {
         // Note: Megazord.init() must be called as soon as possible ...
         Megazord.init()
-        // Give the generated FxNimbus a closure to lazily get the Nimbus object
-        FxNimbus.initialize { components.analytics.experiments }
+
         return GlobalScope.async(Dispatchers.IO) {
             // ... but RustHttpConfig.setClient() and RustLog.enable() can be called later.
             RustHttpConfig.setClient(lazy { components.core.client })

--- a/app/src/main/java/org/mozilla/fenix/components/Analytics.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Analytics.kt
@@ -124,7 +124,9 @@ class Analytics(
     }
 
     val experiments: NimbusApi by lazyMonitored {
-        createNimbus(context, BuildConfig.NIMBUS_ENDPOINT)
+        createNimbus(context, BuildConfig.NIMBUS_ENDPOINT).also { api ->
+            FxNimbus.api = api
+        }
     }
 
     val messagingStorage by lazyMonitored {

--- a/app/src/main/java/org/mozilla/fenix/experiments/NimbusSetup.kt
+++ b/app/src/main/java/org/mozilla/fenix/experiments/NimbusSetup.kt
@@ -13,26 +13,11 @@ import mozilla.components.service.nimbus.NimbusAppInfo
 import mozilla.components.service.nimbus.NimbusDisabled
 import mozilla.components.service.nimbus.NimbusServerSettings
 import mozilla.components.support.base.log.logger.Logger
-import org.mozilla.experiments.nimbus.NimbusInterface
-import org.mozilla.experiments.nimbus.internal.EnrolledExperiment
 import org.mozilla.experiments.nimbus.internal.NimbusException
 import org.mozilla.fenix.BuildConfig
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.settings
-import org.mozilla.fenix.nimbus.FxNimbus
-
-/**
- * Fenix specific observer of Nimbus events.
- *
- * The generated code `FxNimbus` provides a cache which should be invalidated
- * when the experiments recipes are updated.
- */
-private val observer = object : NimbusInterface.Observer {
-    override fun onUpdatesApplied(updated: List<EnrolledExperiment>) {
-        FxNimbus.invalidateCachedValues()
-    }
-}
 
 @Suppress("TooGenericExceptionCaught")
 fun createNimbus(context: Context, url: String?): NimbusApi {
@@ -84,10 +69,6 @@ fun createNimbus(context: Context, url: String?): NimbusApi {
             )
         )
         Nimbus(context, appInfo, serverSettings, errorReporter).apply {
-            // We register our own internal observer for housekeeping the Nimbus SDK and
-            // generated code.
-            register(observer)
-
             // This performs the minimal amount of work required to load branch and enrolment data
             // into memory. If `getExperimentBranch` is called from another thread between here
             // and the next nimbus disk write (setting `globalUserParticipation` or

--- a/app/src/test/java/org/mozilla/fenix/settings/SettingsFragmentTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/SettingsFragmentTest.kt
@@ -11,6 +11,7 @@ import io.mockk.mockk
 import io.mockk.mockkObject
 import kotlinx.coroutines.test.advanceUntilIdle
 import mozilla.components.concept.fetch.Client
+import mozilla.components.service.nimbus.NimbusDisabled
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.rule.MainCoroutineRule
 import mozilla.components.support.test.rule.runTestOnMain
@@ -29,6 +30,7 @@ import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.getPreferenceKey
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+import org.mozilla.fenix.nimbus.FxNimbus
 import org.mozilla.fenix.utils.Settings
 import org.robolectric.Robolectric
 import java.io.IOException
@@ -53,6 +55,8 @@ class SettingsFragmentTest {
 
         mockkObject(Config)
         every { Config.channel } returns ReleaseChannel.Nightly
+
+        FxNimbus.api = NimbusDisabled(testContext)
 
         val activity = Robolectric.buildActivity(FragmentActivity::class.java).create().get()
         activity.supportFragmentManager.beginTransaction()


### PR DESCRIPTION
After debugging https://github.com/mozilla-mobile/fenix/pull/25089 with @jhugman , we found there is an unexpected behavior on`onExperimentsFetched` after the change, more details can be found here https://mozilla-hub.atlassian.net/browse/EXP-2432. We are backing it out and until we can do further investigation.
 
This reverts commit 51ba7ab4634827154b8b12a566451609a1e79639.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
