### PR TITLE
Bug 1781248 - Notify release-signoff@m.o when mobile builds are ready to be tested

### DIFF
--- a/taskcluster/ci/browsertime/kind.yml
+++ b/taskcluster/ci/browsertime/kind.yml
@@ -19,7 +19,7 @@ only-for-abis:
     - armeabi-v7a
     - arm64-v8a
 
-job-defaults:
+task-defaults:
     attributes:
         artifact_prefix: public/test_info
         nightly: true
@@ -100,7 +100,7 @@ job-defaults:
             - linux64-minidump-stackwalk
             - linux64-node-16
 
-jobs:
+tasks:
     tp6m:
         page-load-tests:
             - amazon

--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -13,7 +13,7 @@ kind-dependencies:
     - toolchain
 
 
-job-defaults:
+task-defaults:
     # Builds generate multiple APKs with different ABIs. For each APK described
     # by `gradlew printVariant`, an artifact will be generated. `variant` and
     # the per-apk config from `printVariant` can be used as substitutions in
@@ -44,7 +44,7 @@ job-defaults:
         chain-of-trust: true
 
 
-jobs:
+tasks:
     debug:
         attributes:
             code-review: true

--- a/taskcluster/ci/bump/kind.yml
+++ b/taskcluster/ci/bump/kind.yml
@@ -11,7 +11,7 @@ transforms:
     - taskgraph.transforms.job:transforms
     - taskgraph.transforms.task:transforms
 
-job-defaults:
+task-defaults:
     treeherder:
         kind: build
         symbol: bump(a-c)
@@ -40,7 +40,7 @@ job-defaults:
         max-run-time: 7200
         chain-of-trust: true
 
-jobs:
+tasks:
     android-components:
         attributes:
             bump-type: android-components

--- a/taskcluster/ci/complete/kind.yml
+++ b/taskcluster/ci/complete/kind.yml
@@ -14,11 +14,11 @@ transforms:
     - taskgraph.transforms.code_review:transforms
     - taskgraph.transforms.task:transforms
 
-job-defaults:
+task-defaults:
     worker-type: succeed
 
 
-jobs:
+tasks:
     pr:
         description: PR Summary Task
         run-on-tasks-for: [github-pull-request]

--- a/taskcluster/ci/docker-image/kind.yml
+++ b/taskcluster/ci/docker-image/kind.yml
@@ -10,7 +10,7 @@ transforms:
     - taskgraph.transforms.cached_tasks:transforms
     - taskgraph.transforms.task:transforms
 
-jobs:
+tasks:
     android-build:
         symbol: I(agb)
         parent: base

--- a/taskcluster/ci/fetch/kind.yml
+++ b/taskcluster/ci/fetch/kind.yml
@@ -9,10 +9,10 @@ transforms:
     - taskgraph.transforms.job:transforms
     - taskgraph.transforms.task:transforms
 
-job-defaults:
+task-defaults:
     docker-image: {in-tree: base}
 
-jobs:
+tasks:
     android-sdk-3859397:
         description: Android SDK
         fetch:

--- a/taskcluster/ci/geckoview/kind.yml
+++ b/taskcluster/ci/geckoview/kind.yml
@@ -4,12 +4,12 @@ transforms:
     - taskgraph.transforms.job:transforms
     - taskgraph.transforms.task:transforms
 
-job-defaults:
+task-defaults:
     worker-type: always-optimized
     run:
         using: index-search
 
-jobs:
+tasks:
     nightly:
         description: "upstream nightly job"
         run:

--- a/taskcluster/ci/lint/kind.yml
+++ b/taskcluster/ci/lint/kind.yml
@@ -13,7 +13,7 @@ kind-dependencies:
     - toolchain
 
 
-job-defaults:
+task-defaults:
     attributes:
         code-review: true
         retrigger: true
@@ -33,7 +33,7 @@ job-defaults:
         docker-image: {in-tree: base}
         max-run-time: 7200
 
-jobs:
+tasks:
     compare-locales:
         description: 'Validate strings.xml with compare-locales'
         run:

--- a/taskcluster/ci/release-notify-promote/kind.yml
+++ b/taskcluster/ci/release-notify-promote/kind.yml
@@ -1,0 +1,44 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+loader: taskgraph.loader.transform:loader
+
+transforms:
+    - fenix_taskgraph.transforms.release_deps:transforms
+    - taskgraph.transforms.release_notifications:transforms
+    - taskgraph.transforms.task:transforms
+
+kind-dependencies:
+    - push-apk
+
+primary-dependency: push-apk
+
+group-by: build-type
+
+only-for-build-types:
+    - beta
+    - release
+
+task-defaults:
+    attributes:
+        shipping_phase: promote
+    name: notify-release-drivers-promote
+    description: Sends email to release-drivers telling release was promoted.
+    worker-type: succeed
+    worker:
+        implementation: succeed
+    notifications:
+        subject: "{config[params][project]} {config[params][version]} build{config[params][build_number]} has been pushed to the closed testing track on Google Play"
+        emails:
+            by-level:
+                '3': ["release-signoff@mozilla.org"]
+                default: ["{config[params][owner]}"]
+
+tasks:
+    beta:
+        attributes:
+            release-type: beta
+    release:
+        attributes:
+            release-type: release

--- a/taskcluster/ci/release-notify-ship/kind.yml
+++ b/taskcluster/ci/release-notify-ship/kind.yml
@@ -1,0 +1,47 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+loader: taskgraph.loader.transform:loader
+
+transforms:
+    - fenix_taskgraph.transforms.release_deps:transforms
+    - taskgraph.transforms.release_notifications:transforms
+    - taskgraph.transforms.task:transforms
+
+kind-dependencies:
+    - push-apk
+    - github-release
+    - version-bump
+    - mark-as-shipped
+
+primary-dependency: push-apk
+
+group-by: build-type
+
+only-for-build-types:
+    - beta
+    - release
+
+task-defaults:
+    attributes:
+        shipping_phase: ship
+    name: notify-release-drivers-ship
+    description: Sends email to release-drivers telling release was shipped.
+    worker-type: succeed
+    worker:
+        implementation: succeed
+    notifications:
+        subject: "{config[params][project]} {config[params][version]} build{config[params][build_number]} has been tagged in GitHub"
+        emails:
+            by-level:
+                '3': ["release-signoff@mozilla.org"]
+                default: ["{config[params][owner]}"]
+
+tasks:
+    beta:
+        attributes:
+            release-type: beta
+    release:
+        attributes:
+            release-type: release

--- a/taskcluster/ci/startup-test/kind.yml
+++ b/taskcluster/ci/startup-test/kind.yml
@@ -8,8 +8,8 @@ transforms:
     - taskgraph.transforms.job:transforms
     - taskgraph.transforms.task:transforms
 
-job-defaults:
-    description: Run a simple UI test to verify Nightly build can start 
+task-defaults:
+    description: Run a simple UI test to verify Nightly build can start
     treeherder:
         kind: test
         platform: 'nightly-start-test/opt'
@@ -35,7 +35,7 @@ job-defaults:
               json: true
     run-on-tasks-for: []
     attributes:
-        build-type: nightly 
+        build-type: nightly
         # cannot safely run this in Firebase
         # turning off til we can safely run test in taskcluster
         # https://github.com/mozilla-mobile/fenix/issues/7702
@@ -44,7 +44,7 @@ job-defaults:
         signing: signing-nightly
         signing-android-test: signing-android-test-nightly
 
-jobs:
+tasks:
     nightly-x86:
         run:
             commands:

--- a/taskcluster/ci/test/kind.yml
+++ b/taskcluster/ci/test/kind.yml
@@ -13,13 +13,13 @@ kind-dependencies:
     - toolchain
 
 
-job-defaults:
+task-defaults:
     attributes:
         retrigger: true
     description: Test Fenix
     extra:
         notify:
-            slackBlocks: | 
+            slackBlocks: |
                 [
                   {
                     "type": "header",
@@ -37,7 +37,7 @@ job-defaults:
                          "type": "mrkdwn",
                          "text": "*Task*: <https://firefox-ci-tc.services.mozilla.com/tasks/${status.taskId}|Taskcluster>"
                     }
-                  },                  
+                  },
                   {
                     "type": "section",
                     "text": {
@@ -93,7 +93,7 @@ job-defaults:
         docker-image: {in-tree: base}
         max-run-time: 7200
 
-jobs:
+tasks:
     debug:
         attributes:
             build-type: debug

--- a/taskcluster/ci/toolchain/android.yml
+++ b/taskcluster/ci/toolchain/android.yml
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 ---
-job-defaults:
+task-defaults:
     run:
         using: toolchain-script
     treeherder:

--- a/taskcluster/ci/toolchain/gecko-derived.yml
+++ b/taskcluster/ci/toolchain/gecko-derived.yml
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 ---
-job-defaults:
+task-defaults:
     run:
         using: index-search
     run-on-projects: []

--- a/taskcluster/ci/toolchain/kind.yml
+++ b/taskcluster/ci/toolchain/kind.yml
@@ -13,6 +13,6 @@ transforms:
     - taskgraph.transforms.task:transforms
 
 
-jobs-from:
+tasks-from:
     - android.yml
     - gecko-derived.yml

--- a/taskcluster/ci/ui-test/kind.yml
+++ b/taskcluster/ci/ui-test/kind.yml
@@ -9,7 +9,7 @@ transforms:
     - taskgraph.transforms.job:transforms
     - taskgraph.transforms.task:transforms
 
-job-defaults:
+task-defaults:
     attributes:
         build-type: debug
         code-review: true
@@ -44,7 +44,7 @@ job-defaults:
                          "type": "mrkdwn",
                          "text": "*Task*: <https://firefox-ci-tc.services.mozilla.com/tasks/${status.taskId}|Taskcluster>"
                     }
-                  },                  
+                  },
                   {
                     "type": "section",
                     "text": {
@@ -100,7 +100,7 @@ job-defaults:
         retry-exit-status: [20]
     worker-type: b-android
 
-jobs:
+tasks:
     x86-debug:
         description: Test Fenix
         run-on-tasks-for: [github-pull-request, github-push]

--- a/taskcluster/fenix_taskgraph/parameters.py
+++ b/taskcluster/fenix_taskgraph/parameters.py
@@ -13,17 +13,12 @@ extend_parameters_schema(
         Required("pull_request_number"): Any(All(int, Range(min=1)), None),
         Required("release_type", default=""): str,
         Optional("shipping_phase"): Any("build", "promote", "ship", None),
-        Required("version", default=""): str,
-        Required("next_version", default=""): Any(None, str),
     }
 )
 
 
 def get_decision_parameters(graph_config, parameters):
     parameters.setdefault("release_type", "")
-    head_tag = parameters["head_tag"]
-    parameters["version"] = head_tag[1:] if head_tag else ""
 
     pr_number = os.environ.get("MOBILE_PULL_REQUEST_NUMBER", None)
     parameters["pull_request_number"] = None if pr_number is None else int(pr_number)
-    parameters.setdefault("next_version", None)

--- a/taskcluster/fenix_taskgraph/release_promotion.py
+++ b/taskcluster/fenix_taskgraph/release_promotion.py
@@ -28,9 +28,9 @@ def is_release_promotion_available(parameters):
 
 @register_callback_action(
     name="release-promotion",
-    title="Ship Fenix",
+    title="Release Promotion",
     symbol="${input.release_promotion_flavor}",
-    description="Ship Fenix",
+    description="Promote a release.",
     generic=False,
     order=500,
     context=[],

--- a/taskcluster/fenix_taskgraph/transforms/mark_as_shipped.py
+++ b/taskcluster/fenix_taskgraph/transforms/mark_as_shipped.py
@@ -28,15 +28,15 @@ def resolve_keys(config, tasks):
 
 
 @transforms.add
-def make_task_description(config, jobs):
-    for job in jobs:
+def make_task_description(config, tasks):
+    for task in tasks:
         product = "Fenix"
         version = config.params["version"] or "{ver}"
-        job["worker"][
+        task["worker"][
             "release-name"
         ] = "{product}-{version}-build{build_number}".format(
             product=product,
             version=version,
             build_number=config.params.get("build_number", 1),
         )
-        yield job
+        yield task

--- a/taskcluster/fenix_taskgraph/transforms/release_deps.py
+++ b/taskcluster/fenix_taskgraph/transforms/release_deps.py
@@ -1,0 +1,45 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+"""
+Add dependencies to release tasks.
+"""
+
+from taskgraph.transforms.base import TransformSequence
+
+PHASES = ["build", "promote", "push", "ship"]
+
+transforms = TransformSequence()
+
+
+@transforms.add
+def add_dependencies(config, tasks):
+    for task in tasks:
+        dependencies = {}
+        # Add any kind_dependencies_tasks with matching release_type as dependencies
+        release_type = task["attributes"].get("release-type")
+        phase = task["attributes"].get("shipping_phase")
+        if release_type is None:
+            continue
+
+        for dep_task in config.kind_dependencies_tasks:
+            # Weed out unwanted tasks.
+            # XXX we have run-on-projects which specifies the on-push behavior;
+            # we need another attribute that specifies release promotion,
+            # possibly which action(s) each task belongs in.
+
+            # We can only depend on tasks in the current or previous phases
+            dep_phase = dep_task.attributes.get("shipping_phase")
+            if dep_phase and PHASES.index(dep_phase) > PHASES.index(phase):
+                continue
+
+            # Add matching release_type tasks to deps
+            if (
+                dep_task.task.get("release-type") == release_type
+                or dep_task.attributes.get("release-type") == release_type
+            ):
+                dependencies[dep_task.label] = dep_task.label
+
+        task.setdefault("dependencies", {}).update(dependencies)
+
+        yield task

--- a/taskcluster/requirements.in
+++ b/taskcluster/requirements.in
@@ -1,6 +1,6 @@
 # For instructions on managing dependencies, see:
 # https://taskcluster-taskgraph.readthedocs.io/en/latest/howto/bootstrap-taskgraph.html
 
-taskcluster-taskgraph>=1.3.1
+taskcluster-taskgraph
 mozilla-version
 redo

--- a/taskcluster/requirements.txt
+++ b/taskcluster/requirements.txt
@@ -8,9 +8,9 @@ appdirs==1.4.4 \
     --hash=sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41 \
     --hash=sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128
     # via taskcluster-taskgraph
-attrs==21.4.0 \
-    --hash=sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4 \
-    --hash=sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd
+attrs==22.1.0 \
+    --hash=sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6 \
+    --hash=sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c
     # via
     #   mozilla-version
     #   taskcluster-taskgraph
@@ -91,18 +91,18 @@ slugid==2.0.0 \
     --hash=sha256:a950d98b72691178bdd4d6c52743c4a2aa039207cf7a97d71060a111ff9ba297 \
     --hash=sha256:aec8b0e01c4ad32e38e12d609eab3ec912fd129aaf6b2ded0199b56a5f8fd67c
     # via taskcluster-taskgraph
-taskcluster-taskgraph==1.7.1 \
-    --hash=sha256:736054efee8c56987417d4ad2960cfc99c91338253580eadece072a43e042718 \
-    --hash=sha256:9cb13e19ddf74331c51a9f1dd68afde179f148e7856269e8e5f6182e0a2e5732
+taskcluster-taskgraph==2.0.0 \
+    --hash=sha256:3d22ab488071ddc82997b33fc6c1c524a44bdc7e14b30a274d99dbbdd7389502 \
+    --hash=sha256:93eff40ba39a29cd290fc25a2124ed9bf5806d87891edd7e8de35df568708141
     # via -r requirements.in
 taskcluster-urls==13.0.1 \
     --hash=sha256:5e25e7e6818e8877178b175ff43d2e6548afad72694aa125f404a7329ece0973 \
     --hash=sha256:b25e122ecec249c4299ac7b20b08db76e3e2025bdaeb699a9d444556de5fd367 \
     --hash=sha256:f66dcbd6572a6216ab65949f0fa0b91f2df647918028436c384e6af5cd12ae2b
     # via taskcluster-taskgraph
-urllib3==1.26.9 \
-    --hash=sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14 \
-    --hash=sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e
+urllib3==1.26.11 \
+    --hash=sha256:c33ccba33c819596124764c23a97d25f32b28433ba0dedeb77d873a38722c9bc \
+    --hash=sha256:ea6e8fb210b19d950fab93b60c9009226c63a28808bc8386e05301e25883ac0a
     # via requests
 voluptuous==0.13.1 \
     --hash=sha256:4b838b185f5951f2d6e8752b68fcf18bd7a9c26ded8f143f92d6d28f3921a3e6 \


### PR DESCRIPTION
Depends on https://github.com/taskcluster/taskgraph/pull/85 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
