### PR TITLE
For #25563: Prevent crashes when deleting all items in a history metadata group

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/historymetadata/HistoryMetadataGroupFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/historymetadata/HistoryMetadataGroupFragment.kt
@@ -35,6 +35,7 @@ import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.setTextColor
 import org.mozilla.fenix.ext.showToolbar
 import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.runIfFragmentIsAttached
 import org.mozilla.fenix.ext.toShortUrl
 import org.mozilla.fenix.library.LibraryPageFragment
 import org.mozilla.fenix.library.history.History
@@ -231,10 +232,12 @@ class HistoryMetadataGroupFragment :
     }
 
     private fun allDeletedSnackbar() {
-        showSnackBar(
-            requireView(),
-            getString(R.string.delete_history_group_snackbar)
-        )
+        runIfFragmentIsAttached {
+            showSnackBar(
+                binding.root,
+                getString(R.string.delete_history_group_snackbar)
+            )
+        }
     }
 
     private fun showTabTray() {

--- a/app/src/main/java/org/mozilla/fenix/library/historymetadata/HistoryMetadataGroupFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/historymetadata/HistoryMetadataGroupFragment.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.fenix.library.historymetadata
 
+import android.app.Dialog
 import android.content.Context
 import android.content.DialogInterface
 import android.os.Bundle
@@ -15,11 +16,11 @@ import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AlertDialog
+import androidx.fragment.app.DialogFragment
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.map
 import mozilla.components.lib.state.ext.consumeFrom
 import mozilla.components.lib.state.ext.flowScoped
@@ -218,17 +219,15 @@ class HistoryMetadataGroupFragment :
     }
 
     private fun promptDeleteAll(delete: () -> Unit) {
-        AlertDialog.Builder(requireContext()).apply {
-            setMessage(R.string.delete_history_group_prompt_message)
-            setNegativeButton(R.string.delete_history_group_prompt_cancel) { dialog: DialogInterface, _ ->
-                dialog.cancel()
-            }
-            setPositiveButton(R.string.delete_history_group_prompt_allow) { dialog: DialogInterface, _ ->
-                delete.invoke()
-                dialog.dismiss()
-            }
-            create()
-        }.show()
+        if (childFragmentManager.findFragmentByTag(DeleteAllConfirmationDialogFragment.TAG)
+            as? DeleteAllConfirmationDialogFragment != null
+        ) {
+            return
+        }
+
+        DeleteAllConfirmationDialogFragment(delete).show(
+            childFragmentManager, DeleteAllConfirmationDialogFragment.TAG
+        )
     }
 
     private fun allDeletedSnackbar() {
@@ -253,5 +252,23 @@ class HistoryMetadataGroupFragment :
             requireContext().getString(R.string.history_delete_single_item_snackbar),
             historyItem.url.toShortUrl(requireComponents.publicSuffixList)
         )
+    }
+
+    internal class DeleteAllConfirmationDialogFragment(private val delete: () -> Unit) : DialogFragment() {
+        override fun onCreateDialog(savedInstanceState: Bundle?): Dialog =
+            AlertDialog.Builder(requireContext())
+                .setMessage(R.string.delete_history_group_prompt_message)
+                .setNegativeButton(R.string.delete_history_group_prompt_cancel) { dialog: DialogInterface, _ ->
+                    dialog.cancel()
+                }
+                .setPositiveButton(R.string.delete_history_group_prompt_allow) { dialog: DialogInterface, _ ->
+                    delete.invoke()
+                    dialog.dismiss()
+                }
+                .create()
+
+        companion object {
+            const val TAG = "DELETE_CONFIRMATION_DIALOG_FRAGMENT"
+        }
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/library/historymetadata/controller/HistoryMetadataGroupController.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/historymetadata/controller/HistoryMetadataGroupController.kt
@@ -178,7 +178,7 @@ class DefaultHistoryMetadataGroupController(
             GleanHistory.searchTermGroupRemoveAll.record(NoExtras())
             allDeletedSnackbar.invoke()
             launch(Main) {
-                navController.popBackStack()
+                navController.popBackStack(R.id.historyFragment, false)
             }
         }
     }


### PR DESCRIPTION
The crash could be reproduced if you click the delete button twice fast, thus showing two delete dialogs.
Clicking on both delete buttons would try to show the snackbar and navigate twice.

There were also other alternatives to consider besides refactoring the dialog:
- throttling the menu button to only work once (does not guarantee it cannot be clicked twice  on all devices)
- having a mechanism to prevent the dialog from being shown twice with a var. I usually try to avoid this pattern of having to keep track of UI things manually

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
