### PR TITLE
stop triggering multiple nightlies off the same revision

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -185,6 +185,7 @@ tasks:
                               MOBILE_HEAD_REV: '${head_sha}'
                               MOBILE_REPOSITORY_TYPE: git
                               MOBILE_PIP_REQUIREMENTS: taskcluster/requirements.txt
+                              MOZ_AUTOMATION: "1"
                               REPOSITORIES: {$json: {mobile: "Fenix"}}
                               HG_STORE_PATH: /builds/worker/checkouts/hg-store
                               ANDROID_SDK_ROOT: /builds/worker/android-sdk

--- a/taskcluster/fenix_taskgraph/target_tasks.py
+++ b/taskcluster/fenix_taskgraph/target_tasks.py
@@ -2,7 +2,22 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import os
+from redo import retry
+
 from taskgraph.target_tasks import _target_task
+from taskgraph.util.taskcluster import find_task_id
+
+
+def index_exists(index_path, reason=""):
+    print(f"Looking for existing index {index_path} {reason}...")
+    try:
+        task_id = find_task_id(index_path)
+        print(f"Index {index_path} exists: taskId {task_id}")
+        return True
+    except KeyError:
+        print(f"Index {index_path} doesn't exist.")
+        return False
 
 
 @_target_task("release")
@@ -21,6 +36,19 @@ def target_tasks_nightly(full_task_graph, parameters, graph_config):
 
     def filter(task, parameters):
         return task.attributes.get("nightly", False)
+
+    index_path = (
+        f"{graph_config['trust-domain']}.v2.{parameters['project']}.branch."
+        f"{parameters['head_ref']}.revision.{parameters['head_rev']}.taskgraph.decision-nightly"
+    )
+    if os.environ.get("MOZ_AUTOMATION") and retry(
+        index_exists,
+        args=(index_path,),
+        kwargs={
+            "reason": "to avoid triggering multiple nightlies off the same revision",
+        },
+    ):
+        return []
 
     return [l for l, t in full_task_graph.tasks.items() if filter(t, parameters)]
 

--- a/taskcluster/requirements.in
+++ b/taskcluster/requirements.in
@@ -3,3 +3,4 @@
 
 taskcluster-taskgraph>=1.3.1
 mozilla-version
+redo


### PR DESCRIPTION
Similar to https://github.com/mozilla-mobile/android-components/pull/12294, and https://bugzilla.mozilla.org/show_bug.cgi?id=1380123 before that, we don't want/need to push a new build to the play store if there haven't been any code changes.