### PR TITLE
For #26380 - Wait in tests until telemetry is recorded.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/perf/StartupTypeTelemetry.kt
+++ b/app/src/main/java/org/mozilla/fenix/perf/StartupTypeTelemetry.kt
@@ -10,6 +10,7 @@ import androidx.annotation.VisibleForTesting.PRIVATE
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
@@ -67,14 +68,19 @@ class StartupTypeTelemetry(
     @VisibleForTesting(otherwise = NONE)
     fun getTestCallbacks() = StartupTypeLifecycleObserver()
 
+    /**
+     * Record startup telemetry based on the available [startupStateProvider] and [startupPathProvider].
+     *
+     * @param dispatcher used to control the thread on which telemetry will be recorded. Defaults to [Dispatchers.IO].
+     */
     @VisibleForTesting(otherwise = PRIVATE)
-    fun record() {
+    fun record(dispatcher: CoroutineDispatcher = Dispatchers.IO) {
         val startupState = startupStateProvider.getStartupStateForStartedActivity(activityClass)
         val startupPath = startupPathProvider.startupPathForActivity
         val label = getTelemetryLabel(startupState, startupPath)
 
         @OptIn(DelicateCoroutinesApi::class)
-        GlobalScope.launch(Dispatchers.IO) {
+        GlobalScope.launch(dispatcher) {
             PerfStartup.startupType[label].add(1)
             logger.info("Recorded start up: $label")
         }

--- a/app/src/test/java/org/mozilla/fenix/perf/StartupTypeTelemetryTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/perf/StartupTypeTelemetryTest.kt
@@ -12,8 +12,11 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
+import kotlinx.coroutines.test.advanceUntilIdle
 import mozilla.components.support.ktx.kotlin.crossProduct
 import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.rule.runTestOnMain
 import mozilla.telemetry.glean.testing.GleanTestRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -39,6 +42,9 @@ private val activityClass = HomeActivity::class.java
 class StartupTypeTelemetryTest {
 
     @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
+
+    @get:Rule
     val gleanTestRule = GleanTestRule(testContext)
 
     private lateinit var telemetry: StartupTypeTelemetry
@@ -62,7 +68,7 @@ class StartupTypeTelemetryTest {
     }
 
     @Test
-    fun `GIVEN all possible path and state combinations WHEN record telemetry THEN the labels are incremented the appropriate number of times`() {
+    fun `GIVEN all possible path and state combinations WHEN record telemetry THEN the labels are incremented the appropriate number of times`() = runTestOnMain {
         val allPossibleInputArgs = StartupState.values().toList().crossProduct(
             StartupPath.values().toList()
         ) { state, path ->
@@ -73,7 +79,8 @@ class StartupTypeTelemetryTest {
             every { stateProvider.getStartupStateForStartedActivity(activityClass) } returns state
             every { pathProvider.startupPathForActivity } returns path
 
-            telemetry.record()
+            telemetry.record(coroutinesTestRule.testDispatcher)
+            advanceUntilIdle()
         }
 
         validTelemetryLabels.forEach { label ->
@@ -87,11 +94,12 @@ class StartupTypeTelemetryTest {
     }
 
     @Test
-    fun `WHEN record is called THEN telemetry is recorded with the appropriate label`() {
+    fun `WHEN record is called THEN telemetry is recorded with the appropriate label`() = runTestOnMain {
         every { stateProvider.getStartupStateForStartedActivity(activityClass) } returns StartupState.COLD
         every { pathProvider.startupPathForActivity } returns StartupPath.MAIN
 
-        telemetry.record()
+        telemetry.record(coroutinesTestRule.testDispatcher)
+        advanceUntilIdle()
 
         assertEquals(1, PerfStartup.startupType["cold_main"].testGetValue())
     }
@@ -99,33 +107,33 @@ class StartupTypeTelemetryTest {
     @Test
     fun `GIVEN the activity is launched WHEN onResume is called THEN we record the telemetry`() {
         launchApp()
-        verify(exactly = 1) { telemetry.record() }
+        verify(exactly = 1) { telemetry.record(any()) }
     }
 
     @Test
     fun `GIVEN the activity is launched WHEN the activity is paused and resumed THEN record is not called`() {
         // This part of the test duplicates another test but it's needed to initialize the state of this test.
         launchApp()
-        verify(exactly = 1) { telemetry.record() }
+        verify(exactly = 1) { telemetry.record(any()) }
 
         callbacks.onPause(mockk())
         callbacks.onResume(mockk())
 
-        verify(exactly = 1) { telemetry.record() } // i.e. this shouldn't be called again.
+        verify(exactly = 1) { telemetry.record(any()) } // i.e. this shouldn't be called again.
     }
 
     @Test
     fun `GIVEN the activity is launched WHEN the activity is stopped and resumed THEN record is called again`() {
         // This part of the test duplicates another test but it's needed to initialize the state of this test.
         launchApp()
-        verify(exactly = 1) { telemetry.record() }
+        verify(exactly = 1) { telemetry.record(any()) }
 
         callbacks.onPause(mockk())
         callbacks.onStop(mockk())
         callbacks.onStart(mockk())
         callbacks.onResume(mockk())
 
-        verify(exactly = 2) { telemetry.record() } // i.e. this should be called again.
+        verify(exactly = 2) { telemetry.record(any()) } // i.e. this should be called again.
     }
 
     private fun launchApp() {


### PR DESCRIPTION
We were ["launching and forgetting" about recording](https://github.com/mozilla-mobile/fenix/blob/fb8d22e37b6e8283070602ba76aec915e7b69c45/app/src/main/java/org/mozilla/fenix/perf/StartupTypeTelemetry.kt#L77) so this seems like an old issue.
Why is only started to affect the app now is unclear.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
Fixes #26380