### PR TITLE
For #26286 new verifyRemoveTopSiteFromMainMenu UI test

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/TopSitesTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/TopSitesTest.kt
@@ -172,6 +172,30 @@ class TopSitesTest {
     }
 
     @Test
+    fun verifyRemoveTopSiteFromMainMenu() {
+        val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+        val defaultWebPageTitle = "Test_Page_1"
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(defaultWebPage.url) {
+        }.openThreeDotMenu {
+            expandMenu()
+            verifyAddToTopSitesButton()
+        }.addToFirefoxHome {
+            verifySnackBarText(getStringResource(R.string.snackbar_added_to_shortcuts))
+        }.goToHomescreen {
+            verifyExistingTopSitesList()
+            verifyExistingTopSitesTabs(defaultWebPageTitle)
+        }.openTopSiteTabWithTitle(defaultWebPageTitle) {
+        }.openThreeDotMenu {
+            verifyRemoveFromShortcutsButton()
+        }.clickRemoveFromShortcuts {
+        }.goToHomescreen {
+            verifyNotExistingTopSitesList(defaultWebPageTitle)
+        }
+    }
+
+    @Test
     fun verifyDefaultTopSitesLocale_EN() {
         // en-US defaults
         val defaultTopSites = arrayOf(

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuMainRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuMainRobot.kt
@@ -71,6 +71,7 @@ class ThreeDotMenuMainRobot {
     fun verifyFindInPageButton() = assertFindInPageButton()
     fun verifyWhatsNewButton() = assertWhatsNewButton()
     fun verifyAddToTopSitesButton() = assertAddToTopSitesButton()
+    fun verifyRemoveFromShortcutsButton() = assertRemoveFromShortcutsButton()
     fun verifyAddToMobileHome() = assertAddToMobileHome()
     fun verifyDesktopSite() = assertDesktopSite()
     fun verifyDownloadsButton() = assertDownloadsButton()
@@ -325,6 +326,13 @@ class ThreeDotMenuMainRobot {
             return BrowserRobot.Transition()
         }
 
+        fun clickRemoveFromShortcuts(interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
+            removeFromShortcutsButton().click()
+
+            BrowserRobot().interact()
+            return BrowserRobot.Transition()
+        }
+
         fun openAddToHomeScreen(interact: AddToHomeScreenRobot.() -> Unit): AddToHomeScreenRobot.Transition {
             mDevice.waitNotNull(Until.findObject(By.text("Add to Home screen")), waitingTime)
             addToHomeScreenButton().click()
@@ -513,11 +521,24 @@ private fun assertReaderViewAppearanceButton(visible: Boolean) {
 private fun addToTopSitesButton() =
     onView(allOf(withText(R.string.browser_menu_add_to_shortcuts)))
 
+private fun removeFromShortcutsButton() =
+    onView(allOf(withText(R.string.browser_menu_remove_from_shortcuts)))
+
 private fun assertAddToTopSitesButton() {
     onView(withId(R.id.mozac_browser_menu_recyclerView))
         .perform(
             RecyclerViewActions.scrollTo<RecyclerView.ViewHolder>(
                 hasDescendant(withText(R.string.browser_menu_add_to_shortcuts))
+            )
+        ).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
+}
+
+private fun assertRemoveFromShortcutsButton() {
+
+    onView(withId(R.id.mozac_browser_menu_recyclerView))
+        .perform(
+            RecyclerViewActions.scrollTo<RecyclerView.ViewHolder>(
+                hasDescendant(withText(R.string.browser_menu_settings))
             )
         ).check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 }


### PR DESCRIPTION
For #26286 new `verifyRemoveTopSiteFromMainMenu` UI test ✅ successfully ran 100x on Firebase.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
Fixes #26286