### PR TITLE
Adding support for app-services error reporting

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -538,6 +538,7 @@ dependencies {
 
     implementation Deps.mozilla_support_extensions
     implementation Deps.mozilla_support_base
+    implementation Deps.mozilla_support_rusterrors
     implementation Deps.mozilla_support_images
     implementation Deps.mozilla_support_ktx
     implementation Deps.mozilla_support_rustlog

--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -42,6 +42,7 @@ import mozilla.components.service.fxa.manager.SyncEnginesStorage
 import mozilla.components.service.glean.Glean
 import mozilla.components.service.glean.config.Configuration
 import mozilla.components.service.glean.net.ConceptFetchHttpUploader
+import mozilla.components.support.rusterrors.initializeRustErrors
 import mozilla.components.support.base.facts.register
 import mozilla.components.support.base.log.Log
 import mozilla.components.support.base.log.logger.Logger
@@ -398,8 +399,13 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
         // Give the generated FxNimbus a closure to lazily get the Nimbus object
         FxNimbus.initialize { components.analytics.experiments }
         return GlobalScope.async(Dispatchers.IO) {
+            initializeRustErrors(components.analytics.crashReporter)
             // ... but RustHttpConfig.setClient() and RustLog.enable() can be called later.
             RustHttpConfig.setClient(lazy { components.core.client })
+            // Once application-services has switched to using the new
+            // error reporting system, RustLog shouldn't input a CrashReporter
+            // anymore.
+            // (https://github.com/mozilla/application-services/issues/4981).
             RustLog.enable(components.analytics.crashReporter)
             // We want to ensure Nimbus is initialized as early as possible so we can
             // experiment on features close to startup.

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -164,6 +164,7 @@ object Deps {
     const val mozilla_lib_publicsuffixlist = "org.mozilla.components:lib-publicsuffixlist:${Versions.mozilla_android_components}"
 
     const val mozilla_support_base = "org.mozilla.components:support-base:${Versions.mozilla_android_components}"
+    const val mozilla_support_rusterrors = "org.mozilla.components:support-rusterrors:${Versions.mozilla_android_components}"
     const val mozilla_support_images = "org.mozilla.components:support-images:${Versions.mozilla_android_components}"
     const val mozilla_support_ktx = "org.mozilla.components:support-ktx:${Versions.mozilla_android_components}"
     const val mozilla_support_rusthttp = "org.mozilla.components:support-rusthttp:${Versions.mozilla_android_components}"


### PR DESCRIPTION
Initialize the new `mozilla.components.support.rusterrors` component, which is needed to support the new app-services error reporting system.

See https://github.com/mozilla/application-services/pull/4979 / https://github.com/mozilla-mobile/android-components/pull/12266 for more info.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
