### PR TITLE
For #26399 - Use a list of tabs for recent synced tabs success state

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/recentsyncedtabs/view/RecentSyncedTabViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recentsyncedtabs/view/RecentSyncedTabViewHolder.kt
@@ -48,7 +48,7 @@ class RecentSyncedTabViewHolder(
             val syncedTab = when (it) {
                 RecentSyncedTabState.None,
                 RecentSyncedTabState.Loading -> null
-                is RecentSyncedTabState.Success -> it.tab
+                is RecentSyncedTabState.Success -> it.tabs.firstOrNull()
             }
             RecentSyncedTab(
                 tab = syncedTab,

--- a/app/src/test/java/org/mozilla/fenix/components/AppStoreTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/AppStoreTest.kt
@@ -165,11 +165,11 @@ class AppStoreTest {
         appStore.dispatch(AppAction.RecentSyncedTabStateChange(loading)).join()
         assertEquals(loading, appStore.state.recentSyncedTabState)
 
-        val recentSyncedTab = RecentSyncedTab("device name", DeviceType.DESKTOP, "title", "url", null)
-        val success = RecentSyncedTabState.Success(recentSyncedTab)
+        val recentSyncedTabs = listOf(RecentSyncedTab("device name", DeviceType.DESKTOP, "title", "url", null))
+        val success = RecentSyncedTabState.Success(recentSyncedTabs)
         appStore.dispatch(AppAction.RecentSyncedTabStateChange(success)).join()
         assertEquals(success, appStore.state.recentSyncedTabState)
-        assertEquals(recentSyncedTab, (appStore.state.recentSyncedTabState as RecentSyncedTabState.Success).tab)
+        assertEquals(recentSyncedTabs, (appStore.state.recentSyncedTabState as RecentSyncedTabState.Success).tabs)
     }
 
     @Test


### PR DESCRIPTION
Updated `RecentSyncedTabState.Success` to use a list of tabs.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.











### GitHub Automation
Fixes #26399