### PR TITLE
For #26335: Enable sponsored shortcuts by default

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -1303,10 +1303,9 @@ class Settings(private val appContext: Context) : PreferencesHolder {
     /**
      * Indicates if the Contile functionality should be visible.
      */
-    var showContileFeature by lazyFeatureFlagPreference(
+    var showContileFeature by booleanPreference(
         key = appContext.getPreferenceKey(R.string.pref_key_enable_contile),
-        default = { homescreenSections[HomeScreenSection.CONTILE_TOP_SITES] == true },
-        featureFlag = true,
+        default = true,
     )
 
     /**

--- a/nimbus.fml.yaml
+++ b/nimbus.fml.yaml
@@ -20,7 +20,6 @@ features:
             "recent-explorations": true,
             "pocket": true,
             "pocket-sponsored-stories": false,
-            "contile-top-sites": false,
           }
     defaults:
       - channel: nightly
@@ -31,7 +30,6 @@ features:
             "recently-saved": true,
             "recent-explorations": true,
             "pocket": true,
-            "contile-top-sites": false,
           }
         }
       - channel: developer
@@ -317,8 +315,6 @@ types:
           description: The pocket section. This should only be available in the US.
         pocket-sponsored-stories:
           description: Subsection of the Pocket homescreen section which shows sponsored stories.
-        contile-top-sites:
-          description: The sponsored shortcuts in the homescreen.
     MessageSurfaceId:
       description: The identity of a message surface, used in the default browser experiments
       variants:


### PR DESCRIPTION
Enabled sponsored shortcuts by default for all users.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.








### GitHub Automation
Fixes #26335