### PR TITLE
For #25455 : Let A-C handle toolbar expanding when URL changes

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -768,7 +768,7 @@ abstract class BaseBrowserFragment :
             view = view
         )
 
-        expandToolbarOnNavigation(store)
+        closeFindInPageBarOnNavigation(store)
 
         store.flowScoped(viewLifecycleOwner) { flow ->
             flow.mapNotNull { state -> state.findTabOrCustomTabOrSelectedTab(customTabSessionId) }
@@ -870,11 +870,9 @@ abstract class BaseBrowserFragment :
         context.settings().incrementSecureWarningCount()
     }
 
-    @VisibleForTesting
-    internal fun expandToolbarOnNavigation(store: BrowserStore) {
+    private fun closeFindInPageBarOnNavigation(store: BrowserStore) {
         consumeFlow(store) { flow ->
-            flow.mapNotNull {
-                state ->
+            flow.mapNotNull { state ->
                 state.findCustomTabOrSelectedTab(customTabSessionId)
             }
                 .ifAnyChanged {
@@ -883,7 +881,6 @@ abstract class BaseBrowserFragment :
                 }
                 .collect {
                     findInPageIntegration.onBackPressed()
-                    browserToolbarView.expand()
                 }
         }
     }

--- a/app/src/test/java/org/mozilla/fenix/browser/BrowserFragmentTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/browser/BrowserFragmentTest.kt
@@ -14,11 +14,9 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
-import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.action.RestoreCompleteAction
 import mozilla.components.browser.state.action.TabListAction
 import mozilla.components.browser.state.state.BrowserState
-import mozilla.components.browser.state.state.LoadRequestState
 import mozilla.components.browser.state.state.SessionState
 import mozilla.components.browser.state.state.TabSessionState
 import mozilla.components.browser.state.state.createTab
@@ -150,35 +148,6 @@ class BrowserFragmentTest {
         verify(exactly = 1) {
             browserFragment.resumeDownloadDialogState(newSelectedTab.id, store, context, any())
         }
-    }
-
-    @Test
-    fun `WHEN url changes THEN toolbar is expanded`() {
-        addAndSelectTab(testTab)
-        browserFragment.expandToolbarOnNavigation(store)
-
-        val toolbar: BrowserToolbarView = mockk(relaxed = true)
-        every { browserFragment.browserToolbarView } returns toolbar
-
-        store.dispatch(ContentAction.UpdateUrlAction(testTab.id, "https://firefox.com")).joinBlocking()
-        verify(exactly = 1) { toolbar.expand() }
-    }
-
-    @Test
-    fun `WHEN load request is triggered THEN toolbar is expanded`() {
-        addAndSelectTab(testTab)
-        browserFragment.expandToolbarOnNavigation(store)
-
-        val toolbar: BrowserToolbarView = mockk(relaxed = true)
-        every { browserFragment.browserToolbarView } returns toolbar
-
-        store.dispatch(
-            ContentAction.UpdateLoadRequestAction(
-                testTab.id,
-                LoadRequestState("https://firefox.com", false, true)
-            )
-        ).joinBlocking()
-        verify(exactly = 1) { toolbar.expand() }
     }
 
     @Test


### PR DESCRIPTION
This fix allows the toolbar to be visible after the user clicks on a link and scrolls

Co-Authored-By: Mugurell <Mugurell@users.noreply.github.com>



https://user-images.githubusercontent.com/12825812/171129696-863e84b0-0610-4c97-b31e-d16ded6f425a.mp4




### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
