### PR TITLE
For #26239 - Avoid displaying multiple download items for the same file

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/downloads/DownloadFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/downloads/DownloadFragment.kt
@@ -91,6 +91,7 @@ class DownloadFragment : LibraryPageFragment<DownloadItem>(), UserInteractionHan
     @VisibleForTesting
     internal fun provideDownloads(state: BrowserState): List<DownloadItem> {
         return state.downloads.values
+            .distinctBy { it.fileName }
             .sortedByDescending { it.createdTime } // sort from newest to oldest
             .map {
                 DownloadItem(

--- a/app/src/test/java/org/mozilla/fenix/library/downloads/DownloadFragmentTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/downloads/DownloadFragmentTest.kt
@@ -147,4 +147,37 @@ class DownloadFragmentTest {
         val list = fragment.provideDownloads(state)
         assertEquals(expectedList[0].size, list[0].size)
     }
+
+    @Test
+    fun `WHEN two download states point to the same existing file THEN only one download item is displayed`() {
+        val fragment = DownloadFragment()
+        val downloadedFile0 = File(
+            Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS),
+            "1.pdf"
+        )
+        val state: BrowserState = mockk(relaxed = true)
+        every { state.downloads } returns mapOf(
+            "1" to DownloadState(
+                id = "1",
+                createdTime = 1,
+                url = "url",
+                fileName = "1.pdf",
+                contentLength = 100,
+                status = DownloadState.Status.COMPLETED
+            ),
+            "2" to DownloadState(
+                id = "2",
+                createdTime = 2,
+                url = "url",
+                fileName = "1.pdf",
+                contentLength = 100,
+                status = DownloadState.Status.COMPLETED
+            )
+        )
+
+        downloadedFile0.createNewFile()
+        val providedList = fragment.provideDownloads(state)
+
+        assertEquals(1, providedList.size)
+    }
 }


### PR DESCRIPTION
Added `distinctBy` call to `provideDownloads` which filters multiple instances of a `DownloadItem` for the same file.

https://user-images.githubusercontent.com/35462038/182546143-f49dad38-ce1f-4418-95d0-a5354e876e6a.mp4

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
Fixes #26239