### PR TITLE
Increase the maximum gradle memory limit

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // If you ever need to force a toolchain rebuild (taskcluster) then edit the following comment.
-// FORCE REBUILD 2021-11-24
+// FORCE REBUILD 2022-08-18
 
 object Versions {
     const val kotlin = "1.6.10"

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx6144m
+org.gradle.jvmargs=-Xmx16384m
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects


### PR DESCRIPTION
Fenix gradle-dependencies jobs run on `c5d.18xlarge` instances with 144GB of RAM, but we're limiting them to 6GB at the moment. This compares to 32GB allocated for m-c on `c5.4xlarge` instances that have 32GB available to them. Given how frequently we hit OOM crashes and how much more expensive these instances are, we should increase the limit to get the most out of them and hopefully massively alleviate the unreliability of these jobs.