### PR TITLE
For #26549 - Add Nimbus feature flag for first run onboarding page updates and Jump back in CFR

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -24,9 +24,19 @@ object FeatureFlags {
     const val syncAddressesFeature = false
 
     /**
-     * Enables the on-boarding sync cfr on the home screen.
+     * Enables the onboarding sync CFR on the home screen.
      */
     val showSynCFR = Config.channel.isDebug
+
+    /**
+     * Enables the onboarding jump back in CFR on the home screen.
+     */
+    const val showJumpBackInCFR = true
+
+    /**
+     * Enables the first run onboarding updates.
+     */
+    const val showFirstRunOnboardingUpdates = false
 
     /**
      * Enables the "recent" tabs feature in the home screen.

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -859,9 +859,10 @@ class Settings(private val appContext: Context) : PreferencesHolder {
     /**
      * Indicates if the jump back in CRF should be shown.
      */
-    var shouldShowJumpBackInCFR by booleanPreference(
+    var shouldShowJumpBackInCFR by lazyFeatureFlagPreference(
         appContext.getPreferenceKey(R.string.pref_key_should_show_jump_back_in_tabs_popup),
-        default = true
+        featureFlag = FeatureFlags.showJumpBackInCFR,
+        default = { onboardScreenSection[OnboardingSection.JUMP_BACK_IN_CFR] == true },
     )
 
     fun getSitePermissionsPhoneFeatureAction(
@@ -1224,6 +1225,15 @@ class Settings(private val appContext: Context) : PreferencesHolder {
         appContext.getPreferenceKey(R.string.pref_key_should_show_home_onboarding_dialog),
         featureFlag = FeatureFlags.showHomeOnboarding,
         default = { onboardScreenSection[OnboardingSection.HOME_ONBOARDING_DIALOG] == true },
+    )
+
+    /**
+     * Indicates if home onboarding dialog should be shown.
+     */
+    var showFirstRunOnboardingUpdate by lazyFeatureFlagPreference(
+        appContext.getPreferenceKey(R.string.pref_key_show_first_run_onboarding_update),
+        featureFlag = FeatureFlags.showFirstRunOnboardingUpdates,
+        default = { onboardScreenSection[OnboardingSection.FIRST_RUN_ONBOARDING] == true },
     )
 
     /**

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -239,6 +239,8 @@
     <string name="pref_key_should_show_sync_cfr" translatable="false">pref_key_should_show_sync_cfr</string>
     <!-- A value  of `true` means the home onboarding dialog have not been shown yet -->
     <string name="pref_key_should_show_home_onboarding_dialog" translatable="false">pref_key_should_show_home_onboarding_dialog</string>
+    <!-- A value  of `true` means the first run onboarding updates should be shown -->
+    <string name="pref_key_show_first_run_onboarding_update" translatable="false">pref_key_show_first_run_onboarding_update</string>
 
     <string name="pref_key_debug_settings" translatable="false">pref_key_debug_settings</string>
 

--- a/nimbus.fml.yaml
+++ b/nimbus.fml.yaml
@@ -49,6 +49,8 @@ features:
             "sync-cfr": false,
             "wallpapers": false,
             "home-onboarding-dialog": false,
+            "jump-back-in-cfr": false,
+            "first-run-onboarding": false,
           }
     defaults:
       - channel: nightly
@@ -57,6 +59,8 @@ features:
             "sync-cfr": false,
             "wallpapers": false,
             "home-onboarding-dialog": false,
+            "jump-back-in-cfr": false,
+            "first-run-onboarding": false,
           }
         }
       - channel: developer
@@ -65,6 +69,8 @@ features:
             "sync-cfr": false,
             "wallpapers": true,
             "home-onboarding-dialog": false,
+            "jump-back-in-cfr": false,
+            "first-run-onboarding": false,
           }
         }
   nimbus-validation:
@@ -336,3 +342,7 @@ types:
           description: Wallpapers onboarding dialog.
         home-onboarding-dialog:
           description: Home onboarding dialog for upgraded users.
+        jump-back-in-cfr:
+          description: Jump back in onboarding CFR.
+        first-run-onboarding:
+          description: First run onboarding page updates.


### PR DESCRIPTION



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.







### GitHub Automation
Fixes #26549