### PR TITLE
Fixes #26150: check tabs engine is enabled before displaying tab pickup

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/appstate/AppStoreReducer.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/appstate/AppStoreReducer.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.fenix.components.appstate
 
+import android.util.Log
 import androidx.annotation.VisibleForTesting
 import mozilla.components.service.pocket.PocketStory.PocketRecommendedStory
 import mozilla.components.service.pocket.PocketStory.PocketSponsoredStory
@@ -73,6 +74,7 @@ internal object AppStoreReducer {
             )
         }
         is AppAction.RecentSyncedTabStateChange -> {
+            Log.i("tighe", "${action.state}")
             state.copy(
                 recentSyncedTabState = action.state
             )

--- a/app/src/main/java/org/mozilla/fenix/ext/AppState.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/AppState.kt
@@ -180,6 +180,6 @@ fun AppState.filterState(blocklistHandler: BlocklistHandler): AppState =
  * and the availability of local or Synced tabs.
  */
 fun AppState.shouldShowRecentTabs(settings: Settings): Boolean {
-    val hasTab = recentTabs.isNotEmpty() || recentSyncedTabState is RecentSyncedTabState.Success
+    val hasTab = recentTabs.isNotEmpty() || recentSyncedTabState !is RecentSyncedTabState.None
     return settings.showRecentTabsFeature && hasTab
 }

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -70,6 +70,7 @@ import mozilla.components.feature.top.sites.TopSitesProviderConfig
 import mozilla.components.lib.state.ext.consumeFlow
 import mozilla.components.lib.state.ext.consumeFrom
 import mozilla.components.lib.state.ext.flow
+import mozilla.components.service.fxa.manager.SyncEnginesStorage
 import mozilla.components.service.glean.private.NoExtras
 import mozilla.components.support.base.feature.ViewBoundFeatureWrapper
 import mozilla.components.support.ktx.android.content.res.resolveAttribute
@@ -284,6 +285,7 @@ class HomeFragment : Fragment() {
                         syncStore = requireComponents.backgroundServices.syncStore,
                         storage = requireComponents.backgroundServices.syncedTabsStorage,
                         accountManager = requireComponents.backgroundServices.accountManager,
+                        syncEnginesStorage = SyncEnginesStorage(requireContext()),
                         coroutineScope = viewLifecycleOwner.lifecycleScope,
                     ),
                     owner = viewLifecycleOwner,


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
Fixes #26150