### PR TITLE
Close #26041: Remove un-needed Nimbus workaround

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -434,15 +434,6 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
     private fun setupNimbusObserver(nimbus: Observable<NimbusInterface.Observer>) {
         nimbus.register(object : NimbusInterface.Observer {
             override fun onUpdatesApplied(updated: List<EnrolledExperiment>) {
-                // To workaround a caching bug in Nimbus that appears when we try to query an
-                // experiment **before** `FxNimbus.initialize` is called we need to set the `api`
-                // value again so that we can still access the NimbusApi that is wrapped
-                // in `FxNimbus.initialize.getSdk`.
-                //
-                // We set this value here to minimize the race between setting the `api` value and
-                // the callers of FxNimbus.
-                // See: https://github.com/mozilla/application-services/issues/5075
-                FxNimbus.api = components.analytics.experiments
                 onNimbusStartupAndUpdate()
             }
         })


### PR DESCRIPTION
This workaround was temporary and is not needed with the Nimbus groovy
plugin updates in Android Components.

Will request QA to re-test the patch once it lands.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
Fixes #26041