### PR TITLE
Fix compatibility issues induced by android:gravity

### DIFF
--- a/app/src/main/res/drawable/toolbar_background.xml
+++ b/app/src/main/res/drawable/toolbar_background.xml
@@ -13,7 +13,7 @@
                 android:type="linear" />
         </shape>
     </item>
-    <item android:gravity="top">
+    <item android:bottom="55dp">
         <shape android:shape="rectangle">
             <size android:height="1dp" />
             <solid android:color="?neutralFaded" />

--- a/app/src/main/res/drawable/toolbar_background_top.xml
+++ b/app/src/main/res/drawable/toolbar_background_top.xml
@@ -13,7 +13,7 @@
                 android:type="linear" />
         </shape>
     </item>
-    <item android:gravity="bottom">
+    <item android:top="55dp">
         <shape android:shape="rectangle">
             <size android:height="1dp" />
             <solid android:color="?neutralFaded" />


### PR DESCRIPTION
Hello,

I found compatibility issues in [toolbar_background.xml](https://github.com/mozilla-mobile/fenix/compare/main...rudmannn:fenix:main#diff-d87c72a21bcdb5c29833182f0741f37723a4a78c9524f2e9c9ffe4b7dd72ec61) and [toolbar_background_top.xml](https://github.com/mozilla-mobile/fenix/compare/main...rudmannn:fenix:main#diff-72f3586c8bf2651b5d60f11f01b2cf3a535fb38ebd873df89f81a741223680ed).

You use ``android:gravity`` to draw the edge of the toolbar. However, ``android:gravity`` does not exist at Android < 6.0.
Therefore, the toolbar looks like this.

API Level 32
toolbar_background

![2601659778648_ pic](https://user-images.githubusercontent.com/109571086/183243545-ad166709-8d4d-4da3-be23-22cad834d666.jpg)

toolbar_background_top

![2571659778388_ pic](https://user-images.githubusercontent.com/109571086/183243559-18f1ffd3-365d-4815-8ee2-5fafbf0853ee.jpg)


API Level 22
toolbar_background

![2591659778589_ pic](https://user-images.githubusercontent.com/109571086/183243571-852bbb6c-c02d-4926-a08f-558f27aeff16.jpg)


toolbar_background_top

![2561659778323_ pic](https://user-images.githubusercontent.com/109571086/183243574-c6b63656-4329-44f6-a430-27a9eb619d18.jpg)

This pull request helps fixing the above issues by using ``android:top`` and ``android:bottom``. Such fixes are related to the discussion in [here](https://stackoverflow.com/questions/34831142/how-to-center-vector-drawable-in-layer-list-without-scaling). 55dp is set for ``android:top`` and ``android:bottom`` to match the 1dp edge, since you set the toolbar height as 56dp. 
https://github.com/mozilla-mobile/fenix/blob/4379b06288c0c512c6ab6816456a8c3fc2bb9589/app/src/main/res/layout/component_browser_top_toolbar.xml#L11 

Hope the information is useful for you and the issues can be fixed.

 
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
