### PR TITLE
Bug 1779797 - part 2-6: Let mergify automatically merge l10n bumps to main

### DIFF
--- a/.github/workflows/sync-strings.yml
+++ b/.github/workflows/sync-strings.yml
@@ -39,6 +39,6 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           path: beta
-          branch: automation/sync-strings-${{ steps.fenix-beta-version.outputs.major-beta-version }}
+          branch: automation/sync-strings-${{ steps.fenix-beta-version.outputs.fenix-beta-version }}
           title: "Sync Strings from main to releases_${{steps.fenix-beta-version.outputs.fenix-beta-version}}.0"
           body: "This (automated) PR syncs strings from `main` to `releases_${{steps.fenix-beta-version.outputs.fenix-beta-version}}.0.0`"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,7 @@
 queue_rules:
   - name: default
     conditions:
-      - status-success=pr-complete
+      - status-success=complete-pr
 pull_request_rules:
   - name: Resolve conflict
     conditions:
@@ -12,7 +12,7 @@ pull_request_rules:
   - name: MickeyMoz - Auto Merge
     conditions:
       - author=MickeyMoz
-      - status-success=pr-complete
+      - status-success=complete-pr
       - files~=(Gecko.kt|AndroidComponents.kt)
     actions:
       review:
@@ -30,7 +30,7 @@ pull_request_rules:
           - and:
             - author=mozilla-l10n-automation-bot
             - base=main
-            - status-success=pr-complete
+            - status-success=complete-pr
           - and:
             - author=github-actions[bot]
             - base~=releases[_/].*
@@ -104,7 +104,7 @@ pull_request_rules:
         force: false
   - name: Needs landing - Rebase
     conditions:
-      - check-success=pr-complete
+      - check-success=complete-pr
       - label=pr:needs-landing
       - "#approved-reviews-by>=1"
       - -draft
@@ -117,8 +117,8 @@ pull_request_rules:
         rebase_fallback: none
   - name: Needs landing - Squash
     conditions:
-      - check-success=pr-complete
-      - label=pr:needs-landing-squashed 
+      - check-success=complete-pr
+      - label=pr:needs-landing-squashed
       - "#approved-reviews-by>=1"
       - -draft
       - label!=pr:work-in-progress

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -31,7 +31,11 @@ pull_request_rules:
   - name: L10N - Auto Merge
     conditions:
       - and:
-        - files~=(strings.xml|l10n.toml)
+        - files~=^(l10n.toml|app/src/main/res/values[A-Za-z-]*/strings\.xml)$
+        # /!\ The line above doesn't prevent random files to be changed alongside
+        # l10n ones. That's why the additional condition exists below. For more
+        # information: https://docs.mergify.com/conditions/#how-to-match-lists
+        - -files~=^(?!(l10n.toml|app/src/main/res/values[A-Za-z-]*/strings\.xml)).+$
         - or:
           - and:
             - author=mozilla-l10n-automation-bot

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,13 @@
 queue_rules:
   - name: default
     conditions:
-      - status-success=complete-pr
+      - or:
+        - status-success=complete-pr
+        - and:
+          # For more context, see "L10N - Auto Merge" rule down below
+          - base~=^releases[_/].*
+          - head~=^automation/sync-strings-\d+
+          - status-success=complete-push
 pull_request_rules:
   - name: Resolve conflict
     conditions:
@@ -30,12 +36,17 @@ pull_request_rules:
           - and:
             - author=mozilla-l10n-automation-bot
             - base=main
+            - head=import-l10n
             - status-success=complete-pr
           - and:
             - author=github-actions[bot]
-            - base~=releases[_/].*
-            # Taskcluster doesn't run when PRs are created by github-actions[bot]
-            # because it's not considered a collaborator.
+            - base~=^releases[_/].*
+            - head~=^automation/sync-strings-\d+
+            - status-success=complete-push
+            # Taskcluster only runs on git-push events because github-actions[bot] is not considered
+            # a collaborator, so pull request events are triggered. That said, github-actions[bot]
+            # doesn't create the PR on a separate fork (unlike mozilla-l10n-automation-bot). That's
+            # why git-push events are taken into account
     actions:
       review:
         type: APPROVE

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -16,11 +16,14 @@ tasks:
                 $if: 'event.sender.login == "bors[bot]"'
                 then: 'skaspari+mozlando@mozilla.com'   # It must match what's in bors.toml
                 else:
-                    $if: 'tasks_for == "github-push"'
-                    then: '${event.pusher.email}'
+                    $if: 'event.sender.login == "github-actions[bot]"'
+                    then: 'github-actions[bot]@users.noreply.github.com'
                     else:
-                        $if: 'tasks_for == "github-pull-request"'
-                        then: '${event.pull_request.user.login}@users.noreply.github.com'
+                        $if: 'tasks_for == "github-push"'
+                        then: '${event.pusher.email}'
+                        else:
+                            $if: 'tasks_for == "github-pull-request"'
+                            then: '${event.pull_request.user.login}@users.noreply.github.com'
         baseRepoUrl:
             $if: 'tasks_for == "github-push"'
             then: '${event.repository.html_url}'

--- a/taskcluster/ci/complete/kind.yml
+++ b/taskcluster/ci/complete/kind.yml
@@ -14,8 +14,15 @@ transforms:
     - taskgraph.transforms.code_review:transforms
     - taskgraph.transforms.task:transforms
 
+job-defaults:
+    worker-type: succeed
+
+
 jobs:
-    complete:
+    pr:
         description: PR Summary Task
         run-on-tasks-for: [github-pull-request]
-        worker-type: succeed
+
+    push:
+        description: Push Summary Task
+        run-on-tasks-for: [github-push]


### PR DESCRIPTION
Follows https://github.com/mozilla-mobile/fenix/pull/26046 up. More context in https://github.com/mozilla-mobile/fenix/pull/26046#issuecomment-1186888559. Tested in https://github.com/JohanLorenzo/fenix/pull/3 - CI is red there because I took a shortcut by making the new `complete-push` task green without the rest of the graph being done. That said, the dependencies look correct there so I'm not concerned about this part. 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
