### PR TITLE
Revert "Remove search term tab groups from the homepage"

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -93,6 +93,7 @@ import org.mozilla.fenix.perf.StrictModeManager
 import org.mozilla.fenix.perf.lazyMonitored
 import org.mozilla.fenix.settings.SupportUtils
 import org.mozilla.fenix.settings.advanced.getSelectedLocale
+import org.mozilla.fenix.tabstray.SearchTermTabGroupMiddleware
 import org.mozilla.fenix.telemetry.TelemetryMiddleware
 import org.mozilla.fenix.utils.getUndoDelay
 import org.mozilla.geckoview.GeckoRuntime
@@ -246,6 +247,7 @@ class Core(
                 AdsTelemetryMiddleware(adsTelemetry),
                 LastMediaAccessMiddleware(),
                 HistoryMetadataMiddleware(historyMetadataService),
+                SearchTermTabGroupMiddleware()
             ) + if (tabsPrioritizationEnable) {
                 listOf(SessionPrioritizationMiddleware())
             } else {

--- a/app/src/main/java/org/mozilla/fenix/components/appstate/AppAction.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/appstate/AppAction.kt
@@ -60,6 +60,7 @@ sealed class AppAction : Action {
     data class RemoveRecentBookmark(val recentBookmark: RecentBookmark) : AppAction()
     data class RecentHistoryChange(val recentHistory: List<RecentlyVisitedItem>) : AppAction()
     data class RemoveRecentHistoryHighlight(val highlightUrl: String) : AppAction()
+    data class DisbandSearchGroupAction(val searchTerm: String) : AppAction()
     /**
      * Indicates the given [categoryName] was selected by the user.
      */

--- a/app/src/main/java/org/mozilla/fenix/components/appstate/AppStoreReducer.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/appstate/AppStoreReducer.kt
@@ -4,15 +4,18 @@
 
 package org.mozilla.fenix.components.appstate
 
+import androidx.annotation.VisibleForTesting
 import mozilla.components.service.pocket.PocketStory.PocketRecommendedStory
 import mozilla.components.service.pocket.PocketStory.PocketSponsoredStory
 import mozilla.components.service.pocket.ext.recordNewImpression
 import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.ext.filterOutTab
 import org.mozilla.fenix.ext.getFilteredStories
+import org.mozilla.fenix.ext.recentSearchGroup
 import org.mozilla.fenix.gleanplumb.state.MessagingReducer
 import org.mozilla.fenix.home.pocket.PocketRecommendedStoriesSelectedCategory
 import org.mozilla.fenix.home.recentvisits.RecentlyVisitedItem
+import org.mozilla.fenix.home.recentvisits.RecentlyVisitedItem.RecentHistoryGroup
 
 /**
  * Reducer for [AppStore].
@@ -85,6 +88,14 @@ internal object AppStoreReducer {
         is AppAction.RemoveRecentHistoryHighlight -> state.copy(
             recentHistory = state.recentHistory.filterNot {
                 it is RecentlyVisitedItem.RecentHistoryHighlight && it.url == action.highlightUrl
+            }
+        )
+        is AppAction.DisbandSearchGroupAction -> state.copy(
+            recentHistory = state.recentHistory.filterNot {
+                it is RecentHistoryGroup && (
+                    it.title.equals(action.searchTerm, true) ||
+                        it.title.equals(state.recentSearchGroup?.searchTerm, true)
+                    )
             }
         )
         is AppAction.SelectPocketStoriesCategory -> {
@@ -192,5 +203,18 @@ internal object AppStoreReducer {
             state.copy(
                 wallpaperState = state.wallpaperState.copy(availableWallpapers = action.wallpapers)
             )
+    }
+}
+
+/**
+ * Removes a [RecentHistoryGroup] identified by [groupTitle] if it exists in the current list.
+ *
+ * @param groupTitle [RecentHistoryGroup.title] of the item that should be removed.
+ */
+@VisibleForTesting
+internal fun List<RecentlyVisitedItem>.filterOut(groupTitle: String?): List<RecentlyVisitedItem> {
+    return when (groupTitle != null) {
+        true -> filterNot { it is RecentHistoryGroup && it.title.equals(groupTitle, true) }
+        false -> this
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/components/appstate/AppStoreReducer.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/appstate/AppStoreReducer.kt
@@ -12,10 +12,11 @@ import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.ext.filterOutTab
 import org.mozilla.fenix.ext.getFilteredStories
 import org.mozilla.fenix.ext.recentSearchGroup
-import org.mozilla.fenix.gleanplumb.state.MessagingReducer
 import org.mozilla.fenix.home.pocket.PocketRecommendedStoriesSelectedCategory
+import org.mozilla.fenix.home.recenttabs.RecentTab
 import org.mozilla.fenix.home.recentvisits.RecentlyVisitedItem
 import org.mozilla.fenix.home.recentvisits.RecentlyVisitedItem.RecentHistoryGroup
+import org.mozilla.fenix.gleanplumb.state.MessagingReducer
 
 /**
  * Reducer for [AppStore].
@@ -43,7 +44,12 @@ internal object AppStoreReducer {
             topSites = action.topSites,
             recentBookmarks = action.recentBookmarks,
             recentTabs = action.recentTabs,
-            recentHistory = action.recentHistory,
+            recentHistory = if (action.recentHistory.isNotEmpty() && action.recentTabs.isNotEmpty()) {
+                val recentSearchGroup = action.recentTabs.find { it is RecentTab.SearchGroup } as RecentTab.SearchGroup?
+                action.recentHistory.filterOut(recentSearchGroup?.searchTerm)
+            } else {
+                action.recentHistory
+            }
         )
         is AppAction.CollectionExpanded -> {
             val newExpandedCollection = state.expandedCollections.toMutableSet()
@@ -63,9 +69,10 @@ internal object AppStoreReducer {
             state.copy(showCollectionPlaceholder = false)
         }
         is AppAction.RecentTabsChange -> {
+            val recentSearchGroup = action.recentTabs.find { it is RecentTab.SearchGroup } as RecentTab.SearchGroup?
             state.copy(
                 recentTabs = action.recentTabs,
-                recentHistory = state.recentHistory,
+                recentHistory = state.recentHistory.filterOut(recentSearchGroup?.searchTerm)
             )
         }
         is AppAction.RemoveRecentTab -> {
@@ -83,7 +90,7 @@ internal object AppStoreReducer {
             state.copy(recentBookmarks = state.recentBookmarks.filterNot { it.url == action.recentBookmark.url })
         }
         is AppAction.RecentHistoryChange -> state.copy(
-            recentHistory = action.recentHistory
+            recentHistory = action.recentHistory.filterOut(state.recentSearchGroup?.searchTerm)
         )
         is AppAction.RemoveRecentHistoryHighlight -> state.copy(
             recentHistory = state.recentHistory.filterNot {

--- a/app/src/main/java/org/mozilla/fenix/ext/AppState.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/AppState.kt
@@ -16,6 +16,7 @@ import org.mozilla.fenix.home.pocket.POCKET_STORIES_DEFAULT_CATEGORY_NAME
 import org.mozilla.fenix.home.pocket.PocketRecommendedStoriesCategory
 import org.mozilla.fenix.home.pocket.PocketStory
 import org.mozilla.fenix.home.recentsyncedtabs.RecentSyncedTabState
+import org.mozilla.fenix.home.recenttabs.RecentTab.SearchGroup
 import org.mozilla.fenix.utils.Settings
 
 /**
@@ -160,6 +161,13 @@ internal fun getFilteredSponsoredStories(
         .take(limit)
         .toList()
 }
+
+/**
+ * Get the [SearchGroup] shown in the "Jump back in" section.
+ * May be null if no search group is shown.
+ */
+internal val AppState.recentSearchGroup: SearchGroup?
+    get() = recentTabs.find { it is SearchGroup } as SearchGroup?
 
 /**
  * Filter a [AppState] by the blocklist.

--- a/app/src/main/java/org/mozilla/fenix/ext/RecentTabs.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/RecentTabs.kt
@@ -8,7 +8,7 @@ import androidx.annotation.VisibleForTesting
 import org.mozilla.fenix.home.recenttabs.RecentTab
 
 /**
- * Removes a [RecentTab.Tab] from a list of [RecentTab].
+ * Removes a [RecentTab.Tab] from a list of [RecentTab]. [RecentTab.SearchGroup]s will not be filtered.
  *
  * @param tab [RecentTab] to remove from the list
  */

--- a/app/src/main/java/org/mozilla/fenix/home/recenttabs/RecentTabsListFeature.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recenttabs/RecentTabsListFeature.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.fenix.home.recenttabs
 
+import android.graphics.Bitmap
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -44,4 +45,21 @@ sealed class RecentTab {
      * @param state Recently viewed [TabSessionState]
      */
     data class Tab(val state: TabSessionState) : RecentTab()
+
+    /**
+     * A search term group that was recently viewed
+     *
+     * @param searchTerm The search term that was recently viewed. Forced to start with uppercase.
+     * @param tabId The id of the tab that was recently viewed
+     * @param url The url that was recently viewed
+     * @param thumbnail The thumbnail of the search term that was recently viewed
+     * @param count The number of tabs in the search term group
+     */
+    data class SearchGroup(
+        val searchTerm: String,
+        val tabId: String,
+        val url: String,
+        val thumbnail: Bitmap?,
+        val count: Int
+    ) : RecentTab()
 }

--- a/app/src/main/java/org/mozilla/fenix/home/recenttabs/RecentTabsListFeature.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recenttabs/RecentTabsListFeature.kt
@@ -7,6 +7,7 @@ package org.mozilla.fenix.home.recenttabs
 import android.graphics.Bitmap
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.map
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.TabSessionState
@@ -28,7 +29,8 @@ class RecentTabsListFeature(
 ) : AbstractBinding<BrowserState>(browserStore) {
 
     override suspend fun onState(flow: Flow<BrowserState>) {
-        // Listen for changes regarding the currently selected tab and in progress media tab.
+        // Listen for changes regarding the currently selected tab, in progress media tab
+        // and search term groups.
         flow
             .map { it.asRecentTabs() }
             .ifChanged()

--- a/app/src/main/java/org/mozilla/fenix/home/recenttabs/controller/RecentTabController.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recenttabs/controller/RecentTabController.kt
@@ -10,7 +10,7 @@ import androidx.navigation.NavController
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.feature.tabs.TabsUseCases.SelectTabUseCase
 import mozilla.components.service.glean.private.NoExtras
-import org.mozilla.fenix.GleanMetrics.RecentTabs
+import org.mozilla.fenix.GleanMetrics.SearchTerms
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.components.appstate.AppAction
@@ -18,6 +18,7 @@ import org.mozilla.fenix.ext.inProgressMediaTab
 import org.mozilla.fenix.home.HomeFragmentDirections
 import org.mozilla.fenix.home.recenttabs.RecentTab
 import org.mozilla.fenix.home.recenttabs.interactor.RecentTabInteractor
+import org.mozilla.fenix.GleanMetrics.RecentTabs as RecentTabs
 
 /**
  * An interface that handles the view manipulation of the recent tabs in the Home screen.
@@ -28,6 +29,11 @@ interface RecentTabController {
      * @see [RecentTabInteractor.onRecentTabClicked]
      */
     fun handleRecentTabClicked(tabId: String)
+
+    /**
+     * @see [RecentTabInteractor.onRecentSearchGroupClicked]
+     */
+    fun handleRecentSearchGroupClicked(tabId: String)
 
     /**
      * @see [RecentTabInteractor.onRecentTabShowAllClicked]
@@ -68,6 +74,15 @@ class DefaultRecentTabsController(
         dismissSearchDialogIfDisplayed()
         RecentTabs.showAllClicked.record(NoExtras())
         navController.navigate(HomeFragmentDirections.actionGlobalTabsTrayFragment())
+    }
+
+    override fun handleRecentSearchGroupClicked(tabId: String) {
+        SearchTerms.jumpBackInGroupTapped.record(NoExtras())
+        navController.navigate(
+            HomeFragmentDirections.actionGlobalTabsTrayFragment(
+                focusGroupTabId = tabId
+            )
+        )
     }
 
     override fun handleRecentTabRemoved(tab: RecentTab.Tab) {

--- a/app/src/main/java/org/mozilla/fenix/home/recenttabs/interactor/RecentTabInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recenttabs/interactor/RecentTabInteractor.kt
@@ -18,6 +18,13 @@ interface RecentTabInteractor {
     fun onRecentTabClicked(tabId: String)
 
     /**
+     * Opens the tabs tray and scroll to the search group.  Called when a user clicks on a search group.
+     *
+     * @param tabId The ID of the tab to open.
+     */
+    fun onRecentSearchGroupClicked(tabId: String)
+
+    /**
      * Show the tabs tray. Called when a user clicks on the "Show all" button besides the recent
      * tabs.
      */

--- a/app/src/main/java/org/mozilla/fenix/home/recenttabs/view/RecentTabViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recenttabs/view/RecentTabViewHolder.kt
@@ -58,6 +58,7 @@ class RecentTabViewHolder(
             RecentTabs(
                 recentTabs = recentTabs.value ?: emptyList(),
                 onRecentTabClick = { recentTabInteractor.onRecentTabClicked(it) },
+                onRecentSearchGroupClick = { recentTabInteractor.onRecentSearchGroupClicked(it) },
                 menuItems = listOf(
                     RecentTabMenuItem(
                         title = stringResource(id = R.string.recent_tab_menu_item_remove),

--- a/app/src/main/java/org/mozilla/fenix/home/recenttabs/view/RecentTabs.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recenttabs/view/RecentTabs.kt
@@ -10,6 +10,7 @@ import android.graphics.Bitmap
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
@@ -28,6 +29,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Card
 import androidx.compose.material.DropdownMenu
 import androidx.compose.material.DropdownMenuItem
+import androidx.compose.material.Icon
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -42,6 +44,8 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -49,6 +53,7 @@ import mozilla.components.browser.icons.compose.Loader
 import mozilla.components.browser.icons.compose.Placeholder
 import mozilla.components.browser.icons.compose.WithIcon
 import mozilla.components.ui.colors.PhotonColors
+import org.mozilla.fenix.R
 import org.mozilla.fenix.components.components
 import org.mozilla.fenix.compose.Image
 import org.mozilla.fenix.compose.ThumbnailCard
@@ -61,12 +66,14 @@ import org.mozilla.fenix.theme.FirefoxTheme
  * @param recentTabs List of [RecentTab] to display.
  * @param menuItems List of [RecentTabMenuItem] shown long clicking a [RecentTab].
  * @param onRecentTabClick Invoked when the user clicks on a recent tab.
+ * @param onRecentSearchGroupClick Invoked when the user clicks on a recent search group.
  */
 @Composable
 fun RecentTabs(
     recentTabs: List<RecentTab>,
     menuItems: List<RecentTabMenuItem>,
     onRecentTabClick: (String) -> Unit = {},
+    onRecentSearchGroupClick: (String) -> Unit = {},
 ) {
     Column(
         modifier = Modifier.fillMaxWidth(),
@@ -81,7 +88,16 @@ fun RecentTabs(
                         onRecentTabClick = onRecentTabClick
                     )
                 }
-                else -> {}
+                is RecentTab.SearchGroup -> {
+                    if (components.settings.searchTermTabGroupsAreEnabled) {
+                        RecentSearchGroupItem(
+                            searchTerm = tab.searchTerm,
+                            tabId = tab.tabId,
+                            count = tab.count,
+                            onSearchGroupClick = onRecentSearchGroupClick
+                        )
+                    }
+                }
             }
         }
     }
@@ -165,6 +181,81 @@ private fun RecentTabItem(
                 tab = tab,
                 onDismissRequest = { isMenuExpanded = false }
             )
+        }
+    }
+}
+
+/**
+ * A recent search group item.
+ *
+ * @param searchTerm The search term for the group.
+ * @param tabId The id of the last accessed tab in the group.
+ * @param count Count of how many tabs belongs to the group.
+ * @param onSearchGroupClick Invoked when the user clicks on a group.
+ */
+@Composable
+private fun RecentSearchGroupItem(
+    searchTerm: String,
+    tabId: String,
+    count: Int,
+    onSearchGroupClick: (String) -> Unit = {}
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(112.dp)
+            .clickable { onSearchGroupClick(tabId) },
+        shape = RoundedCornerShape(8.dp),
+        backgroundColor = FirefoxTheme.colors.layer2,
+        elevation = 6.dp
+    ) {
+        Row(
+            modifier = Modifier.padding(16.dp)
+        ) {
+            Image(
+                painter = painterResource(id = R.drawable.ic_search_group_thumbnail),
+                contentDescription = null,
+                modifier = Modifier.size(108.dp, 80.dp),
+                contentScale = ContentScale.FillWidth,
+                alignment = Alignment.Center
+            )
+
+            Spacer(modifier = Modifier.width(16.dp))
+
+            Column(
+                modifier = Modifier.fillMaxSize(),
+                verticalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = stringResource(R.string.recent_tabs_search_term, searchTerm),
+                    color = FirefoxTheme.colors.textPrimary,
+                    fontSize = 14.sp,
+                    overflow = TextOverflow.Ellipsis,
+                    maxLines = 2,
+                )
+
+                Row {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_all_tabs),
+                        modifier = Modifier.size(18.dp),
+                        contentDescription = null,
+                        tint = when (isSystemInDarkTheme()) {
+                            true -> FirefoxTheme.colors.textPrimary
+                            false -> FirefoxTheme.colors.textSecondary
+                        }
+                    )
+
+                    Spacer(modifier = Modifier.width(8.dp))
+
+                    Text(
+                        text = stringResource(R.string.recent_tabs_search_term_count_2, count),
+                        color = FirefoxTheme.colors.textSecondary,
+                        fontSize = 12.sp,
+                        overflow = TextOverflow.Ellipsis,
+                        maxLines = 1,
+                    )
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/home/recenttabs/view/RecentTabs.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recenttabs/view/RecentTabs.kt
@@ -81,6 +81,7 @@ fun RecentTabs(
                         onRecentTabClick = onRecentTabClick
                     )
                 }
+                else -> {}
             }
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/home/recentvisits/RecentlyVisitedItem.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recentvisits/RecentlyVisitedItem.kt
@@ -4,8 +4,11 @@
 
 package org.mozilla.fenix.home.recentvisits
 
+import mozilla.components.concept.storage.HistoryMetadata
+import org.mozilla.fenix.home.recentvisits.RecentlyVisitedItem.RecentHistoryGroup
+
 /**
- * History items of previously accessed webpages.
+ * History items as individual or groups of previously accessed webpages.
  */
 sealed class RecentlyVisitedItem {
     /**
@@ -18,4 +21,18 @@ sealed class RecentlyVisitedItem {
         val title: String,
         val url: String
     ) : RecentlyVisitedItem()
+
+    /**
+     * A group of previously accessed webpages related by their search terms.
+     *
+     * @property title The title of the group.
+     * @property historyMetadata A list of [HistoryMetadata] records that matches the title.
+     */
+    data class RecentHistoryGroup(
+        val title: String,
+        val historyMetadata: List<HistoryMetadata> = emptyList()
+    ) : RecentlyVisitedItem()
 }
+
+// The last updated time of the group is based on the most recently updated item in the group
+fun RecentHistoryGroup.lastUpdated(): Long = historyMetadata.maxOf { it.updatedAt }

--- a/app/src/main/java/org/mozilla/fenix/home/recentvisits/interactor/RecentVisitsInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recentvisits/interactor/RecentVisitsInteractor.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.fenix.home.recentvisits.interactor
 
+import org.mozilla.fenix.home.recentvisits.RecentlyVisitedItem.RecentHistoryGroup
 import org.mozilla.fenix.home.recentvisits.RecentlyVisitedItem.RecentHistoryHighlight
 
 /**
@@ -15,6 +16,20 @@ interface RecentVisitsInteractor {
      * Callback for when the user clicks on the "Show all" button besides the recent visits header.
      */
     fun onHistoryShowAllClicked()
+
+    /**
+     * Callbacks for when the user clicks on a [RecentHistoryGroup].
+     *
+     * @param recentHistoryGroup The just clicked [RecentHistoryGroup].
+     */
+    fun onRecentHistoryGroupClicked(recentHistoryGroup: RecentHistoryGroup)
+
+    /**
+     * Callback for when the user selected an option to remove a [RecentHistoryGroup].
+     *
+     * @param groupTitle [RecentHistoryGroup.title] of the item to remove.
+     */
+    fun onRemoveRecentHistoryGroup(groupTitle: String)
 
     /**
      * Callback for when the user clicks on a [RecentHistoryHighlight].

--- a/app/src/main/java/org/mozilla/fenix/home/recentvisits/view/RecentlyVisited.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recentvisits/view/RecentlyVisited.kt
@@ -5,8 +5,10 @@
 package org.mozilla.fenix.home.recentvisits.view
 
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -16,6 +18,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyListState
@@ -37,13 +40,17 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import org.mozilla.fenix.R
 import org.mozilla.fenix.compose.EagerFlingBehavior
 import org.mozilla.fenix.compose.Favicon
 import org.mozilla.fenix.home.recentvisits.RecentlyVisitedItem
+import org.mozilla.fenix.home.recentvisits.RecentlyVisitedItem.RecentHistoryGroup
 import org.mozilla.fenix.home.recentvisits.RecentlyVisitedItem.RecentHistoryHighlight
 import org.mozilla.fenix.theme.FirefoxTheme
 import org.mozilla.fenix.theme.Theme
@@ -96,11 +103,87 @@ fun RecentlyVisited(
                                     onRecentVisitClick(it, pageIndex + 1)
                                 }
                             )
+                            is RecentHistoryGroup -> RecentlyVisitedHistoryGroup(
+                                recentVisit = recentVisit,
+                                menuItems = menuItems,
+                                clickableEnabled = listState.atLeastHalfVisibleItems.contains(pageIndex),
+                                showDividerLine = index < items.size - 1,
+                                onRecentVisitClick = {
+                                    onRecentVisitClick(it, pageIndex + 1)
+                                }
+                            )
                         }
                     }
                 }
             }
         }
+    }
+}
+
+/**
+ * A recently visited history group.
+ *
+ * @param recentVisit The [RecentHistoryGroup] to display.
+ * @param menuItems List of [RecentVisitMenuItem] to display in a recent visit dropdown menu.
+ * @param clickableEnabled Whether click actions should be invoked or not.
+ * @param showDividerLine Whether to show a divider line at the bottom.
+ * @param onRecentVisitClick Invoked when the user clicks on a recent visit.
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun RecentlyVisitedHistoryGroup(
+    recentVisit: RecentHistoryGroup,
+    menuItems: List<RecentVisitMenuItem>,
+    clickableEnabled: Boolean,
+    showDividerLine: Boolean,
+    onRecentVisitClick: (RecentHistoryGroup) -> Unit = { _ -> },
+) {
+    var isMenuExpanded by remember { mutableStateOf(false) }
+
+    Row(
+        modifier = Modifier
+            .combinedClickable(
+                enabled = clickableEnabled,
+                onClick = { onRecentVisitClick(recentVisit) },
+                onLongClick = { isMenuExpanded = true }
+            )
+            .size(268.dp, 56.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Image(
+            painter = painterResource(R.drawable.ic_multiple_tabs),
+            contentDescription = null,
+            modifier = Modifier.size(24.dp),
+        )
+
+        Spacer(modifier = Modifier.width(16.dp))
+
+        Column(
+            modifier = Modifier.fillMaxSize()
+        ) {
+            RecentlyVisitedTitle(
+                text = recentVisit.title,
+                modifier = Modifier
+                    .padding(top = 7.dp, bottom = 2.dp)
+                    .weight(1f)
+            )
+
+            RecentlyVisitedCaption(
+                count = recentVisit.historyMetadata.size,
+                modifier = Modifier.weight(1f)
+            )
+
+            if (showDividerLine) {
+                RecentlyVisitedDivider()
+            }
+        }
+
+        RecentlyVisitedMenu(
+            showMenu = isMenuExpanded,
+            menuItems = menuItems,
+            recentVisit = recentVisit,
+            onDismissRequest = { isMenuExpanded = false }
+        )
     }
 }
 
@@ -176,6 +259,36 @@ private fun RecentlyVisitedTitle(
         fontSize = 16.sp,
         overflow = TextOverflow.Ellipsis,
         maxLines = 1,
+    )
+}
+
+/**
+ * The caption text for a recent visit.
+ *
+ * @param count Number of recently visited items to display in the caption.
+ * @param modifier [Modifier] allowing to perfectly place this.
+ */
+@Composable
+private fun RecentlyVisitedCaption(
+    count: Int,
+    modifier: Modifier
+) {
+    val stringId = if (count == 1) {
+        R.string.history_search_group_site
+    } else {
+        R.string.history_search_group_sites
+    }
+
+    Text(
+        text = String.format(LocalContext.current.getString(stringId), count),
+        modifier = modifier,
+        color = when (isSystemInDarkTheme()) {
+            true -> FirefoxTheme.colors.textPrimary
+            false -> FirefoxTheme.colors.textSecondary
+        },
+        fontSize = 12.sp,
+        overflow = TextOverflow.Ellipsis,
+        maxLines = 1
     )
 }
 
@@ -260,14 +373,10 @@ private fun RecentlyVisitedPreview() {
     FirefoxTheme(theme = Theme.getTheme()) {
         RecentlyVisited(
             recentVisits = listOf(
-                RecentHistoryHighlight(
-                    title = "Google",
-                    url = "www.google.com",
-                ),
-                RecentHistoryHighlight(
-                    title = "Firefox",
-                    url = "www.firefox.com",
-                ),
+                RecentHistoryGroup(title = "running shoes"),
+                RecentHistoryGroup(title = "mozilla"),
+                RecentHistoryGroup(title = "firefox"),
+                RecentHistoryGroup(title = "pocket")
             ),
             menuItems = emptyList()
         )

--- a/app/src/main/java/org/mozilla/fenix/home/recentvisits/view/RecentlyVisitedViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recentvisits/view/RecentlyVisitedViewHolder.kt
@@ -11,11 +11,13 @@ import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.LifecycleOwner
 import mozilla.components.lib.state.ext.observeAsComposableState
 import mozilla.components.service.glean.private.NoExtras
+import org.mozilla.fenix.GleanMetrics.History
 import org.mozilla.fenix.GleanMetrics.RecentlyVisitedHomepage
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.components
 import org.mozilla.fenix.compose.ComposeViewHolder
 import org.mozilla.fenix.home.recentvisits.RecentlyVisitedItem
+import org.mozilla.fenix.home.recentvisits.RecentlyVisitedItem.RecentHistoryGroup
 import org.mozilla.fenix.home.recentvisits.RecentlyVisitedItem.RecentHistoryHighlight
 import org.mozilla.fenix.home.recentvisits.interactor.RecentVisitsInteractor
 
@@ -49,6 +51,7 @@ class RecentlyVisitedViewHolder(
                     title = stringResource(R.string.recently_visited_menu_item_remove),
                     onClick = { visit ->
                         when (visit) {
+                            is RecentHistoryGroup -> interactor.onRemoveRecentHistoryGroup(visit.title)
                             is RecentHistoryHighlight -> interactor.onRemoveRecentHistoryHighlight(
                                 visit.url
                             )
@@ -56,11 +59,20 @@ class RecentlyVisitedViewHolder(
                     }
                 )
             ),
-            onRecentVisitClick = { recentlyVisitedItem, _ ->
+            onRecentVisitClick = { recentlyVisitedItem, pageNumber ->
                 when (recentlyVisitedItem) {
                     is RecentHistoryHighlight -> {
                         RecentlyVisitedHomepage.historyHighlightOpened.record(NoExtras())
                         interactor.onRecentHistoryHighlightClicked(recentlyVisitedItem)
+                    }
+                    is RecentHistoryGroup -> {
+                        RecentlyVisitedHomepage.searchGroupOpened.record(NoExtras())
+                        History.recentSearchesTapped.record(
+                            History.RecentSearchesTappedExtra(
+                                pageNumber.toString()
+                            )
+                        )
+                        interactor.onRecentHistoryGroupClicked(recentlyVisitedItem)
                     }
                 }
             }

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlInteractor.kt
@@ -23,6 +23,7 @@ import org.mozilla.fenix.home.recentsyncedtabs.interactor.RecentSyncedTabInterac
 import org.mozilla.fenix.home.recenttabs.RecentTab
 import org.mozilla.fenix.home.recenttabs.controller.RecentTabController
 import org.mozilla.fenix.home.recenttabs.interactor.RecentTabInteractor
+import org.mozilla.fenix.home.recentvisits.RecentlyVisitedItem.RecentHistoryGroup
 import org.mozilla.fenix.home.recentvisits.RecentlyVisitedItem.RecentHistoryHighlight
 import org.mozilla.fenix.home.recentvisits.controller.RecentVisitsController
 import org.mozilla.fenix.home.recentvisits.interactor.RecentVisitsInteractor
@@ -401,6 +402,16 @@ class SessionControlInteractor(
 
     override fun onHistoryShowAllClicked() {
         recentVisitsController.handleHistoryShowAllClicked()
+    }
+
+    override fun onRecentHistoryGroupClicked(recentHistoryGroup: RecentHistoryGroup) {
+        recentVisitsController.handleRecentHistoryGroupClicked(
+            recentHistoryGroup
+        )
+    }
+
+    override fun onRemoveRecentHistoryGroup(groupTitle: String) {
+        recentVisitsController.handleRemoveRecentHistoryGroup(groupTitle)
     }
 
     override fun onRecentHistoryHighlightClicked(recentHistoryHighlight: RecentHistoryHighlight) {

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlInteractor.kt
@@ -372,6 +372,10 @@ class SessionControlInteractor(
         recentTabController.handleRecentTabClicked(tabId)
     }
 
+    override fun onRecentSearchGroupClicked(tabId: String) {
+        recentTabController.handleRecentSearchGroupClicked(tabId)
+    }
+
     override fun onRecentTabShowAllClicked() {
         recentTabController.handleRecentTabShowAllClicked()
     }

--- a/app/src/main/java/org/mozilla/fenix/tabstray/SearchTermTabGroupMiddleware.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/SearchTermTabGroupMiddleware.kt
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabstray
+
+import mozilla.components.browser.state.action.BrowserAction
+import mozilla.components.browser.state.action.HistoryMetadataAction
+import mozilla.components.browser.state.action.TabGroupAction
+import mozilla.components.browser.state.action.TabListAction
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.state.getGroupByName
+import mozilla.components.lib.state.Middleware
+import mozilla.components.lib.state.MiddlewareContext
+
+const val SEARCH_TERM_TAB_GROUPS = "searchTermTabGroups"
+const val SEARCH_TERM_TAB_GROUPS_MIN_SIZE = 2
+
+/**
+ * This [Middleware] manages tab groups for search terms.
+ */
+class SearchTermTabGroupMiddleware : Middleware<BrowserState, BrowserAction> {
+
+    override fun invoke(
+        context: MiddlewareContext<BrowserState, BrowserAction>,
+        next: (BrowserAction) -> Unit,
+        action: BrowserAction
+    ) {
+
+        next(action)
+
+        when (action) {
+            is HistoryMetadataAction.SetHistoryMetadataKeyAction -> {
+                action.historyMetadataKey.searchTerm?.let { searchTerm ->
+                    context.dispatch(
+                        TabGroupAction.AddTabAction(SEARCH_TERM_TAB_GROUPS, searchTerm, action.tabId)
+                    )
+                }
+            }
+            is HistoryMetadataAction.DisbandSearchGroupAction -> {
+                val group = context.state.tabPartitions[SEARCH_TERM_TAB_GROUPS]?.getGroupByName(action.searchTerm)
+                group?.let {
+                    context.dispatch(TabGroupAction.RemoveTabGroupAction(SEARCH_TERM_TAB_GROUPS, it.id))
+                }
+            }
+            is TabListAction.RestoreAction -> {
+                action.tabs.forEach { tab ->
+                    tab.state.historyMetadata?.searchTerm?.let { searchTerm ->
+                        context.dispatch(
+                            TabGroupAction.AddTabAction(SEARCH_TERM_TAB_GROUPS, searchTerm, tab.state.id)
+                        )
+                    }
+                }
+            }
+            else -> {
+                // no-op
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
@@ -153,6 +153,7 @@ class TabsTrayFragment : AppCompatDialogFragment() {
                 initialState = TabsTrayState(
                     selectedPage = initialPage,
                     mode = initialMode,
+                    focusGroupTabId = args.focusGroupTabId
                 ),
                 middlewares = listOf(
                     TabsTrayMiddleware()

--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayStore.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayStore.kt
@@ -19,9 +19,10 @@ import org.mozilla.fenix.tabstray.syncedtabs.SyncedTabsListItem
  * @property mode Whether the browser tab list is in multi-select mode or not with the set of
  * currently selected tabs.
  * @property inactiveTabs The list of tabs are considered inactive.
- * @property normalTabs The list of normal tabs that do not fall under [inactiveTabs].
+ * @property normalTabs The list of normal tabs that do not fall under [inactiveTabs] or search term groups.
  * @property privateTabs The list of tabs that are [ContentState.private].
  * @property syncing Whether the Synced Tabs feature should fetch the latest tabs from paired devices.
+ * @property focusGroupTabId The search group tab id to focus. Defaults to null.
  */
 data class TabsTrayState(
     val selectedPage: Page = Page.NormalTabs,
@@ -31,6 +32,7 @@ data class TabsTrayState(
     val privateTabs: List<TabSessionState> = emptyList(),
     val syncedTabs: List<SyncedTabsListItem> = emptyList(),
     val syncing: Boolean = false,
+    val focusGroupTabId: String? = null
 ) : State {
 
     /**
@@ -129,6 +131,11 @@ sealed class TabsTrayAction : Action {
     object SyncCompleted : TabsTrayAction()
 
     /**
+     * Removes the [TabsTrayState.focusGroupTabId] of the [TabsTrayState].
+     */
+    object ConsumeFocusGroupTabId : TabsTrayAction()
+
+    /**
      * Updates the list of tabs in [TabsTrayState.inactiveTabs].
      */
     data class UpdateInactiveTabs(val tabs: List<TabSessionState>) : TabsTrayAction()
@@ -177,6 +184,8 @@ internal object TabsTrayReducer {
                 state.copy(syncing = true)
             is TabsTrayAction.SyncCompleted ->
                 state.copy(syncing = false)
+            is TabsTrayAction.ConsumeFocusGroupTabId ->
+                state.copy(focusGroupTabId = null)
             is TabsTrayAction.UpdateInactiveTabs ->
                 state.copy(inactiveTabs = action.tabs)
             is TabsTrayAction.UpdateNormalTabs ->

--- a/app/src/main/java/org/mozilla/fenix/tabstray/viewholders/NormalBrowserPageViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/viewholders/NormalBrowserPageViewHolder.kt
@@ -27,6 +27,7 @@ import org.mozilla.fenix.tabstray.TabsTrayInteractor
 import org.mozilla.fenix.tabstray.TabsTrayStore
 import org.mozilla.fenix.tabstray.ext.browserAdapter
 import org.mozilla.fenix.tabstray.ext.defaultBrowserLayoutColumns
+import org.mozilla.fenix.tabstray.ext.getNormalTrayTabs
 import org.mozilla.fenix.tabstray.ext.inactiveTabsAdapter
 import org.mozilla.fenix.tabstray.ext.isNormalTabInactive
 import org.mozilla.fenix.tabstray.ext.observeFirstInsert
@@ -78,6 +79,7 @@ class NormalBrowserPageViewHolder(
         layoutManager: RecyclerView.LayoutManager
     ) {
         val concatAdapter = adapter as ConcatAdapter
+        val browserAdapter = concatAdapter.browserAdapter
         val inactiveTabAdapter = concatAdapter.inactiveTabsAdapter
         val inactiveTabsAreEnabled = containerView.context.settings().inactiveTabsAreEnabled
 
@@ -85,6 +87,7 @@ class NormalBrowserPageViewHolder(
         // It's safe to read the state directly (i.e. won't cause bugs because of the store actions
         // processed on a separate thread) instead of observing it because this value is only set during
         // the initialState of the TabsTrayStore being created.
+        val focusGroupTabId = tabsTrayStore.state.focusGroupTabId
 
         // Update tabs into the inactive adapter.
         if (inactiveTabsAreEnabled && selectedTab.isNormalTabInactive(maxActiveTime)) {
@@ -97,6 +100,23 @@ class NormalBrowserPageViewHolder(
                 inactiveTabsList.forEach { item ->
                     if (item.id == selectedTab.id) {
                         containerView.post { layoutManager.scrollToPosition(0) }
+
+                        return@observeFirstInsert
+                    }
+                }
+            }
+        }
+
+        if (focusGroupTabId.isNullOrEmpty()) {
+            // Updates tabs into the normal browser tabs adapter.
+            browserAdapter.observeFirstInsert {
+                val activeTabsList = browserStore.state.getNormalTrayTabs(inactiveTabsAreEnabled)
+                activeTabsList.forEachIndexed { tabIndex, trayTab ->
+                    if (trayTab.id == selectedTab.id) {
+                        // Index is based on tabs above (inactive) with our calculated index.
+                        val indexToScrollTo = inactiveTabAdapter.itemCount + tabIndex
+
+                        containerView.post { layoutManager.scrollToPosition(indexToScrollTo) }
 
                         return@observeFirstInsert
                     }

--- a/app/src/main/res/drawable/ic_all_tabs.xml
+++ b/app/src/main/res/drawable/ic_all_tabs.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="18dp"
+    android:height="18dp"
+    android:viewportWidth="18"
+    android:viewportHeight="18">
+  <path
+      android:pathData="M0,2.5C0,1.119 1.119,0 2.5,0H15.5C16.881,0 18,1.119 18,2.5V10.5C18,11.881 16.881,13 15.5,13H2.5C1.119,13 0,11.881 0,10.5V2.5ZM15.7,11.5L16.5,10.7V2.3L15.7,1.5H2.3L1.5,2.3V10.7L2.3,11.5H15.7ZM1.5,15.7L2.3,16.5H15.7L16.5,15.7V14.75C16.5,14.336 16.836,14 17.25,14C17.664,14 18,14.336 18,14.75V15.5C18,16.881 16.881,18 15.5,18H2.5C1.119,18 0,16.881 0,15.5V14.75C0,14.336 0.336,14 0.75,14C1.164,14 1.5,14.336 1.5,14.75V15.7Z"
+      android:fillColor="?attr/textSecondary"
+      android:fillType="evenOdd"/>
+</vector>

--- a/app/src/main/res/drawable/ic_search_group_thumbnail.xml
+++ b/app/src/main/res/drawable/ic_search_group_thumbnail.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:width="108dp"
+    android:height="80dp"
+    android:viewportWidth="108"
+    android:viewportHeight="80">
+  <group>
+    <clip-path
+        android:pathData="M8,0L100,0A8,8 0,0 1,108 8L108,72A8,8 0,0 1,100 80L8,80A8,8 0,0 1,0 72L0,8A8,8 0,0 1,8 0z"/>
+    <path
+        android:pathData="M8,0L100,0A8,8 0,0 1,108 8L108,72A8,8 0,0 1,100 80L8,80A8,8 0,0 1,0 72L0,8A8,8 0,0 1,8 0z">
+      <aapt:attr name="android:fillColor">
+        <gradient
+            android:startY="0"
+            android:startX="108"
+            android:endY="103.313"
+            android:endX="31.4721"
+            android:type="linear">
+          <item android:offset="0" android:color="#FF9059FF"/>
+          <item android:offset="1" android:color="#FF0250BB"/>
+        </gradient>
+      </aapt:attr>
+    </path>
+    <path
+        android:pathData="M100,80L8,80A8,8 0,0 1,0 72L0,8A8,8 0,0 1,8 0L100,0A8,8 0,0 1,108 8L108,72A8,8 0,0 1,100 80z"
+        android:strokeAlpha="0.5"
+        android:fillAlpha="0.5">
+      <aapt:attr name="android:fillColor">
+        <gradient
+            android:startY="80"
+            android:startX="54"
+            android:endY="0"
+            android:endX="54"
+            android:type="linear">
+          <item android:offset="0.0104167" android:color="#FF000000"/>
+          <item android:offset="0.567708" android:color="#FF81535C"/>
+          <item android:offset="1" android:color="#00C4C4C4"/>
+        </gradient>
+      </aapt:attr>
+    </path>
+    <path
+        android:pathData="M60.55,43.687C62.019,41.645 62.888,39.145 62.888,36.444C62.888,29.584 57.306,24 50.444,24C43.582,24 38,29.584 38,36.444C38,43.305 43.582,48.889 50.444,48.889C53.155,48.889 55.663,48.014 57.709,46.535L58.641,46.524L67.725,55.609C67.985,55.868 68.326,56 68.667,56C69.008,56 69.35,55.87 69.609,55.609C70.13,55.088 70.13,54.244 69.609,53.723L60.532,44.644L60.55,43.687ZM50.444,46.222C45.052,46.222 40.667,41.835 40.667,36.444C40.667,31.054 45.052,26.667 50.444,26.667C55.836,26.667 60.221,31.054 60.221,36.444C60.221,41.835 55.836,46.222 50.444,46.222Z"
+        android:fillColor="#F9F9FB"/>
+  </group>
+</vector>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -162,6 +162,11 @@
             android:defaultValue="false"
             app:argType="boolean" />
         <argument
+            android:name="focusGroupTabId"
+            app:nullable="true"
+            android:defaultValue="@null"
+            app:argType="string" />
+        <argument
             android:name="page"
             android:defaultValue="NormalTabs"
             app:argType="org.mozilla.fenix.tabstray.Page" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -117,10 +117,10 @@
     <string name="recent_tabs_show_all_content_description_2">Show all recent tabs button</string>
     <!-- Title for showing a group item in the 'Jump back in' section of the new tab
         The first parameter is the search term that the user used. (for example: your search for "cat")-->
-    <string name="recent_tabs_search_term" moz:RemovedIn="105" tools:ignore="UnusedResources">Your search for \"%1$s\"</string>
+    <string name="recent_tabs_search_term">Your search for \"%1$s\"</string>
     <!-- Text for the number of tabs in a group in the 'Jump back in' section of the new tab
         %d is a placeholder for the number of sites in the group. This number will always be more than one. -->
-    <string name="recent_tabs_search_term_count_2" moz:RemovedIn="105" tools:ignore="UnusedResources">%d sites</string>
+    <string name="recent_tabs_search_term_count_2">%d sites</string>
     <!-- Text for button in synced tab card that opens synced tabs tray -->
     <string name="recent_tabs_see_all_synced_tabs_button_text">See all synced tabs</string>
     <!-- Accessibility description for device icon used for recent synced tab -->

--- a/app/src/test/java/org/mozilla/fenix/components/AppStoreTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/AppStoreTest.kt
@@ -31,6 +31,7 @@ import org.mozilla.fenix.browser.browsingmode.BrowsingModeManager
 import org.mozilla.fenix.components.appstate.AppAction
 import org.mozilla.fenix.components.appstate.AppAction.MessagingAction.UpdateMessageToShow
 import org.mozilla.fenix.components.appstate.AppState
+import org.mozilla.fenix.components.appstate.filterOut
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.getFilteredStories
 import org.mozilla.fenix.home.CurrentMode
@@ -42,6 +43,7 @@ import org.mozilla.fenix.home.recentsyncedtabs.RecentSyncedTab
 import org.mozilla.fenix.home.recentsyncedtabs.RecentSyncedTabState
 import org.mozilla.fenix.home.recenttabs.RecentTab
 import org.mozilla.fenix.home.recentvisits.RecentlyVisitedItem
+import org.mozilla.fenix.home.recentvisits.RecentlyVisitedItem.RecentHistoryGroup
 import org.mozilla.fenix.home.recentvisits.RecentlyVisitedItem.RecentHistoryHighlight
 import org.mozilla.fenix.onboarding.FenixOnboarding
 
@@ -131,10 +133,13 @@ class AppStoreTest {
 
     @Test
     fun `Test changing the recent tabs in AppStore`() = runTest {
-        val highlight = RecentHistoryHighlight(title = "title", "")
+        val group1 = RecentHistoryGroup(title = "title1")
+        val group2 = RecentHistoryGroup(title = "title2")
+        val group3 = RecentHistoryGroup(title = "title3")
+        val highlight = RecentHistoryHighlight(title = group2.title, "")
         appStore = AppStore(
             AppState(
-                recentHistory = listOf(highlight)
+                recentHistory = listOf(group1, group2, group3, highlight)
             )
         )
         assertEquals(0, appStore.state.recentTabs.size)
@@ -146,7 +151,7 @@ class AppStoreTest {
         appStore.dispatch(AppAction.RecentTabsChange(recentTabs)).join()
 
         assertEquals(recentTabs, appStore.state.recentTabs)
-        assertEquals(listOf(highlight), appStore.state.recentHistory)
+        assertEquals(listOf(group1, group3, highlight), appStore.state.recentHistory)
     }
 
     @Test
@@ -172,7 +177,7 @@ class AppStoreTest {
     fun `Test changing the history metadata in AppStore`() = runTest {
         assertEquals(0, appStore.state.recentHistory.size)
 
-        val historyMetadata: List<RecentHistoryHighlight> = listOf(mockk(), mockk())
+        val historyMetadata: List<RecentHistoryGroup> = listOf(mockk(), mockk())
         appStore.dispatch(AppAction.RecentHistoryChange(historyMetadata)).join()
 
         assertEquals(historyMetadata, appStore.state.recentHistory)
@@ -180,10 +185,12 @@ class AppStoreTest {
 
     @Test
     fun `Test removing a history highlight from AppStore`() = runTest {
+        val g1 = RecentHistoryGroup(title = "group One")
+        val g2 = RecentHistoryGroup(title = "grup two")
         val h1 = RecentHistoryHighlight(title = "highlight One", url = "url1")
         val h2 = RecentHistoryHighlight(title = "highlight two", url = "url2")
         val recentHistoryState = AppState(
-            recentHistory = listOf(h1, h2)
+            recentHistory = listOf(g1, g2, h1, h2)
         )
         appStore = AppStore(recentHistoryState)
 
@@ -195,7 +202,7 @@ class AppStoreTest {
 
         appStore.dispatch(AppAction.RemoveRecentHistoryHighlight(h1.url)).join()
         assertEquals(
-            recentHistoryState.copy(recentHistory = listOf(h2)),
+            recentHistoryState.copy(recentHistory = listOf(g1, g2, h2)),
             appStore.state
         )
     }
@@ -234,12 +241,16 @@ class AppStoreTest {
             assertEquals(0, appStore.state.recentHistory.size)
             assertEquals(Mode.Normal, appStore.state.mode)
 
+            val recentGroup = RecentTab.SearchGroup("testSearchTerm", "id", "url", null, 3)
             val collections: List<TabCollection> = listOf(mockk())
             val topSites: List<TopSite> = listOf(mockk(), mockk())
             val recentTabs: List<RecentTab> = listOf(mockk(), mockk())
             val recentBookmarks: List<RecentBookmark> = listOf(mockk(), mockk())
-            val highlight = RecentHistoryHighlight("title", "")
-            val recentHistory: List<RecentlyVisitedItem> = listOf(highlight)
+            val group1 = RecentHistoryGroup(title = "test One")
+            val group2 = RecentHistoryGroup(title = recentGroup.searchTerm.lowercase())
+            val group3 = RecentHistoryGroup(title = "test two")
+            val highlight = RecentHistoryHighlight(group2.title, "")
+            val recentHistory: List<RecentlyVisitedItem> = listOf(group1, group2, group3, highlight)
 
             appStore.dispatch(
                 AppAction.Change(
@@ -257,7 +268,7 @@ class AppStoreTest {
             assertEquals(topSites, appStore.state.topSites)
             assertEquals(recentTabs, appStore.state.recentTabs)
             assertEquals(recentBookmarks, appStore.state.recentBookmarks)
-            assertEquals(listOf(highlight), appStore.state.recentHistory)
+            assertEquals(listOf(group1, group3, highlight), appStore.state.recentHistory)
             assertEquals(Mode.Private, appStore.state.mode)
         }
 
@@ -468,5 +479,22 @@ class AppStoreTest {
             )
             assertSame(firstFilteredStories, appStore.state.pocketStories)
         }
+    }
+
+    @Test
+    fun `Test filtering out search groups`() {
+        val group1 = RecentHistoryGroup("title1")
+        val group2 = RecentHistoryGroup("title2")
+        val group3 = RecentHistoryGroup("title3")
+        val highLight1 = RecentHistoryHighlight("title1", "")
+        val highLight2 = RecentHistoryHighlight("title2", "")
+        val highLight3 = RecentHistoryHighlight("title3", "")
+        val recentHistory = listOf(group1, highLight1, group2, highLight2, group3, highLight3)
+
+        assertEquals(recentHistory, recentHistory.filterOut(null))
+        assertEquals(recentHistory, recentHistory.filterOut(""))
+        assertEquals(recentHistory, recentHistory.filterOut(" "))
+        assertEquals(recentHistory - group2, recentHistory.filterOut("Title2"))
+        assertEquals(recentHistory - group3, recentHistory.filterOut("title3"))
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/components/AppStoreTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/AppStoreTest.kt
@@ -147,7 +147,8 @@ class AppStoreTest {
         // Add 2 RecentTabs to the AppStore
         // A new SearchGroup already shown in history should hide the HistoryGroup.
         val recentTab1: RecentTab.Tab = mockk()
-        val recentTabs: List<RecentTab> = listOf(recentTab1)
+        val recentTab2 = RecentTab.SearchGroup(group2.title, "tabId", "url", null, 2)
+        val recentTabs: List<RecentTab> = listOf(recentTab1, recentTab2)
         appStore.dispatch(AppAction.RecentTabsChange(recentTabs)).join()
 
         assertEquals(recentTabs, appStore.state.recentTabs)
@@ -208,6 +209,20 @@ class AppStoreTest {
     }
 
     @Test
+    fun `Test disbanding search group in AppStore`() = runTest {
+        val g1 = RecentHistoryGroup(title = "test One")
+        val g2 = RecentHistoryGroup(title = "test two")
+        val h1 = RecentHistoryHighlight(title = "highlight One", url = "url1")
+        val h2 = RecentHistoryHighlight(title = "highlight two", url = "url2")
+        val recentHistory: List<RecentlyVisitedItem> = listOf(g1, g2, h1, h2)
+        appStore.dispatch(AppAction.RecentHistoryChange(recentHistory)).join()
+        assertEquals(recentHistory, appStore.state.recentHistory)
+
+        appStore.dispatch(AppAction.DisbandSearchGroupAction("Test one")).join()
+        assertEquals(listOf(g2, h1, h2), appStore.state.recentHistory)
+    }
+
+    @Test
     fun `Test changing hiding collections placeholder`() = runTest {
         assertTrue(appStore.state.showCollectionPlaceholder)
 
@@ -244,7 +259,7 @@ class AppStoreTest {
             val recentGroup = RecentTab.SearchGroup("testSearchTerm", "id", "url", null, 3)
             val collections: List<TabCollection> = listOf(mockk())
             val topSites: List<TopSite> = listOf(mockk(), mockk())
-            val recentTabs: List<RecentTab> = listOf(mockk(), mockk())
+            val recentTabs: List<RecentTab> = listOf(mockk(), recentGroup, mockk())
             val recentBookmarks: List<RecentBookmark> = listOf(mockk(), mockk())
             val group1 = RecentHistoryGroup(title = "test One")
             val group2 = RecentHistoryGroup(title = recentGroup.searchTerm.lowercase())

--- a/app/src/test/java/org/mozilla/fenix/ext/AppStateTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/ext/AppStateTest.kt
@@ -21,6 +21,7 @@ import org.mozilla.fenix.home.pocket.POCKET_STORIES_DEFAULT_CATEGORY_NAME
 import org.mozilla.fenix.home.pocket.PocketRecommendedStoriesCategory
 import org.mozilla.fenix.home.pocket.PocketRecommendedStoriesSelectedCategory
 import org.mozilla.fenix.home.recentsyncedtabs.RecentSyncedTabState
+import org.mozilla.fenix.home.recenttabs.RecentTab
 import org.mozilla.fenix.utils.Settings
 import java.util.concurrent.TimeUnit
 import kotlin.random.Random
@@ -495,6 +496,24 @@ class AppStateTest {
                 it is PocketRecommendedStory && it.category != anotherStoriesCategory.name
             }
         )
+    }
+
+    @Test
+    fun `GIVEN recentTabs contains a SearchGroup WHEN recentSearchGroup is called THEN return the group`() {
+        val searchGroup: RecentTab.SearchGroup = mockk()
+        val normalTab: RecentTab.Tab = mockk()
+        val state = AppState(recentTabs = listOf(normalTab, searchGroup))
+
+        assertEquals(searchGroup, state.recentSearchGroup)
+    }
+
+    @Test
+    fun `GIVEN recentTabs does not contains SearchGroup WHEN recentSearchGroup is called THEN return null`() {
+        val normalTab1: RecentTab.Tab = mockk()
+        val normalTab2: RecentTab.Tab = mockk()
+        val state = AppState(recentTabs = listOf(normalTab1, normalTab2))
+
+        assertNull(state.recentSearchGroup)
     }
 
     @Test

--- a/app/src/test/java/org/mozilla/fenix/ext/BrowserStateTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/ext/BrowserStateTest.kt
@@ -8,6 +8,8 @@ import io.mockk.every
 import io.mockk.mockk
 import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.browser.state.state.LastMediaAccessState
+import mozilla.components.browser.state.state.TabGroup
+import mozilla.components.browser.state.state.TabPartition
 import mozilla.components.browser.state.state.createTab
 import mozilla.components.concept.storage.HistoryMetadataKey
 import org.junit.Assert.assertEquals
@@ -15,6 +17,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mozilla.fenix.home.recenttabs.RecentTab
+import org.mozilla.fenix.tabstray.SEARCH_TERM_TAB_GROUPS
 import org.mozilla.fenix.utils.Settings
 
 class BrowserStateTest {
@@ -158,6 +161,74 @@ class BrowserStateTest {
     }
 
     @Test
+    fun `GIVEN only normal tabs from a search group are open WHEN recentTabs is called THEN return only the tab group`() {
+        val searchGroupTab1 = createTab(
+            url = "https://www.mozilla.org",
+            id = "1",
+            historyMetadata = HistoryMetadataKey(
+                url = "https://www.mozilla.org",
+                searchTerm = "Test",
+                referrerUrl = "https://www.mozilla.org"
+            )
+        )
+        val searchGroupTab2 = createTab(
+            url = "https://www.mozilla.org",
+            id = "2",
+            historyMetadata = HistoryMetadataKey(
+                url = "https://www.mozilla.org",
+                searchTerm = "Test",
+                referrerUrl = "https://www.mozilla.org"
+            )
+        )
+        val tabGroup = listOf(TabGroup("Test", "", listOf(searchGroupTab1.id, searchGroupTab2.id)))
+        val browserState = BrowserState(
+            tabs = listOf(searchGroupTab1, searchGroupTab2),
+            tabPartitions = mapOf(Pair(SEARCH_TERM_TAB_GROUPS, TabPartition(SEARCH_TERM_TAB_GROUPS, tabGroup))),
+            selectedTabId = searchGroupTab1.id
+        )
+
+        val result = browserState.asRecentTabs()
+
+        assertEquals(1, result.size)
+        assert(result[0] is RecentTab.SearchGroup)
+        assertEquals(searchGroupTab1.historyMetadata?.searchTerm, (result[0] as RecentTab.SearchGroup).searchTerm)
+        assertEquals(searchGroupTab1.id, (result[0] as RecentTab.SearchGroup).tabId)
+        assertEquals(searchGroupTab1.content.url, (result[0] as RecentTab.SearchGroup).url)
+        assertEquals(searchGroupTab1.content.thumbnail, (result[0] as RecentTab.SearchGroup).thumbnail)
+        assertEquals(2, (result[0] as RecentTab.SearchGroup).count)
+    }
+
+    @Test
+    fun `GIVEN tabs with different search terms are opened WHEN recentTabs is called THEN return the most recent tab and tab group`() {
+        val searchGroupTab = createTab(
+            url = "https://www.mozilla.org",
+            id = "1",
+            historyMetadata = HistoryMetadataKey(
+                url = "https://www.mozilla.org",
+                searchTerm = "Test",
+                referrerUrl = "https://www.mozilla.org"
+            )
+        )
+        val otherTab = createTab(url = "https://www.mozilla.org/firefox", id = "2")
+        val browserState = BrowserState(
+            tabs = listOf(searchGroupTab, otherTab, searchGroupTab),
+            tabPartitions = mapOf(Pair(SEARCH_TERM_TAB_GROUPS, TabPartition(SEARCH_TERM_TAB_GROUPS, listOf(TabGroup("Test", "", listOf("1", "3")))))),
+            selectedTabId = searchGroupTab.id
+        )
+
+        val result = browserState.asRecentTabs()
+
+        assertEquals(2, result.size)
+        assertEquals(otherTab, (result[0] as RecentTab.Tab).state)
+        assert(result[1] is RecentTab.SearchGroup)
+        assertEquals("Test", (result[1] as RecentTab.SearchGroup).searchTerm)
+        assertEquals(searchGroupTab.id, (result[1] as RecentTab.SearchGroup).tabId)
+        assertEquals(searchGroupTab.content.url, (result[1] as RecentTab.SearchGroup).url)
+        assertEquals(searchGroupTab.content.thumbnail, (result[1] as RecentTab.SearchGroup).thumbnail)
+        assertEquals(2, (result[1] as RecentTab.SearchGroup).count)
+    }
+
+    @Test
     fun `GIVEN the selected tab is a normal tab and tab group with one tab exists WHEN asRecentTabs is called THEN return only the normal tab`() {
         val selectedTab = createTab(url = "url", id = "3")
         val searchGroupTab = createTab(
@@ -187,6 +258,46 @@ class BrowserStateTest {
 
         assertEquals(1, result.size)
         assertEquals(selectedTab, (result[0] as RecentTab.Tab).state)
+    }
+
+    @Test
+    fun `GIVEN the selected tab is a normal tab and tab group with two tabs exists WHEN asRecentTabs is called THEN return a list of these tabs`() {
+        val selectedTab = createTab(url = "url", id = "3")
+        val searchGroupTab1 = createTab(
+            url = "https://www.mozilla.org",
+            id = "4",
+            historyMetadata = HistoryMetadataKey(
+                url = "https://www.mozilla.org",
+                searchTerm = "Test",
+                referrerUrl = "https://www.mozilla.org"
+            )
+        )
+        val searchGroupTab2 = createTab(
+            url = "https://www.mozilla.org",
+            id = "5",
+            historyMetadata = HistoryMetadataKey(
+                url = "https://www.mozilla.org",
+                searchTerm = "Test",
+                referrerUrl = "https://www.mozilla.org"
+            )
+        )
+        val tabGroup = listOf(TabGroup("Test", "", listOf(searchGroupTab1.id, searchGroupTab2.id)))
+        val browserState = BrowserState(
+            tabs = listOf(mockk(relaxed = true), selectedTab, searchGroupTab1, searchGroupTab1),
+            tabPartitions = mapOf(Pair(SEARCH_TERM_TAB_GROUPS, TabPartition(SEARCH_TERM_TAB_GROUPS, tabGroup))),
+            selectedTabId = selectedTab.id
+        )
+
+        val result = browserState.asRecentTabs()
+
+        assertEquals(2, result.size)
+        assertEquals(selectedTab, (result[0] as RecentTab.Tab).state)
+        assert(result[1] is RecentTab.SearchGroup)
+        assertEquals(searchGroupTab1.historyMetadata?.searchTerm, (result[1] as RecentTab.SearchGroup).searchTerm)
+        assertEquals(searchGroupTab1.id, (result[1] as RecentTab.SearchGroup).tabId)
+        assertEquals(searchGroupTab1.content.url, (result[1] as RecentTab.SearchGroup).url)
+        assertEquals(searchGroupTab1.content.thumbnail, (result[1] as RecentTab.SearchGroup).thumbnail)
+        assertEquals(2, (result[1] as RecentTab.SearchGroup).count)
     }
 
     @Test
@@ -355,5 +466,39 @@ class BrowserStateTest {
 
         assertEquals(2, result.size)
         assertTrue(result.containsAll(listOf(normalTab1, normalTab3)))
+    }
+
+    @Test
+    fun `GIVEN tabs exist with search terms WHEN lastTabGroup is called THEN return the last accessed TabGroup`() {
+        val tab1 = createTab(url = "url1", id = "id1", searchTerms = "test1", lastAccess = 10)
+        val tab2 = createTab(url = "url2", id = "id2", searchTerms = "test1", lastAccess = 11)
+        val tab3 = createTab(url = "url3", id = "id3", searchTerms = "test3", lastAccess = 100)
+        val tab4 = createTab(url = "url4", id = "id4", searchTerms = "test3", lastAccess = 111)
+        val tab5 = createTab(url = "url5", id = "id5", searchTerms = "test5", lastAccess = 1000)
+        val tab6 = createTab(url = "url6", id = "id6", searchTerms = "test5", lastAccess = 1111)
+        val tabGroup1 = TabGroup("test1", "", listOf(tab1.id, tab2.id))
+        val tabGroup2 = TabGroup("test3", "", listOf(tab3.id, tab4.id))
+        val tabGroup3 = TabGroup("test5", "", listOf(tab5.id, tab6.id))
+
+        val browserState = BrowserState(
+            tabs = listOf(tab1, tab2, tab3, tab4, tab5, tab6),
+            tabPartitions = mapOf(Pair(SEARCH_TERM_TAB_GROUPS, TabPartition(SEARCH_TERM_TAB_GROUPS, listOf(tabGroup1, tabGroup2, tabGroup3))))
+        )
+        val expected = TabGroup("test5", "", listOf(tab5.id, tab6.id))
+
+        val result = browserState.lastTabGroup
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `GIVEN no tabs exist with search terms WHEN lastTabGroup is called THEN return the last accessed TabGroup`() {
+        val tab1 = createTab(url = "url1", id = "id1", lastAccess = 10)
+        val tab2 = createTab(url = "url2", id = "id2", lastAccess = 11)
+        val browserState = BrowserState(tabs = listOf(tab1, tab2))
+
+        val result = browserState.lastTabGroup
+
+        assertNull(result)
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/ext/RecentTabsTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/ext/RecentTabsTest.kt
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.ext
+
+import io.mockk.every
+import io.mockk.mockk
+import mozilla.components.browser.state.state.TabSessionState
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mozilla.fenix.home.recenttabs.RecentTab
+
+class RecentTabsTest {
+    @Test
+    fun `Test filtering out tab`() {
+        val filteredId = "id"
+        val mockSessionState: TabSessionState = mockk()
+        every { mockSessionState.id } returns filteredId
+        val tab = RecentTab.Tab(mockSessionState)
+        val searchGroup = RecentTab.SearchGroup(
+            tabId = filteredId,
+            searchTerm = "",
+            url = "",
+            thumbnail = null,
+            count = 0
+        )
+
+        val recentTabs = listOf(tab, searchGroup)
+        val result = recentTabs.filterOutTab(tab)
+
+        assertEquals(listOf(searchGroup), result)
+    }
+}

--- a/app/src/test/java/org/mozilla/fenix/home/SessionControlInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/SessionControlInteractorTest.kt
@@ -163,6 +163,13 @@ class SessionControlInteractorTest {
     }
 
     @Test
+    fun onRecentSearchGroupClicked() {
+        val tabId = "tabId"
+        interactor.onRecentSearchGroupClicked(tabId)
+        verify { recentTabController.handleRecentSearchGroupClicked(tabId) }
+    }
+
+    @Test
     fun onRecentTabShowAllClicked() {
         interactor.onRecentTabShowAllClicked()
         verify { recentTabController.handleRecentTabShowAllClicked() }

--- a/app/src/test/java/org/mozilla/fenix/home/recenttabs/controller/RecentTabControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/recenttabs/controller/RecentTabControllerTest.kt
@@ -28,6 +28,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.GleanMetrics.RecentTabs
+import org.mozilla.fenix.GleanMetrics.SearchTerms
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
@@ -161,5 +162,22 @@ class RecentTabControllerTest {
         }
 
         assertNotNull(RecentTabs.showAllClicked.testGetValue())
+    }
+
+    @Test
+    fun `WHEN handleRecentSearchGroupClicked is called THEN navigate to the tabsTrayFragment and record the correct metric`() {
+        assertNull(SearchTerms.jumpBackInGroupTapped.testGetValue())
+
+        controller.handleRecentSearchGroupClicked("1")
+
+        verify {
+            navController.navigate(
+                match<NavDirections> {
+                    it.actionId == R.id.action_global_tabsTrayFragment &&
+                        it.arguments["focusGroupTabId"] == "1"
+                }
+            )
+        }
+        assertNotNull(SearchTerms.jumpBackInGroupTapped.testGetValue())
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/home/recentvisits/interactor/RecentVisitsInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/recentvisits/interactor/RecentVisitsInteractorTest.kt
@@ -6,12 +6,16 @@ package org.mozilla.fenix.home.recentvisits.interactor
 
 import io.mockk.mockk
 import io.mockk.verify
+import mozilla.components.concept.storage.DocumentType
+import mozilla.components.concept.storage.HistoryMetadata
+import mozilla.components.concept.storage.HistoryMetadataKey
 import org.junit.Before
 import org.junit.Test
 import org.mozilla.fenix.home.pocket.PocketStoriesController
 import org.mozilla.fenix.home.recentbookmarks.controller.RecentBookmarksController
 import org.mozilla.fenix.home.recentsyncedtabs.controller.RecentSyncedTabController
 import org.mozilla.fenix.home.recenttabs.controller.RecentTabController
+import org.mozilla.fenix.home.recentvisits.RecentlyVisitedItem.RecentHistoryGroup
 import org.mozilla.fenix.home.recentvisits.RecentlyVisitedItem.RecentHistoryHighlight
 import org.mozilla.fenix.home.recentvisits.controller.RecentVisitsController
 import org.mozilla.fenix.home.sessioncontrol.DefaultSessionControlController
@@ -41,9 +45,64 @@ class RecentVisitsInteractorTest {
     }
 
     @Test
+    fun handleRecentHistoryGroupClicked() {
+        val historyGroup =
+            RecentHistoryGroup(
+                title = "mozilla",
+                historyMetadata = listOf(
+                    HistoryMetadata(
+                        key = HistoryMetadataKey("http://www.mozilla.com", null, null),
+                        title = "mozilla",
+                        createdAt = System.currentTimeMillis(),
+                        updatedAt = System.currentTimeMillis(),
+                        totalViewTime = 10,
+                        documentType = DocumentType.Regular,
+                        previewImageUrl = null
+                    )
+                )
+            )
+
+        interactor.onRecentHistoryGroupClicked(historyGroup)
+        verify {
+            recentVisitsController.handleRecentHistoryGroupClicked(historyGroup)
+        }
+    }
+
+    @Test
     fun handleHistoryShowAllClicked() {
         interactor.onHistoryShowAllClicked()
         verify { recentVisitsController.handleHistoryShowAllClicked() }
+    }
+
+    @Test
+    fun onRemoveRecentHistoryGroup() {
+        val historyMetadataKey = HistoryMetadataKey(
+            "http://www.mozilla.com",
+            "mozilla",
+            null
+        )
+
+        val historyGroup =
+            RecentHistoryGroup(
+                title = "mozilla",
+                historyMetadata = listOf(
+                    HistoryMetadata(
+                        key = historyMetadataKey,
+                        title = "mozilla",
+                        createdAt = System.currentTimeMillis(),
+                        updatedAt = System.currentTimeMillis(),
+                        totalViewTime = 10,
+                        documentType = DocumentType.Regular,
+                        previewImageUrl = null
+                    )
+                )
+            )
+
+        interactor.onRemoveRecentHistoryGroup(historyGroup.title)
+
+        verify {
+            recentVisitsController.handleRemoveRecentHistoryGroup(historyGroup.title)
+        }
     }
 
     @Test

--- a/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/SessionControlViewTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/SessionControlViewTest.kt
@@ -24,7 +24,7 @@ import org.mozilla.fenix.gleanplumb.Message
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.home.recentbookmarks.RecentBookmark
 import org.mozilla.fenix.home.recenttabs.RecentTab
-import org.mozilla.fenix.home.recentvisits.RecentlyVisitedItem
+import org.mozilla.fenix.home.recentvisits.RecentlyVisitedItem.RecentHistoryGroup
 import org.mozilla.fenix.utils.Settings
 
 @RunWith(FenixRobolectricTestRunner::class)
@@ -56,7 +56,7 @@ class SessionControlViewTest {
 
     @Test
     fun `GIVEN historyMetadata WHEN calling shouldShowHomeOnboardingDialog THEN show the dialog `() {
-        val historyMetadata = listOf(RecentlyVisitedItem.RecentHistoryHighlight("title", ""))
+        val historyMetadata = listOf(RecentHistoryGroup("title", emptyList()))
         val settings: Settings = mockk()
 
         every { settings.hasShownHomeOnboardingDialog } returns false
@@ -138,7 +138,7 @@ class SessionControlViewTest {
         val collections = emptyList<TabCollection>()
         val expandedCollections = emptySet<Long>()
         val recentBookmarks = listOf(RecentBookmark())
-        val historyMetadata = emptyList<RecentlyVisitedItem>()
+        val historyMetadata = emptyList<RecentHistoryGroup>()
         val pocketStories = emptyList<PocketStory>()
 
         every { settings.showTopSitesFeature } returns true
@@ -173,7 +173,7 @@ class SessionControlViewTest {
         val collections = emptyList<TabCollection>()
         val expandedCollections = emptySet<Long>()
         val recentBookmarks = listOf(RecentBookmark())
-        val historyMetadata = emptyList<RecentlyVisitedItem>()
+        val historyMetadata = emptyList<RecentHistoryGroup>()
         val pocketStories = emptyList<PocketStory>()
         val nimbusMessageCard: Message = mockk()
 
@@ -206,7 +206,7 @@ class SessionControlViewTest {
         val collections = emptyList<TabCollection>()
         val expandedCollections = emptySet<Long>()
         val recentBookmarks = listOf<RecentBookmark>()
-        val historyMetadata = emptyList<RecentlyVisitedItem>()
+        val historyMetadata = emptyList<RecentHistoryGroup>()
         val pocketStories = emptyList<PocketStory>()
 
         every { settings.showTopSitesFeature } returns true
@@ -241,7 +241,7 @@ class SessionControlViewTest {
         val collections = emptyList<TabCollection>()
         val expandedCollections = emptySet<Long>()
         val recentBookmarks = listOf<RecentBookmark>()
-        val historyMetadata = listOf<RecentlyVisitedItem>(mockk())
+        val historyMetadata = listOf(RecentHistoryGroup("title", emptyList()))
         val pocketStories = emptyList<PocketStory>()
 
         every { settings.showTopSitesFeature } returns true
@@ -276,7 +276,7 @@ class SessionControlViewTest {
         val collections = emptyList<TabCollection>()
         val expandedCollections = emptySet<Long>()
         val recentBookmarks = listOf<RecentBookmark>()
-        val historyMetadata = emptyList<RecentlyVisitedItem>()
+        val historyMetadata = emptyList<RecentHistoryGroup>()
         val pocketStories = listOf(PocketRecommendedStory("", "", "", "", "", 1, 1))
 
         every { settings.showTopSitesFeature } returns true
@@ -312,7 +312,7 @@ class SessionControlViewTest {
         val collections = emptyList<TabCollection>()
         val expandedCollections = emptySet<Long>()
         val recentBookmarks = listOf<RecentBookmark>()
-        val historyMetadata = emptyList<RecentlyVisitedItem>()
+        val historyMetadata = emptyList<RecentHistoryGroup>()
         val pocketStories = emptyList<PocketStory>()
 
         every { settings.showTopSitesFeature } returns true
@@ -347,7 +347,7 @@ class SessionControlViewTest {
         val collections = listOf(collection)
         val expandedCollections = emptySet<Long>()
         val recentBookmarks = listOf<RecentBookmark>(mockk())
-        val historyMetadata = listOf<RecentlyVisitedItem>(mockk())
+        val historyMetadata = listOf<RecentHistoryGroup>(mockk())
         val pocketStories = listOf<PocketStory>(mockk())
 
         every { settings.showTopSitesFeature } returns true

--- a/app/src/test/java/org/mozilla/fenix/tabstray/SearchTermTabGroupMiddlewareTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/SearchTermTabGroupMiddlewareTest.kt
@@ -1,0 +1,104 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.tabstray
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import mozilla.components.browser.state.action.BrowserAction
+import mozilla.components.browser.state.action.HistoryMetadataAction
+import mozilla.components.browser.state.action.TabGroupAction
+import mozilla.components.browser.state.action.TabListAction
+import mozilla.components.browser.state.engine.EngineMiddleware
+import mozilla.components.browser.state.state.BrowserState
+import mozilla.components.browser.state.state.TabGroup
+import mozilla.components.browser.state.state.TabPartition
+import mozilla.components.browser.state.state.recover.RecoverableTab
+import mozilla.components.browser.state.state.recover.TabState
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.concept.storage.HistoryMetadataKey
+import mozilla.components.lib.state.MiddlewareContext
+import org.junit.Before
+import org.junit.Test
+
+class SearchTermTabGroupMiddlewareTest {
+
+    private lateinit var store: BrowserStore
+    private lateinit var searchTermTabGroupMiddleware: SearchTermTabGroupMiddleware
+
+    @Before
+    fun setUp() {
+        searchTermTabGroupMiddleware = SearchTermTabGroupMiddleware()
+        store = BrowserStore(
+            middleware = listOf(searchTermTabGroupMiddleware) + EngineMiddleware.create(engine = mockk()),
+            initialState = BrowserState()
+        )
+    }
+
+    @Test
+    fun `WHEN invoking with set history metadata key action THEN dispatch add tab action`() {
+        val context: MiddlewareContext<BrowserState, BrowserAction> = mockk()
+        val next: (BrowserAction) -> Unit = {}
+
+        every { context.dispatch(any()) } returns Unit
+
+        searchTermTabGroupMiddleware.invoke(
+            context,
+            next,
+            HistoryMetadataAction.SetHistoryMetadataKeyAction("tabId", HistoryMetadataKey("url", "search term", "url"))
+        )
+
+        verify { context.dispatch(TabGroupAction.AddTabAction(SEARCH_TERM_TAB_GROUPS, "search term", "tabId")) }
+    }
+
+    @Test
+    fun `WHEN invoking with disband search group action THEN dispatch remove tab group action`() {
+        val context: MiddlewareContext<BrowserState, BrowserAction> = mockk()
+        val next: (BrowserAction) -> Unit = {}
+        val state: BrowserState = mockk()
+        val tabPartitions =
+            mapOf(Pair(SEARCH_TERM_TAB_GROUPS, TabPartition(SEARCH_TERM_TAB_GROUPS, listOf(TabGroup("testId", "search term", listOf("tab1"))))))
+
+        every { context.dispatch(any()) } returns Unit
+        every { context.state } returns state
+        every { state.tabPartitions } returns tabPartitions
+
+        searchTermTabGroupMiddleware.invoke(
+            context,
+            next,
+            HistoryMetadataAction.DisbandSearchGroupAction("search term")
+        )
+
+        verify { context.dispatch(TabGroupAction.RemoveTabGroupAction(SEARCH_TERM_TAB_GROUPS, "testId")) }
+    }
+
+    @Test
+    fun `WHEN invoking with restore action THEN dispatch add tab action`() {
+        val context: MiddlewareContext<BrowserState, BrowserAction> = mockk()
+        val next: (BrowserAction) -> Unit = {}
+
+        every { context.dispatch(any()) } returns Unit
+
+        searchTermTabGroupMiddleware.invoke(
+            context,
+            next,
+            TabListAction.RestoreAction(
+                listOf(
+                    RecoverableTab(
+                        engineSessionState = null,
+                        state = TabState(
+                            id = "testId",
+                            url = "url",
+                            historyMetadata = HistoryMetadataKey("url", "search term", "url")
+                        )
+                    )
+                ),
+                restoreLocation = TabListAction.RestoreAction.RestoreLocation.BEGINNING
+            )
+        )
+
+        verify { context.dispatch(TabGroupAction.AddTabAction(SEARCH_TERM_TAB_GROUPS, "search term", "testId")) }
+    }
+}

--- a/app/src/test/java/org/mozilla/fenix/tabstray/TabsTrayStoreReducerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabstray/TabsTrayStoreReducerTest.kt
@@ -10,6 +10,18 @@ import org.junit.Test
 import org.mozilla.fenix.tabstray.syncedtabs.getFakeSyncedTabList
 
 class TabsTrayStoreReducerTest {
+    @Test
+    fun `GIVEN focusGroupTabId WHEN ConsumeFocusGroupTabIdAction THEN focusGroupTabId must be consumed`() {
+        val initialState = TabsTrayState(focusGroupTabId = "id")
+        val expectedState = initialState.copy(focusGroupTabId = null)
+
+        val resultState = TabsTrayReducer.reduce(
+            initialState,
+            TabsTrayAction.ConsumeFocusGroupTabId
+        )
+
+        assertEquals(expectedState, resultState)
+    }
 
     @Test
     fun `WHEN UpdateInactiveTabs THEN inactive tabs are added`() {


### PR DESCRIPTION
Reverts mozilla-mobile/fenix#26288

The PR should've only removed tab groups from "Jump Back In", not history groups from "Recently Visited". It had separate commits per section, but let's revert the whole PR and test / re-land again tomorrow.