### PR TITLE
Revert "Closes #25942: use HistoryFragment to show synced history"

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryAdapter.kt
@@ -16,7 +16,6 @@ import org.mozilla.fenix.library.history.viewholders.HistoryListItemViewHolder
  */
 class HistoryAdapter(
     private val historyInteractor: HistoryInteractor,
-    private val isSyncedHistory: Boolean,
     private val onEmptyStateChanged: (Boolean) -> Unit,
 ) : PagingDataAdapter<History, HistoryListItemViewHolder>(historyDiffCallback),
     SelectionHolder<History> {
@@ -117,12 +116,12 @@ class HistoryAdapter(
         }
 
         holder.bind(
-            item = current,
-            timeGroup = timeGroup,
-            showTopContent = !isSyncedHistory && position == 0,
-            mode = mode,
-            isPendingDeletion = isPendingDeletion,
-            groupPendingDeletionCount = groupPendingDeletionCount,
+            current,
+            timeGroup,
+            position == 0,
+            mode,
+            isPendingDeletion,
+            groupPendingDeletionCount
         )
     }
 

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryController.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryController.kt
@@ -22,6 +22,7 @@ import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.components.appstate.AppAction
 import org.mozilla.fenix.components.history.DefaultPagedHistoryProvider
 import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.ext.navigateSafe
 import org.mozilla.fenix.library.history.HistoryFragment.DeleteConfirmationDialogFragment
 import org.mozilla.fenix.utils.Settings
 import org.mozilla.fenix.GleanMetrics.History as GleanHistory
@@ -51,7 +52,7 @@ interface HistoryController {
     fun handleEnterRecentlyClosed()
 
     /**
-     * Navigates to [HistoryFragment] that would display history synced from other devices.
+     * Navigates to [org.mozilla.fenix.library.syncedhistory.SyncedHistoryFragment]
      */
     fun handleEnterSyncedHistory()
 }
@@ -127,7 +128,7 @@ class DefaultHistoryController(
             HistoryFragmentDirections.actionGlobalHistorySearchDialog()
         }
 
-        navController.navigate(directions)
+        navController.navigateSafe(R.id.historyFragment, directions)
     }
 
     override fun handleDeleteTimeRange() {
@@ -217,6 +218,8 @@ class DefaultHistoryController(
     }
 
     override fun handleEnterSyncedHistory() {
-        navController.navigate(HistoryFragmentDirections.actionSyncedHistoryFragment())
+        navController.navigate(
+            HistoryFragmentDirections.actionHistoryFragmentToSyncedHistoryFragment()
+        )
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragment.kt
@@ -21,14 +21,13 @@ import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavDirections
 import androidx.navigation.fragment.findNavController
-import androidx.navigation.fragment.navArgs
 import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers.IO
-import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.launch
 import mozilla.components.concept.engine.prompt.ShareData
 import mozilla.components.lib.state.ext.consumeFrom
@@ -69,11 +68,10 @@ class HistoryFragment : LibraryPageFragment<History>(), UserInteractionHandler {
     ) {
         HistoryDataSource(
             historyProvider = historyProvider,
-            isRemote = if (FeatureFlags.showSyncedHistory) args.isSyncedHistory else null,
+            isRemote = if (FeatureFlags.showSyncedHistory) false else null
         )
     }.flow
 
-    private val args: HistoryFragmentArgs by navArgs()
     private var _historyView: HistoryView? = null
     private val historyView: HistoryView
         get() = _historyView!!
@@ -129,8 +127,7 @@ class HistoryFragment : LibraryPageFragment<History>(), UserInteractionHandler {
                 historyStore.dispatch(
                     HistoryFragmentAction.ChangeEmptyState(it)
                 )
-            },
-            isSyncedHistory = args.isSyncedHistory,
+            }
         )
 
         return view

--- a/app/src/main/java/org/mozilla/fenix/library/syncedhistory/SyncedHistoryFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/syncedhistory/SyncedHistoryFragment.kt
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.library.syncedhistory
+
+import mozilla.components.support.base.feature.UserInteractionHandler
+import org.mozilla.fenix.library.LibraryPageFragment
+import org.mozilla.fenix.library.history.History
+
+/**
+ * A screen displaying history items that were opened on other devices, not local.
+ */
+class SyncedHistoryFragment : LibraryPageFragment<History>(), UserInteractionHandler {
+
+    override fun onBackPressed(): Boolean {
+        return false
+    }
+
+    override val selectedItems: Set<History>
+        get() = setOf()
+}

--- a/app/src/main/res/layout/fragment_synced_history.xml
+++ b/app/src/main/res/layout/fragment_synced_history.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/historyLayout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="org.mozilla.fenix.library.syncedhistory.SyncedHistoryFragment" />

--- a/app/src/main/res/layout/history_list_item.xml
+++ b/app/src/main/res/layout/history_list_item.xml
@@ -4,6 +4,7 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:importantForAccessibility="no"
@@ -26,7 +27,7 @@
     <View
         android:id="@+id/bottom_spacer"
         android:layout_width="match_parent"
-        android:layout_height="8dp"
+        android:layout_height="32dp"
         android:visibility="gone"/>
 
     <TextView
@@ -35,7 +36,6 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginBottom="8dp"
-        android:layout_marginTop="24dp"
         android:layout_marginStart="16dp"
         android:layout_marginEnd="0dp"
         android:textColor="?attr/textPrimary"

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -85,11 +85,7 @@
     <action
         android:id="@+id/action_global_historyFragment"
         app:destination="@id/historyFragment" />
-    <action
-        android:id="@+id/action_global_history_search_dialog"
-        app:destination="@id/historySearchDialogFragment"
-        app:popUpTo="@id/historySearchDialogFragment"
-        app:popUpToInclusive="true" />
+
     <action
         android:id="@+id/action_global_downloadsFragment"
         app:destination="@id/downloadsFragment" />
@@ -270,27 +266,14 @@
         android:label="@string/library_history"
         tools:layout="@layout/fragment_history">
 
-        <argument
-            android:name="isSyncedHistory"
-            android:defaultValue="false"
-            app:argType="boolean" />
         <action
-            android:id="@+id/action_synced_historyFragment"
-            app:destination="@id/syncedHistoryFragment" />
-    </fragment>
+            android:id="@+id/action_global_history_search_dialog"
+            app:destination="@id/historySearchDialogFragment"
+            app:popUpTo="@id/historySearchDialogFragment"
+            app:popUpToInclusive="true" />
 
-    <fragment
-        android:id="@+id/syncedHistoryFragment"
-        android:name="org.mozilla.fenix.library.history.HistoryFragment"
-        android:label="@string/history_from_other_devices"
-        tools:layout="@layout/fragment_history">
-
-        <argument
-            android:name="isSyncedHistory"
-            android:defaultValue="true"
-            app:argType="boolean" />
         <action
-            android:id="@+id/action_synced_historyFragment"
+            android:id="@+id/action_historyFragment_to_syncedHistoryFragment"
             app:destination="@id/syncedHistoryFragment" />
     </fragment>
 
@@ -309,6 +292,13 @@
         <argument
             android:name="historyMetadataItems"
             app:argType="org.mozilla.fenix.library.history.History[]" />
+    </fragment>
+
+    <fragment
+        android:id="@+id/syncedHistoryFragment"
+        android:name="org.mozilla.fenix.library.syncedhistory.SyncedHistoryFragment"
+        android:label="@string/history_from_other_devices"
+        tools:layout="@layout/fragment_synced_history">
     </fragment>
 
     <fragment

--- a/app/src/test/java/org/mozilla/fenix/library/history/HistoryControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/library/history/HistoryControllerTest.kt
@@ -25,9 +25,10 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mozilla.fenix.NavGraphDirections
+import org.mozilla.fenix.R
 import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.components.history.DefaultPagedHistoryProvider
+import org.mozilla.fenix.ext.navigateSafe
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.utils.Settings
 
@@ -143,8 +144,9 @@ class HistoryControllerTest {
 
         controller.handleSearch()
         verify {
-            navController.navigate(
-                NavGraphDirections.actionGlobalHistorySearchDialog()
+            navController.navigateSafe(
+                R.id.historyFragment,
+                HistoryFragmentDirections.actionGlobalHistorySearchDialog()
             )
         }
     }


### PR DESCRIPTION
Due to difficult UX edge cases, we decided to pause the development of synced history feature until a solution we are sure about is not designed.

Reverts mozilla-mobile/fenix#25943