### PR TITLE
For #24843, #24815, #17416: removed idling resources. Retrying add-on installation if it fails.

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/Constants.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/Constants.kt
@@ -19,4 +19,5 @@ object Constants {
     const val SPEECH_RECOGNITION = "android.speech.action.RECOGNIZE_SPEECH"
     const val LONG_CLICK_DURATION: Long = 5000
     const val LISTS_MAXSWIPES: Int = 3
+    const val RETRY_COUNT = 3
 }

--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/IdlingResourceHelper.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/IdlingResourceHelper.kt
@@ -29,4 +29,10 @@ object IdlingResourceHelper {
             )
         )
     }
+
+    fun unregisterAllIdlingResources() {
+        for (resource in IdlingRegistry.getInstance().resources) {
+            IdlingRegistry.getInstance().unregister(resource)
+        }
+    }
 }

--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/RetryTestRule.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/RetryTestRule.kt
@@ -11,7 +11,7 @@ import junit.framework.AssertionFailedError
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
-import java.lang.AssertionError
+import org.mozilla.fenix.helpers.IdlingResourceHelper.unregisterAllIdlingResources
 
 class RetryTestRule(private val retryCount: Int = 5) : TestRule {
 
@@ -23,30 +23,37 @@ class RetryTestRule(private val retryCount: Int = 5) : TestRule {
                     base.evaluate()
                     break
                 } catch (t: AssertionError) {
+                    unregisterAllIdlingResources()
                     if (i == retryCount) {
                         throw t
                     }
                 } catch (t: AssertionFailedError) {
+                    unregisterAllIdlingResources()
                     if (i == retryCount) {
                         throw t
                     }
                 } catch (t: UiObjectNotFoundException) {
+                    unregisterAllIdlingResources()
                     if (i == retryCount) {
                         throw t
                     }
                 } catch (t: NoMatchingViewException) {
+                    unregisterAllIdlingResources()
                     if (i == retryCount) {
                         throw t
                     }
                 } catch (t: IdlingResourceTimeoutException) {
+                    unregisterAllIdlingResources()
                     if (i == retryCount) {
                         throw t
                     }
                 } catch (t: RuntimeException) {
+                    unregisterAllIdlingResources()
                     if (i == retryCount) {
                         throw t
                     }
                 } catch (t: NullPointerException) {
+                    unregisterAllIdlingResources()
                     if (i == retryCount) {
                         throw t
                     }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAddonsManagerRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuAddonsManagerRobot.kt
@@ -6,9 +6,9 @@
 
 package org.mozilla.fenix.ui.robots
 
+import android.util.Log
 import android.widget.RelativeLayout
 import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.IdlingResourceTimeoutException
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.Visibility
@@ -22,7 +22,6 @@ import androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withParent
 import androidx.test.espresso.matcher.ViewMatchers.withText
-import androidx.test.rule.ActivityTestRule
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
@@ -30,12 +29,15 @@ import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.CoreMatchers.instanceOf
 import org.hamcrest.CoreMatchers.not
-import org.mozilla.fenix.HomeActivity
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.mozilla.fenix.R
-import org.mozilla.fenix.helpers.IdlingResourceHelper.registerAddonInstallingIdlingResource
-import org.mozilla.fenix.helpers.IdlingResourceHelper.unregisterAddonInstallingIdlingResource
+import org.mozilla.fenix.helpers.Constants.RETRY_COUNT
+import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
+import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeLong
 import org.mozilla.fenix.helpers.TestHelper.appName
+import org.mozilla.fenix.helpers.TestHelper.restartApp
 import org.mozilla.fenix.helpers.TestHelper.scrollToElementByText
 import org.mozilla.fenix.helpers.click
 import org.mozilla.fenix.helpers.ext.waitNotNull
@@ -47,21 +49,57 @@ import org.mozilla.fenix.helpers.ext.waitNotNull
 class SettingsSubMenuAddonsManagerRobot {
     fun verifyAddonPermissionPrompt(addonName: String) = assertAddonPermissionPrompt(addonName)
 
-    fun clickInstallAddon(addonName: String) = selectInstallAddon(addonName)
+    fun clickInstallAddon(addonName: String) {
+        mDevice.waitNotNull(
+            Until.findObject(By.textContains(addonName)),
+            waitingTime
+        )
 
-    fun closeAddonInstallCompletePrompt(
-        addonName: String,
-        activityTestRule: ActivityTestRule<HomeActivity>
-    ) {
-        try {
-            assertAddonInstallCompletePrompt(addonName, activityTestRule)
-        } catch (e: IdlingResourceTimeoutException) {
-            if (mDevice.findObject(UiSelector().text("Failed to install $addonName")).exists()) {
-                clickInstallAddon(addonName)
-                acceptPermissionToInstallAddon()
-                assertAddonInstallCompletePrompt(addonName, activityTestRule)
+        installButtonForAddon(addonName)
+            .check(matches(isCompletelyDisplayed()))
+            .perform(click())
+    }
+
+    fun verifyAddonInstallCompleted(addonName: String, activityTestRule: HomeActivityIntentTestRule) {
+        for (i in 1..RETRY_COUNT) {
+            try {
+                assertFalse(
+                    mDevice.findObject(UiSelector().text("Failed to install $addonName"))
+                        .waitForExists(waitingTime)
+                )
+
+                assertTrue(
+                    mDevice.findObject(UiSelector().text("Okay, Got it"))
+                        .waitForExists(waitingTimeLong)
+                )
+                break
+            } catch (e: AssertionError) {
+                if (i == RETRY_COUNT) {
+                    throw e
+                } else {
+                    Log.e("TestLog", "Addon failed to install on try #$i")
+                    restartApp(activityTestRule)
+                    installAddon(addonName)
+                }
             }
         }
+    }
+
+    fun verifyAddonInstallCompletedPrompt(addonName: String) {
+        onView(
+            allOf(
+                withText("Okay, Got it"),
+                withParent(instanceOf(RelativeLayout::class.java)),
+                hasSibling(withText("$addonName has been added to $appName")),
+                hasSibling(withText("Open it in the menu")),
+                hasSibling(withText("Allow in private browsing"))
+            )
+        )
+            .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+    }
+
+    fun closeAddonInstallCompletePrompt() {
+        onView(withText("Okay, Got it")).click()
     }
 
     fun verifyAddonIsInstalled(addonName: String) {
@@ -79,10 +117,23 @@ class SettingsSubMenuAddonsManagerRobot {
     fun verifyAddonsItems() = assertAddonsItems()
     fun verifyAddonCanBeInstalled(addonName: String) = assertAddonCanBeInstalled(addonName)
 
-    fun selectAllowInPrivateBrowsing(activityTestRule: ActivityTestRule<HomeActivity>) {
-        registerAddonInstallingIdlingResource(activityTestRule)
+    fun selectAllowInPrivateBrowsing() {
+        assertTrue(
+            "Addon install confirmation prompt not displayed",
+            mDevice.findObject(UiSelector().text("Allow in private browsing"))
+                .waitForExists(waitingTimeLong)
+        )
         onView(withId(R.id.allow_in_private_browsing)).click()
-        unregisterAddonInstallingIdlingResource(activityTestRule)
+    }
+
+    fun installAddon(addonName: String) {
+        homeScreen {
+        }.openThreeDotMenu {
+        }.openAddonsManagerMenu {
+            clickInstallAddon(addonName)
+            verifyAddonPermissionPrompt(addonName)
+            acceptPermissionToInstallAddon()
+        }
     }
 
     class Transition {
@@ -127,17 +178,6 @@ class SettingsSubMenuAddonsManagerRobot {
             )
         )
 
-    private fun selectInstallAddon(addonName: String) {
-        mDevice.waitNotNull(
-            Until.findObject(By.textContains(addonName)),
-            waitingTime
-        )
-
-        installButtonForAddon(addonName)
-            .check(matches(isCompletelyDisplayed()))
-            .perform(click())
-    }
-
     private fun assertAddonIsEnabled(addonName: String) {
         installButtonForAddon(addonName)
             .check(matches(not(isCompletelyDisplayed())))
@@ -160,27 +200,6 @@ class SettingsSubMenuAddonsManagerRobot {
 
         onView(allOf(withId(R.id.deny_button), withText("Cancel")))
             .check(matches(isCompletelyDisplayed()))
-    }
-
-    private fun assertAddonInstallCompletePrompt(
-        addonName: String,
-        activityTestRule: ActivityTestRule<HomeActivity>
-    ) {
-        registerAddonInstallingIdlingResource(activityTestRule)
-
-        onView(
-            allOf(
-                withText("Okay, Got it"),
-                withParent(instanceOf(RelativeLayout::class.java)),
-                hasSibling(withText("$addonName has been added to $appName")),
-                hasSibling(withText("Open it in the menu")),
-                hasSibling(withText("Allow in private browsing"))
-            )
-        )
-            .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-            .perform(click())
-
-        unregisterAddonInstallingIdlingResource(activityTestRule)
     }
 
     private fun assertAddonIsInstalled(addonName: String) {


### PR DESCRIPTION
For #24843, #24815, #17416 
- when the RetryTestRule was invoked, some idling resources remained registered, causing crashes because the fragment didn't exist anymore.
- some idling resources timed out when the permission prompt appeared, even if a call to unregister them was made. Don't know what happened there, so I removed and replaced them with the waitForExists method.
- I ran the tests hundreds of times, the last one is https://github.com/mozilla-mobile/fenix/runs/6794296501, the addons still fail to install after restarting the app, but overall the stability of the tests seems to be improved a bit compared to prior runs (because I removed the other possible reasons for failures): https://github.com/mozilla-mobile/fenix/runs/6723804592 or https://github.com/mozilla-mobile/fenix/runs/6726807316

Extra: I've modified a bit the RetryTestRule to unregister any idling resources left before retrying a test, to prevent these kinds of crashes in the future. @AaronMT If you don't agree with that, I can drop that commit.

The conclusion is there's still one flaky test remaining (I could leave it disabled if that's the safest), but the issue of failing to install addons only seems to be related to API 30: https://github.com/mozilla-mobile/fenix/runs/6606662528 and maybe it can't be avoided for now.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
