### PR TITLE
For #26144 new PWA permissions UI tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/PwaTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/PwaTest.kt
@@ -1,7 +1,9 @@
 package org.mozilla.fenix.ui
 
 import android.Manifest
+import android.os.Build
 import androidx.core.net.toUri
+import androidx.test.filters.SdkSuppress
 import androidx.test.rule.GrantPermissionRule
 import org.junit.After
 import org.junit.Before
@@ -34,6 +36,7 @@ class PwaTest {
 
     @get:Rule
     val grantPermissionRule: GrantPermissionRule = GrantPermissionRule.grant(
+        Manifest.permission.CAMERA,
         Manifest.permission.ACCESS_COARSE_LOCATION
     )
 
@@ -139,6 +142,27 @@ class PwaTest {
         browserScreen {
         }.clickOpenNotificationButton {
             verifyNotificationsPermissionPrompt(testPageSubstring)
+        }
+    }
+
+    @SdkSuppress(maxSdkVersion = Build.VERSION_CODES.P, codeName = "P")
+    @SmokeTest
+    @Test
+    fun cameraPermissionsPWATest() {
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(testPage.toUri()) {
+            waitForPageToLoad()
+            verifyNotificationDotOnMainMenu()
+        }.openThreeDotMenu {
+        }.clickInstall {
+            clickAddAutomaticallyButton()
+        }.openHomeScreenShortcut(shortcutTitle) {
+        }
+
+        browserScreen {
+        }.clickStartCameraButton {
+            verifyCameraPermissionPrompt(testPageSubstring)
         }
     }
 }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/PwaTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/PwaTest.kt
@@ -1,6 +1,8 @@
 package org.mozilla.fenix.ui
 
+import android.Manifest
 import androidx.core.net.toUri
+import androidx.test.rule.GrantPermissionRule
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -11,6 +13,7 @@ import org.mozilla.fenix.helpers.Constants.PackageName.PHONE_APP
 import org.mozilla.fenix.helpers.FeatureSettingsHelper
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.TestHelper.assertNativeAppOpens
+import org.mozilla.fenix.ui.robots.browserScreen
 import org.mozilla.fenix.ui.robots.customTabScreen
 import org.mozilla.fenix.ui.robots.navigationToolbar
 
@@ -20,12 +23,19 @@ class PwaTest {
        changed the hypertext reference to mozilla-mobile.github.io/testapp/downloads for "External link"
      */
     private val externalLinksPWAPage = "https://mozilla-mobile.github.io/testapp/v2.0/externalLinks.html"
+    private val testPage = "https://mozilla-mobile.github.io/testapp/permissions"
+    private val testPageSubstring = "https://mozilla-mobile.github.io:443"
     private val emailLink = "mailto://example@example.com"
     private val phoneLink = "tel://1234567890"
     private val shortcutTitle = "TEST_APP"
 
     @get:Rule
     val activityTestRule = HomeActivityIntentTestRule()
+
+    @get:Rule
+    val grantPermissionRule: GrantPermissionRule = GrantPermissionRule.grant(
+        Manifest.permission.ACCESS_COARSE_LOCATION
+    )
 
     @Before
     fun setUp() {
@@ -89,6 +99,46 @@ class PwaTest {
         }.openHomeScreenShortcut(shortcutTitle) {
             clickLinkMatchingText("Telephone link")
             assertNativeAppOpens(PHONE_APP, phoneLink)
+        }
+    }
+
+    @SmokeTest
+    @Test
+    fun locationPermissionsPWATest() {
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(testPage.toUri()) {
+            waitForPageToLoad()
+            verifyNotificationDotOnMainMenu()
+        }.openThreeDotMenu {
+        }.clickInstall {
+            clickAddAutomaticallyButton()
+        }.openHomeScreenShortcut(shortcutTitle) {
+        }
+
+        browserScreen {
+        }.clickGetLocationButton {
+            verifyLocationPermissionPrompt(testPageSubstring)
+        }
+    }
+
+    @SmokeTest
+    @Test
+    fun notificationsPermissionsPWATest() {
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(testPage.toUri()) {
+            waitForPageToLoad()
+            verifyNotificationDotOnMainMenu()
+        }.openThreeDotMenu {
+        }.clickInstall {
+            clickAddAutomaticallyButton()
+        }.openHomeScreenShortcut(shortcutTitle) {
+        }
+
+        browserScreen {
+        }.clickOpenNotificationButton {
+            verifyNotificationsPermissionPrompt(testPageSubstring)
         }
     }
 }

--- a/automation/taskcluster/androidTest/flank-x86-legacy-api-tests.yml
+++ b/automation/taskcluster/androidTest/flank-x86-legacy-api-tests.yml
@@ -51,6 +51,7 @@ gcloud:
     - class org.mozilla.fenix.ui.SitePermissionsTest#rememberBlockCameraPermissionChoiceTest
     - class org.mozilla.fenix.ui.SitePermissionsTest#rememberBlockMicrophonePermissionChoiceTest
     - class org.mozilla.fenix.ui.SmokeTest#redirectToAppPermissionsSystemSettingsTest
+    - class org.mozilla.fenix.ui.PwaTest#cameraPermissionsPWATest
 
   device:
     - model: Pixel2


### PR DESCRIPTION
• New PWA location and notifications permissions UI tests
`locationPermissionsPWATest` ✅  successfully passed 100x on Firebase 
`notificationsPermissionsPWATest` ✅  successfully passed 100x on Firebase 

• New PWA camera permission UI test (will run on on legacy x86 due to the known issues)
`cameraPermissionsPWATest` ✅  successfully passed 100x on Firebase 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
Fixes #26144