### PR TITLE
Closes #26446: add wallpaper oboarding Nimbus flag

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -102,4 +102,9 @@ object FeatureFlags {
      * Enables compose on the tabs tray items.
      */
     val composeTabsTray = Config.channel.isDebug
+
+    /**
+     * Enables the wallpaper onboarding.
+     */
+    val wallpaperOnboardingEnabled = Config.channel.isDebug
 }

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -195,6 +195,15 @@ class Settings(private val appContext: Context) : PreferencesHolder {
         default = true
     )
 
+    /**
+     * Indicates if the wallpaper onboarding dialog should be shown.
+     */
+    val showWallpaperOnboarding by lazyFeatureFlagPreference(
+        key = appContext.getPreferenceKey(R.string.pref_key_wallpapers_onboarding),
+        featureFlag = FeatureFlags.wallpaperOnboardingEnabled,
+        default = { onboardScreenSection[OnboardingSection.WALLPAPERS] == true },
+    )
+
     var openLinksInAPrivateTab by booleanPreference(
         appContext.getPreferenceKey(R.string.pref_key_open_links_in_a_private_tab),
         default = false

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -204,6 +204,7 @@
     <string name="pref_key_current_wallpaper" translatable="false">pref_key_current_wallpaper</string>
     <string name="pref_key_wallpapers_switched_by_logo_tap">pref_key_wallpapers_switched_by_logo_tap</string>
     <string name="pref_key_show_logo_animation" translatable="false">pref_key_show_logo_animation</string>
+    <string name="pref_key_wallpapers_onboarding" translatable="false">pref_key_wallpapers_onboarding</string>
 
     <string name="pref_key_encryption_key_generated" translatable="false">pref_key_encryption_key_generated</string>
 

--- a/nimbus.fml.yaml
+++ b/nimbus.fml.yaml
@@ -41,13 +41,22 @@ features:
         type: Map<OnboardingSection, Boolean>
         default:
           {
-            "sync-cfr": false
+            "sync-cfr": false,
+            "wallpapers": false
           }
     defaults:
       - channel: nightly
         value: {
           "sections-enabled": {
-            "sync-cfr": false
+            "sync-cfr": false,
+            "wallpapers": false
+          }
+        }
+      - channel: developer
+        value: {
+          "sections-enabled": {
+            "sync-cfr": false,
+            "wallpapers": true
           }
         }
   nimbus-validation:
@@ -327,3 +336,5 @@ types:
       variants:
         sync-cfr:
           description: Sync onboarding CFR.
+        wallpapers:
+          description: Wallpapers onboarding dialog.


### PR DESCRIPTION
Adding a nimbus flag for wallpaper onbarding.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
Fixes #26446