### PR TITLE
For #26412 - Remove try catch for NimbusFeatureException from FxNimbus value() getter

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/settings/FeatureFlagPreference.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/settings/FeatureFlagPreference.kt
@@ -4,10 +4,8 @@
 
 package org.mozilla.fenix.components.settings
 
-import mozilla.components.support.base.log.logger.Logger
 import mozilla.components.support.ktx.android.content.PreferencesHolder
 import mozilla.components.support.ktx.android.content.booleanPreference
-import org.mozilla.experiments.nimbus.internal.NimbusFeatureException
 import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
 
@@ -29,16 +27,8 @@ fun featureFlagPreference(key: String, default: Boolean, featureFlag: Boolean) =
 private class LazyPreference(val key: String, val default: () -> Boolean) :
     ReadWriteProperty<PreferencesHolder, Boolean> {
 
-    override fun getValue(thisRef: PreferencesHolder, property: KProperty<*>): Boolean {
-        val defValue = try {
-            default()
-        } catch (e: NimbusFeatureException) {
-            Logger.error("Failed fetch default value for $key", e)
-            false
-        }
-
-        return thisRef.preferences.getBoolean(key, defValue)
-    }
+    override fun getValue(thisRef: PreferencesHolder, property: KProperty<*>): Boolean =
+        thisRef.preferences.getBoolean(key, default())
 
     override fun setValue(thisRef: PreferencesHolder, property: KProperty<*>, value: Boolean) =
         thisRef.preferences.edit().putBoolean(key, value).apply()

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -28,7 +28,6 @@ import mozilla.components.support.ktx.android.content.longPreference
 import mozilla.components.support.ktx.android.content.stringPreference
 import mozilla.components.support.ktx.android.content.stringSetPreference
 import mozilla.components.support.locale.LocaleManager
-import org.mozilla.experiments.nimbus.internal.NimbusFeatureException
 import org.mozilla.fenix.BuildConfig
 import org.mozilla.fenix.Config
 import org.mozilla.fenix.FeatureFlags
@@ -1204,11 +1203,8 @@ class Settings(private val appContext: Context) : PreferencesHolder {
     private val onboardScreenSection: Map<OnboardingSection, Boolean> get() =
         FxNimbus.features.onboarding.value().sectionsEnabled
 
-    private val homescreenSections: Map<HomeScreenSection, Boolean> get() = try {
+    private val homescreenSections: Map<HomeScreenSection, Boolean> get() =
         FxNimbus.features.homescreen.value().sectionsEnabled
-    } catch (e: NimbusFeatureException) {
-        emptyMap()
-    }
 
     var historyMetadataUIFeature by lazyFeatureFlagPreference(
         appContext.getPreferenceKey(R.string.pref_key_history_metadata_feature),


### PR DESCRIPTION



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.











### GitHub Automation
Fixes #26412