### PR TITLE
For #26414 - Have the Pocket spocs feature as part of the homescreen sections experiments

### DIFF
--- a/.experimenter.yaml
+++ b/.experimenter.yaml
@@ -66,14 +66,6 @@ onboarding:
     sections-enabled:
       type: json
       description: This property provides a lookup table of whether or not the given section should be enabled.
-pocket-sponsored-stories:
-  description: A feature showing sponsored stories in between the other Pocket recommended stories on homescreen.
-  hasExposure: true
-  exposureDescription: ""
-  variables:
-    enabled:
-      type: boolean
-      description: "If true, the Pocket stories shown on homescreen should contain sponsored stories also."
 search-term-groups:
   description: A feature allowing the grouping of URLs around the search term that it came from.
   hasExposure: true

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -1296,7 +1296,7 @@ class Settings(private val appContext: Context) : PreferencesHolder {
      */
     val showPocketSponsoredStories by lazyFeatureFlagPreference(
         key = appContext.getPreferenceKey(R.string.pref_key_pocket_sponsored_stories),
-        default = { FxNimbus.features.pocketSponsoredStories.value(appContext).enabled },
+        default = { homescreenSections[HomeScreenSection.POCKET_SPONSORED_STORIES] == true },
         featureFlag = FeatureFlags.isPocketSponsoredStoriesFeatureEnabled(appContext)
     )
 

--- a/nimbus.fml.yaml
+++ b/nimbus.fml.yaml
@@ -19,6 +19,7 @@ features:
             "recently-saved": true,
             "recent-explorations": true,
             "pocket": true,
+            "pocket-sponsored-stories": false,
             "contile-top-sites": false,
           }
     defaults:
@@ -31,6 +32,12 @@ features:
             "recent-explorations": true,
             "pocket": true,
             "contile-top-sites": false,
+          }
+        }
+      - channel: developer
+        value: {
+          "sections-enabled": {
+            "pocket-sponsored-stories": true,
           }
         }
   onboarding:
@@ -201,18 +208,6 @@ features:
         value:
           enabled: false
 
-  pocket-sponsored-stories:
-    description: A feature showing sponsored stories in between the other Pocket recommended stories on homescreen.
-    variables:
-      enabled:
-        description:  If true, the Pocket stories shown on homescreen should contain sponsored stories also.
-        type: Boolean
-        default: false
-    defaults:
-      - channel: developer
-        value:
-          enabled: true
-
   engine-settings:
     description: Contains a set of settings for controlling the web engine configurations.
     variables:
@@ -311,6 +306,8 @@ types:
           description: The tab groups
         pocket:
           description: The pocket section. This should only be available in the US.
+        pocket-sponsored-stories:
+          description: Subsection of the Pocket homescreen section which shows sponsored stories.
         contile-top-sites:
           description: The sponsored shortcuts in the homescreen.
     MessageSurfaceId:


### PR DESCRIPTION
Just a small refactoring of a feature not yet launched or part of Nimbus.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
Fixes #26414