### PR TITLE
For #26400 - Add long-press option to remove tab pickup from homescreen

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/appstate/AppAction.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/appstate/AppAction.kt
@@ -21,6 +21,7 @@ import org.mozilla.fenix.home.recentvisits.RecentlyVisitedItem
 import org.mozilla.fenix.library.history.PendingDeletionHistory
 import org.mozilla.fenix.gleanplumb.Message
 import org.mozilla.fenix.gleanplumb.MessagingState
+import org.mozilla.fenix.home.recentsyncedtabs.RecentSyncedTab
 import org.mozilla.fenix.wallpapers.Wallpaper
 
 /**
@@ -44,7 +45,8 @@ sealed class AppAction : Action {
         val showCollectionPlaceholder: Boolean,
         val recentTabs: List<RecentTab>,
         val recentBookmarks: List<RecentBookmark>,
-        val recentHistory: List<RecentlyVisitedItem>
+        val recentHistory: List<RecentlyVisitedItem>,
+        val recentSyncedTabState: RecentSyncedTabState,
     ) :
         AppAction()
 
@@ -107,6 +109,12 @@ sealed class AppAction : Action {
      * Updates the [RecentSyncedTabState] with the given [state].
      */
     data class RecentSyncedTabStateChange(val state: RecentSyncedTabState) : AppAction()
+
+    /**
+     * Add a [RecentSyncedTab] url to the homescreen blocklist and remove it
+     * from the recent synced tabs list.
+     */
+    data class RemoveRecentSyncedTab(val syncedTab: RecentSyncedTab) : AppAction()
 
     /**
      * [Action]s related to interactions with the Messaging Framework.

--- a/app/src/main/java/org/mozilla/fenix/components/appstate/AppStoreReducer.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/appstate/AppStoreReducer.kt
@@ -13,6 +13,7 @@ import org.mozilla.fenix.ext.filterOutTab
 import org.mozilla.fenix.ext.getFilteredStories
 import org.mozilla.fenix.gleanplumb.state.MessagingReducer
 import org.mozilla.fenix.home.pocket.PocketRecommendedStoriesSelectedCategory
+import org.mozilla.fenix.home.recentsyncedtabs.RecentSyncedTabState
 import org.mozilla.fenix.home.recentvisits.RecentlyVisitedItem
 import org.mozilla.fenix.home.recentvisits.RecentlyVisitedItem.RecentHistoryGroup
 
@@ -43,6 +44,7 @@ internal object AppStoreReducer {
             recentBookmarks = action.recentBookmarks,
             recentTabs = action.recentTabs,
             recentHistory = action.recentHistory,
+            recentSyncedTabState = action.recentSyncedTabState
         )
         is AppAction.CollectionExpanded -> {
             val newExpandedCollection = state.expandedCollections.toMutableSet()
@@ -87,6 +89,14 @@ internal object AppStoreReducer {
         is AppAction.RemoveRecentHistoryHighlight -> state.copy(
             recentHistory = state.recentHistory.filterNot {
                 it is RecentlyVisitedItem.RecentHistoryHighlight && it.url == action.highlightUrl
+            }
+        )
+        is AppAction.RemoveRecentSyncedTab -> state.copy(
+            recentSyncedTabState = when (state.recentSyncedTabState) {
+                is RecentSyncedTabState.Success -> RecentSyncedTabState.Success(
+                    state.recentSyncedTabState.tabs - action.syncedTab
+                )
+                else -> state.recentSyncedTabState
             }
         )
         is AppAction.DisbandSearchGroupAction -> state.copy(

--- a/app/src/main/java/org/mozilla/fenix/ext/AppState.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/AppState.kt
@@ -171,7 +171,8 @@ fun AppState.filterState(blocklistHandler: BlocklistHandler): AppState =
         copy(
             recentBookmarks = recentBookmarks.filteredByBlocklist(),
             recentTabs = recentTabs.filteredByBlocklist(),
-            recentHistory = recentHistory.filteredByBlocklist()
+            recentHistory = recentHistory.filteredByBlocklist(),
+            recentSyncedTabState = recentSyncedTabState.filteredByBlocklist()
         )
     }
 

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -26,8 +26,8 @@ import androidx.constraintlayout.widget.ConstraintSet.PARENT_ID
 import androidx.constraintlayout.widget.ConstraintSet.TOP
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.content.ContextCompat
-import androidx.core.view.isVisible
 import androidx.core.view.doOnPreDraw
+import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
@@ -45,7 +45,6 @@ import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.Dispatchers.Main
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -354,6 +353,7 @@ class HomeFragment : Fragment() {
                 tabsUseCase = requireComponents.useCases.tabsUseCases,
                 navController = findNavController(),
                 accessPoint = TabsTrayAccessPoint.HomeRecentSyncedTab,
+                appStore = components.appStore,
             ),
             recentBookmarksController = DefaultRecentBookmarksController(
                 activity = activity,

--- a/app/src/main/java/org/mozilla/fenix/home/blocklist/BlocklistHandler.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/blocklist/BlocklistHandler.kt
@@ -7,7 +7,7 @@ package org.mozilla.fenix.home.blocklist
 import androidx.annotation.VisibleForTesting
 import mozilla.components.support.ktx.kotlin.sha1
 import org.mozilla.fenix.home.recentbookmarks.RecentBookmark
-import org.mozilla.fenix.home.recentsyncedtabs.RecentSyncedTab
+import org.mozilla.fenix.home.recentsyncedtabs.RecentSyncedTabState
 import org.mozilla.fenix.home.recenttabs.RecentTab
 import org.mozilla.fenix.home.recentvisits.RecentlyVisitedItem
 import org.mozilla.fenix.utils.Settings
@@ -53,6 +53,28 @@ class BlocklistHandler(private val settings: Settings) {
         }
 
     /**
+     * If the state is set to [RecentSyncedTabState.Success], filter the list of recently synced
+     * tabs by the blocklist. If the filtered list of tabs is empty, change the state to
+     * [RecentSyncedTabState.None]
+     */
+    @JvmName("filterRecentSyncedTabState")
+    fun RecentSyncedTabState.filteredByBlocklist() =
+        if (this is RecentSyncedTabState.Success) {
+            val filteredTabs = settings.homescreenBlocklist.let { blocklist ->
+                this.tabs.filterNot {
+                    blocklistContainsUrl(blocklist, it.url)
+                }
+            }
+            if (filteredTabs.isEmpty()) {
+                RecentSyncedTabState.None
+            } else {
+                RecentSyncedTabState.Success(filteredTabs)
+            }
+        } else {
+            this
+        }
+
+    /**
      * Filter a list of recent history items by the blocklist. Requires this class to be contextually
      * in a scope.
      */
@@ -62,18 +84,6 @@ class BlocklistHandler(private val settings: Settings) {
             filterNot {
                 it is RecentlyVisitedItem.RecentHistoryHighlight &&
                     blocklistContainsUrl(blocklist, it.url)
-            }
-        }
-
-    /**
-     * Filter a list of recently synced tabs by the blocklist. Requires this class to be contextually
-     * in a scope.
-     */
-    @JvmName("filterRecentSyncedTab")
-    fun List<RecentSyncedTab>.filteredByBlocklist(): List<RecentSyncedTab> =
-        settings.homescreenBlocklist.let { blocklist ->
-            filterNot {
-                blocklistContainsUrl(blocklist, it.url)
             }
         }
 

--- a/app/src/main/java/org/mozilla/fenix/home/recentsyncedtabs/RecentSyncedTabFeature.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recentsyncedtabs/RecentSyncedTabFeature.kt
@@ -8,8 +8,8 @@ import android.content.Context
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import mozilla.components.concept.storage.HistoryStorage
 import mozilla.components.browser.storage.sync.Tab
+import mozilla.components.concept.storage.HistoryStorage
 import mozilla.components.concept.sync.Device
 import mozilla.components.concept.sync.DeviceType
 import mozilla.components.feature.syncedtabs.storage.SyncedTabsStorage

--- a/app/src/main/java/org/mozilla/fenix/home/recentsyncedtabs/controller/RecentSyncedTabController.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recentsyncedtabs/controller/RecentSyncedTabController.kt
@@ -8,6 +8,8 @@ import androidx.navigation.NavController
 import mozilla.components.feature.tabs.TabsUseCases
 import org.mozilla.fenix.GleanMetrics.RecentSyncedTabs
 import org.mozilla.fenix.R
+import org.mozilla.fenix.components.AppStore
+import org.mozilla.fenix.components.appstate.AppAction
 import org.mozilla.fenix.home.HomeFragmentDirections
 import org.mozilla.fenix.home.recentsyncedtabs.RecentSyncedTab
 import org.mozilla.fenix.home.recentsyncedtabs.interactor.RecentSyncedTabInteractor
@@ -27,6 +29,13 @@ interface RecentSyncedTabController {
      * @see [RecentSyncedTabInteractor.onRecentSyncedTabClicked]
      */
     fun handleSyncedTabShowAllClicked()
+
+    /**
+     * Handle removing the synced tab from the homescreen.
+     *
+     * @param tab The recent synced tab to be removed.
+     */
+    fun handleRecentSyncedTabRemoved(tab: RecentSyncedTab)
 }
 
 /**
@@ -39,6 +48,7 @@ class DefaultRecentSyncedTabController(
     private val tabsUseCase: TabsUseCases,
     private val navController: NavController,
     private val accessPoint: TabsTrayAccessPoint,
+    private val appStore: AppStore,
 ) : RecentSyncedTabController {
     override fun handleRecentSyncedTabClick(tab: RecentSyncedTab) {
         RecentSyncedTabs.recentSyncedTabOpened[tab.deviceType.name.lowercase()].add()
@@ -54,5 +64,9 @@ class DefaultRecentSyncedTabController(
                 accessPoint = accessPoint
             )
         )
+    }
+
+    override fun handleRecentSyncedTabRemoved(tab: RecentSyncedTab) {
+        appStore.dispatch(AppAction.RemoveRecentSyncedTab(tab))
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/home/recentsyncedtabs/interactor/RecentSyncedTabInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recentsyncedtabs/interactor/RecentSyncedTabInteractor.kt
@@ -22,4 +22,12 @@ interface RecentSyncedTabInteractor {
      * tabs" button.
      */
     fun onSyncedTabShowAllClicked()
+
+    /**
+     * Adds the url of the synced tab to the homescreen blocklist and removes the tab
+     * from the recent synced tabs.
+     *
+     * @param tab The recent synced tab to be removed.
+     */
+    fun onRemovedRecentSyncedTab(tab: RecentSyncedTab)
 }

--- a/app/src/main/java/org/mozilla/fenix/home/recentsyncedtabs/view/RecentSyncedTabViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recentsyncedtabs/view/RecentSyncedTabViewHolder.kt
@@ -54,6 +54,7 @@ class RecentSyncedTabViewHolder(
                 tab = syncedTab,
                 onRecentSyncedTabClick = recentSyncedTabInteractor::onRecentSyncedTabClicked,
                 onSeeAllSyncedTabsButtonClick = recentSyncedTabInteractor::onSyncedTabShowAllClicked,
+                onRemoveSyncedTab = recentSyncedTabInteractor::onRemovedRecentSyncedTab
             )
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlInteractor.kt
@@ -388,6 +388,10 @@ class SessionControlInteractor(
         recentSyncedTabController.handleSyncedTabShowAllClicked()
     }
 
+    override fun onRemovedRecentSyncedTab(tab: RecentSyncedTab) {
+        recentSyncedTabController.handleRecentSyncedTabRemoved(tab)
+    }
+
     override fun onRecentBookmarkClicked(bookmark: RecentBookmark) {
         recentBookmarksController.handleBookmarkClicked(bookmark)
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -128,6 +128,8 @@
     <string name="recent_tabs_see_all_synced_tabs_button_text">See all synced tabs</string>
     <!-- Accessibility description for device icon used for recent synced tab -->
     <string name="recent_tabs_synced_device_icon_content_description">Synced device</string>
+    <!-- Text for the dropdown menu to remove a recent synced tab from the homescreen -->
+    <string name="recent_synced_tab_menu_item_remove">Remove</string>
     <!-- Text for the menu button to remove a grouped highlight from the user's browsing history
          in the Recently visited section -->
     <string name="recent_tab_menu_item_remove">Remove</string>

--- a/app/src/test/java/org/mozilla/fenix/home/recentsyncedtabs/controller/DefaultRecentSyncedTabControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/recentsyncedtabs/controller/DefaultRecentSyncedTabControllerTest.kt
@@ -29,6 +29,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.GleanMetrics.RecentSyncedTabs
 import org.mozilla.fenix.R
+import org.mozilla.fenix.components.AppStore
+import org.mozilla.fenix.components.appstate.AppAction
 import org.mozilla.fenix.home.HomeFragmentDirections
 import org.mozilla.fenix.home.recentsyncedtabs.RecentSyncedTab
 import org.mozilla.fenix.tabstray.Page
@@ -42,6 +44,7 @@ class DefaultRecentSyncedTabControllerTest {
 
     private val tabsUseCases: TabsUseCases = mockk()
     private val navController: NavController = mockk()
+    private val appStore: AppStore = mockk(relaxed = true)
     private val accessPoint = TabsTrayAccessPoint.HomeRecentSyncedTab
 
     private lateinit var controller: RecentSyncedTabController
@@ -52,6 +55,7 @@ class DefaultRecentSyncedTabControllerTest {
             tabsUseCase = tabsUseCases,
             navController = navController,
             accessPoint = accessPoint,
+            appStore = appStore
         )
     }
 
@@ -173,5 +177,20 @@ class DefaultRecentSyncedTabControllerTest {
         controller.handleSyncedTabShowAllClicked()
 
         assertEquals(1, RecentSyncedTabs.showAllSyncedTabsClicked.testGetValue())
+    }
+
+    @Test
+    fun `WHEN synced tab is removed from homescreen THEN RemoveRecentSyncedTab action is dispatched`() {
+        val tab = RecentSyncedTab(
+            deviceDisplayName = "display",
+            deviceType = DeviceType.DESKTOP,
+            title = "title",
+            url = "https://mozilla.org",
+            previewImageUrl = null
+        )
+
+        controller.handleRecentSyncedTabRemoved(tab)
+
+        verify { appStore.dispatch(AppAction.RemoveRecentSyncedTab(tab)) }
     }
 }


### PR DESCRIPTION
Added option to add recent synced tab to homescreen blocklist by long press.

https://user-images.githubusercontent.com/35462038/185149620-2f1416ae-f337-48a3-b27d-04dbe1420c70.mp4

Depends on the work from #26399 and  #26398

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.










### GitHub Automation
Fixes #26400