### PR TITLE
For #25852: Fixes visibility issue of private tabs notification in UI tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NotificationRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/NotificationRobot.kt
@@ -65,8 +65,8 @@ class NotificationRobot {
     }
 
     fun verifyPrivateTabsNotification() {
-        mDevice.waitNotNull(Until.hasObject(text("Close private tabs")), waitingTime)
-        assertPrivateTabsNotification()
+        verifySystemNotificationExists("$appName (Private)")
+        verifySystemNotificationExists("Close private tabs")
     }
 
     fun clickMediaNotificationControlButton(action: String) {
@@ -115,7 +115,14 @@ class NotificationRobot {
     class Transition {
 
         fun clickClosePrivateTabsNotification(interact: HomeScreenRobot.() -> Unit): HomeScreenRobot.Transition {
-            NotificationRobot().verifySystemNotificationExists("Close private tabs")
+            try {
+                assertTrue(
+                    closePrivateTabsNotification().exists()
+                )
+            } catch (e: AssertionError) {
+                notificationTray().flingToEnd(1)
+            }
+
             closePrivateTabsNotification().click()
 
             HomeScreenRobot().interact()
@@ -127,11 +134,6 @@ class NotificationRobot {
 fun notificationShade(interact: NotificationRobot.() -> Unit): NotificationRobot.Transition {
     NotificationRobot().interact()
     return NotificationRobot.Transition()
-}
-
-private fun assertPrivateTabsNotification() {
-    mDevice.findObject(UiSelector().text("Firefox Preview (Private)")).exists()
-    mDevice.findObject(UiSelector().text("Close private tabs")).exists()
 }
 
 private fun closePrivateTabsNotification() =


### PR DESCRIPTION
Ran the test for 50 times on Firebase and all passed.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
