### PR TITLE
Closes #25368: duplicate items in history

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryDataSource.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryDataSource.kt
@@ -33,7 +33,7 @@ class HistoryDataSource(
         val nextOffset = if (historyItems.isEmpty()) {
             null
         } else {
-            historyItems.last().position + 1
+            offset + params.loadSize
         }
         return LoadResult.Page(
             data = historyItems,


### PR DESCRIPTION
Closes #25368

Current problem:
Let's say, we uploaded 75 items, scrolled down a bit, and loaded another 25.
What happens technically is, `HistoryDataSource` asks `PagedHistoryProvider` to get 75 items of `HistoryDB`, assigns each of them a position. Then uses the position of the last element as an offset for a next pagination call.
The problem comes from `PagedHistoryProvider` doing some operations on the list, like [removing duplicates](https://searchfox.org/mozilla-mobile/source/fenix/app/src/main/java/org/mozilla/fenix/components/history/PagedHistoryProvider.kt#219). Although 75 items were requested and pulled out of the DB, let's say after removing 5 duplicated, 70 items were returned. `HistoryDataSource` will use 70 as an offset for the next call, and 5 items from the previous page will get into the next one.

Solution:
Currently, we base pagination on the data returned by Provider. But we could keep track of the data we requested from it instead. `DataSource` has a constant [parameter](https://searchfox.org/mozilla-mobile/source/fenix/app/src/main/java/org/mozilla/fenix/library/history/HistoryDataSource.kt#30) of `loadSize` inside the `load` method. We also can pass the previous offset to the next load call using the Result class. Summing up the old offset with new loadSize should give us a consistent pagination, without duplicates or missing items.

I tested by debugging, comparing the data in the DB itself with the results and debugging `PagedHistoryProvider` here, [https://searchfox.org/mozilla-mobile/source/fenix/app/src/main/java/org/mozilla/fenix/components/history/PagedHistoryProvider.kt#219](url) where the size of the list is often modified and we can check that the latest items from the first call get loaded into the following.

Reaching the end of the list doesn't break the pagination and works like this: let's say we have 20 items. `DataSource` requests 75 items, receives 20. The next offset will be still 75, because we are keeping track not of the result but of the requests. DB in AS will use 75 as offset and will return an empty list. `DataSource` will consider that to be the end of pagination.