### PR TITLE
Fixes #26377: re-open already opened recent synced tabs

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -350,7 +350,7 @@ class HomeFragment : Fragment() {
                 appStore = components.appStore,
             ),
             recentSyncedTabController = DefaultRecentSyncedTabController(
-                addNewTabUseCase = requireComponents.useCases.tabsUseCases.addTab,
+                tabsUseCase = requireComponents.useCases.tabsUseCases,
                 navController = findNavController(),
                 accessPoint = TabsTrayAccessPoint.HomeRecentSyncedTab,
             ),

--- a/app/src/main/java/org/mozilla/fenix/home/recentsyncedtabs/controller/RecentSyncedTabController.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recentsyncedtabs/controller/RecentSyncedTabController.kt
@@ -32,17 +32,17 @@ interface RecentSyncedTabController {
 /**
  * The default implementation of [RecentSyncedTabController].
  *
- * @property addNewTabUseCase Use case to open the synced tab when clicked.
+ * @property tabsUseCase Use cases to open the synced tab when clicked.
  * @property navController [NavController] to navigate to synced tabs tray.
  */
 class DefaultRecentSyncedTabController(
-    private val addNewTabUseCase: TabsUseCases.AddNewTabUseCase,
+    private val tabsUseCase: TabsUseCases,
     private val navController: NavController,
     private val accessPoint: TabsTrayAccessPoint,
 ) : RecentSyncedTabController {
     override fun handleRecentSyncedTabClick(tab: RecentSyncedTab) {
         RecentSyncedTabs.recentSyncedTabOpened[tab.deviceType.name.lowercase()].add()
-        addNewTabUseCase.invoke(tab.url)
+        tabsUseCase.selectOrAddTab(tab.url)
         navController.navigate(R.id.browserFragment)
     }
 


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
Fixes #26377