### PR TITLE
Close #26198: Add debounce to account manager syncs

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -340,8 +340,13 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
             lifecycleScope.launch {
                 // If we're authenticated, kick-off a sync and a device state refresh.
                 components.backgroundServices.accountManager.authenticatedAccount()?.let {
+                    val syncReason = when (isVisuallyComplete) {
+                        true -> SyncReason.User
+                        false -> SyncReason.Startup
+                    }
+
                     components.backgroundServices.accountManager.syncNow(
-                        SyncReason.Startup,
+                        reason = syncReason,
                         debounce = true
                     )
                 }

--- a/app/src/main/java/org/mozilla/fenix/home/recentsyncedtabs/RecentSyncedTabFeature.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recentsyncedtabs/RecentSyncedTabFeature.kt
@@ -60,7 +60,11 @@ class RecentSyncedTabFeature(
                     // Sync tabs storage will fail to retrieve tabs aren't refreshed, as that action
                     // is what populates the device constellation state
                     accountManager.withConstellation { refreshDevices() }
-                    accountManager.syncNow(SyncReason.User, customEngineSubset = listOf(SyncEngine.Tabs))
+                    accountManager.syncNow(
+                        reason = SyncReason.User,
+                        debounce = true,
+                        customEngineSubset = listOf(SyncEngine.Tabs),
+                    )
                 }
             }.launchIn(coroutineScope)
     }

--- a/app/src/test/java/org/mozilla/fenix/home/recentsyncedtabs/RecentSyncedTabFeatureTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/recentsyncedtabs/RecentSyncedTabFeatureTest.kt
@@ -128,7 +128,7 @@ class RecentSyncedTabFeatureTest {
 
         verify { appStore.dispatch(AppAction.RecentSyncedTabStateChange(RecentSyncedTabState.Loading)) }
         coVerify { accountManager.withConstellation { refreshDevices() } }
-        coVerify { accountManager.syncNow(reason = SyncReason.User, debounce = false, customEngineSubset = listOf(SyncEngine.Tabs)) }
+        coVerify { accountManager.syncNow(reason = SyncReason.User, debounce = true, customEngineSubset = listOf(SyncEngine.Tabs)) }
     }
 
     @Test


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.









### GitHub Automation
Fixes #26198