### PR TITLE
For #25381 - Add a setting allowing to toggle Pocket sponsored stories

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/appstate/AppStoreReducer.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/appstate/AppStoreReducer.kt
@@ -150,9 +150,15 @@ internal object AppStoreReducer {
             pocketStories = emptyList(),
             pocketSponsoredStories = emptyList()
         )
-        is AppAction.PocketSponsoredStoriesChange -> state.copy(
-            pocketSponsoredStories = action.sponsoredStories
-        )
+        is AppAction.PocketSponsoredStoriesChange -> {
+            val updatedStoriesState = state.copy(
+                pocketSponsoredStories = action.sponsoredStories,
+            )
+
+            updatedStoriesState.copy(
+                pocketStories = updatedStoriesState.getFilteredStories()
+            )
+        }
         is AppAction.PocketStoriesShown -> {
             var updatedCategories = state.pocketStoriesCategories
             action.storiesShown.filterIsInstance<PocketRecommendedStory>().forEach { shownStory ->

--- a/app/src/main/java/org/mozilla/fenix/settings/HomeSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/HomeSettingsFragment.kt
@@ -13,6 +13,8 @@ import androidx.preference.SwitchPreference
 import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.GleanMetrics.CustomizeHome
 import org.mozilla.fenix.R
+import org.mozilla.fenix.components.appstate.AppAction
+import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.ext.showToolbar
 import org.mozilla.fenix.utils.view.addToRadioGroup
@@ -110,6 +112,28 @@ class HomeSettingsFragment : PreferenceFragmentCompat() {
                             "pocket"
                         )
                     )
+
+                    return super.onPreferenceChange(preference, newValue)
+                }
+            }
+        }
+
+        requirePreference<CheckBoxPreference>(R.string.pref_key_pocket_sponsored_stories).apply {
+            isVisible = FeatureFlags.isPocketSponsoredStoriesFeatureEnabled(context)
+            isChecked = context.settings().showPocketSponsoredStories
+            onPreferenceChangeListener = object : SharedPreferenceUpdater() {
+                override fun onPreferenceChange(preference: Preference, newValue: Any?): Boolean {
+                    when (newValue) {
+                        true -> {
+                            context.components.core.pocketStoriesService.startPeriodicSponsoredStoriesRefresh()
+                        }
+                        false -> {
+                            context.components.core.pocketStoriesService.deleteProfile()
+                            context.components.appStore.dispatch(
+                                AppAction.PocketSponsoredStoriesChange(emptyList())
+                            )
+                        }
+                    }
 
                     return super.onPreferenceChange(preference, newValue)
                 }

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -1269,6 +1269,9 @@ class Settings(private val appContext: Context) : PreferencesHolder {
         default = true
     )
 
+    /**
+     * Indicates if the Pocket recommended stories homescreen section should be shown.
+     */
     var showPocketRecommendationsFeature by lazyFeatureFlagPreference(
         appContext.getPreferenceKey(R.string.pref_key_pocket_homescreen_recommendations),
         featureFlag = FeatureFlags.isPocketRecommendationsFeatureEnabled(appContext),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -409,6 +409,8 @@
     <string name="customize_toggle_recently_visited">Recently visited</string>
     <!-- Title for the customize home screen section with Pocket. -->
     <string name="customize_toggle_pocket">Pocket</string>
+    <!-- Title for the customize home screen section with sponsored Pocket stories. -->
+    <string name="customize_toggle_pocket_sponsored">Sponsored stories</string>
     <!-- Title for the opening wallpaper settings screen -->
     <string name="customize_wallpapers">Wallpapers</string>
     <!-- Title for the customize home screen section with sponsored shortcuts. -->

--- a/app/src/main/res/xml/home_preferences.xml
+++ b/app/src/main/res/xml/home_preferences.xml
@@ -35,6 +35,12 @@
         android:title="@string/customize_toggle_pocket"
         app:isPreferenceVisible="false" />
 
+    <androidx.preference.CheckBoxPreference
+        android:dependency="@string/pref_key_pocket_homescreen_recommendations"
+        android:layout="@layout/checkbox_left_sub_preference"
+        android:key="@string/pref_key_pocket_sponsored_stories"
+        android:title="@string/customize_toggle_pocket_sponsored" />
+
     <androidx.preference.Preference
         android:key="@string/pref_key_wallpapers"
         android:title="@string/customize_wallpapers" />

--- a/app/src/test/java/org/mozilla/fenix/settings/HomeSettingsFragmentTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/HomeSettingsFragmentTest.kt
@@ -1,0 +1,154 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.settings
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+import androidx.preference.CheckBoxPreference
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import mozilla.components.service.pocket.PocketStoriesService
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.fenix.FeatureFlags
+import org.mozilla.fenix.R
+import org.mozilla.fenix.components.AppStore
+import org.mozilla.fenix.components.appstate.AppAction
+import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.getPreferenceKey
+import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.ext.showToolbar
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+import org.mozilla.fenix.utils.Settings
+import org.robolectric.Robolectric
+
+@RunWith(FenixRobolectricTestRunner::class)
+internal class HomeSettingsFragmentTest {
+    private lateinit var homeSettingsFragment: HomeSettingsFragment
+    private lateinit var sponsoredStoriesSetting: CheckBoxPreference
+    private lateinit var appSettings: Settings
+    private lateinit var appPrefs: SharedPreferences
+    private lateinit var appPrefsEditor: SharedPreferences.Editor
+    private lateinit var pocketService: PocketStoriesService
+    private lateinit var store: AppStore
+
+    @Before
+    fun setup() {
+        mockkStatic("org.mozilla.fenix.ext.FragmentKt")
+        every { any<Fragment>().showToolbar(any()) } just Runs
+        mockkStatic("org.mozilla.fenix.ext.ContextKt")
+        appPrefsEditor = mockk(relaxed = true)
+        appPrefs = mockk(relaxed = true) {
+            every { edit() } returns appPrefsEditor
+        }
+        appSettings = mockk(relaxed = true) {
+            every { preferences } returns appPrefs
+        }
+        every { any<Context>().settings() } returns appSettings
+        store = mockk(relaxed = true)
+        pocketService = mockk(relaxed = true)
+        every { any<Context>().components } returns mockk {
+            every { appStore } returns store
+            every { core.pocketStoriesService } returns pocketService
+        }
+
+        homeSettingsFragment = HomeSettingsFragment()
+
+        val activity = Robolectric.buildActivity(FragmentActivity::class.java).create().get()
+        activity.supportFragmentManager.beginTransaction()
+            .add(homeSettingsFragment, "HomeSettingFragmentTest")
+            .commitNow()
+
+        sponsoredStoriesSetting = homeSettingsFragment.findPreference(
+            homeSettingsFragment.getPreferenceKey(R.string.pref_key_pocket_sponsored_stories)
+        )!!
+    }
+
+    @After
+    fun teardown() {
+        unmockkStatic("org.mozilla.fenix.ext.ContextKt")
+        unmockkStatic("org.mozilla.fenix.ext.FragmentKt")
+    }
+
+    @Test
+    fun `GIVEN the Pocket sponsored stories feature is disabled for the app WHEN accessing settings THEN the settings for it are not visible`() {
+        every { any<Context>().settings() } returns mockk(relaxed = true)
+
+        mockkObject(FeatureFlags) {
+            every { FeatureFlags.isPocketSponsoredStoriesFeatureEnabled(any()) } returns false
+
+            homeSettingsFragment.onResume()
+
+            assertFalse(sponsoredStoriesSetting.isVisible)
+        }
+    }
+
+    @Test
+    fun `GIVEN the Pocket sponsored stories feature is enabled for the app WHEN accessing settings THEN the settings for it are visible`() {
+        every { any<Context>().settings() } returns mockk(relaxed = true)
+
+        mockkObject(FeatureFlags) {
+            every { FeatureFlags.isPocketSponsoredStoriesFeatureEnabled(any()) } returns true
+
+            homeSettingsFragment.onResume()
+
+            assertTrue(sponsoredStoriesSetting.isVisible)
+        }
+    }
+
+    @Test
+    fun `GIVEN the Pocket sponsored stories preference is false WHEN accessing settings THEN the setting for it is unchecked`() {
+        every { appSettings.showPocketSponsoredStories } returns false
+
+        homeSettingsFragment.onResume()
+
+        assertFalse(sponsoredStoriesSetting.isChecked)
+    }
+
+    @Test
+    fun `GIVEN the Pocket sponsored stories preference is true WHEN accessing settings THEN the setting for it is checked`() {
+        every { appSettings.showPocketSponsoredStories } returns true
+
+        homeSettingsFragment.onResume()
+
+        assertTrue(sponsoredStoriesSetting.isChecked)
+    }
+
+    @Test
+    fun `GIVEN the setting for Pocket sponsored stories is unchecked WHEN tapping it THEN toggle it and start downloading stories`() {
+        homeSettingsFragment.onResume()
+
+        val result = sponsoredStoriesSetting.callChangeListener(true)
+
+        assertTrue(result)
+        verify { appPrefsEditor.putBoolean(testContext.getString(R.string.pref_key_pocket_sponsored_stories), true) }
+        verify { pocketService.startPeriodicSponsoredStoriesRefresh() }
+    }
+
+    @Test
+    fun `GIVEN the setting for Pocket sponsored stories is checked WHEN tapping it THEN toggle it, delete Pocket profile and remove sponsored stories from showing`() {
+        homeSettingsFragment.onResume()
+
+        val result = sponsoredStoriesSetting.callChangeListener(false)
+
+        assertTrue(result)
+        verify { appPrefsEditor.putBoolean(testContext.getString(R.string.pref_key_pocket_sponsored_stories), false) }
+        verify { pocketService.deleteProfile() }
+        verify { store.dispatch(AppAction.PocketSponsoredStoriesChange(emptyList())) }
+    }
+}


### PR DESCRIPTION
Issue #25381 
More details and a video in the tracking Jira ticket - https://mozilla-hub.atlassian.net/browse/FNXV2-20135
Needs https://github.com/mozilla-mobile/android-components/pull/12259 which changes `deleteProfile` to not be a suspending function anymore.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
