### PR TITLE
For #24528 - Remove isPrivate conditional in getTheme in favor of inComposePreview

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/compose/ClickableSubstringLink.kt
+++ b/app/src/main/java/org/mozilla/fenix/compose/ClickableSubstringLink.kt
@@ -87,7 +87,7 @@ fun ClickableSubstringLink(
 private fun ClickableSubstringTextPreview() {
     val text = "This text contains a link"
 
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         Box(modifier = Modifier.background(color = FirefoxTheme.colors.layer1)) {
             ClickableSubstringLink(
                 text = text,

--- a/app/src/main/java/org/mozilla/fenix/compose/Favicon.kt
+++ b/app/src/main/java/org/mozilla/fenix/compose/Favicon.kt
@@ -98,7 +98,7 @@ private fun FaviconPlaceholder(
 @Composable
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 private fun FaviconPreview() {
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         Box(Modifier.background(FirefoxTheme.colors.layer1)) {
             Favicon(
                 url = "www.mozilla.com",

--- a/app/src/main/java/org/mozilla/fenix/compose/ListItemTabLarge.kt
+++ b/app/src/main/java/org/mozilla/fenix/compose/ListItemTabLarge.kt
@@ -154,7 +154,7 @@ fun ListItemTabSurface(
 @Composable
 @Preview
 private fun ListItemTabLargePreview() {
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         ListItemTabLarge(
             imageUrl = "",
             title = "This is a very long title for a tab but needs to be so for this preview",
@@ -166,7 +166,7 @@ private fun ListItemTabLargePreview() {
 @Composable
 @Preview
 private fun ListItemTabSurfacePreview() {
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         ListItemTabSurface(
             imageUrl = ""
         ) {

--- a/app/src/main/java/org/mozilla/fenix/compose/ListItemTabLargePlaceholder.kt
+++ b/app/src/main/java/org/mozilla/fenix/compose/ListItemTabLargePlaceholder.kt
@@ -74,7 +74,7 @@ fun ListItemTabLargePlaceholder(
 @Composable
 @Preview
 private fun ListItemTabLargePlaceholderPreview() {
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         ListItemTabLargePlaceholder(text = "Item placeholder")
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/compose/MessageCard.kt
+++ b/app/src/main/java/org/mozilla/fenix/compose/MessageCard.kt
@@ -137,7 +137,7 @@ fun MessageCard(
 @Composable
 @Preview
 private fun MessageCardPreview() {
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         Box(Modifier.background(FirefoxTheme.colors.layer1)) {
             MessageCard(
                 message = Message(
@@ -166,7 +166,7 @@ private fun MessageCardPreview() {
 @Composable
 @Preview
 private fun MessageCardWithoutTitlePreview() {
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         Box(Modifier.background(FirefoxTheme.colors.layer1)) {
             MessageCard(
                 message = Message(
@@ -191,7 +191,7 @@ private fun MessageCardWithoutTitlePreview() {
 @Composable
 @Preview
 private fun MessageCardWithButtonLabelPreview() {
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         Box(Modifier.background(FirefoxTheme.colors.layer1)) {
             MessageCard(
                 message = Message(

--- a/app/src/main/java/org/mozilla/fenix/compose/SelectableChip.kt
+++ b/app/src/main/java/org/mozilla/fenix/compose/SelectableChip.kt
@@ -68,7 +68,7 @@ fun SelectableChip(
 @Composable
 @Preview(uiMode = UI_MODE_NIGHT_YES)
 private fun SelectableChipDarkThemePreview() {
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -84,7 +84,7 @@ private fun SelectableChipDarkThemePreview() {
 @Composable
 @Preview(uiMode = UI_MODE_NIGHT_NO)
 private fun SelectableChipLightThemePreview() {
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()

--- a/app/src/main/java/org/mozilla/fenix/compose/StaggeredHorizontalGrid.kt
+++ b/app/src/main/java/org/mozilla/fenix/compose/StaggeredHorizontalGrid.kt
@@ -121,7 +121,7 @@ fun StaggeredHorizontalGrid(
 @Composable
 @Preview
 private fun StaggeredHorizontalGridPreview() {
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         Box(Modifier.background(FirefoxTheme.colors.layer2)) {
             StaggeredHorizontalGrid(
                 horizontalItemsSpacing = 8.dp,

--- a/app/src/main/java/org/mozilla/fenix/compose/TabSubtitleWithInterdot.kt
+++ b/app/src/main/java/org/mozilla/fenix/compose/TabSubtitleWithInterdot.kt
@@ -106,7 +106,7 @@ fun TabSubtitleWithInterdot(
 @Composable
 @Preview
 private fun TabSubtitleWithInterdotPreview() {
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         Box(Modifier.background(FirefoxTheme.colors.layer2)) {
             TabSubtitleWithInterdot(
                 firstText = "firstText",

--- a/app/src/main/java/org/mozilla/fenix/compose/ThumbnailCard.kt
+++ b/app/src/main/java/org/mozilla/fenix/compose/ThumbnailCard.kt
@@ -130,7 +130,7 @@ private fun ThumbnailImage(
 @Preview
 @Composable
 private fun ThumbnailCardPreview() {
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         ThumbnailCard(
             url = "https://mozilla.com",
             key = "123",

--- a/app/src/main/java/org/mozilla/fenix/compose/button/Button.kt
+++ b/app/src/main/java/org/mozilla/fenix/compose/button/Button.kt
@@ -171,7 +171,7 @@ fun DestructiveButton(
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_NO)
 private fun ButtonPreview() {
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         Column(
             modifier = Modifier
                 .background(FirefoxTheme.colors.layer1)

--- a/app/src/main/java/org/mozilla/fenix/compose/button/TextButton.kt
+++ b/app/src/main/java/org/mozilla/fenix/compose/button/TextButton.kt
@@ -48,7 +48,7 @@ fun TextButton(
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_NO)
 private fun TextButtonPreview() {
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         Box(Modifier.background(FirefoxTheme.colors.layer1)) {
             TextButton(
                 text = "label",

--- a/app/src/main/java/org/mozilla/fenix/compose/home/HomeSectionHeader.kt
+++ b/app/src/main/java/org/mozilla/fenix/compose/home/HomeSectionHeader.kt
@@ -66,7 +66,7 @@ fun HomeSectionHeader(
 @Composable
 @Preview
 private fun HomeSectionsHeaderPreview() {
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         HomeSectionHeader(
             headerText = stringResource(R.string.recent_bookmarks_title),
             description = stringResource(R.string.recently_saved_show_all_content_description_2),

--- a/app/src/main/java/org/mozilla/fenix/compose/list/ExpandableListHeader.kt
+++ b/app/src/main/java/org/mozilla/fenix/compose/list/ExpandableListHeader.kt
@@ -96,7 +96,7 @@ fun ExpandableListHeader(
 @Composable
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 private fun TextOnlyHeaderPreview() {
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         Box(Modifier.background(FirefoxTheme.colors.layer1)) {
             ExpandableListHeader(headerText = "Section title")
         }
@@ -106,7 +106,7 @@ private fun TextOnlyHeaderPreview() {
 @Composable
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 private fun CollapsibleHeaderPreview() {
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         Box(Modifier.background(FirefoxTheme.colors.layer1)) {
             ExpandableListHeader(
                 headerText = "Collapsible section title",
@@ -122,7 +122,7 @@ private fun CollapsibleHeaderPreview() {
 @Composable
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_NO)
 private fun HeaderWithClickableIconPreview() {
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         Box(Modifier.background(FirefoxTheme.colors.layer1)) {
             ExpandableListHeader(headerText = "Section title") {
                 Box(
@@ -145,7 +145,7 @@ private fun HeaderWithClickableIconPreview() {
 @Composable
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_NO)
 private fun CollapsibleHeaderWithClickableIconPreview() {
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         Box(Modifier.background(FirefoxTheme.colors.layer1)) {
             ExpandableListHeader(
                 headerText = "Section title",

--- a/app/src/main/java/org/mozilla/fenix/compose/list/ListItem.kt
+++ b/app/src/main/java/org/mozilla/fenix/compose/list/ListItem.kt
@@ -250,7 +250,7 @@ private fun ListItem(
 @Composable
 @Preview(name = "TextListItem", uiMode = Configuration.UI_MODE_NIGHT_YES)
 private fun TextListItemPreview() {
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         Box(Modifier.background(FirefoxTheme.colors.layer1)) {
             TextListItem(label = "Label only")
         }
@@ -260,7 +260,7 @@ private fun TextListItemPreview() {
 @Composable
 @Preview(name = "TextListItem with a description", uiMode = Configuration.UI_MODE_NIGHT_YES)
 private fun TextListItemWithDescriptionPreview() {
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         Box(Modifier.background(FirefoxTheme.colors.layer1)) {
             TextListItem(
                 label = "Label + description",
@@ -273,7 +273,7 @@ private fun TextListItemWithDescriptionPreview() {
 @Composable
 @Preview(name = "TextListItem with a right icon", uiMode = Configuration.UI_MODE_NIGHT_YES)
 private fun TextListItemWithIconPreview() {
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         Box(Modifier.background(FirefoxTheme.colors.layer1)) {
             TextListItem(
                 label = "Label + right icon",
@@ -288,7 +288,7 @@ private fun TextListItemWithIconPreview() {
 @Composable
 @Preview(name = "IconListItem", uiMode = Configuration.UI_MODE_NIGHT_YES)
 private fun IconListItemPreview() {
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         Box(Modifier.background(FirefoxTheme.colors.layer1)) {
             IconListItem(
                 label = "Left icon list item",
@@ -305,7 +305,7 @@ private fun IconListItemPreview() {
     uiMode = Configuration.UI_MODE_NIGHT_YES
 )
 private fun IconListItemWithRightIconPreview() {
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         Box(Modifier.background(FirefoxTheme.colors.layer1)) {
             IconListItem(
                 label = "Left icon list item + right icon",
@@ -325,7 +325,7 @@ private fun IconListItemWithRightIconPreview() {
     uiMode = Configuration.UI_MODE_NIGHT_YES
 )
 private fun FaviconListItemPreview() {
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         Box(Modifier.background(FirefoxTheme.colors.layer1)) {
             FaviconListItem(
                 label = "Favicon + right icon + clicks",

--- a/app/src/main/java/org/mozilla/fenix/compose/tabstray/MediaImage.kt
+++ b/app/src/main/java/org/mozilla/fenix/compose/tabstray/MediaImage.kt
@@ -59,7 +59,7 @@ fun MediaImage(
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_NO)
 private fun ImagePreview() {
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         MediaImage(
             tab = createTab(url = "https://mozilla.com"),
             onMediaIconClicked = {},

--- a/app/src/main/java/org/mozilla/fenix/compose/tabstray/TabListItem.kt
+++ b/app/src/main/java/org/mozilla/fenix/compose/tabstray/TabListItem.kt
@@ -173,7 +173,7 @@ private fun Thumbnail(
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_NO)
 private fun TabListItemPreview() {
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         TabListItem(
             tab = createTab(url = "www.mozilla.com", title = "Mozilla"),
             onCloseClick = {},
@@ -188,7 +188,7 @@ private fun TabListItemPreview() {
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_NO)
 private fun SelectedTabListItemPreview() {
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         TabListItem(
             tab = createTab(url = "www.mozilla.com", title = "Mozilla"),
             onCloseClick = {},

--- a/app/src/main/java/org/mozilla/fenix/home/collections/CollectionItem.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/collections/CollectionItem.kt
@@ -195,7 +195,7 @@ private fun Modifier.clipTop() = this.then(
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_NO)
 private fun TabInCollectionPreview() {
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         Column {
             Box(modifier = Modifier.height(56.dp)) {
                 DismissedTabBackground(

--- a/app/src/main/java/org/mozilla/fenix/home/pocket/PocketCategoriesViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/pocket/PocketCategoriesViewHolder.kt
@@ -104,7 +104,7 @@ private fun PocketTopics(
 @Composable
 @Preview
 private fun PocketCategoriesViewHolderPreview() {
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         PocketTopics(
             categories = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor"
                 .split(" ")

--- a/app/src/main/java/org/mozilla/fenix/home/pocket/PocketRecommendationsHeaderViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/pocket/PocketRecommendationsHeaderViewHolder.kt
@@ -60,7 +60,7 @@ class PocketRecommendationsHeaderViewHolder(
 @Composable
 @Preview
 fun PocketRecommendationsFooterViewHolderPreview() {
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         PoweredByPocketHeader(
             onLearnMoreClicked = {}
         )

--- a/app/src/main/java/org/mozilla/fenix/home/pocket/PocketStoriesComposables.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/pocket/PocketStoriesComposables.kt
@@ -446,7 +446,7 @@ fun PoweredByPocketHeader(
 @Composable
 @Preview
 private fun PocketStoriesComposablesPreview() {
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         Box(Modifier.background(FirefoxTheme.colors.layer2)) {
             Column {
                 PocketStories(

--- a/app/src/main/java/org/mozilla/fenix/home/pocket/PocketStoriesViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/pocket/PocketStoriesViewHolder.kt
@@ -103,7 +103,7 @@ class PocketStoriesViewHolder(
 @Composable
 @Preview
 fun PocketStoriesViewHolderPreview() {
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         Column {
             SectionHeader(
                 text = stringResource(R.string.pocket_stories_header_1),

--- a/app/src/main/java/org/mozilla/fenix/home/recentbookmarks/view/RecentBookmarks.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recentbookmarks/view/RecentBookmarks.kt
@@ -219,7 +219,7 @@ private fun RecentBookmarksMenu(
 @Composable
 @Preview
 private fun RecentBookmarksPreview() {
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         RecentBookmarks(
             bookmarks = listOf(
                 RecentBookmark(

--- a/app/src/main/java/org/mozilla/fenix/home/recentsyncedtabs/view/RecentSyncedTab.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recentsyncedtabs/view/RecentSyncedTab.kt
@@ -200,7 +200,7 @@ private fun LoadedRecentSyncedTab() {
         url = "https://mozilla.org",
         iconUrl = "https://mozilla.org",
     )
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         RecentSyncedTab(
             tab = tab,
             onRecentSyncedTabClick = {},
@@ -212,7 +212,7 @@ private fun LoadedRecentSyncedTab() {
 @Preview
 @Composable
 private fun LoadingRecentSyncedTab() {
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         RecentSyncedTab(
             tab = null,
             onRecentSyncedTabClick = {},

--- a/app/src/main/java/org/mozilla/fenix/home/recentvisits/view/RecentlyVisited.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recentvisits/view/RecentlyVisited.kt
@@ -370,7 +370,7 @@ private val LazyListState.atLeastHalfVisibleItems
 @Composable
 @Preview
 private fun RecentlyVisitedPreview() {
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         RecentlyVisited(
             recentVisits = listOf(
                 RecentHistoryGroup(title = "running shoes"),

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/PrivateBrowsingDescriptionViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/PrivateBrowsingDescriptionViewHolder.kt
@@ -116,7 +116,7 @@ fun PrivateBrowsingDescription(
 @Composable
 @Preview
 private fun PrivateBrowsingDescriptionPreview() {
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         PrivateBrowsingDescription(
             onLearnMoreClick = {}
         )

--- a/app/src/main/java/org/mozilla/fenix/settings/address/view/AddressList.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/address/view/AddressList.kt
@@ -61,7 +61,7 @@ fun AddressList(
 @Preview
 @Composable
 private fun AddressListPreview() {
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         Box(Modifier.background(FirefoxTheme.colors.layer2)) {
             AddressList(
                 addresses = listOf(

--- a/app/src/main/java/org/mozilla/fenix/settings/wallpaper/WallpaperSettings.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/wallpaper/WallpaperSettings.kt
@@ -294,7 +294,7 @@ private fun WallpaperLogoSwitch(
 @Preview
 @Composable
 private fun WallpaperThumbnailsPreview() {
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         val context = LocalContext.current
         val wallpaperManager = context.components.wallpaperManager
 
@@ -316,7 +316,7 @@ private fun WallpaperThumbnailsPreview() {
 @Preview
 @Composable
 private fun WallpaperSnackbarPreview() {
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         WallpaperSnackbar(
             onViewWallpaper = {}
         )

--- a/app/src/main/java/org/mozilla/fenix/tabstray/inactivetabs/InactiveTabs.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/inactivetabs/InactiveTabs.kt
@@ -229,7 +229,7 @@ private fun InactiveTabsAutoClosePrompt(
 @Preview(name = "Auto close dialog dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Preview(name = "Auto close dialog light", uiMode = Configuration.UI_MODE_NIGHT_NO)
 private fun InactiveTabsAutoClosePromptPreview() {
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         Box(Modifier.background(FirefoxTheme.colors.layer1)) {
             InactiveTabsAutoClosePrompt(
                 onDismissClick = {},
@@ -246,7 +246,7 @@ private fun InactiveTabsListPreview() {
     var expanded by remember { mutableStateOf(true) }
     var showAutoClosePrompt by remember { mutableStateOf(true) }
 
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         Box(Modifier.background(FirefoxTheme.colors.layer1)) {
             InactiveTabsList(
                 inactiveTabs = generateFakeInactiveTabsList(),

--- a/app/src/main/java/org/mozilla/fenix/tabstray/syncedtabs/SyncedTabs.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/syncedtabs/SyncedTabs.kt
@@ -240,7 +240,7 @@ fun SyncedTabsNoTabsItem() {
 @Composable
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 private fun SyncedTabsListItemsPreview() {
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         Column(Modifier.background(FirefoxTheme.colors.layer1)) {
             SyncedTabsSectionHeader(headerText = "Google Pixel Pro Max +Ultra 5000")
 
@@ -276,7 +276,7 @@ private fun SyncedTabsListItemsPreview() {
 @Composable
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 private fun SyncedTabsErrorPreview() {
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         Box(Modifier.background(FirefoxTheme.colors.layer1)) {
             SyncedTabsErrorItem(
                 errorText = stringResource(R.string.synced_tabs_no_tabs),
@@ -293,7 +293,7 @@ private fun SyncedTabsErrorPreview() {
 @Composable
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 private fun SyncedTabsListPreview() {
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         Box(Modifier.background(FirefoxTheme.colors.layer1)) {
             SyncedTabsList(
                 syncedTabs = getFakeSyncedTabList(),

--- a/app/src/main/java/org/mozilla/fenix/theme/FenixTypography.kt
+++ b/app/src/main/java/org/mozilla/fenix/theme/FenixTypography.kt
@@ -144,7 +144,7 @@ private fun TypographyPreview() {
         Pair("Overline", defaultTypography.overline),
     )
 
-    FirefoxTheme(theme = Theme.getTheme(isPrivate = false)) {
+    FirefoxTheme(theme = Theme.getTheme()) {
         LazyColumn(
             modifier = Modifier
                 .background(FirefoxTheme.colors.layer1)

--- a/app/src/main/java/org/mozilla/fenix/theme/FirefoxTheme.kt
+++ b/app/src/main/java/org/mozilla/fenix/theme/FirefoxTheme.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import mozilla.components.ui.colors.PhotonColors
+import org.mozilla.fenix.compose.inComposePreview
 import org.mozilla.fenix.ext.settings
 
 /**
@@ -33,12 +34,11 @@ enum class Theme {
         /**
          * Returns the current [Theme] that is displayed.
          *
-         * @param isPrivate Whether or not private browsing mode is enabled.
          * @return the current [Theme] that is displayed.
          */
         @Composable
-        fun getTheme(isPrivate: Boolean = LocalContext.current.settings().lastKnownMode.isPrivate) =
-            if (isPrivate) {
+        fun getTheme() =
+            if (!inComposePreview && LocalContext.current.settings().lastKnownMode.isPrivate) {
                 Private
             } else if (isSystemInDarkTheme()) {
                 Dark


### PR DESCRIPTION
Removed the `isPrivate` paramater from the `getTheme` method and replaced it with 
`!inComposePreview && lastKnownMode.isPrivate`

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
