### PR TITLE
Closes #25954: add new delete time range dialog for History and HistoryGroup screens

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HistoryRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HistoryRobot.kt
@@ -71,7 +71,7 @@ class HistoryRobot {
         deleteButton(item).click()
     }
 
-    fun clickDeleteAllHistoryButton() = deleteAllButton().click()
+    fun clickDeleteAllHistoryButton() = deleteButton().click()
 
     fun confirmDeleteAllHistory() {
         onView(withText("Delete"))
@@ -104,7 +104,7 @@ private fun pageUrl() = onView(withId(R.id.url))
 private fun deleteButton(title: String) =
     onView(allOf(withId(R.id.overflow_menu), hasSibling(withText(title))))
 
-private fun deleteAllButton() = onView(withId(R.id.history_delete_all))
+private fun deleteButton() = onView(withId(R.id.history_delete))
 
 private fun snackBarText() = onView(withId(R.id.snackbar_text))
 
@@ -147,7 +147,7 @@ private fun assertPageUrl(expectedUrl: Uri) = pageUrl()
     .check(matches(withText(Matchers.containsString(expectedUrl.toString()))))
 
 private fun assertDeleteConfirmationMessage() =
-    onView(withText("This will delete all of your browsing data."))
+    onView(withText("Removes history (including history synced from other devices), cookies and other browsing data."))
         .inRoot(isDialog())
         .check(matches(isDisplayed()))
 

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryInteractor.kt
@@ -28,15 +28,23 @@ interface HistoryInteractor : SelectionInteractor<History> {
     fun onSearch()
 
     /**
-     * Called when delete all is tapped
+     * Called when the delete menu button is tapped.
      */
-    fun onDeleteAll()
+    fun onDeleteTimeRange()
 
     /**
      * Called when multiple history items are deleted
      * @param items the history items to delete
      */
     fun onDeleteSome(items: Set<History>)
+
+    /**
+     * Called when the user has confirmed deletion of a time range.
+     *
+     * @param timeFrame The selected timeframe. `null` means no specific time frame has been
+     * selected; should remove everything.
+     */
+    fun onDeleteTimeRangeConfirmed(timeFrame: RemoveTimeFrame?)
 
     /**
      * Called when the user requests a sync of the history
@@ -86,12 +94,16 @@ class DefaultHistoryInteractor(
         historyController.handleSearch()
     }
 
-    override fun onDeleteAll() {
-        historyController.handleDeleteAll()
+    override fun onDeleteTimeRange() {
+        historyController.handleDeleteTimeRange()
     }
 
     override fun onDeleteSome(items: Set<History>) {
         historyController.handleDeleteSome(items)
+    }
+
+    override fun onDeleteTimeRangeConfirmed(timeFrame: RemoveTimeFrame?) {
+        historyController.handleDeleteTimeRangeConfirmed(timeFrame)
     }
 
     override fun onRequestSync() {

--- a/app/src/main/java/org/mozilla/fenix/library/history/RemoveTimeFrame.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/RemoveTimeFrame.kt
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.library.history
+
+import java.util.Calendar
+import java.util.Date
+
+/**
+ * A helper class that provides starting and ending timestamps for a set time frame. Is used by
+ * [HistoryFragment] to provide timestamps for options inside the delete history dialog.
+ */
+enum class RemoveTimeFrame {
+    LastHour,
+    TodayAndYesterday;
+
+    /**
+     * Provides starting and ending timestamps for a set time frame. Each call is calculated at the
+     * moment of execution, which is different from [HistoryItemTimeGroup] implementation.
+     */
+    fun toLongRange(): LongRange {
+        return when (this) {
+            LastHour -> LongRange(getHourAgo(hoursAgo = 1).time, Long.MAX_VALUE)
+            TodayAndYesterday -> LongRange(getDaysAgo(daysAgo = 1).time, Long.MAX_VALUE)
+        }
+    }
+
+    private fun getHourAgo(hoursAgo: Int): Date {
+        return Calendar.getInstance().apply {
+            add(Calendar.HOUR_OF_DAY, -hoursAgo)
+        }.time
+    }
+
+    private fun getDaysAgo(daysAgo: Int): Date {
+        return Calendar.getInstance().apply {
+            set(Calendar.HOUR_OF_DAY, 0)
+            set(Calendar.MINUTE, 0)
+            set(Calendar.SECOND, 0)
+            set(Calendar.MILLISECOND, 0)
+            add(Calendar.DAY_OF_YEAR, -daysAgo)
+        }.time
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/library/historymetadata/HistoryMetadataGroupFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/historymetadata/HistoryMetadataGroupFragment.kt
@@ -98,6 +98,7 @@ class HistoryMetadataGroupFragment :
                 store = historyMetadataGroupStore,
                 selectOrAddUseCase = requireComponents.useCases.tabsUseCases.selectOrAddTab,
                 navController = findNavController(),
+                scope = CoroutineScope(Dispatchers.IO),
                 searchTerm = args.title,
                 deleteSnackbar = :: deleteSnackbar,
                 promptDeleteAll = :: promptDeleteAll,
@@ -194,8 +195,8 @@ class HistoryMetadataGroupFragment :
                 showTabTray()
                 true
             }
-            R.id.history_delete_all -> {
-                interactor.onDeleteAllMenuItem()
+            R.id.history_delete -> {
+                interactor.onDeleteAll()
                 true
             }
             else -> super.onOptionsItemSelected(item)
@@ -218,14 +219,14 @@ class HistoryMetadataGroupFragment :
         )
     }
 
-    private fun promptDeleteAll(delete: () -> Unit) {
+    private fun promptDeleteAll() {
         if (childFragmentManager.findFragmentByTag(DeleteAllConfirmationDialogFragment.TAG)
             as? DeleteAllConfirmationDialogFragment != null
         ) {
             return
         }
 
-        DeleteAllConfirmationDialogFragment(delete).show(
+        DeleteAllConfirmationDialogFragment(interactor, args.title).show(
             childFragmentManager, DeleteAllConfirmationDialogFragment.TAG
         )
     }
@@ -254,15 +255,23 @@ class HistoryMetadataGroupFragment :
         )
     }
 
-    internal class DeleteAllConfirmationDialogFragment(private val delete: () -> Unit) : DialogFragment() {
+    internal class DeleteAllConfirmationDialogFragment(
+        private val interactor: HistoryMetadataGroupInteractor,
+        private val groupName: String
+    ) : DialogFragment() {
         override fun onCreateDialog(savedInstanceState: Bundle?): Dialog =
             AlertDialog.Builder(requireContext())
-                .setMessage(R.string.delete_history_group_prompt_message)
+                .setMessage(
+                    String.format(
+                        getString(R.string.delete_all_history_group_prompt_message),
+                        groupName
+                    )
+                )
                 .setNegativeButton(R.string.delete_history_group_prompt_cancel) { dialog: DialogInterface, _ ->
                     dialog.cancel()
                 }
                 .setPositiveButton(R.string.delete_history_group_prompt_allow) { dialog: DialogInterface, _ ->
-                    delete.invoke()
+                    interactor.onDeleteAllConfirmed()
                     dialog.dismiss()
                 }
                 .create()

--- a/app/src/main/java/org/mozilla/fenix/library/historymetadata/interactor/HistoryMetadataGroupInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/historymetadata/interactor/HistoryMetadataGroupInteractor.kt
@@ -29,10 +29,14 @@ interface HistoryMetadataGroupInteractor : SelectionInteractor<History.Metadata>
     fun onDelete(items: Set<History.Metadata>)
 
     /**
-     * Deletes all the history items in the history metadata group. Called when a user clicks
-     * on the "Delete history" menu item.
+     * Called when a user clicks on the "Delete history" menu item.
      */
-    fun onDeleteAllMenuItem()
+    fun onDeleteAll()
+
+    /**
+     * Called when a user has confirmed the deletion of the group.
+     */
+    fun onDeleteAllConfirmed()
 
     /**
      * Opens the share sheet for a set of history [items]. Called when a user clicks on the
@@ -70,8 +74,12 @@ class DefaultHistoryMetadataGroupInteractor(
         controller.handleDelete(items)
     }
 
-    override fun onDeleteAllMenuItem() {
+    override fun onDeleteAll() {
         controller.handleDeleteAll()
+    }
+
+    override fun onDeleteAllConfirmed() {
+        controller.handleDeleteAllConfirmed()
     }
 
     override fun onShareMenuItem(items: Set<History.Metadata>) {

--- a/app/src/main/res/layout/delete_history_time_range_dialog.xml
+++ b/app/src/main/res/layout/delete_history_time_range_dialog.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="24dp"
+        android:layout_marginTop="24dp"
+        android:layout_marginEnd="24dp"
+        android:ellipsize="end"
+        android:text="@string/delete_history_prompt_title"
+        android:textColor="?attr/textPrimary"
+        android:textSize="16sp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/body"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="24dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="24dp"
+        android:text="@string/delete_history_prompt_body"
+        android:textColor="?attr/textPrimary"
+        android:textSize="14sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/title" />
+
+    <RadioGroup
+        android:id="@+id/radio_group"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/body">
+
+        <RadioButton
+            android:id="@+id/last_hour_button"
+            android:layout_width="match_parent"
+            android:layout_height="48dp"
+            android:background="?android:attr/selectableItemBackground"
+            android:ellipsize="end"
+            android:buttonTint="?attr/textSecondary"
+            android:layout_marginStart="18dp"
+            android:paddingStart="32dp"
+            android:paddingEnd="8dp"
+            android:text="@string/delete_history_prompt_button_last_hour"
+            android:textColor="?attr/textPrimary"
+            android:textSize="16sp" />
+
+        <RadioButton
+            android:id="@+id/today_and_yesterday_button"
+            android:layout_width="match_parent"
+            android:layout_height="48dp"
+            android:background="?android:attr/selectableItemBackground"
+            android:ellipsize="end"
+            android:buttonTint="?attr/textSecondary"
+            android:layout_marginStart="18dp"
+            android:paddingStart="32dp"
+            android:paddingEnd="8dp"
+            android:text="@string/delete_history_prompt_button_today_and_yesterday"
+            android:textColor="?attr/textPrimary"
+            android:textSize="16sp" />
+
+        <RadioButton
+            android:id="@+id/everything_button"
+            android:layout_width="match_parent"
+            android:layout_height="48dp"
+            android:background="?android:attr/selectableItemBackground"
+            android:ellipsize="end"
+            android:buttonTint="?attr/textSecondary"
+            android:layout_marginStart="18dp"
+            android:paddingStart="32dp"
+            android:paddingEnd="8dp"
+            android:text="@string/delete_history_prompt_button_everything"
+            android:textColor="?attr/textPrimary"
+            android:textSize="16sp" />
+    </RadioGroup>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/menu/history_menu.xml
+++ b/app/src/main/res/menu/history_menu.xml
@@ -11,7 +11,7 @@
         app:iconTint="?attr/textPrimary"
         app:showAsAction="ifRoom" />
     <item
-        android:id="@+id/history_delete_all"
+        android:id="@+id/history_delete"
         android:icon="@drawable/ic_delete"
         android:title="@string/history_delete_all"
         app:iconTint="?attr/textPrimary"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1118,7 +1118,18 @@
     <string name="delete_browsing_data_on_quit_action">Quit</string>
 
     <!-- Dialog message to the user asking to delete browsing data. -->
-    <string name="delete_browsing_data_prompt_message">This will delete all of your browsing data.</string>
+    <string moz:removedIn="105" name="delete_browsing_data_prompt_message" tools:ignore="UnusedResources">This will delete all of your browsing data.</string>
+    <!-- Title text of a delete browsing data dialog. -->
+    <string name="delete_history_prompt_title">Time range to delete</string>
+    <!-- Body text of a delete browsing data dialog. -->
+    <string name="delete_history_prompt_body">Removes history (including history synced from other devices), cookies and other browsing data.</string>
+    <!-- Radio button of a delete browsing data dialog, to delete history items for the last hour.  -->
+    <string name="delete_history_prompt_button_last_hour">Last hour</string>
+    <!-- Radio button of a delete browsing data dialog, to delete history items for today and yesterday.  -->
+    <string name="delete_history_prompt_button_today_and_yesterday">Today and yesterday</string>
+    <!-- Radio button of a delete browsing data dialog, to delete all history. -->
+    <string name="delete_history_prompt_button_everything">Everything</string>
+
     <!-- Dialog message to the user asking to delete browsing data. Parameter will be replaced by app name. -->
     <string name="delete_browsing_data_prompt_message_3">%s will delete the selected browsing data.</string>
     <!-- Text for the cancel button for the data deletion dialog -->
@@ -1131,7 +1142,7 @@
     <string name="deleting_browsing_data_in_progress">Deleting browsing data&#8230;</string>
 
     <!-- Dialog message to the user asking to delete all history items inside the opened group. -->
-    <string name="delete_history_group_prompt_message">This will delete all items.</string>
+    <string name="delete_all_history_group_prompt_message">Delete all sites in \"%s\"</string>
     <!-- Text for the cancel button for the history group deletion dialog -->
     <string name="delete_history_group_prompt_cancel">Cancel</string>
     <!-- Text for the allow button for the history group dialog -->

--- a/app/src/test/java/org/mozilla/fenix/library/history/HistoryInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/history/HistoryInteractorTest.kt
@@ -75,11 +75,20 @@ class HistoryInteractorTest {
     }
 
     @Test
-    fun onDeleteAll() {
-        interactor.onDeleteAll()
+    fun onDeleteTimeRange() {
+        interactor.onDeleteTimeRange()
 
         verifyAll {
-            controller.handleDeleteAll()
+            controller.handleDeleteTimeRange()
+        }
+    }
+
+    @Test
+    fun onDeleteTimeRangeConfirmed() {
+        interactor.onDeleteTimeRangeConfirmed(null)
+
+        verifyAll {
+            controller.handleDeleteTimeRangeConfirmed(null)
         }
     }
 

--- a/app/src/test/java/org/mozilla/fenix/library/history/RemoveTimeFrameTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/history/RemoveTimeFrameTest.kt
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.library.history
+
+import org.junit.Assert
+import org.junit.Test
+import java.util.Calendar
+import java.util.concurrent.TimeUnit
+
+class RemoveTimeFrameTest {
+
+    @Test
+    fun `WHEN LastHour is calculated THEN first timeStamp is one hour ago`() {
+        val lastHourRange = RemoveTimeFrame.LastHour.toLongRange()
+        val nowMillis = Calendar.getInstance().timeInMillis
+        val millisDif = nowMillis - lastHourRange.first
+        val hourDif = TimeUnit.HOURS.convert(millisDif, TimeUnit.MILLISECONDS)
+        Assert.assertEquals(1, hourDif)
+    }
+
+    @Test
+    fun `WHEN LastHour is calculated THEN second timeStamp is equal or greater than now`() {
+        val lastHourRange = RemoveTimeFrame.LastHour.toLongRange()
+        val nowMillis = Calendar.getInstance().timeInMillis
+        Assert.assertTrue(nowMillis <= lastHourRange.last)
+    }
+
+    @Test
+    fun `WHEN TodayAndYesterday is calculated THEN first timeStamp is one day ago`() {
+        val lastHourRange = RemoveTimeFrame.TodayAndYesterday.toLongRange()
+        val nowMillis = Calendar.getInstance().timeInMillis
+        val millisDif = nowMillis - lastHourRange.first
+        val daysDif = TimeUnit.DAYS.convert(millisDif, TimeUnit.MILLISECONDS)
+        Assert.assertEquals(1, daysDif)
+    }
+
+    @Test
+    fun `WHEN TodayAndYesterday is calculated THEN first timeStamp is the start of the previous day`() {
+        val todayAndYesterdayRange = RemoveTimeFrame.TodayAndYesterday.toLongRange()
+        val yesterdayStartMillis = Calendar.getInstance().apply {
+            add(Calendar.DAY_OF_YEAR, -1)
+            set(Calendar.HOUR_OF_DAY, 0)
+            set(Calendar.MINUTE, 0)
+            set(Calendar.SECOND, 0)
+            set(Calendar.MILLISECOND, 0)
+        }.timeInMillis
+        Assert.assertEquals(yesterdayStartMillis, todayAndYesterdayRange.first)
+    }
+
+    @Test
+    fun `WHEN TodayAndYesterday is calculated THEN second timeStamp is equal or greater than now`() {
+        val lastHourRange = RemoveTimeFrame.TodayAndYesterday.toLongRange()
+        val nowMillis = Calendar.getInstance().timeInMillis
+        Assert.assertTrue(nowMillis <= lastHourRange.last)
+    }
+}


### PR DESCRIPTION
Closes #25954:

Replaces the old `deleteAll` prompt on History screens with the new one, that provides selection of time frames to delete, like `lastHour`, `yesterday&&today` or `everything`.

Also changed `string` inside `deleteAll` button in `HistoryGroup` screen, it will use the group name in the prompt text.

A part of breaking down [this](https://github.com/mozilla-mobile/fenix/pull/25879) synced history too big of a PR.
Jira ticket: [link](https://mozilla-hub.atlassian.net/browse/FNXV2-19087)
Design: [link](https://www.figma.com/file/SO8Cd5lnmgNqJQY9KpORc9/History%2C-Bookmarks%2C-Downloads?node-id=879%3A41209)

Old|New
---|---
<img width="441" alt="old_no_lb" src="https://user-images.githubusercontent.com/92760693/178067927-3469241b-4021-49fa-bacb-dbfc4f71e626.png">|<img width="441" alt="new_no_lb" src="https://user-images.githubusercontent.com/92760693/178126492-35b6e2a9-8911-48dc-98ea-96f53d89776b.png">
<img width="441" alt="old_lb" src="https://user-images.githubusercontent.com/92760693/178067926-f343a8f8-9c3d-4f5b-a788-60fc8a580185.png">|<img width="441" alt="new_lb" src="https://user-images.githubusercontent.com/92760693/178126491-a38dfca3-080e-4a7f-84df-53fdb661107c.png">
<img width="441" alt="old_lb" src="https://user-images.githubusercontent.com/92760693/178155651-89065933-07c4-420c-b83a-9feccb1b12b9.png">|<img width="441" alt="new_lb" src="https://user-images.githubusercontent.com/92760693/178155652-8842d029-8adc-4702-9508-b74bde1e36e8.png">

Fixes #25954
Fixes #25954
Fixes #25954
Fixes #25954
Fixes #25954
Fixes #25954
Fixes #25954
Fixes #25954
Fixes #25954
Fixes #25954
Fixes #25954