### PR TITLE
For #25061: Update debug maxSdkVersion for screenshots

### DIFF
--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -11,8 +11,9 @@
     <!-- Allows for storing and retrieving screenshots -->
     <uses-permission
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"
-        android:maxSdkVersion="28"
+        android:maxSdkVersion="30"
         tools:ignore="ScopedStorage"
+        tools:replace="android:maxSdkVersion"
         />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 


### PR DESCRIPTION
For #25061 - update debug maxSdkVersion to SDK 30, and override instead of merge on main manifest (currently 28)

Should fix the permission granting issue in #25061 

re override, went with suggestion mentioned in AS (unknown if this causes any problems):

> Manifest merger failed : Attribute uses-permission#android.permission.WRITE_EXTERNAL_STORAGE@maxSdkVersion value=(30) from AndroidManifest.xml:11:9-35
	is also present at AndroidManifest.xml:11:9-35 value=(28).
	Suggestion: add 'tools:replace="android:maxSdkVersion"' to <uses-permission> element at AndroidManifest.xml:12:5-16:11 to override.