### PR TITLE
For #25511 fix failing shortcutButtonTest UI test

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SearchTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SearchTest.kt
@@ -24,6 +24,7 @@ import org.mozilla.fenix.helpers.TestHelper.appContext
 import org.mozilla.fenix.helpers.TestHelper.exitMenu
 import org.mozilla.fenix.helpers.TestHelper.longTapSelectItem
 import org.mozilla.fenix.helpers.TestHelper.setCustomSearchEngine
+import org.mozilla.fenix.ui.robots.browserScreen
 import org.mozilla.fenix.ui.robots.homeScreen
 import org.mozilla.fenix.ui.robots.multipleSelectionToolbar
 
@@ -89,6 +90,8 @@ class SearchTest {
 
     @Test
     fun shortcutButtonTest() {
+        val searchEngineURL = "bing.com/search?q=mozilla%20firefox"
+
         homeScreen {
         }.openThreeDotMenu {
         }.openSettings {
@@ -98,11 +101,15 @@ class SearchTest {
         }.goBack {
         }.openSearch {
             verifySearchBarEmpty()
-            clickSearchEngineButton(activityTestRule, "DuckDuckGo")
+            clickSearchEngineButton(activityTestRule, "Bing")
             typeSearch("mozilla")
-            verifySearchEngineResults(activityTestRule, "mozilla firefox", "DuckDuckGo")
+            verifySearchEngineResults(activityTestRule, "mozilla firefox", "Bing")
             clickSearchEngineResult(activityTestRule, "mozilla firefox")
-            verifySearchEngineURL("DuckDuckGo")
+        }
+
+        browserScreen {
+            waitForPageToLoad()
+            verifyUrl(searchEngineURL)
         }
     }
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SearchRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SearchRobot.kt
@@ -40,7 +40,6 @@ import androidx.test.uiautomator.UiScrollable
 import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
 import org.hamcrest.CoreMatchers.allOf
-import org.hamcrest.CoreMatchers.startsWith
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -106,8 +105,6 @@ class SearchRobot {
         assertSearchEngineSuggestionResults(rule, searchSuggestion)
     fun verifyNoSuggestionsAreDisplayed(rule: ComposeTestRule, searchSuggestion: String) =
         assertNoSuggestionsAreDisplayed(rule, searchSuggestion)
-
-    fun verifySearchEngineURL(searchEngineName: String) = assertSearchEngineURL(searchEngineName)
     fun verifySearchSettings() = assertSearchSettings()
     fun verifySearchBarEmpty() = assertSearchBarEmpty()
 
@@ -303,15 +300,6 @@ private fun clearButton() =
     mDevice.findObject(UiSelector().resourceId("$packageName:id/mozac_browser_toolbar_clear_view"))
 
 private fun searchWrapper() = mDevice.findObject(UiSelector().resourceId("$packageName:id/search_wrapper"))
-
-private fun assertSearchEngineURL(searchEngineName: String) {
-    mDevice.waitNotNull(
-        Until.findObject(By.textContains("${searchEngineName.lowercase()}.com/?q=mozilla")),
-        waitingTime
-    )
-    onView(allOf(withText(startsWith("${searchEngineName.lowercase()}.com"))))
-        .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
-}
 
 private fun assertSearchEngineResults(rule: ComposeTestRule, searchSuggestion: String, searchEngineName: String) {
     rule.waitUntil(waitingTime, waitForSearchSuggestions(rule, searchSuggestion, searchEngineName))


### PR DESCRIPTION
For #25511 fix failing `shortcutButtonTest` UI test ✅ successfully ran 100x on Firebase

Sumary:
• Switched from "DuckDuckGo" to using "Bing" as a search shortcut because I've found an [actual bug](https://github.com/mozilla-mobile/fenix/issues/23864#issuecomment-1160064818)
• Removed `assertSearchEngineURL` because we only used it in this test, and decided to use `verifyUrl` instead.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
