### PR TITLE
For #7866: Add field to set custom search engine suggestion URL

### DIFF
--- a/app/src/main/res/layout/custom_search_engine.xml
+++ b/app/src/main/res/layout/custom_search_engine.xml
@@ -70,6 +70,32 @@
         android:visibility="visible"
         app:layout_constraintTop_toBottomOf="@id/exceptions_empty_message" />
 
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/custom_search_engine_suggest_string_field"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:hintTextColor="?attr/textSecondary"
+        android:textColorHint="?attr/textSecondary"
+        app:hintTextAppearance="@style/EngineTextField"
+        android:paddingBottom="8dp"
+        app:errorEnabled="true">
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/edit_suggest_string"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="@dimen/accessibility_min_height"
+            android:hint="@string/search_add_custom_engine_suggest_string_hint"
+            android:inputType="text" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/search_add_custom_engine_suggest_string_example"
+        android:lineHeight="18sp"
+        android:labelFor="@id/edit_suggest_string"
+        android:textColor="@android:color/tertiary_text_dark" />
+
     <ProgressBar
         android:id="@+id/progress"
         style="@style/Widget.AppCompat.ProgressBar"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1659,6 +1659,10 @@
     <string name="search_add_custom_engine_search_string_example" formatted="false">Replace query with “%s”. Example:\nhttps://www.google.com/search?q=%s</string>
     <!-- Accessibility description for the form in which details about the custom search engine are entered -->
     <string name="search_add_custom_engine_form_description">Custom search engine details</string>
+    <!-- Placeholder text shown in the Search Suggestion String TextField before a user enters text -->
+    <string name="search_add_custom_engine_suggest_string_hint">Search suggestion string to use</string>
+    <!-- Description text for the Search Suggestion String TextField. The %s is part of the string -->
+    <string name="search_add_custom_engine_suggest_string_example" formatted="false">Replace query with “%s”. Example:\nhttp://suggestqueries.google.com/complete/search?client=firefox&amp;q=%s</string>
 
     <!-- Text shown when a user leaves the name field empty -->
     <string name="search_add_custom_engine_error_empty_name">Enter search engine name</string>


### PR DESCRIPTION
Add a field to the "Add search engine" and "Edit search engine" fragments to allow users to add a custom URL to provide search auto-suggestions. If this field is left blank, the custom search engine feature will function exactly as it did before this change.

Fixes #7866.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

### Tests
The files I modified had no existing test files. Please let me know if you'd like to to add tests for the modified code.

### Screenshots
![image](https://user-images.githubusercontent.com/1380292/170550161-09763cc6-10fb-42b8-aa40-d9c96cfdb166.png)
![image](https://user-images.githubusercontent.com/1380292/170550230-e40e851b-7e90-4235-8bfe-df200247c9ca.png)

### Accessibility
All new UI reuses existing components that already existed in the pages I edited.
Fixes #7866