### PR TITLE
Closes #26530: add top spacing to header in history list

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryView.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryView.kt
@@ -114,6 +114,8 @@ class HistoryView(
     private fun updateEmptyState(userHasHistory: Boolean) {
         binding.historyList.isInvisible = !userHasHistory
         binding.historyEmptyView.isVisible = !userHasHistory
+        binding.topSpacer.isVisible = !userHasHistory
+
         with(binding.recentlyClosedNavEmpty) {
             recentlyClosedNav.setOnClickListener {
                 interactor.onRecentlyClosedClicked()

--- a/app/src/main/java/org/mozilla/fenix/library/history/viewholders/HistoryListItemViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/viewholders/HistoryListItemViewHolder.kt
@@ -113,6 +113,7 @@ class HistoryListItemViewHolder(
         } else {
             binding.headerTitle.visibility = View.GONE
         }
+        binding.bottomSpacer.isVisible = headerText != null
     }
 
     private fun toggleTopContent(
@@ -120,6 +121,7 @@ class HistoryListItemViewHolder(
         isNormalMode: Boolean,
     ) {
         binding.recentlyClosedNavEmpty.recentlyClosedNav.isVisible = showTopContent
+        binding.topSpacer.isVisible = showTopContent
 
         if (showTopContent) {
             val numRecentTabs = itemView.context.components.core.store.state.closedTabs.size

--- a/app/src/main/res/layout/component_history.xml
+++ b/app/src/main/res/layout/component_history.xml
@@ -20,12 +20,19 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <View
+        android:id="@+id/top_spacer"
+        android:layout_width="match_parent"
+        android:layout_height="8dp"
+        app:layout_constraintTop_toTopOf="parent"
+        android:visibility="gone"/>
+
     <include
         android:id="@+id/recently_closed_nav_empty"
         layout="@layout/recently_closed_nav_item"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toBottomOf="@+id/top_spacer" />
 
     <TextView
         android:id="@+id/history_empty_view"

--- a/app/src/main/res/layout/history_list_item.xml
+++ b/app/src/main/res/layout/history_list_item.xml
@@ -10,9 +10,21 @@
     android:importantForAccessibility="no"
     android:orientation="vertical">
 
+    <View
+        android:id="@+id/top_spacer"
+        android:layout_width="match_parent"
+        android:layout_height="8dp"
+        android:visibility="gone"/>
+
     <include
         android:id="@+id/recently_closed_nav_empty"
         layout="@layout/recently_closed_nav_item" />
+
+    <View
+        android:id="@+id/bottom_spacer"
+        android:layout_width="match_parent"
+        android:layout_height="32dp"
+        android:visibility="gone"/>
 
     <TextView
         android:id="@+id/header_title"

--- a/app/src/main/res/layout/recently_closed_nav_item.xml
+++ b/app/src/main/res/layout/recently_closed_nav_item.xml
@@ -8,8 +8,6 @@
     android:id="@+id/recently_closed_nav"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginTop="8dp"
-    android:layout_marginBottom="8dp"
     android:background="?android:attr/selectableItemBackground"
     android:clickable="true"
     android:focusable="true"


### PR DESCRIPTION
Closes #26557

Restored a removed spacing between tab button and first element, that is already in production.
<img width="441" alt="top_spacing" src="https://user-images.githubusercontent.com/92760693/185037274-534029d8-b60a-493d-bc0b-8626ce7c1d40.png">

Added spacing to match the one above. As part of this [redesign](https://www.figma.com/file/SO8Cd5lnmgNqJQY9KpORc9/History%2C-Bookmarks%2C-Downloads?node-id=879%3A41209). Fully updated version should be merged with this [PR](https://github.com/mozilla-mobile/fenix/pull/26117).
Old|New
---|---
<img width="441" alt="spacing_old" src="https://user-images.githubusercontent.com/92760693/185037558-79ee4d25-94b9-4551-9e1d-9f970b82b184.png">|<img width="441" alt="spacing_new" src="https://user-images.githubusercontent.com/92760693/185037562-eddad0ba-3d40-4b21-aac5-a737237a1129.png">

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
Fixes #26530