### PR TITLE
For #25994: Make installToHomescreen item a collapsing menu limit.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
@@ -184,6 +184,7 @@ open class DefaultToolbarMenu(
             label = context.getString(R.string.browser_menu_install_on_homescreen),
             notificationTint = getColor(context, R.color.fx_mobile_icon_color_information)
         ),
+        isCollapsingMenuLimit = true,
         isHighlighted = {
             !context.settings().installPwaOpened
         }


### PR DESCRIPTION
The item is visible instead of addToHomeScreenItem when
the current session can be installed as a PWA.

Before and after the fix:

<img src = https://user-images.githubusercontent.com/48995920/178734553-8084a1f2-a51d-4780-a128-35538d1ba02e.png width = 45%> <img src = https://user-images.githubusercontent.com/48995920/178734548-cfa8f661-14ae-41bb-90a3-6ef8ae811558.png width = 45%>

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture
