### PR TITLE
Fixes: #26052 remove WallpaperManager::updateWallpaper

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
@@ -11,7 +11,6 @@ import androidx.test.uiautomator.Until
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.helpers.HomeActivityTestRule
 import org.mozilla.fenix.helpers.RetryTestRule
@@ -152,21 +151,6 @@ class HomeScreenTest {
             verifyKeyboardVisibility()
         }.dismissSearchBar {
             verifyWelcomeHeader()
-        }
-    }
-
-    @SmokeTest
-    @Test
-    fun tapLogoToChangeWallpaperTest() {
-        homeScreen {
-            clickFirefoxLogo()
-            verifyWallpaperImageApplied(true)
-            clickFirefoxLogo()
-            verifyWallpaperImageApplied(true)
-            clickFirefoxLogo()
-            verifyWallpaperImageApplied(true)
-            clickFirefoxLogo()
-            verifyWallpaperImageApplied(false)
         }
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -120,7 +120,7 @@ import org.mozilla.fenix.tabstray.TabsTrayAccessPoint
 import org.mozilla.fenix.utils.Settings.Companion.TOP_SITES_PROVIDER_MAX_THRESHOLD
 import org.mozilla.fenix.utils.ToolbarPopupWindow
 import org.mozilla.fenix.utils.allowUndo
-import org.mozilla.fenix.wallpapers.WallpaperManager
+import org.mozilla.fenix.wallpapers.Wallpaper
 import java.lang.ref.WeakReference
 import kotlin.math.min
 
@@ -754,10 +754,6 @@ class HomeFragment : Fragment() {
                         themeCollection = newWallpaper::class.simpleName
                     )
                 )
-                manager.updateWallpaper(
-                    wallpaperContainer = binding.wallpaperImageView,
-                    newWallpaper = newWallpaper
-                )
             }
         }
     }
@@ -967,12 +963,17 @@ class HomeFragment : Fragment() {
                 .onEach { state ->
                     // We only want to update the wallpaper when it's different from the default one
                     // as the default is applied already on xml by default.
-                    val currentWallpaper = state.wallpaperState.currentWallpaper
-                    if (currentWallpaper != WallpaperManager.defaultWallpaper) {
-                        requireComponents.wallpaperManager.updateWallpaper(
-                            binding.wallpaperImageView,
-                            currentWallpaper
-                        )
+                    when (val currentWallpaper = state.wallpaperState.currentWallpaper) {
+                        is Wallpaper.Default -> {
+                            binding.wallpaperImageView.visibility = View.GONE
+                        }
+                        else -> {
+                            with(requireComponents.wallpaperManager) {
+                                val bitmap = currentWallpaper.load(requireContext()) ?: return@onEach
+                                bitmap.scaleBitmapToBottomOfView(binding.wallpaperImageView)
+                            }
+                            binding.wallpaperImageView.visibility = View.VISIBLE
+                        }
                     }
                 }
                 .launchIn(viewLifecycleOwner.lifecycleScope)

--- a/app/src/main/java/org/mozilla/fenix/settings/wallpaper/WallpaperSettings.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/wallpaper/WallpaperSettings.kt
@@ -297,8 +297,8 @@ private fun WallpaperThumbnailsPreview() {
 
         WallpaperSettings(
             defaultWallpaper = WallpaperManager.defaultWallpaper,
-            loadWallpaperResource = {
-                wallpaperManager.loadSavedWallpaper(context, it)
+            loadWallpaperResource = { wallpaper ->
+                with(wallpaperManager) { wallpaper.load(context) }
             },
             wallpapers = wallpaperManager.wallpapers,
             selectedWallpaper = wallpaperManager.currentWallpaper,

--- a/app/src/main/java/org/mozilla/fenix/settings/wallpaper/WallpaperSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/wallpaper/WallpaperSettingsFragment.kt
@@ -49,8 +49,8 @@ class WallpaperSettingsFragment : Fragment() {
                     WallpaperSettings(
                         wallpapers = wallpaperManager.wallpapers,
                         defaultWallpaper = WallpaperManager.defaultWallpaper,
-                        loadWallpaperResource = {
-                            wallpaperManager.loadSavedWallpaper(requireContext(), it)
+                        loadWallpaperResource = { wallpaper ->
+                            with(wallpaperManager) { wallpaper.load(context) }
                         },
                         selectedWallpaper = currentWallpaper,
                         onSelectWallpaper = { selectedWallpaper: Wallpaper ->

--- a/app/src/main/java/org/mozilla/fenix/wallpapers/WallpaperManager.kt
+++ b/app/src/main/java/org/mozilla/fenix/wallpapers/WallpaperManager.kt
@@ -59,30 +59,6 @@ class WallpaperManager(
     }
 
     /**
-     * Apply the [newWallpaper] into the [wallpaperContainer] and update the [currentWallpaper].
-     */
-    fun updateWallpaper(wallpaperContainer: ImageView, newWallpaper: Wallpaper) {
-        val context = wallpaperContainer.context
-        if (newWallpaper == defaultWallpaper) {
-            wallpaperContainer.visibility = View.GONE
-            logger.info("Wallpaper update to default background")
-        } else {
-            val bitmap = loadSavedWallpaper(context, newWallpaper)
-            if (bitmap == null) {
-                val message = "Could not load wallpaper bitmap. Resetting to default."
-                logger.error(message)
-                currentWallpaper = defaultWallpaper
-                wallpaperContainer.visibility = View.GONE
-                return
-            } else {
-                wallpaperContainer.visibility = View.VISIBLE
-                scaleBitmapToBottom(bitmap, wallpaperContainer)
-            }
-        }
-        currentWallpaper = newWallpaper
-    }
-
-    /**
      * Download all known remote wallpapers.
      */
     suspend fun downloadAllRemoteWallpapers() {
@@ -104,7 +80,7 @@ class WallpaperManager(
         } else {
             values[index]
         }.also {
-            appStore.dispatch(AppAction.WallpaperAction.UpdateCurrentWallpaper(it))
+            currentWallpaper = it
         }
     }
 
@@ -139,10 +115,10 @@ class WallpaperManager(
     /**
      * Load a wallpaper that is saved locally.
      */
-    fun loadSavedWallpaper(context: Context, wallpaper: Wallpaper): Bitmap? =
-        when (wallpaper) {
-            is Wallpaper.Local -> loadWallpaperFromDrawables(context, wallpaper)
-            is Wallpaper.Remote -> loadWallpaperFromDisk(context, wallpaper)
+    fun Wallpaper.load(context: Context): Bitmap? =
+        when (this) {
+            is Wallpaper.Local -> loadWallpaperFromDrawables(context, this)
+            is Wallpaper.Remote -> loadWallpaperFromDisk(context, this)
             else -> null
         }
 
@@ -163,7 +139,14 @@ class WallpaperManager(
         }
     }.getOrNull()
 
-    private fun scaleBitmapToBottom(bitmap: Bitmap, view: ImageView) {
+    /**
+     * This will scale the received [Bitmap] to the size of the [view]. It retains the bitmap's
+     * original aspect ratio, but will shrink or enlarge it to fit the viewport. If bitmap does not
+     * correctly fit the aspect ratio of the view, it will be shifted to prioritize the bottom-left
+     * of the bitmap.
+     */
+    fun Bitmap.scaleBitmapToBottomOfView(view: ImageView) {
+        val bitmap = this
         view.setImageBitmap(bitmap)
         view.scaleType = ImageView.ScaleType.MATRIX
         val matrix = Matrix()


### PR DESCRIPTION
This is part of https://github.com/mozilla-mobile/fenix/issues/26034. The main point of this PR was to remove `updateWallpaper`, which included the side-effect of updating the `currentWallpaper`, which should instead now be handled by dispatching the `UpdateCurrentWallpaper`.

The next step will likely be to refactor the `WallpaperManager` into a `WallpaperUseCase`, as filed in https://github.com/mozilla-mobile/fenix/issues/26245. That patch will probably introduce the largest number of changes in this initiative.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.








### GitHub Automation
Fixes #26052