### PR TITLE
Close #26495: Move Huawei checks to ManufacturerCodes

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -127,6 +127,7 @@ import org.mozilla.fenix.theme.DefaultThemeManager
 import org.mozilla.fenix.theme.ThemeManager
 import org.mozilla.fenix.trackingprotection.TrackingProtectionPanelDialogFragmentDirections
 import org.mozilla.fenix.utils.BrowsersCache
+import org.mozilla.fenix.utils.ManufacturerCodes
 import org.mozilla.fenix.utils.Settings
 import java.lang.ref.WeakReference
 
@@ -617,8 +618,7 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
             Build.VERSION.SDK_INT == Build.VERSION_CODES.N || Build.VERSION.SDK_INT == Build.VERSION_CODES.N_MR1
         // Huawei devices seem to have problems with onKeyLongPress
         // See https://github.com/mozilla-mobile/fenix/issues/13498
-        val isHuawei = Build.MANUFACTURER.equals("huawei", ignoreCase = true)
-        return isAndroidN || isHuawei
+        return isAndroidN || ManufacturerCodes.isHuawei
     }
 
     private fun handleBackLongPress(): Boolean {

--- a/app/src/main/java/org/mozilla/fenix/utils/ManufacturerCodes.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/ManufacturerCodes.kt
@@ -19,4 +19,5 @@ object ManufacturerCodes {
 
     val isLG get() = Build.MANUFACTURER.equals(LG, ignoreCase = true)
     val isSamsung get() = Build.MANUFACTURER.equals(SAMSUNG, ignoreCase = true)
+    val isHuawei get() = Build.MANUFACTURER.equals(HUAWEI, ignoreCase = true)
 }


### PR DESCRIPTION
No tests needed; this is only moving code to a better location.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
Fixes #26495