### PR TITLE
Closes #26502: add isLocal parameter for history openItem telemetry event

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -3041,17 +3041,23 @@ history:
     type: event
     description: |
       A user opened a history item
+    extra_keys:
+      is_remote:
+        type: boolean
+        description: |
+          True if the history item is synced from other devices otherwise false.
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/18178
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/18261
       - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
       - https://github.com/mozilla-mobile/fenix/pull/21038#issuecomment-906757301
+      - https://github.com/mozilla-mobile/fenix/pull/26503#issuecomment-1219761407
     data_sensitivity:
       - interaction
     notification_emails:
       - android-probes@mozilla.com
-      - erichards@mozilla.com
+      - mavduevskiy@mozilla.com
     expires: never
     metadata:
       tags:

--- a/app/src/main/java/org/mozilla/fenix/components/history/PagedHistoryProvider.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/history/PagedHistoryProvider.kt
@@ -35,7 +35,8 @@ sealed class HistoryDB {
         override val title: String,
         val url: String,
         override val visitedAt: Long,
-        override val selected: Boolean = false
+        override val selected: Boolean = false,
+        val isRemote: Boolean = false,
     ) : HistoryDB()
 
     data class Metadata(
@@ -250,7 +251,8 @@ class DefaultPagedHistoryProvider(
         return HistoryDB.Regular(
             title = title,
             url = visit.url,
-            visitedAt = visit.visitTime
+            visitedAt = visit.visitTime,
+            isRemote = visit.isRemote
         )
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryDataSource.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryDataSource.kt
@@ -105,5 +105,6 @@ private fun HistoryDB.Regular.positioned(position: Int): History.Regular {
         url = this.url,
         visitedAt = this.visitedAt,
         historyTimeGroup = this.historyTimeGroup,
+        isRemote = this.isRemote
     )
 }

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragment.kt
@@ -68,7 +68,7 @@ class HistoryFragment : LibraryPageFragment<History>(), UserInteractionHandler {
     ) {
         HistoryDataSource(
             historyProvider = historyProvider,
-            isRemote = if (FeatureFlags.showSyncedHistory) false else null
+            isRemote = null
         )
     }.flow
 
@@ -334,7 +334,7 @@ class HistoryFragment : LibraryPageFragment<History>(), UserInteractionHandler {
     }
 
     private fun openItem(item: History.Regular) {
-        GleanHistory.openedItem.record(NoExtras())
+        GleanHistory.openedItem.record(GleanHistory.OpenedItemExtra(item.isRemote))
 
         (activity as HomeActivity).openToBrowserAndLoad(
             searchTermOrURL = item.url,

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragmentStore.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragmentStore.kt
@@ -32,6 +32,7 @@ sealed class History : Parcelable {
      * @property visitedAt Timestamp of when this history item was visited.
      * @property historyTimeGroup [HistoryItemTimeGroup] of the history item.
      * @property selected Whether or not the history item is selected.
+     * @property isRemote A history item is either opened locally or synced from other devices.
      */
     @Parcelize
     data class Regular(
@@ -40,7 +41,8 @@ sealed class History : Parcelable {
         val url: String,
         override val visitedAt: Long,
         override val historyTimeGroup: HistoryItemTimeGroup,
-        override val selected: Boolean = false
+        override val selected: Boolean = false,
+        val isRemote: Boolean = false,
     ) : History()
 
     /**


### PR DESCRIPTION
Closes #26502 

Adding a new parameter to an existing event.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.














### GitHub Automation
Fixes #26502