### PR TITLE
Closes #26185: add telemetry events for synced history screen

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -3244,6 +3244,247 @@ history:
       - android-probes@mozilla.com
     expires: 112
 
+synced_history:
+  opened:
+    type: event
+    description: |
+      A user opened the synced history screen
+    bugs:
+      - https://github.com/mozilla-mobile/fenix/issues/26185
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/issues/26185
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: 117
+    metadata:
+      tags:
+        - History
+  removed:
+    type: event
+    description: |
+      A user removed a synced history item
+    bugs:
+      - https://github.com/mozilla-mobile/fenix/issues/26185
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/issues/26185
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: 117
+    metadata:
+      tags:
+        - History
+  removed_all:
+    type: event
+    description: |
+      A user removed all history items
+    bugs:
+      - https://github.com/mozilla-mobile/fenix/issues/26185
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/issues/26185
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: 117
+    metadata:
+      tags:
+        - History
+  removed_last_hour:
+    type: event
+    description: |
+      A user removed history items opened during last hour.
+    bugs:
+      - https://github.com/mozilla-mobile/fenix/issues/26185
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/issues/26185
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: 117
+    metadata:
+      tags:
+        - History
+  removed_today_and_yesterday:
+    type: event
+    description: |
+      A user removed history items opened that day and the day before.
+    bugs:
+      - https://github.com/mozilla-mobile/fenix/issues/26185
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/issues/26185
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: 117
+    metadata:
+      tags:
+        - History
+  remove_prompt_opened:
+    type: event
+    description: |
+      A user opened delete history prompt.
+    bugs:
+      - https://github.com/mozilla-mobile/fenix/issues/26185
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/issues/26185
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: 117
+    metadata:
+      tags:
+        - History
+  remove_prompt_cancelled:
+    type: event
+    description: |
+      A user cancelled delete history prompt.
+    bugs:
+      - https://github.com/mozilla-mobile/fenix/issues/26185
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/issues/26185
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: 117
+    metadata:
+      tags:
+        - History
+  shared:
+    type: event
+    description: |
+      A user shared a synced history item
+    bugs:
+      - https://github.com/mozilla-mobile/fenix/issues/26185
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/issues/26185
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: 117
+    metadata:
+      tags:
+        - History
+  opened_item:
+    type: event
+    description: |
+      A user opened a synced history item
+    bugs:
+      - https://github.com/mozilla-mobile/fenix/issues/26185
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/issues/26185
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+      - erichards@mozilla.com
+    expires: never
+    metadata:
+      tags:
+        - History
+  opened_item_in_new_tab:
+    type: event
+    description: |
+      A user opened a synced history item in a new tab
+    bugs:
+      - https://github.com/mozilla-mobile/fenix/issues/26185
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/issues/26185
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+      - erichards@mozilla.com
+    expires: never
+    metadata:
+      tags:
+        - History
+  opened_items_in_new_tabs:
+    type: event
+    description: |
+      A user opened multiple synced history items in new tabs
+    bugs:
+      - https://github.com/mozilla-mobile/fenix/issues/26185
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/issues/26185
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+      - erichards@mozilla.com
+    expires: never
+    metadata:
+      tags:
+        - History
+  opened_item_in_private_tab:
+    type: event
+    description: |
+      A user opened a synced history item in a private tab
+    bugs:
+      - https://github.com/mozilla-mobile/fenix/issues/26185
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/issues/26185
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+      - erichards@mozilla.com
+    expires: never
+    metadata:
+      tags:
+        - History
+  opened_items_in_private_tabs:
+    type: event
+    description: |
+      A user opened multiple synced history items in private tabs
+    bugs:
+      - https://github.com/mozilla-mobile/fenix/issues/26185
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/issues/26185
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+      - erichards@mozilla.com
+    expires: never
+    metadata:
+      tags:
+        - History
+  search_icon_tapped:
+    type: event
+    description: |
+      A user tapped on the search icon in synced history.
+    bugs:
+      - https://github.com/mozilla-mobile/fenix/issues/26185
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/issues/26185
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: 117
+  search_result_tapped:
+    type: event
+    description: |
+      A user tapped on the search result in synced history.
+    bugs:
+      - https://github.com/mozilla-mobile/fenix/issues/26185
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/issues/26185
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: 117
+
 recently_closed_tabs:
   opened:
     type: event


### PR DESCRIPTION
Closes #26185 

draft 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
Fixes #26185