### PR TITLE
Add "manage account and devices" button to home menu

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeMenu.kt
@@ -19,10 +19,12 @@ import mozilla.components.browser.menu.item.BrowserMenuDivider
 import mozilla.components.browser.menu.item.BrowserMenuHighlightableItem
 import mozilla.components.browser.menu.item.BrowserMenuImageSwitch
 import mozilla.components.browser.menu.item.BrowserMenuImageText
+import mozilla.components.browser.menu.item.SimpleBrowserMenuItem
 import mozilla.components.concept.sync.AccountObserver
 import mozilla.components.concept.sync.AuthType
 import mozilla.components.concept.sync.OAuthAccount
 import mozilla.components.support.ktx.android.content.getColorFromAttr
+import org.mozilla.fenix.Config
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.accounts.AccountState
 import org.mozilla.fenix.components.accounts.FenixAccountManager
@@ -46,6 +48,10 @@ class HomeMenu(
         object Downloads : Item()
         object Extensions : Item()
         data class SyncAccount(val accountState: AccountState) : Item()
+        /**
+         * A button item to open up the settings page of FxA, shown up in mozilla online builds.
+         */
+        object ManageAccountAndDevices : Item()
         object WhatsNew : Item()
         object Help : Item()
         object CustomizeHome : Item()
@@ -145,6 +151,13 @@ class HomeMenu(
             onItemTapped.invoke(Item.Extensions)
         }
 
+        val manageAccountAndDevicesItem = SimpleBrowserMenuItem(
+            context.getString(R.string.browser_menu_manage_account_and_devices),
+            textColorResource = primaryTextColor
+        ) {
+            onItemTapped.invoke(Item.ManageAccountAndDevices)
+        }
+
         val whatsNewItem = BrowserMenuHighlightableItem(
             context.getString(R.string.browser_menu_whats_new),
             R.drawable.ic_whats_new,
@@ -201,6 +214,7 @@ class HomeMenu(
             extensionsItem,
             syncSignInMenuItem,
             accountAuthItem,
+            if (Config.channel.isMozillaOnline) manageAccountAndDevicesItem else null,
             BrowserMenuDivider(),
             desktopItem,
             BrowserMenuDivider(),

--- a/app/src/main/java/org/mozilla/fenix/home/HomeMenuBuilder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeMenuBuilder.kt
@@ -16,6 +16,7 @@ import mozilla.appservices.places.BookmarkRoot
 import mozilla.components.browser.menu.view.MenuButton
 import mozilla.components.service.glean.private.NoExtras
 import org.mozilla.fenix.BrowserDirection
+import org.mozilla.fenix.Config
 import org.mozilla.fenix.GleanMetrics.Events
 import org.mozilla.fenix.GleanMetrics.HomeScreen
 import org.mozilla.fenix.HomeActivity
@@ -77,7 +78,7 @@ class HomeMenuBuilder(
     /**
      * Callback invoked when a menu item is tapped on.
      */
-    @Suppress("LongMethod")
+    @Suppress("LongMethod", "ComplexMethod")
     @VisibleForTesting(otherwise = PRIVATE)
     internal fun onItemTapped(item: HomeMenu.Item) {
         if (item !is HomeMenu.Item.DesktopMode) {
@@ -112,6 +113,18 @@ class HomeMenuBuilder(
                         AccountState.NO_ACCOUNT ->
                             HomeFragmentDirections.actionGlobalTurnOnSync()
                     }
+                )
+            }
+            HomeMenu.Item.ManageAccountAndDevices -> {
+                homeActivity.openToBrowserAndLoad(
+                    searchTermOrURL =
+                    if (context.settings().allowDomesticChinaFxaServer) {
+                        mozilla.appservices.fxaclient.Config.Server.CHINA.contentUrl + "/settings"
+                    } else {
+                        mozilla.appservices.fxaclient.Config.Server.RELEASE.contentUrl + "/settings"
+                    },
+                    newTab = true,
+                    from = BrowserDirection.FromHome
                 )
             }
             HomeMenu.Item.Bookmarks -> {

--- a/app/src/main/res/values-zh-rCN/mozonline_strings.xml
+++ b/app/src/main/res/values-zh-rCN/mozonline_strings.xml
@@ -40,5 +40,9 @@
     <string name="pair_instructions_2_cn"><![CDATA[打开 <b>firefox.com.cn/pair</b> 并扫描网站上的二维码]]></string>
     <!-- Instructions on how to access pairing -->
     <string name="sign_in_instructions_cn"><![CDATA[在计算机上使用 Firefox 打开 <b>https://firefox.com.cn/pair</b>]]></string>
+
+    <!-- Homescreen menu button -->
+    <!-- Browser menu button that opens the account setting page -->
+    <string name="browser_menu_manage_account_and_devices">管理账户和设备</string>
 </resources>
 

--- a/app/src/main/res/values/mozonline_strings.xml
+++ b/app/src/main/res/values/mozonline_strings.xml
@@ -39,4 +39,8 @@
     <string name="pair_instructions_2_cn"><![CDATA[Scan the QR code shown at <b>firefox.com.cn/pair</b>]]></string>
     <!-- Instructions on how to access pairing -->
     <string name="sign_in_instructions_cn"><![CDATA[On your computer open Firefox and go to <b>https://firefox.com.cn/pair</b>]]></string>
+
+    <!-- Homescreen menu button -->
+    <!-- Browser menu button that opens the account setting page -->
+    <string name="browser_menu_manage_account_and_devices">Manage Account and Devices</string>
 </resources>


### PR DESCRIPTION
Due to the regulations of app stores in China, we should provide a straightforward way for users to delete the accounts.

What I did in this patch is  just to add a button of managing account and devices in the home menu, to tap the button is just open the settings page of FxA in a new tab. 
 
![Screenshot_20220812_125845_org mozilla fenix debu](https://user-images.githubusercontent.com/33616048/183353711-4380d843-7a57-4142-8f94-a2531e3195b6.jpg)
.