### PR TITLE
For #25726 fix failing testStrictVisitSheetDetails UI test

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/StrictEnhancedTrackingProtectionTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/StrictEnhancedTrackingProtectionTest.kt
@@ -161,7 +161,6 @@ class StrictEnhancedTrackingProtectionTest {
         }
     }
 
-    @Ignore("Failing, see: https://github.com/mozilla-mobile/fenix/issues/25726")
     @Test
     fun testStrictVisitSheetDetails() {
         val genericPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
@@ -176,7 +175,9 @@ class StrictEnhancedTrackingProtectionTest {
         }
 
         navigationToolbar {
-        }.enterURLAndEnterToBrowser(trackingProtectionTest.url) {}
+        }.enterURLAndEnterToBrowser(trackingProtectionTest.url) {
+            verifyTrackingProtectionWebContent("blocked")
+        }
         enhancedTrackingProtection {
         }.openEnhancedTrackingProtectionSheet {
             verifyEnhancedTrackingProtectionSheetStatus("ON", true)

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -41,6 +41,7 @@ import org.junit.Assert.fail
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.helpers.Constants.LONG_CLICK_DURATION
+import org.mozilla.fenix.helpers.Constants.RETRY_COUNT
 import org.mozilla.fenix.helpers.SessionLoadedIdlingResource
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeLong
@@ -680,6 +681,31 @@ class BrowserRobot {
                     .resourceId("$packageName:id/feature_prompt_login_fragment")
             ).waitForExists(waitingTime)
         )
+    }
+
+    fun verifyTrackingProtectionWebContent(state: String) {
+        for (i in 1..RETRY_COUNT) {
+            try {
+                assertTrue(
+                    mDevice.findObject(
+                        UiSelector().textContains(state)
+                    ).waitForExists(waitingTimeLong)
+                )
+
+                break
+            } catch (e: AssertionError) {
+                if (i == RETRY_COUNT) {
+                    throw e
+                } else {
+                    Log.e("TestLog", "On try $i, trackers are not: $state")
+
+                    navigationToolbar {
+                    }.openThreeDotMenu {
+                    }.refreshPage {
+                    }
+                }
+            }
+        }
     }
 
     class Transition {


### PR DESCRIPTION
For #25726 fix failing `testStrictVisitSheetDetails` UI test ✅ successfully passed 100x

Summary:
The ETP problem not blocking on first run is still happening from time to time, so I've added the retryRule to overcome this problem.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
