### PR TITLE
For #25721 - Remove 'Daylight' from the 'About Firefox' screen

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/about/AboutFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/about/AboutFragment.kt
@@ -17,7 +17,6 @@ import androidx.recyclerview.widget.DividerItemDecoration
 import mozilla.components.service.glean.private.NoExtras
 import org.mozilla.fenix.BrowserDirection
 import org.mozilla.fenix.BuildConfig
-import org.mozilla.fenix.Config
 import org.mozilla.fenix.GleanMetrics.Events
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
@@ -40,7 +39,6 @@ import org.mozilla.geckoview.BuildConfig as GeckoViewBuildConfig
  */
 class AboutFragment : Fragment(), AboutPageListener {
 
-    private lateinit var headerAppName: String
     private lateinit var appName: String
     private var aboutPageAdapter: AboutPageAdapter? = AboutPageAdapter(this)
     private var _binding: FragmentAboutBinding? = null
@@ -54,8 +52,6 @@ class AboutFragment : Fragment(), AboutPageListener {
     ): View {
         _binding = FragmentAboutBinding.inflate(inflater, container, false)
         appName = getString(R.string.app_name)
-        headerAppName =
-            if (Config.channel.isRelease) getString(R.string.daylight_app_name) else appName
 
         return binding.root
     }
@@ -128,7 +124,7 @@ class AboutFragment : Fragment(), AboutPageListener {
             ""
         }
 
-        val content = getString(R.string.about_content, headerAppName)
+        val content = getString(R.string.about_content, appName)
         val buildDate = BuildConfig.BUILD_DATE
 
         binding.aboutText.text = aboutText

--- a/app/src/main/res/values/static_strings.xml
+++ b/app/src/main/res/values/static_strings.xml
@@ -52,9 +52,6 @@
     <!-- Content description (not visible, for screen readers etc.) used to announce [LinkTextView]. -->
     <string name="link_text_view_type_announcement" translatable="false">link</string>
 
-    <!-- Name of the application for about page -->
-    <string name="daylight_app_name" translatable="false">Firefox Daylight</string>
-
     <!-- Secret debug info strings -->
     <string name="debug_info_region_home" translatable="false">Home region</string>
     <string name="debug_info_region_current" translatable="false">Current region</string>


### PR DESCRIPTION
Removed `Daylight` from the `AboutFirefox` screen.

![Screenshot_20220623_152705](https://user-images.githubusercontent.com/35462038/175298444-497c811d-a097-4e5b-a6e3-93298f5b6e0f.png)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
