### PR TITLE
Close #26150: Do not show sync tabs in home when sync open tabs setting is disabled

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -281,6 +281,7 @@ class HomeFragment : Fragment() {
             if (requireContext().settings().enableTaskContinuityEnhancements) {
                 recentSyncedTabFeature.set(
                     feature = RecentSyncedTabFeature(
+                        context = requireContext(),
                         appStore = requireComponents.appStore,
                         syncStore = requireComponents.backgroundServices.syncStore,
                         storage = requireComponents.backgroundServices.syncedTabsStorage,

--- a/app/src/main/java/org/mozilla/fenix/home/recenttabs/view/RecentTabViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recenttabs/view/RecentTabViewHolder.kt
@@ -67,16 +67,11 @@ class RecentTabViewHolder(
             )
 
             recentSyncedTabState.value?.let {
-                if (components.settings.enableTaskContinuityEnhancements && it != RecentSyncedTabState.None) {
+                if (components.settings.enableTaskContinuityEnhancements && it is RecentSyncedTabState.Success) {
                     Spacer(modifier = Modifier.height(8.dp))
 
-                    val syncedTab = when (it) {
-                        RecentSyncedTabState.None,
-                        RecentSyncedTabState.Loading -> null
-                        is RecentSyncedTabState.Success -> it.tab
-                    }
                     RecentSyncedTab(
-                        tab = syncedTab,
+                        tab = it.tab,
                         onRecentSyncedTabClick = { tab ->
                             recentSyncedTabInteractor.onRecentSyncedTabClicked(tab)
                         },


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.













### GitHub Automation
Fixes #26150