### PR TITLE
Add more Gradle JVM memory flags.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx8196m
+org.gradle.jvmargs=-Xmx8g -Xms2g -XX:MaxMetaspaceSize=6g
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects


### PR DESCRIPTION
The recent experiments with changing the `org.gradle.jvmargs` `-Xmx` (max heap size) value to a higher number was certainly enlightening.

I've been doing some research on the intermittent `Gradle build daemon disappeared unexpectedly (it may have been killed or may have crashed)` crashes we saw and came upon an interesting issue:
https://github.com/gradle/gradle/issues/19750

The big footgun here is that by setting `org.gradle.jvmargs` in our `gradle.properties`, we completely _clobber_ **all** flags set by default by Gradle. In particular, Gradle normally sets `-XX:MaxMetaspaceSize=256m` to put a limit on the [Metaspace](https://matthung0807.blogspot.com/2019/03/about-g1-garbage-collector-permanent.html) memory usage. By setting our own `org.gradle.jvmargs` arguments, we're effectively leaving `MaxMetaspaceSize` un-set (it's not defined by default in Java 8+), allowing for unbounded memory growth. Combine that with a higher JVM memory limit and hilarity ensued.

This PR attempts to add a couple new parameters to our `org.gradle.jvmargs` that may improve things a bit:

- Set a minimum heap size of 2gb to go with already-set max of 8gb (may result in less system churn having to resize it from a smaller starting value as memory usage goes up)
- Set a max Metaspace value of 6gb. This will prevent unbounded growth while hopefully allowing us to play around with higher max heap size values as need dictates. I picked 6gb for alignment with the previous 6gb max heap size limit we used to have.

Longer-term, we should look into having these values defined at the task level so we can optimize for each job & instance type. Per the documentation below, I think we have ways to accomplish it:
https://docs.gradle.org/current/userguide/build_environment.html