### PR TITLE
For #25472 - Set `context_id` to have "application" lifetime.

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -5095,7 +5095,7 @@ top_sites:
       A UUID that is unjoinable with other browser metrics. This ID will not be
       shared with AdM, only for internal uses. This ID is shared across all
       contextual services features.
-    lifetime: ping
+    lifetime: application
     send_in_pings:
       - topsites-impression
     bugs:


### PR DESCRIPTION
This change mitigates it being set only once in FenixApplication and then
being reset after the first ping is sent.
By having "application" lifetime once set in FenixApplication will be available 
in all future contile pings for that application run.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
