### PR TITLE
For #26089 - Record metrics for save credit card prompt shown

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -7484,6 +7484,22 @@ credit_cards:
     metadata:
       tags:
         - Autofill
+  save_prompt_shown:
+    type: event
+    description: |
+      The autofill save prompt is shown.
+    bugs:
+      - https://github.com/mozilla-mobile/fenix/issues/26089
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/26095
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: 118
+    metadata:
+      tags:
+        - Autofill
 
 addresses:
   saved:

--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -7487,7 +7487,7 @@ credit_cards:
   save_prompt_shown:
     type: event
     description: |
-      The autofill save prompt is shown.
+      The credit card autofill save prompt is shown.
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/26089
     data_reviews:

--- a/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/metrics/MetricController.kt
@@ -172,6 +172,8 @@ internal class ReleaseMetricController(
             CreditCards.savePromptCreate.record(NoExtras())
         Component.FEATURE_PROMPTS to CreditCardAutofillDialogFacts.Items.AUTOFILL_CREDIT_CARD_UPDATED ->
             CreditCards.savePromptUpdate.record(NoExtras())
+        Component.FEATURE_PROMPTS to CreditCardAutofillDialogFacts.Items.AUTOFILL_CREDIT_CARD_SAVE_PROMPT_SHOWN ->
+            CreditCards.savePromptShown.record(NoExtras())
 
         Component.FEATURE_PROMPTS to AddressAutofillDialogFacts.Items.AUTOFILL_ADDRESS_FORM_DETECTED ->
             Addresses.formDetected.record(NoExtras())

--- a/app/src/test/java/org/mozilla/fenix/components/metrics/MetricControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/metrics/MetricControllerTest.kt
@@ -584,6 +584,7 @@ class MetricControllerTest {
             CreditCardAutofillDialogFacts.Items.AUTOFILL_CREDIT_CARD_PROMPT_DISMISSED to CreditCards.autofillPromptDismissed,
             CreditCardAutofillDialogFacts.Items.AUTOFILL_CREDIT_CARD_CREATED to CreditCards.savePromptCreate,
             CreditCardAutofillDialogFacts.Items.AUTOFILL_CREDIT_CARD_UPDATED to CreditCards.savePromptUpdate,
+            CreditCardAutofillDialogFacts.Items.AUTOFILL_CREDIT_CARD_SAVE_PROMPT_SHOWN to CreditCards.savePromptShown,
         )
 
         itemsToEvents.forEach { (item, event) ->


### PR DESCRIPTION
Record metrics for the facts emmited when the save credit card prompt is shown.

Waiting for [12524](https://github.com/mozilla-mobile/android-components/pull/12524) to be merged.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR:
1. click on Show All Checks,
2. click Details next to "Taskcluster (pull_request)" after it appears and then finishes with a green checkmark,
3. click on the "Fenix - assemble" task, then click "Run Artifacts".
4. the APK links should be on the left side of the screen, named for each CPU architecture









### GitHub Automation
Fixes #26089