### PR TITLE
For #25985: Remove ability to click the logo to change the wallpaper

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/Components.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Components.kt
@@ -163,9 +163,7 @@ class Components(private val context: Context) {
     val wallpaperManager by lazyMonitored {
         strictMode.resetAfter(StrictMode.allowThreadDiskReads()) {
             WallpaperManager(
-                settings,
                 appStore,
-                useCases.wallpaperUseCases.selectWallpaper,
             )
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -14,7 +14,6 @@ import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.ViewTreeObserver
 import android.widget.Button
 import android.widget.LinearLayout
 import android.widget.PopupWindow
@@ -77,7 +76,6 @@ import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
 import org.mozilla.fenix.Config
 import org.mozilla.fenix.GleanMetrics.Events
 import org.mozilla.fenix.GleanMetrics.HomeScreen
-import org.mozilla.fenix.GleanMetrics.Wallpapers
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.browser.BrowserAnimator.Companion.getToolbarNavOptions
@@ -742,21 +740,6 @@ class HomeFragment : Fragment() {
         lifecycleScope.launch(IO) {
             requireComponents.reviewPromptController.promptReview(requireActivity())
         }
-
-        if (shouldEnableWallpaper() && context.settings().wallpapersSwitchedByLogoTap) {
-            binding.wordmark.contentDescription =
-                context.getString(R.string.wallpaper_logo_content_description)
-            binding.wordmark.setOnClickListener {
-                val manager = requireComponents.wallpaperManager
-                val newWallpaper = manager.switchToNextWallpaper()
-                Wallpapers.wallpaperSwitched.record(
-                    Wallpapers.WallpaperSwitchedExtra(
-                        name = newWallpaper.name,
-                        themeCollection = newWallpaper::class.simpleName
-                    )
-                )
-            }
-        }
     }
 
     private fun dispatchModeChanges(mode: Mode) {
@@ -800,25 +783,6 @@ class HomeFragment : Fragment() {
         // triggered to cause an automatic update on warm start (no tab selection occurs). So we
         // update it manually here.
         requireComponents.useCases.sessionUseCases.updateLastAccess()
-        if (shouldAnimateLogoForWallpaper()) {
-            _binding?.sessionControlRecyclerView?.viewTreeObserver?.addOnGlobalLayoutListener(
-                homeLayoutListenerForLogoAnimation
-            )
-        }
-    }
-
-    // To try to find a good time to show the logo animation, we are waiting until all
-    // the sub-recyclerviews (recentBookmarks, collections, recentTabs,recentVisits
-    // and pocketStories) on the home screen have been layout.
-    private val homeLayoutListenerForLogoAnimation = object : ViewTreeObserver.OnGlobalLayoutListener {
-        override fun onGlobalLayout() {
-            _binding?.let { safeBindings ->
-                requireComponents.wallpaperManager.animateLogoIfNeeded(safeBindings.wordmark)
-                safeBindings.sessionControlRecyclerView.viewTreeObserver.removeOnGlobalLayoutListener(
-                    this
-                )
-            }
-        }
     }
 
     override fun onPause() {
@@ -979,22 +943,6 @@ class HomeFragment : Fragment() {
                 }
                 .launchIn(viewLifecycleOwner.lifecycleScope)
         }
-    }
-
-    // We want to show the animation in a time when the user less distracted
-    // The Heuristics are:
-    // 1) The animation hasn't shown before.
-    // 2) The user has onboarded.
-    // 3) It's the third time the user enters the app.
-    // 4) The user is part of the right audience.
-    @Suppress("MagicNumber")
-    private fun shouldAnimateLogoForWallpaper(): Boolean {
-        val localContext = context ?: return false
-        val settings = localContext.settings()
-
-        return shouldEnableWallpaper() && settings.shouldAnimateFirefoxLogo &&
-            onboarding.userHasBeenOnboarded() &&
-            settings.numberOfAppLaunches >= 3
     }
 
     private fun shouldEnableWallpaper() =

--- a/app/src/main/java/org/mozilla/fenix/settings/wallpaper/WallpaperSettings.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/wallpaper/WallpaperSettings.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -28,8 +27,6 @@ import androidx.compose.material.Snackbar
 import androidx.compose.material.SnackbarDuration
 import androidx.compose.material.SnackbarHost
 import androidx.compose.material.Surface
-import androidx.compose.material.Switch
-import androidx.compose.material.SwitchDefaults
 import androidx.compose.material.Text
 import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
@@ -48,7 +45,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.launch
 import org.mozilla.fenix.R
 import org.mozilla.fenix.compose.button.TextButton
@@ -66,8 +62,6 @@ import org.mozilla.fenix.wallpapers.Wallpaper
  * @param loadWallpaperResource Callback to handle loading a wallpaper bitmap. Only optional in the default case.
  * @param onSelectWallpaper Callback for when a new wallpaper is selected.
  * @param onViewWallpaper Callback for when the view action is clicked from snackbar.
- * @param tapLogoSwitchChecked Enabled state for switch controlling taps to change wallpaper.
- * @param onTapLogoSwitchCheckedChange Callback for when state of above switch is updated.
  */
 @Composable
 @Suppress("LongParameterList")
@@ -78,8 +72,6 @@ fun WallpaperSettings(
     selectedWallpaper: Wallpaper,
     onSelectWallpaper: (Wallpaper) -> Unit,
     onViewWallpaper: () -> Unit,
-    tapLogoSwitchChecked: Boolean,
-    onTapLogoSwitchCheckedChange: (Boolean) -> Unit
 ) {
     val coroutineScope = rememberCoroutineScope()
     val scaffoldState = rememberScaffoldState()
@@ -109,7 +101,6 @@ fun WallpaperSettings(
                     onSelectWallpaper(updatedWallpaper)
                 },
             )
-            WallpaperLogoSwitch(tapLogoSwitchChecked, onCheckedChange = onTapLogoSwitchCheckedChange)
         }
     }
 }
@@ -253,38 +244,6 @@ private fun WallpaperThumbnailItem(
     }
 }
 
-@Composable
-@Suppress("MagicNumber")
-private fun WallpaperLogoSwitch(
-    checked: Boolean,
-    onCheckedChange: (Boolean) -> Unit
-) {
-    Row(
-        modifier = Modifier
-            .padding(horizontal = 16.dp, vertical = 16.dp)
-            .fillMaxWidth(),
-        horizontalArrangement = Arrangement.SpaceBetween
-    ) {
-        Text(
-            text = stringResource(R.string.wallpaper_tap_to_change_switch_label_1),
-            color = FirefoxTheme.colors.textPrimary,
-            fontSize = 18.sp,
-            modifier = Modifier
-                .weight(0.8f)
-        )
-
-        Switch(
-            checked = checked,
-            onCheckedChange = onCheckedChange,
-            colors = SwitchDefaults.colors(
-                checkedThumbColor = FirefoxTheme.colors.formSelected,
-                checkedTrackColor = FirefoxTheme.colors.formSurface,
-                uncheckedTrackColor = FirefoxTheme.colors.formSurface
-            )
-        )
-    }
-}
-
 @Preview
 @Composable
 private fun WallpaperThumbnailsPreview() {
@@ -297,8 +256,6 @@ private fun WallpaperThumbnailsPreview() {
             selectedWallpaper = Wallpaper.Default,
             onSelectWallpaper = {},
             onViewWallpaper = {},
-            tapLogoSwitchChecked = false,
-            onTapLogoSwitchCheckedChange = {}
         )
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/settings/wallpaper/WallpaperSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/wallpaper/WallpaperSettingsFragment.kt
@@ -8,10 +8,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.fragment.app.Fragment
@@ -34,10 +30,6 @@ class WallpaperSettingsFragment : Fragment() {
         requireComponents.useCases.wallpaperUseCases
     }
 
-    private val settings by lazy {
-        requireComponents.settings
-    }
-
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -54,7 +46,6 @@ class WallpaperSettingsFragment : Fragment() {
                     val currentWallpaper = appStore.observeAsComposableState { state ->
                         state.wallpaperState.currentWallpaper
                     }.value ?: Wallpaper.Default
-                    var wallpapersSwitchedByLogo by remember { mutableStateOf(settings.wallpapersSwitchedByLogoTap) }
 
                     WallpaperSettings(
                         wallpapers = wallpapers,
@@ -63,16 +54,6 @@ class WallpaperSettingsFragment : Fragment() {
                         selectedWallpaper = currentWallpaper,
                         onSelectWallpaper = { wallpaperUseCases.selectWallpaper(it) },
                         onViewWallpaper = { findNavController().navigate(R.id.homeFragment) },
-                        tapLogoSwitchChecked = wallpapersSwitchedByLogo,
-                        onTapLogoSwitchCheckedChange = {
-                            settings.wallpapersSwitchedByLogoTap = it
-                            wallpapersSwitchedByLogo = it
-                            Wallpapers.changeWallpaperLogoToggled.record(
-                                Wallpapers.ChangeWallpaperLogoToggledExtra(
-                                    checked = it
-                                )
-                            )
-                        }
                     )
                 }
             }

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -190,11 +190,6 @@ class Settings(private val appContext: Context) : PreferencesHolder {
         default = Wallpaper.Default.name
     )
 
-    var wallpapersSwitchedByLogoTap by booleanPreference(
-        appContext.getPreferenceKey(R.string.pref_key_wallpapers_switched_by_logo_tap),
-        default = true
-    )
-
     var openLinksInAPrivateTab by booleanPreference(
         appContext.getPreferenceKey(R.string.pref_key_open_links_in_a_private_tab),
         default = false
@@ -407,15 +402,6 @@ class Settings(private val appContext: Context) : PreferencesHolder {
         appContext.getPreferenceKey(R.string.pref_key_inactive_tabs),
         default = FeatureFlags.inactiveTabs,
         featureFlag = FeatureFlags.inactiveTabs
-    )
-
-    /**
-     * Indicates if the Firefox logo on the home screen should be animated,
-     * to show users that they can change the wallpaper by tapping on the Firefox logo.
-     */
-    var shouldAnimateFirefoxLogo by booleanPreference(
-        appContext.getPreferenceKey(R.string.pref_key_show_logo_animation),
-        default = true,
     )
 
     @VisibleForTesting

--- a/app/src/main/java/org/mozilla/fenix/wallpapers/WallpaperManager.kt
+++ b/app/src/main/java/org/mozilla/fenix/wallpapers/WallpaperManager.kt
@@ -4,11 +4,6 @@
 
 package org.mozilla.fenix.wallpapers
 
-import android.animation.AnimatorSet
-import android.animation.ObjectAnimator
-import android.os.Handler
-import android.os.Looper
-import android.view.View
 import mozilla.components.support.base.log.logger.Logger
 import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.utils.Settings
@@ -18,64 +13,12 @@ import org.mozilla.fenix.utils.Settings
  */
 @Suppress("TooManyFunctions")
 class WallpaperManager(
-    private val settings: Settings,
     private val appStore: AppStore,
-    private val selectWallpaperUseCase: WallpapersUseCases.SelectWallpaperUseCase,
 ) {
     val logger = Logger("WallpaperManager")
 
     val wallpapers get() = appStore.state.wallpaperState.availableWallpapers
     val currentWallpaper: Wallpaper get() = appStore.state.wallpaperState.currentWallpaper
-
-    /**
-     * Returns the next available [Wallpaper], the [currentWallpaper] is the last one then
-     * the first available [Wallpaper] will be returned.
-     */
-    fun switchToNextWallpaper(): Wallpaper {
-        val values = wallpapers
-        val index = values.indexOf(currentWallpaper) + 1
-
-        return if (index >= values.size) {
-            values.first()
-        } else {
-            values[index]
-        }.also {
-            selectWallpaperUseCase(it)
-        }
-    }
-
-    /**
-     * Animates the Firefox logo, if it hasn't been animated before, otherwise nothing will happen.
-     * After animating the first time, the [Settings.shouldAnimateFirefoxLogo] setting
-     * will be updated.
-     */
-    @Suppress("MagicNumber")
-    fun animateLogoIfNeeded(logo: View) {
-        if (!settings.shouldAnimateFirefoxLogo) {
-            return
-        }
-        Handler(Looper.getMainLooper()).postDelayed(
-            {
-                val animator1 = ObjectAnimator.ofFloat(logo, "rotation", 0f, 10f)
-                val animator2 = ObjectAnimator.ofFloat(logo, "rotation", 10f, 0f)
-                val animator3 = ObjectAnimator.ofFloat(logo, "rotation", 0f, 10f)
-                val animator4 = ObjectAnimator.ofFloat(logo, "rotation", 10f, 0f)
-
-                animator1.duration = 200
-                animator2.duration = 200
-                animator3.duration = 200
-                animator4.duration = 200
-
-                val set = AnimatorSet()
-
-                set.play(animator1).before(animator2).after(animator3).before(animator4)
-                set.start()
-
-                settings.shouldAnimateFirefoxLogo = false
-            },
-            ANIMATION_DELAY_MS
-        )
-    }
 
     companion object {
         /**
@@ -86,6 +29,5 @@ class WallpaperManager(
         }
 
         val defaultWallpaper = Wallpaper.Default
-        private const val ANIMATION_DELAY_MS = 1500L
     }
 }

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -202,8 +202,6 @@
     <!-- Wallpaper Settings -->
     <string name="pref_key_wallpapers" translatable="false">pref_key_wallpapers</string>
     <string name="pref_key_current_wallpaper" translatable="false">pref_key_current_wallpaper</string>
-    <string name="pref_key_wallpapers_switched_by_logo_tap">pref_key_wallpapers_switched_by_logo_tap</string>
-    <string name="pref_key_show_logo_animation" translatable="false">pref_key_show_logo_animation</string>
 
     <string name="pref_key_encryption_key_generated" translatable="false">pref_key_encryption_key_generated</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -427,10 +427,10 @@
     <!-- Snackbar label for action to view selected wallpaper -->
     <string name="wallpaper_updated_snackbar_action">View</string>
     <!-- Label for switch which toggles the "tap-to-switch" behavior on home screen logo -->
-    <string name="wallpaper_tap_to_change_switch_label_1">Change wallpaper by tapping Firefox homepage logo</string>
+    <string name="wallpaper_tap_to_change_switch_label_1" moz:removedIn="105" tools:ignore="UnusedResources">Change wallpaper by tapping Firefox homepage logo</string>
     <!-- This is the accessibility content description for the wallpapers functionality. Users are
     able to tap on the app logo in the home screen and can switch to different wallpapers by tapping. -->
-    <string name="wallpaper_logo_content_description">Firefox logo - change the wallpaper, button</string>
+    <string name="wallpaper_logo_content_description" moz:removedIn="105" tools:ignore="UnusedResources">Firefox logo - change the wallpaper, button</string>
 
     <!-- Add-on Installation from AMO-->
     <!-- Error displayed when user attempts to install an add-on from AMO (addons.mozilla.org) that is not supported -->


### PR DESCRIPTION
Local copy of contributor PR found https://github.com/mozilla-mobile/fenix/pull/26478, with the original and additional conversation at https://github.com/mozilla-mobile/fenix/pull/26290

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
Fixes #25985