### PR TITLE
For #26144 new PWA HTML controls UI smoke tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/PwaTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/PwaTest.kt
@@ -13,6 +13,7 @@ import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.TestHelper.assertNativeAppOpens
 import org.mozilla.fenix.ui.robots.customTabScreen
 import org.mozilla.fenix.ui.robots.navigationToolbar
+import org.mozilla.fenix.ui.robots.pwaScreen
 
 class PwaTest {
     private val featureSettingsHelper = FeatureSettingsHelper()
@@ -20,9 +21,16 @@ class PwaTest {
        changed the hypertext reference to mozilla-mobile.github.io/testapp/downloads for "External link"
      */
     private val externalLinksPWAPage = "https://mozilla-mobile.github.io/testapp/v2.0/externalLinks.html"
+
+    // Updated TestApp versioning to v3.0, created a new HTMLforms.html
+    private val htmlControlsPage = "https://andiaj.github.io/testapp/v3.0/HTMLforms.html"
+
     private val emailLink = "mailto://example@example.com"
     private val phoneLink = "tel://1234567890"
     private val shortcutTitle = "TEST_APP"
+    private val hour = 10
+    private val minute = 10
+    private val colorHexValue = "#5b2067"
 
     @get:Rule
     val activityTestRule = HomeActivityIntentTestRule()
@@ -89,6 +97,144 @@ class PwaTest {
         }.openHomeScreenShortcut(shortcutTitle) {
             clickLinkMatchingText("Telephone link")
             assertNativeAppOpens(PHONE_APP, phoneLink)
+        }
+    }
+
+    @SmokeTest
+    @Test
+    fun cancelCalendarFormPWATest() {
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(htmlControlsPage.toUri()) {
+            waitForPageToLoad()
+            verifyNotificationDotOnMainMenu()
+        }.openThreeDotMenu {
+        }.clickInstall {
+            clickAddAutomaticallyButton()
+        }.openHomeScreenShortcut(shortcutTitle) {
+        }
+        pwaScreen {
+            clickForm("Calendar Form", true)
+            clickFormViewButton("CANCEL")
+            clickSubmitDateButton()
+            verifyNoDateIsSelected()
+        }
+    }
+
+    @SmokeTest
+    @Test
+    fun setAndClearCalendarFormPWATest() {
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(htmlControlsPage.toUri()) {
+            waitForPageToLoad()
+            verifyNotificationDotOnMainMenu()
+        }.openThreeDotMenu {
+        }.clickInstall {
+            clickAddAutomaticallyButton()
+        }.openHomeScreenShortcut(shortcutTitle) {
+        }
+        pwaScreen {
+            clickForm("Calendar Form", true)
+            selectDate()
+            clickFormViewButton("OK")
+            clickSubmitDateButton()
+            verifySelectedDate()
+            clickForm("Calendar Form", true)
+            clickFormViewButton("CLEAR")
+            clickSubmitDateButton()
+            verifyNoDateIsSelected()
+        }
+    }
+
+    @SmokeTest
+    @Test
+    fun cancelClockFormPWATest() {
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(htmlControlsPage.toUri()) {
+            waitForPageToLoad()
+            verifyNotificationDotOnMainMenu()
+        }.openThreeDotMenu {
+        }.clickInstall {
+            clickAddAutomaticallyButton()
+        }.openHomeScreenShortcut(shortcutTitle) {
+        }
+        pwaScreen {
+            clickForm("Clock Form", false)
+            clickFormViewButton("CANCEL")
+            clickSubmitTimeButton()
+            verifyNoTimeIsSelected(hour, minute)
+        }
+    }
+
+    @SmokeTest
+    @Test
+    fun setAndClearClockFormPWATest() {
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(htmlControlsPage.toUri()) {
+            waitForPageToLoad()
+            verifyNotificationDotOnMainMenu()
+        }.openThreeDotMenu {
+        }.clickInstall {
+            clickAddAutomaticallyButton()
+        }.openHomeScreenShortcut(shortcutTitle) {
+        }
+        pwaScreen {
+            clickForm("Clock Form", clockForm = true)
+            selectTime(hour, minute)
+            clickFormViewButton("OK")
+            clickSubmitTimeButton()
+            verifySelectedTime(hour, minute)
+            clickForm("Clock Form", clockForm = true)
+            clickFormViewButton("CLEAR")
+            clickSubmitTimeButton()
+            verifyNoTimeIsSelected(hour, minute)
+        }
+    }
+
+    @SmokeTest
+    @Test
+    fun cancelColorFormPWATest() {
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(htmlControlsPage.toUri()) {
+            waitForPageToLoad()
+            verifyNotificationDotOnMainMenu()
+        }.openThreeDotMenu {
+        }.clickInstall {
+            clickAddAutomaticallyButton()
+        }.openHomeScreenShortcut(shortcutTitle) {
+        }
+        pwaScreen {
+            clickForm("Color Form")
+            selectColor(colorHexValue)
+            clickFormViewButton("CANCEL")
+            clickSubmitColorButton()
+            verifyColorIsNotSelected(colorHexValue)
+        }
+    }
+
+    @SmokeTest
+    @Test
+    fun setColorFormPWATest() {
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(htmlControlsPage.toUri()) {
+            waitForPageToLoad()
+            verifyNotificationDotOnMainMenu()
+        }.openThreeDotMenu {
+        }.clickInstall {
+            clickAddAutomaticallyButton()
+        }.openHomeScreenShortcut(shortcutTitle) {
+        }
+        pwaScreen {
+            clickForm("Color Form")
+            selectColor(colorHexValue)
+            clickFormViewButton("SET")
+            clickSubmitColorButton()
+            verifySelectedColor(colorHexValue)
         }
     }
 }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -191,6 +191,24 @@ class BrowserRobot {
     }
 
     fun verifyNotificationDotOnMainMenu() {
+        for (i in 1..RETRY_COUNT) {
+            try {
+                assertTrue(
+                    mDevice.findObject(UiSelector().resourceId("$packageName:id/notification_dot"))
+                        .waitForExists(waitingTime)
+                )
+
+                break
+            } catch (e: AssertionError) {
+                Log.e("TestLog", "Main menu dot isn't displayed ${e.localizedMessage}")
+
+                navigationToolbar {
+                }.openThreeDotMenu {
+                }.refreshPage {
+                }
+            }
+        }
+
         assertTrue(
             mDevice.findObject(UiSelector().resourceId("$packageName:id/notification_dot"))
                 .waitForExists(waitingTime)

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/PwaRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/PwaRobot.kt
@@ -1,0 +1,268 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+@file:Suppress("TooManyFunctions")
+
+package org.mozilla.fenix.ui.robots
+
+import android.util.Log
+import android.widget.TimePicker
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.contrib.PickerActions
+import androidx.test.espresso.matcher.RootMatchers
+import androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom
+import androidx.test.uiautomator.UiSelector
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.mozilla.fenix.helpers.Constants.RETRY_COUNT
+import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
+import org.mozilla.fenix.helpers.TestHelper.mDevice
+import org.mozilla.fenix.helpers.TestHelper.packageName
+import java.time.LocalDate
+
+class PwaRobot {
+
+    fun clickForm(formType: String, calendarForm: Boolean = false, clockForm: Boolean = false) {
+        mDevice.findObject(UiSelector().resourceId("$packageName:id/engineView"))
+            .waitForExists(waitingTime)
+        mDevice.findObject(UiSelector().textContains(formType)).waitForExists(waitingTime)
+
+        if (calendarForm) {
+            calendarBox.click()
+            mDevice.waitForIdle(waitingTime)
+        } else if (clockForm) {
+            clockBox.click()
+            mDevice.waitForIdle(waitingTime)
+        } else {
+            colorBox.click()
+            mDevice.waitForIdle(waitingTime)
+        }
+    }
+
+    fun clickFormViewButton(button: String) {
+        val clockAndCalendarButton = mDevice.findObject(UiSelector().textContains(button))
+        clockAndCalendarButton.click()
+    }
+
+    fun selectDate() {
+        mDevice.findObject(UiSelector().resourceId("android:id/month_view")).waitForExists(waitingTime)
+
+        val monthViewerCurrentDay =
+            mDevice.findObject(
+                UiSelector()
+                    .textContains("$currentDay")
+                    .descriptionContains("$currentDay $currentMonth $currentYear")
+            )
+
+        monthViewerCurrentDay.click()
+    }
+
+    fun selectTime(hour: Int, minute: Int) =
+        onView(isAssignableFrom(TimePicker::class.java)).inRoot(RootMatchers.isDialog()).perform(PickerActions.setTime(hour, minute))
+
+    fun selectColor(hexValue: String) {
+        mDevice.findObject(
+            UiSelector()
+                .textContains("Choose a color")
+                .resourceId("$packageName:id/alertTitle")
+        ).waitForExists(waitingTime)
+
+        val colorSelection =
+            mDevice.findObject(
+                UiSelector()
+                    .resourceId("$packageName:id/color_item")
+                    .descriptionContains(hexValue)
+            )
+        colorSelection.click()
+    }
+
+    fun clickSubmitDateButton() {
+        submitDateButton.waitForExists(waitingTime)
+        submitDateButton.click()
+    }
+
+    fun clickSubmitTimeButton() {
+        submitTimeButton.waitForExists(waitingTime)
+        submitTimeButton.click()
+    }
+
+    fun clickSubmitColorButton() {
+        submitColorButton.waitForExists(waitingTime)
+        submitColorButton.click()
+    }
+
+    fun verifySelectedDate() {
+        for (i in 1..RETRY_COUNT) {
+            try {
+                assertTrue(
+                    mDevice.findObject(
+                        UiSelector()
+                            .text("Selected date is: $currentDate")
+                    ).waitForExists(waitingTime)
+                )
+            } catch (e: AssertionError) {
+                Log.e("TestLog", "Selected time isn't displayed ${e.localizedMessage}")
+
+                clickForm("Calendar Form", true)
+                selectDate()
+                clickFormViewButton("OK")
+                clickSubmitDateButton()
+            }
+        }
+
+        assertTrue(
+            mDevice.findObject(
+                UiSelector()
+                    .text("Selected date is: $currentDate")
+            ).waitForExists(waitingTime)
+        )
+    }
+
+    fun verifyNoDateIsSelected() {
+        assertFalse(
+            mDevice.findObject(
+                UiSelector()
+                    .text("Selected date is: $currentDate")
+            ).waitForExists(waitingTime)
+        )
+    }
+
+    fun verifySelectedTime(hour: Int, minute: Int) {
+        for (i in 1..RETRY_COUNT) {
+            try {
+                assertTrue(
+                    mDevice.findObject(
+                        UiSelector()
+                            .text("Selected time is: $hour:$minute")
+                    ).waitForExists(waitingTime)
+                )
+
+                break
+            } catch (e: AssertionError) {
+                Log.e("TestLog", "Selected time isn't displayed ${e.localizedMessage}")
+
+                clickForm("Clock Form", clockForm = true)
+                clickFormViewButton("CLEAR")
+                clickForm("Clock Form", clockForm = true)
+                selectTime(hour, minute)
+                clickFormViewButton("OK")
+                clickSubmitTimeButton()
+            }
+        }
+
+        assertTrue(
+            mDevice.findObject(
+                UiSelector()
+                    .text("Selected time is: $hour:$minute")
+            ).waitForExists(waitingTime)
+        )
+    }
+
+    fun verifySelectedColor(hexValue: String) {
+        for (i in 1..RETRY_COUNT) {
+            try {
+                assertTrue(
+                    mDevice.findObject(
+                        UiSelector()
+                            .text("Selected color is: $hexValue")
+                    ).waitForExists(waitingTime)
+                )
+
+                break
+            } catch (e: AssertionError) {
+                Log.e("TestLog", "Selected color isn't displayed ${e.localizedMessage}")
+
+                clickForm("Color Form")
+                selectColor(hexValue)
+                clickFormViewButton("SET")
+                clickSubmitColorButton()
+            }
+        }
+
+        assertTrue(
+            mDevice.findObject(
+                UiSelector()
+                    .text("Selected color is: $hexValue")
+            ).waitForExists(waitingTime)
+        )
+    }
+
+    fun verifyNoTimeIsSelected(hour: Int, minute: Int) {
+        assertFalse(
+            mDevice.findObject(
+                UiSelector()
+                    .text("Selected date is: $hour:$minute")
+            ).waitForExists(waitingTime)
+        )
+    }
+
+    fun verifyColorIsNotSelected(hexValue: String) {
+        assertFalse(
+            mDevice.findObject(
+                UiSelector()
+                    .text("Selected date is: $hexValue")
+            ).waitForExists(waitingTime)
+        )
+    }
+
+    class Transition
+}
+
+fun pwaScreen(interact: PwaRobot.() -> Unit): PwaRobot.Transition {
+    PwaRobot().interact()
+    return PwaRobot.Transition()
+}
+
+val calendarBox =
+    mDevice.findObject(
+        UiSelector()
+            .index(0)
+            .resourceId("calendar")
+            .className("android.widget.Spinner")
+            .packageName("$packageName")
+    )
+
+val clockBox =
+    mDevice.findObject(
+        UiSelector()
+            .index(0)
+            .resourceId("clock")
+            .className("android.view.View")
+            .packageName("$packageName")
+    )
+
+val colorBox =
+    mDevice.findObject(
+        UiSelector()
+            .index(0)
+            .resourceId("colorPicker")
+            .className("android.widget.Button")
+            .packageName("$packageName")
+    )
+
+val currentDate = LocalDate.now()
+val currentDay = currentDate.dayOfMonth
+val currentMonth = currentDate.month
+val currentYear = currentDate.year
+
+val submitDateButton =
+    mDevice.findObject(
+        UiSelector()
+            .textContains("Submit date")
+            .resourceId("submitDate")
+    )
+
+val submitTimeButton =
+    mDevice.findObject(
+        UiSelector()
+            .textContains("Submit time")
+            .resourceId("submitTime")
+    )
+
+val submitColorButton =
+    mDevice.findObject(
+        UiSelector()
+            .textContains("Submit color")
+            .resourceId("submitColor")
+    )


### PR DESCRIPTION
New PWA HTML controls UI smoke tests.
`cancelCalendarFormPWATest` ✅ successfully passed 100x on Firebase
`setAndClearCalendarFormPWATest` ✅ successfully passed 100x on Firebase
`cancelClockFormPWATest` ✅ successfully passed 100x on Firebase
`setAndClearClockFormPWATest` ✅ successfully passed 100x on Firebase
`cancelColorFormPWATest` ✅ successfully passed 100x on Firebase
`setColorFormPWATest` ✅ successfully passed 100x on Firebase

❗ Will need to update the page links before landing (currently using the link from my repo)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

Fixes #26144