### PR TITLE
For #26423: simplify wallpaper types to single data class

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -965,7 +965,7 @@ class HomeFragment : Fragment() {
                     // We only want to update the wallpaper when it's different from the default one
                     // as the default is applied already on xml by default.
                     when (val currentWallpaper = state.wallpaperState.currentWallpaper) {
-                        is Wallpaper.Default -> {
+                        Wallpaper.Default -> {
                             binding.wallpaperImageView.visibility = View.GONE
                         }
                         else -> {

--- a/app/src/main/java/org/mozilla/fenix/wallpapers/Wallpaper.kt
+++ b/app/src/main/java/org/mozilla/fenix/wallpapers/Wallpaper.kt
@@ -4,88 +4,43 @@
 
 package org.mozilla.fenix.wallpapers
 
-import androidx.annotation.DrawableRes
-import java.util.Calendar
 import java.util.Date
 
 /**
- * Type hierarchy defining the various wallpapers that are available as home screen backgrounds.
+ * Type that represents wallpapers.
+ *
  * @property name The name of the wallpaper.
+ * @property collectionName The name of the collection the wallpaper belongs to.
+ * @property availableLocales The locales that this wallpaper is restricted to. If null, the wallpaper
+ * is not restricted.
+ * @property startDate The date the wallpaper becomes available in a promotion. If null, it is available
+ * from any date.
+ * @property endDate The date the wallpaper stops being available in a promotion. If null,
+ * the wallpaper will be available to any date.
  */
-sealed class Wallpaper {
-    abstract val name: String
-
-    /**
-     * The default wallpaper. This uses the standard color resource to as a background, instead of
-     * loading a bitmap.
-     */
-    object Default : Wallpaper() {
-        override val name = "default"
-    }
-
-    /**
-     * If a user had previously selected a wallpaper, they are allowed to retain it even if
-     * the wallpaper is otherwise expired. This type exists as a wrapper around that current
-     * wallpaper.
-     */
-    data class Expired(override val name: String) : Wallpaper()
-
-    /**
-     * Wallpapers that are included directly in the shipped APK.
-     *
-     * @property drawableId The drawable bitmap used as the background.
-     */
-    sealed class Local : Wallpaper() {
-        abstract val drawableId: Int
-        data class Firefox(override val name: String, @DrawableRes override val drawableId: Int) : Local()
-    }
-
-    /**
-     * Wallpapers that need to be fetched from a network resource.
-     *
-     * @property expirationDate Optional date at which this wallpaper should no longer be available.
-     */
-    sealed class Remote : Wallpaper() {
-        abstract val expirationDate: Date?
-        abstract val remoteParentDirName: String
-        @Suppress("MagicNumber")
-        /**
-         * A promotional partnered wallpaper.
-         */
-        data class House(
-            override val name: String,
-            override val expirationDate: Date? = Calendar.getInstance().run {
-                set(2022, Calendar.APRIL, 30)
-                time
-            }
-        ) : Remote(), Promotional {
-            override val remoteParentDirName: String = "house"
-            override fun isAvailableInLocale(locale: String): Boolean =
-                listOf("en-US", "es-US").contains(locale)
-        }
-
-        /**
-         * Wallpapers that are original Firefox creations.
-         */
-        data class Firefox(
-            override val name: String,
-        ) : Remote() {
-            override val expirationDate: Date? = null
-            override val remoteParentDirName: String = "firefox"
-        }
-    }
-
-    /**
-     * Designates whether a wallpaper is part of a promotion that is locale-restricted.
-     */
-    interface Promotional {
-        /**
-         * Returns whether the wallpaper is available in [locale] or not.
-         */
-        fun isAvailableInLocale(locale: String): Boolean
-    }
-
+data class Wallpaper(
+    val name: String,
+    val collectionName: String,
+    val availableLocales: List<String>?,
+    val startDate: Date?,
+    val endDate: Date?
+) {
     companion object {
+        const val amethystName = "amethyst"
+        const val ceruleanName = "cerulean"
+        const val sunriseName = "sunrise"
+        const val twilightHillsName = "twilight-hills"
+        const val beachVibeName = "beach-vibe"
+        const val firefoxCollectionName = "firefox"
+        const val defaultName = "default"
+        val Default = Wallpaper(
+            name = defaultName,
+            collectionName = defaultName,
+            availableLocales = null,
+            startDate = null,
+            endDate = null,
+        )
+
         /**
          * Defines the standard path at which a wallpaper resource is kept on disk.
          *

--- a/app/src/main/java/org/mozilla/fenix/wallpapers/WallpaperDownloader.kt
+++ b/app/src/main/java/org/mozilla/fenix/wallpapers/WallpaperDownloader.kt
@@ -33,7 +33,7 @@ class WallpaperDownloader(
      * found at a remote path in the form:
      * <WALLPAPER_URL>/<resolution>/<orientation>/<app theme>/<wallpaper theme>/<wallpaper name>.png
      */
-    suspend fun downloadWallpaper(wallpaper: Wallpaper.Remote) = withContext(Dispatchers.IO) {
+    suspend fun downloadWallpaper(wallpaper: Wallpaper) = withContext(Dispatchers.IO) {
         if (remoteHost.isNullOrEmpty()) {
             return@withContext
         }
@@ -71,14 +71,14 @@ class WallpaperDownloader(
 
     private data class WallpaperMetadata(val remotePath: String, val localPath: String)
 
-    private fun Wallpaper.Remote.toMetadata(context: Context): List<WallpaperMetadata> =
+    private fun Wallpaper.toMetadata(context: Context): List<WallpaperMetadata> =
         listOf("landscape", "portrait").flatMap { orientation ->
             listOf("light", "dark").map { theme ->
                 val localPath = "wallpapers/$orientation/$theme/$name.png"
                 val remotePath = "${context.resolutionSegment()}/" +
                     "$orientation/" +
                     "$theme/" +
-                    "$remoteParentDirName/" +
+                    "$collectionName/" +
                     "$name.png"
                 WallpaperMetadata(remotePath, localPath)
             }

--- a/app/src/main/java/org/mozilla/fenix/wallpapers/WallpaperFileManager.kt
+++ b/app/src/main/java/org/mozilla/fenix/wallpapers/WallpaperFileManager.kt
@@ -24,9 +24,15 @@ class WallpaperFileManager(
      * files for each of the following orientation and theme combinations:
      * light/portrait - light/landscape - dark/portrait - dark/landscape
      */
-    suspend fun lookupExpiredWallpaper(name: String): Wallpaper.Expired? = withContext(Dispatchers.IO) {
+    suspend fun lookupExpiredWallpaper(name: String): Wallpaper? = withContext(Dispatchers.IO) {
         if (getAllLocalWallpaperPaths(name).all { File(rootDirectory, it).exists() }) {
-            Wallpaper.Expired(name)
+            Wallpaper(
+                name = name,
+                collectionName = "",
+                availableLocales = null,
+                startDate = null,
+                endDate = null,
+            )
         } else null
     }
 
@@ -40,7 +46,7 @@ class WallpaperFileManager(
     /**
      * Remove all wallpapers that are not the [currentWallpaper] or in [availableWallpapers].
      */
-    fun clean(currentWallpaper: Wallpaper, availableWallpapers: List<Wallpaper.Remote>) {
+    fun clean(currentWallpaper: Wallpaper, availableWallpapers: List<Wallpaper>) {
         scope.launch {
             val wallpapersToKeep = (listOf(currentWallpaper) + availableWallpapers).map { it.name }
             cleanChildren(portraitDirectory, wallpapersToKeep)

--- a/app/src/test/java/org/mozilla/fenix/wallpapers/WallpaperFileManagerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/wallpapers/WallpaperFileManagerTest.kt
@@ -46,7 +46,7 @@ class WallpaperFileManagerTest {
 
         val result = fileManager.lookupExpiredWallpaper(wallpaperName)
 
-        val expected = Wallpaper.Expired(name = wallpaperName)
+        val expected = generateWallpaper(name = wallpaperName)
         assertEquals(expected, result)
     }
 
@@ -64,9 +64,9 @@ class WallpaperFileManagerTest {
     @Test
     fun `WHEN cleaned THEN current wallpaper and available wallpapers kept`() {
         val currentName = "current"
-        val currentWallpaper = Wallpaper.Expired(currentName)
+        val currentWallpaper = generateWallpaper(name = currentName)
         val availableName = "available"
-        val available = Wallpaper.Remote.House(name = availableName)
+        val available = generateWallpaper(name = availableName)
         val unavailableName = "unavailable"
         createAllFiles(currentName)
         createAllFiles(availableName)
@@ -93,4 +93,12 @@ class WallpaperFileManagerTest {
             File(landscapeDarkFolder, "$name.png"),
         )
     }
+
+    private fun generateWallpaper(name: String) = Wallpaper(
+        name = name,
+        collectionName = "",
+        availableLocales = null,
+        startDate = null,
+        endDate = null
+    )
 }


### PR DESCRIPTION
This refactors the wallpaper types from a `sealed class` to a `data class`. This should make the type generally more extensible, and opens the door to fetching all required data about a wallpaper instance from our remote source. Moving forward, we won't be keeping metadata like the names of the wallpapers explicitly hard-coded and instead pull it from network. Splitting off this refactor seemed like a more manageable piece for review than doing everything at once, but I will have a follow-up available soon that adds pulling the metadata down from network. The work is mostly done, just need to rebase it over this patch.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
Fixes #26423