### PR TITLE
No issue: Add number_of_app_launches custom attribute to nimbus messages

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/gleanplumb/CustomAttributeProvider.kt
+++ b/app/src/main/java/org/mozilla/fenix/gleanplumb/CustomAttributeProvider.kt
@@ -6,6 +6,7 @@ package org.mozilla.fenix.gleanplumb
 
 import android.content.Context
 import org.json.JSONObject
+import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.utils.BrowsersCache
 import java.text.SimpleDateFormat
 import java.util.Locale
@@ -27,7 +28,8 @@ object CustomAttributeProvider {
         return JSONObject(
             mapOf(
                 "is_default_browser_string" to BrowsersCache.all(context).isDefaultBrowser.toString(),
-                "date_string" to formatter.format(now.time)
+                "date_string" to formatter.format(now.time),
+                "number_of_app_launches" to context.settings().numberOfAppLaunches
             )
         )
     }

--- a/nimbus.fml.yaml
+++ b/nimbus.fml.yaml
@@ -125,6 +125,7 @@ features:
             NEVER: "false"
             I_AM_DEFAULT_BROWSER: "is_default_browser_string == 'true'"
             I_AM_NOT_DEFAULT_BROWSER: "is_default_browser_string == 'false'"
+            USER_ESTABLISHED_INSTALL: "number_of_app_launches >=4"
           actions:
             ENABLE_PRIVATE_BROWSING: ://enable_private_browsing
             INSTALL_SEARCH_WIDGET: ://install_search_widget
@@ -164,7 +165,7 @@ features:
             default-browser:
               text: default_browser_experiment_card_text
               action: "MAKE_DEFAULT_BROWSER"
-              trigger: [ "I_AM_NOT_DEFAULT_BROWSER" ]
+              trigger: [ "I_AM_NOT_DEFAULT_BROWSER","USER_ESTABLISHED_INSTALL" ]
               style: "DEFAULT"
               button-label: preferences_set_as_default_browser
 


### PR DESCRIPTION
This PR will add the `number_of_app_launches` custom attribute indicating how many times the app has been launched. This attribute will give the capability to nimbus messages to show in an appropriate time and don't distract users. We have been working on reducing the startup time from when the user launched Fenix to when it's first interactive, normally we would like to show messages to users in the right time, as now all messages could show in the first app run. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
