### PR TITLE
Closes #26116: use new viewholders on history screen

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HistoryRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HistoryRobot.kt
@@ -118,7 +118,7 @@ private fun assertHistoryMenuView() {
 private fun assertEmptyHistoryView() =
     onView(
         allOf(
-            withId(R.id.history_empty_view),
+            withId(R.id.empty_message),
             withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)
         )
     )

--- a/app/src/main/java/org/mozilla/fenix/components/history/PagedHistoryProvider.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/history/PagedHistoryProvider.kt
@@ -35,7 +35,8 @@ sealed class HistoryDB {
         override val title: String,
         val url: String,
         override val visitedAt: Long,
-        override val selected: Boolean = false
+        override val selected: Boolean = false,
+        val isRemote: Boolean = false,
     ) : HistoryDB()
 
     data class Metadata(
@@ -250,7 +251,8 @@ class DefaultPagedHistoryProvider(
         return HistoryDB.Regular(
             title = title,
             url = visit.url,
-            visitedAt = visit.visitTime
+            visitedAt = visit.visitTime,
+            isRemote = visit.isRemote,
         )
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryAdapter.kt
@@ -170,7 +170,7 @@ class HistoryAdapter(
         removedItems: Set<History>,
         snapshot: List<HistoryViewItem> = snapshot().items
     ): Set<HistoryItemTimeGroup> {
-        val result: MutableSet<HistoryItemTimeGroup> = mutableSetOf()
+        val headersToRemove: MutableSet<HistoryItemTimeGroup> = mutableSetOf()
 
         // Group selected for removal items into timeGroup buckets, and rely on a bucket size to
         // determine if all items under a header have been removed.
@@ -195,7 +195,7 @@ class HistoryAdapter(
                     // Except the very first item, which is irrelevant in this case.
                     val timeGroupSize = (index - previousTimeGroupPosition) - 2
                     if (timeGroupMap[previousTimeGroup]!!.size == timeGroupSize) {
-                        result.add(previousTimeGroup)
+                        headersToRemove.add(previousTimeGroup)
                     }
                     previousTimeGroup = null
                 }
@@ -211,10 +211,10 @@ class HistoryAdapter(
         if (previousTimeGroup != null) {
             val timeGroupSize = (snapshot.size - previousTimeGroupPosition) - 1
             if (timeGroupMap[previousTimeGroup]!!.size == timeGroupSize) {
-                result.add(previousTimeGroup)
+                headersToRemove.add(previousTimeGroup)
             }
         }
-        return result
+        return headersToRemove
     }
 
     override fun onAttachedToRecyclerView(recyclerView: RecyclerView) {

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryAdapter.kt
@@ -156,7 +156,7 @@ class HistoryAdapter(
                 else -> null
             }?.let { historyItem ->
                 val headerToRemove = calculateTimeGroupsToRemove(setOf(historyItem))
-                historyInteractor.onDeleteSome(setOf(historyItem), headerToRemove)
+                historyInteractor.onDeleteHistoryItems(setOf(historyItem), headerToRemove)
             }
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryController.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryController.kt
@@ -42,14 +42,13 @@ interface HistoryController {
     fun handleDeleteTimeRange()
 
     /**
-     * Hides the deleted items from the UI and triggers the UNDO snackbar, that gives the user a
-     * chance to cancel the removal. After the snackbar is gone, [DefaultHistoryController.delete]
-     * would remove the items from the data layer.
+     * Hides the deleted items from the UI and triggers the UNDO snackbar.
+     * After the snackbar is gone, the items are removed from the data layer.
      *
      * @param items History and History group items to be deleted.
      * @param groups Header to be hidden from the UI.
      */
-    fun handleDeleteSome(items: Set<History>, groups: Set<HistoryItemTimeGroup> = setOf())
+    fun handleDeleteHistoryItems(items: Set<History>, groups: Set<HistoryItemTimeGroup> = setOf())
 
     /**
      * Deletes history items inside the time frame.
@@ -71,7 +70,7 @@ interface HistoryController {
     fun handleSignIn()
 
     /**
-     * Invokes [DefaultHistoryController.createAccount] that starts the authentication process.
+     * Handles a user's request to create an account.
      */
     fun handleCreateAccount()
 }
@@ -155,7 +154,7 @@ class DefaultHistoryController(
         displayDeleteTimeRange.invoke()
     }
 
-    override fun handleDeleteSome(items: Set<History>, groups: Set<HistoryItemTimeGroup>) {
+    override fun handleDeleteHistoryItems(items: Set<History>, groups: Set<HistoryItemTimeGroup>) {
         val pendingDeletionItems = items.map { it.toPendingDeletionHistory() }.toSet()
         appStore.dispatch(AppAction.AddPendingDeletionSet(pendingDeletionItems))
         store.dispatch(HistoryFragmentAction.AddPendingDeletionSet(pendingDeletionItems, groups))
@@ -250,6 +249,6 @@ class DefaultHistoryController(
     }
 
     override fun handleCreateAccount() {
-        createAccount.invoke()
+        createAccount()
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryDataSource.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryDataSource.kt
@@ -5,7 +5,6 @@
 package org.mozilla.fenix.library.history
 
 import android.content.res.Resources
-import androidx.annotation.VisibleForTesting
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import mozilla.components.browser.state.store.BrowserStore
@@ -37,7 +36,7 @@ class HistoryDataSource(
     private val accountManager: FxaAccountManager,
 ) : PagingSource<Int, HistoryViewItem>() {
 
-    // A map that helps to insure that headers don't get duplicated. It is cleared open pull to
+    // A map that helps to insure that headers don't get duplicated. It is cleared upon pull to
     // refresh.
     private lateinit var headerPositions: SortedMap<HistoryItemTimeGroup, Int>
 
@@ -96,7 +95,7 @@ class HistoryDataSource(
         }.mapIndexed { position, history ->
             // Calculating header positions.
             previousItem?.let {
-                // Adding headers between items.
+                // Calculating header positions between items.
                 val isHeaderRequired = it.historyTimeGroup != history.historyTimeGroup &&
                     !this.headerPositions.contains(history.historyTimeGroup)
                 if (isHeaderRequired) {
@@ -108,7 +107,7 @@ class HistoryDataSource(
                     headerPositions.add(Pair(header, position))
                 }
             } ?: run {
-                // Adding a header before the first item.
+                // Checking if a header before the first item is needed.
                 if (!this.headerPositions.contains(history.historyTimeGroup)) {
                     val header = HistoryViewItem.TimeGroupHeader(
                         title = history.historyTimeGroup.humanReadable(resources),
@@ -132,7 +131,6 @@ class HistoryDataSource(
             for (header in headerPositions.reversed()) {
                 mutableList.add(header.second, header.first)
             }
-
             // Adding synced and recently closed buttons.
             val isFirstLoad = params.key == null
             if (isFirstLoad) {
@@ -144,7 +142,6 @@ class HistoryDataSource(
                         )
                     )
                 }
-
                 // For local or mixed history show RecentlyClosed button.
                 if (isRemote == false || isRemote == null) {
                     val numRecentTabs = browserStore.state.closedTabs.size
@@ -185,8 +182,7 @@ class HistoryDataSource(
     }
 }
 
-@VisibleForTesting
-internal fun List<HistoryDB>.positionWithOffset(offset: Int): List<History> {
+private fun List<HistoryDB>.positionWithOffset(offset: Int): List<History> {
     return this.foldIndexed(listOf()) { index, prev, item ->
         // Only offset once while folding, so that we don't accumulate the offset for each element.
         val itemOffset = if (index == 0) {

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryDataSource.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryDataSource.kt
@@ -36,8 +36,7 @@ class HistoryDataSource(
     private val accountManager: FxaAccountManager,
 ) : PagingSource<Int, HistoryViewItem>() {
 
-    // A map that helps to insure that headers don't get duplicated. It is cleared upon pull to
-    // refresh.
+    // A map that helps to insure that headers don't get duplicated. It is cleared when refreshed.
     private lateinit var headerPositions: SortedMap<HistoryItemTimeGroup, Int>
 
     // The refresh key is set to null so that it will always reload the entire list for any data

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryDataSource.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryDataSource.kt
@@ -4,37 +4,179 @@
 
 package org.mozilla.fenix.library.history
 
+import android.content.res.Resources
 import androidx.annotation.VisibleForTesting
 import androidx.paging.PagingSource
 import androidx.paging.PagingState
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.service.fxa.manager.FxaAccountManager
+import org.mozilla.fenix.R
 import org.mozilla.fenix.components.history.HistoryDB
 import org.mozilla.fenix.components.history.PagedHistoryProvider
+import java.util.SortedMap
+import java.util.TreeMap
+import java.util.LinkedList
 
 /**
- * PagingSource of History items, used in History Screen. It is the data source for the
- * Flow<PagingData>, that provides HistoryAdapter with items to display.
+ * PagingSource of [HistoryViewItem], used in [HistoryFragment] to display history.
+ * It is the backbone of [HistoryViewItemFlow] data stream, that provides [HistoryAdapter] with
+ * items to display.
+ *
+ * @param historyProvider Data source of history and history group items.
+ * @param browserStore Provides information about numbers of recently closed tabs.
+ * @param isRemote The dataSource can provide local, remote and mixed history.
+ * @param resources A class that provides access to String resources for building ViewItems' text
+ * fields.
+ * @param accountManager Is used to get information if the user is authenticated or not.
  */
 class HistoryDataSource(
     private val historyProvider: PagedHistoryProvider,
+    private val browserStore: BrowserStore,
     private val isRemote: Boolean? = null,
-) : PagingSource<Int, History>() {
+    private val resources: Resources,
+    private val accountManager: FxaAccountManager,
+) : PagingSource<Int, HistoryViewItem>() {
+
+    // A map that helps to insure that headers don't get duplicated. It is cleared open pull to
+    // refresh.
+    private lateinit var headerPositions: SortedMap<HistoryItemTimeGroup, Int>
 
     // The refresh key is set to null so that it will always reload the entire list for any data
     // updates such as pull to refresh, and return the user to the start of the list.
-    override fun getRefreshKey(state: PagingState<Int, History>): Int? = null
+    override fun getRefreshKey(state: PagingState<Int, HistoryViewItem>): Int? = null
 
-    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, History> {
+    @Suppress("LongMethod", "ComplexMethod")
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, HistoryViewItem> {
         // Get the offset of the last loaded page or default to 0 when it is null on the initial
         // load or a refresh.
         val offset = params.key ?: 0
-        val historyItems = historyProvider.getHistory(offset, params.loadSize, isRemote).run {
-            positionWithOffset(offset)
+        if (offset == 0) {
+            headerPositions = TreeMap()
         }
-        val nextOffset = if (historyItems.isEmpty()) {
+
+        // If the user isn't authenticated, we display the SignIn view and stop loading.
+        if (isRemote == true && accountManager.authenticatedAccount() == null) {
+            return LoadResult.Page(
+                data = listOf(HistoryViewItem.SignInHistoryItem),
+                prevKey = null,
+                nextKey = null
+            )
+        }
+
+        var finishedLoading = false
+        var previousItem: History? = null
+        val headerPositions: MutableList<Pair<HistoryViewItem.TimeGroupHeader, Int>> = LinkedList()
+
+        val historyItems = historyProvider.getHistory(offset, params.loadSize, null).run {
+            if (size == 0) {
+                finishedLoading = true
+            }
+            // We want to get all of the items of local/remote type. A single payload might contain
+            // items only of the wrong type, which stops the pagination. Hence, filtering is done here.
+            filter {
+                if (isRemote == true) {
+                    // Filtering only remote history items.
+                    when (it) {
+                        is HistoryDB.Regular -> it.isRemote
+                        is HistoryDB.Group -> false // Groups are always local.
+                        else -> true
+                    }
+                } else if (isRemote == false) {
+                    // Filtering local history items and history groups.
+                    if (it is HistoryDB.Regular) {
+                        !it.isRemote
+                    } else {
+                        true
+                    }
+                } else {
+                    // Otherwise, passing down both.
+                    true
+                }
+            }.positionWithOffset(offset)
+        }.mapIndexed { position, history ->
+            // Calculating header positions.
+            previousItem?.let {
+                // Adding headers between items.
+                val isHeaderRequired = it.historyTimeGroup != history.historyTimeGroup &&
+                    !this.headerPositions.contains(history.historyTimeGroup)
+                if (isHeaderRequired) {
+                    val header = HistoryViewItem.TimeGroupHeader(
+                        title = history.historyTimeGroup.humanReadable(resources),
+                        timeGroup = history.historyTimeGroup,
+                    )
+                    this.headerPositions[history.historyTimeGroup] = position
+                    headerPositions.add(Pair(header, position))
+                }
+            } ?: run {
+                // Adding a header before the first item.
+                if (!this.headerPositions.contains(history.historyTimeGroup)) {
+                    val header = HistoryViewItem.TimeGroupHeader(
+                        title = history.historyTimeGroup.humanReadable(resources),
+                        timeGroup = history.historyTimeGroup,
+                    )
+                    this.headerPositions[history.historyTimeGroup] = position
+                    headerPositions.add(Pair(header, position))
+                }
+            }
+
+            when (history) {
+                is History.Regular -> HistoryViewItem.HistoryItem(history)
+                is History.Group -> HistoryViewItem.HistoryGroupItem(history)
+                is History.Metadata -> throw IllegalStateException("Unexpected dataType.")
+            }.apply {
+                previousItem = history
+            }
+        }.let {
+            // Adding headers.
+            val mutableList = it.toMutableList()
+            for (header in headerPositions.reversed()) {
+                mutableList.add(header.second, header.first)
+            }
+
+            // Adding synced and recently closed buttons.
+            val isFirstLoad = params.key == null
+            if (isFirstLoad) {
+                if (isRemote == false) {
+                    mutableList.add(
+                        0,
+                        HistoryViewItem.SyncedHistoryItem(
+                            resources.getString(R.string.history_synced_from_other_devices)
+                        )
+                    )
+                }
+
+                // For local or mixed history show RecentlyClosed button.
+                if (isRemote == false || isRemote == null) {
+                    val numRecentTabs = browserStore.state.closedTabs.size
+                    mutableList.add(
+                        0,
+                        HistoryViewItem.RecentlyClosedItem(
+                            resources.getString(R.string.library_recently_closed_tabs),
+                            String.format(
+                                resources.getString(
+                                    if (numRecentTabs == 1) {
+                                        R.string.recently_closed_tab
+                                    } else {
+                                        R.string.recently_closed_tabs
+                                    }
+                                ),
+                                numRecentTabs
+                            )
+                        )
+                    )
+                }
+                // Adding a top spacing.
+                mutableList.add(0, HistoryViewItem.TopSeparatorHistoryItem)
+            }
+            mutableList
+        }
+
+        val nextOffset = if (finishedLoading) {
             null
         } else {
             offset + params.loadSize
         }
+
         return LoadResult.Page(
             data = historyItems,
             prevKey = null, // Only paging forward.
@@ -98,7 +240,7 @@ private fun HistoryDB.Metadata.positioned(position: Int): History.Metadata {
     )
 }
 
-private fun HistoryDB.Regular.positioned(position: Int): History.Regular {
+internal fun HistoryDB.Regular.positioned(position: Int): History.Regular {
     return History.Regular(
         position = position,
         title = this.title,

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragment.kt
@@ -260,7 +260,7 @@ class HistoryFragment : LibraryPageFragment<History>(), UserInteractionHandler {
         }
         R.id.delete_history_multi_select -> {
             val headers = historyView.historyAdapter.calculateTimeGroupsToRemove(historyStore.state.mode.selectedItems)
-            historyInteractor.onDeleteSome(historyStore.state.mode.selectedItems, headers)
+            historyInteractor.onDeleteHistoryItems(historyStore.state.mode.selectedItems, headers)
             historyStore.dispatch(HistoryFragmentAction.ExitEditMode)
             true
         }

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragmentStore.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragmentStore.kt
@@ -150,6 +150,7 @@ sealed class HistoryFragmentAction : Action {
  * The state for the History Screen
  * @property items List of History to display
  * @property mode Current Mode of History
+ * @property isEmpty An indication of whether the user has history.
  */
 data class HistoryFragmentState(
     val items: List<History>,

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragmentStore.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragmentStore.kt
@@ -150,7 +150,10 @@ sealed class HistoryFragmentAction : Action {
  * The state for the History Screen
  * @property items List of History to display
  * @property mode Current Mode of History
+ * @property pendingDeletionItems Set of history items that have been hidden from the UI and were marked for removal.
  * @property isEmpty An indication of whether the user has history.
+ * @property isDeletingItems Whether or not history items are being removed from the storage.
+ * @property hiddenHeaders Set of headers in history list that have been hidden from the UI.
  */
 data class HistoryFragmentState(
     val items: List<History>,

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryInteractor.kt
@@ -38,7 +38,7 @@ interface HistoryInteractor : SelectionInteractor<History> {
      * @param items The history items to delete.
      * @param headers The time group headers to hide.
      */
-    fun onDeleteSome(items: Set<History>, headers: Set<HistoryItemTimeGroup> = setOf())
+    fun onDeleteHistoryItems(items: Set<History>, headers: Set<HistoryItemTimeGroup> = setOf())
 
     /**
      * Called when the user has confirmed deletion of a time range.
@@ -110,8 +110,8 @@ class DefaultHistoryInteractor(
         historyController.handleDeleteTimeRange()
     }
 
-    override fun onDeleteSome(items: Set<History>, headers: Set<HistoryItemTimeGroup>) {
-        historyController.handleDeleteSome(items, headers)
+    override fun onDeleteHistoryItems(items: Set<History>, headers: Set<HistoryItemTimeGroup>) {
+        historyController.handleDeleteHistoryItems(items, headers)
     }
 
     override fun onDeleteTimeRangeConfirmed(timeFrame: RemoveTimeFrame?) {

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryInteractor.kt
@@ -34,9 +34,11 @@ interface HistoryInteractor : SelectionInteractor<History> {
 
     /**
      * Called when multiple history items are deleted
-     * @param items the history items to delete
+     *
+     * @param items The history items to delete.
+     * @param headers The time group headers to hide.
      */
-    fun onDeleteSome(items: Set<History>)
+    fun onDeleteSome(items: Set<History>, headers: Set<HistoryItemTimeGroup> = setOf())
 
     /**
      * Called when the user has confirmed deletion of a time range.
@@ -60,6 +62,16 @@ interface HistoryInteractor : SelectionInteractor<History> {
      * Called when the user clicks on synced history button.
      */
     fun onSyncedHistoryClicked()
+
+    /**
+     * Called when the user clicks on the sign in button.
+     */
+    fun onSignInClicked()
+
+    /**
+     * Called when the user clicks on the create account button.
+     */
+    fun onCreateAccountClicked()
 }
 
 /**
@@ -98,8 +110,8 @@ class DefaultHistoryInteractor(
         historyController.handleDeleteTimeRange()
     }
 
-    override fun onDeleteSome(items: Set<History>) {
-        historyController.handleDeleteSome(items)
+    override fun onDeleteSome(items: Set<History>, headers: Set<HistoryItemTimeGroup>) {
+        historyController.handleDeleteSome(items, headers)
     }
 
     override fun onDeleteTimeRangeConfirmed(timeFrame: RemoveTimeFrame?) {
@@ -116,5 +128,13 @@ class DefaultHistoryInteractor(
 
     override fun onSyncedHistoryClicked() {
         historyController.handleEnterSyncedHistory()
+    }
+
+    override fun onSignInClicked() {
+        historyController.handleSignIn()
+    }
+
+    override fun onCreateAccountClicked() {
+        historyController.handleCreateAccount()
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryItemTimeGroup.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryItemTimeGroup.kt
@@ -4,7 +4,7 @@
 
 package org.mozilla.fenix.library.history
 
-import android.content.Context
+import android.content.res.Resources
 import org.mozilla.fenix.R
 import java.util.Calendar
 import java.util.Date
@@ -12,12 +12,15 @@ import java.util.Date
 enum class HistoryItemTimeGroup {
     Today, Yesterday, ThisWeek, ThisMonth, Older;
 
-    fun humanReadable(context: Context): String = when (this) {
-        Today -> context.getString(R.string.history_today)
-        Yesterday -> context.getString(R.string.history_yesterday)
-        ThisWeek -> context.getString(R.string.history_7_days)
-        ThisMonth -> context.getString(R.string.history_30_days)
-        Older -> context.getString(R.string.history_older)
+    /**
+     * Converts a [HistoryItemTimeGroup] enum to a matching string resource.
+     */
+    fun humanReadable(resources: Resources): String = when (this) {
+        Today -> resources.getString(R.string.history_today)
+        Yesterday -> resources.getString(R.string.history_yesterday)
+        ThisWeek -> resources.getString(R.string.history_7_days)
+        ThisMonth -> resources.getString(R.string.history_30_days)
+        Older -> resources.getString(R.string.history_older)
     }
 
     companion object {

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryViewItemFlow.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryViewItemFlow.kt
@@ -1,0 +1,152 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.library.history
+
+import android.content.res.Resources
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
+import androidx.paging.cachedIn
+import androidx.paging.filter
+import androidx.paging.insertFooterItem
+import androidx.paging.insertSeparators
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.service.fxa.manager.FxaAccountManager
+import org.mozilla.fenix.R
+import org.mozilla.fenix.components.history.PagedHistoryProvider
+
+/**
+ * Flow of [HistoryViewItem] items used in [HistoryFragment] screen to populate the history list
+ * in [HistoryAdapter].
+ *
+ * @param historyProvider Data source of history and history group items.
+ * @param browserStore Provides information about numbers of recently closed tabs.
+ * @param isRemote The dataSource can provide local, remote and mixed history.
+ * @param resources A class that provides access to String resources for building ViewItems' text
+ * fields.
+ * @param accountManager Is used to get information if the user is authenticated or not.
+ * @param scope Scope used for caching.
+ */
+class HistoryViewItemFlow(
+    historyProvider: PagedHistoryProvider,
+    browserStore: BrowserStore,
+    isRemote: Boolean? = null,
+    resources: Resources,
+    accountManager: FxaAccountManager,
+    scope: CoroutineScope,
+) {
+    private val deleteFlow =
+        MutableStateFlow(Pair(emptySet<PendingDeletionHistory>(), emptySet<HistoryItemTimeGroup>()))
+    private val emptyFlow = MutableStateFlow(false)
+    val historyFlow: Flow<PagingData<HistoryViewItem>> = Pager(
+        PagingConfig(PAGE_SIZE),
+        null
+    ) {
+        HistoryDataSource(
+            historyProvider = historyProvider,
+            browserStore = browserStore,
+            isRemote = isRemote,
+            resources = resources,
+            accountManager = accountManager
+        )
+    }.flow
+        .cachedIn(scope)
+        // Filtering out items that have been marked for removal.
+        .combine(deleteFlow) { historyItems: PagingData<HistoryViewItem>,
+            deletedItems: Pair<Set<PendingDeletionHistory>, Set<HistoryItemTimeGroup>> ->
+            historyItems.filter { historyItem ->
+                when (historyItem) {
+                    is HistoryViewItem.HistoryItem -> {
+                        deletedItems.first.find { pendingItem ->
+                            pendingItem.visitedAt == historyItem.data.visitedAt
+                        } == null
+                    }
+                    is HistoryViewItem.HistoryGroupItem -> {
+                        deletedItems.first.find { pendingItem ->
+                            pendingItem is PendingDeletionHistory.Group &&
+                                pendingItem.visitedAt == historyItem.data.visitedAt
+                        } == null
+                    }
+                    is HistoryViewItem.TimeGroupHeader -> {
+                        deletedItems.second.find { historyItemTimeGroup ->
+                            historyItem.timeGroup == historyItemTimeGroup
+                        } == null
+                    }
+                    else -> true
+                }
+            }
+        }
+        // Adding an empty view. Note that a footer item won't be shown until the end of the list is
+        // reached. Because of local/remote item separation, there might be cases when the only
+        // visible item is being deleted, but the pager is still trying to load items and footer the
+        // item won't be shown until the loading is complete.
+        .combine(emptyFlow) { historyItems: PagingData<HistoryViewItem>, isEmpty: Boolean ->
+            if (isEmpty) {
+                historyItems.insertFooterItem(
+                    item = HistoryViewItem.EmptyHistoryItem(
+                        resources.getString(R.string.history_empty_message)
+                    )
+                )
+            } else {
+                historyItems
+            }
+        }
+        // Adding separators for extra space above time group headers.
+        .map { pagingData ->
+            pagingData.insertSeparators { history: HistoryViewItem?, history2: HistoryViewItem? ->
+                if (history2 is HistoryViewItem.TimeGroupHeader) {
+                    if (history is HistoryViewItem.TimeGroupHeader ||
+                        history is HistoryViewItem.TopSeparatorHistoryItem
+                    ) {
+                        return@insertSeparators null
+                    } else {
+                        val separatorTimeGroup = when (history) {
+                            is HistoryViewItem.HistoryItem -> history.data.historyTimeGroup
+                            is HistoryViewItem.HistoryGroupItem -> history.data.historyTimeGroup
+                            else -> null
+                        }
+                        return@insertSeparators HistoryViewItem.TimeGroupSeparatorHistoryItem(
+                            separatorTimeGroup
+                        )
+                    }
+                } else {
+                    return@insertSeparators null
+                }
+            }
+        }
+
+    /**
+     * Updates [HistoryViewItemFlow.deleteFlow] with the new value, which triggers an update of
+     * [HistoryViewItemFlow.historyFlow].
+     *
+     * @param historyItems Items to be filtered out from the data source.
+     * @param historyHeaders Headers to be filtered out from the data source.
+     */
+    fun setDeleteItems(
+        historyItems: Set<PendingDeletionHistory>,
+        historyHeaders: Set<HistoryItemTimeGroup>
+    ) {
+        deleteFlow.value = Pair(historyItems, historyHeaders)
+    }
+
+    /**
+     * Updates [HistoryViewItemFlow.emptyFlow] with the new value, which triggers an update of
+     * [HistoryViewItemFlow.historyFlow].
+     *
+     * @param isEmpty The new empty state.
+     */
+    fun setEmptyState(isEmpty: Boolean) {
+        emptyFlow.value = isEmpty
+    }
+
+    companion object {
+        const val PAGE_SIZE = 25
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryViewItemFlow.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryViewItemFlow.kt
@@ -44,7 +44,8 @@ class HistoryViewItemFlow(
 ) {
     private val deleteFlow =
         MutableStateFlow(Pair(emptySet<PendingDeletionHistory>(), emptySet<HistoryItemTimeGroup>()))
-    private val emptyFlow = MutableStateFlow(false)
+    // The flow adds an emptyView item as a footer to the list.
+    private val emptyStateFlow = MutableStateFlow(false)
     val historyFlow: Flow<PagingData<HistoryViewItem>> = Pager(
         PagingConfig(PAGE_SIZE),
         null
@@ -87,7 +88,7 @@ class HistoryViewItemFlow(
         // reached. Because of local/remote item separation, there might be cases when the only
         // visible item is being deleted, but the pager is still trying to load items and footer the
         // item won't be shown until the loading is complete.
-        .combine(emptyFlow) { historyItems: PagingData<HistoryViewItem>, isEmpty: Boolean ->
+        .combine(emptyStateFlow) { historyItems: PagingData<HistoryViewItem>, isEmpty: Boolean ->
             if (isEmpty) {
                 historyItems.insertFooterItem(
                     item = HistoryViewItem.EmptyHistoryItem(
@@ -143,7 +144,7 @@ class HistoryViewItemFlow(
      * @param isEmpty The new empty state.
      */
     fun setEmptyState(isEmpty: Boolean) {
-        emptyFlow.value = isEmpty
+        emptyStateFlow.value = isEmpty
     }
 
     companion object {

--- a/app/src/main/java/org/mozilla/fenix/library/history/PendingDeletionHistory.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/PendingDeletionHistory.kt
@@ -65,6 +65,10 @@ fun History.toPendingDeletionHistory(): PendingDeletionHistory {
                 )
             }
         )
-        is History.Metadata -> PendingDeletionHistory.MetaData(visitedAt, historyTimeGroup, historyMetadataKey)
+        is History.Metadata -> PendingDeletionHistory.MetaData(
+            visitedAt,
+            historyTimeGroup,
+            historyMetadataKey
+        )
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/library/history/viewholders/HistoryListItemViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/viewholders/HistoryListItemViewHolder.kt
@@ -88,7 +88,7 @@ class HistoryListItemViewHolder(
 
         toggleTopContent(showTopContent, mode === HistoryFragmentState.Mode.Normal)
 
-        val headerText = timeGroup?.humanReadable(itemView.context)
+        val headerText = timeGroup?.humanReadable(itemView.resources)
         toggleHeader(headerText)
 
         binding.historyLayout.setSelectionInteractor(item, selectionHolder, historyInteractor)

--- a/app/src/main/java/org/mozilla/fenix/library/history/viewholders/HistoryListItemViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/viewholders/HistoryListItemViewHolder.kt
@@ -43,7 +43,7 @@ class HistoryListItemViewHolder(
             contentDescription = view.context.getString(R.string.history_delete_item)
             setOnClickListener {
                 val item = item ?: return@setOnClickListener
-                historyInteractor.onDeleteSome(setOf(item))
+                historyInteractor.onDeleteHistoryItems(setOf(item))
             }
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/library/history/viewholders/SignInViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/viewholders/SignInViewHolder.kt
@@ -21,7 +21,7 @@ import org.mozilla.fenix.library.history.HistoryInteractor
  */
 class SignInViewHolder(
     view: View,
-    private val historyInteractor: HistoryInteractor
+    private val historyInteractor: HistoryInteractor,
 ) : RecyclerView.ViewHolder(view) {
 
     private val binding = HistoryListSignInBinding.bind(view)
@@ -34,7 +34,7 @@ class SignInViewHolder(
             historyInteractor.onCreateAccountClicked()
         }
         binding.createAccount.text = HtmlCompat.fromHtml(
-            binding.createAccount.text.toString(),
+            binding.root.resources.getString(R.string.history_sign_in_create_account),
             HtmlCompat.FROM_HTML_MODE_LEGACY
         )
     }

--- a/app/src/main/java/org/mozilla/fenix/library/history/viewholders/SignInViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/viewholders/SignInViewHolder.kt
@@ -5,34 +5,38 @@
 package org.mozilla.fenix.library.history.viewholders
 
 import android.view.View
+import androidx.core.text.HtmlCompat
 import androidx.recyclerview.widget.RecyclerView
 import org.mozilla.fenix.R
 import org.mozilla.fenix.databinding.HistoryListSignInBinding
 import org.mozilla.fenix.library.history.HistoryAdapter
+import org.mozilla.fenix.library.history.HistoryInteractor
 
 /**
  * A view representing a sign in window inside the synced history screen.
  * [HistoryAdapter] is responsible for creating and populating the view.
  *
  * @param view that is passed down to the parent's constructor.
- * @param onSignInClicked Invokes when a signIn button is pressed.
- * @param onCreateAccountClicked Invokes when a createAccount button is pressed.
+ * @param historyInteractor Interactor to capture user interactions with the UI element.
  */
 class SignInViewHolder(
     view: View,
-    private val onSignInClicked: () -> Unit,
-    private val onCreateAccountClicked: () -> Unit
+    private val historyInteractor: HistoryInteractor
 ) : RecyclerView.ViewHolder(view) {
 
     private val binding = HistoryListSignInBinding.bind(view)
 
     init {
         binding.signInButton.setOnClickListener {
-            onSignInClicked.invoke()
+            historyInteractor.onSignInClicked()
         }
         binding.createAccount.setOnClickListener {
-            onCreateAccountClicked.invoke()
+            historyInteractor.onCreateAccountClicked()
         }
+        binding.createAccount.text = HtmlCompat.fromHtml(
+            binding.createAccount.text.toString(),
+            HtmlCompat.FROM_HTML_MODE_LEGACY
+        )
     }
 
     companion object {

--- a/app/src/main/res/layout/component_history.xml
+++ b/app/src/main/res/layout/component_history.xml
@@ -2,8 +2,7 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/history_wrapper"
     android:layout_width="match_parent"
@@ -16,58 +15,18 @@
         android:layout_height="8dp"
         android:indeterminate="true"
         android:translationY="-3dp"
-        android:visibility="gone"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-    <View
-        android:id="@+id/top_spacer"
-        android:layout_width="match_parent"
-        android:layout_height="8dp"
-        app:layout_constraintTop_toTopOf="parent"
-        android:visibility="gone"/>
-
-    <include
-        android:id="@+id/recently_closed_nav_empty"
-        layout="@layout/recently_closed_nav_item"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:layout_constraintTop_toBottomOf="@+id/top_spacer" />
-
-    <include
-        android:id="@+id/synced_history_nav_empty"
-        layout="@layout/synced_history_nav_item"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:layout_constraintTop_toBottomOf="@id/recently_closed_nav_empty" />
-
-    <TextView
-        android:id="@+id/history_empty_view"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:gravity="center"
-        android:text="@string/history_empty_message"
-        android:textColor="?attr/textSecondary"
-        android:textSize="16sp"
-        android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/synced_history_nav_empty" />
+        android:visibility="gone" />
 
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/swipe_refresh"
         android:layout_width="match_parent"
-        android:layout_height="0dp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/synced_history_nav_empty">
+        android:layout_height="match_parent">
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/history_list"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:scrollbars="vertical"
-            android:visibility="gone"
             tools:listitem="@layout/history_list_item" />
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
-</androidx.constraintlayout.widget.ConstraintLayout>
+</FrameLayout>

--- a/app/src/test/java/org/mozilla/fenix/library/history/HistoryAdapterTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/history/HistoryAdapterTest.kt
@@ -1,0 +1,330 @@
+package org.mozilla.fenix.library.history
+
+import androidx.paging.PagingData
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+import java.util.Calendar
+
+@RunWith(FenixRobolectricTestRunner::class)
+internal class HistoryAdapterTest {
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(StandardTestDispatcher())
+    }
+
+    @Test
+    fun `WHEN the only item in the list is deleted THEN header is deleted as well`() {
+        val adapter = HistoryAdapter(mockk()) {}
+
+        val removedItem = createHistory(visitedAt = Calendar.getInstance().timeInMillis)
+        val notRemovedItem = createHistory(
+            visitedAt = Calendar.getInstance().apply {
+                add(Calendar.DAY_OF_YEAR, -1)
+            }.timeInMillis
+        )
+        val snapshot = listOf(
+            HistoryViewItem.TopSeparatorHistoryItem,
+            HistoryViewItem.TimeGroupHeader(
+                title = removedItem.historyTimeGroup.humanReadable(testContext.resources),
+                timeGroup = removedItem.historyTimeGroup,
+                collapsed = false,
+            ),
+            createHistoryViewItem(removedItem),
+            HistoryViewItem.TimeGroupSeparatorHistoryItem(removedItem.historyTimeGroup),
+            HistoryViewItem.TimeGroupHeader(
+                title = notRemovedItem.historyTimeGroup.humanReadable(testContext.resources),
+                timeGroup = notRemovedItem.historyTimeGroup,
+                collapsed = false,
+            ),
+            createHistoryViewItem(notRemovedItem)
+        )
+
+        assert(
+            adapter.calculateTimeGroupsToRemove(
+                removedItems = setOf(removedItem),
+                snapshot = snapshot
+            ).contains(removedItem.historyTimeGroup)
+        )
+    }
+
+    @Test
+    fun `WHEN the only item in the group is deleted THEN header of that group is deleted as well`() {
+        val adapter = HistoryAdapter(mockk()) {}
+
+        val now = Calendar.getInstance().timeInMillis
+        val removedItem = createHistory(visitedAt = now)
+        val snapshot = listOf(
+            HistoryViewItem.TopSeparatorHistoryItem,
+            HistoryViewItem.TimeGroupHeader(
+                title = removedItem.historyTimeGroup.humanReadable(testContext.resources),
+                timeGroup = removedItem.historyTimeGroup,
+                collapsed = false
+            ),
+            createHistoryViewItem(removedItem)
+        )
+
+        assert(
+            adapter.calculateTimeGroupsToRemove(
+                removedItems = setOf(removedItem),
+                snapshot = snapshot
+            ).contains(removedItem.historyTimeGroup)
+        )
+    }
+
+    @Test
+    fun `WHEN not all items inside a group are deleted THEN header of the group is not deleted`() {
+        val adapter = HistoryAdapter(mockk()) {}
+
+        val today = Calendar.getInstance().apply {
+            set(Calendar.HOUR_OF_DAY, 0)
+            set(Calendar.MINUTE, 0)
+            set(Calendar.SECOND, 0)
+            set(Calendar.MILLISECOND, 0)
+        }
+
+        val removedItemA = createHistory(visitedAt = today.timeInMillis)
+        val removedItemB = createHistory(visitedAt = today.timeInMillis)
+        val removedItemC = createHistory(visitedAt = today.timeInMillis)
+        val notRemovedItem = createHistory(visitedAt = today.timeInMillis)
+
+        val snapshot = listOf(
+            HistoryViewItem.TopSeparatorHistoryItem,
+            HistoryViewItem.TimeGroupHeader(
+                title = removedItemA.historyTimeGroup.humanReadable(testContext.resources),
+                timeGroup = removedItemA.historyTimeGroup,
+                collapsed = false,
+            ),
+            createHistoryViewItem(removedItemA),
+            createHistoryViewItem(removedItemB),
+            createHistoryViewItem(removedItemC),
+            createHistoryViewItem(notRemovedItem)
+        )
+
+        assert(
+            !adapter.calculateTimeGroupsToRemove(
+                removedItems = setOf(removedItemA, removedItemB, removedItemC),
+                snapshot = snapshot
+            ).contains(notRemovedItem.historyTimeGroup)
+        )
+    }
+
+    @Test
+    fun `WHEN all items inside a group are deleted THEN header of the group is deleted as well`() {
+        val adapter = HistoryAdapter(mockk()) {}
+
+        val today = Calendar.getInstance().apply {
+            set(Calendar.HOUR_OF_DAY, 0)
+            set(Calendar.MINUTE, 0)
+            set(Calendar.SECOND, 0)
+            set(Calendar.MILLISECOND, 0)
+        }
+
+        val removedItemA = createHistory(visitedAt = today.timeInMillis)
+        val removedItemB = createHistory(visitedAt = today.timeInMillis)
+        val removedItemC = createHistory(visitedAt = today.timeInMillis)
+        val removedItemD = createHistory(visitedAt = today.timeInMillis)
+
+        val snapshot = listOf(
+            HistoryViewItem.TopSeparatorHistoryItem,
+            HistoryViewItem.TimeGroupHeader(
+                title = removedItemA.historyTimeGroup.humanReadable(testContext.resources),
+                timeGroup = removedItemA.historyTimeGroup,
+                collapsed = false,
+            ),
+            createHistoryViewItem(removedItemA),
+            createHistoryViewItem(removedItemB),
+            createHistoryViewItem(removedItemC),
+            createHistoryViewItem(removedItemD)
+        )
+
+        assert(
+            !adapter.calculateTimeGroupsToRemove(
+                removedItems = setOf(removedItemA, removedItemB, removedItemC),
+                snapshot = snapshot
+            ).contains(HistoryItemTimeGroup.Today)
+        )
+    }
+
+    @Test
+    fun `WHEN all items inside multiple groups are deleted THEN headers of the groups are deleted as well`() {
+        val adapter = HistoryAdapter(mockk()) {}
+
+        val removedItemA = createHistory(
+            visitedAt = Calendar.getInstance().apply {
+                add(Calendar.DAY_OF_YEAR, 0)
+            }.timeInMillis
+        )
+        val notRemovedItemA = createHistory(
+            visitedAt = Calendar.getInstance().apply {
+                add(Calendar.DAY_OF_YEAR, -1)
+            }.timeInMillis
+        )
+        val removedItemB = createHistory(
+            visitedAt = Calendar.getInstance().apply {
+                add(Calendar.DAY_OF_YEAR, -4)
+            }.timeInMillis
+        )
+        val notRemovedItemB = createHistory(
+            visitedAt = Calendar.getInstance().apply {
+                add(Calendar.DAY_OF_YEAR, -15)
+            }.timeInMillis
+        )
+
+        val snapshot = listOf(
+            HistoryViewItem.TopSeparatorHistoryItem,
+
+            HistoryViewItem.TimeGroupHeader(
+                title = removedItemA.historyTimeGroup.humanReadable(testContext.resources),
+                timeGroup = removedItemA.historyTimeGroup,
+                collapsed = false,
+            ),
+            createHistoryViewItem(removedItemA),
+            HistoryViewItem.TimeGroupSeparatorHistoryItem(removedItemA.historyTimeGroup),
+
+            HistoryViewItem.TimeGroupHeader(
+                title = notRemovedItemA.historyTimeGroup.humanReadable(testContext.resources),
+                timeGroup = notRemovedItemA.historyTimeGroup,
+                collapsed = false,
+            ),
+            createHistoryViewItem(notRemovedItemA),
+            createHistoryViewItem(notRemovedItemA.copy()),
+            createHistoryViewItem(notRemovedItemA.copy()),
+            createHistoryViewItem(notRemovedItemA.copy()),
+            HistoryViewItem.TimeGroupSeparatorHistoryItem(notRemovedItemA.historyTimeGroup),
+
+            HistoryViewItem.TimeGroupHeader(
+                title = removedItemB.historyTimeGroup.humanReadable(testContext.resources),
+                timeGroup = removedItemB.historyTimeGroup,
+                collapsed = false,
+            ),
+            createHistoryViewItem(removedItemB),
+            HistoryViewItem.TimeGroupSeparatorHistoryItem(removedItemB.historyTimeGroup),
+
+            HistoryViewItem.TimeGroupHeader(
+                title = notRemovedItemB.historyTimeGroup.humanReadable(testContext.resources),
+                timeGroup = notRemovedItemB.historyTimeGroup,
+                collapsed = false,
+            ),
+            createHistoryViewItem(notRemovedItemB),
+            createHistoryViewItem(notRemovedItemB.copy()),
+            createHistoryViewItem(notRemovedItemB.copy()),
+            createHistoryViewItem(notRemovedItemB.copy()),
+            HistoryViewItem.TimeGroupSeparatorHistoryItem(notRemovedItemB.historyTimeGroup),
+        )
+
+        val result = adapter.calculateTimeGroupsToRemove(
+            removedItems = setOf(removedItemA, removedItemB),
+            snapshot = snapshot
+        )
+
+        assert(result.contains(removedItemA.historyTimeGroup))
+        assert(result.contains(removedItemB.historyTimeGroup))
+    }
+
+    @Test
+    fun `WHEN adapter has a single history item THEN it is not empty`() = runTest {
+        var isEmpty: Boolean? = null
+        val adapter = HistoryAdapter(mockk()) {
+            isEmpty = it
+        }
+        val data = PagingData.from(
+            listOf<HistoryViewItem>(
+                createHistoryViewItem(),
+                createHistoryViewItem(),
+                createHistoryViewItem()
+            )
+        )
+        adapter.submitData(data)
+        advanceUntilIdle()
+        assert(isEmpty == false)
+    }
+
+    @Test
+    fun `WHEN adapter has a single history group item THEN it is not empty`() = runTest {
+        var isEmpty: Boolean? = null
+        val adapter = HistoryAdapter(mockk()) {
+            isEmpty = it
+        }
+        val data = PagingData.from(
+            listOf<HistoryViewItem>(
+                createGroupHistoryViewItem(),
+                createGroupHistoryViewItem(),
+                createGroupHistoryViewItem()
+            )
+        )
+        adapter.submitData(data)
+        advanceUntilIdle()
+        assert(isEmpty == false)
+    }
+
+    @Test
+    fun `WHEN adapter does not have a history or history group item THEN it is empty`() = runTest {
+        var isEmpty: Boolean? = null
+        val adapter = HistoryAdapter(mockk()) {
+            isEmpty = it
+        }
+        val data = PagingData.from(
+            listOf(
+                HistoryViewItem.TopSeparatorHistoryItem,
+                HistoryViewItem.RecentlyClosedItem("", ""),
+                HistoryViewItem.SyncedHistoryItem(""),
+            )
+        )
+        adapter.submitData(data)
+        advanceUntilIdle()
+        assert(isEmpty == true)
+    }
+
+    private fun createHistory(
+        visitedAt: Long = 1658496038799,
+    ) = History.Regular(
+        position = 0,
+        title = "Mozilla",
+        url = "mozilla.org",
+        visitedAt = visitedAt,
+        historyTimeGroup = HistoryItemTimeGroup.timeGroupForTimestamp(visitedAt),
+        selected = false,
+    )
+
+    private fun createHistoryViewItem(
+        data: History.Regular = createHistory()
+    ) = HistoryViewItem.HistoryItem(
+        data = data,
+        collapsed = false
+    )
+
+    private fun createGroupHistory(
+        visitedAt: Long = 1658496038799,
+    ) = History.Group(
+        position = 0,
+        title = "Mozilla",
+        visitedAt = visitedAt,
+        historyTimeGroup = HistoryItemTimeGroup.timeGroupForTimestamp(visitedAt),
+        items = listOf(),
+        selected = false,
+    )
+
+    private fun createGroupHistoryViewItem(
+        data: History.Group = createGroupHistory()
+    ) = HistoryViewItem.HistoryGroupItem(
+        data = data,
+        collapsed = false
+    )
+}

--- a/app/src/test/java/org/mozilla/fenix/library/history/HistoryAdapterTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/history/HistoryAdapterTest.kt
@@ -156,7 +156,7 @@ internal class HistoryAdapterTest {
 
         assert(
             !adapter.calculateTimeGroupsToRemove(
-                removedItems = setOf(removedItemA, removedItemB, removedItemC),
+                removedItems = setOf(removedItemA, removedItemB, removedItemC, removedItemD),
                 snapshot = snapshot
             ).contains(HistoryItemTimeGroup.Today)
         )

--- a/app/src/test/java/org/mozilla/fenix/library/history/HistoryAdapterTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/history/HistoryAdapterTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.library.history
 
 import androidx.paging.PagingData

--- a/app/src/test/java/org/mozilla/fenix/library/history/HistoryControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/history/HistoryControllerTest.kt
@@ -251,7 +251,8 @@ class HistoryControllerTest {
         onTimeFrameDeleted: () -> Unit = {},
         invalidateOptionsMenu: () -> Unit = {},
         deleteHistoryItems: (Set<History>) -> Unit = { _ -> },
-        syncHistory: suspend () -> Unit = {}
+        createAccount: () -> Unit = {},
+        syncHistory: suspend () -> Unit = {},
     ): HistoryController {
         return DefaultHistoryController(
             store,
@@ -267,6 +268,7 @@ class HistoryControllerTest {
             invalidateOptionsMenu,
             { items, _, _ -> deleteHistoryItems.invoke(items) },
             syncHistory,
+            createAccount,
             settings,
         )
     }

--- a/app/src/test/java/org/mozilla/fenix/library/history/HistoryControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/history/HistoryControllerTest.kt
@@ -223,7 +223,7 @@ class HistoryControllerTest {
             }
         )
 
-        controller.handleDeleteSome(itemsToDelete)
+        controller.handleDeleteHistoryItems(itemsToDelete)
         assertEquals(itemsToDelete, actualItems)
     }
 

--- a/app/src/test/java/org/mozilla/fenix/library/history/HistoryControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/history/HistoryControllerTest.kt
@@ -251,8 +251,8 @@ class HistoryControllerTest {
         onTimeFrameDeleted: () -> Unit = {},
         invalidateOptionsMenu: () -> Unit = {},
         deleteHistoryItems: (Set<History>) -> Unit = { _ -> },
-        createAccount: () -> Unit = {},
         syncHistory: suspend () -> Unit = {},
+        createAccount: () -> Unit = {},
     ): HistoryController {
         return DefaultHistoryController(
             store,

--- a/app/src/test/java/org/mozilla/fenix/library/history/HistoryDataSourceTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/history/HistoryDataSourceTest.kt
@@ -275,7 +275,7 @@ class HistoryDataSourceTest {
     }
 
     @Test
-    fun `WHEN data source is local THEN the first loaded page does not contain a recently closed item`() = runTest {
+    fun `WHEN data source is local THEN the first loaded page contains a recently closed item`() = runTest {
         val dataSource = createDataSource(isRemote = false)
 
         val firstPage = dataSource.load(

--- a/app/src/test/java/org/mozilla/fenix/library/history/HistoryDataSourceTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/history/HistoryDataSourceTest.kt
@@ -1,207 +1,349 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 package org.mozilla.fenix.library.history
 
-import mozilla.components.concept.storage.HistoryMetadataKey
-import org.junit.Assert.assertEquals
+import android.content.res.Resources
+import androidx.paging.PagingSource
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.service.fxa.manager.FxaAccountManager
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.mozilla.fenix.components.history.HistoryDB
+import org.mozilla.fenix.components.history.PagedHistoryProvider
+import org.robolectric.RobolectricTestRunner
+import java.util.Calendar
 
+@RunWith(RobolectricTestRunner::class)
 class HistoryDataSourceTest {
-    private val testCases = listOf(
-        listOf<Int>() to listOf(),
 
-        listOf(1) to listOf(
-            TestHistory.Regular("http://www.mozilla.com")
-        ),
-        listOf(1, 2) to listOf(
-            TestHistory.Regular("http://www.mozilla.com"),
-            TestHistory.Regular("http://www.mozilla.com/2")
-        ),
-        listOf(1, 2) to listOf(
-            TestHistory.Metadata("http://www.mozilla.com"),
-            TestHistory.Regular("http://www.mozilla.com/2")
-        ),
-        listOf(1, 2, 3) to listOf(
-            TestHistory.Metadata("http://www.mozilla.com"),
-            TestHistory.Regular("http://www.mozilla.com/2"),
-            TestHistory.Metadata("http://www.mozilla.com"),
-        ),
-        listOf(1, 2, 3, 4, 5) to listOf(
-            TestHistory.Metadata("http://www.mozilla.com"),
-            TestHistory.Regular("http://www.mozilla.com/2"),
-            TestHistory.Metadata("http://www.mozilla.com"),
-            TestHistory.Regular("http://www.mozilla.com/3"),
-            TestHistory.Regular("http://www.mozilla.com/2"),
-        ),
-        listOf(1, 2, 3) to listOf(
-            TestHistory.Metadata("http://www.mozilla.com"),
-            TestHistory.Regular("http://www.mozilla.com/2"),
-            TestHistory.Group("firefox", items = listOf())
-        ),
-        listOf(1, 2, 3) to listOf(
-            TestHistory.Metadata("http://www.mozilla.com"),
-            TestHistory.Regular("http://www.mozilla.com/2"),
-            TestHistory.Group(
-                "firefox",
-                items = listOf(
-                    "http://www.firefox.com"
-                )
-            )
-        ),
-        listOf(1, 2, 7) to listOf(
-            TestHistory.Metadata("http://www.mozilla.com"),
-            TestHistory.Regular("http://www.mozilla.com/2"),
-            TestHistory.Group(
-                "firefox",
-                items = listOf(
-                    "http://www.firefox.com",
-                    "http://www.firefox.com/2",
-                    "http://www.firefox.com/3",
-                    "http://www.firefox.com/4",
-                    "http://www.firefox.com/5"
-                )
-            )
-        ),
-        listOf(5, 6, 7) to listOf(
-            TestHistory.Group(
-                "firefox",
-                items = listOf(
-                    "http://www.firefox.com",
-                    "http://www.firefox.com/2",
-                    "http://www.firefox.com/3",
-                    "http://www.firefox.com/4",
-                    "http://www.firefox.com/5"
-                )
-            ),
-            TestHistory.Metadata("http://www.mozilla.com"),
-            TestHistory.Regular("http://www.mozilla.com/2")
-        ),
-        listOf(1, 6, 7) to listOf(
-            TestHistory.Metadata("http://www.mozilla.com"),
-            TestHistory.Group(
-                "firefox",
-                items = listOf(
-                    "http://www.firefox.com",
-                    "http://www.firefox.com/2",
-                    "http://www.firefox.com/3",
-                    "http://www.firefox.com/4",
-                    "http://www.firefox.com/5"
-                )
-            ),
-            TestHistory.Regular("http://www.mozilla.com/2")
-        ),
-        listOf(1, 6, 8, 9) to listOf(
-            TestHistory.Metadata("http://www.mozilla.com"),
-            TestHistory.Group(
-                "firefox",
-                items = listOf(
-                    "http://www.firefox.com",
-                    "http://www.firefox.com/2",
-                    "http://www.firefox.com/3",
-                    "http://www.firefox.com/4",
-                    "http://www.firefox.com/5"
-                )
-            ),
-            TestHistory.Group(
-                "mdn",
-                items = listOf(
-                    "https://developer.mozilla.org/en-US/1",
-                    "https://developer.mozilla.org/en-US/2"
-                )
-            ),
-            TestHistory.Regular("http://www.mozilla.com/2")
-        ),
-        listOf(1) to listOf(
-            TestHistory.Group(
-                "mozilla",
-                items = listOf(
-                    "http://www.mozilla.com"
-                )
+    private val historyProvider: PagedHistoryProvider = mockk()
+    private val browserStore: BrowserStore = mockk()
+    private val accountManager: FxaAccountManager = mockk()
+
+    @Before
+    fun setup() {
+        coEvery {
+            historyProvider.getHistory(0, 25, null)
+        } returns listOf(
+            createRegularHistory(isRemote = false),
+            createRegularHistory(isRemote = false),
+            createRegularHistory(isRemote = true),
+            createRegularHistory(isRemote = true),
+            createRegularHistory(isRemote = true),
+            createRegularHistory(isRemote = true),
+        )
+
+        every { accountManager.authenticatedAccount() } returns mockk()
+        every { browserStore.state } returns BrowserState()
+    }
+
+    @Test
+    fun `WHEN data source is mixed THEN a loaded page contains both remote and local items`() = runTest {
+        val dataSource = createDataSource(isRemote = null)
+
+        val firstPage = dataSource.load(
+            PagingSource.LoadParams.Refresh(
+                key = null,
+                loadSize = 25,
+                placeholdersEnabled = false
             )
         )
+        val loadedItems = (firstPage as PagingSource.LoadResult.Page).data
+
+        assert(loadedItems.filterIsInstance<HistoryViewItem.HistoryItem>().size == 6)
+    }
+
+    @Test
+    fun `WHEN data source is remote THEN a loaded page contains only remote items`() = runTest {
+        val dataSource = createDataSource(isRemote = true)
+
+        val firstPage = dataSource.load(
+            PagingSource.LoadParams.Refresh(
+                key = null,
+                loadSize = 25,
+                placeholdersEnabled = false
+            )
+        )
+        val loadedItems = (firstPage as PagingSource.LoadResult.Page).data
+
+        assert(loadedItems.filterIsInstance<HistoryViewItem.HistoryItem>().size == 4)
+    }
+
+    @Test
+    fun `WHEN data source is local THEN a loaded page contains only local items`() = runTest {
+        val dataSource = createDataSource(isRemote = false)
+
+        val firstPage = dataSource.load(
+            PagingSource.LoadParams.Refresh(
+                key = null,
+                loadSize = 25,
+                placeholdersEnabled = false
+            )
+        )
+        val loadedItems = (firstPage as PagingSource.LoadResult.Page).data
+
+        assert(loadedItems.filterIsInstance<HistoryViewItem.HistoryItem>().size == 2)
+    }
+
+    @Test
+    fun `WHEN data source is remote and the user is not authenticated THEN the first loaded page contains a sign in item`() =
+        runTest {
+            val dataSource = createDataSource(isRemote = true)
+            every { accountManager.authenticatedAccount() } returns null
+
+            val firstPage = dataSource.load(
+                PagingSource.LoadParams.Refresh(
+                    key = null,
+                    loadSize = 25,
+                    placeholdersEnabled = false
+                )
+            )
+            val loadedItems = (firstPage as PagingSource.LoadResult.Page).data
+
+            assert(loadedItems.contains(HistoryViewItem.SignInHistoryItem))
+        }
+
+    @Test
+    fun `WHEN data source is local and the user is not authenticated THEN the first loaded page does not contain sign in item`() =
+        runTest {
+            val dataSource = createDataSource(isRemote = false)
+            every { accountManager.authenticatedAccount() } returns null
+
+            val firstPage = dataSource.load(
+                PagingSource.LoadParams.Refresh(
+                    key = null,
+                    loadSize = 25,
+                    placeholdersEnabled = false
+                )
+            )
+            val loadedItems = (firstPage as PagingSource.LoadResult.Page).data
+
+            assertFalse(loadedItems.contains(HistoryViewItem.SignInHistoryItem))
+        }
+
+    @Test
+    fun `GIVEN items of all time frames THEN the page contains headers of all types`() =
+        runTest {
+            val dataSource = createDataSource(isRemote = null)
+            coEvery {
+                historyProvider.getHistory(0, 25, null)
+            } returns listOf(
+                createRegularHistory(
+                    isRemote = false,
+                    visitedAt = Calendar.getInstance().timeInMillis
+                ),
+                createRegularHistory(
+                    isRemote = false,
+                    visitedAt = Calendar.getInstance().apply {
+                        add(Calendar.DAY_OF_YEAR, -1)
+                    }.timeInMillis
+                ),
+                createRegularHistory(
+                    isRemote = false,
+                    visitedAt = Calendar.getInstance().apply {
+                        add(Calendar.DAY_OF_YEAR, -4)
+                    }.timeInMillis
+                ),
+                createRegularHistory(
+                    isRemote = false,
+                    visitedAt = Calendar.getInstance().apply {
+                        add(Calendar.DAY_OF_YEAR, -15)
+                    }.timeInMillis
+                ),
+                createRegularHistory(
+                    isRemote = false,
+                    visitedAt = Calendar.getInstance().apply {
+                        add(Calendar.DAY_OF_YEAR, -35)
+                    }.timeInMillis
+                ),
+            )
+
+            val firstPage = dataSource.load(
+                PagingSource.LoadParams.Refresh(
+                    key = null,
+                    loadSize = 25,
+                    placeholdersEnabled = false
+                )
+            )
+            val loadedItems = (firstPage as PagingSource.LoadResult.Page).data
+
+            assertNotNull(
+                loadedItems.find {
+                    it is HistoryViewItem.TimeGroupHeader &&
+                        it.timeGroup == HistoryItemTimeGroup.Today
+                }
+            )
+            assertNotNull(
+                loadedItems.find {
+                    it is HistoryViewItem.TimeGroupHeader &&
+                        it.timeGroup == HistoryItemTimeGroup.Yesterday
+                }
+            )
+            assertNotNull(
+                loadedItems.find {
+                    it is HistoryViewItem.TimeGroupHeader &&
+                        it.timeGroup == HistoryItemTimeGroup.ThisWeek
+                }
+            )
+            assertNotNull(
+                loadedItems.find {
+                    it is HistoryViewItem.TimeGroupHeader &&
+                        it.timeGroup == HistoryItemTimeGroup.ThisMonth
+                }
+            )
+            assertNotNull(
+                loadedItems.find {
+                    it is HistoryViewItem.TimeGroupHeader &&
+                        it.timeGroup == HistoryItemTimeGroup.Older
+                }
+            )
+        }
+
+    @Test
+    fun `GIVEN items are not sorted properly by their time group THEN headers are not duplicated`() = runTest {
+        val dataSource = createDataSource(isRemote = false)
+        coEvery {
+            historyProvider.getHistory(0, 25, null)
+        } returns listOf(
+            createRegularHistory(
+                isRemote = false,
+                visitedAt = Calendar.getInstance().timeInMillis
+            ),
+            createRegularHistory(
+                isRemote = false,
+                visitedAt = Calendar.getInstance().apply {
+                    add(Calendar.DAY_OF_YEAR, -1)
+                }.timeInMillis
+            ),
+            createRegularHistory(
+                isRemote = false,
+                visitedAt = Calendar.getInstance().timeInMillis
+            ),
+            createRegularHistory(
+                isRemote = false,
+                visitedAt = Calendar.getInstance().apply {
+                    add(Calendar.DAY_OF_YEAR, -1)
+                }.timeInMillis
+            ),
+        )
+
+        val firstPage = dataSource.load(
+            PagingSource.LoadParams.Refresh(
+                key = null,
+                loadSize = 25,
+                placeholdersEnabled = false
+            )
+        )
+        val loadedItems = (firstPage as PagingSource.LoadResult.Page).data
+
+        assert(
+            loadedItems.count {
+                it is HistoryViewItem.TimeGroupHeader &&
+                    it.timeGroup == HistoryItemTimeGroup.Today
+            } == 1
+        )
+        assert(
+            loadedItems.count {
+                it is HistoryViewItem.TimeGroupHeader &&
+                    it.timeGroup == HistoryItemTimeGroup.Yesterday
+            } == 1
+        )
+    }
+
+    @Test
+    fun `WHEN data source is mixed THEN the first loaded page contains a recently closed item`() = runTest {
+        val dataSource = createDataSource(isRemote = null)
+
+        val firstPage = dataSource.load(
+            PagingSource.LoadParams.Refresh(
+                key = null,
+                loadSize = 25,
+                placeholdersEnabled = false
+            )
+        )
+        val loadedItems = (firstPage as PagingSource.LoadResult.Page).data
+
+        assertNotNull(loadedItems.find { it is HistoryViewItem.RecentlyClosedItem })
+    }
+
+    @Test
+    fun `WHEN data source is local THEN the first loaded page does not contain a recently closed item`() = runTest {
+        val dataSource = createDataSource(isRemote = false)
+
+        val firstPage = dataSource.load(
+            PagingSource.LoadParams.Refresh(
+                key = null,
+                loadSize = 25,
+                placeholdersEnabled = false
+            )
+        )
+        val loadedItems = (firstPage as PagingSource.LoadResult.Page).data
+
+        assertNotNull(loadedItems.find { it is HistoryViewItem.RecentlyClosedItem })
+    }
+
+    @Test
+    fun `WHEN data source is local THEN the first loaded page contains a synced history item`() = runTest {
+        val dataSource = createDataSource(isRemote = false)
+
+        val firstPage = dataSource.load(
+            PagingSource.LoadParams.Refresh(
+                key = null,
+                loadSize = 25,
+                placeholdersEnabled = false
+            )
+        )
+        val loadedItems = (firstPage as PagingSource.LoadResult.Page).data
+
+        assertNotNull(loadedItems.find { it is HistoryViewItem.SyncedHistoryItem })
+    }
+
+    @Test
+    fun `WHEN data source is remote THEN the first loaded page does not contain a synced history item`() = runTest {
+        val dataSource = createDataSource(isRemote = true)
+
+        val firstPage = dataSource.load(
+            PagingSource.LoadParams.Refresh(
+                key = null,
+                loadSize = 25,
+                placeholdersEnabled = false
+            )
+        )
+        val loadedItems = (firstPage as PagingSource.LoadResult.Page).data
+
+        assertNull(loadedItems.find { it is HistoryViewItem.SyncedHistoryItem })
+    }
+
+    private fun createRegularHistory(
+        isRemote: Boolean = false,
+        visitedAt: Long = 1658496038799,
+    ) = HistoryDB.Regular(
+        title = "Mozilla",
+        url = "mozilla.org",
+        visitedAt = visitedAt,
+        selected = false,
+        isRemote = isRemote
     )
 
-    @Test
-    fun `assign positions basics - initial offset`() {
-        testCases.forEach {
-            verifyPositions(it.first, offset = 0, it.second)
-        }
-    }
-
-    @Test
-    fun `assign position basics - positive offset`() {
-        val offset = 25
-        testCases.forEach {
-            verifyPositions(it.first.map { pos -> pos + offset }, offset = offset, it.second)
-        }
-    }
-
-    @Test
-    fun `assign position basics - negative offset`() {
-        // Even though conceptually it doesn't make sense for us to handle negative offsets,
-        // as far as simple positioning logic is concerned there's no harm in doing the naive thing.
-        // Assertions around offset being a positive value should happen elsewhere, before we're
-        // even dealing with positions.
-        val offset = -25
-        testCases.forEach {
-            verifyPositions(it.first.map { pos -> pos + offset }, offset = offset, it.second)
-        }
-    }
-
-    private fun verifyPositions(expectedPositions: List<Int>, offset: Int, history: List<TestHistory>) {
-        assertEquals(
-            "For case $history with offset $offset",
-            expectedPositions,
-            history.toHistoryDB().positionWithOffset(offset).map { it.position }
-        )
-    }
-
-    private sealed class TestHistory {
-        data class Regular(val url: String) : TestHistory()
-        data class Metadata(val url: String) : TestHistory()
-        data class Group(val title: String, val items: List<String>) : TestHistory()
-    }
-
-    // For position tests, we just care about the basic tree structure here,
-    // the details (view times, timestamps, etc) don't matter.
-    private fun List<TestHistory>.toHistoryDB(): List<HistoryDB> {
-        return this.map {
-            when (it) {
-                is TestHistory.Regular -> {
-                    HistoryDB.Regular(
-                        title = it.url,
-                        url = it.url,
-                        visitedAt = 0
-                    )
-                }
-                is TestHistory.Metadata -> {
-                    HistoryDB.Metadata(
-                        title = it.url,
-                        url = it.url,
-                        visitedAt = 0,
-                        totalViewTime = 0,
-                        historyMetadataKey = HistoryMetadataKey(url = it.url)
-                    )
-                }
-                is TestHistory.Group -> {
-                    HistoryDB.Group(
-                        title = it.title,
-                        visitedAt = 0,
-                        items = it.items.map { item ->
-                            HistoryDB.Metadata(
-                                title = item,
-                                url = item,
-                                visitedAt = 0,
-                                totalViewTime = 0,
-                                historyMetadataKey = HistoryMetadataKey(url = item)
-                            )
-                        }
-                    )
-                }
-            }
-        }
-    }
+    private fun createDataSource(
+        historyProvider: PagedHistoryProvider = this@HistoryDataSourceTest.historyProvider,
+        browserStore: BrowserStore = this@HistoryDataSourceTest.browserStore,
+        isRemote: Boolean? = null,
+        resources: Resources = testContext.resources,
+        accountManager: FxaAccountManager = this@HistoryDataSourceTest.accountManager
+    ) = HistoryDataSource(
+        historyProvider = historyProvider,
+        browserStore = browserStore,
+        isRemote = isRemote,
+        resources = resources,
+        accountManager = accountManager
+    )
 }

--- a/app/src/test/java/org/mozilla/fenix/library/history/HistoryDataSourceTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/history/HistoryDataSourceTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.library.history
 
 import android.content.res.Resources

--- a/app/src/test/java/org/mozilla/fenix/library/history/HistoryInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/history/HistoryInteractorTest.kt
@@ -96,10 +96,10 @@ class HistoryInteractorTest {
     fun onDeleteSome() {
         val items = setOf(historyItem)
 
-        interactor.onDeleteSome(items)
+        interactor.onDeleteHistoryItems(items)
 
         verifyAll {
-            controller.handleDeleteSome(items)
+            controller.handleDeleteHistoryItems(items)
         }
     }
 

--- a/app/src/test/java/org/mozilla/fenix/library/history/HistoryViewItemFlowTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/history/HistoryViewItemFlowTest.kt
@@ -1,0 +1,229 @@
+package org.mozilla.fenix.library.history
+
+import android.content.res.Resources
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.service.fxa.manager.FxaAccountManager
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.After
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.fenix.components.history.HistoryDB
+import org.mozilla.fenix.components.history.PagedHistoryProvider
+import org.robolectric.RobolectricTestRunner
+import java.util.Calendar
+
+@RunWith(RobolectricTestRunner::class)
+class HistoryViewItemFlowTest {
+
+    private val historyProvider: PagedHistoryProvider = mockk()
+    private val browserStore: BrowserStore = mockk()
+    private val accountManager: FxaAccountManager = mockk()
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(StandardTestDispatcher())
+
+        every { accountManager.authenticatedAccount() } returns mockk()
+        every { browserStore.state } returns BrowserState()
+
+        // Loading first page
+        coEvery {
+            historyProvider.getHistory(0, 75, null)
+        } returns listOf(
+            createRegularHistory(isRemote = false, visitedAt = 1658496038199),
+            createRegularHistory(isRemote = false, visitedAt = 1658496038299),
+            createRegularHistory(isRemote = true, visitedAt = 1658496038399),
+            createRegularHistory(isRemote = true, visitedAt = 1658496038499),
+            createRegularHistory(isRemote = true, visitedAt = 1658496038599),
+            createRegularHistory(isRemote = true, visitedAt = 1658496038699),
+        )
+
+        // Loading second page
+        coEvery {
+            historyProvider.getHistory(75, 25, null)
+        } returns listOf()
+    }
+
+    @Test
+    fun `WHEN empty flow changes THEN empty item is either added or removed`() = runTest {
+        val flow = createHistoryViewItemFlow()
+        var adapter: HistoryAdapter = mockk()
+
+        val job = launch {
+            flow.historyFlow.collectLatest {
+                adapter = HistoryAdapter(mockk()) {}
+                adapter.submitData(it)
+            }
+        }
+
+        flow.setEmptyState(true)
+        advanceUntilIdle()
+        var viewItems = adapter.snapshot().items
+        assertNotNull(viewItems.find { it is HistoryViewItem.EmptyHistoryItem })
+
+        flow.setEmptyState(false)
+        advanceUntilIdle()
+        viewItems = adapter.snapshot().items
+        assertNull(viewItems.find { it is HistoryViewItem.EmptyHistoryItem })
+
+        job.cancel()
+    }
+
+    @Test
+    fun `WHEN delete flow is updated with items THEN matching items are removed`() = runTest {
+        var adapter: HistoryAdapter = mockk()
+        val flow = createHistoryViewItemFlow()
+        val job = launch {
+            flow.historyFlow.collectLatest {
+                adapter = HistoryAdapter(mockk()) {}
+                adapter.submitData(it)
+            }
+        }
+
+        advanceUntilIdle()
+        var viewItems = adapter.snapshot().items
+
+        // Deleting first history item in the list.
+        val itemToDelete = viewItems.find { it is HistoryViewItem.HistoryItem }?.let {
+            (it as HistoryViewItem.HistoryItem)
+        } ?: throw RuntimeException()
+
+        val pendingDeletion = itemToDelete.data.toPendingDeletionHistory()
+        flow.setDeleteItems(setOf(pendingDeletion), setOf())
+
+        advanceUntilIdle()
+        viewItems = adapter.snapshot().items
+
+        assertNull(viewItems.find { it == itemToDelete })
+        job.cancel()
+    }
+
+    @Test
+    fun `WHEN data source is mixed GIVEN data set contains a header THEN every header has spacing above it`() {
+        testHeaderStopSpacing(null)
+    }
+
+    @Test
+    fun `WHEN data source is local GIVEN data set contains a header THEN every header has spacing above it`() {
+        testHeaderStopSpacing(false)
+    }
+
+    @Test
+    fun `WHEN data source is remote GIVEN data set contains a header THEN the first header does not have spacing above it`() {
+        testHeaderStopSpacing(true)
+    }
+
+    private fun testHeaderStopSpacing(isRemote: Boolean?) = runTest {
+        coEvery {
+            historyProvider.getHistory(0, 25, null)
+        } returns listOf(
+            createRegularHistory(
+                isRemote = false,
+                visitedAt = Calendar.getInstance().timeInMillis
+            ),
+            createRegularHistory(
+                isRemote = false,
+                visitedAt = Calendar.getInstance().apply {
+                    add(Calendar.DAY_OF_YEAR, -1)
+                }.timeInMillis
+            ),
+            createRegularHistory(
+                isRemote = false,
+                visitedAt = Calendar.getInstance().apply {
+                    add(Calendar.DAY_OF_YEAR, -4)
+                }.timeInMillis
+            ),
+            createRegularHistory(
+                isRemote = false,
+                visitedAt = Calendar.getInstance().apply {
+                    add(Calendar.DAY_OF_YEAR, -15)
+                }.timeInMillis
+            ),
+            createRegularHistory(
+                isRemote = false,
+                visitedAt = Calendar.getInstance().apply {
+                    add(Calendar.DAY_OF_YEAR, -35)
+                }.timeInMillis
+            ),
+        )
+
+        var adapter = HistoryAdapter(mockk()) {}
+        val flow = createHistoryViewItemFlow(isRemote = isRemote)
+        val job = launch {
+            flow.historyFlow.collectLatest {
+                adapter = HistoryAdapter(mockk()) {}
+                adapter.submitData(it)
+            }
+        }
+
+        advanceUntilIdle()
+        val viewItems = adapter.snapshot().items
+
+        if (isRemote == true) {
+            var previousItem: HistoryViewItem? = null
+            for (item in viewItems) {
+                if (item is HistoryViewItem.TimeGroupHeader) {
+                    assert(previousItem !is HistoryViewItem.TimeGroupSeparatorHistoryItem)
+                    break
+                }
+                previousItem = item
+            }
+        } else {
+            assert(
+                viewItems.count { it is HistoryViewItem.TimeGroupHeader } ==
+                    viewItems.count { it is HistoryViewItem.TimeGroupSeparatorHistoryItem }
+            )
+        }
+
+        job.cancel()
+    }
+
+    private fun createRegularHistory(
+        isRemote: Boolean = false,
+        visitedAt: Long = 1658496038799,
+    ) = HistoryDB.Regular(
+        title = "Internet for people, not profit",
+        url = "www.mozilla.org",
+        visitedAt = visitedAt,
+        selected = false,
+        isRemote = isRemote
+    )
+
+    private fun createHistoryViewItemFlow(
+        historyProvider: PagedHistoryProvider = this@HistoryViewItemFlowTest.historyProvider,
+        browserStore: BrowserStore = this@HistoryViewItemFlowTest.browserStore,
+        isRemote: Boolean? = null,
+        resources: Resources = testContext.resources,
+        accountManager: FxaAccountManager = this@HistoryViewItemFlowTest.accountManager,
+        scope: CoroutineScope = TestScope(),
+    ) = HistoryViewItemFlow(
+        historyProvider = historyProvider,
+        browserStore = browserStore,
+        isRemote = isRemote,
+        resources = resources,
+        accountManager = accountManager,
+        scope = scope,
+    )
+}

--- a/app/src/test/java/org/mozilla/fenix/library/history/HistoryViewItemFlowTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/history/HistoryViewItemFlowTest.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.fenix.library.history
 
 import android.content.res.Resources


### PR DESCRIPTION
Using all fancy new viewholders.

Main features: filtering of remote/local items inside `HistoryDataSource`, calculating headers to remove when items are being removed inside `HistoryAdapter`, tracking of the empty state in `HistoryAdapter`.

Comments on tests are especially welcomed.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.










### GitHub Automation
Fixes #26116