### PR TITLE
For #25505: Clear the stored result in case there is no listener with the same key set.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/share/ShareFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/share/ShareFragment.kt
@@ -10,6 +10,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatDialogFragment
+import androidx.fragment.app.clearFragmentResult
 import androidx.fragment.app.setFragmentResult
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory
@@ -128,6 +129,8 @@ class ShareFragment : AppCompatDialogFragment() {
 
     override fun onDestroy() {
         setFragmentResult(RESULT_KEY, Bundle())
+        // Clear the stored result in case there is no listener with the same key set.
+        clearFragmentResult(RESULT_KEY)
 
         super.onDestroy()
     }


### PR DESCRIPTION

This is the case when the sharing happens outside the tabs tray.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
