### PR TITLE
Close #25170: Fix flaky search fragment store tests

### DIFF
--- a/app/src/test/java/org/mozilla/fenix/search/SearchFragmentStoreTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/search/SearchFragmentStoreTest.kt
@@ -16,6 +16,7 @@ import mozilla.components.browser.state.state.ContentState
 import mozilla.components.browser.state.state.SearchState
 import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.support.test.ext.joinBlocking
+import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -23,7 +24,6 @@ import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Test
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
@@ -226,8 +226,7 @@ class SearchFragmentStoreTest {
     }
 
     @Test
-    @Ignore("Flaky, needs investigation: https://github.com/mozilla-mobile/fenix/issues/25170")
-    fun `Updating SearchFragmentState from SearchState`() = runTest {
+    fun `Updating SearchFragmentState from SearchState`() {
         val store = SearchFragmentStore(
             emptyDefaultState(
                 searchEngineSource = SearchEngineSource.None,
@@ -270,7 +269,9 @@ class SearchFragmentStoreTest {
                     userSelectedSearchEngineName = null
                 )
             )
-        ).join()
+        )
+
+        store.waitUntilIdle()
 
         assertNotNull(store.state.defaultEngine)
         assertEquals("Engine B", store.state.defaultEngine!!.name)
@@ -284,8 +285,7 @@ class SearchFragmentStoreTest {
     }
 
     @Test
-    @Ignore("Flaky, needs investigation: https://github.com/mozilla-mobile/fenix/issues/25170")
-    fun `Updating SearchFragmentState from SearchState - shortcuts disabled`() = runTest {
+    fun `Updating SearchFragmentState from SearchState - shortcuts disabled`() {
         val store = SearchFragmentStore(
             emptyDefaultState(
                 searchEngineSource = SearchEngineSource.None,
@@ -328,7 +328,9 @@ class SearchFragmentStoreTest {
                     userSelectedSearchEngineName = null
                 )
             )
-        ).join()
+        )
+
+        store.waitUntilIdle()
 
         assertNotNull(store.state.defaultEngine)
         assertEquals("Engine B", store.state.defaultEngine!!.name)


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
