### PR TITLE
For #25551 fix disabled openLinkInAppTest UI test

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/TestHelper.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/TestHelper.kt
@@ -43,6 +43,7 @@ import org.hamcrest.CoreMatchers
 import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.Matcher
 import org.junit.Assert
+import org.junit.Assert.assertTrue
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.helpers.Constants.PackageName.GOOGLE_APPS_PHOTOS
@@ -229,7 +230,7 @@ object TestHelper {
     fun assertNativeAppOpens(appPackageName: String, url: String) {
         if (isPackageInstalled(appPackageName)) {
             mDevice.waitForIdle(waitingTimeShort)
-            intended(toPackage(appPackageName))
+            assertTrue(mDevice.findObject(UiSelector().packageName(appPackageName)).waitForExists(waitingTime))
         } else {
             BrowserRobot().verifyUrl(url)
         }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAdvancedTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAdvancedTest.kt
@@ -9,7 +9,6 @@ import androidx.test.uiautomator.UiDevice
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.customannotations.SmokeTest
@@ -17,7 +16,6 @@ import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.Constants.PackageName.GOOGLE_PLAY_SERVICES
 import org.mozilla.fenix.helpers.FeatureSettingsHelper
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
-import org.mozilla.fenix.helpers.RetryTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.helpers.TestHelper.assertNativeAppOpens
 import org.mozilla.fenix.ui.robots.homeScreen
@@ -37,10 +35,6 @@ class SettingsAdvancedTest {
 
     @get:Rule
     val activityIntentTestRule = HomeActivityIntentTestRule()
-
-    @Rule
-    @JvmField
-    val retryTestRule = RetryTestRule(3)
 
     @Before
     fun setUp() {
@@ -75,7 +69,6 @@ class SettingsAdvancedTest {
         }
     }
 
-    @Ignore("Failing, see: https://github.com/mozilla-mobile/fenix/issues/25551")
     @SmokeTest
     @Test
     // Assumes Play Store is installed and enabled


### PR DESCRIPTION
For #25551 fix disabled `openLinkInAppTest` UI test ✅ successfully passed 100x on Firebase.

Summary:
• Removed the retry rule from SettingsAdvancedTest because at re-run it could mess up the settings (in this case disable the "Open links in apps toggle")

•Changed the way we verify that the native app is opened
Also verified that the change work properly for the other tests as well
`emailLinkPWATest`  ✅ successfully passed 50X on Firebase.
`telephoneLinkPWATest`  ✅ successfully passed 50X on Firebase.
`mainMenuOpenInAppTest`  ✅ successfully passed 50X on Firebase.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
