### PR TITLE
Bug 1771730 - Upgrade to Glean v50 and adopt new Glean APIs

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
@@ -276,7 +276,7 @@ internal class ReleaseMetricController(
                         Logger("Metrics").error("Unknown suggestion provider: $provider")
                         null
                     }
-                }?.accumulateSamples(longArrayOf(providerTiming.second as Long))
+                }?.accumulateSamples(listOf(providerTiming.second as Long))
             }
             Unit
         }

--- a/app/src/main/java/org/mozilla/fenix/home/recentsyncedtabs/RecentSyncedTabFeature.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recentsyncedtabs/RecentSyncedTabFeature.kt
@@ -111,7 +111,7 @@ class RecentSyncedTabFeature(
         syncStartId: GleanTimerId?
     ) {
         RecentSyncedTabs.recentSyncedTabShown[tab.deviceType.name.lowercase()].add()
-        RecentSyncedTabs.recentSyncedTabTimeToLoad.stopAndAccumulate(syncStartId)
+        syncStartId?.let { RecentSyncedTabs.recentSyncedTabTimeToLoad.stopAndAccumulate(it) }
         if (tab == lastSyncedTab) {
             RecentSyncedTabs.latestSyncedTabIsStale.add()
         }

--- a/app/src/main/java/org/mozilla/fenix/perf/ColdStartupDurationTelemetry.kt
+++ b/app/src/main/java/org/mozilla/fenix/perf/ColdStartupDurationTelemetry.kt
@@ -66,7 +66,7 @@ class ColdStartupDurationTelemetry {
 
         val startNanos = StartupTimeline.frameworkStartMeasurement.applicationInitNanos
         val durationMillis = TimeUnit.NANOSECONDS.toMillis(firstFrameNanos - startNanos)
-        metric.accumulateSamples(longArrayOf(durationMillis))
+        metric.accumulateSamples(listOf(durationMillis))
         logger.info("COLD $typeForLog Application.<init> to first frame: $durationMillis ms")
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayMiddleware.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayMiddleware.kt
@@ -56,7 +56,7 @@ class TabsTrayMiddleware : Middleware<TabsTrayState, TabsTrayAction> {
                         )
 
                         val tabGroupSizeMapping = tabsPerGroup.map { generateTabGroupSizeMappedValue(it) }
-                        SearchTerms.groupSizeDistribution.accumulateSamples(tabGroupSizeMapping.toLongArray())
+                        SearchTerms.groupSizeDistribution.accumulateSamples(tabGroupSizeMapping.toList())
                     }
                 }
             }

--- a/app/src/main/java/org/mozilla/fenix/telemetry/TelemetryMiddleware.kt
+++ b/app/src/main/java/org/mozilla/fenix/telemetry/TelemetryMiddleware.kt
@@ -106,9 +106,9 @@ class TelemetryMiddleware(
 
         // Record the age of the engine session of the killed foreground/background tab.
         if (isSelected && age != null) {
-            EngineMetrics.killForegroundAge.accumulateSamples(listOf(age).toLongArray())
+            EngineMetrics.killForegroundAge.accumulateSamples(listOf(age))
         } else if (age != null) {
-            EngineMetrics.killBackgroundAge.accumulateSamples(listOf(age).toLongArray())
+            EngineMetrics.killBackgroundAge.accumulateSamples(listOf(age))
         }
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/AppRequestInterceptorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/AppRequestInterceptorTest.kt
@@ -191,10 +191,9 @@ class AppRequestInterceptorTest {
 
             assertEquals(expectedPage, actualPage)
             // Check if the error metric was recorded
-            assertEquals(true, ErrorPage.visitedError.testHasValue())
             assertEquals(
                 error.name,
-                ErrorPage.visitedError.testGetValue().last().extra?.get("error_type")
+                ErrorPage.visitedError.testGetValue()!!.last().extra?.get("error_type")
             )
         }
     }
@@ -214,10 +213,9 @@ class AppRequestInterceptorTest {
 
             assertEquals(expectedPage, actualPage)
             // Check if the error metric was recorded
-            assertEquals(true, ErrorPage.visitedError.testHasValue())
             assertEquals(
                 error.name,
-                ErrorPage.visitedError.testGetValue().last().extra?.get("error_type")
+                ErrorPage.visitedError.testGetValue()!!.last().extra?.get("error_type")
             )
         }
     }
@@ -238,10 +236,9 @@ class AppRequestInterceptorTest {
 
             assertEquals(expectedPage, actualPage)
             // Check if the error metric was recorded
-            assertEquals(true, ErrorPage.visitedError.testHasValue())
             assertEquals(
                 error.name,
-                ErrorPage.visitedError.testGetValue().last().extra?.get("error_type")
+                ErrorPage.visitedError.testGetValue()!!.last().extra?.get("error_type")
             )
         }
     }

--- a/app/src/test/java/org/mozilla/fenix/FenixApplicationTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/FenixApplicationTest.kt
@@ -21,7 +21,8 @@ import mozilla.components.feature.addons.migration.DefaultSupportedAddonsChecker
 import mozilla.components.service.glean.testing.GleanTestRule
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -146,7 +147,7 @@ class FenixApplicationTest {
         every { settings.inactiveTabsAreEnabled } returns true
 
         assertTrue(settings.contileContextId.isEmpty())
-        assertFalse(TopSites.contextId.testHasValue())
+        assertNull(TopSites.contextId.testGetValue())
 
         application.setStartupMetrics(browserStore, settings, browsersCache, mozillaProductDetector)
 
@@ -187,20 +188,20 @@ class FenixApplicationTest {
         assertEquals(true, Preferences.inactiveTabsEnabled.testGetValue())
         assertEquals(expectedAppInstallSource, Metrics.installSource.testGetValue())
 
-        val contextId = TopSites.contextId.testGetValue().toString()
+        val contextId = TopSites.contextId.testGetValue()!!.toString()
 
-        assertTrue(TopSites.contextId.testHasValue())
+        assertNotNull(TopSites.contextId.testGetValue())
         assertEquals(contextId, settings.contileContextId)
 
         // Verify that search engine defaults are NOT set. This test does
         // not mock most of the objects telemetry is collected from.
-        assertFalse(SearchDefaultEngine.code.testHasValue())
-        assertFalse(SearchDefaultEngine.name.testHasValue())
-        assertFalse(SearchDefaultEngine.searchUrl.testHasValue())
+        assertNull(SearchDefaultEngine.code.testGetValue())
+        assertNull(SearchDefaultEngine.name.testGetValue())
+        assertNull(SearchDefaultEngine.searchUrl.testGetValue())
 
         application.setStartupMetrics(browserStore, settings, browsersCache, mozillaProductDetector)
 
-        assertEquals(contextId, TopSites.contextId.testGetValue().toString())
+        assertEquals(contextId, TopSites.contextId.testGetValue()!!.toString())
         assertEquals(contextId, settings.contileContextId)
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/IntentReceiverActivityTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/IntentReceiverActivityTest.kt
@@ -24,7 +24,8 @@ import mozilla.components.support.test.robolectric.testContext
 import mozilla.telemetry.glean.testing.GleanTestRule
 import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -80,7 +81,7 @@ class IntentReceiverActivityTest {
     fun `process intent with flag launched from history`() = runTest {
         val intent = Intent()
         intent.flags = FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY
-        assertFalse(Events.openedLink.testHasValue())
+        assertNull(Events.openedLink.testGetValue())
 
         val activity = Robolectric.buildActivity(IntentReceiverActivity::class.java, intent).get()
         attachMocks(activity)
@@ -89,7 +90,7 @@ class IntentReceiverActivityTest {
         val shadow = shadowOf(activity)
         val actualIntent = shadow.peekNextStartedActivity()
 
-        assertTrue(Events.openedLink.testHasValue())
+        assertNotNull(Events.openedLink.testGetValue())
         assertEquals(HomeActivity::class.java.name, actualIntent.component?.className)
         assertEquals(true, actualIntent.flags == FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY)
     }
@@ -99,7 +100,7 @@ class IntentReceiverActivityTest {
         runTest {
             val uri = Uri.parse(BuildConfig.DEEP_LINK_SCHEME + "://settings_wallpapers")
             val intent = Intent("", uri)
-            assertFalse(Events.openedLink.testHasValue())
+            assertNull(Events.openedLink.testGetValue())
 
             coEvery { intentProcessors.intentProcessor.process(any()) } returns false
             coEvery { intentProcessors.externalDeepLinkIntentProcessor.process(any()) } returns true
@@ -112,7 +113,7 @@ class IntentReceiverActivityTest {
             val shadow = shadowOf(activity)
             val actualIntent = shadow.peekNextStartedActivity()
 
-            assertTrue(Events.openedLink.testHasValue())
+            assertNotNull(Events.openedLink.testGetValue())
             assertEquals(HomeActivity::class.java.name, actualIntent.component?.className)
         }
 
@@ -120,7 +121,7 @@ class IntentReceiverActivityTest {
     fun `process intent with action OPEN_PRIVATE_TAB`() = runTest {
         val intent = Intent()
         intent.action = NewTabShortcutIntentProcessor.ACTION_OPEN_PRIVATE_TAB
-        assertFalse(Events.openedLink.testHasValue())
+        assertNull(Events.openedLink.testGetValue())
 
         coEvery { intentProcessors.intentProcessor.process(intent) } returns false
         coEvery { intentProcessors.customTabIntentProcessor.process(intent) } returns false
@@ -131,7 +132,7 @@ class IntentReceiverActivityTest {
         val shadow = shadowOf(activity)
         val actualIntent = shadow.peekNextStartedActivity()
 
-        assertTrue(Events.openedLink.testHasValue())
+        assertNotNull(Events.openedLink.testGetValue())
         assertEquals(HomeActivity::class.java.name, actualIntent.component?.className)
         assertEquals(true, actualIntent.getBooleanExtra(HomeActivity.PRIVATE_BROWSING_MODE, false))
         assertEquals(false, actualIntent.getBooleanExtra(HomeActivity.OPEN_TO_BROWSER, true))
@@ -139,7 +140,7 @@ class IntentReceiverActivityTest {
 
     @Test
     fun `process intent with action OPEN_TAB`() = runTest {
-        assertFalse(Events.openedLink.testHasValue())
+        assertNull(Events.openedLink.testGetValue())
         val intent = Intent()
         intent.action = NewTabShortcutIntentProcessor.ACTION_OPEN_TAB
 
@@ -152,12 +153,12 @@ class IntentReceiverActivityTest {
 
         assertEquals(HomeActivity::class.java.name, actualIntent.component?.className)
         assertEquals(false, actualIntent.getBooleanExtra(HomeActivity.PRIVATE_BROWSING_MODE, false))
-        assertTrue(Events.openedLink.testHasValue())
+        assertNotNull(Events.openedLink.testGetValue())
     }
 
     @Test
     fun `process intent starts Activity`() = runTest {
-        assertFalse(Events.openedLink.testHasValue())
+        assertNull(Events.openedLink.testGetValue())
         val intent = Intent()
         val activity = Robolectric.buildActivity(IntentReceiverActivity::class.java, intent).get()
         attachMocks(activity)
@@ -168,12 +169,12 @@ class IntentReceiverActivityTest {
 
         assertEquals(HomeActivity::class.java.name, actualIntent.component?.className)
         assertEquals(true, actualIntent.getBooleanExtra(HomeActivity.OPEN_TO_BROWSER, true))
-        assertTrue(Events.openedLink.testHasValue())
+        assertNotNull(Events.openedLink.testGetValue())
     }
 
     @Test
     fun `process intent with launchLinksInPrivateTab set to true`() = runTest {
-        assertFalse(Events.openedLink.testHasValue())
+        assertNull(Events.openedLink.testGetValue())
 
         every { settings.openLinksInAPrivateTab } returns true
 
@@ -193,12 +194,12 @@ class IntentReceiverActivityTest {
         verify { intentProcessors.privateIntentProcessor.process(intent) }
         assertEquals(HomeActivity::class.java.name, actualIntent.component?.className)
         assertTrue(actualIntent.getBooleanExtra(HomeActivity.PRIVATE_BROWSING_MODE, false))
-        assertTrue(Events.openedLink.testHasValue())
+        assertNotNull(Events.openedLink.testGetValue())
     }
 
     @Test
     fun `process intent with launchLinksInPrivateTab set to false`() = runTest {
-        assertFalse(Events.openedLink.testHasValue())
+        assertNull(Events.openedLink.testGetValue())
         val intent = Intent()
 
         val activity = Robolectric.buildActivity(IntentReceiverActivity::class.java, intent).get()
@@ -207,16 +208,16 @@ class IntentReceiverActivityTest {
 
         coVerify(exactly = 0) { intentProcessors.privateIntentProcessor.process(intent) }
         coVerify { intentProcessors.intentProcessor.process(intent) }
-        assertTrue(Events.openedLink.testHasValue())
+        assertNotNull(Events.openedLink.testGetValue())
     }
 
     @Test
     fun `process custom tab intent`() = runTest {
-        assertFalse(Events.openedLink.testHasValue())
+        assertNull(Events.openedLink.testGetValue())
         val intent = Intent()
         coEvery { intentProcessors.intentProcessor.process(intent) } returns false
         coEvery { intentProcessors.customTabIntentProcessor.process(intent) } returns true
-        assertFalse(Events.openedLink.testHasValue())
+        assertNull(Events.openedLink.testGetValue())
 
         val activity = Robolectric.buildActivity(IntentReceiverActivity::class.java, intent).get()
         attachMocks(activity)
@@ -227,12 +228,12 @@ class IntentReceiverActivityTest {
 
         assertEquals(ExternalAppBrowserActivity::class.java.name, intent.component!!.className)
         assertTrue(intent.getBooleanExtra(HomeActivity.OPEN_TO_BROWSER, false))
-        assertTrue(Events.openedLink.testHasValue())
+        assertNotNull(Events.openedLink.testGetValue())
     }
 
     @Test
     fun `process private custom tab intent`() = runTest {
-        assertFalse(Events.openedLink.testHasValue())
+        assertNull(Events.openedLink.testGetValue())
         every { settings.openLinksInAPrivateTab } returns true
 
         val intent = Intent()
@@ -248,7 +249,7 @@ class IntentReceiverActivityTest {
 
         assertEquals(ExternalAppBrowserActivity::class.java.name, intent.component!!.className)
         assertTrue(intent.getBooleanExtra(HomeActivity.OPEN_TO_BROWSER, false))
-        assertTrue(Events.openedLink.testHasValue())
+        assertNotNull(Events.openedLink.testGetValue())
     }
 
     @Test

--- a/app/src/test/java/org/mozilla/fenix/collections/DefaultCollectionCreationControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/collections/DefaultCollectionCreationControllerTest.kt
@@ -97,8 +97,8 @@ class DefaultCollectionCreationControllerTest {
         assertTrue(dismissed)
         coVerify { tabCollectionStorage.createCollection("name", listOf(tab1)) }
 
-        assertTrue(Collections.saved.testHasValue())
-        val recordedEvents = Collections.saved.testGetValue()
+        assertNotNull(Collections.saved.testGetValue())
+        val recordedEvents = Collections.saved.testGetValue()!!
         assertEquals(1, recordedEvents.size)
         val eventExtra = recordedEvents.single().extra
         assertNotNull(eventExtra)
@@ -152,8 +152,8 @@ class DefaultCollectionCreationControllerTest {
 
         assertTrue(dismissed)
 
-        assertTrue(Collections.renamed.testHasValue())
-        val recordedEvents = Collections.renamed.testGetValue()
+        assertNotNull(Collections.renamed.testGetValue())
+        val recordedEvents = Collections.renamed.testGetValue()!!
         assertEquals(1, recordedEvents.size)
         assertNull(recordedEvents.single().extra)
 
@@ -203,8 +203,8 @@ class DefaultCollectionCreationControllerTest {
         assertTrue(dismissed)
         coVerify { tabCollectionStorage.addTabsToCollection(collection, listOf(tab1)) }
 
-        assertTrue(Collections.tabsAdded.testHasValue())
-        val recordedEvents = Collections.tabsAdded.testGetValue()
+        assertNotNull(Collections.tabsAdded.testGetValue())
+        val recordedEvents = Collections.tabsAdded.testGetValue()!!
         assertEquals(1, recordedEvents.size)
         val eventExtra = recordedEvents.single().extra
         assertNotNull(eventExtra)

--- a/app/src/test/java/org/mozilla/fenix/components/BackgroundServicesTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/BackgroundServicesTest.kt
@@ -54,9 +54,8 @@ class BackgroundServicesTest {
         val account = mockk<OAuthAccount>()
 
         registry.notifyObservers { onAuthenticated(account, AuthType.Signin) }
-        assertEquals(true, SyncAuth.signIn.testHasValue())
-        assertEquals(1, SyncAuth.signIn.testGetValue().size)
-        assertEquals(null, SyncAuth.signIn.testGetValue().single().extra)
+        assertEquals(1, SyncAuth.signIn.testGetValue()!!.size)
+        assertEquals(null, SyncAuth.signIn.testGetValue()!!.single().extra)
         verify { settings.signedInFxaAccount = true }
         confirmVerified(settings)
     }
@@ -66,9 +65,8 @@ class BackgroundServicesTest {
         val account = mockk<OAuthAccount>()
 
         registry.notifyObservers { onAuthenticated(account, AuthType.Signup) }
-        assertEquals(true, SyncAuth.signUp.testHasValue())
-        assertEquals(1, SyncAuth.signUp.testGetValue().size)
-        assertEquals(null, SyncAuth.signUp.testGetValue().single().extra)
+        assertEquals(1, SyncAuth.signUp.testGetValue()!!.size)
+        assertEquals(null, SyncAuth.signUp.testGetValue()!!.single().extra)
         verify { settings.signedInFxaAccount = true }
         confirmVerified(settings)
     }
@@ -78,9 +76,8 @@ class BackgroundServicesTest {
         val account = mockk<OAuthAccount>()
 
         registry.notifyObservers { onAuthenticated(account, AuthType.Pairing) }
-        assertEquals(true, SyncAuth.paired.testHasValue())
-        assertEquals(1, SyncAuth.paired.testGetValue().size)
-        assertEquals(null, SyncAuth.paired.testGetValue().single().extra)
+        assertEquals(1, SyncAuth.paired.testGetValue()!!.size)
+        assertEquals(null, SyncAuth.paired.testGetValue()!!.single().extra)
         verify { settings.signedInFxaAccount = true }
         confirmVerified(settings)
     }
@@ -90,9 +87,8 @@ class BackgroundServicesTest {
         val account = mockk<OAuthAccount>()
 
         registry.notifyObservers { onAuthenticated(account, AuthType.Recovered) }
-        assertEquals(true, SyncAuth.recovered.testHasValue())
-        assertEquals(1, SyncAuth.recovered.testGetValue().size)
-        assertEquals(null, SyncAuth.recovered.testGetValue().single().extra)
+        assertEquals(1, SyncAuth.recovered.testGetValue()!!.size)
+        assertEquals(null, SyncAuth.recovered.testGetValue()!!.single().extra)
         verify { settings.signedInFxaAccount = true }
         confirmVerified(settings)
     }
@@ -102,9 +98,8 @@ class BackgroundServicesTest {
         val account = mockk<OAuthAccount>()
 
         registry.notifyObservers { onAuthenticated(account, AuthType.OtherExternal(null)) }
-        assertEquals(true, SyncAuth.otherExternal.testHasValue())
-        assertEquals(1, SyncAuth.otherExternal.testGetValue().size)
-        assertEquals(null, SyncAuth.otherExternal.testGetValue().single().extra)
+        assertEquals(1, SyncAuth.otherExternal.testGetValue()!!.size)
+        assertEquals(null, SyncAuth.otherExternal.testGetValue()!!.single().extra)
         verify { settings.signedInFxaAccount = true }
         confirmVerified(settings)
     }
@@ -114,9 +109,8 @@ class BackgroundServicesTest {
         val account = mockk<OAuthAccount>()
 
         registry.notifyObservers { onAuthenticated(account, AuthType.OtherExternal("someAction")) }
-        assertEquals(true, SyncAuth.otherExternal.testHasValue())
-        assertEquals(1, SyncAuth.otherExternal.testGetValue().size)
-        assertEquals(null, SyncAuth.otherExternal.testGetValue().single().extra)
+        assertEquals(1, SyncAuth.otherExternal.testGetValue()!!.size)
+        assertEquals(null, SyncAuth.otherExternal.testGetValue()!!.single().extra)
         verify { settings.signedInFxaAccount = true }
         confirmVerified(settings)
     }
@@ -124,9 +118,8 @@ class BackgroundServicesTest {
     @Test
     fun `telemetry account observer tracks sign out event`() {
         registry.notifyObservers { onLoggedOut() }
-        assertEquals(true, SyncAuth.signOut.testHasValue())
-        assertEquals(1, SyncAuth.signOut.testGetValue().size)
-        assertEquals(null, SyncAuth.signOut.testGetValue().single().extra)
+        assertEquals(1, SyncAuth.signOut.testGetValue()!!.size)
+        assertEquals(null, SyncAuth.signOut.testGetValue()!!.single().extra)
         verify { settings.signedInFxaAccount = false }
         confirmVerified(settings)
     }

--- a/app/src/test/java/org/mozilla/fenix/components/metrics/MetricControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/metrics/MetricControllerTest.kt
@@ -34,9 +34,8 @@ import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.webextensions.facts.WebExtensionFacts
 import mozilla.telemetry.glean.testing.GleanTestRule
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -173,13 +172,13 @@ class MetricControllerTest {
             metadata = metadata
         )
         // Verify history based suggestions
-        assertFalse(PerfAwesomebar.historySuggestions.testHasValue())
+        assertNull(PerfAwesomebar.historySuggestions.testGetValue())
 
         with(controller) {
             fact.process()
         }
 
-        assertTrue(PerfAwesomebar.historySuggestions.testHasValue())
+        assertNotNull(PerfAwesomebar.historySuggestions.testGetValue())
 
         // Verify bookmark based suggestions
         metadata = mapOf(
@@ -189,13 +188,13 @@ class MetricControllerTest {
             )
         )
         fact = fact.copy(metadata = metadata)
-        assertFalse(PerfAwesomebar.bookmarkSuggestions.testHasValue())
+        assertNull(PerfAwesomebar.bookmarkSuggestions.testGetValue())
 
         with(controller) {
             fact.process()
         }
 
-        assertTrue(PerfAwesomebar.bookmarkSuggestions.testHasValue())
+        assertNotNull(PerfAwesomebar.bookmarkSuggestions.testGetValue())
 
         // Verify session based suggestions
         metadata = mapOf(
@@ -205,13 +204,13 @@ class MetricControllerTest {
             )
         )
         fact = fact.copy(metadata = metadata)
-        assertFalse(PerfAwesomebar.sessionSuggestions.testHasValue())
+        assertNull(PerfAwesomebar.sessionSuggestions.testGetValue())
 
         with(controller) {
             fact.process()
         }
 
-        assertTrue(PerfAwesomebar.sessionSuggestions.testHasValue())
+        assertNotNull(PerfAwesomebar.sessionSuggestions.testGetValue())
 
         // Verify search engine suggestions
         metadata = mapOf(
@@ -221,13 +220,13 @@ class MetricControllerTest {
             )
         )
         fact = fact.copy(metadata = metadata)
-        assertFalse(PerfAwesomebar.searchEngineSuggestions.testHasValue())
+        assertNull(PerfAwesomebar.searchEngineSuggestions.testGetValue())
 
         with(controller) {
             fact.process()
         }
 
-        assertTrue(PerfAwesomebar.searchEngineSuggestions.testHasValue())
+        assertNotNull(PerfAwesomebar.searchEngineSuggestions.testGetValue())
 
         // Verify clipboard based suggestions
         metadata = mapOf(
@@ -237,13 +236,13 @@ class MetricControllerTest {
             )
         )
         fact = fact.copy(metadata = metadata)
-        assertFalse(PerfAwesomebar.clipboardSuggestions.testHasValue())
+        assertNull(PerfAwesomebar.clipboardSuggestions.testGetValue())
 
         with(controller) {
             fact.process()
         }
 
-        assertTrue(PerfAwesomebar.clipboardSuggestions.testHasValue())
+        assertNotNull(PerfAwesomebar.clipboardSuggestions.testGetValue())
 
         // Verify shortcut based suggestions
         metadata = mapOf(
@@ -253,13 +252,13 @@ class MetricControllerTest {
             )
         )
         fact = fact.copy(metadata = metadata)
-        assertFalse(PerfAwesomebar.shortcutsSuggestions.testHasValue())
+        assertNull(PerfAwesomebar.shortcutsSuggestions.testGetValue())
 
         with(controller) {
             fact.process()
         }
 
-        assertTrue(PerfAwesomebar.shortcutsSuggestions.testHasValue())
+        assertNotNull(PerfAwesomebar.shortcutsSuggestions.testGetValue())
     }
 
     @Test
@@ -354,52 +353,52 @@ class MetricControllerTest {
         val action = mockk<Action>()
 
         // Verify display interaction
-        assertFalse(LoginDialog.displayed.testHasValue())
+        assertNull(LoginDialog.displayed.testGetValue())
         var fact = Fact(Component.FEATURE_PROMPTS, action, LoginDialogFacts.Items.DISPLAY)
 
         controller.run {
             fact.process()
         }
 
-        assertTrue(LoginDialog.displayed.testHasValue())
-        assertEquals(1, LoginDialog.displayed.testGetValue().size)
-        assertNull(LoginDialog.displayed.testGetValue().single().extra)
+        assertNotNull(LoginDialog.displayed.testGetValue())
+        assertEquals(1, LoginDialog.displayed.testGetValue()!!.size)
+        assertNull(LoginDialog.displayed.testGetValue()!!.single().extra)
 
         // Verify cancel interaction
-        assertFalse(LoginDialog.cancelled.testHasValue())
+        assertNull(LoginDialog.cancelled.testGetValue())
         fact = Fact(Component.FEATURE_PROMPTS, action, LoginDialogFacts.Items.CANCEL)
 
         controller.run {
             fact.process()
         }
 
-        assertTrue(LoginDialog.cancelled.testHasValue())
-        assertEquals(1, LoginDialog.cancelled.testGetValue().size)
-        assertNull(LoginDialog.cancelled.testGetValue().single().extra)
+        assertNotNull(LoginDialog.cancelled.testGetValue())
+        assertEquals(1, LoginDialog.cancelled.testGetValue()!!.size)
+        assertNull(LoginDialog.cancelled.testGetValue()!!.single().extra)
 
         // Verify never save interaction
-        assertFalse(LoginDialog.neverSave.testHasValue())
+        assertNull(LoginDialog.neverSave.testGetValue())
         fact = Fact(Component.FEATURE_PROMPTS, action, LoginDialogFacts.Items.NEVER_SAVE)
 
         controller.run {
             fact.process()
         }
 
-        assertTrue(LoginDialog.neverSave.testHasValue())
-        assertEquals(1, LoginDialog.neverSave.testGetValue().size)
-        assertNull(LoginDialog.neverSave.testGetValue().single().extra)
+        assertNotNull(LoginDialog.neverSave.testGetValue())
+        assertEquals(1, LoginDialog.neverSave.testGetValue()!!.size)
+        assertNull(LoginDialog.neverSave.testGetValue()!!.single().extra)
 
         // Verify save interaction
-        assertFalse(LoginDialog.saved.testHasValue())
+        assertNull(LoginDialog.saved.testGetValue())
         fact = Fact(Component.FEATURE_PROMPTS, action, LoginDialogFacts.Items.SAVE)
 
         controller.run {
             fact.process()
         }
 
-        assertTrue(LoginDialog.saved.testHasValue())
-        assertEquals(1, LoginDialog.saved.testGetValue().size)
-        assertNull(LoginDialog.saved.testGetValue().single().extra)
+        assertNotNull(LoginDialog.saved.testGetValue())
+        assertEquals(1, LoginDialog.saved.testGetValue()!!.size)
+        assertNull(LoginDialog.saved.testGetValue()!!.single().extra)
     }
 
     @Test
@@ -407,27 +406,27 @@ class MetricControllerTest {
         val controller = ReleaseMetricController(emptyList(), { true }, { true }, mockk())
         // Verify the play action
         var fact = Fact(Component.FEATURE_MEDIA, Action.PLAY, MediaFacts.Items.NOTIFICATION)
-        assertFalse(MediaNotification.play.testHasValue())
+        assertNull(MediaNotification.play.testGetValue())
 
         controller.run {
             fact.process()
         }
 
-        assertTrue(MediaNotification.play.testHasValue())
-        assertEquals(1, MediaNotification.play.testGetValue().size)
-        assertNull(MediaNotification.play.testGetValue().single().extra)
+        assertNotNull(MediaNotification.play.testGetValue())
+        assertEquals(1, MediaNotification.play.testGetValue()!!.size)
+        assertNull(MediaNotification.play.testGetValue()!!.single().extra)
 
         // Verify the pause action
         fact = Fact(Component.FEATURE_MEDIA, Action.PAUSE, MediaFacts.Items.NOTIFICATION)
-        assertFalse(MediaNotification.pause.testHasValue())
+        assertNull(MediaNotification.pause.testGetValue())
 
         controller.run {
             fact.process()
         }
 
-        assertTrue(MediaNotification.pause.testHasValue())
-        assertEquals(1, MediaNotification.pause.testGetValue().size)
-        assertNull(MediaNotification.pause.testGetValue().single().extra)
+        assertNotNull(MediaNotification.pause.testGetValue())
+        assertEquals(1, MediaNotification.pause.testGetValue()!!.size)
+        assertNull(MediaNotification.pause.testGetValue()!!.single().extra)
     }
 
     @Test
@@ -441,60 +440,60 @@ class MetricControllerTest {
         )
 
         with(controller) {
-            assertFalse(AndroidAutofill.requestMatchingLogins.testHasValue())
+            assertNull(AndroidAutofill.requestMatchingLogins.testGetValue())
 
             fact.process()
 
-            assertTrue(AndroidAutofill.requestMatchingLogins.testHasValue())
+            assertNotNull(AndroidAutofill.requestMatchingLogins.testGetValue())
 
             fact = fact.copy(metadata = mapOf(AutofillFacts.Metadata.HAS_MATCHING_LOGINS to false))
-            assertFalse(AndroidAutofill.requestNoMatchingLogins.testHasValue())
+            assertNull(AndroidAutofill.requestNoMatchingLogins.testGetValue())
 
             fact.process()
 
-            assertTrue(AndroidAutofill.requestNoMatchingLogins.testHasValue())
+            assertNotNull(AndroidAutofill.requestNoMatchingLogins.testGetValue())
 
             fact = fact.copy(item = AutofillFacts.Items.AUTOFILL_SEARCH, action = Action.DISPLAY, metadata = null)
-            assertFalse(AndroidAutofill.searchDisplayed.testHasValue())
+            assertNull(AndroidAutofill.searchDisplayed.testGetValue())
 
             fact.process()
 
-            assertTrue(AndroidAutofill.searchDisplayed.testHasValue())
+            assertNotNull(AndroidAutofill.searchDisplayed.testGetValue())
 
             fact = fact.copy(action = Action.SELECT)
-            assertFalse(AndroidAutofill.searchItemSelected.testHasValue())
+            assertNull(AndroidAutofill.searchItemSelected.testGetValue())
 
             fact.process()
 
-            assertTrue(AndroidAutofill.searchItemSelected.testHasValue())
+            assertNotNull(AndroidAutofill.searchItemSelected.testGetValue())
 
             fact = fact.copy(item = AutofillFacts.Items.AUTOFILL_CONFIRMATION, action = Action.CONFIRM)
-            assertFalse(AndroidAutofill.confirmSuccessful.testHasValue())
+            assertNull(AndroidAutofill.confirmSuccessful.testGetValue())
 
             fact.process()
 
-            assertTrue(AndroidAutofill.confirmSuccessful.testHasValue())
+            assertNotNull(AndroidAutofill.confirmSuccessful.testGetValue())
 
             fact = fact.copy(action = Action.DISPLAY)
-            assertFalse(AndroidAutofill.confirmCancelled.testHasValue())
+            assertNull(AndroidAutofill.confirmCancelled.testGetValue())
 
             fact.process()
 
-            assertTrue(AndroidAutofill.confirmCancelled.testHasValue())
+            assertNotNull(AndroidAutofill.confirmCancelled.testGetValue())
 
             fact = fact.copy(item = AutofillFacts.Items.AUTOFILL_LOCK, action = Action.CONFIRM)
-            assertFalse(AndroidAutofill.unlockSuccessful.testHasValue())
+            assertNull(AndroidAutofill.unlockSuccessful.testGetValue())
 
             fact.process()
 
-            assertTrue(AndroidAutofill.unlockSuccessful.testHasValue())
+            assertNotNull(AndroidAutofill.unlockSuccessful.testGetValue())
 
             fact = fact.copy(action = Action.DISPLAY)
-            assertFalse(AndroidAutofill.unlockCancelled.testHasValue())
+            assertNull(AndroidAutofill.unlockCancelled.testGetValue())
 
             fact.process()
 
-            assertTrue(AndroidAutofill.unlockCancelled.testHasValue())
+            assertNotNull(AndroidAutofill.unlockCancelled.testGetValue())
         }
     }
 
@@ -509,15 +508,15 @@ class MetricControllerTest {
             ContextMenuFacts.Items.TEXT_SELECTION_OPTION,
             metadata = mapOf("textSelectionOption" to Companion.CONTEXT_MENU_COPY)
         )
-        assertFalse(ContextualMenu.copyTapped.testHasValue())
+        assertNull(ContextualMenu.copyTapped.testGetValue())
 
         with(controller) {
             fact.process()
         }
 
-        assertTrue(ContextualMenu.copyTapped.testHasValue())
-        assertEquals(1, ContextualMenu.copyTapped.testGetValue().size)
-        assertNull(ContextualMenu.copyTapped.testGetValue().single().extra)
+        assertNotNull(ContextualMenu.copyTapped.testGetValue())
+        assertEquals(1, ContextualMenu.copyTapped.testGetValue()!!.size)
+        assertNull(ContextualMenu.copyTapped.testGetValue()!!.single().extra)
 
         // Verify search button interaction
         fact = Fact(
@@ -526,15 +525,15 @@ class MetricControllerTest {
             ContextMenuFacts.Items.TEXT_SELECTION_OPTION,
             metadata = mapOf("textSelectionOption" to Companion.CONTEXT_MENU_SEARCH)
         )
-        assertFalse(ContextualMenu.searchTapped.testHasValue())
+        assertNull(ContextualMenu.searchTapped.testGetValue())
 
         with(controller) {
             fact.process()
         }
 
-        assertTrue(ContextualMenu.searchTapped.testHasValue())
-        assertEquals(1, ContextualMenu.searchTapped.testGetValue().size)
-        assertNull(ContextualMenu.searchTapped.testGetValue().single().extra)
+        assertNotNull(ContextualMenu.searchTapped.testGetValue())
+        assertEquals(1, ContextualMenu.searchTapped.testGetValue()!!.size)
+        assertNull(ContextualMenu.searchTapped.testGetValue()!!.single().extra)
 
         // Verify select all button interaction
         fact = Fact(
@@ -543,15 +542,15 @@ class MetricControllerTest {
             ContextMenuFacts.Items.TEXT_SELECTION_OPTION,
             metadata = mapOf("textSelectionOption" to Companion.CONTEXT_MENU_SELECT_ALL)
         )
-        assertFalse(ContextualMenu.selectAllTapped.testHasValue())
+        assertNull(ContextualMenu.selectAllTapped.testGetValue())
 
         with(controller) {
             fact.process()
         }
 
-        assertTrue(ContextualMenu.selectAllTapped.testHasValue())
-        assertEquals(1, ContextualMenu.selectAllTapped.testGetValue().size)
-        assertNull(ContextualMenu.selectAllTapped.testGetValue().single().extra)
+        assertNotNull(ContextualMenu.selectAllTapped.testGetValue())
+        assertEquals(1, ContextualMenu.selectAllTapped.testGetValue()!!.size)
+        assertNull(ContextualMenu.selectAllTapped.testGetValue()!!.single().extra)
 
         // Verify share button interaction
         fact = Fact(
@@ -560,15 +559,15 @@ class MetricControllerTest {
             ContextMenuFacts.Items.TEXT_SELECTION_OPTION,
             metadata = mapOf("textSelectionOption" to Companion.CONTEXT_MENU_SHARE)
         )
-        assertFalse(ContextualMenu.shareTapped.testHasValue())
+        assertNull(ContextualMenu.shareTapped.testGetValue())
 
         with(controller) {
             fact.process()
         }
 
-        assertTrue(ContextualMenu.shareTapped.testHasValue())
-        assertEquals(1, ContextualMenu.shareTapped.testGetValue().size)
-        assertNull(ContextualMenu.shareTapped.testGetValue().single().extra)
+        assertNotNull(ContextualMenu.shareTapped.testGetValue())
+        assertEquals(1, ContextualMenu.shareTapped.testGetValue()!!.size)
+        assertNull(ContextualMenu.shareTapped.testGetValue()!!.single().extra)
     }
 
     @Test
@@ -591,9 +590,8 @@ class MetricControllerTest {
                 fact.process()
             }
 
-            assertEquals(true, event.testHasValue())
-            assertEquals(1, event.testGetValue().size)
-            assertEquals(null, event.testGetValue().single().extra)
+            assertEquals(1, event.testGetValue()!!.size)
+            assertEquals(null, event.testGetValue()!!.single().extra)
         }
     }
 
@@ -609,11 +607,11 @@ class MetricControllerTest {
             ProgressiveWebAppFacts.Items.HOMESCREEN_ICON_TAP,
         )
 
-        assertFalse(ProgressiveWebApp.homescreenTap.testHasValue())
+        assertNull(ProgressiveWebApp.homescreenTap.testGetValue())
         controller.run {
             openPWA.process()
         }
-        assertTrue(ProgressiveWebApp.homescreenTap.testHasValue())
+        assertNotNull(ProgressiveWebApp.homescreenTap.testGetValue())
 
         // a PWA shortcut was installed
         val installPWA = Fact(
@@ -622,13 +620,13 @@ class MetricControllerTest {
             ProgressiveWebAppFacts.Items.INSTALL_SHORTCUT,
         )
 
-        assertFalse(ProgressiveWebApp.installTap.testHasValue())
+        assertNull(ProgressiveWebApp.installTap.testGetValue())
 
         controller.run {
             installPWA.process()
         }
 
-        assertTrue(ProgressiveWebApp.installTap.testHasValue())
+        assertNotNull(ProgressiveWebApp.installTap.testGetValue())
     }
 
     @Test
@@ -636,64 +634,64 @@ class MetricControllerTest {
         val controller = ReleaseMetricController(emptyList(), { true }, { true }, mockk())
 
         // Verify synced tabs suggestion clicked
-        assertFalse(SyncedTabs.syncedTabsSuggestionClicked.testHasValue())
+        assertNull(SyncedTabs.syncedTabsSuggestionClicked.testGetValue())
         var fact = Fact(Component.FEATURE_SYNCEDTABS, Action.CANCEL, SyncedTabsFacts.Items.SYNCED_TABS_SUGGESTION_CLICKED)
 
         with(controller) {
             fact.process()
         }
 
-        assertTrue(SyncedTabs.syncedTabsSuggestionClicked.testHasValue())
+        assertNotNull(SyncedTabs.syncedTabsSuggestionClicked.testGetValue())
 
         // Verify bookmark suggestion clicked
-        assertFalse(Awesomebar.bookmarkSuggestionClicked.testHasValue())
+        assertNull(Awesomebar.bookmarkSuggestionClicked.testGetValue())
         fact = Fact(Component.FEATURE_AWESOMEBAR, Action.CANCEL, AwesomeBarFacts.Items.BOOKMARK_SUGGESTION_CLICKED)
 
         with(controller) {
             fact.process()
         }
 
-        assertTrue(Awesomebar.bookmarkSuggestionClicked.testHasValue())
+        assertNotNull(Awesomebar.bookmarkSuggestionClicked.testGetValue())
 
         // Verify clipboard suggestion clicked
-        assertFalse(Awesomebar.clipboardSuggestionClicked.testHasValue())
+        assertNull(Awesomebar.clipboardSuggestionClicked.testGetValue())
         fact = Fact(Component.FEATURE_AWESOMEBAR, Action.CANCEL, AwesomeBarFacts.Items.CLIPBOARD_SUGGESTION_CLICKED)
 
         with(controller) {
             fact.process()
         }
 
-        assertTrue(Awesomebar.clipboardSuggestionClicked.testHasValue())
+        assertNotNull(Awesomebar.clipboardSuggestionClicked.testGetValue())
 
         // Verify history suggestion clicked
-        assertFalse(Awesomebar.historySuggestionClicked.testHasValue())
+        assertNull(Awesomebar.historySuggestionClicked.testGetValue())
         fact = Fact(Component.FEATURE_AWESOMEBAR, Action.CANCEL, AwesomeBarFacts.Items.HISTORY_SUGGESTION_CLICKED)
 
         with(controller) {
             fact.process()
         }
 
-        assertTrue(Awesomebar.historySuggestionClicked.testHasValue())
+        assertNotNull(Awesomebar.historySuggestionClicked.testGetValue())
 
         // Verify search action clicked
-        assertFalse(Awesomebar.searchActionClicked.testHasValue())
+        assertNull(Awesomebar.searchActionClicked.testGetValue())
         fact = Fact(Component.FEATURE_AWESOMEBAR, Action.CANCEL, AwesomeBarFacts.Items.SEARCH_ACTION_CLICKED)
 
         with(controller) {
             fact.process()
         }
 
-        assertTrue(Awesomebar.searchActionClicked.testHasValue())
+        assertNotNull(Awesomebar.searchActionClicked.testGetValue())
 
         // Verify bookmark opened tab suggestion clicked
-        assertFalse(Awesomebar.openedTabSuggestionClicked.testHasValue())
+        assertNull(Awesomebar.openedTabSuggestionClicked.testGetValue())
         fact = Fact(Component.FEATURE_AWESOMEBAR, Action.CANCEL, AwesomeBarFacts.Items.OPENED_TAB_SUGGESTION_CLICKED)
 
         with(controller) {
             fact.process()
         }
 
-        assertTrue(Awesomebar.openedTabSuggestionClicked.testHasValue())
+        assertNotNull(Awesomebar.openedTabSuggestionClicked.testGetValue())
     }
 
     @Test
@@ -709,11 +707,11 @@ class MetricControllerTest {
             "provider"
         )
 
-        assertFalse(BrowserSearch.adClicks["provider"].testHasValue())
+        assertNull(BrowserSearch.adClicks["provider"].testGetValue())
         controller.run {
             addClickedInSearchFact.process()
         }
-        assertTrue(BrowserSearch.adClicks["provider"].testHasValue())
+        assertNotNull(BrowserSearch.adClicks["provider"].testGetValue())
         assertEquals(1, BrowserSearch.adClicks["provider"].testGetValue())
 
         // the user opened a Search Engine Result Page of one of our search providers which contains ads
@@ -724,13 +722,13 @@ class MetricControllerTest {
             "provider"
         )
 
-        assertFalse(BrowserSearch.withAds["provider"].testHasValue())
+        assertNull(BrowserSearch.withAds["provider"].testGetValue())
 
         controller.run {
             searchWithAdsOpenedFact.process()
         }
 
-        assertTrue(BrowserSearch.withAds["provider"].testHasValue())
+        assertNotNull(BrowserSearch.withAds["provider"].testGetValue())
         assertEquals(1, BrowserSearch.withAds["provider"].testGetValue())
 
         // the user performed a search
@@ -741,13 +739,13 @@ class MetricControllerTest {
             "provider"
         )
 
-        assertFalse(BrowserSearch.inContent["provider"].testHasValue())
+        assertNull(BrowserSearch.inContent["provider"].testGetValue())
 
         controller.run {
             inContentSearchFact.process()
         }
 
-        assertTrue(BrowserSearch.inContent["provider"].testHasValue())
+        assertNotNull(BrowserSearch.inContent["provider"].testGetValue())
         assertEquals(1, BrowserSearch.inContent["provider"].testGetValue())
 
         // the user performed another search

--- a/app/src/test/java/org/mozilla/fenix/components/metrics/MetricsUtilsTestRobolectric.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/metrics/MetricsUtilsTestRobolectric.kt
@@ -10,8 +10,8 @@ import mozilla.components.browser.state.search.SearchEngine
 import mozilla.components.service.glean.testing.GleanTestRule
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -32,7 +32,7 @@ class MetricsUtilsTestRobolectric {
 
     @Test
     fun `given a CUSTOM engine, when the search source is a ACTION the proper labeled metric is recorded`() {
-        assertFalse(Metrics.searchCount["custom.action"].testHasValue())
+        assertNull(Metrics.searchCount["custom.action"].testGetValue())
 
         val engine: SearchEngine = mockk(relaxed = true)
 
@@ -45,12 +45,12 @@ class MetricsUtilsTestRobolectric {
             MetricsUtils.Source.ACTION
         )
 
-        assertTrue(Metrics.searchCount["custom.action"].testHasValue())
+        assertNotNull(Metrics.searchCount["custom.action"].testGetValue())
     }
 
     @Test
     fun `given a CUSTOM engine, when the search source is a SHORTCUT the proper labeled metric is recorded`() {
-        assertFalse(Metrics.searchCount["custom.shortcut"].testHasValue())
+        assertNull(Metrics.searchCount["custom.shortcut"].testGetValue())
 
         val engine: SearchEngine = mockk(relaxed = true)
 
@@ -63,12 +63,12 @@ class MetricsUtilsTestRobolectric {
             MetricsUtils.Source.SHORTCUT
         )
 
-        assertTrue(Metrics.searchCount["custom.shortcut"].testHasValue())
+        assertNotNull(Metrics.searchCount["custom.shortcut"].testGetValue())
     }
 
     @Test
     fun `given a CUSTOM engine, when the search source is a SUGGESTION the proper labeled metric is recorded`() {
-        assertFalse(Metrics.searchCount["custom.suggestion"].testHasValue())
+        assertNull(Metrics.searchCount["custom.suggestion"].testGetValue())
 
         val engine: SearchEngine = mockk(relaxed = true)
 
@@ -81,12 +81,12 @@ class MetricsUtilsTestRobolectric {
             MetricsUtils.Source.SUGGESTION
         )
 
-        assertTrue(Metrics.searchCount["custom.suggestion"].testHasValue())
+        assertNotNull(Metrics.searchCount["custom.suggestion"].testGetValue())
     }
 
     @Test
     fun `given a CUSTOM engine, when the search source is a TOPSITE the proper labeled metric is recorded`() {
-        assertFalse(Metrics.searchCount["custom.topsite"].testHasValue())
+        assertNull(Metrics.searchCount["custom.topsite"].testGetValue())
 
         val engine: SearchEngine = mockk(relaxed = true)
 
@@ -99,12 +99,12 @@ class MetricsUtilsTestRobolectric {
             MetricsUtils.Source.TOPSITE
         )
 
-        assertTrue(Metrics.searchCount["custom.topsite"].testHasValue())
+        assertNotNull(Metrics.searchCount["custom.topsite"].testGetValue())
     }
 
     @Test
     fun `given a CUSTOM engine, when the search source is a WIDGET the proper labeled metric is recorded`() {
-        assertFalse(Metrics.searchCount["custom.widget"].testHasValue())
+        assertNull(Metrics.searchCount["custom.widget"].testGetValue())
 
         val engine: SearchEngine = mockk(relaxed = true)
 
@@ -117,12 +117,12 @@ class MetricsUtilsTestRobolectric {
             MetricsUtils.Source.WIDGET
         )
 
-        assertTrue(Metrics.searchCount["custom.widget"].testHasValue())
+        assertNotNull(Metrics.searchCount["custom.widget"].testGetValue())
     }
 
     @Test
     fun `given a BUNDLED engine, when the search source is an ACTION the proper labeled metric is recorded`() {
-        assertFalse(Metrics.searchCount["$ENGINE_SOURCE_IDENTIFIER.action"].testHasValue())
+        assertNull(Metrics.searchCount["$ENGINE_SOURCE_IDENTIFIER.action"].testGetValue())
 
         val engine: SearchEngine = mockk(relaxed = true)
 
@@ -135,12 +135,12 @@ class MetricsUtilsTestRobolectric {
             MetricsUtils.Source.ACTION
         )
 
-        assertTrue(Metrics.searchCount["$ENGINE_SOURCE_IDENTIFIER.action"].testHasValue())
+        assertNotNull(Metrics.searchCount["$ENGINE_SOURCE_IDENTIFIER.action"].testGetValue())
     }
 
     @Test
     fun `given a BUNDLED engine, when the search source is a TOPSITE the proper labeled metric is recorded`() {
-        assertFalse(Metrics.searchCount["$ENGINE_SOURCE_IDENTIFIER.topsite"].testHasValue())
+        assertNull(Metrics.searchCount["$ENGINE_SOURCE_IDENTIFIER.topsite"].testGetValue())
 
         val engine: SearchEngine = mockk(relaxed = true)
 
@@ -153,12 +153,12 @@ class MetricsUtilsTestRobolectric {
             MetricsUtils.Source.TOPSITE
         )
 
-        assertTrue(Metrics.searchCount["$ENGINE_SOURCE_IDENTIFIER.topsite"].testHasValue())
+        assertNotNull(Metrics.searchCount["$ENGINE_SOURCE_IDENTIFIER.topsite"].testGetValue())
     }
 
     @Test
     fun `given a BUNDLED engine, when the search source is a SHORTCUT the proper labeled metric is recorded`() {
-        assertFalse(Metrics.searchCount["$ENGINE_SOURCE_IDENTIFIER.shortcut"].testHasValue())
+        assertNull(Metrics.searchCount["$ENGINE_SOURCE_IDENTIFIER.shortcut"].testGetValue())
 
         val engine: SearchEngine = mockk(relaxed = true)
 
@@ -171,12 +171,12 @@ class MetricsUtilsTestRobolectric {
             MetricsUtils.Source.SHORTCUT
         )
 
-        assertTrue(Metrics.searchCount["$ENGINE_SOURCE_IDENTIFIER.shortcut"].testHasValue())
+        assertNotNull(Metrics.searchCount["$ENGINE_SOURCE_IDENTIFIER.shortcut"].testGetValue())
     }
 
     @Test
     fun `given a BUNDLED engine, when the search source is a SUGGESTION the proper labeled metric is recorded`() {
-        assertFalse(Metrics.searchCount["$ENGINE_SOURCE_IDENTIFIER.suggestion"].testHasValue())
+        assertNull(Metrics.searchCount["$ENGINE_SOURCE_IDENTIFIER.suggestion"].testGetValue())
 
         val engine: SearchEngine = mockk(relaxed = true)
 
@@ -189,12 +189,12 @@ class MetricsUtilsTestRobolectric {
             MetricsUtils.Source.SUGGESTION
         )
 
-        assertTrue(Metrics.searchCount["$ENGINE_SOURCE_IDENTIFIER.suggestion"].testHasValue())
+        assertNotNull(Metrics.searchCount["$ENGINE_SOURCE_IDENTIFIER.suggestion"].testGetValue())
     }
 
     @Test
     fun `given a BUNDLED engine, when the search source is a WIDGET the proper labeled metric is recorded`() {
-        assertFalse(Metrics.searchCount["$ENGINE_SOURCE_IDENTIFIER.widget"].testHasValue())
+        assertNull(Metrics.searchCount["$ENGINE_SOURCE_IDENTIFIER.widget"].testGetValue())
 
         val engine: SearchEngine = mockk(relaxed = true)
 
@@ -207,12 +207,12 @@ class MetricsUtilsTestRobolectric {
             MetricsUtils.Source.WIDGET
         )
 
-        assertTrue(Metrics.searchCount["$ENGINE_SOURCE_IDENTIFIER.widget"].testHasValue())
+        assertNotNull(Metrics.searchCount["$ENGINE_SOURCE_IDENTIFIER.widget"].testGetValue())
     }
 
     @Test
     fun `given a DEFAULT engine, when the search source is a WIDGET the proper labeled metric is recorded`() {
-        assertFalse(Events.performedSearch.testHasValue())
+        assertNull(Events.performedSearch.testGetValue())
 
         val engine: SearchEngine = mockk(relaxed = true)
 
@@ -225,15 +225,15 @@ class MetricsUtilsTestRobolectric {
             MetricsUtils.Source.WIDGET
         )
 
-        assertTrue(Events.performedSearch.testHasValue())
-        val snapshot = Events.performedSearch.testGetValue()
+        assertNotNull(Events.performedSearch.testGetValue())
+        val snapshot = Events.performedSearch.testGetValue()!!
         assertEquals(1, snapshot.size)
         assertEquals("default.widget", snapshot.single().extra?.getValue("source"))
     }
 
     @Test
     fun `given a NON DEFAULT engine, when the search source is a WIDGET the proper labeled metric is recorded`() {
-        assertFalse(Events.performedSearch.testHasValue())
+        assertNull(Events.performedSearch.testGetValue())
 
         val engine: SearchEngine = mockk(relaxed = true)
 
@@ -246,8 +246,8 @@ class MetricsUtilsTestRobolectric {
             MetricsUtils.Source.WIDGET
         )
 
-        assertTrue(Events.performedSearch.testHasValue())
-        val snapshot = Events.performedSearch.testGetValue()
+        assertNotNull(Events.performedSearch.testGetValue())
+        val snapshot = Events.performedSearch.testGetValue()!!
         assertEquals(1, snapshot.size)
         assertEquals("shortcut.widget", snapshot.single().extra?.getValue("source"))
     }

--- a/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarControllerTest.kt
@@ -34,6 +34,7 @@ import mozilla.telemetry.glean.testing.GleanTestRule
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -209,31 +210,31 @@ class DefaultBrowserToolbarControllerTest {
     @Test
     fun `handle reader mode enabled`() {
         val controller = createController()
-        assertFalse(ReaderMode.opened.testHasValue())
+        assertNull(ReaderMode.opened.testGetValue())
 
         controller.handleReaderModePressed(enabled = true)
 
         verify { readerModeController.showReaderView() }
-        assertTrue(ReaderMode.opened.testHasValue())
-        assertNull(ReaderMode.opened.testGetValue().single().extra)
+        assertNotNull(ReaderMode.opened.testGetValue())
+        assertNull(ReaderMode.opened.testGetValue()!!.single().extra)
     }
 
     @Test
     fun `handle reader mode disabled`() {
         val controller = createController()
-        assertFalse(ReaderMode.closed.testHasValue())
+        assertNull(ReaderMode.closed.testGetValue())
 
         controller.handleReaderModePressed(enabled = false)
 
         verify { readerModeController.hideReaderView() }
-        assertTrue(ReaderMode.closed.testHasValue())
-        assertNull(ReaderMode.closed.testGetValue().single().extra)
+        assertNotNull(ReaderMode.closed.testGetValue())
+        assertNull(ReaderMode.closed.testGetValue()!!.single().extra)
     }
 
     @Test
     fun handleToolbarClick() {
         val controller = createController()
-        assertFalse(Events.searchBarTapped.testHasValue())
+        assertNull(Events.searchBarTapped.testGetValue())
 
         controller.handleToolbarClick()
 
@@ -242,8 +243,8 @@ class DefaultBrowserToolbarControllerTest {
             sessionId = "1"
         )
 
-        assertTrue(Events.searchBarTapped.testHasValue())
-        val snapshot = Events.searchBarTapped.testGetValue()
+        assertNotNull(Events.searchBarTapped.testGetValue())
+        val snapshot = Events.searchBarTapped.testGetValue()!!
         assertEquals(1, snapshot.size)
         assertEquals("BROWSER", snapshot.single().extra?.getValue("source"))
 
@@ -259,7 +260,7 @@ class DefaultBrowserToolbarControllerTest {
         val searchResultsTab = createTab("https://google.com?q=mozilla+website", searchTerms = "mozilla website")
         store.dispatch(TabListAction.AddTabAction(searchResultsTab, select = true)).joinBlocking()
 
-        assertFalse(Events.searchBarTapped.testHasValue())
+        assertNull(Events.searchBarTapped.testGetValue())
 
         val controller = createController()
         controller.handleToolbarClick()
@@ -269,8 +270,8 @@ class DefaultBrowserToolbarControllerTest {
             sessionId = searchResultsTab.id
         )
 
-        assertTrue(Events.searchBarTapped.testHasValue())
-        val snapshot = Events.searchBarTapped.testGetValue()
+        assertNotNull(Events.searchBarTapped.testGetValue())
+        val snapshot = Events.searchBarTapped.testGetValue()!!
         assertEquals(1, snapshot.size)
         assertEquals("BROWSER", snapshot.single().extra?.getValue("source"))
 
@@ -356,13 +357,13 @@ class DefaultBrowserToolbarControllerTest {
 
     @Test
     fun handleHomeButtonClick() {
-        assertFalse(Events.browserToolbarHomeTapped.testHasValue())
+        assertNull(Events.browserToolbarHomeTapped.testGetValue())
 
         val controller = createController()
         controller.handleHomeButtonClick()
 
         verify { navController.navigate(BrowserFragmentDirections.actionGlobalHome()) }
-        assertTrue(Events.browserToolbarHomeTapped.testHasValue())
+        assertNotNull(Events.browserToolbarHomeTapped.testGetValue())
     }
 
     private fun createController(

--- a/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarMenuControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarMenuControllerTest.kt
@@ -51,7 +51,6 @@ import mozilla.components.support.test.rule.MainCoroutineRule
 import mozilla.components.support.test.rule.runTestOnMain
 import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -172,12 +171,12 @@ class DefaultBrowserToolbarMenuControllerTest {
                 bookmarkTappedInvoked = true
             }
         )
-        assertFalse(Events.browserMenuAction.testHasValue())
+        assertNull(Events.browserMenuAction.testGetValue())
 
         controller.handleToolbarItemInteraction(item)
 
-        assertTrue(Events.browserMenuAction.testHasValue())
-        val snapshot = Events.browserMenuAction.testGetValue()
+        assertNotNull(Events.browserMenuAction.testGetValue())
+        val snapshot = Events.browserMenuAction.testGetValue()!!
         assertEquals(1, snapshot.size)
         assertEquals("bookmark", snapshot.single().extra?.getValue("item"))
 
@@ -206,12 +205,12 @@ class DefaultBrowserToolbarMenuControllerTest {
                 bookmarkTappedInvoked = true
             }
         )
-        assertFalse(Events.browserMenuAction.testHasValue())
+        assertNull(Events.browserMenuAction.testGetValue())
 
         controller.handleToolbarItemInteraction(item)
 
-        assertTrue(Events.browserMenuAction.testHasValue())
-        val snapshot = Events.browserMenuAction.testGetValue()
+        assertNotNull(Events.browserMenuAction.testGetValue())
+        val snapshot = Events.browserMenuAction.testGetValue()!!
         assertEquals(1, snapshot.size)
         assertEquals("bookmark", snapshot.single().extra?.getValue("item"))
 
@@ -242,15 +241,15 @@ class DefaultBrowserToolbarMenuControllerTest {
     @Test
     fun `WHEN reader mode menu item is pressed THEN handle appearance change`() = runTest {
         val item = ToolbarMenu.Item.CustomizeReaderView
-        assertFalse(ReaderMode.appearance.testHasValue())
+        assertNull(ReaderMode.appearance.testGetValue())
 
         val controller = createController(scope = this, store = browserStore)
 
         controller.handleToolbarItemInteraction(item)
 
         verify { readerModeController.showControls() }
-        assertTrue(ReaderMode.appearance.testHasValue())
-        assertNull(ReaderMode.appearance.testGetValue().single().extra)
+        assertNotNull(ReaderMode.appearance.testGetValue())
+        assertNull(ReaderMode.appearance.testGetValue()!!.single().extra)
     }
 
     @Test
@@ -270,12 +269,12 @@ class DefaultBrowserToolbarMenuControllerTest {
         val item = ToolbarMenu.Item.Back(false)
 
         val controller = createController(scope = this, store = browserStore)
-        assertFalse(Events.browserMenuAction.testHasValue())
+        assertNull(Events.browserMenuAction.testGetValue())
 
         controller.handleToolbarItemInteraction(item)
 
-        assertTrue(Events.browserMenuAction.testHasValue())
-        val snapshot = Events.browserMenuAction.testGetValue()
+        assertNotNull(Events.browserMenuAction.testGetValue())
+        val snapshot = Events.browserMenuAction.testGetValue()!!
         assertEquals(1, snapshot.size)
         assertEquals("back", snapshot.single().extra?.getValue("item"))
 
@@ -287,12 +286,12 @@ class DefaultBrowserToolbarMenuControllerTest {
         val item = ToolbarMenu.Item.Back(true)
 
         val controller = createController(scope = this, store = browserStore)
-        assertFalse(Events.browserMenuAction.testHasValue())
+        assertNull(Events.browserMenuAction.testGetValue())
 
         controller.handleToolbarItemInteraction(item)
 
-        assertTrue(Events.browserMenuAction.testHasValue())
-        val snapshot = Events.browserMenuAction.testGetValue()
+        assertNotNull(Events.browserMenuAction.testGetValue())
+        val snapshot = Events.browserMenuAction.testGetValue()!!
         assertEquals(1, snapshot.size)
         assertEquals("back", snapshot.single().extra?.getValue("item"))
         val directions = BrowserFragmentDirections.actionGlobalTabHistoryDialogFragment(null)
@@ -305,12 +304,12 @@ class DefaultBrowserToolbarMenuControllerTest {
         val item = ToolbarMenu.Item.Forward(false)
 
         val controller = createController(scope = this, store = browserStore)
-        assertFalse(Events.browserMenuAction.testHasValue())
+        assertNull(Events.browserMenuAction.testGetValue())
 
         controller.handleToolbarItemInteraction(item)
 
-        assertTrue(Events.browserMenuAction.testHasValue())
-        val snapshot = Events.browserMenuAction.testGetValue()
+        assertNotNull(Events.browserMenuAction.testGetValue())
+        val snapshot = Events.browserMenuAction.testGetValue()!!
         assertEquals(1, snapshot.size)
         assertEquals("forward", snapshot.single().extra?.getValue("item"))
 
@@ -322,12 +321,12 @@ class DefaultBrowserToolbarMenuControllerTest {
         val item = ToolbarMenu.Item.Forward(true)
 
         val controller = createController(scope = this, store = browserStore)
-        assertFalse(Events.browserMenuAction.testHasValue())
+        assertNull(Events.browserMenuAction.testGetValue())
 
         controller.handleToolbarItemInteraction(item)
 
-        assertTrue(Events.browserMenuAction.testHasValue())
-        val snapshot = Events.browserMenuAction.testGetValue()
+        assertNotNull(Events.browserMenuAction.testGetValue())
+        val snapshot = Events.browserMenuAction.testGetValue()!!
         assertEquals(1, snapshot.size)
         assertEquals("forward", snapshot.single().extra?.getValue("item"))
 
@@ -341,12 +340,12 @@ class DefaultBrowserToolbarMenuControllerTest {
         val item = ToolbarMenu.Item.Reload(false)
 
         val controller = createController(scope = this, store = browserStore)
-        assertFalse(Events.browserMenuAction.testHasValue())
+        assertNull(Events.browserMenuAction.testGetValue())
 
         controller.handleToolbarItemInteraction(item)
 
-        assertTrue(Events.browserMenuAction.testHasValue())
-        val snapshot = Events.browserMenuAction.testGetValue()
+        assertNotNull(Events.browserMenuAction.testGetValue())
+        val snapshot = Events.browserMenuAction.testGetValue()!!
         assertEquals(1, snapshot.size)
         assertEquals("reload", snapshot.single().extra?.getValue("item"))
 
@@ -358,12 +357,12 @@ class DefaultBrowserToolbarMenuControllerTest {
         val item = ToolbarMenu.Item.Reload(true)
 
         val controller = createController(scope = this, store = browserStore)
-        assertFalse(Events.browserMenuAction.testHasValue())
+        assertNull(Events.browserMenuAction.testGetValue())
 
         controller.handleToolbarItemInteraction(item)
 
-        assertTrue(Events.browserMenuAction.testHasValue())
-        val snapshot = Events.browserMenuAction.testGetValue()
+        assertNotNull(Events.browserMenuAction.testGetValue())
+        val snapshot = Events.browserMenuAction.testGetValue()!!
         assertEquals(1, snapshot.size)
         assertEquals("reload", snapshot.single().extra?.getValue("item"))
 
@@ -380,12 +379,12 @@ class DefaultBrowserToolbarMenuControllerTest {
         val item = ToolbarMenu.Item.Stop
 
         val controller = createController(scope = this, store = browserStore)
-        assertFalse(Events.browserMenuAction.testHasValue())
+        assertNull(Events.browserMenuAction.testGetValue())
 
         controller.handleToolbarItemInteraction(item)
 
-        assertTrue(Events.browserMenuAction.testHasValue())
-        val snapshot = Events.browserMenuAction.testGetValue()
+        assertNotNull(Events.browserMenuAction.testGetValue())
+        val snapshot = Events.browserMenuAction.testGetValue()!!
         assertEquals(1, snapshot.size)
         assertEquals("stop", snapshot.single().extra?.getValue("item"))
 
@@ -397,12 +396,12 @@ class DefaultBrowserToolbarMenuControllerTest {
         val item = ToolbarMenu.Item.Settings
 
         val controller = createController(scope = this, store = browserStore)
-        assertFalse(Events.browserMenuAction.testHasValue())
+        assertNull(Events.browserMenuAction.testGetValue())
 
         controller.handleToolbarItemInteraction(item)
 
-        assertTrue(Events.browserMenuAction.testHasValue())
-        val snapshot = Events.browserMenuAction.testGetValue()
+        assertNotNull(Events.browserMenuAction.testGetValue())
+        val snapshot = Events.browserMenuAction.testGetValue()!!
         assertEquals(1, snapshot.size)
         assertEquals("settings", snapshot.single().extra?.getValue("item"))
         val directions = BrowserFragmentDirections.actionBrowserFragmentToSettingsFragment()
@@ -415,12 +414,12 @@ class DefaultBrowserToolbarMenuControllerTest {
         val item = ToolbarMenu.Item.Bookmarks
 
         val controller = createController(scope = this, store = browserStore)
-        assertFalse(Events.browserMenuAction.testHasValue())
+        assertNull(Events.browserMenuAction.testGetValue())
 
         controller.handleToolbarItemInteraction(item)
 
-        assertTrue(Events.browserMenuAction.testHasValue())
-        val snapshot = Events.browserMenuAction.testGetValue()
+        assertNotNull(Events.browserMenuAction.testGetValue())
+        val snapshot = Events.browserMenuAction.testGetValue()!!
         assertEquals(1, snapshot.size)
         assertEquals("bookmarks", snapshot.single().extra?.getValue("item"))
         val directions = BrowserFragmentDirections.actionGlobalBookmarkFragment(BookmarkRoot.Mobile.id)
@@ -433,12 +432,12 @@ class DefaultBrowserToolbarMenuControllerTest {
         val item = ToolbarMenu.Item.History
 
         val controller = createController(scope = this, store = browserStore)
-        assertFalse(Events.browserMenuAction.testHasValue())
+        assertNull(Events.browserMenuAction.testGetValue())
 
         controller.handleToolbarItemInteraction(item)
 
-        assertTrue(Events.browserMenuAction.testHasValue())
-        val snapshot = Events.browserMenuAction.testGetValue()
+        assertNotNull(Events.browserMenuAction.testGetValue())
+        val snapshot = Events.browserMenuAction.testGetValue()!!
         assertEquals(1, snapshot.size)
         assertEquals("history", snapshot.single().extra?.getValue("item"))
         val directions = BrowserFragmentDirections.actionGlobalHistoryFragment()
@@ -455,12 +454,12 @@ class DefaultBrowserToolbarMenuControllerTest {
         every { sessionUseCases.requestDesktopSite } returns requestDesktopSiteUseCase
 
         val controller = createController(scope = this, store = browserStore)
-        assertFalse(Events.browserMenuAction.testHasValue())
+        assertNull(Events.browserMenuAction.testGetValue())
 
         controller.handleToolbarItemInteraction(item)
 
-        assertTrue(Events.browserMenuAction.testHasValue())
-        val snapshot = Events.browserMenuAction.testGetValue()
+        assertNotNull(Events.browserMenuAction.testGetValue())
+        val snapshot = Events.browserMenuAction.testGetValue()!!
         assertEquals(1, snapshot.size)
         assertEquals("desktop_view_on", snapshot.single().extra?.getValue("item"))
 
@@ -481,12 +480,12 @@ class DefaultBrowserToolbarMenuControllerTest {
         every { sessionUseCases.requestDesktopSite } returns requestDesktopSiteUseCase
 
         val controller = createController(scope = this, store = browserStore)
-        assertFalse(Events.browserMenuAction.testHasValue())
+        assertNull(Events.browserMenuAction.testGetValue())
 
         controller.handleToolbarItemInteraction(item)
 
-        assertTrue(Events.browserMenuAction.testHasValue())
-        val snapshot = Events.browserMenuAction.testGetValue()
+        assertNotNull(Events.browserMenuAction.testGetValue())
+        val snapshot = Events.browserMenuAction.testGetValue()!!
         assertEquals(1, snapshot.size)
         assertEquals("desktop_view_off", snapshot.single().extra?.getValue("item"))
 
@@ -509,12 +508,12 @@ class DefaultBrowserToolbarMenuControllerTest {
         } returns "Added to shortcuts!"
 
         val controller = createController(scope = this, store = browserStore)
-        assertFalse(Events.browserMenuAction.testHasValue())
+        assertNull(Events.browserMenuAction.testGetValue())
 
         controller.handleToolbarItemInteraction(item)
 
-        assertTrue(Events.browserMenuAction.testHasValue())
-        val snapshot = Events.browserMenuAction.testGetValue()
+        assertNotNull(Events.browserMenuAction.testGetValue())
+        val snapshot = Events.browserMenuAction.testGetValue()!!
         assertEquals(1, snapshot.size)
         assertEquals("add_to_top_sites", snapshot.single().extra?.getValue("item"))
 
@@ -537,12 +536,12 @@ class DefaultBrowserToolbarMenuControllerTest {
         } returns snackbarMessage
 
         val controller = createController(scope = this, store = browserStore)
-        assertFalse(Events.browserMenuAction.testHasValue())
+        assertNull(Events.browserMenuAction.testGetValue())
 
         controller.handleToolbarItemInteraction(item)
 
-        assertTrue(Events.browserMenuAction.testHasValue())
-        val snapshot = Events.browserMenuAction.testGetValue()
+        assertNotNull(Events.browserMenuAction.testGetValue())
+        val snapshot = Events.browserMenuAction.testGetValue()!!
         assertEquals(1, snapshot.size)
         assertEquals("remove_from_top_sites", snapshot.single().extra?.getValue("item"))
 
@@ -555,12 +554,12 @@ class DefaultBrowserToolbarMenuControllerTest {
         val item = ToolbarMenu.Item.AddonsManager
 
         val controller = createController(scope = this, store = browserStore)
-        assertFalse(Events.browserMenuAction.testHasValue())
+        assertNull(Events.browserMenuAction.testGetValue())
 
         controller.handleToolbarItemInteraction(item)
 
-        assertTrue(Events.browserMenuAction.testHasValue())
-        val snapshot = Events.browserMenuAction.testGetValue()
+        assertNotNull(Events.browserMenuAction.testGetValue())
+        val snapshot = Events.browserMenuAction.testGetValue()!!
         assertEquals(1, snapshot.size)
         assertEquals("addons_manager", snapshot.single().extra?.getValue("item"))
     }
@@ -570,12 +569,12 @@ class DefaultBrowserToolbarMenuControllerTest {
         val item = ToolbarMenu.Item.AddToHomeScreen
 
         val controller = createController(scope = this, store = browserStore)
-        assertFalse(Events.browserMenuAction.testHasValue())
+        assertNull(Events.browserMenuAction.testGetValue())
 
         controller.handleToolbarItemInteraction(item)
 
-        assertTrue(Events.browserMenuAction.testHasValue())
-        val snapshot = Events.browserMenuAction.testGetValue()
+        assertNotNull(Events.browserMenuAction.testGetValue())
+        val snapshot = Events.browserMenuAction.testGetValue()!!
         assertEquals(1, snapshot.size)
         assertEquals("add_to_homescreen", snapshot.single().extra?.getValue("item"))
     }
@@ -592,12 +591,12 @@ class DefaultBrowserToolbarMenuControllerTest {
         )
         browserStore = BrowserStore(BrowserState(tabs = listOf(regularTab), selectedTabId = regularTab.id))
         val controller = createController(scope = this, store = browserStore)
-        assertFalse(Events.browserMenuAction.testHasValue())
+        assertNull(Events.browserMenuAction.testGetValue())
 
         controller.handleToolbarItemInteraction(item)
 
-        assertTrue(Events.browserMenuAction.testHasValue())
-        val snapshot = Events.browserMenuAction.testGetValue()
+        assertNotNull(Events.browserMenuAction.testGetValue())
+        val snapshot = Events.browserMenuAction.testGetValue()!!
         assertEquals(1, snapshot.size)
         assertEquals("share", snapshot.single().extra?.getValue("item"))
 
@@ -625,12 +624,12 @@ class DefaultBrowserToolbarMenuControllerTest {
         )
         browserStore = BrowserStore(BrowserState(tabs = listOf(readerTab), selectedTabId = readerTab.id))
         val controller = createController(scope = this, store = browserStore)
-        assertFalse(Events.browserMenuAction.testHasValue())
+        assertNull(Events.browserMenuAction.testGetValue())
 
         controller.handleToolbarItemInteraction(item)
 
-        assertTrue(Events.browserMenuAction.testHasValue())
-        val snapshot = Events.browserMenuAction.testGetValue()
+        assertNotNull(Events.browserMenuAction.testGetValue())
+        val snapshot = Events.browserMenuAction.testGetValue()!!
         assertEquals(1, snapshot.size)
         assertEquals("share", snapshot.single().extra?.getValue("item"))
 
@@ -669,17 +668,17 @@ class DefaultBrowserToolbarMenuControllerTest {
         every { tabCollectionStorage.cachedTabCollections } returns cachedTabCollections
 
         val controller = createController(scope = this, store = browserStore)
-        assertFalse(Events.browserMenuAction.testHasValue())
+        assertNull(Events.browserMenuAction.testGetValue())
 
         controller.handleToolbarItemInteraction(item)
 
-        assertTrue(Events.browserMenuAction.testHasValue())
-        val snapshot = Events.browserMenuAction.testGetValue()
+        assertNotNull(Events.browserMenuAction.testGetValue())
+        val snapshot = Events.browserMenuAction.testGetValue()!!
         assertEquals(1, snapshot.size)
         assertEquals("save_to_collection", snapshot.single().extra?.getValue("item"))
 
-        assertTrue(Collections.saveButton.testHasValue())
-        val recordedEvents = Collections.saveButton.testGetValue()
+        assertNotNull(Collections.saveButton.testGetValue())
+        val recordedEvents = Collections.saveButton.testGetValue()!!
         assertEquals(1, recordedEvents.size)
         val eventExtra = recordedEvents.single().extra
         assertNotNull(eventExtra)
@@ -704,17 +703,17 @@ class DefaultBrowserToolbarMenuControllerTest {
         every { tabCollectionStorage.cachedTabCollections } returns cachedTabCollectionsEmpty
 
         val controller = createController(scope = this, store = browserStore)
-        assertFalse(Events.browserMenuAction.testHasValue())
+        assertNull(Events.browserMenuAction.testGetValue())
 
         controller.handleToolbarItemInteraction(item)
 
-        assertTrue(Events.browserMenuAction.testHasValue())
-        val snapshot = Events.browserMenuAction.testGetValue()
+        assertNotNull(Events.browserMenuAction.testGetValue())
+        val snapshot = Events.browserMenuAction.testGetValue()!!
         assertEquals(1, snapshot.size)
         assertEquals("save_to_collection", snapshot.single().extra?.getValue("item"))
 
-        assertTrue(Collections.saveButton.testHasValue())
-        val recordedEvents = Collections.saveButton.testGetValue()
+        assertNotNull(Collections.saveButton.testGetValue())
+        val recordedEvents = Collections.saveButton.testGetValue()!!
         assertEquals(1, recordedEvents.size)
         val eventExtra = recordedEvents.single().extra
         assertNotNull(eventExtra)
@@ -794,11 +793,11 @@ class DefaultBrowserToolbarMenuControllerTest {
             bookmarkTapped = { _, _ -> }
         )
 
-        assertFalse(ExperimentsDefaultBrowser.toolbarMenuClicked.testHasValue())
+        assertNull(ExperimentsDefaultBrowser.toolbarMenuClicked.testGetValue())
 
         controller.handleToolbarItemInteraction(item)
 
-        assertTrue(ExperimentsDefaultBrowser.toolbarMenuClicked.testHasValue())
+        assertNotNull(ExperimentsDefaultBrowser.toolbarMenuClicked.testGetValue())
     }
 
     @Suppress("LongParameterList")

--- a/app/src/test/java/org/mozilla/fenix/gleanplumb/DefaultMessageControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/gleanplumb/DefaultMessageControllerTest.kt
@@ -12,8 +12,8 @@ import io.mockk.verify
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.telemetry.glean.testing.GleanTestRule
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -54,12 +54,12 @@ class DefaultMessageControllerTest {
         val message = mockMessage()
         every { customController.handleAction(any()) } returns mockk()
         every { storageNimbus.getMessageAction(message) } returns Pair("uuid", message.id)
-        assertFalse(Messaging.messageClicked.testHasValue())
+        assertNull(Messaging.messageClicked.testGetValue())
 
         customController.onMessagePressed(message)
 
-        assertTrue(Messaging.messageClicked.testHasValue())
-        val event = Messaging.messageClicked.testGetValue()
+        assertNotNull(Messaging.messageClicked.testGetValue())
+        val event = Messaging.messageClicked.testGetValue()!!
         assertEquals(1, event.size)
         assertEquals(message.id, event.single().extra!!["message_key"])
         assertEquals("uuid", event.single().extra!!["action_uuid"])
@@ -92,12 +92,12 @@ class DefaultMessageControllerTest {
     @Test
     fun `WHEN calling onMessageDismissed THEN report to the messageManager`() {
         val message = mockMessage()
-        assertFalse(Messaging.messageDismissed.testHasValue())
+        assertNull(Messaging.messageDismissed.testGetValue())
 
         controller.onMessageDismissed(message)
 
-        assertTrue(Messaging.messageDismissed.testHasValue())
-        val event = Messaging.messageDismissed.testGetValue()
+        assertNotNull(Messaging.messageDismissed.testGetValue())
+        val event = Messaging.messageDismissed.testGetValue()!!
         assertEquals(1, event.size)
         assertEquals(message.id, event.single().extra!!["message_key"])
         verify { store.dispatch(AppAction.MessagingAction.MessageDismissed(message)) }
@@ -107,18 +107,18 @@ class DefaultMessageControllerTest {
     fun `WHEN calling onMessageDisplayed THEN report to the messageManager`() {
         val data = MessageData()
         val message = mockMessage(data)
-        assertFalse(Messaging.messageExpired.testHasValue())
-        assertFalse(Messaging.messageShown.testHasValue())
+        assertNull(Messaging.messageExpired.testGetValue())
+        assertNull(Messaging.messageShown.testGetValue())
 
         controller.onMessageDisplayed(message)
 
-        assertTrue(Messaging.messageExpired.testHasValue())
-        val messageExpiredEvent = Messaging.messageExpired.testGetValue()
+        assertNotNull(Messaging.messageExpired.testGetValue())
+        val messageExpiredEvent = Messaging.messageExpired.testGetValue()!!
         assertEquals(1, messageExpiredEvent.size)
         assertEquals(message.id, messageExpiredEvent.single().extra!!["message_key"])
 
-        assertTrue(Messaging.messageShown.testHasValue())
-        val event = Messaging.messageShown.testGetValue()
+        assertNotNull(Messaging.messageShown.testGetValue())
+        val event = Messaging.messageShown.testGetValue()!!
         assertEquals(1, event.size)
         assertEquals(message.id, event.single().extra!!["message_key"])
 

--- a/app/src/test/java/org/mozilla/fenix/home/DefaultSessionControlControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/DefaultSessionControlControllerTest.kt
@@ -38,6 +38,7 @@ import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.rule.MainCoroutineRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -159,8 +160,8 @@ class DefaultSessionControlControllerTest {
         }
         createController().handleCollectionAddTabTapped(collection)
 
-        assertTrue(Collections.addTabButton.testHasValue())
-        val recordedEvents = Collections.addTabButton.testGetValue()
+        assertNotNull(Collections.addTabButton.testGetValue())
+        val recordedEvents = Collections.addTabButton.testGetValue()!!
         assertEquals(1, recordedEvents.size)
         assertEquals(null, recordedEvents.single().extra)
 
@@ -176,11 +177,11 @@ class DefaultSessionControlControllerTest {
 
     @Test
     fun handleCustomizeHomeTapped() {
-        assertFalse(HomeScreen.customizeHomeClicked.testHasValue())
+        assertNull(HomeScreen.customizeHomeClicked.testGetValue())
 
         createController().handleCustomizeHomeTapped()
 
-        assertTrue(HomeScreen.customizeHomeClicked.testHasValue())
+        assertNotNull(HomeScreen.customizeHomeClicked.testGetValue())
         verify {
             navController.navigate(
                 match<NavDirections> {
@@ -214,8 +215,8 @@ class DefaultSessionControlControllerTest {
         }
         createController().handleCollectionOpenTabClicked(tab)
 
-        assertTrue(Collections.tabRestored.testHasValue())
-        val recordedEvents = Collections.tabRestored.testGetValue()
+        assertNotNull(Collections.tabRestored.testGetValue())
+        val recordedEvents = Collections.tabRestored.testGetValue()!!
         assertEquals(1, recordedEvents.size)
         assertEquals(null, recordedEvents.single().extra)
 
@@ -256,8 +257,8 @@ class DefaultSessionControlControllerTest {
 
         createController().handleCollectionOpenTabClicked(tab)
 
-        assertTrue(Collections.tabRestored.testHasValue())
-        val recordedEvents = Collections.tabRestored.testGetValue()
+        assertNotNull(Collections.tabRestored.testGetValue())
+        val recordedEvents = Collections.tabRestored.testGetValue()!!
         assertEquals(1, recordedEvents.size)
         assertEquals(null, recordedEvents.single().extra)
 
@@ -291,8 +292,8 @@ class DefaultSessionControlControllerTest {
 
         createController().handleCollectionOpenTabClicked(tab)
 
-        assertTrue(Collections.tabRestored.testHasValue())
-        val recordedEvents = Collections.tabRestored.testGetValue()
+        assertNotNull(Collections.tabRestored.testGetValue())
+        val recordedEvents = Collections.tabRestored.testGetValue()!!
         assertEquals(1, recordedEvents.size)
         assertEquals(null, recordedEvents.single().extra)
 
@@ -308,8 +309,8 @@ class DefaultSessionControlControllerTest {
         }
         createController().handleCollectionOpenTabsTapped(collection)
 
-        assertTrue(Collections.allTabsRestored.testHasValue())
-        val recordedEvents = Collections.allTabsRestored.testGetValue()
+        assertNotNull(Collections.allTabsRestored.testGetValue())
+        val recordedEvents = Collections.allTabsRestored.testGetValue()!!
         assertEquals(1, recordedEvents.size)
         assertEquals(null, recordedEvents.single().extra)
     }
@@ -339,8 +340,8 @@ class DefaultSessionControlControllerTest {
             }
         ).handleCollectionRemoveTab(expectedCollection, tab, false)
 
-        assertTrue(Collections.tabRemoved.testHasValue())
-        val recordedEvents = Collections.tabRemoved.testGetValue()
+        assertNotNull(Collections.tabRemoved.testGetValue())
+        val recordedEvents = Collections.tabRemoved.testGetValue()!!
         assertEquals(1, recordedEvents.size)
         assertEquals(null, recordedEvents.single().extra)
 
@@ -353,8 +354,8 @@ class DefaultSessionControlControllerTest {
         val tab: ComponentTab = mockk(relaxed = true)
         createController().handleCollectionRemoveTab(collection, tab, false)
 
-        assertTrue(Collections.tabRemoved.testHasValue())
-        val recordedEvents = Collections.tabRemoved.testGetValue()
+        assertNotNull(Collections.tabRemoved.testGetValue())
+        val recordedEvents = Collections.tabRemoved.testGetValue()!!
         assertEquals(1, recordedEvents.size)
         assertEquals(null, recordedEvents.single().extra)
     }
@@ -367,8 +368,8 @@ class DefaultSessionControlControllerTest {
         }
         createController().handleCollectionShareTabsClicked(collection)
 
-        assertTrue(Collections.shared.testHasValue())
-        val recordedEvents = Collections.shared.testGetValue()
+        assertNotNull(Collections.shared.testGetValue())
+        val recordedEvents = Collections.shared.testGetValue()!!
         assertEquals(1, recordedEvents.size)
         assertEquals(null, recordedEvents.single().extra)
 
@@ -398,8 +399,8 @@ class DefaultSessionControlControllerTest {
         ).handleDeleteCollectionTapped(expectedCollection)
 
         assertEquals(expectedCollection, actualCollection)
-        assertTrue(Collections.removed.testHasValue())
-        val recordedEvents = Collections.removed.testGetValue()
+        assertNotNull(Collections.removed.testGetValue())
+        val recordedEvents = Collections.removed.testGetValue()!!
         assertEquals(1, recordedEvents.size)
         assertEquals(null, recordedEvents.single().extra)
     }
@@ -424,8 +425,8 @@ class DefaultSessionControlControllerTest {
         }
         createController().handleRenameCollectionTapped(collection)
 
-        assertTrue(Collections.renameButton.testHasValue())
-        val recordedEvents = Collections.renameButton.testGetValue()
+        assertNotNull(Collections.renameButton.testGetValue())
+        val recordedEvents = Collections.renameButton.testGetValue()!!
         assertEquals(1, recordedEvents.size)
         assertEquals(null, recordedEvents.single().extra)
 
@@ -451,13 +452,13 @@ class DefaultSessionControlControllerTest {
 
         controller.handleSelectTopSite(topSite, position = 0)
 
-        assertTrue(TopSites.openInNewTab.testHasValue())
-        assertEquals(1, TopSites.openInNewTab.testGetValue().size)
-        assertNull(TopSites.openInNewTab.testGetValue().single().extra)
+        assertNotNull(TopSites.openInNewTab.testGetValue())
+        assertEquals(1, TopSites.openInNewTab.testGetValue()!!.size)
+        assertNull(TopSites.openInNewTab.testGetValue()!!.single().extra)
 
-        assertTrue(TopSites.openDefault.testHasValue())
-        assertEquals(1, TopSites.openDefault.testGetValue().size)
-        assertNull(TopSites.openDefault.testGetValue().single().extra)
+        assertNotNull(TopSites.openDefault.testGetValue())
+        assertEquals(1, TopSites.openDefault.testGetValue()!!.size)
+        assertNull(TopSites.openDefault.testGetValue()!!.single().extra)
 
         verify {
             tabsUseCases.addTab.invoke(
@@ -483,9 +484,9 @@ class DefaultSessionControlControllerTest {
 
         controller.handleSelectTopSite(topSite, position = 0)
 
-        assertTrue(TopSites.openInNewTab.testHasValue())
-        assertEquals(1, TopSites.openInNewTab.testGetValue().size)
-        assertNull(TopSites.openInNewTab.testGetValue().single().extra)
+        assertNotNull(TopSites.openInNewTab.testGetValue())
+        assertEquals(1, TopSites.openInNewTab.testGetValue()!!.size)
+        assertNull(TopSites.openInNewTab.testGetValue()!!.single().extra)
 
         verify {
             tabsUseCases.addTab.invoke(
@@ -513,17 +514,17 @@ class DefaultSessionControlControllerTest {
 
         controller.handleSelectTopSite(topSite, position = 0)
 
-        assertTrue(TopSites.openInNewTab.testHasValue())
-        assertEquals(1, TopSites.openInNewTab.testGetValue().size)
-        assertNull(TopSites.openInNewTab.testGetValue().single().extra)
+        assertNotNull(TopSites.openInNewTab.testGetValue())
+        assertEquals(1, TopSites.openInNewTab.testGetValue()!!.size)
+        assertNull(TopSites.openInNewTab.testGetValue()!!.single().extra)
 
-        assertTrue(TopSites.openDefault.testHasValue())
-        assertEquals(1, TopSites.openDefault.testGetValue().size)
-        assertNull(TopSites.openDefault.testGetValue().single().extra)
+        assertNotNull(TopSites.openDefault.testGetValue())
+        assertEquals(1, TopSites.openDefault.testGetValue()!!.size)
+        assertNull(TopSites.openDefault.testGetValue()!!.single().extra)
 
-        assertTrue(TopSites.openGoogleSearchAttribution.testHasValue())
-        assertEquals(1, TopSites.openGoogleSearchAttribution.testGetValue().size)
-        assertNull(TopSites.openGoogleSearchAttribution.testGetValue().single().extra)
+        assertNotNull(TopSites.openGoogleSearchAttribution.testGetValue())
+        assertEquals(1, TopSites.openGoogleSearchAttribution.testGetValue()!!.size)
+        assertNull(TopSites.openGoogleSearchAttribution.testGetValue()!!.single().extra)
 
         verify {
             tabsUseCases.addTab.invoke(
@@ -551,17 +552,17 @@ class DefaultSessionControlControllerTest {
 
         controller.handleSelectTopSite(topSite, position = 0)
 
-        assertTrue(TopSites.openInNewTab.testHasValue())
-        assertEquals(1, TopSites.openInNewTab.testGetValue().size)
-        assertNull(TopSites.openInNewTab.testGetValue().single().extra)
+        assertNotNull(TopSites.openInNewTab.testGetValue())
+        assertEquals(1, TopSites.openInNewTab.testGetValue()!!.size)
+        assertNull(TopSites.openInNewTab.testGetValue()!!.single().extra)
 
-        assertTrue(TopSites.openDefault.testHasValue())
-        assertEquals(1, TopSites.openDefault.testGetValue().size)
-        assertNull(TopSites.openDefault.testGetValue().single().extra)
+        assertNotNull(TopSites.openDefault.testGetValue())
+        assertEquals(1, TopSites.openDefault.testGetValue()!!.size)
+        assertNull(TopSites.openDefault.testGetValue()!!.single().extra)
 
-        assertTrue(TopSites.openGoogleSearchAttribution.testHasValue())
-        assertEquals(1, TopSites.openGoogleSearchAttribution.testGetValue().size)
-        assertNull(TopSites.openGoogleSearchAttribution.testGetValue().single().extra)
+        assertNotNull(TopSites.openGoogleSearchAttribution.testGetValue())
+        assertEquals(1, TopSites.openGoogleSearchAttribution.testGetValue()!!.size)
+        assertNull(TopSites.openGoogleSearchAttribution.testGetValue()!!.single().extra)
 
         verify {
             tabsUseCases.addTab.invoke(
@@ -575,7 +576,7 @@ class DefaultSessionControlControllerTest {
 
     @Test
     fun handleSelectGoogleDefaultTopSite_EventPerformedSearchTopSite() {
-        assertFalse(Events.performedSearch.testHasValue())
+        assertNull(Events.performedSearch.testGetValue())
 
         val topSite = TopSite.Default(
             id = 1L,
@@ -594,15 +595,15 @@ class DefaultSessionControlControllerTest {
 
             controller.handleSelectTopSite(topSite, position = 0)
 
-            assertTrue(Events.performedSearch.testHasValue())
+            assertNotNull(Events.performedSearch.testGetValue())
 
-            assertTrue(TopSites.openDefault.testHasValue())
-            assertEquals(1, TopSites.openDefault.testGetValue().size)
-            assertNull(TopSites.openDefault.testGetValue().single().extra)
+            assertNotNull(TopSites.openDefault.testGetValue())
+            assertEquals(1, TopSites.openDefault.testGetValue()!!.size)
+            assertNull(TopSites.openDefault.testGetValue()!!.single().extra)
 
-            assertTrue(TopSites.openGoogleSearchAttribution.testHasValue())
-            assertEquals(1, TopSites.openGoogleSearchAttribution.testGetValue().size)
-            assertNull(TopSites.openGoogleSearchAttribution.testGetValue().single().extra)
+            assertNotNull(TopSites.openGoogleSearchAttribution.testGetValue())
+            assertEquals(1, TopSites.openGoogleSearchAttribution.testGetValue()!!.size)
+            assertNull(TopSites.openGoogleSearchAttribution.testGetValue()!!.single().extra)
         } finally {
             unmockkStatic("mozilla.components.browser.state.state.SearchStateKt")
         }
@@ -610,7 +611,7 @@ class DefaultSessionControlControllerTest {
 
     @Test
     fun handleSelectDuckDuckGoTopSite_EventPerformedSearchTopSite() {
-        assertFalse(Events.performedSearch.testHasValue())
+        assertNull(Events.performedSearch.testGetValue())
 
         val topSite = TopSite.Pinned(
             id = 1L,
@@ -629,7 +630,7 @@ class DefaultSessionControlControllerTest {
 
             controller.handleSelectTopSite(topSite, position = 0)
 
-            assertTrue(Events.performedSearch.testHasValue())
+            assertNotNull(Events.performedSearch.testGetValue())
         } finally {
             unmockkStatic("mozilla.components.browser.state.state.SearchStateKt")
         }
@@ -651,17 +652,17 @@ class DefaultSessionControlControllerTest {
 
         controller.handleSelectTopSite(topSite, position = 0)
 
-        assertTrue(TopSites.openInNewTab.testHasValue())
-        assertEquals(1, TopSites.openInNewTab.testGetValue().size)
-        assertNull(TopSites.openInNewTab.testGetValue().single().extra)
+        assertNotNull(TopSites.openInNewTab.testGetValue())
+        assertEquals(1, TopSites.openInNewTab.testGetValue()!!.size)
+        assertNull(TopSites.openInNewTab.testGetValue()!!.single().extra)
 
-        assertTrue(TopSites.openPinned.testHasValue())
-        assertEquals(1, TopSites.openPinned.testGetValue().size)
-        assertNull(TopSites.openPinned.testGetValue().single().extra)
+        assertNotNull(TopSites.openPinned.testGetValue())
+        assertEquals(1, TopSites.openPinned.testGetValue()!!.size)
+        assertNull(TopSites.openPinned.testGetValue()!!.single().extra)
 
-        assertTrue(TopSites.openGoogleSearchAttribution.testHasValue())
-        assertEquals(1, TopSites.openGoogleSearchAttribution.testGetValue().size)
-        assertNull(TopSites.openGoogleSearchAttribution.testGetValue().single().extra)
+        assertNotNull(TopSites.openGoogleSearchAttribution.testGetValue())
+        assertEquals(1, TopSites.openGoogleSearchAttribution.testGetValue()!!.size)
+        assertNull(TopSites.openGoogleSearchAttribution.testGetValue()!!.single().extra)
 
         verify {
             tabsUseCases.addTab.invoke(
@@ -689,17 +690,17 @@ class DefaultSessionControlControllerTest {
 
         controller.handleSelectTopSite(topSite, position = 0)
 
-        assertTrue(TopSites.openInNewTab.testHasValue())
-        assertEquals(1, TopSites.openInNewTab.testGetValue().size)
-        assertNull(TopSites.openInNewTab.testGetValue().single().extra)
+        assertNotNull(TopSites.openInNewTab.testGetValue())
+        assertEquals(1, TopSites.openInNewTab.testGetValue()!!.size)
+        assertNull(TopSites.openInNewTab.testGetValue()!!.single().extra)
 
-        assertTrue(TopSites.openPinned.testHasValue())
-        assertEquals(1, TopSites.openPinned.testGetValue().size)
-        assertNull(TopSites.openPinned.testGetValue().single().extra)
+        assertNotNull(TopSites.openPinned.testGetValue())
+        assertEquals(1, TopSites.openPinned.testGetValue()!!.size)
+        assertNull(TopSites.openPinned.testGetValue()!!.single().extra)
 
-        assertTrue(TopSites.openGoogleSearchAttribution.testHasValue())
-        assertEquals(1, TopSites.openGoogleSearchAttribution.testGetValue().size)
-        assertNull(TopSites.openGoogleSearchAttribution.testGetValue().single().extra)
+        assertNotNull(TopSites.openGoogleSearchAttribution.testGetValue())
+        assertEquals(1, TopSites.openGoogleSearchAttribution.testGetValue()!!.size)
+        assertNull(TopSites.openGoogleSearchAttribution.testGetValue()!!.single().extra)
 
         verify {
             tabsUseCases.addTab.invoke(
@@ -727,17 +728,17 @@ class DefaultSessionControlControllerTest {
 
         controller.handleSelectTopSite(topSite, position = 0)
 
-        assertTrue(TopSites.openInNewTab.testHasValue())
-        assertEquals(1, TopSites.openInNewTab.testGetValue().size)
-        assertNull(TopSites.openInNewTab.testGetValue().single().extra)
+        assertNotNull(TopSites.openInNewTab.testGetValue())
+        assertEquals(1, TopSites.openInNewTab.testGetValue()!!.size)
+        assertNull(TopSites.openInNewTab.testGetValue()!!.single().extra)
 
-        assertTrue(TopSites.openFrecency.testHasValue())
-        assertEquals(1, TopSites.openFrecency.testGetValue().size)
-        assertNull(TopSites.openFrecency.testGetValue().single().extra)
+        assertNotNull(TopSites.openFrecency.testGetValue())
+        assertEquals(1, TopSites.openFrecency.testGetValue()!!.size)
+        assertNull(TopSites.openFrecency.testGetValue()!!.single().extra)
 
-        assertTrue(TopSites.openGoogleSearchAttribution.testHasValue())
-        assertEquals(1, TopSites.openGoogleSearchAttribution.testGetValue().size)
-        assertNull(TopSites.openGoogleSearchAttribution.testGetValue().single().extra)
+        assertNotNull(TopSites.openGoogleSearchAttribution.testGetValue())
+        assertEquals(1, TopSites.openGoogleSearchAttribution.testGetValue()!!.size)
+        assertNull(TopSites.openGoogleSearchAttribution.testGetValue()!!.single().extra)
 
         verify {
             tabsUseCases.addTab.invoke(
@@ -765,17 +766,17 @@ class DefaultSessionControlControllerTest {
 
         controller.handleSelectTopSite(topSite, position = 0)
 
-        assertTrue(TopSites.openInNewTab.testHasValue())
-        assertEquals(1, TopSites.openInNewTab.testGetValue().size)
-        assertNull(TopSites.openInNewTab.testGetValue().single().extra)
+        assertNotNull(TopSites.openInNewTab.testGetValue())
+        assertEquals(1, TopSites.openInNewTab.testGetValue()!!.size)
+        assertNull(TopSites.openInNewTab.testGetValue()!!.single().extra)
 
-        assertTrue(TopSites.openFrecency.testHasValue())
-        assertEquals(1, TopSites.openFrecency.testGetValue().size)
-        assertNull(TopSites.openFrecency.testGetValue().single().extra)
+        assertNotNull(TopSites.openFrecency.testGetValue())
+        assertEquals(1, TopSites.openFrecency.testGetValue()!!.size)
+        assertNull(TopSites.openFrecency.testGetValue()!!.single().extra)
 
-        assertTrue(TopSites.openGoogleSearchAttribution.testHasValue())
-        assertEquals(1, TopSites.openGoogleSearchAttribution.testGetValue().size)
-        assertNull(TopSites.openGoogleSearchAttribution.testGetValue().single().extra)
+        assertNotNull(TopSites.openGoogleSearchAttribution.testGetValue())
+        assertEquals(1, TopSites.openGoogleSearchAttribution.testGetValue()!!.size)
+        assertNull(TopSites.openGoogleSearchAttribution.testGetValue()!!.single().extra)
 
         verify {
             tabsUseCases.addTab.invoke(
@@ -805,13 +806,13 @@ class DefaultSessionControlControllerTest {
 
         controller.handleSelectTopSite(topSite, position)
 
-        assertTrue(TopSites.openInNewTab.testHasValue())
-        assertEquals(1, TopSites.openInNewTab.testGetValue().size)
-        assertNull(TopSites.openInNewTab.testGetValue().single().extra)
+        assertNotNull(TopSites.openInNewTab.testGetValue())
+        assertEquals(1, TopSites.openInNewTab.testGetValue()!!.size)
+        assertNull(TopSites.openInNewTab.testGetValue()!!.single().extra)
 
-        assertTrue(TopSites.openContileTopSite.testHasValue())
-        assertEquals(1, TopSites.openContileTopSite.testGetValue().size)
-        assertNull(TopSites.openContileTopSite.testGetValue().single().extra)
+        assertNotNull(TopSites.openContileTopSite.testGetValue())
+        assertEquals(1, TopSites.openContileTopSite.testGetValue()!!.size)
+        assertNull(TopSites.openContileTopSite.testGetValue()!!.single().extra)
 
         verify {
             tabsUseCases.addTab.invoke(
@@ -837,17 +838,17 @@ class DefaultSessionControlControllerTest {
             createdAt = 3
         )
         val position = 0
-        assertFalse(TopSites.contileImpression.testHasValue())
+        assertNull(TopSites.contileImpression.testGetValue())
 
         var topSiteImpressionPinged = false
         Pings.topsitesImpression.testBeforeNextSubmit {
-            assertTrue(TopSites.contileTileId.testHasValue())
-            assertEquals(3, TopSites.contileTileId.testGetValue())
+            assertNotNull(TopSites.contileTileId.testGetValue())
+            assertEquals(3L, TopSites.contileTileId.testGetValue())
 
-            assertTrue(TopSites.contileAdvertiser.testHasValue())
+            assertNotNull(TopSites.contileAdvertiser.testGetValue())
             assertEquals("mozilla", TopSites.contileAdvertiser.testGetValue())
 
-            assertTrue(TopSites.contileReportingUrl.testHasValue())
+            assertNotNull(TopSites.contileReportingUrl.testGetValue())
             assertEquals(topSite.clickUrl, TopSites.contileReportingUrl.testGetValue())
 
             topSiteImpressionPinged = true
@@ -855,9 +856,9 @@ class DefaultSessionControlControllerTest {
 
         controller.submitTopSitesImpressionPing(topSite, position)
 
-        assertTrue(TopSites.contileClick.testHasValue())
+        assertNotNull(TopSites.contileClick.testGetValue())
 
-        val event = TopSites.contileClick.testGetValue()
+        val event = TopSites.contileClick.testGetValue()!!
 
         assertEquals(1, event.size)
         assertEquals("top_sites", event[0].category)
@@ -877,18 +878,18 @@ class DefaultSessionControlControllerTest {
             url = SupportUtils.GOOGLE_URL,
             createdAt = 0
         )
-        assertFalse(TopSites.remove.testHasValue())
-        assertFalse(TopSites.googleTopSiteRemoved.testHasValue())
+        assertNull(TopSites.remove.testGetValue())
+        assertNull(TopSites.googleTopSiteRemoved.testGetValue())
 
         controller.handleRemoveTopSiteClicked(topSite)
 
-        assertTrue(TopSites.googleTopSiteRemoved.testHasValue())
-        assertEquals(1, TopSites.googleTopSiteRemoved.testGetValue().size)
-        assertNull(TopSites.googleTopSiteRemoved.testGetValue().single().extra)
+        assertNotNull(TopSites.googleTopSiteRemoved.testGetValue())
+        assertEquals(1, TopSites.googleTopSiteRemoved.testGetValue()!!.size)
+        assertNull(TopSites.googleTopSiteRemoved.testGetValue()!!.single().extra)
 
-        assertTrue(TopSites.remove.testHasValue())
-        assertEquals(1, TopSites.remove.testGetValue().size)
-        assertNull(TopSites.remove.testGetValue().single().extra)
+        assertNotNull(TopSites.remove.testGetValue())
+        assertEquals(1, TopSites.remove.testGetValue()!!.size)
+        assertNull(TopSites.remove.testGetValue()!!.single().extra)
     }
 
     @Test
@@ -932,8 +933,8 @@ class DefaultSessionControlControllerTest {
 
     @Test
     fun handlePasteAndGo() {
-        assertFalse(Events.enteredUrl.testHasValue())
-        assertFalse(Events.performedSearch.testHasValue())
+        assertNull(Events.enteredUrl.testGetValue())
+        assertNull(Events.performedSearch.testGetValue())
 
         createController().handlePasteAndGo("text")
 
@@ -946,7 +947,7 @@ class DefaultSessionControlControllerTest {
             )
         }
 
-        assertTrue(Events.performedSearch.testHasValue())
+        assertNotNull(Events.performedSearch.testGetValue())
 
         createController().handlePasteAndGo("https://mozilla.org")
         verify {
@@ -957,7 +958,7 @@ class DefaultSessionControlControllerTest {
                 engine = searchEngine
             )
         }
-        assertTrue(Events.enteredUrl.testHasValue())
+        assertNotNull(Events.enteredUrl.testGetValue())
     }
 
     @Test
@@ -1096,36 +1097,36 @@ class DefaultSessionControlControllerTest {
 
     @Test
     fun `WHEN handleReportSessionMetrics is called AND there are zero recent tabs THEN report Event#RecentTabsSectionIsNotVisible`() {
-        assertFalse(RecentTabs.sectionVisible.testHasValue())
+        assertNull(RecentTabs.sectionVisible.testGetValue())
 
         every { appState.recentTabs } returns emptyList()
         createController().handleReportSessionMetrics(appState)
-        assertTrue(RecentTabs.sectionVisible.testHasValue())
-        assertFalse(RecentTabs.sectionVisible.testGetValue())
+        assertNotNull(RecentTabs.sectionVisible.testGetValue())
+        assertFalse(RecentTabs.sectionVisible.testGetValue()!!)
     }
 
     @Test
     fun `WHEN handleReportSessionMetrics is called AND there is at least one recent tab THEN report Event#RecentTabsSectionIsVisible`() {
-        assertFalse(RecentTabs.sectionVisible.testHasValue())
+        assertNull(RecentTabs.sectionVisible.testGetValue())
 
         val recentTab: RecentTab = mockk(relaxed = true)
         every { appState.recentTabs } returns listOf(recentTab)
         createController().handleReportSessionMetrics(appState)
 
-        assertTrue(RecentTabs.sectionVisible.testHasValue())
-        assertTrue(RecentTabs.sectionVisible.testGetValue())
+        assertNotNull(RecentTabs.sectionVisible.testGetValue())
+        assertTrue(RecentTabs.sectionVisible.testGetValue()!!)
     }
 
     @Test
     fun `WHEN handleReportSessionMetrics is called AND there are zero recent bookmarks THEN report Event#RecentBookmarkCount(0)`() {
         every { appState.recentBookmarks } returns emptyList()
         every { appState.recentTabs } returns emptyList()
-        assertFalse(RecentBookmarks.recentBookmarksCount.testHasValue())
+        assertNull(RecentBookmarks.recentBookmarksCount.testGetValue())
 
         createController().handleReportSessionMetrics(appState)
 
-        assertTrue(RecentBookmarks.recentBookmarksCount.testHasValue())
-        assertEquals(0, RecentBookmarks.recentBookmarksCount.testGetValue())
+        assertNotNull(RecentBookmarks.recentBookmarksCount.testGetValue())
+        assertEquals(0L, RecentBookmarks.recentBookmarksCount.testGetValue())
     }
 
     @Test
@@ -1133,21 +1134,21 @@ class DefaultSessionControlControllerTest {
         val recentBookmark: RecentBookmark = mockk(relaxed = true)
         every { appState.recentBookmarks } returns listOf(recentBookmark)
         every { appState.recentTabs } returns emptyList()
-        assertFalse(RecentBookmarks.recentBookmarksCount.testHasValue())
+        assertNull(RecentBookmarks.recentBookmarksCount.testGetValue())
 
         createController().handleReportSessionMetrics(appState)
 
-        assertTrue(RecentBookmarks.recentBookmarksCount.testHasValue())
-        assertEquals(1, RecentBookmarks.recentBookmarksCount.testGetValue())
+        assertNotNull(RecentBookmarks.recentBookmarksCount.testGetValue())
+        assertEquals(1L, RecentBookmarks.recentBookmarksCount.testGetValue())
     }
 
     @Test
     fun `WHEN handleTopSiteSettingsClicked is called THEN navigate to the HomeSettingsFragment AND report the interaction`() {
         createController().handleTopSiteSettingsClicked()
 
-        assertTrue(TopSites.contileSettings.testHasValue())
-        assertEquals(1, TopSites.contileSettings.testGetValue().size)
-        assertNull(TopSites.contileSettings.testGetValue().single().extra)
+        assertNotNull(TopSites.contileSettings.testGetValue())
+        assertEquals(1, TopSites.contileSettings.testGetValue()!!.size)
+        assertNull(TopSites.contileSettings.testGetValue()!!.single().extra)
         verify {
             navController.navigate(
                 match<NavDirections> {
@@ -1162,9 +1163,9 @@ class DefaultSessionControlControllerTest {
     fun `WHEN handleSponsorPrivacyClicked is called THEN navigate to the privacy webpage AND report the interaction`() {
         createController().handleSponsorPrivacyClicked()
 
-        assertTrue(TopSites.contileSponsorsAndPrivacy.testHasValue())
-        assertEquals(1, TopSites.contileSponsorsAndPrivacy.testGetValue().size)
-        assertNull(TopSites.contileSponsorsAndPrivacy.testGetValue().single().extra)
+        assertNotNull(TopSites.contileSponsorsAndPrivacy.testGetValue())
+        assertEquals(1, TopSites.contileSponsorsAndPrivacy.testGetValue()!!.size)
+        assertNull(TopSites.contileSponsorsAndPrivacy.testGetValue()!!.single().extra)
         verify {
             activity.openToBrowserAndLoad(
                 searchTermOrURL = SupportUtils.getGenericSumoURLForTopic(SupportUtils.SumoTopic.SPONSOR_PRIVACY),
@@ -1187,9 +1188,9 @@ class DefaultSessionControlControllerTest {
         )
         createController().handleOpenInPrivateTabClicked(topSite)
 
-        assertTrue(TopSites.openContileInPrivateTab.testHasValue())
-        assertEquals(1, TopSites.openContileInPrivateTab.testGetValue().size)
-        assertNull(TopSites.openContileInPrivateTab.testGetValue().single().extra)
+        assertNotNull(TopSites.openContileInPrivateTab.testGetValue())
+        assertEquals(1, TopSites.openContileInPrivateTab.testGetValue()!!.size)
+        assertNull(TopSites.openContileInPrivateTab.testGetValue()!!.single().extra)
     }
 
     @Test
@@ -1213,15 +1214,15 @@ class DefaultSessionControlControllerTest {
             url = "mozilla.org",
             createdAt = 0
         )
-        assertFalse(TopSites.openInPrivateTab.testHasValue())
+        assertNull(TopSites.openInPrivateTab.testGetValue())
 
         controller.handleOpenInPrivateTabClicked(topSite1)
         controller.handleOpenInPrivateTabClicked(topSite2)
         controller.handleOpenInPrivateTabClicked(topSite3)
 
-        assertTrue(TopSites.openInPrivateTab.testHasValue())
-        assertEquals(3, TopSites.openInPrivateTab.testGetValue().size)
-        for (event in TopSites.openInPrivateTab.testGetValue()) {
+        assertNotNull(TopSites.openInPrivateTab.testGetValue())
+        assertEquals(3, TopSites.openInPrivateTab.testGetValue()!!.size)
+        for (event in TopSites.openInPrivateTab.testGetValue()!!) {
             assertNull(event.extra)
         }
     }

--- a/app/src/test/java/org/mozilla/fenix/home/HomeMenuBuilderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/HomeMenuBuilderTest.kt
@@ -14,7 +14,8 @@ import mozilla.appservices.places.BookmarkRoot
 import mozilla.components.browser.menu.view.MenuButton
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.telemetry.glean.testing.GleanTestRule
-import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -69,11 +70,11 @@ class HomeMenuBuilderTest {
 
     @Test
     fun `WHEN Settings menu item is tapped THEN navigate to settings fragment and record metrics`() {
-        assertFalse(HomeMenuMetrics.settingsItemClicked.testHasValue())
+        assertNull(HomeMenuMetrics.settingsItemClicked.testGetValue())
 
         homeMenuBuilder.onItemTapped(HomeMenu.Item.Settings)
 
-        assertTrue(HomeMenuMetrics.settingsItemClicked.testHasValue())
+        assertNotNull(HomeMenuMetrics.settingsItemClicked.testGetValue())
 
         verify {
             navController.nav(
@@ -85,11 +86,11 @@ class HomeMenuBuilderTest {
 
     @Test
     fun `WHEN Customize Home menu item is tapped THEN navigate to home settings fragment and record metrics`() {
-        assertFalse(HomeScreen.customizeHomeClicked.testHasValue())
+        assertNull(HomeScreen.customizeHomeClicked.testGetValue())
 
         homeMenuBuilder.onItemTapped(HomeMenu.Item.CustomizeHome)
 
-        assertTrue(HomeScreen.customizeHomeClicked.testHasValue())
+        assertNotNull(HomeScreen.customizeHomeClicked.testGetValue())
 
         verify {
             navController.nav(
@@ -183,11 +184,11 @@ class HomeMenuBuilderTest {
 
     @Test
     fun `WHEN Whats New menu item is tapped THEN open the browser to the SUMO whats new page and record metrics`() {
-        assertFalse(Events.whatsNewTapped.testHasValue())
+        assertNull(Events.whatsNewTapped.testGetValue())
 
         homeMenuBuilder.onItemTapped(HomeMenu.Item.WhatsNew)
 
-        assertTrue(Events.whatsNewTapped.testHasValue())
+        assertNotNull(Events.whatsNewTapped.testGetValue())
 
         verify {
             WhatsNew.userViewedWhatsNew(testContext)

--- a/app/src/test/java/org/mozilla/fenix/home/intent/DefaultBrowserIntentProcessorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/intent/DefaultBrowserIntentProcessorTest.kt
@@ -13,7 +13,8 @@ import io.mockk.verify
 import mozilla.components.service.glean.testing.GleanTestRule
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -51,14 +52,14 @@ class DefaultBrowserIntentProcessorTest {
         every { activity.startActivity(any()) } returns Unit
         every { activity.applicationContext } returns testContext
 
-        assertFalse(Events.defaultBrowserNotifTapped.testHasValue())
+        assertNull(Events.defaultBrowserNotifTapped.testGetValue())
 
         val result = DefaultBrowserIntentProcessor(activity)
             .process(intent, navController, out)
 
         assert(result)
 
-        assertTrue(Events.defaultBrowserNotifTapped.testHasValue())
+        assertNotNull(Events.defaultBrowserNotifTapped.testGetValue())
         verify { navController wasNot Called }
         verify { out wasNot Called }
     }

--- a/app/src/test/java/org/mozilla/fenix/home/intent/StartSearchIntentProcessorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/intent/StartSearchIntentProcessorTest.kt
@@ -13,7 +13,7 @@ import io.mockk.verify
 import mozilla.components.service.glean.testing.GleanTestRule
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
+import org.junit.Assert.assertNotNull
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -61,8 +61,8 @@ class StartSearchIntentProcessorTest {
             popUpTo = R.id.homeFragment
         }
 
-        assertTrue(SearchWidget.newTabButton.testHasValue())
-        val recordedEvents = SearchWidget.newTabButton.testGetValue()
+        assertNotNull(SearchWidget.newTabButton.testGetValue())
+        val recordedEvents = SearchWidget.newTabButton.testGetValue()!!
         assertEquals(1, recordedEvents.size)
         assertEquals(null, recordedEvents.single().extra)
 

--- a/app/src/test/java/org/mozilla/fenix/home/pocket/DefaultPocketStoriesControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/pocket/DefaultPocketStoriesControllerTest.kt
@@ -16,7 +16,7 @@ import mozilla.components.service.pocket.PocketStory.PocketSponsoredStory
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.telemetry.glean.testing.GleanTestRule
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -51,14 +51,14 @@ class DefaultPocketStoriesControllerTest {
             )
         )
         val controller = DefaultPocketStoriesController(mockk(), store, mockk())
-        assertFalse(Pocket.homeRecsCategoryClicked.testHasValue())
+        assertNull(Pocket.homeRecsCategoryClicked.testGetValue())
 
         controller.handleCategoryClick(category2)
         verify(exactly = 0) { store.dispatch(AppAction.SelectPocketStoriesCategory(category2.name)) }
         verify { store.dispatch(AppAction.DeselectPocketStoriesCategory(category2.name)) }
 
-        assertTrue(Pocket.homeRecsCategoryClicked.testHasValue())
-        val event = Pocket.homeRecsCategoryClicked.testGetValue()
+        assertNotNull(Pocket.homeRecsCategoryClicked.testGetValue())
+        val event = Pocket.homeRecsCategoryClicked.testGetValue()!!
         assertEquals(1, event.size)
         assertTrue(event.single().extra!!.containsKey("category_name"))
         assertEquals(category2.name, event.single().extra!!["category_name"])
@@ -89,15 +89,15 @@ class DefaultPocketStoriesControllerTest {
             )
         )
         val controller = DefaultPocketStoriesController(mockk(), store, mockk())
-        assertFalse(Pocket.homeRecsCategoryClicked.testHasValue())
+        assertNull(Pocket.homeRecsCategoryClicked.testGetValue())
 
         controller.handleCategoryClick(PocketRecommendedStoriesCategory(newSelectedCategory.name))
 
         verify { store.dispatch(AppAction.DeselectPocketStoriesCategory(oldestSelectedCategory.name)) }
         verify { store.dispatch(AppAction.SelectPocketStoriesCategory(newSelectedCategory.name)) }
 
-        assertTrue(Pocket.homeRecsCategoryClicked.testHasValue())
-        val event = Pocket.homeRecsCategoryClicked.testGetValue()
+        assertNotNull(Pocket.homeRecsCategoryClicked.testGetValue())
+        val event = Pocket.homeRecsCategoryClicked.testGetValue()!!
         assertEquals(1, event.size)
         assertTrue(event.single().extra!!.containsKey("category_name"))
         assertEquals(newSelectedCategory.name, event.single().extra!!["category_name"])
@@ -133,8 +133,8 @@ class DefaultPocketStoriesControllerTest {
         verify(exactly = 0) { store.dispatch(AppAction.DeselectPocketStoriesCategory(oldestSelectedCategory.name)) }
         verify { store.dispatch(AppAction.SelectPocketStoriesCategory(newSelectedCategoryName)) }
 
-        assertTrue(Pocket.homeRecsCategoryClicked.testHasValue())
-        val event = Pocket.homeRecsCategoryClicked.testGetValue()
+        assertNotNull(Pocket.homeRecsCategoryClicked.testGetValue())
+        val event = Pocket.homeRecsCategoryClicked.testGetValue()!!
         assertEquals(1, event.size)
         assertTrue(event.single().extra!!.containsKey("category_name"))
         assertEquals(newSelectedCategoryName, event.single().extra!!["category_name"])
@@ -160,14 +160,14 @@ class DefaultPocketStoriesControllerTest {
         val store = spyk(AppStore())
         val controller = DefaultPocketStoriesController(mockk(), store, mockk())
         val storiesShown: List<PocketStory> = mockk()
-        assertFalse(Pocket.homeRecsShown.testHasValue())
+        assertNull(Pocket.homeRecsShown.testGetValue())
 
         controller.handleStoriesShown(storiesShown)
 
         verify { store.dispatch(AppAction.PocketStoriesShown(storiesShown)) }
-        assertTrue(Pocket.homeRecsShown.testHasValue())
-        assertEquals(1, Pocket.homeRecsShown.testGetValue().size)
-        assertNull(Pocket.homeRecsShown.testGetValue().single().extra)
+        assertNotNull(Pocket.homeRecsShown.testGetValue())
+        assertEquals(1, Pocket.homeRecsShown.testGetValue()!!.size)
+        assertNull(Pocket.homeRecsShown.testGetValue()!!.single().extra)
     }
 
     @Test
@@ -183,14 +183,14 @@ class DefaultPocketStoriesControllerTest {
         )
         val homeActivity: HomeActivity = mockk(relaxed = true)
         val controller = DefaultPocketStoriesController(homeActivity, mockk(), mockk(relaxed = true))
-        assertFalse(Pocket.homeRecsStoryClicked.testHasValue())
+        assertNull(Pocket.homeRecsStoryClicked.testGetValue())
 
         controller.handleStoryClicked(story, 1 to 2)
 
         verify { homeActivity.openToBrowserAndLoad(story.url, true, BrowserDirection.FromHome) }
 
-        assertTrue(Pocket.homeRecsStoryClicked.testHasValue())
-        val event = Pocket.homeRecsStoryClicked.testGetValue()
+        assertNotNull(Pocket.homeRecsStoryClicked.testGetValue())
+        val event = Pocket.homeRecsStoryClicked.testGetValue()!!
         assertEquals(1, event.size)
         assertTrue(event.single().extra!!.containsKey("position"))
         assertEquals("1x2", event.single().extra!!["position"])
@@ -212,12 +212,12 @@ class DefaultPocketStoriesControllerTest {
         )
         val homeActivity: HomeActivity = mockk(relaxed = true)
         val controller = DefaultPocketStoriesController(homeActivity, mockk(), mockk(relaxed = true))
-        assertFalse(Pocket.homeRecsStoryClicked.testHasValue())
+        assertNull(Pocket.homeRecsStoryClicked.testGetValue())
 
         controller.handleStoryClicked(story, 1 to 2)
 
         verify { homeActivity.openToBrowserAndLoad(story.url, true, BrowserDirection.FromHome) }
-        assertFalse(Pocket.homeRecsStoryClicked.testHasValue())
+        assertNull(Pocket.homeRecsStoryClicked.testGetValue())
     }
 
     @Test
@@ -225,14 +225,14 @@ class DefaultPocketStoriesControllerTest {
         val link = "http://getpocket.com/explore"
         val homeActivity: HomeActivity = mockk(relaxed = true)
         val controller = DefaultPocketStoriesController(homeActivity, mockk(), mockk(relaxed = true))
-        assertFalse(Pocket.homeRecsDiscoverClicked.testHasValue())
+        assertNull(Pocket.homeRecsDiscoverClicked.testGetValue())
 
         controller.handleDiscoverMoreClicked(link)
 
         verify { homeActivity.openToBrowserAndLoad(link, true, BrowserDirection.FromHome) }
-        assertTrue(Pocket.homeRecsDiscoverClicked.testHasValue())
-        assertEquals(1, Pocket.homeRecsDiscoverClicked.testGetValue().size)
-        assertNull(Pocket.homeRecsDiscoverClicked.testGetValue().single().extra)
+        assertNotNull(Pocket.homeRecsDiscoverClicked.testGetValue())
+        assertEquals(1, Pocket.homeRecsDiscoverClicked.testGetValue()!!.size)
+        assertNull(Pocket.homeRecsDiscoverClicked.testGetValue()!!.single().extra)
     }
 
     @Test
@@ -240,13 +240,13 @@ class DefaultPocketStoriesControllerTest {
         val link = "https://www.mozilla.org/en-US/firefox/pocket/"
         val homeActivity: HomeActivity = mockk(relaxed = true)
         val controller = DefaultPocketStoriesController(homeActivity, mockk(), mockk(relaxed = true))
-        assertFalse(Pocket.homeRecsLearnMoreClicked.testHasValue())
+        assertNull(Pocket.homeRecsLearnMoreClicked.testGetValue())
 
         controller.handleLearnMoreClicked(link)
 
         verify { homeActivity.openToBrowserAndLoad(link, true, BrowserDirection.FromHome) }
-        assertTrue(Pocket.homeRecsLearnMoreClicked.testHasValue())
-        assertNull(Pocket.homeRecsLearnMoreClicked.testGetValue().single().extra)
+        assertNotNull(Pocket.homeRecsLearnMoreClicked.testGetValue())
+        assertNull(Pocket.homeRecsLearnMoreClicked.testGetValue()!!.single().extra)
     }
 
     @Test

--- a/app/src/test/java/org/mozilla/fenix/home/recentbookmarks/DefaultRecentBookmarksControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/recentbookmarks/DefaultRecentBookmarksControllerTest.kt
@@ -19,8 +19,8 @@ import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.rule.MainCoroutineRule
 import mozilla.components.support.test.rule.runTestOnMain
 import mozilla.telemetry.glean.testing.GleanTestRule
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -70,7 +70,7 @@ class DefaultRecentBookmarksControllerTest {
         every { navController.currentDestination } returns mockk {
             every { id } returns R.id.homeFragment
         }
-        assertFalse(RecentBookmarks.bookmarkClicked.testHasValue())
+        assertNull(RecentBookmarks.bookmarkClicked.testGetValue())
 
         val bookmark = RecentBookmark(
             title = null,
@@ -88,7 +88,7 @@ class DefaultRecentBookmarksControllerTest {
                 from = BrowserDirection.FromHome
             )
         }
-        assertTrue(RecentBookmarks.bookmarkClicked.testHasValue())
+        assertNotNull(RecentBookmarks.bookmarkClicked.testGetValue())
         verify(exactly = 0) {
             navController.navigateUp()
         }
@@ -99,7 +99,7 @@ class DefaultRecentBookmarksControllerTest {
         every { navController.currentDestination } returns mockk {
             every { id } returns R.id.homeFragment
         }
-        assertFalse(RecentBookmarks.showAllBookmarks.testHasValue())
+        assertNull(RecentBookmarks.showAllBookmarks.testGetValue())
 
         controller.handleShowAllBookmarksClicked()
 
@@ -107,7 +107,7 @@ class DefaultRecentBookmarksControllerTest {
         verify {
             navController.navigate(directions)
         }
-        assertTrue(RecentBookmarks.showAllBookmarks.testHasValue())
+        assertNotNull(RecentBookmarks.showAllBookmarks.testGetValue())
         verify(exactly = 0) {
             navController.navigateUp()
         }
@@ -118,7 +118,7 @@ class DefaultRecentBookmarksControllerTest {
         every { navController.currentDestination } returns mockk {
             every { id } returns R.id.searchDialogFragment
         }
-        assertFalse(RecentBookmarks.showAllBookmarks.testHasValue())
+        assertNull(RecentBookmarks.showAllBookmarks.testGetValue())
 
         controller.handleShowAllBookmarksClicked()
 
@@ -129,6 +129,6 @@ class DefaultRecentBookmarksControllerTest {
             navController.navigateUp()
             navController.navigate(directions)
         }
-        assertTrue(RecentBookmarks.showAllBookmarks.testHasValue())
+        assertNotNull(RecentBookmarks.showAllBookmarks.testGetValue())
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/home/recentsyncedtabs/RecentSyncedTabFeatureTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/recentsyncedtabs/RecentSyncedTabFeatureTest.kt
@@ -18,8 +18,8 @@ import mozilla.components.service.fxa.manager.FxaAccountManager
 import mozilla.components.service.glean.testing.GleanTestRule
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -198,7 +198,7 @@ class RecentSyncedTabFeatureTest {
         feature.startLoading()
         feature.displaySyncedTabs(listOf(tab))
 
-        assertTrue(RecentSyncedTabs.recentSyncedTabTimeToLoad.testHasValue())
+        assertNotNull(RecentSyncedTabs.recentSyncedTabTimeToLoad.testGetValue())
     }
 
     @Test
@@ -219,7 +219,7 @@ class RecentSyncedTabFeatureTest {
         feature.displaySyncedTabs(listOf(tab1))
         feature.displaySyncedTabs(listOf(tab2))
 
-        assertFalse(RecentSyncedTabs.latestSyncedTabIsStale.testHasValue())
+        assertNull(RecentSyncedTabs.latestSyncedTabIsStale.testGetValue())
     }
 
     @Test

--- a/app/src/test/java/org/mozilla/fenix/home/recenttabs/controller/RecentTabControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/recenttabs/controller/RecentTabControllerTest.kt
@@ -21,8 +21,8 @@ import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.rule.MainCoroutineRule
 import mozilla.telemetry.glean.testing.GleanTestRule
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -69,8 +69,8 @@ class RecentTabControllerTest {
 
     @Test
     fun handleRecentTabClicked() {
-        assertFalse(RecentTabs.recentTabOpened.testHasValue())
-        assertFalse(RecentTabs.inProgressMediaTabOpened.testHasValue())
+        assertNull(RecentTabs.recentTabOpened.testGetValue())
+        assertNull(RecentTabs.inProgressMediaTabOpened.testGetValue())
 
         every { navController.currentDestination } returns mockk {
             every { id } returns R.id.homeFragment
@@ -89,14 +89,14 @@ class RecentTabControllerTest {
             selectTabUseCase.selectTab.invoke(tab.id)
             navController.navigate(R.id.browserFragment)
         }
-        assertTrue(RecentTabs.recentTabOpened.testHasValue())
-        assertFalse(RecentTabs.inProgressMediaTabOpened.testHasValue())
+        assertNotNull(RecentTabs.recentTabOpened.testGetValue())
+        assertNull(RecentTabs.inProgressMediaTabOpened.testGetValue())
     }
 
     @Test
     fun handleRecentTabClickedForMediaTab() {
-        assertFalse(RecentTabs.recentTabOpened.testHasValue())
-        assertFalse(RecentTabs.inProgressMediaTabOpened.testHasValue())
+        assertNull(RecentTabs.recentTabOpened.testGetValue())
+        assertNull(RecentTabs.inProgressMediaTabOpened.testGetValue())
 
         every { navController.currentDestination } returns mockk {
             every { id } returns R.id.homeFragment
@@ -116,13 +116,13 @@ class RecentTabControllerTest {
             selectTabUseCase.selectTab.invoke(inProgressMediaTab.id)
             navController.navigate(R.id.browserFragment)
         }
-        assertFalse(RecentTabs.recentTabOpened.testHasValue())
-        assertTrue(RecentTabs.inProgressMediaTabOpened.testHasValue())
+        assertNull(RecentTabs.recentTabOpened.testGetValue())
+        assertNotNull(RecentTabs.inProgressMediaTabOpened.testGetValue())
     }
 
     @Test
     fun handleRecentTabShowAllClickedFromHome() {
-        assertFalse(RecentTabs.showAllClicked.testHasValue())
+        assertNull(RecentTabs.showAllClicked.testGetValue())
 
         every { navController.currentDestination } returns mockk {
             every { id } returns R.id.homeFragment
@@ -140,12 +140,12 @@ class RecentTabControllerTest {
             navController.navigateUp()
         }
 
-        assertTrue(RecentTabs.showAllClicked.testHasValue())
+        assertNotNull(RecentTabs.showAllClicked.testGetValue())
     }
 
     @Test
     fun handleRecentTabShowAllClickedFromSearchDialog() {
-        assertFalse(RecentTabs.showAllClicked.testHasValue())
+        assertNull(RecentTabs.showAllClicked.testGetValue())
 
         every { navController.currentDestination } returns mockk {
             every { id } returns R.id.searchDialogFragment
@@ -161,12 +161,12 @@ class RecentTabControllerTest {
             )
         }
 
-        assertTrue(RecentTabs.showAllClicked.testHasValue())
+        assertNotNull(RecentTabs.showAllClicked.testGetValue())
     }
 
     @Test
     fun `WHEN handleRecentSearchGroupClicked is called THEN navigate to the tabsTrayFragment and record the correct metric`() {
-        assertFalse(SearchTerms.jumpBackInGroupTapped.testHasValue())
+        assertNull(SearchTerms.jumpBackInGroupTapped.testGetValue())
 
         controller.handleRecentSearchGroupClicked("1")
 
@@ -178,6 +178,6 @@ class RecentTabControllerTest {
                 }
             )
         }
-        assertTrue(SearchTerms.jumpBackInGroupTapped.testHasValue())
+        assertNotNull(SearchTerms.jumpBackInGroupTapped.testGetValue())
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/home/recentvisits/controller/RecentVisitsControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/recentvisits/controller/RecentVisitsControllerTest.kt
@@ -26,8 +26,8 @@ import mozilla.components.service.glean.testing.GleanTestRule
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.rule.MainCoroutineRule
 import mozilla.components.support.test.rule.runTestOnMain
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -140,7 +140,7 @@ class RecentVisitsControllerTest {
                 )
             )
         )
-        assertFalse(RecentSearches.groupDeleted.testHasValue())
+        assertNull(RecentSearches.groupDeleted.testGetValue())
 
         controller.handleRemoveRecentHistoryGroup(historyGroup.title)
 
@@ -149,7 +149,7 @@ class RecentVisitsControllerTest {
             store.dispatch(HistoryMetadataAction.DisbandSearchGroupAction(searchTerm = historyGroup.title))
             appStore.dispatch(AppAction.DisbandSearchGroupAction(searchTerm = historyGroup.title))
         }
-        assertTrue(RecentSearches.groupDeleted.testHasValue())
+        assertNotNull(RecentSearches.groupDeleted.testGetValue())
 
         coVerify {
             storage.deleteHistoryMetadata(historyGroup.title)

--- a/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingFinishViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingFinishViewHolderTest.kt
@@ -11,8 +11,8 @@ import io.mockk.verify
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.telemetry.glean.testing.GleanTestRule
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -46,8 +46,8 @@ class OnboardingFinishViewHolderTest {
         binding.finishButton.performClick()
         verify { interactor.onStartBrowsingClicked() }
         // Check if the event was recorded
-        assertTrue(Onboarding.finish.testHasValue())
-        assertEquals(1, Onboarding.finish.testGetValue().size)
-        assertNull(Onboarding.finish.testGetValue().single().extra)
+        assertNotNull(Onboarding.finish.testGetValue())
+        assertEquals(1, Onboarding.finish.testGetValue()!!.size)
+        assertNull(Onboarding.finish.testGetValue()!!.single().extra)
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingManualSignInViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingManualSignInViewHolderTest.kt
@@ -73,8 +73,8 @@ class OnboardingManualSignInViewHolderTest {
 
         verify { navController.navigate(HomeFragmentDirections.actionGlobalTurnOnSync()) }
         // Check if the event was recorded
-        Assert.assertTrue(Onboarding.fxaManualSignin.testHasValue())
-        assertEquals(1, Onboarding.fxaManualSignin.testGetValue().size)
-        Assert.assertNull(Onboarding.fxaManualSignin.testGetValue().single().extra)
+        Assert.assertNotNull(Onboarding.fxaManualSignin.testGetValue())
+        assertEquals(1, Onboarding.fxaManualSignin.testGetValue()!!.size)
+        Assert.assertNull(Onboarding.fxaManualSignin.testGetValue()!!.single().extra)
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingPrivacyNoticeViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingPrivacyNoticeViewHolderTest.kt
@@ -12,8 +12,8 @@ import io.mockk.verify
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.telemetry.glean.testing.GleanTestRule
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -49,8 +49,8 @@ class OnboardingPrivacyNoticeViewHolderTest {
         binding.readButton.performClick()
         verify { interactor.onReadPrivacyNoticeClicked() }
         // Check if the event was recorded
-        assertTrue(Onboarding.privacyNotice.testHasValue())
-        assertEquals(1, Onboarding.privacyNotice.testGetValue().size)
-        assertNull(Onboarding.privacyNotice.testGetValue().single().extra)
+        assertNotNull(Onboarding.privacyNotice.testGetValue())
+        assertEquals(1, Onboarding.privacyNotice.testGetValue()!!.size)
+        assertNull(Onboarding.privacyNotice.testGetValue()!!.single().extra)
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingToolbarPositionPickerViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/OnboardingToolbarPositionPickerViewHolderTest.kt
@@ -11,6 +11,7 @@ import mozilla.components.support.test.robolectric.testContext
 import mozilla.telemetry.glean.testing.GleanTestRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -71,10 +72,10 @@ class OnboardingToolbarPositionPickerViewHolderTest {
 
         binding.toolbarTopImage.performClick()
 
-        assertTrue(Onboarding.prefToggledToolbarPosition.testHasValue())
+        assertNotNull(Onboarding.prefToggledToolbarPosition.testGetValue())
         assertEquals(
             OnboardingToolbarPositionPickerViewHolder.Companion.Position.TOP.name,
-            Onboarding.prefToggledToolbarPosition.testGetValue()
+            Onboarding.prefToggledToolbarPosition.testGetValue()!!
                 .last().extra?.get("position")
         )
     }
@@ -86,10 +87,10 @@ class OnboardingToolbarPositionPickerViewHolderTest {
 
         binding.toolbarBottomImage.performClick()
 
-        assertTrue(Onboarding.prefToggledToolbarPosition.testHasValue())
+        assertNotNull(Onboarding.prefToggledToolbarPosition.testGetValue())
         assertEquals(
             OnboardingToolbarPositionPickerViewHolder.Companion.Position.BOTTOM.name,
-            Onboarding.prefToggledToolbarPosition.testGetValue()
+            Onboarding.prefToggledToolbarPosition.testGetValue()!!
                 .last().extra?.get("position")
         )
     }

--- a/app/src/test/java/org/mozilla/fenix/home/topsites/TopSiteItemViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/topsites/TopSiteItemViewHolderTest.kt
@@ -14,7 +14,6 @@ import mozilla.components.feature.top.sites.TopSite
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.telemetry.glean.testing.GleanTestRule
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -129,17 +128,17 @@ class TopSiteItemViewHolderTest {
             createdAt = 3
         )
         val position = 0
-        assertFalse(TopSites.contileImpression.testHasValue())
+        assertNull(TopSites.contileImpression.testGetValue())
 
         var topSiteImpressionSubmitted = false
         Pings.topsitesImpression.testBeforeNextSubmit {
-            assertTrue(TopSites.contileTileId.testHasValue())
-            assertEquals(3, TopSites.contileTileId.testGetValue())
+            assertNotNull(TopSites.contileTileId.testGetValue())
+            assertEquals(3L, TopSites.contileTileId.testGetValue())
 
-            assertTrue(TopSites.contileAdvertiser.testHasValue())
+            assertNotNull(TopSites.contileAdvertiser.testGetValue())
             assertEquals("mozilla", TopSites.contileAdvertiser.testGetValue())
 
-            assertTrue(TopSites.contileReportingUrl.testHasValue())
+            assertNotNull(TopSites.contileReportingUrl.testGetValue())
             assertEquals(topSite.impressionUrl, TopSites.contileReportingUrl.testGetValue())
 
             topSiteImpressionSubmitted = true
@@ -147,9 +146,9 @@ class TopSiteItemViewHolderTest {
 
         TopSiteItemViewHolder(binding.root, lifecycleOwner, interactor).submitTopSitesImpressionPing(topSite, position)
 
-        assertTrue(TopSites.contileImpression.testHasValue())
+        assertNotNull(TopSites.contileImpression.testGetValue())
 
-        val event = TopSites.contileImpression.testGetValue()
+        val event = TopSites.contileImpression.testGetValue()!!
 
         assertEquals(1, event.size)
         assertEquals("top_sites", event[0].category)

--- a/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkFragmentInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/bookmarks/BookmarkFragmentInteractorTest.kt
@@ -11,8 +11,8 @@ import mozilla.components.concept.storage.BookmarkNodeType
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.telemetry.glean.testing.GleanTestRule
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -59,9 +59,9 @@ class BookmarkFragmentInteractorTest {
         interactor.open(item)
 
         verify { bookmarkController.handleBookmarkTapped(item) }
-        assertTrue(BookmarksManagement.open.testHasValue())
-        assertEquals(1, BookmarksManagement.open.testGetValue().size)
-        assertNull(BookmarksManagement.open.testGetValue().single().extra)
+        assertNotNull(BookmarksManagement.open.testGetValue())
+        assertEquals(1, BookmarksManagement.open.testGetValue()!!.size)
+        assertNull(BookmarksManagement.open.testGetValue()!!.single().extra)
     }
 
     @Test(expected = IllegalStateException::class)
@@ -128,9 +128,9 @@ class BookmarkFragmentInteractorTest {
         interactor.onCopyPressed(item)
 
         verify { bookmarkController.handleCopyUrl(item) }
-        assertTrue(BookmarksManagement.copied.testHasValue())
-        assertEquals(1, BookmarksManagement.copied.testGetValue().size)
-        assertNull(BookmarksManagement.copied.testGetValue().single().extra)
+        assertNotNull(BookmarksManagement.copied.testGetValue())
+        assertEquals(1, BookmarksManagement.copied.testGetValue()!!.size)
+        assertNull(BookmarksManagement.copied.testGetValue()!!.single().extra)
     }
 
     @Test
@@ -138,9 +138,9 @@ class BookmarkFragmentInteractorTest {
         interactor.onSharePressed(item)
 
         verify { bookmarkController.handleBookmarkSharing(item) }
-        assertTrue(BookmarksManagement.shared.testHasValue())
-        assertEquals(1, BookmarksManagement.shared.testGetValue().size)
-        assertNull(BookmarksManagement.shared.testGetValue().single().extra)
+        assertNotNull(BookmarksManagement.shared.testGetValue())
+        assertEquals(1, BookmarksManagement.shared.testGetValue()!!.size)
+        assertNull(BookmarksManagement.shared.testGetValue()!!.single().extra)
     }
 
     @Test
@@ -148,9 +148,9 @@ class BookmarkFragmentInteractorTest {
         interactor.onOpenInNormalTab(item)
 
         verify { bookmarkController.handleOpeningBookmark(item, BrowsingMode.Normal) }
-        assertTrue(BookmarksManagement.openInNewTab.testHasValue())
-        assertEquals(1, BookmarksManagement.openInNewTab.testGetValue().size)
-        assertNull(BookmarksManagement.openInNewTab.testGetValue().single().extra)
+        assertNotNull(BookmarksManagement.openInNewTab.testGetValue())
+        assertEquals(1, BookmarksManagement.openInNewTab.testGetValue()!!.size)
+        assertNull(BookmarksManagement.openInNewTab.testGetValue()!!.single().extra)
     }
 
     @Test
@@ -158,9 +158,9 @@ class BookmarkFragmentInteractorTest {
         interactor.onOpenInPrivateTab(item)
 
         verify { bookmarkController.handleOpeningBookmark(item, BrowsingMode.Private) }
-        assertTrue(BookmarksManagement.openInPrivateTab.testHasValue())
-        assertEquals(1, BookmarksManagement.openInPrivateTab.testGetValue().size)
-        assertNull(BookmarksManagement.openInPrivateTab.testGetValue().single().extra)
+        assertNotNull(BookmarksManagement.openInPrivateTab.testGetValue())
+        assertEquals(1, BookmarksManagement.openInPrivateTab.testGetValue()!!.size)
+        assertNull(BookmarksManagement.openInPrivateTab.testGetValue()!!.single().extra)
     }
 
     @Test

--- a/app/src/test/java/org/mozilla/fenix/library/history/HistorySearchControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/history/HistorySearchControllerTest.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.test.runTest
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.telemetry.glean.testing.GleanTestRule
-import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -71,13 +71,13 @@ class HistorySearchControllerTest {
     fun `WHEN url is tapped THEN openToBrowserAndLoad is called`() {
         val url = "https://www.google.com/"
         val flags = EngineSession.LoadUrlFlags.none()
-        assertFalse(History.searchResultTapped.testHasValue())
+        assertNull(History.searchResultTapped.testGetValue())
 
         createController().handleUrlTapped(url, flags)
         createController().handleUrlTapped(url)
 
-        assertTrue(History.searchResultTapped.testHasValue())
-        assertNull(History.searchResultTapped.testGetValue().last().extra)
+        assertNotNull(History.searchResultTapped.testGetValue())
+        assertNull(History.searchResultTapped.testGetValue()!!.last().extra)
         verify {
             activity.openToBrowserAndLoad(
                 searchTermOrURL = url,

--- a/app/src/test/java/org/mozilla/fenix/library/historymetadata/controller/HistoryMetadataGroupControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/historymetadata/controller/HistoryMetadataGroupControllerTest.kt
@@ -24,6 +24,7 @@ import mozilla.components.support.test.rule.runTestOnMain
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Ignore
@@ -114,7 +115,7 @@ class HistoryMetadataGroupControllerTest {
 
     @Test
     fun handleOpen() {
-        assertFalse(GleanHistory.searchTermGroupOpenTab.testHasValue())
+        assertNull(GleanHistory.searchTermGroupOpenTab.testGetValue())
 
         controller.handleOpen(mozillaHistoryMetadataItem)
 
@@ -125,13 +126,13 @@ class HistoryMetadataGroupControllerTest {
             )
             navController.navigate(R.id.browserFragment)
         }
-        assertTrue(GleanHistory.searchTermGroupOpenTab.testHasValue())
+        assertNotNull(GleanHistory.searchTermGroupOpenTab.testGetValue())
         assertEquals(
             1,
-            GleanHistory.searchTermGroupOpenTab.testGetValue().size
+            GleanHistory.searchTermGroupOpenTab.testGetValue()!!.size
         )
         assertNull(
-            GleanHistory.searchTermGroupOpenTab.testGetValue()
+            GleanHistory.searchTermGroupOpenTab.testGetValue()!!
                 .single().extra
         )
     }
@@ -190,7 +191,7 @@ class HistoryMetadataGroupControllerTest {
     @Test
     @Ignore("Intermittent test: https://github.com/mozilla-mobile/fenix/issues/25167")
     fun handleDeleteSingle() = runTestOnMain {
-        assertFalse(GleanHistory.searchTermGroupRemoveTab.testHasValue())
+        assertNull(GleanHistory.searchTermGroupRemoveTab.testGetValue())
 
         controller.handleDelete(setOf(mozillaHistoryMetadataItem))
 
@@ -198,13 +199,13 @@ class HistoryMetadataGroupControllerTest {
             store.dispatch(HistoryMetadataGroupFragmentAction.Delete(mozillaHistoryMetadataItem))
             historyStorage.deleteVisitsFor(mozillaHistoryMetadataItem.url)
         }
-        assertTrue(GleanHistory.searchTermGroupRemoveTab.testHasValue())
+        assertNotNull(GleanHistory.searchTermGroupRemoveTab.testGetValue())
         assertEquals(
             1,
-            GleanHistory.searchTermGroupRemoveTab.testGetValue().size
+            GleanHistory.searchTermGroupRemoveTab.testGetValue()!!.size
         )
         assertNull(
-            GleanHistory.searchTermGroupRemoveTab.testGetValue()
+            GleanHistory.searchTermGroupRemoveTab.testGetValue()!!
                 .single().extra
         )
         // Here we don't expect the action to be dispatched, because items inside the store
@@ -219,7 +220,7 @@ class HistoryMetadataGroupControllerTest {
     @Test
     @Ignore("Intermittent test: https://github.com/mozilla-mobile/fenix/issues/25167")
     fun handleDeleteMultiple() = runTestOnMain {
-        assertFalse(GleanHistory.searchTermGroupRemoveTab.testHasValue())
+        assertNull(GleanHistory.searchTermGroupRemoveTab.testGetValue())
         controller.handleDelete(getMetadataItemsList().toSet())
 
         coVerify {
@@ -228,9 +229,9 @@ class HistoryMetadataGroupControllerTest {
                 historyStorage.deleteVisitsFor(it.url)
             }
         }
-        assertTrue(GleanHistory.searchTermGroupRemoveTab.testHasValue())
+        assertNotNull(GleanHistory.searchTermGroupRemoveTab.testGetValue())
         assertNull(
-            GleanHistory.searchTermGroupRemoveTab.testGetValue()
+            GleanHistory.searchTermGroupRemoveTab.testGetValue()!!
                 .last().extra
         )
         // Here we expect the action to be dispatched, because both deleted items and items inside
@@ -252,7 +253,7 @@ class HistoryMetadataGroupControllerTest {
             mozillaHistoryMetadataItem.copy(title = "BBC", url = "https://www.bbc.com/"),
             mozillaHistoryMetadataItem.copy(title = "Stackoverflow", url = "https://stackoverflow.com/")
         )
-        assertFalse(GleanHistory.searchTermGroupRemoveTab.testHasValue())
+        assertNull(GleanHistory.searchTermGroupRemoveTab.testGetValue())
 
         controller.handleDelete(abnormalList.toSet())
         coVerify {
@@ -261,9 +262,9 @@ class HistoryMetadataGroupControllerTest {
                 historyStorage.deleteVisitsFor(it.url)
             }
         }
-        assertTrue(GleanHistory.searchTermGroupRemoveTab.testHasValue())
+        assertNotNull(GleanHistory.searchTermGroupRemoveTab.testGetValue())
         assertNull(
-            GleanHistory.searchTermGroupRemoveTab.testGetValue()
+            GleanHistory.searchTermGroupRemoveTab.testGetValue()!!
                 .last().extra
         )
         coVerify {
@@ -272,9 +273,9 @@ class HistoryMetadataGroupControllerTest {
                 historyStorage.deleteVisitsFor(it.url)
             }
         }
-        assertTrue(GleanHistory.searchTermGroupRemoveTab.testHasValue())
+        assertNotNull(GleanHistory.searchTermGroupRemoveTab.testGetValue())
         assertNull(
-            GleanHistory.searchTermGroupRemoveTab.testGetValue()
+            GleanHistory.searchTermGroupRemoveTab.testGetValue()!!
                 .last().extra
         )
         // Here we expect the action to be dispatched, because deleted items include the items
@@ -289,7 +290,7 @@ class HistoryMetadataGroupControllerTest {
 
     @Test
     fun handleDeleteAll() = runTestOnMain {
-        assertFalse(GleanHistory.searchTermGroupRemoveAll.testHasValue())
+        assertNull(GleanHistory.searchTermGroupRemoveAll.testGetValue())
 
         controller.handleDeleteAll()
 
@@ -302,13 +303,13 @@ class HistoryMetadataGroupControllerTest {
                 HistoryMetadataAction.DisbandSearchGroupAction(searchTerm = searchTerm)
             )
         }
-        assertTrue(GleanHistory.searchTermGroupRemoveAll.testHasValue())
+        assertNotNull(GleanHistory.searchTermGroupRemoveAll.testGetValue())
         assertEquals(
             1,
-            GleanHistory.searchTermGroupRemoveAll.testGetValue().size
+            GleanHistory.searchTermGroupRemoveAll.testGetValue()!!.size
         )
         assertNull(
-            GleanHistory.searchTermGroupRemoveAll.testGetValue()
+            GleanHistory.searchTermGroupRemoveAll.testGetValue()!!
                 .single().extra
         )
     }

--- a/app/src/test/java/org/mozilla/fenix/library/recentlyclosed/DefaultRecentlyClosedControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/recentlyclosed/DefaultRecentlyClosedControllerTest.kt
@@ -26,9 +26,8 @@ import mozilla.components.feature.tabs.TabsUseCases
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.telemetry.glean.testing.GleanTestRule
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -98,7 +97,7 @@ class DefaultRecentlyClosedControllerTest {
                 actualBrowsingModes.add(mode)
             }
         )
-        assertFalse(RecentlyClosedTabs.menuOpenInNormalTab.testHasValue())
+        assertNull(RecentlyClosedTabs.menuOpenInNormalTab.testGetValue())
 
         controller.handleOpen(tabs.toSet(), BrowsingMode.Normal)
 
@@ -107,8 +106,8 @@ class DefaultRecentlyClosedControllerTest {
         assertEquals(tabs[1].url, tabUrls[1])
         assertEquals(BrowsingMode.Normal, actualBrowsingModes[0])
         assertEquals(BrowsingMode.Normal, actualBrowsingModes[1])
-        assertTrue(RecentlyClosedTabs.menuOpenInNormalTab.testHasValue())
-        assertNull(RecentlyClosedTabs.menuOpenInNormalTab.testGetValue().last().extra)
+        assertNotNull(RecentlyClosedTabs.menuOpenInNormalTab.testGetValue())
+        assertNull(RecentlyClosedTabs.menuOpenInNormalTab.testGetValue()!!.last().extra)
 
         tabUrls.clear()
         actualBrowsingModes.clear()
@@ -120,23 +119,23 @@ class DefaultRecentlyClosedControllerTest {
         assertEquals(tabs[1].url, tabUrls[1])
         assertEquals(BrowsingMode.Private, actualBrowsingModes[0])
         assertEquals(BrowsingMode.Private, actualBrowsingModes[1])
-        assertTrue(RecentlyClosedTabs.menuOpenInPrivateTab.testHasValue())
-        assertEquals(1, RecentlyClosedTabs.menuOpenInPrivateTab.testGetValue().size)
-        assertNull(RecentlyClosedTabs.menuOpenInPrivateTab.testGetValue().single().extra)
+        assertNotNull(RecentlyClosedTabs.menuOpenInPrivateTab.testGetValue())
+        assertEquals(1, RecentlyClosedTabs.menuOpenInPrivateTab.testGetValue()!!.size)
+        assertNull(RecentlyClosedTabs.menuOpenInPrivateTab.testGetValue()!!.single().extra)
     }
 
     @Test
     fun `handle selecting first tab`() {
         val selectedTab = createFakeTab()
         every { recentlyClosedStore.state.selectedTabs } returns emptySet()
-        assertFalse(RecentlyClosedTabs.enterMultiselect.testHasValue())
+        assertNull(RecentlyClosedTabs.enterMultiselect.testGetValue())
 
         createController().handleSelect(selectedTab)
 
         verify { recentlyClosedStore.dispatch(RecentlyClosedFragmentAction.Select(selectedTab)) }
-        assertTrue(RecentlyClosedTabs.enterMultiselect.testHasValue())
-        assertEquals(1, RecentlyClosedTabs.enterMultiselect.testGetValue().size)
-        assertNull(RecentlyClosedTabs.enterMultiselect.testGetValue().single().extra)
+        assertNotNull(RecentlyClosedTabs.enterMultiselect.testGetValue())
+        assertEquals(1, RecentlyClosedTabs.enterMultiselect.testGetValue()!!.size)
+        assertNull(RecentlyClosedTabs.enterMultiselect.testGetValue()!!.single().extra)
     }
 
     @Test
@@ -147,21 +146,21 @@ class DefaultRecentlyClosedControllerTest {
         createController().handleSelect(selectedTab)
 
         verify { recentlyClosedStore.dispatch(RecentlyClosedFragmentAction.Select(selectedTab)) }
-        assertFalse(RecentlyClosedTabs.enterMultiselect.testHasValue())
+        assertNull(RecentlyClosedTabs.enterMultiselect.testGetValue())
     }
 
     @Test
     fun `handle deselect last tab`() {
         val deselectedTab = createFakeTab()
         every { recentlyClosedStore.state.selectedTabs } returns setOf(deselectedTab)
-        assertFalse(RecentlyClosedTabs.exitMultiselect.testHasValue())
+        assertNull(RecentlyClosedTabs.exitMultiselect.testGetValue())
 
         createController().handleDeselect(deselectedTab)
 
         verify { recentlyClosedStore.dispatch(RecentlyClosedFragmentAction.Deselect(deselectedTab)) }
-        assertTrue(RecentlyClosedTabs.exitMultiselect.testHasValue())
-        assertEquals(1, RecentlyClosedTabs.exitMultiselect.testGetValue().size)
-        assertNull(RecentlyClosedTabs.exitMultiselect.testGetValue().single().extra)
+        assertNotNull(RecentlyClosedTabs.exitMultiselect.testGetValue())
+        assertEquals(1, RecentlyClosedTabs.exitMultiselect.testGetValue()!!.size)
+        assertNull(RecentlyClosedTabs.exitMultiselect.testGetValue()!!.single().extra)
     }
 
     @Test
@@ -172,28 +171,28 @@ class DefaultRecentlyClosedControllerTest {
         createController().handleDeselect(deselectedTab)
 
         verify { recentlyClosedStore.dispatch(RecentlyClosedFragmentAction.Deselect(deselectedTab)) }
-        assertFalse(RecentlyClosedTabs.exitMultiselect.testHasValue())
+        assertNull(RecentlyClosedTabs.exitMultiselect.testGetValue())
     }
 
     @Test
     fun handleDelete() {
         val item: TabState = mockk(relaxed = true)
-        assertFalse(RecentlyClosedTabs.deleteTab.testHasValue())
+        assertNull(RecentlyClosedTabs.deleteTab.testGetValue())
 
         createController().handleDelete(item)
 
         verify {
             browserStore.dispatch(RecentlyClosedAction.RemoveClosedTabAction(item))
         }
-        assertTrue(RecentlyClosedTabs.deleteTab.testHasValue())
-        assertEquals(1, RecentlyClosedTabs.deleteTab.testGetValue().size)
-        assertNull(RecentlyClosedTabs.deleteTab.testGetValue().single().extra)
+        assertNotNull(RecentlyClosedTabs.deleteTab.testGetValue())
+        assertEquals(1, RecentlyClosedTabs.deleteTab.testGetValue()!!.size)
+        assertNull(RecentlyClosedTabs.deleteTab.testGetValue()!!.single().extra)
     }
 
     @Test
     fun `delete multiple tabs`() {
         val tabs = createFakeTabList(2)
-        assertFalse(RecentlyClosedTabs.menuDelete.testHasValue())
+        assertNull(RecentlyClosedTabs.menuDelete.testGetValue())
 
         createController().handleDelete(tabs.toSet())
 
@@ -201,13 +200,13 @@ class DefaultRecentlyClosedControllerTest {
             browserStore.dispatch(RecentlyClosedAction.RemoveClosedTabAction(tabs[0]))
             browserStore.dispatch(RecentlyClosedAction.RemoveClosedTabAction(tabs[1]))
         }
-        assertTrue(RecentlyClosedTabs.menuDelete.testHasValue())
-        assertNull(RecentlyClosedTabs.menuDelete.testGetValue().last().extra)
+        assertNotNull(RecentlyClosedTabs.menuDelete.testGetValue())
+        assertNull(RecentlyClosedTabs.menuDelete.testGetValue()!!.last().extra)
     }
 
     @Test
     fun handleNavigateToHistory() {
-        assertFalse(RecentlyClosedTabs.showFullHistory.testHasValue())
+        assertNull(RecentlyClosedTabs.showFullHistory.testGetValue())
 
         createController().handleNavigateToHistory()
 
@@ -219,15 +218,15 @@ class DefaultRecentlyClosedControllerTest {
                 optionsEq(NavOptions.Builder().setPopUpTo(R.id.historyFragment, true).build())
             )
         }
-        assertTrue(RecentlyClosedTabs.showFullHistory.testHasValue())
-        assertEquals(1, RecentlyClosedTabs.showFullHistory.testGetValue().size)
-        assertNull(RecentlyClosedTabs.showFullHistory.testGetValue().single().extra)
+        assertNotNull(RecentlyClosedTabs.showFullHistory.testGetValue())
+        assertEquals(1, RecentlyClosedTabs.showFullHistory.testGetValue()!!.size)
+        assertNull(RecentlyClosedTabs.showFullHistory.testGetValue()!!.single().extra)
     }
 
     @Test
     fun `share multiple tabs`() {
         val tabs = createFakeTabList(2)
-        assertFalse(RecentlyClosedTabs.menuShare.testHasValue())
+        assertNull(RecentlyClosedTabs.menuShare.testGetValue())
 
         createController().handleShare(tabs.toSet())
 
@@ -240,49 +239,49 @@ class DefaultRecentlyClosedControllerTest {
                 directionsEq(RecentlyClosedFragmentDirections.actionGlobalShareFragment(data))
             )
         }
-        assertTrue(RecentlyClosedTabs.menuShare.testHasValue())
-        assertEquals(1, RecentlyClosedTabs.menuShare.testGetValue().size)
-        assertNull(RecentlyClosedTabs.menuShare.testGetValue().single().extra)
+        assertNotNull(RecentlyClosedTabs.menuShare.testGetValue())
+        assertEquals(1, RecentlyClosedTabs.menuShare.testGetValue()!!.size)
+        assertNull(RecentlyClosedTabs.menuShare.testGetValue()!!.single().extra)
     }
 
     @Test
     fun handleRestore() = runTest {
         val item: TabState = mockk(relaxed = true)
-        assertFalse(RecentlyClosedTabs.openTab.testHasValue())
+        assertNull(RecentlyClosedTabs.openTab.testGetValue())
 
         createController(scope = this).handleRestore(item)
         runCurrent()
 
         coVerify { tabsUseCases.restore.invoke(eq(item), any(), true) }
-        assertTrue(RecentlyClosedTabs.openTab.testHasValue())
-        assertEquals(1, RecentlyClosedTabs.openTab.testGetValue().size)
-        assertNull(RecentlyClosedTabs.openTab.testGetValue().single().extra)
+        assertNotNull(RecentlyClosedTabs.openTab.testGetValue())
+        assertEquals(1, RecentlyClosedTabs.openTab.testGetValue()!!.size)
+        assertNull(RecentlyClosedTabs.openTab.testGetValue()!!.single().extra)
     }
 
     @Test
     fun `exist multi-select mode when back is pressed`() {
         every { recentlyClosedStore.state.selectedTabs } returns createFakeTabList(3).toSet()
-        assertFalse(RecentlyClosedTabs.exitMultiselect.testHasValue())
+        assertNull(RecentlyClosedTabs.exitMultiselect.testGetValue())
 
         createController().handleBackPressed()
 
         verify { recentlyClosedStore.dispatch(RecentlyClosedFragmentAction.DeselectAll) }
-        assertTrue(RecentlyClosedTabs.exitMultiselect.testHasValue())
-        assertEquals(1, RecentlyClosedTabs.exitMultiselect.testGetValue().size)
-        assertNull(RecentlyClosedTabs.exitMultiselect.testGetValue().single().extra)
+        assertNotNull(RecentlyClosedTabs.exitMultiselect.testGetValue())
+        assertEquals(1, RecentlyClosedTabs.exitMultiselect.testGetValue()!!.size)
+        assertNull(RecentlyClosedTabs.exitMultiselect.testGetValue()!!.single().extra)
     }
 
     @Test
     fun `report closing the fragment when back is pressed`() {
         every { recentlyClosedStore.state.selectedTabs } returns emptySet()
-        assertFalse(RecentlyClosedTabs.closed.testHasValue())
+        assertNull(RecentlyClosedTabs.closed.testGetValue())
 
         createController().handleBackPressed()
 
         verify(exactly = 0) { recentlyClosedStore.dispatch(RecentlyClosedFragmentAction.DeselectAll) }
-        assertTrue(RecentlyClosedTabs.closed.testHasValue())
-        assertEquals(1, RecentlyClosedTabs.closed.testGetValue().size)
-        assertNull(RecentlyClosedTabs.closed.testGetValue().single().extra)
+        assertNotNull(RecentlyClosedTabs.closed.testGetValue())
+        assertEquals(1, RecentlyClosedTabs.closed.testGetValue()!!.size)
+        assertNull(RecentlyClosedTabs.closed.testGetValue()!!.single().extra)
     }
 
     private fun createController(

--- a/app/src/test/java/org/mozilla/fenix/perf/StartupTypeTelemetryTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/perf/StartupTypeTelemetryTest.kt
@@ -15,7 +15,7 @@ import mozilla.components.support.ktx.kotlin.crossProduct
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.telemetry.glean.testing.GleanTestRule
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -83,7 +83,7 @@ class StartupTypeTelemetryTest {
         }
 
         // All invalid labels go to a single bucket: let's verify it has no value.
-        assertFalse(PerfStartup.startupType["__other__"].testHasValue())
+        assertNull(PerfStartup.startupType["__other__"].testGetValue())
     }
 
     @Test

--- a/app/src/test/java/org/mozilla/fenix/perf/StorageStatsMetricsTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/perf/StorageStatsMetricsTest.kt
@@ -14,7 +14,7 @@ import io.mockk.impl.annotations.RelaxedMockK
 import mozilla.components.service.glean.testing.GleanTestRule
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
+import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -48,14 +48,14 @@ class StorageStatsMetricsTest {
 
         StorageStatsMetrics.reportSync(mockContext)
 
-        assertEquals(100, Metrics.appBytes.testGetValue().sum)
-        assertEquals(200, Metrics.cacheBytes.testGetValue().sum)
-        assertEquals(800, Metrics.dataDirBytes.testGetValue().sum)
+        assertEquals(100, Metrics.appBytes.testGetValue()!!.sum)
+        assertEquals(200, Metrics.cacheBytes.testGetValue()!!.sum)
+        assertEquals(800, Metrics.dataDirBytes.testGetValue()!!.sum)
     }
 
     @Test
     fun `WHEN reporting THEN the query duration is measured`() {
         StorageStatsMetrics.reportSync(mockContext)
-        assertTrue(Metrics.queryStatsDuration.testHasValue())
+        assertNotNull(Metrics.queryStatsDuration.testGetValue())
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/search/SearchDialogControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/search/SearchDialogControllerTest.kt
@@ -33,6 +33,7 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -93,7 +94,7 @@ class SearchDialogControllerTest {
     @Test
     fun handleUrlCommitted() {
         val url = "https://www.google.com/"
-        assertFalse(Events.enteredUrl.testHasValue())
+        assertNull(Events.enteredUrl.testGetValue())
 
         createController().handleUrlCommitted(url)
 
@@ -106,8 +107,8 @@ class SearchDialogControllerTest {
             )
         }
 
-        assertTrue(Events.enteredUrl.testHasValue())
-        val snapshot = Events.enteredUrl.testGetValue()
+        assertNotNull(Events.enteredUrl.testGetValue())
+        val snapshot = Events.enteredUrl.testGetValue()!!
         assertEquals(1, snapshot.size)
         assertEquals("false", snapshot.single().extra?.getValue("autocomplete"))
     }
@@ -192,7 +193,7 @@ class SearchDialogControllerTest {
     @Test
     fun handleMozillaUrlCommitted() {
         val url = "moz://a"
-        assertFalse(Events.enteredUrl.testHasValue())
+        assertNull(Events.enteredUrl.testGetValue())
 
         createController().handleUrlCommitted(url)
 
@@ -205,8 +206,8 @@ class SearchDialogControllerTest {
             )
         }
 
-        assertTrue(Events.enteredUrl.testHasValue())
-        val snapshot = Events.enteredUrl.testGetValue()
+        assertNotNull(Events.enteredUrl.testGetValue())
+        val snapshot = Events.enteredUrl.testGetValue()!!
         assertEquals(1, snapshot.size)
         assertEquals("false", snapshot.single().extra?.getValue("autocomplete"))
     }
@@ -297,7 +298,7 @@ class SearchDialogControllerTest {
     fun handleUrlTapped() {
         val url = "https://www.google.com/"
         val flags = EngineSession.LoadUrlFlags.all()
-        assertFalse(Events.enteredUrl.testHasValue())
+        assertNull(Events.enteredUrl.testGetValue())
 
         createController().handleUrlTapped(url, flags)
         createController().handleUrlTapped(url)
@@ -311,8 +312,8 @@ class SearchDialogControllerTest {
             )
         }
 
-        assertTrue(Events.enteredUrl.testHasValue())
-        val snapshot = Events.enteredUrl.testGetValue()
+        assertNotNull(Events.enteredUrl.testGetValue())
+        val snapshot = Events.enteredUrl.testGetValue()!!
         assertEquals(2, snapshot.size)
         assertEquals("false", snapshot.first().extra?.getValue("autocomplete"))
         assertEquals("false", snapshot[1].extra?.getValue("autocomplete"))
@@ -349,8 +350,8 @@ class SearchDialogControllerTest {
         assertTrue(focusToolbarInvoked)
         verify { store.dispatch(SearchFragmentAction.SearchShortcutEngineSelected(searchEngine, settings)) }
 
-        assertTrue(SearchShortcuts.selected.testHasValue())
-        val recordedEvents = SearchShortcuts.selected.testGetValue()
+        assertNotNull(SearchShortcuts.selected.testGetValue())
+        val recordedEvents = SearchShortcuts.selected.testGetValue()!!
         assertEquals(1, recordedEvents.size)
         val eventExtra = recordedEvents.single().extra
         assertNotNull(eventExtra)
@@ -365,7 +366,7 @@ class SearchDialogControllerTest {
         every { searchEngine.id } returns Core.HISTORY_SEARCH_ENGINE_ID
         every { settings.showUnifiedSearchFeature } returns true
 
-        assertFalse(UnifiedSearch.engineSelected.testHasValue())
+        assertNull(UnifiedSearch.engineSelected.testGetValue())
 
         var focusToolbarInvoked = false
         createController(
@@ -377,8 +378,8 @@ class SearchDialogControllerTest {
         assertTrue(focusToolbarInvoked)
         verify { store.dispatch(SearchFragmentAction.SearchHistoryEngineSelected(searchEngine)) }
 
-        assertTrue(UnifiedSearch.engineSelected.testHasValue())
-        val recordedEvents = UnifiedSearch.engineSelected.testGetValue()
+        assertNotNull(UnifiedSearch.engineSelected.testGetValue())
+        val recordedEvents = UnifiedSearch.engineSelected.testGetValue()!!
         assertEquals(1, recordedEvents.size)
         val eventExtra = recordedEvents.single().extra
         assertNotNull(eventExtra)
@@ -393,7 +394,7 @@ class SearchDialogControllerTest {
         every { searchEngine.id } returns Core.BOOKMARKS_SEARCH_ENGINE_ID
         every { settings.showUnifiedSearchFeature } returns true
 
-        assertFalse(UnifiedSearch.engineSelected.testHasValue())
+        assertNull(UnifiedSearch.engineSelected.testGetValue())
 
         var focusToolbarInvoked = false
         createController(
@@ -405,8 +406,8 @@ class SearchDialogControllerTest {
         assertTrue(focusToolbarInvoked)
         verify { store.dispatch(SearchFragmentAction.SearchBookmarksEngineSelected(searchEngine)) }
 
-        assertTrue(UnifiedSearch.engineSelected.testHasValue())
-        val recordedEvents = UnifiedSearch.engineSelected.testGetValue()
+        assertNotNull(UnifiedSearch.engineSelected.testGetValue())
+        val recordedEvents = UnifiedSearch.engineSelected.testGetValue()!!
         assertEquals(1, recordedEvents.size)
         val eventExtra = recordedEvents.single().extra
         assertNotNull(eventExtra)
@@ -421,7 +422,7 @@ class SearchDialogControllerTest {
         every { searchEngine.id } returns Core.TABS_SEARCH_ENGINE_ID
         every { settings.showUnifiedSearchFeature } returns true
 
-        assertFalse(UnifiedSearch.engineSelected.testHasValue())
+        assertNull(UnifiedSearch.engineSelected.testGetValue())
 
         var focusToolbarInvoked = false
         createController(
@@ -433,8 +434,8 @@ class SearchDialogControllerTest {
         assertTrue(focusToolbarInvoked)
         verify { store.dispatch(SearchFragmentAction.SearchTabsEngineSelected(searchEngine)) }
 
-        assertTrue(UnifiedSearch.engineSelected.testHasValue())
-        val recordedEvents = UnifiedSearch.engineSelected.testGetValue()
+        assertNotNull(UnifiedSearch.engineSelected.testGetValue())
+        val recordedEvents = UnifiedSearch.engineSelected.testGetValue()!!
         assertEquals(1, recordedEvents.size)
         val eventExtra = recordedEvents.single().extra
         assertNotNull(eventExtra)

--- a/app/src/test/java/org/mozilla/fenix/search/toolbar/SearchSelectorToolbarActionTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/search/toolbar/SearchSelectorToolbarActionTest.kt
@@ -25,7 +25,8 @@ import mozilla.components.service.glean.testing.GleanTestRule
 import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.rule.MainCoroutineRule
-import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -78,12 +79,12 @@ class SearchSelectorToolbarActionTest {
             )
         )
         val view = action.createView(LinearLayout(testContext) as ViewGroup) as SearchSelector
-        assertFalse(UnifiedSearch.searchMenuTapped.testHasValue())
+        assertNull(UnifiedSearch.searchMenuTapped.testGetValue())
 
         every { settings.shouldUseBottomToolbar } returns false
         view.performClick()
 
-        assertTrue(UnifiedSearch.searchMenuTapped.testHasValue())
+        assertNotNull(UnifiedSearch.searchMenuTapped.testGetValue())
         verify {
             menu.menuController.show(view, Orientation.DOWN)
         }
@@ -91,7 +92,7 @@ class SearchSelectorToolbarActionTest {
         every { settings.shouldUseBottomToolbar } returns true
         view.performClick()
 
-        assertTrue(UnifiedSearch.searchMenuTapped.testHasValue())
+        assertNotNull(UnifiedSearch.searchMenuTapped.testGetValue())
         verify {
             menu.menuController.show(view, Orientation.UP)
         }

--- a/app/src/test/java/org/mozilla/fenix/settings/creditcards/DefaultCreditCardEditorControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/creditcards/DefaultCreditCardEditorControllerTest.kt
@@ -20,8 +20,8 @@ import mozilla.components.support.test.rule.MainCoroutineRule
 import mozilla.components.support.test.rule.runTestOnMain
 import mozilla.components.support.utils.CreditCardNetworkType
 import mozilla.telemetry.glean.testing.GleanTestRule
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -78,7 +78,7 @@ class DefaultCreditCardEditorControllerTest {
     @Test
     fun handleDeleteCreditCard() = runTestOnMain {
         val creditCardId = "id"
-        assertFalse(CreditCards.deleted.testHasValue())
+        assertNull(CreditCards.deleted.testGetValue())
 
         controller.handleDeleteCreditCard(creditCardId)
 
@@ -86,7 +86,7 @@ class DefaultCreditCardEditorControllerTest {
             storage.deleteCreditCard(creditCardId)
             navController.popBackStack()
         }
-        assertTrue(CreditCards.deleted.testHasValue())
+        assertNotNull(CreditCards.deleted.testGetValue())
     }
 
     @Test
@@ -99,7 +99,7 @@ class DefaultCreditCardEditorControllerTest {
             expiryYear = 2030,
             cardType = CreditCardNetworkType.DISCOVER.cardName
         )
-        assertFalse(CreditCards.saved.testHasValue())
+        assertNull(CreditCards.saved.testGetValue())
 
         controller.handleSaveCreditCard(creditCardFields)
 
@@ -107,7 +107,7 @@ class DefaultCreditCardEditorControllerTest {
             storage.addCreditCard(creditCardFields)
             navController.popBackStack()
         }
-        assertTrue(CreditCards.saved.testHasValue())
+        assertNotNull(CreditCards.saved.testGetValue())
     }
 
     @Test
@@ -121,7 +121,7 @@ class DefaultCreditCardEditorControllerTest {
             expiryYear = 2034,
             cardType = CreditCardNetworkType.DISCOVER.cardName
         )
-        assertFalse(CreditCards.modified.testHasValue())
+        assertNull(CreditCards.modified.testGetValue())
 
         controller.handleUpdateCreditCard(creditCardId, creditCardFields)
 
@@ -129,6 +129,6 @@ class DefaultCreditCardEditorControllerTest {
             storage.updateCreditCard(creditCardId, creditCardFields)
             navController.popBackStack()
         }
-        assertTrue(CreditCards.modified.testHasValue())
+        assertNotNull(CreditCards.modified.testGetValue())
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/settings/creditcards/DefaultCreditCardsManagementInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/creditcards/DefaultCreditCardsManagementInteractorTest.kt
@@ -9,8 +9,8 @@ import io.mockk.verify
 import mozilla.components.concept.storage.CreditCard
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.telemetry.glean.testing.GleanTestRule
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -38,19 +38,19 @@ class DefaultCreditCardsManagementInteractorTest {
     @Test
     fun onSelectCreditCard() {
         val creditCard: CreditCard = mockk(relaxed = true)
-        assertFalse(CreditCards.managementCardTapped.testHasValue())
+        assertNull(CreditCards.managementCardTapped.testGetValue())
 
         interactor.onSelectCreditCard(creditCard)
         verify { controller.handleCreditCardClicked(creditCard) }
-        assertTrue(CreditCards.managementCardTapped.testHasValue())
+        assertNotNull(CreditCards.managementCardTapped.testGetValue())
     }
 
     @Test
     fun onClickAddCreditCard() {
-        assertFalse(CreditCards.managementAddTapped.testHasValue())
+        assertNull(CreditCards.managementAddTapped.testGetValue())
 
         interactor.onAddCreditCardClick()
         verify { controller.handleAddCreditCardClicked() }
-        assertTrue(CreditCards.managementAddTapped.testHasValue())
+        assertNotNull(CreditCards.managementAddTapped.testGetValue())
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/settings/logins/LoginsListControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/logins/LoginsListControllerTest.kt
@@ -10,9 +10,8 @@ import io.mockk.verifyAll
 import mozilla.components.service.glean.testing.GleanTestRule
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -55,7 +54,7 @@ class LoginsListControllerTest {
     @Test
     fun `handle login item clicked`() {
         val login: SavedLogin = mockk(relaxed = true)
-        assertFalse(Logins.openIndividualLogin.testHasValue())
+        assertNull(Logins.openIndividualLogin.testGetValue())
 
         controller.handleItemClicked(login)
 
@@ -66,9 +65,9 @@ class LoginsListControllerTest {
             )
         }
 
-        assertTrue(Logins.openIndividualLogin.testHasValue())
-        assertEquals(1, Logins.openIndividualLogin.testGetValue().size)
-        assertNull(Logins.openIndividualLogin.testGetValue().single().extra)
+        assertNotNull(Logins.openIndividualLogin.testGetValue())
+        assertEquals(1, Logins.openIndividualLogin.testGetValue()!!.size)
+        assertNull(Logins.openIndividualLogin.testGetValue()!!.single().extra)
     }
 
     @Test

--- a/app/src/test/java/org/mozilla/fenix/settings/quicksettings/DefaultQuickSettingsControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/quicksettings/DefaultQuickSettingsControllerTest.kt
@@ -31,7 +31,8 @@ import mozilla.components.support.test.rule.MainCoroutineRule
 import mozilla.components.support.test.rule.runTestOnMain
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -323,11 +324,11 @@ class DefaultQuickSettingsControllerTest {
         }
 
         isEnabled = false
-        assertFalse(TrackingProtection.exceptionAdded.testHasValue())
+        assertNull(TrackingProtection.exceptionAdded.testGetValue())
 
         controller.handleTrackingProtectionToggled(isEnabled)
 
-        assertTrue(TrackingProtection.exceptionAdded.testHasValue())
+        assertNotNull(TrackingProtection.exceptionAdded.testGetValue())
         verify {
             trackingProtectionUseCases.addException(tab.id)
             sessionUseCases.reload.invoke(tab.id)

--- a/app/src/test/java/org/mozilla/fenix/share/ShareControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/share/ShareControllerTest.kt
@@ -31,6 +31,7 @@ import mozilla.components.support.test.rule.MainCoroutineRule
 import mozilla.components.support.test.rule.runTestOnMain
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -255,9 +256,9 @@ class ShareControllerTest {
 
         controller.handleShareToDevice(deviceToShareTo)
 
-        assertTrue(SyncAccount.sendTab.testHasValue())
-        assertEquals(1, SyncAccount.sendTab.testGetValue().size)
-        assertNull(SyncAccount.sendTab.testGetValue().single().extra)
+        assertNotNull(SyncAccount.sendTab.testGetValue())
+        assertEquals(1, SyncAccount.sendTab.testGetValue()!!.size)
+        assertNull(SyncAccount.sendTab.testGetValue()!!.single().extra)
 
         // Verify all the needed methods are called.
         verify {
@@ -314,9 +315,9 @@ class ShareControllerTest {
     fun `handleSignIn should navigate to the Sync Fragment and dismiss this one`() {
         controller.handleSignIn()
 
-        assertTrue(SyncAccount.signInToSendTab.testHasValue())
-        assertEquals(1, SyncAccount.signInToSendTab.testGetValue().size)
-        assertNull(SyncAccount.signInToSendTab.testGetValue().single().extra)
+        assertNotNull(SyncAccount.signInToSendTab.testGetValue())
+        assertEquals(1, SyncAccount.signInToSendTab.testGetValue()!!.size)
+        assertNull(SyncAccount.signInToSendTab.testGetValue()!!.single().extra)
 
         verifyOrder {
             navController.nav(

--- a/app/src/test/java/org/mozilla/fenix/tabstray/DefaultTabsTrayControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/DefaultTabsTrayControllerTest.kt
@@ -28,6 +28,8 @@ import mozilla.components.service.glean.testing.GleanTestRule
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -78,11 +80,11 @@ class DefaultTabsTrayControllerTest {
             every { getProfilerTime() } returns Double.MAX_VALUE
         }
 
-        assertFalse(TabsTray.newPrivateTabTapped.testHasValue())
+        assertNull(TabsTray.newPrivateTabTapped.testGetValue())
 
         createController().handleOpeningNewTab(true)
 
-        assertTrue(TabsTray.newPrivateTabTapped.testHasValue())
+        assertNotNull(TabsTray.newPrivateTabTapped.testGetValue())
 
         verifyOrder {
             profiler.getProfilerTime()
@@ -120,26 +122,26 @@ class DefaultTabsTrayControllerTest {
 
     @Test
     fun `GIVEN private mode WHEN handleOpeningNewTab is called THEN Event#NewPrivateTabTapped is added to telemetry`() {
-        assertFalse(TabsTray.newPrivateTabTapped.testHasValue())
+        assertNull(TabsTray.newPrivateTabTapped.testGetValue())
 
         createController().handleOpeningNewTab(true)
 
-        assertTrue(TabsTray.newPrivateTabTapped.testHasValue())
+        assertNotNull(TabsTray.newPrivateTabTapped.testGetValue())
     }
 
     @Test
     fun `GIVEN private mode WHEN handleOpeningNewTab is called THEN Event#NewTabTapped is added to telemetry`() {
-        assertFalse(TabsTray.newTabTapped.testHasValue())
+        assertNull(TabsTray.newTabTapped.testGetValue())
 
         createController().handleOpeningNewTab(false)
 
-        assertTrue(TabsTray.newTabTapped.testHasValue())
+        assertNotNull(TabsTray.newTabTapped.testGetValue())
     }
 
     @Test
     fun `WHEN handleTabDeletion is called THEN Event#ClosedExistingTab is added to telemetry`() {
         val tab: TabSessionState = mockk { every { content.private } returns true }
-        assertFalse(TabsTray.closedExistingTab.testHasValue())
+        assertNull(TabsTray.closedExistingTab.testGetValue())
 
         every { browserStore.state } returns mockk()
         try {
@@ -148,7 +150,7 @@ class DefaultTabsTrayControllerTest {
             every { browserStore.state.getNormalOrPrivateTabs(any()) } returns listOf(tab)
 
             createController().handleTabDeletion("testTabId", "unknown")
-            assertTrue(TabsTray.closedExistingTab.testHasValue())
+            assertNotNull(TabsTray.closedExistingTab.testGetValue())
         } finally {
             unmockkStatic("mozilla.components.browser.state.selector.SelectorsKt")
         }
@@ -342,8 +344,8 @@ class DefaultTabsTrayControllerTest {
 
             controller.handleMultipleTabsDeletion(listOf(privateTab, mockk()))
 
-            assertTrue(TabsTray.closeSelectedTabs.testHasValue())
-            val snapshot = TabsTray.closeSelectedTabs.testGetValue()
+            assertNotNull(TabsTray.closeSelectedTabs.testGetValue())
+            val snapshot = TabsTray.closeSelectedTabs.testGetValue()!!
             assertEquals(1, snapshot.size)
             assertEquals("2", snapshot.single().extra?.getValue("tab_count"))
 
@@ -376,8 +378,8 @@ class DefaultTabsTrayControllerTest {
 
             controller.handleMultipleTabsDeletion(listOf(normalTab, normalTab))
 
-            assertTrue(TabsTray.closeSelectedTabs.testHasValue())
-            val snapshot = TabsTray.closeSelectedTabs.testGetValue()
+            assertNotNull(TabsTray.closeSelectedTabs.testGetValue())
+            val snapshot = TabsTray.closeSelectedTabs.testGetValue()!!
             assertEquals(1, snapshot.size)
             assertEquals("2", snapshot.single().extra?.getValue("tab_count"))
 
@@ -402,8 +404,8 @@ class DefaultTabsTrayControllerTest {
 
             controller.handleMultipleTabsDeletion(listOf(privateTab))
 
-            assertTrue(TabsTray.closeSelectedTabs.testHasValue())
-            val snapshot = TabsTray.closeSelectedTabs.testGetValue()
+            assertNotNull(TabsTray.closeSelectedTabs.testGetValue())
+            val snapshot = TabsTray.closeSelectedTabs.testGetValue()!!
             assertEquals(1, snapshot.size)
             assertEquals("1", snapshot.single().extra?.getValue("tab_count"))
 
@@ -428,8 +430,8 @@ class DefaultTabsTrayControllerTest {
 
             controller.handleMultipleTabsDeletion(listOf(privateTab))
 
-            assertTrue(TabsTray.closeSelectedTabs.testHasValue())
-            val snapshot = TabsTray.closeSelectedTabs.testGetValue()
+            assertNotNull(TabsTray.closeSelectedTabs.testGetValue())
+            val snapshot = TabsTray.closeSelectedTabs.testGetValue()!!
             assertEquals(1, snapshot.size)
             assertEquals("1", snapshot.single().extra?.getValue("tab_count"))
 
@@ -445,16 +447,16 @@ class DefaultTabsTrayControllerTest {
     fun `GIVEN private mode selected WHEN sendNewTabEvent is called THEN NewPrivateTabTapped is tracked in telemetry`() {
         createController().sendNewTabEvent(true)
 
-        assertTrue(TabsTray.newPrivateTabTapped.testHasValue())
+        assertNotNull(TabsTray.newPrivateTabTapped.testGetValue())
     }
 
     @Test
     fun `GIVEN normal mode selected WHEN sendNewTabEvent is called THEN NewTabTapped is tracked in telemetry`() {
-        assertFalse(TabsTray.newTabTapped.testHasValue())
+        assertNull(TabsTray.newTabTapped.testGetValue())
 
         createController().sendNewTabEvent(false)
 
-        assertTrue(TabsTray.newTabTapped.testHasValue())
+        assertNotNull(TabsTray.newTabTapped.testGetValue())
     }
 
     @Test
@@ -518,7 +520,7 @@ class DefaultTabsTrayControllerTest {
             }
         }
         every { browserStore.state } returns mockk()
-        assertFalse(TabsTray.closeAllInactiveTabs.testHasValue())
+        assertNull(TabsTray.closeAllInactiveTabs.testGetValue())
 
         try {
             mockkStatic("mozilla.components.browser.state.selector.SelectorsKt")
@@ -526,7 +528,7 @@ class DefaultTabsTrayControllerTest {
 
             createController().handleDeleteAllInactiveTabs()
 
-            assertTrue(TabsTray.closeAllInactiveTabs.testHasValue())
+            assertNotNull(TabsTray.closeAllInactiveTabs.testGetValue())
         } finally {
             unmockkStatic("mozilla.components.browser.state.selector.SelectorsKt")
         }

--- a/app/src/test/java/org/mozilla/fenix/tabstray/NavigationInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/NavigationInteractorTest.kt
@@ -27,7 +27,8 @@ import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.rule.MainCoroutineRule
 import mozilla.components.support.test.rule.runTestOnMain
 import org.junit.Assert
-import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -76,7 +77,7 @@ class NavigationInteractorTest {
     fun `onTabTrayDismissed calls dismissTabTray on DefaultNavigationInteractor`() {
         var dismissTabTrayInvoked = false
 
-        assertFalse(TabsTray.closed.testHasValue())
+        assertNull(TabsTray.closed.testGetValue())
 
         createInteractor(
             dismissTabTray = {
@@ -85,7 +86,7 @@ class NavigationInteractorTest {
         ).onTabTrayDismissed()
 
         assertTrue(dismissTabTrayInvoked)
-        assertTrue(TabsTray.closed.testHasValue())
+        assertNotNull(TabsTray.closed.testGetValue())
     }
 
     @Test
@@ -114,12 +115,12 @@ class NavigationInteractorTest {
 
     @Test
     fun `onOpenRecentlyClosedClicked calls navigation on DefaultNavigationInteractor`() {
-        assertFalse(Events.recentlyClosedTabsOpened.testHasValue())
+        assertNull(Events.recentlyClosedTabsOpened.testGetValue())
 
         createInteractor().onOpenRecentlyClosedClicked()
 
         verify(exactly = 1) { navController.navigate(TabsTrayFragmentDirections.actionGlobalRecentlyClosed()) }
-        assertTrue(Events.recentlyClosedTabsOpened.testHasValue())
+        assertNotNull(Events.recentlyClosedTabsOpened.testGetValue())
     }
 
     @Test
@@ -182,8 +183,8 @@ class NavigationInteractorTest {
 
         verify(exactly = 1) { navController.navigate(any<NavDirections>()) }
 
-        assertTrue(TabsTray.shareSelectedTabs.testHasValue())
-        val snapshot = TabsTray.shareSelectedTabs.testGetValue()
+        assertNotNull(TabsTray.shareSelectedTabs.testGetValue())
+        val snapshot = TabsTray.shareSelectedTabs.testGetValue()!!
         Assert.assertEquals(1, snapshot.size)
         Assert.assertEquals("1", snapshot.single().extra?.getValue("tab_count"))
     }
@@ -193,11 +194,11 @@ class NavigationInteractorTest {
         mockkStatic("org.mozilla.fenix.collections.CollectionsDialogKt")
 
         every { any<CollectionsDialog>().show(any()) } answers { }
-        assertFalse(TabsTray.saveToCollection.testHasValue())
+        assertNull(TabsTray.saveToCollection.testGetValue())
 
         createInteractor().onSaveToCollections(listOf(testTab))
 
-        assertTrue(TabsTray.saveToCollection.testHasValue())
+        assertNotNull(TabsTray.saveToCollection.testGetValue())
 
         unmockkStatic("org.mozilla.fenix.collections.CollectionsDialogKt")
     }
@@ -214,8 +215,8 @@ class NavigationInteractorTest {
         coVerify(exactly = 1) { bookmarksUseCase.addBookmark(any(), any(), any()) }
         assertTrue(showBookmarkSnackbarInvoked)
 
-        assertTrue(TabsTray.bookmarkSelectedTabs.testHasValue())
-        val snapshot = TabsTray.bookmarkSelectedTabs.testGetValue()
+        assertNotNull(TabsTray.bookmarkSelectedTabs.testGetValue())
+        val snapshot = TabsTray.bookmarkSelectedTabs.testGetValue()!!
         Assert.assertEquals(1, snapshot.size)
         Assert.assertEquals("1", snapshot.single().extra?.getValue("tab_count"))
     }
@@ -224,7 +225,7 @@ class NavigationInteractorTest {
     fun `onSyncedTabsClicked sets metrics and opens browser`() {
         val tab = mockk<SyncTab>()
         val entry = mockk<TabEntry>()
-        assertFalse(Events.syncedTabOpened.testHasValue())
+        assertNull(Events.syncedTabOpened.testGetValue())
 
         every { tab.active() }.answers { entry }
         every { entry.url }.answers { "https://mozilla.org" }
@@ -237,7 +238,7 @@ class NavigationInteractorTest {
         ).onSyncedTabClicked(tab)
 
         assertTrue(dismissTabTrayInvoked)
-        assertTrue(Events.syncedTabOpened.testHasValue())
+        assertNotNull(Events.syncedTabOpened.testGetValue())
 
         verify {
             activity.openToBrowserAndLoad(

--- a/app/src/test/java/org/mozilla/fenix/tabstray/TabLayoutObserverTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/TabLayoutObserverTest.kt
@@ -12,8 +12,8 @@ import mozilla.components.service.glean.testing.GleanTestRule
 import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import mozilla.components.support.test.middleware.CaptureActionsMiddleware
 import mozilla.components.support.test.robolectric.testContext
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -40,34 +40,34 @@ class TabLayoutObserverTest {
         val observer = TabLayoutObserver(interactor)
         val tab = mockk<TabLayout.Tab>()
         every { tab.position } returns 1
-        assertFalse(TabsTray.privateModeTapped.testHasValue())
+        assertNull(TabsTray.privateModeTapped.testGetValue())
 
         observer.onTabSelected(tab)
 
         store.waitUntilIdle()
 
         verify { interactor.onTrayPositionSelected(1, false) }
-        assertTrue(TabsTray.privateModeTapped.testHasValue())
+        assertNotNull(TabsTray.privateModeTapped.testGetValue())
 
         every { tab.position } returns 0
-        assertFalse(TabsTray.normalModeTapped.testHasValue())
+        assertNull(TabsTray.normalModeTapped.testGetValue())
 
         observer.onTabSelected(tab)
 
         store.waitUntilIdle()
 
         verify { interactor.onTrayPositionSelected(0, true) }
-        assertTrue(TabsTray.normalModeTapped.testHasValue())
+        assertNotNull(TabsTray.normalModeTapped.testGetValue())
 
         every { tab.position } returns 2
-        assertFalse(TabsTray.syncedModeTapped.testHasValue())
+        assertNull(TabsTray.syncedModeTapped.testGetValue())
 
         observer.onTabSelected(tab)
 
         store.waitUntilIdle()
 
         verify { interactor.onTrayPositionSelected(2, true) }
-        assertTrue(TabsTray.syncedModeTapped.testHasValue())
+        assertNotNull(TabsTray.syncedModeTapped.testGetValue())
     }
 
     @Test
@@ -75,16 +75,16 @@ class TabLayoutObserverTest {
         val observer = TabLayoutObserver(interactor)
         val tab = mockk<TabLayout.Tab>()
         every { tab.position } returns 1
-        assertFalse(TabsTray.privateModeTapped.testHasValue())
+        assertNull(TabsTray.privateModeTapped.testGetValue())
 
         observer.onTabSelected(tab)
 
         verify { interactor.onTrayPositionSelected(1, false) }
-        assertTrue(TabsTray.privateModeTapped.testHasValue())
+        assertNotNull(TabsTray.privateModeTapped.testGetValue())
 
         observer.onTabSelected(tab)
 
         verify { interactor.onTrayPositionSelected(1, true) }
-        assertTrue(TabsTray.privateModeTapped.testHasValue())
+        assertNotNull(TabsTray.privateModeTapped.testGetValue())
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/tabstray/TabsTrayFragmentTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/TabsTrayFragmentTest.kt
@@ -36,7 +36,8 @@ import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertSame
-import org.junit.Assert.assertTrue
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -255,12 +256,12 @@ class TabsTrayFragmentTest {
             }
             every { fragment.getTrayMenu(any(), any(), any(), any(), any()) } returns menuBuilder
 
-            assertFalse(TabsTray.menuOpened.testHasValue())
+            assertNull(TabsTray.menuOpened.testGetValue())
 
             fragment.setupMenu(navigationInteractor)
             tabsTrayBinding.tabTrayOverflow.performClick()
 
-            assertTrue(TabsTray.menuOpened.testHasValue())
+            assertNotNull(TabsTray.menuOpened.testGetValue())
             verify { menuBuilder.build() }
             verify { menu.showWithTheme(tabsTrayBinding.tabTrayOverflow) }
         } finally {

--- a/app/src/test/java/org/mozilla/fenix/tabstray/TabsTrayMiddlewareTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/TabsTrayMiddlewareTest.kt
@@ -12,8 +12,8 @@ import mozilla.components.service.glean.testing.GleanTestRule
 import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -43,39 +43,39 @@ class TabsTrayMiddlewareTest {
 
     @Test
     fun `WHEN search term groups are updated AND there is at least one group THEN report the average tabs per group`() {
-        assertFalse(SearchTerms.averageTabsPerGroup.testHasValue())
+        assertNull(SearchTerms.averageTabsPerGroup.testGetValue())
 
         store.dispatch(TabsTrayAction.UpdateTabPartitions(generateSearchTermTabGroupsForAverage()))
         store.waitUntilIdle()
 
-        assertTrue(SearchTerms.averageTabsPerGroup.testHasValue())
-        val event = SearchTerms.averageTabsPerGroup.testGetValue()
+        assertNotNull(SearchTerms.averageTabsPerGroup.testGetValue())
+        val event = SearchTerms.averageTabsPerGroup.testGetValue()!!
         assertEquals(1, event.size)
         assertEquals("5.0", event.single().extra!!["count"])
     }
 
     @Test
     fun `WHEN search term groups are updated AND there is at least one group THEN report the distribution of tab sizes`() {
-        assertFalse(SearchTerms.groupSizeDistribution.testHasValue())
+        assertNull(SearchTerms.groupSizeDistribution.testGetValue())
 
         store.dispatch(TabsTrayAction.UpdateTabPartitions(generateSearchTermTabGroupsForDistribution()))
         store.waitUntilIdle()
 
-        assertTrue(SearchTerms.groupSizeDistribution.testHasValue())
-        val event = SearchTerms.groupSizeDistribution.testGetValue().values
+        assertNotNull(SearchTerms.groupSizeDistribution.testGetValue())
+        val event = SearchTerms.groupSizeDistribution.testGetValue()!!.values
         // Verify the distribution correctly describes the tab group sizes
         assertEquals(mapOf(0L to 0L, 1L to 1L, 2L to 1L, 3L to 1L, 4L to 1L), event)
     }
 
     @Test
     fun `WHEN search term groups are updated THEN report the count of search term tab groups`() {
-        assertFalse(SearchTerms.numberOfSearchTermGroup.testHasValue())
+        assertNull(SearchTerms.numberOfSearchTermGroup.testGetValue())
 
         store.dispatch(TabsTrayAction.UpdateTabPartitions(null))
         store.waitUntilIdle()
 
-        assertTrue(SearchTerms.numberOfSearchTermGroup.testHasValue())
-        val event = SearchTerms.numberOfSearchTermGroup.testGetValue()
+        assertNotNull(SearchTerms.numberOfSearchTermGroup.testGetValue())
+        val event = SearchTerms.numberOfSearchTermGroup.testGetValue()!!
         assertEquals(1, event.size)
         assertEquals("0", event.single().extra!!["count"])
     }
@@ -83,14 +83,14 @@ class TabsTrayMiddlewareTest {
     @Test
     fun `WHEN inactive tabs are updated THEN report the count of inactive tabs`() {
 
-        assertFalse(TabsTray.hasInactiveTabs.testHasValue())
-        assertFalse(Metrics.inactiveTabsCount.testHasValue())
+        assertNull(TabsTray.hasInactiveTabs.testGetValue())
+        assertNull(Metrics.inactiveTabsCount.testGetValue())
 
         store.dispatch(TabsTrayAction.UpdateInactiveTabs(emptyList()))
         store.waitUntilIdle()
-        assertTrue(TabsTray.hasInactiveTabs.testHasValue())
-        assertTrue(Metrics.inactiveTabsCount.testHasValue())
-        assertEquals(0, Metrics.inactiveTabsCount.testGetValue())
+        assertNotNull(TabsTray.hasInactiveTabs.testGetValue())
+        assertNotNull(Metrics.inactiveTabsCount.testGetValue())
+        assertEquals(0L, Metrics.inactiveTabsCount.testGetValue())
     }
 
     @Test
@@ -112,13 +112,13 @@ class TabsTrayMiddlewareTest {
 
     @Test
     fun `WHEN multi select mode from menu is entered THEN relevant metrics are collected`() {
-        assertFalse(TabsTray.enterMultiselectMode.testHasValue())
+        assertNull(TabsTray.enterMultiselectMode.testGetValue())
 
         store.dispatch(TabsTrayAction.EnterSelectMode)
         store.waitUntilIdle()
 
-        assertTrue(TabsTray.enterMultiselectMode.testHasValue())
-        val snapshot = TabsTray.enterMultiselectMode.testGetValue()
+        assertNotNull(TabsTray.enterMultiselectMode.testGetValue())
+        val snapshot = TabsTray.enterMultiselectMode.testGetValue()!!
         assertEquals(1, snapshot.size)
         assertEquals("false", snapshot.single().extra?.getValue("tab_selected"))
     }
@@ -128,8 +128,8 @@ class TabsTrayMiddlewareTest {
         store.dispatch(TabsTrayAction.AddSelectTab(mockk()))
         store.waitUntilIdle()
 
-        assertTrue(TabsTray.enterMultiselectMode.testHasValue())
-        val snapshot = TabsTray.enterMultiselectMode.testGetValue()
+        assertNotNull(TabsTray.enterMultiselectMode.testGetValue())
+        val snapshot = TabsTray.enterMultiselectMode.testGetValue()!!
         assertEquals(1, snapshot.size)
         assertEquals("true", snapshot.single().extra?.getValue("tab_selected"))
     }

--- a/app/src/test/java/org/mozilla/fenix/tabstray/browser/AbstractBrowserTabViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/browser/AbstractBrowserTabViewHolderTest.kt
@@ -28,7 +28,7 @@ import mozilla.components.concept.engine.mediasession.MediaSession
 import mozilla.components.lib.publicsuffixlist.PublicSuffixList
 import mozilla.telemetry.glean.testing.GleanTestRule
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Rule
 import org.mozilla.fenix.GleanMetrics.Tab
@@ -109,15 +109,15 @@ class AbstractBrowserTabViewHolderTest {
             mediaBrowserStore,
             interactor
         )
-        assertFalse(Tab.mediaPlay.testHasValue())
+        assertNull(Tab.mediaPlay.testGetValue())
 
         holder.bind(mediaTab, false, mockk(), mockk())
 
         holder.itemView.findViewById<ImageButton>(R.id.play_pause_button).performClick()
 
-        assertTrue(Tab.mediaPlay.testHasValue())
-        assertEquals(1, Tab.mediaPlay.testGetValue().size)
-        assertNull(Tab.mediaPlay.testGetValue().single().extra)
+        assertNotNull(Tab.mediaPlay.testGetValue())
+        assertEquals(1, Tab.mediaPlay.testGetValue()!!.size)
+        assertNull(Tab.mediaPlay.testGetValue()!!.single().extra)
 
         verify { mediaSessionController.play() }
     }
@@ -146,15 +146,15 @@ class AbstractBrowserTabViewHolderTest {
             mediaBrowserStore,
             interactor
         )
-        assertFalse(Tab.mediaPause.testHasValue())
+        assertNull(Tab.mediaPause.testGetValue())
 
         holder.bind(mediaTab, false, mockk(), mockk())
 
         holder.itemView.findViewById<ImageButton>(R.id.play_pause_button).performClick()
 
-        assertTrue(Tab.mediaPause.testHasValue())
-        assertEquals(1, Tab.mediaPause.testGetValue().size)
-        assertNull(Tab.mediaPause.testGetValue().single().extra)
+        assertNotNull(Tab.mediaPause.testGetValue())
+        assertEquals(1, Tab.mediaPause.testGetValue()!!.size)
+        assertNull(Tab.mediaPause.testGetValue()!!.single().extra)
 
         verify { mediaSessionController.pause() }
     }

--- a/app/src/test/java/org/mozilla/fenix/tabstray/browser/InactiveTabsControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/browser/InactiveTabsControllerTest.kt
@@ -11,8 +11,8 @@ import mozilla.components.browser.state.state.ContentState
 import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.service.glean.testing.GleanTestRule
 import mozilla.components.support.test.robolectric.testContext
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -36,37 +36,37 @@ class InactiveTabsControllerTest {
     fun `WHEN the inactive tabs section is expanded THEN the expanded telemetry event should be report`() {
         val controller = InactiveTabsController(appStore, settings, browserInteractor)
 
-        assertFalse(TabsTrayMetrics.inactiveTabsExpanded.testHasValue())
-        assertFalse(TabsTrayMetrics.inactiveTabsCollapsed.testHasValue())
+        assertNull(TabsTrayMetrics.inactiveTabsExpanded.testGetValue())
+        assertNull(TabsTrayMetrics.inactiveTabsCollapsed.testGetValue())
 
         controller.updateCardExpansion(true)
 
-        assertTrue(TabsTrayMetrics.inactiveTabsExpanded.testHasValue())
-        assertFalse(TabsTrayMetrics.inactiveTabsCollapsed.testHasValue())
+        assertNotNull(TabsTrayMetrics.inactiveTabsExpanded.testGetValue())
+        assertNull(TabsTrayMetrics.inactiveTabsCollapsed.testGetValue())
     }
 
     @Test
     fun `WHEN the inactive tabs section is collapsed THEN the collapsed telemetry event should be report`() {
         val controller = InactiveTabsController(appStore, settings, browserInteractor)
 
-        assertFalse(TabsTrayMetrics.inactiveTabsExpanded.testHasValue())
-        assertFalse(TabsTrayMetrics.inactiveTabsCollapsed.testHasValue())
+        assertNull(TabsTrayMetrics.inactiveTabsExpanded.testGetValue())
+        assertNull(TabsTrayMetrics.inactiveTabsCollapsed.testGetValue())
 
         controller.updateCardExpansion(false)
 
-        assertFalse(TabsTrayMetrics.inactiveTabsExpanded.testHasValue())
-        assertTrue(TabsTrayMetrics.inactiveTabsCollapsed.testHasValue())
+        assertNull(TabsTrayMetrics.inactiveTabsExpanded.testGetValue())
+        assertNotNull(TabsTrayMetrics.inactiveTabsCollapsed.testGetValue())
     }
 
     @Test
     fun `WHEN the inactive tabs auto-close feature prompt is dismissed THEN update settings and report the telemetry event`() {
         val controller = spyk(InactiveTabsController(appStore, settings, browserInteractor))
 
-        assertFalse(TabsTrayMetrics.autoCloseDimissed.testHasValue())
+        assertNull(TabsTrayMetrics.autoCloseDimissed.testGetValue())
 
         controller.close()
 
-        assertTrue(TabsTrayMetrics.autoCloseDimissed.testHasValue())
+        assertNotNull(TabsTrayMetrics.autoCloseDimissed.testGetValue())
         verify { settings.hasInactiveTabsAutoCloseDialogBeenDismissed = true }
     }
 
@@ -74,11 +74,12 @@ class InactiveTabsControllerTest {
     fun `WHEN the inactive tabs auto-close feature prompt is accepted THEN update settings and report the telemetry event`() {
         val controller = spyk(InactiveTabsController(appStore, settings, browserInteractor))
 
-        assertFalse(TabsTrayMetrics.autoCloseTurnOnClicked.testHasValue())
+        assertNull(TabsTrayMetrics.autoCloseTurnOnClicked.testGetValue())
 
         controller.enableAutoClosed()
 
-        assertTrue(TabsTrayMetrics.autoCloseTurnOnClicked.testHasValue())
+        assertNotNull(TabsTrayMetrics.autoCloseTurnOnClicked.testGetValue())
+
         verify { settings.closeTabsAfterOneMonth = true }
         verify { settings.closeTabsAfterOneWeek = false }
         verify { settings.closeTabsAfterOneDay = false }
@@ -96,13 +97,13 @@ class InactiveTabsControllerTest {
             )
         )
 
-        assertFalse(TabsTrayMetrics.openInactiveTab.testHasValue())
+        assertNull(TabsTrayMetrics.openInactiveTab.testGetValue())
 
         controller.openInactiveTab(tab)
 
         verify { browserInteractor.onTabSelected(tab, TrayPagerAdapter.INACTIVE_TABS_FEATURE_NAME) }
 
-        assertTrue(TabsTrayMetrics.openInactiveTab.testHasValue())
+        assertNotNull(TabsTrayMetrics.openInactiveTab.testGetValue())
     }
 
     @Test
@@ -115,12 +116,12 @@ class InactiveTabsControllerTest {
             )
         )
 
-        assertFalse(TabsTrayMetrics.openInactiveTab.testHasValue())
+        assertNull(TabsTrayMetrics.openInactiveTab.testGetValue())
 
         controller.openInactiveTab(tab)
 
         verify { browserInteractor.onTabSelected(tab, TrayPagerAdapter.INACTIVE_TABS_FEATURE_NAME) }
 
-        assertTrue(TabsTrayMetrics.openInactiveTab.testHasValue())
+        assertNotNull(TabsTrayMetrics.openInactiveTab.testGetValue())
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/tabstray/browser/RemoveTabUseCaseWrapperTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/browser/RemoveTabUseCaseWrapperTest.kt
@@ -7,8 +7,8 @@ package org.mozilla.fenix.tabstray.browser
 import mozilla.components.service.glean.testing.GleanTestRule
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -29,12 +29,12 @@ class RemoveTabUseCaseWrapperTest {
         }
         val wrapper = RemoveTabUseCaseWrapper(onRemove)
 
-        assertFalse(TabsTray.closedExistingTab.testHasValue())
+        assertNull(TabsTray.closedExistingTab.testGetValue())
 
         wrapper("123")
 
-        assertTrue(TabsTray.closedExistingTab.testHasValue())
-        val snapshot = TabsTray.closedExistingTab.testGetValue()
+        assertNotNull(TabsTray.closedExistingTab.testGetValue())
+        val snapshot = TabsTray.closedExistingTab.testGetValue()!!
         assertEquals(1, snapshot.size)
         assertEquals("unknown", snapshot.single().extra?.getValue("source"))
         assertEquals("123", actualTabId)
@@ -48,12 +48,12 @@ class RemoveTabUseCaseWrapperTest {
         }
         val wrapper = RemoveTabUseCaseWrapper(onRemove)
 
-        assertFalse(TabsTray.closedExistingTab.testHasValue())
+        assertNull(TabsTray.closedExistingTab.testGetValue())
 
         wrapper("123", "Test")
 
-        assertTrue(TabsTray.closedExistingTab.testHasValue())
-        val snapshot = TabsTray.closedExistingTab.testGetValue()
+        assertNotNull(TabsTray.closedExistingTab.testGetValue())
+        val snapshot = TabsTray.closedExistingTab.testGetValue()!!
         assertEquals(1, snapshot.size)
         assertEquals("Test", snapshot.single().extra?.getValue("source"))
         assertEquals("123", actualTabId)

--- a/app/src/test/java/org/mozilla/fenix/tabstray/browser/SelectTabUseCaseWrapperTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/browser/SelectTabUseCaseWrapperTest.kt
@@ -10,8 +10,8 @@ import mozilla.components.feature.tabs.TabsUseCases
 import mozilla.components.service.glean.testing.GleanTestRule
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -32,12 +32,12 @@ class SelectTabUseCaseWrapperTest {
         val onSelect: (String) -> Unit = { invoked = it }
         val wrapper = SelectTabUseCaseWrapper(selectUseCase, onSelect)
 
-        assertFalse(TabsTray.openedExistingTab.testHasValue())
+        assertNull(TabsTray.openedExistingTab.testGetValue())
 
         wrapper("123")
 
-        assertTrue(TabsTray.openedExistingTab.testHasValue())
-        val snapshot = TabsTray.openedExistingTab.testGetValue()
+        assertNotNull(TabsTray.openedExistingTab.testGetValue())
+        val snapshot = TabsTray.openedExistingTab.testGetValue()!!
         assertEquals(1, snapshot.size)
         assertEquals("unknown", snapshot.single().extra?.getValue("source"))
 
@@ -51,12 +51,12 @@ class SelectTabUseCaseWrapperTest {
         val onSelect: (String) -> Unit = { invoked = it }
         val wrapper = SelectTabUseCaseWrapper(selectUseCase, onSelect)
 
-        assertFalse(TabsTray.openedExistingTab.testHasValue())
+        assertNull(TabsTray.openedExistingTab.testGetValue())
 
         wrapper("123", "Test")
 
-        assertTrue(TabsTray.openedExistingTab.testHasValue())
-        val snapshot = TabsTray.openedExistingTab.testGetValue()
+        assertNotNull(TabsTray.openedExistingTab.testGetValue())
+        val snapshot = TabsTray.openedExistingTab.testGetValue()!!
         assertEquals(1, snapshot.size)
         assertEquals("Test", snapshot.single().extra?.getValue("source"))
 

--- a/app/src/test/java/org/mozilla/fenix/telemetry/TelemetryLifecycleObserverTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/telemetry/TelemetryLifecycleObserverTest.kt
@@ -16,9 +16,8 @@ import mozilla.components.support.base.android.Clock
 import mozilla.components.support.test.ext.joinBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertTrue
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -49,7 +48,7 @@ class TelemetryLifecycleObserverTest {
         val observer = TelemetryLifecycleObserver(store)
         observer.onResume(mockk())
 
-        assertFalse(EngineMetrics.foregroundMetrics.testHasValue())
+        assertNull(EngineMetrics.foregroundMetrics.testGetValue())
     }
 
     @Test
@@ -63,9 +62,9 @@ class TelemetryLifecycleObserverTest {
 
         observer.onResume(mockk())
 
-        assertTrue(EngineMetrics.foregroundMetrics.testHasValue())
+        assertNotNull(EngineMetrics.foregroundMetrics.testGetValue())
 
-        val metrics = EngineMetrics.foregroundMetrics.testGetValue()
+        val metrics = EngineMetrics.foregroundMetrics.testGetValue()!!
         assertEquals(1, metrics.size)
 
         val metric = metrics[0]
@@ -106,9 +105,9 @@ class TelemetryLifecycleObserverTest {
 
         observer.onResume(mockk())
 
-        assertTrue(EngineMetrics.foregroundMetrics.testHasValue())
+        assertNotNull(EngineMetrics.foregroundMetrics.testGetValue())
 
-        val metrics = EngineMetrics.foregroundMetrics.testGetValue()
+        val metrics = EngineMetrics.foregroundMetrics.testGetValue()!!
         assertEquals(1, metrics.size)
 
         val metric = metrics[0]

--- a/app/src/test/java/org/mozilla/fenix/telemetry/TelemetryMiddlewareTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/telemetry/TelemetryMiddlewareTest.kt
@@ -23,6 +23,8 @@ import mozilla.components.support.test.rule.MainCoroutineRule
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -69,31 +71,29 @@ class TelemetryMiddlewareTest {
     @Test
     fun `WHEN a tab is added THEN the open tab count is updated`() {
         assertEquals(0, settings.openTabsCount)
-        assertFalse(Metrics.hasOpenTabs.testHasValue())
+        assertNull(Metrics.hasOpenTabs.testGetValue())
 
         store.dispatch(TabListAction.AddTabAction(createTab("https://mozilla.org"))).joinBlocking()
         assertEquals(1, settings.openTabsCount)
 
-        assertTrue(Metrics.hasOpenTabs.testHasValue())
-        assertTrue(Metrics.hasOpenTabs.testGetValue())
+        assertTrue(Metrics.hasOpenTabs.testGetValue()!!)
     }
 
     @Test
     fun `WHEN a private tab is added THEN the open tab count is not updated`() {
         assertEquals(0, settings.openTabsCount)
-        assertFalse(Metrics.hasOpenTabs.testHasValue())
+        assertNull(Metrics.hasOpenTabs.testGetValue())
 
         store.dispatch(TabListAction.AddTabAction(createTab("https://mozilla.org", private = true))).joinBlocking()
         assertEquals(0, settings.openTabsCount)
 
-        assertTrue(Metrics.hasOpenTabs.testHasValue())
-        assertFalse(Metrics.hasOpenTabs.testGetValue())
+        assertFalse(Metrics.hasOpenTabs.testGetValue()!!)
     }
 
     @Test
     fun `WHEN multiple tabs are added THEN the open tab count is updated`() {
         assertEquals(0, settings.openTabsCount)
-        assertFalse(Metrics.hasOpenTabs.testHasValue())
+        assertNull(Metrics.hasOpenTabs.testGetValue())
 
         store.dispatch(
             TabListAction.AddMultipleTabsAction(
@@ -106,13 +106,12 @@ class TelemetryMiddlewareTest {
 
         assertEquals(2, settings.openTabsCount)
 
-        assertTrue(Metrics.hasOpenTabs.testHasValue())
-        assertTrue(Metrics.hasOpenTabs.testGetValue())
+        assertTrue(Metrics.hasOpenTabs.testGetValue()!!)
     }
 
     @Test
     fun `WHEN a tab is removed THEN the open tab count is updated`() {
-        assertFalse(Metrics.hasOpenTabs.testHasValue())
+        assertNull(Metrics.hasOpenTabs.testGetValue())
 
         store.dispatch(
             TabListAction.AddMultipleTabsAction(
@@ -127,13 +126,12 @@ class TelemetryMiddlewareTest {
         store.dispatch(TabListAction.RemoveTabAction("1")).joinBlocking()
         assertEquals(1, settings.openTabsCount)
 
-        assertTrue(Metrics.hasOpenTabs.testHasValue())
-        assertTrue(Metrics.hasOpenTabs.testGetValue())
+        assertTrue(Metrics.hasOpenTabs.testGetValue()!!)
     }
 
     @Test
     fun `WHEN all tabs are removed THEN the open tab count is updated`() {
-        assertFalse(Metrics.hasOpenTabs.testHasValue())
+        assertNull(Metrics.hasOpenTabs.testGetValue())
 
         store.dispatch(
             TabListAction.AddMultipleTabsAction(
@@ -145,19 +143,17 @@ class TelemetryMiddlewareTest {
         ).joinBlocking()
         assertEquals(2, settings.openTabsCount)
 
-        assertTrue(Metrics.hasOpenTabs.testHasValue())
-        assertTrue(Metrics.hasOpenTabs.testGetValue())
+        assertTrue(Metrics.hasOpenTabs.testGetValue()!!)
 
         store.dispatch(TabListAction.RemoveAllTabsAction()).joinBlocking()
         assertEquals(0, settings.openTabsCount)
 
-        assertTrue(Metrics.hasOpenTabs.testHasValue())
-        assertFalse(Metrics.hasOpenTabs.testGetValue())
+        assertFalse(Metrics.hasOpenTabs.testGetValue()!!)
     }
 
     @Test
     fun `WHEN all normal tabs are removed THEN the open tab count is updated`() {
-        assertFalse(Metrics.hasOpenTabs.testHasValue())
+        assertNull(Metrics.hasOpenTabs.testGetValue())
 
         store.dispatch(
             TabListAction.AddMultipleTabsAction(
@@ -169,19 +165,17 @@ class TelemetryMiddlewareTest {
             )
         ).joinBlocking()
         assertEquals(2, settings.openTabsCount)
-        assertTrue(Metrics.hasOpenTabs.testHasValue())
-        assertTrue(Metrics.hasOpenTabs.testGetValue())
+        assertTrue(Metrics.hasOpenTabs.testGetValue()!!)
 
         store.dispatch(TabListAction.RemoveAllNormalTabsAction).joinBlocking()
         assertEquals(0, settings.openTabsCount)
-        assertTrue(Metrics.hasOpenTabs.testHasValue())
-        assertFalse(Metrics.hasOpenTabs.testGetValue())
+        assertFalse(Metrics.hasOpenTabs.testGetValue()!!)
     }
 
     @Test
     fun `WHEN tabs are restored THEN the open tab count is updated`() {
         assertEquals(0, settings.openTabsCount)
-        assertFalse(Metrics.hasOpenTabs.testHasValue())
+        assertNull(Metrics.hasOpenTabs.testGetValue())
 
         val tabsToRestore = listOf(
             RecoverableTab(null, TabState(url = "https://mozilla.org", id = "1")),
@@ -196,36 +190,34 @@ class TelemetryMiddlewareTest {
         ).joinBlocking()
         assertEquals(2, settings.openTabsCount)
 
-        assertTrue(Metrics.hasOpenTabs.testHasValue())
-        assertTrue(Metrics.hasOpenTabs.testGetValue())
+        assertTrue(Metrics.hasOpenTabs.testGetValue()!!)
     }
 
     @Test
     fun `GIVEN a normal page is loading WHEN loading is complete THEN we record a UriOpened event`() {
         val tab = createTab(id = "1", url = "https://mozilla.org")
-        assertFalse(Events.normalAndPrivateUriCount.testHasValue())
+        assertNull(Events.normalAndPrivateUriCount.testGetValue())
 
         store.dispatch(TabListAction.AddTabAction(tab)).joinBlocking()
         store.dispatch(ContentAction.UpdateLoadingStateAction(tab.id, true)).joinBlocking()
-        assertFalse(Events.normalAndPrivateUriCount.testHasValue())
+        assertNull(Events.normalAndPrivateUriCount.testGetValue())
 
         store.dispatch(ContentAction.UpdateLoadingStateAction(tab.id, false)).joinBlocking()
-        assertTrue(Events.normalAndPrivateUriCount.testHasValue())
-        val count = Events.normalAndPrivateUriCount.testGetValue()
+        val count = Events.normalAndPrivateUriCount.testGetValue()!!
         assertEquals(1, count)
     }
 
     @Test
     fun `GIVEN a private page is loading WHEN loading is complete THEN we record a UriOpened event`() {
         val tab = createTab(id = "1", url = "https://mozilla.org", private = true)
-        assertFalse(Events.normalAndPrivateUriCount.testHasValue())
+        assertNull(Events.normalAndPrivateUriCount.testGetValue())
 
         store.dispatch(TabListAction.AddTabAction(tab)).joinBlocking()
         store.dispatch(ContentAction.UpdateLoadingStateAction(tab.id, true)).joinBlocking()
-        assertFalse(Events.normalAndPrivateUriCount.testHasValue())
+        assertNull(Events.normalAndPrivateUriCount.testGetValue())
 
         store.dispatch(ContentAction.UpdateLoadingStateAction(tab.id, false)).joinBlocking()
-        val count = Events.normalAndPrivateUriCount.testGetValue()
+        val count = Events.normalAndPrivateUriCount.testGetValue()!!
         assertEquals(1, count)
     }
 
@@ -243,14 +235,14 @@ class TelemetryMiddlewareTest {
             )
         ).joinBlocking()
 
-        assertFalse(EngineMetrics.kills["foreground"].testHasValue())
-        assertFalse(EngineMetrics.kills["background"].testHasValue())
+        assertNull(EngineMetrics.kills["foreground"].testGetValue())
+        assertNull(EngineMetrics.kills["background"].testGetValue())
 
         store.dispatch(
             EngineAction.KillEngineSessionAction("foreground")
         ).joinBlocking()
 
-        assertTrue(EngineMetrics.kills["foreground"].testHasValue())
+        assertNotNull(EngineMetrics.kills["foreground"].testGetValue())
     }
 
     @Test
@@ -267,23 +259,21 @@ class TelemetryMiddlewareTest {
             )
         ).joinBlocking()
 
-        assertFalse(EngineMetrics.kills["foreground"].testHasValue())
-        assertFalse(EngineMetrics.kills["background"].testHasValue())
+        assertNull(EngineMetrics.kills["foreground"].testGetValue())
+        assertNull(EngineMetrics.kills["background"].testGetValue())
 
         store.dispatch(
             EngineAction.KillEngineSessionAction("background_pocket")
         ).joinBlocking()
 
-        assertFalse(EngineMetrics.kills["foreground"].testHasValue())
-        assertTrue(EngineMetrics.kills["background"].testHasValue())
+        assertNull(EngineMetrics.kills["foreground"].testGetValue())
         assertEquals(1, EngineMetrics.kills["background"].testGetValue())
 
         store.dispatch(
             EngineAction.KillEngineSessionAction("background_verge")
         ).joinBlocking()
 
-        assertFalse(EngineMetrics.kills["foreground"].testHasValue())
-        assertTrue(EngineMetrics.kills["background"].testHasValue())
+        assertNull(EngineMetrics.kills["foreground"].testGetValue())
         assertEquals(2, EngineMetrics.kills["background"].testGetValue())
     }
 
@@ -310,8 +300,8 @@ class TelemetryMiddlewareTest {
             )
         ).joinBlocking()
 
-        assertFalse(EngineMetrics.killForegroundAge.testHasValue())
-        assertFalse(EngineMetrics.killBackgroundAge.testHasValue())
+        assertNull(EngineMetrics.killForegroundAge.testGetValue())
+        assertNull(EngineMetrics.killBackgroundAge.testGetValue())
 
         clock.elapsedTime = 500
 
@@ -319,9 +309,8 @@ class TelemetryMiddlewareTest {
             EngineAction.KillEngineSessionAction("foreground")
         ).joinBlocking()
 
-        assertTrue(EngineMetrics.killForegroundAge.testHasValue())
-        assertFalse(EngineMetrics.killBackgroundAge.testHasValue())
-        assertEquals(400_000_000, EngineMetrics.killForegroundAge.testGetValue().sum)
+        assertNull(EngineMetrics.killBackgroundAge.testGetValue())
+        assertEquals(400_000_000, EngineMetrics.killForegroundAge.testGetValue()!!.sum)
     }
 
     @Test
@@ -349,16 +338,15 @@ class TelemetryMiddlewareTest {
 
         clock.elapsedTime = 700
 
-        assertFalse(EngineMetrics.killForegroundAge.testHasValue())
-        assertFalse(EngineMetrics.killBackgroundAge.testHasValue())
+        assertNull(EngineMetrics.killForegroundAge.testGetValue())
+        assertNull(EngineMetrics.killBackgroundAge.testGetValue())
 
         store.dispatch(
             EngineAction.KillEngineSessionAction("background_pocket")
         ).joinBlocking()
 
-        assertTrue(EngineMetrics.killBackgroundAge.testHasValue())
-        assertFalse(EngineMetrics.killForegroundAge.testHasValue())
-        assertEquals(600_000_000, EngineMetrics.killBackgroundAge.testGetValue().sum)
+        assertNull(EngineMetrics.killForegroundAge.testGetValue())
+        assertEquals(600_000_000, EngineMetrics.killBackgroundAge.testGetValue()!!.sum)
     }
 }
 

--- a/app/src/test/java/org/mozilla/fenix/trackingprotection/TrackingProtectionPanelViewTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/trackingprotection/TrackingProtectionPanelViewTest.kt
@@ -14,6 +14,8 @@ import mozilla.components.service.glean.testing.GleanTestRule
 import mozilla.components.support.test.robolectric.testContext
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -118,11 +120,11 @@ class TrackingProtectionPanelViewTest {
     @Test
     fun testCrossSiteTrackerClick() {
         every { testContext.components.analytics } returns mockk(relaxed = true)
-        assertFalse(TrackingProtection.etpTrackerList.testHasValue())
+        assertNull(TrackingProtection.etpTrackerList.testGetValue())
 
         view.binding.crossSiteTracking.performClick()
 
-        assertTrue(TrackingProtection.etpTrackerList.testHasValue())
+        assertNotNull(TrackingProtection.etpTrackerList.testGetValue())
         verify { interactor.openDetails(CROSS_SITE_TRACKING_COOKIES, categoryBlocked = true) }
 
         view.binding.crossSiteTrackingLoaded.performClick()

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "103.0.20220609143105"
+    const val VERSION = "103.0.20220609181205"
 }


### PR DESCRIPTION
These are mostly mechanical changes to replace usage of `testHasValue` with `testGetValue`.
`testGetValue` will now return `null` instead of throwing an exception if no data is available.

Requires https://github.com/mozilla-mobile/android-components/pull/12248

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
