### PR TITLE
Refactor collections UI tests for Compose

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/FeatureSettingsHelper.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/FeatureSettingsHelper.kt
@@ -16,6 +16,7 @@ class FeatureSettingsHelper {
     private var isPocketEnabled: Boolean = settings.showPocketRecommendationsFeature
     private var isJumpBackInCFREnabled: Boolean = settings.shouldShowJumpBackInCFR
     private var isRecentTabsFeatureEnabled: Boolean = settings.showRecentTabsFeature
+    private var isRecentlyVisitedFeatureEnabled: Boolean = settings.historyMetadataUIFeature
     private var isUserKnowsAboutPwasTrue: Boolean = settings.userKnowsAboutPwas
 
     fun setPocketEnabled(enabled: Boolean) {
@@ -28,6 +29,10 @@ class FeatureSettingsHelper {
 
     fun setRecentTabsFeatureEnabled(enabled: Boolean) {
         settings.showRecentTabsFeature = enabled
+    }
+
+    fun setRecentlyVisitedFeatureEnabled(enabled: Boolean) {
+        settings.historyMetadataUIFeature = enabled
     }
 
     fun setStrictETPEnabled() {
@@ -49,6 +54,7 @@ class FeatureSettingsHelper {
         settings.showPocketRecommendationsFeature = isPocketEnabled
         settings.shouldShowJumpBackInCFR = isJumpBackInCFREnabled
         settings.showRecentTabsFeature = isRecentTabsFeatureEnabled
+        settings.historyMetadataUIFeature = isRecentlyVisitedFeatureEnabled
         settings.userKnowsAboutPwas = isUserKnowsAboutPwasTrue
     }
 }

--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/TestAssetHelper.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/TestAssetHelper.kt
@@ -15,6 +15,7 @@ import org.mozilla.fenix.helpers.ext.toUri
 object TestAssetHelper {
     @Suppress("MagicNumber")
     val waitingTime: Long = TimeUnit.SECONDS.toMillis(15)
+    val waitingTimeLong = TimeUnit.SECONDS.toMillis(25)
     val waitingTimeShort: Long = TimeUnit.SECONDS.toMillis(3)
 
     data class TestAsset(val url: Uri, val content: String, val title: String)

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/CollectionTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/CollectionTest.kt
@@ -4,19 +4,24 @@
 
 package org.mozilla.fenix.ui
 
+import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
+import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.FeatureSettingsHelper
-import org.mozilla.fenix.helpers.HomeActivityTestRule
+import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper.getGenericAsset
+import org.mozilla.fenix.ui.robots.browserScreen
+import org.mozilla.fenix.ui.robots.collectionRobot
+import org.mozilla.fenix.ui.robots.homeScreen
 import org.mozilla.fenix.ui.robots.navigationToolbar
+import org.mozilla.fenix.ui.robots.tabDrawer
 
 /**
  *  Tests for verifying basic functionality of tab collections
@@ -24,24 +29,27 @@ import org.mozilla.fenix.ui.robots.navigationToolbar
  */
 
 class CollectionTest {
-    /* ktlint-disable no-blank-line-before-rbrace */
-    // This imposes unreadable grouping.
-
     private val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
     private lateinit var mockWebServer: MockWebServer
     private val firstCollectionName = "testcollection_1"
     private val secondCollectionName = "testcollection_2"
+    private val collectionName = "First Collection"
     private val featureSettingsHelper = FeatureSettingsHelper()
 
     @get:Rule
-    val activityTestRule = HomeActivityTestRule()
+    val composeTestRule = AndroidComposeTestRule(
+        HomeActivityIntentTestRule(),
+        { it.activity }
+    )
 
     @Before
     fun setUp() {
-        // disabling these features to have better visibility of Collections
+        // disabling these features to have better visibility of Collections,
+        // and to avoid multiple matches on tab items
         featureSettingsHelper.setRecentTabsFeatureEnabled(false)
         featureSettingsHelper.setPocketEnabled(false)
         featureSettingsHelper.setJumpBackCFREnabled(false)
+        featureSettingsHelper.setRecentlyVisitedFeatureEnabled(false)
 
         mockWebServer = MockWebServer().apply {
             dispatcher = AndroidAssetDispatcher()
@@ -57,6 +65,171 @@ class CollectionTest {
         featureSettingsHelper.resetAllFeatureFlags()
     }
 
+    @SmokeTest
+    @Test
+    fun createFirstCollectionTest() {
+        val firstWebPage = getGenericAsset(mockWebServer, 1)
+        val secondWebPage = getGenericAsset(mockWebServer, 2)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(firstWebPage.url) {
+            mDevice.waitForIdle()
+        }.openTabDrawer {
+        }.openNewTab {
+        }.submitQuery(secondWebPage.url.toString()) {
+            mDevice.waitForIdle()
+        }.goToHomescreen {
+            swipeToBottom()
+        }.clickSaveTabsToCollectionButton {
+            longClickTab(firstWebPage.title)
+            selectTab(secondWebPage.title, numOfTabs = 2)
+        }.clickSaveCollection {
+            typeCollectionNameAndSave(collectionName)
+        }
+
+        tabDrawer {
+            verifySnackBarText("Collection saved!")
+            snackBarButtonClick("VIEW")
+        }
+
+        homeScreen {
+            verifyCollectionIsDisplayed(collectionName)
+        }
+    }
+
+    @SmokeTest
+    @Test
+    fun verifyExpandedCollectionItemsTest() {
+        val webPage = getGenericAsset(mockWebServer, 1)
+        val webPageUrl = webPage.url.host.toString()
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(webPage.url) {
+        }.openTabDrawer {
+            createCollection(webPage.title, collectionName = collectionName)
+            snackBarButtonClick("VIEW")
+        }
+
+        homeScreen {
+            verifyCollectionIsDisplayed(collectionName)
+        }.expandCollection(collectionName, composeTestRule) {
+            verifyTabSavedInCollection(webPage.title)
+            verifyCollectionTabUrl(true, webPageUrl)
+            verifyShareCollectionButtonIsVisible(true)
+            verifyCollectionMenuIsVisible(true, composeTestRule)
+            verifyCollectionItemRemoveButtonIsVisible(webPage.title, true)
+        }.collapseCollection(collectionName) {}
+
+        collectionRobot {
+            verifyTabSavedInCollection(webPage.title, false)
+            verifyShareCollectionButtonIsVisible(false)
+            verifyCollectionMenuIsVisible(false, composeTestRule)
+            verifyCollectionTabUrl(false, webPageUrl)
+            verifyCollectionItemRemoveButtonIsVisible(webPage.title, false)
+        }
+
+        homeScreen {
+        }.expandCollection(collectionName, composeTestRule) {
+            verifyTabSavedInCollection(webPage.title)
+            verifyCollectionTabUrl(true, webPageUrl)
+            verifyShareCollectionButtonIsVisible(true)
+            verifyCollectionMenuIsVisible(true, composeTestRule)
+            verifyCollectionItemRemoveButtonIsVisible(webPage.title, true)
+        }.collapseCollection(collectionName) {}
+
+        collectionRobot {
+            verifyTabSavedInCollection(webPage.title, false)
+            verifyShareCollectionButtonIsVisible(false)
+            verifyCollectionMenuIsVisible(false, composeTestRule)
+            verifyCollectionTabUrl(false, webPageUrl)
+            verifyCollectionItemRemoveButtonIsVisible(webPage.title, false)
+        }
+    }
+
+    @SmokeTest
+    @Test
+    fun openAllTabsInCollectionTest() {
+        val firstTestPage = getGenericAsset(mockWebServer, 1)
+        val secondTestPage = getGenericAsset(mockWebServer, 2)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(firstTestPage.url) {
+            waitForPageToLoad()
+        }.openTabDrawer {
+        }.openNewTab {
+        }.submitQuery(secondTestPage.url.toString()) {
+            waitForPageToLoad()
+        }.openTabDrawer {
+            createCollection(
+                firstTestPage.title,
+                secondTestPage.title,
+                collectionName = collectionName
+            )
+            closeTab()
+        }
+
+        homeScreen {
+        }.expandCollection(collectionName, composeTestRule) {
+            clickCollectionThreeDotButton(composeTestRule)
+            selectOpenTabs(composeTestRule)
+        }
+        tabDrawer {
+            verifyExistingOpenTabs(firstTestPage.title, secondTestPage.title)
+        }
+    }
+
+    @SmokeTest
+    @Test
+    fun shareCollectionTest() {
+        val firstWebsite = getGenericAsset(mockWebServer, 1)
+        val secondWebsite = getGenericAsset(mockWebServer, 2)
+        val sharingApp = "Gmail"
+        val urlString = "${secondWebsite.url}\n\n${firstWebsite.url}"
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(firstWebsite.url) {
+        }.openTabDrawer {
+        }.openNewTab {
+        }.submitQuery(secondWebsite.url.toString()) {
+            waitForPageToLoad()
+        }.openTabDrawer {
+            createCollection(firstWebsite.title, secondWebsite.title, collectionName = collectionName)
+            verifySnackBarText("Collection saved!")
+        }.openTabsListThreeDotMenu {
+        }.closeAllTabs {
+        }.expandCollection(collectionName, composeTestRule) {
+        }.clickShareCollectionButton {
+            verifyShareTabsOverlay(firstWebsite.title, secondWebsite.title)
+            verifySharingWithSelectedApp(sharingApp, urlString, collectionName)
+        }
+    }
+
+    @SmokeTest
+    @Test
+    // Test running on beta/release builds in CI:
+    // caution when making changes to it, so they don't block the builds
+    fun deleteCollectionTest() {
+        val webPage = getGenericAsset(mockWebServer, 1)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(webPage.url) {
+        }.openTabDrawer {
+            createCollection(webPage.title, collectionName = collectionName)
+            snackBarButtonClick("VIEW")
+        }
+
+        homeScreen {
+        }.expandCollection(collectionName, composeTestRule) {
+            clickCollectionThreeDotButton(composeTestRule)
+            selectDeleteCollection(composeTestRule)
+        }
+
+        homeScreen {
+            verifySnackBarText("Collection deleted")
+            verifyNoCollectionsText()
+        }
+    }
+
     @Test
     // open a webpage, and add currently opened tab to existing collection
     fun mainMenuSaveToExistingCollection() {
@@ -66,7 +239,7 @@ class CollectionTest {
         navigationToolbar {
         }.enterURLAndEnterToBrowser(firstWebPage.url) {
         }.openTabDrawer {
-            createCollection(firstWebPage.title, firstCollectionName)
+            createCollection(firstWebPage.title, collectionName = collectionName)
             verifySnackBarText("Collection saved!")
         }.closeTabDrawer {}
 
@@ -75,12 +248,12 @@ class CollectionTest {
             verifyPageContent(secondWebPage.content)
         }.openThreeDotMenu {
         }.openSaveToCollection {
-        }.selectExistingCollection(firstCollectionName) {
+        }.selectExistingCollection(collectionName) {
             verifySnackBarText("Tab saved!")
-            // }.goToHomescreen {
-            // }.expandCollection(firstCollectionName) {
-            //     verifyTabSavedInCollection(firstWebPage.title)
-            //     verifyTabSavedInCollection(secondWebPage.title)
+        }.goToHomescreen {
+        }.expandCollection(collectionName, composeTestRule) {
+            verifyTabSavedInCollection(firstWebPage.title)
+            verifyTabSavedInCollection(secondWebPage.title)
         }
     }
 
@@ -92,7 +265,7 @@ class CollectionTest {
         navigationToolbar {
         }.enterURLAndEnterToBrowser(firstWebPage.url) {
         }.openTabDrawer {
-            createCollection(firstWebPage.title, firstCollectionName)
+            createCollection(firstWebPage.title, collectionName = collectionName)
             verifySnackBarText("Collection saved!")
             closeTab()
         }
@@ -100,117 +273,131 @@ class CollectionTest {
         navigationToolbar {
         }.enterURLAndEnterToBrowser(secondWebPage.url) {
         }.goToHomescreen {
-            // }.expandCollection(firstCollectionName) {
-            //     clickCollectionThreeDotButton()
-            //     selectAddTabToCollection()
-            //     verifyTabsSelectedCounterText(1)
-            //     saveTabsSelectedForCollection()
-            //     verifySnackBarText("Tab saved!")
-            //     verifyTabSavedInCollection(secondWebPage.title)
+        }.expandCollection(collectionName, composeTestRule) {
+            clickCollectionThreeDotButton(composeTestRule)
+            selectAddTabToCollection(composeTestRule)
+            verifyTabsSelectedCounterText(1)
+            saveTabsSelectedForCollection()
+            verifySnackBarText("Tab saved!")
+            verifyTabSavedInCollection(secondWebPage.title)
         }
     }
 
-    // @Test
-    // fun renameCollectionTest() {
-    //     val webPage = getGenericAsset(mockWebServer, 1)
-    //
-    //     navigationToolbar {
-    //     }.enterURLAndEnterToBrowser(webPage.url) {
-    //     }.openTabDrawer {
-    //         createCollection(webPage.title, firstCollectionName)
-    //         verifySnackBarText("Collection saved!")
-    //     }.closeTabDrawer {
-    //     }.goToHomescreen {
-    //     }.expandCollection(firstCollectionName) {
-    //         clickCollectionThreeDotButton()
-    //         selectRenameCollection()
-    //     }.typeCollectionNameAndSave("renamed_collection") {}
-    //
-    //     homeScreen {
-    //         verifyCollectionIsDisplayed("renamed_collection")
-    //     }
-    // }
+    @Test
+    fun renameCollectionTest() {
+        val webPage = getGenericAsset(mockWebServer, 1)
 
-    // @Test
-    // fun createSecondCollectionTest() {
-    //     val webPage = getGenericAsset(mockWebServer, 1)
-    //
-    //     navigationToolbar {
-    //     }.enterURLAndEnterToBrowser(webPage.url) {
-    //     }.openTabDrawer {
-    //         createCollection(webPage.title, firstCollectionName)
-    //         verifySnackBarText("Collection saved!")
-    //         createCollection(webPage.title, secondCollectionName, false)
-    //         verifySnackBarText("Collection saved!")
-    //     }.closeTabDrawer {
-    //     }.goToHomescreen {}
-    //
-    //     homeScreen {
-    //         verifyCollectionIsDisplayed(firstCollectionName)
-    //         verifyCollectionIsDisplayed(secondCollectionName)
-    //     }
-    // }
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(webPage.url) {
+        }.openTabDrawer {
+            createCollection(webPage.title, collectionName = firstCollectionName)
+            verifySnackBarText("Collection saved!")
+        }.closeTabDrawer {
+        }.goToHomescreen {
+        }.expandCollection(firstCollectionName, composeTestRule) {
+            clickCollectionThreeDotButton(composeTestRule)
+            selectRenameCollection(composeTestRule)
+        }.typeCollectionNameAndSave(secondCollectionName) {}
+        homeScreen {
+            verifyCollectionIsDisplayed(secondCollectionName)
+        }
+    }
 
-//     @Test
-//     fun removeTabFromCollectionTest() {
-//         val webPage = getGenericAsset(mockWebServer, 1)
-//
-//         navigationToolbar {
-//         }.enterURLAndEnterToBrowser(webPage.url) {
-//         }.openTabDrawer {
-//             createCollection(webPage.title, firstCollectionName)
-//             verifySnackBarText("Collection saved!")
-//             closeTab()
-//         }
-//
-//         homeScreen {
-//         }.expandCollection(firstCollectionName) {
-//             removeTabFromCollection(webPage.title)
-//             verifyTabSavedInCollection(webPage.title, false)
-//         }
-//         // To add this step when https://github.com/mozilla-mobile/fenix/issues/13177 is fixed
-// //        homeScreen {
-// //            verifyCollectionIsDisplayed(firstCollectionName, false)
-// //        }
-//     }
+    @Test
+    fun createSecondCollectionTest() {
+        val webPage = getGenericAsset(mockWebServer, 1)
 
-    // @Test
-    // fun swipeToRemoveTabFromCollectionTest() {
-    //     val firstWebPage = getGenericAsset(mockWebServer, 1)
-    //     val secondWebPage = getGenericAsset(mockWebServer, 2)
-    //
-    //     navigationToolbar {
-    //     }.enterURLAndEnterToBrowser(firstWebPage.url) {
-    //     }.openTabDrawer {
-    //         createCollection(firstWebPage.title, firstCollectionName)
-    //         verifySnackBarText("Collection saved!")
-    //         closeTab()
-    //     }
-    //
-    //     navigationToolbar {
-    //     }.enterURLAndEnterToBrowser(secondWebPage.url) {
-    //     }.openThreeDotMenu {
-    //     }.openSaveToCollection {
-    //     }.selectExistingCollection(firstCollectionName) {
-    //     }.openTabDrawer {
-    //         closeTab()
-    //     }
-    //
-    //     homeScreen {
-    //     }.expandCollection(firstCollectionName) {
-    //         swipeToBottom()
-    //         swipeCollectionItemLeft(firstWebPage.title)
-    //         verifyTabSavedInCollection(firstWebPage.title, false)
-    //         swipeCollectionItemRight(secondWebPage.title)
-    //         verifyTabSavedInCollection(secondWebPage.title, false)
-    //     }
-    // To add this step when https://github.com/mozilla-mobile/fenix/issues/13177 is fixed
-//        homeScreen {
-//            verifyCollectionIsDisplayed(firstCollectionName, false)
-//        }
-//     }
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(webPage.url) {
+        }.openTabDrawer {
+            createCollection(webPage.title, collectionName = firstCollectionName)
+            verifySnackBarText("Collection saved!")
+            createCollection(
+                webPage.title, collectionName = secondCollectionName,
+                firstCollection = false
+            )
+            verifySnackBarText("Collection saved!")
+        }.closeTabDrawer {
+        }.goToHomescreen {
+            verifyCollectionIsDisplayed(firstCollectionName)
+            verifyCollectionIsDisplayed(secondCollectionName)
+        }
+    }
 
-    @Ignore("Failing, see: https://github.com/mozilla-mobile/fenix/issues/24997")
+    @Test
+    fun removeTabFromCollectionTest() {
+        val webPage = getGenericAsset(mockWebServer, 1)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(webPage.url) {
+        }.openTabDrawer {
+            createCollection(webPage.title, collectionName = collectionName)
+            closeTab()
+        }
+
+        homeScreen {
+        }.expandCollection(collectionName, composeTestRule) {
+            verifyTabSavedInCollection(webPage.title, true)
+            removeTabFromCollection(webPage.title)
+            verifyTabSavedInCollection(webPage.title, false)
+        }
+        homeScreen {
+            verifyCollectionIsDisplayed(collectionName, false)
+        }
+    }
+
+    @Test
+    fun swipeLeftToRemoveTabFromCollectionTest() {
+        val testPage = getGenericAsset(mockWebServer, 1)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(testPage.url) {
+            waitForPageToLoad()
+        }.openTabDrawer {
+            createCollection(
+                testPage.title,
+                collectionName = collectionName
+            )
+            closeTab()
+        }
+
+        homeScreen {
+        }.expandCollection(collectionName, composeTestRule) {
+            swipeToBottom()
+            swipeTabLeft(testPage.title, composeTestRule)
+            verifyTabSavedInCollection(testPage.title, false)
+        }
+        homeScreen {
+            verifyCollectionIsDisplayed(collectionName, false)
+        }
+    }
+
+    @Test
+    fun swipeRightToRemoveTabFromCollectionTest() {
+        val testPage = getGenericAsset(mockWebServer, 1)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(testPage.url) {
+            waitForPageToLoad()
+        }.openTabDrawer {
+            createCollection(
+                testPage.title,
+                collectionName = collectionName
+            )
+            closeTab()
+        }
+
+        homeScreen {
+        }.expandCollection(collectionName, composeTestRule) {
+            swipeToBottom()
+            swipeTabRight(testPage.title, composeTestRule)
+            verifyTabSavedInCollection(testPage.title, false)
+        }
+        homeScreen {
+            verifyCollectionIsDisplayed(collectionName, false)
+        }
+    }
+
     @Test
     fun selectTabOnLongTapTest() {
         val firstWebPage = getGenericAsset(mockWebServer, 1)
@@ -218,83 +405,84 @@ class CollectionTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(firstWebPage.url) {
+            waitForPageToLoad()
         }.openTabDrawer {
         }.openNewTab {
         }.submitQuery(secondWebPage.url.toString()) {
-            mDevice.waitForIdle()
+            waitForPageToLoad()
         }.openTabDrawer {
+            verifyExistingOpenTabs(firstWebPage.title, secondWebPage.title)
             longClickTab(firstWebPage.title)
             verifyTabsMultiSelectionCounter(1)
-            selectTab(secondWebPage.title)
-            verifyTabsMultiSelectionCounter(2)
+            selectTab(secondWebPage.title, numOfTabs = 2)
         }.clickSaveCollection {
-            typeCollectionNameAndSave(firstCollectionName)
+            typeCollectionNameAndSave(collectionName)
             verifySnackBarText("Tabs saved!")
         }
 
-        // tabDrawer {
-        // }.closeTabDrawer {
-        // }.goToHomescreen {
-        // }.expandCollection(firstCollectionName) {
-        //     verifyTabSavedInCollection(firstWebPage.title)
-        //     verifyTabSavedInCollection(secondWebPage.title)
-        // }
+        tabDrawer {
+        }.closeTabDrawer {
+        }.goToHomescreen {
+        }.expandCollection(collectionName, composeTestRule) {
+            verifyTabSavedInCollection(firstWebPage.title)
+            verifyTabSavedInCollection(secondWebPage.title)
+        }
     }
 
-    // @Test
-    // fun navigateBackInCollectionFlowTest() {
-    //     val webPage = getGenericAsset(mockWebServer, 1)
-    //
-    //     navigationToolbar {
-    //     }.enterURLAndEnterToBrowser(webPage.url) {
-    //     }.openTabDrawer {
-    //         createCollection(webPage.title, firstCollectionName)
-    //         verifySnackBarText("Collection saved!")
-    //     }.closeTabDrawer {
-    //     }.openThreeDotMenu {
-    //     }.openSaveToCollection {
-    //         verifySelectCollectionScreen()
-    //         goBackInCollectionFlow()
-    //     }
-    //
-    //     browserScreen {
-    //     }.openThreeDotMenu {
-    //     }.openSaveToCollection {
-    //         verifySelectCollectionScreen()
-    //         clickAddNewCollection()
-    //         verifyCollectionNameTextField()
-    //         goBackInCollectionFlow()
-    //         verifySelectCollectionScreen()
-    //         goBackInCollectionFlow()
-    //     }
-    //     // verify the browser layout is visible
-    //     browserScreen {
-    //         verifyMenuButton()
-    //     }
-    // }
+    @Test
+    fun navigateBackInCollectionFlowTest() {
+        val webPage = getGenericAsset(mockWebServer, 1)
 
-    // @SmokeTest
-    // @Test
-    // fun undoDeleteCollectionTest() {
-    //     val webPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-    //
-    //     navigationToolbar {
-    //     }.enterURLAndEnterToBrowser(webPage.url) {
-    //     }.openTabDrawer {
-    //         createCollection(webPage.title, firstCollectionName)
-    //         snackBarButtonClick("VIEW")
-    //     }
-    //
-    //     homeScreen {
-    //     }.expandCollection(firstCollectionName) {
-    //         clickCollectionThreeDotButton()
-    //         selectDeleteCollection()
-    //     }
-    //
-    //     homeScreen {
-    //         verifySnackBarText("Collection deleted")
-    //         clickUndoCollectionDeletion("UNDO")
-    //         verifyCollectionIsDisplayed(firstCollectionName, true)
-    //     }
-    // }
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(webPage.url) {
+        }.openTabDrawer {
+            createCollection(webPage.title, collectionName = collectionName)
+            verifySnackBarText("Collection saved!")
+        }.closeTabDrawer {
+        }.openThreeDotMenu {
+        }.openSaveToCollection {
+            verifySelectCollectionScreen()
+            goBackInCollectionFlow()
+        }
+
+        browserScreen {
+        }.openThreeDotMenu {
+        }.openSaveToCollection {
+            verifySelectCollectionScreen()
+            clickAddNewCollection()
+            verifyCollectionNameTextField()
+            goBackInCollectionFlow()
+            verifySelectCollectionScreen()
+            goBackInCollectionFlow()
+        }
+        // verify the browser layout is visible
+        browserScreen {
+            verifyMenuButton()
+        }
+    }
+
+    @SmokeTest
+    @Test
+    fun undoDeleteCollectionTest() {
+        val webPage = getGenericAsset(mockWebServer, 1)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(webPage.url) {
+        }.openTabDrawer {
+            createCollection(webPage.title, collectionName = collectionName)
+            snackBarButtonClick("VIEW")
+        }
+
+        homeScreen {
+        }.expandCollection(collectionName, composeTestRule) {
+            clickCollectionThreeDotButton(composeTestRule)
+            selectDeleteCollection(composeTestRule)
+        }
+
+        homeScreen {
+            verifySnackBarText("Collection deleted")
+            clickUndoCollectionDeletion("UNDO")
+            verifyCollectionIsDisplayed(collectionName, true)
+        }
+    }
 }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -67,7 +67,6 @@ class SmokeTest {
     private var addonsListIdlingResource: RecyclerViewIdlingResource? = null
     private var recentlyClosedTabsListIdlingResource: RecyclerViewIdlingResource? = null
     private var readerViewNotification: ViewVisibilityIdlingResource? = null
-    private val collectionName = "First Collection"
     private var bookmarksListIdlingResource: RecyclerViewIdlingResource? = null
     private var localeListIdlingResource: RecyclerViewIdlingResource? = null
     private val customMenuItem = "TestMenuItem"
@@ -346,18 +345,18 @@ class SmokeTest {
         }
     }
 
-    // @Test
-    // // Verifies the Add to collection option in a tab's 3 dot menu
-    // fun openMainMenuAddToCollectionTest() {
-    //     val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-    //
-    //     navigationToolbar {
-    //     }.enterURLAndEnterToBrowser(defaultWebPage.url) {
-    //     }.openThreeDotMenu {
-    //     }.openSaveToCollection {
-    //         verifyCollectionNameTextField()
-    //     }
-    // }
+    @Test
+    // Verifies the Add to collection option in a tab's 3 dot menu
+    fun openMainMenuAddToCollectionTest() {
+        val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(defaultWebPage.url) {
+        }.openThreeDotMenu {
+        }.openSaveToCollection {
+            verifyCollectionNameTextField()
+        }
+    }
 
     @Test
     // Verifies the Bookmark button in a tab's 3 dot menu
@@ -616,172 +615,6 @@ class SmokeTest {
         }
     }
 
-    // @Test
-    // fun createFirstCollectionTest() {
-    //     // disabling these features to have better visibility of Collections
-    //     featureSettingsHelper.setRecentTabsFeatureEnabled(false)
-    //     featureSettingsHelper.setPocketEnabled(false)
-    //
-    //     val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-    //     val secondWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 2)
-    //
-    //     navigationToolbar {
-    //     }.enterURLAndEnterToBrowser(firstWebPage.url) {
-    //         mDevice.waitForIdle()
-    //     }.openTabDrawer {
-    //     }.openNewTab {
-    //     }.submitQuery(secondWebPage.url.toString()) {
-    //         mDevice.waitForIdle()
-    //     }.goToHomescreen {
-    //         swipeToBottom()
-    //     }.clickSaveTabsToCollectionButton {
-    //         longClickTab(firstWebPage.title)
-    //         selectTab(secondWebPage.title)
-    //     }.clickSaveCollection {
-    //         typeCollectionNameAndSave(collectionName)
-    //     }
-    //
-    //     tabDrawer {
-    //         verifySnackBarText("Collection saved!")
-    //         snackBarButtonClick("VIEW")
-    //     }
-    //
-    //     homeScreen {
-    //         verifyCollectionIsDisplayed(collectionName)
-    //         verifyCollectionIcon()
-    //     }
-    // }
-
-    // @Test
-    // fun verifyExpandedCollectionItemsTest() {
-    //     // disabling these features to have better visibility of Collections
-    //     featureSettingsHelper.setRecentTabsFeatureEnabled(false)
-    //     featureSettingsHelper.setPocketEnabled(false)
-    //
-    //     val webPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-    //
-    //     navigationToolbar {
-    //     }.enterURLAndEnterToBrowser(webPage.url) {
-    //     }.openTabDrawer {
-    //         createCollection(webPage.title, collectionName)
-    //         snackBarButtonClick("VIEW")
-    //     }
-    //
-    //     homeScreen {
-    //         verifyCollectionIsDisplayed(collectionName)
-    //         verifyCollectionIcon()
-    //     }.expandCollection(collectionName) {
-    //         verifyTabSavedInCollection(webPage.title)
-    //         verifyCollectionTabLogo(true)
-    //         verifyCollectionTabUrl(true)
-    //         verifyShareCollectionButtonIsVisible(true)
-    //         verifyCollectionMenuIsVisible(true)
-    //         verifyCollectionItemRemoveButtonIsVisible(webPage.title, true)
-    //     }.collapseCollection(collectionName) {}
-    //
-    //     collectionRobot {
-    //         verifyTabSavedInCollection(webPage.title, false)
-    //         verifyShareCollectionButtonIsVisible(false)
-    //         verifyCollectionMenuIsVisible(false)
-    //         verifyCollectionTabLogo(false)
-    //         verifyCollectionTabUrl(false)
-    //         verifyCollectionItemRemoveButtonIsVisible(webPage.title, false)
-    //     }
-    //
-    //     homeScreen {
-    //     }.expandCollection(collectionName) {
-    //         verifyTabSavedInCollection(webPage.title)
-    //         verifyCollectionTabLogo(true)
-    //         verifyCollectionTabUrl(true)
-    //         verifyShareCollectionButtonIsVisible(true)
-    //         verifyCollectionMenuIsVisible(true)
-    //         verifyCollectionItemRemoveButtonIsVisible(webPage.title, true)
-    //     }.collapseCollection(collectionName) {}
-    //
-    //     collectionRobot {
-    //         verifyTabSavedInCollection(webPage.title, false)
-    //         verifyShareCollectionButtonIsVisible(false)
-    //         verifyCollectionMenuIsVisible(false)
-    //         verifyCollectionTabLogo(false)
-    //         verifyCollectionTabUrl(false)
-    //         verifyCollectionItemRemoveButtonIsVisible(webPage.title, false)
-    //     }
-    // }
-    //
-    // @Test
-    // fun openAllTabsInCollectionTest() {
-    //     val webPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-    //
-    //     navigationToolbar {
-    //     }.enterURLAndEnterToBrowser(webPage.url) {
-    //     }.openTabDrawer {
-    //         createCollection(webPage.title, collectionName)
-    //         verifySnackBarText("Collection saved!")
-    //         closeTab()
-    //     }
-    //
-    //     homeScreen {
-    //     }.expandCollection(collectionName) {
-    //         clickCollectionThreeDotButton()
-    //         selectOpenTabs()
-    //     }
-    //     tabDrawer {
-    //         verifyExistingOpenTabs(webPage.title)
-    //     }
-    // }
-    //
-    // @Test
-    // fun shareCollectionTest() {
-    //     val firstWebsite = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-    //     val secondWebsite = TestAssetHelper.getGenericAsset(mockWebServer, 2)
-    //     val sharingApp = "Gmail"
-    //     val urlString = "${secondWebsite.url}\n\n${firstWebsite.url}"
-    //
-    //     navigationToolbar {
-    //     }.enterURLAndEnterToBrowser(firstWebsite.url) {
-    //         verifyPageContent(firstWebsite.content)
-    //     }.openTabDrawer {
-    //         createCollection(firstWebsite.title, collectionName)
-    //     }.openNewTab {
-    //     }.submitQuery(secondWebsite.url.toString()) {
-    //         verifyPageContent(secondWebsite.content)
-    //     }.openThreeDotMenu {
-    //     }.openSaveToCollection {
-    //     }.selectExistingCollection(collectionName) {
-    //     }.goToHomescreen {
-    //     }.expandCollection(collectionName) {
-    //     }.clickShareCollectionButton {
-    //         verifyShareTabsOverlay(firstWebsite.title, secondWebsite.title)
-    //         selectAppToShareWith(sharingApp)
-    //         verifySharedTabsIntent(urlString, collectionName)
-    //     }
-    // }
-    //
-    // @Test
-    // // Test running on beta/release builds in CI:
-    // // caution when making changes to it, so they don't block the builds
-    // fun deleteCollectionTest() {
-    //     val webPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-    //
-    //     navigationToolbar {
-    //     }.enterURLAndEnterToBrowser(webPage.url) {
-    //     }.openTabDrawer {
-    //         createCollection(webPage.title, collectionName)
-    //         snackBarButtonClick("VIEW")
-    //     }
-    //
-    //     homeScreen {
-    //     }.expandCollection(collectionName) {
-    //         clickCollectionThreeDotButton()
-    //         selectDeleteCollection()
-    //     }
-    //
-    //     homeScreen {
-    //         verifySnackBarText("Collection deleted")
-    //         verifyNoCollectionsText()
-    //     }
-    // }
-
     @Test
     // Verifies that deleting a Bookmarks folder also removes the item from inside it.
     fun deleteNonEmptyBookmarkFolderTest() {
@@ -852,9 +685,8 @@ class SmokeTest {
             verifyShareAllTabsButton()
         }.clickShareAllTabsButton {
             verifyShareTabsOverlay(firstWebsiteTitle, secondWebsiteTitle)
-            selectAppToShareWith(sharingApp)
-            verifySharedTabsIntent(
-                sharedUrlsString,
+            verifySharingWithSelectedApp(
+                sharingApp, sharedUrlsString,
                 "$firstWebsiteTitle, $secondWebsiteTitle"
             )
         }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
@@ -8,6 +8,10 @@ package org.mozilla.fenix.ui.robots
 
 import android.graphics.Bitmap
 import android.widget.EditText
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.performClick
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions
@@ -42,6 +46,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.helpers.Constants.LISTS_MAXSWIPES
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeShort
 import org.mozilla.fenix.helpers.TestHelper.appContext
@@ -188,8 +193,6 @@ class HomeScreenRobot {
             assertTrue(mDevice.findObject(UiSelector().text(title)).waitUntilGone(waitingTime))
         }
     }
-
-    fun verifyCollectionIcon() = onView(withId(R.id.collection_icon)).check(matches(isDisplayed()))
 
     fun togglePrivateBrowsingModeOnOff() {
         onView(ViewMatchers.withResourceName("privateBrowsingButton"))
@@ -392,21 +395,15 @@ class HomeScreenRobot {
             return TabDrawerRobot.Transition()
         }
 
-        // fun expandCollection(
-        //     title: String,
-        //     interact: CollectionRobot.() -> Unit
-        // ): CollectionRobot.Transition {
-        //     // Depending on the screen dimensions collections might report as visible on screen
-        //     // but actually have the bottom toolbar above so interactions with collections might fail.
-        //     // As a quick solution we'll try scrolling to the element below collection on the homescreen
-        //     // so that they are displayed above in their entirety.
-        //     scrollToElementByText(appContext.getString(R.string.pocket_stories_header_1))
-        //
-        //     collectionTitle(title).click()
-        //
-        //     CollectionRobot().interact()
-        //     return CollectionRobot.Transition()
-        // }
+        fun expandCollection(title: String, rule: ComposeTestRule, interact: CollectionRobot.() -> Unit): CollectionRobot.Transition {
+            homeScreenList().scrollToEnd(LISTS_MAXSWIPES)
+            collectionTitle(title, rule)
+                .assertIsDisplayed()
+                .performClick()
+
+            CollectionRobot().interact()
+            return CollectionRobot.Transition()
+        }
 
         fun openRecentlyVisitedSearchGroupHistoryList(title: String, interact: HistoryRobot.() -> Unit): HistoryRobot.Transition {
             val searchGroup = recentlyVisitedList.getChildByText(UiSelector().text(title), title, true)
@@ -648,6 +645,9 @@ private fun assertPrivateSessionMessage() =
                 )
         ).waitForExists(waitingTime)
     )
+
+private fun collectionTitle(title: String, rule: ComposeTestRule) =
+    rule.onNode(hasText(title))
 
 private fun assertExistingTopSitesList() =
     onView(allOf(withId(R.id.top_sites_list)))

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ShareOverlayRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ShareOverlayRobot.kt
@@ -49,8 +49,13 @@ class ShareOverlayRobot {
         mDevice.waitNotNull(Until.findObject(By.res("android:id/resolver_list")))
     }
 
-    fun selectAppToShareWith(appName: String) =
-        mDevice.findObject(UiSelector().text(appName)).clickAndWaitForNewWindow()
+    fun verifySharingWithSelectedApp(appName: String, content: String, subject: String) {
+        val sharingApp = mDevice.findObject(UiSelector().text(appName))
+        if (sharingApp.exists()) {
+            sharingApp.clickAndWaitForNewWindow()
+            verifySharedTabsIntent(content, subject)
+        }
+    }
 
     fun verifySendToDeviceTitle() = assertSendToDeviceTitle()
 

--- a/automation/taskcluster/androidTest/flank-x86-beta.yml
+++ b/automation/taskcluster/androidTest/flank-x86-beta.yml
@@ -42,7 +42,7 @@ gcloud:
     - class org.mozilla.fenix.ui.HistoryTest#visitedUrlHistoryTest
     - class org.mozilla.fenix.ui.SmokeTest#openMainMenuSettingsItemTest
     - class org.mozilla.fenix.ui.SettingsSearchTest#toggleSearchSuggestionsTest
-    - class org.mozilla.fenix.ui.SmokeTest#deleteCollectionTest
+    - class org.mozilla.fenix.ui.CollectionTest#deleteCollectionTest
     - class org.mozilla.fenix.ui.SmokeTest#noHistoryInPrivateBrowsingTest
     - class org.mozilla.fenix.ui.NoNetworkAccessStartupTests#noNetworkConnectionStartupTest
 

--- a/automation/taskcluster/androidTest/flank-x86-start-test.yml
+++ b/automation/taskcluster/androidTest/flank-x86-start-test.yml
@@ -38,7 +38,7 @@ gcloud:
    - class org.mozilla.fenix.ui.HistoryTest#visitedUrlHistoryTest
    - class org.mozilla.fenix.ui.SmokeTest#openMainMenuSettingsItemTest
    - class org.mozilla.fenix.ui.SettingsSearchTest#toggleSearchSuggestionsTest
-   - class org.mozilla.fenix.ui.SmokeTest#deleteCollectionTest
+   - class org.mozilla.fenix.ui.CollectionTest#deleteCollectionTest
    - class org.mozilla.fenix.ui.SmokeTest#noHistoryInPrivateBrowsingTest
    - class org.mozilla.fenix.ui.NoNetworkAccessStartupTests#noNetworkConnectionStartupTest
 


### PR DESCRIPTION
Tests disabled by refactoring work to migrate collections UI to Compose.
Ran the tests more than 50 times on Firebase and all passed: https://github.com/mozilla-mobile/fenix/runs/6654479847
Issues fixed by this PR : 
#24533
#24265
#23605
#23741
#23739
#22845
#24997
#23296

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
