### PR TITLE
For #25933 - Ensure sponsored tiles are enable if enrolled in active experiment

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -428,8 +428,6 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
                 onNimbusStartupAndUpdate()
             }
         })
-
-        onNimbusStartupAndUpdate()
     }
 
     private fun onNimbusStartupAndUpdate() {

--- a/app/src/main/java/org/mozilla/fenix/components/settings/FeatureFlagPreference.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/settings/FeatureFlagPreference.kt
@@ -26,15 +26,12 @@ fun featureFlagPreference(key: String, default: Boolean, featureFlag: Boolean) =
 
 private class LazyPreference(val key: String, val default: () -> Boolean) :
     ReadWriteProperty<PreferencesHolder, Boolean> {
-    private val property: ReadWriteProperty<PreferencesHolder, Boolean> by lazy {
-        booleanPreference(key, default())
-    }
 
     override fun getValue(thisRef: PreferencesHolder, property: KProperty<*>) =
-        this.property.getValue(thisRef, property)
+        thisRef.preferences.getBoolean(key, default())
 
     override fun setValue(thisRef: PreferencesHolder, property: KProperty<*>, value: Boolean) =
-        this.property.setValue(thisRef, property, value)
+        thisRef.preferences.edit().putBoolean(key, value).apply()
 }
 
 /**

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -1233,9 +1233,8 @@ class Settings(private val appContext: Context) : PreferencesHolder {
         default = false
     )
 
-    private val homescreenSections: Map<HomeScreenSection, Boolean> by lazy {
+    private val homescreenSections: Map<HomeScreenSection, Boolean> get() =
         FxNimbus.features.homescreen.value().sectionsEnabled
-    }
 
     var historyMetadataUIFeature by lazyFeatureFlagPreference(
         appContext.getPreferenceKey(R.string.pref_key_history_metadata_feature),


### PR DESCRIPTION
Fixes #25933 


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
