### PR TITLE
For #26528 - Add a nimbus feature flag for MR Home Onboarding Dialog

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -1208,13 +1208,22 @@ class Settings(private val appContext: Context) : PreferencesHolder {
     )
 
     /**
-     * Indicates if sync on-boarding CFR should be shown
+     * Indicates if sync onboarding CFR should be shown.
      * Returns true if the [FeatureFlags.showSynCFR] and [R.string.pref_key_should_show_sync_cfr] are true.
      */
     var showSyncCFR by lazyFeatureFlagPreference(
         appContext.getPreferenceKey(R.string.pref_key_should_show_sync_cfr),
         featureFlag = FeatureFlags.showSynCFR,
         default = { onboardScreenSection[OnboardingSection.SYNC_CFR] == true },
+    )
+
+    /**
+     * Indicates if home onboarding dialog should be shown.
+     */
+    var showHomeOnboardingDialog by lazyFeatureFlagPreference(
+        appContext.getPreferenceKey(R.string.pref_key_should_show_home_onboarding_dialog),
+        featureFlag = FeatureFlags.showHomeOnboarding,
+        default = { onboardScreenSection[OnboardingSection.HOME_ONBOARDING_DIALOG] == true },
     )
 
     /**

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -235,8 +235,10 @@
     <string name="pref_key_has_inactive_tabs_auto_close_dialog_dismissed" translatable="false">pref_key_has_inactive_tabs_auto_close_dialog_dismissed</string>
     <!-- A value  of `true` means the jump back in onboarding popup has not been shown yet -->
     <string name="pref_key_should_show_jump_back_in_tabs_popup" translatable="false">pref_key_should_show_jump_back_in_tabs_popup</string>
-    <!-- A value  of `true` means the  on-boarding sync CFR have not been shown yet -->
+    <!-- A value  of `true` means the onboarding sync CFR have not been shown yet -->
     <string name="pref_key_should_show_sync_cfr" translatable="false">pref_key_should_show_sync_cfr</string>
+    <!-- A value  of `true` means the home onboarding dialog have not been shown yet -->
+    <string name="pref_key_should_show_home_onboarding_dialog" translatable="false">pref_key_should_show_home_onboarding_dialog</string>
 
     <string name="pref_key_debug_settings" translatable="false">pref_key_debug_settings</string>
 

--- a/nimbus.fml.yaml
+++ b/nimbus.fml.yaml
@@ -47,21 +47,24 @@ features:
         default:
           {
             "sync-cfr": false,
-            "wallpapers": false
+            "wallpapers": false,
+            "home-onboarding-dialog": false,
           }
     defaults:
       - channel: nightly
         value: {
           "sections-enabled": {
             "sync-cfr": false,
-            "wallpapers": false
+            "wallpapers": false,
+            "home-onboarding-dialog": false,
           }
         }
       - channel: developer
         value: {
           "sections-enabled": {
             "sync-cfr": false,
-            "wallpapers": true
+            "wallpapers": true,
+            "home-onboarding-dialog": false,
           }
         }
   nimbus-validation:
@@ -331,3 +334,5 @@ types:
           description: Sync onboarding CFR.
         wallpapers:
           description: Wallpapers onboarding dialog.
+        home-onboarding-dialog:
+          description: Home onboarding dialog for upgraded users.


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.










### GitHub Automation
Fixes #26528