### PR TITLE
For #25837 - Invalidate cached nimbusValidation values when changing locale settings

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/advanced/DefaultLocaleSettingsController.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/advanced/DefaultLocaleSettingsController.kt
@@ -8,6 +8,7 @@ import android.app.Activity
 import android.content.Context
 import mozilla.components.support.locale.LocaleManager
 import mozilla.components.support.locale.LocaleUseCases
+import org.mozilla.fenix.nimbus.FxNimbus
 import java.util.Locale
 
 interface LocaleSettingsController {
@@ -31,6 +32,9 @@ class DefaultLocaleSettingsController(
         localeSettingsStore.dispatch(LocaleSettingsAction.Select(locale))
         LocaleManager.setNewLocale(activity, localeUseCase, locale)
         LocaleManager.updateBaseConfiguration(activity, locale)
+
+        // Invalidate cached values to use the new locale
+        FxNimbus.features.nimbusValidation.withCachedValue(null)
         activity.recreate()
         activity.overridePendingTransition(0, 0)
     }
@@ -42,6 +46,9 @@ class DefaultLocaleSettingsController(
         localeSettingsStore.dispatch(LocaleSettingsAction.Select(localeSettingsStore.state.localeList[0]))
         LocaleManager.resetToSystemDefault(activity, localeUseCase)
         LocaleManager.updateBaseConfiguration(activity, localeSettingsStore.state.localeList[0])
+
+        // Invalidate cached values to use the default locale
+        FxNimbus.features.nimbusValidation.withCachedValue(null)
         activity.recreate()
         activity.overridePendingTransition(0, 0)
     }


### PR DESCRIPTION
Invalidate `nimbusValidation` values when handling locale selected. `nimbusValidation.settingsTitle` should update with the locale translated settings title.

https://user-images.githubusercontent.com/35462038/181785020-6dc8d4e4-6134-4958-a918-d993286dc0f6.mp4

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
Fixes #25837