### PR TITLE
Use parallel execution for Gradle

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,13 +10,12 @@ org.gradle.jvmargs=-Xmx8g -Xms2g -XX:MaxMetaspaceSize=6g
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
+org.gradle.parallel=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 android.useAndroidX=true
 android.enableJetifier=false
 android.enableUnitTestBinaryResources=false
-org.gradle.parallel=false
 
 # Enables copying of Jetpack Benchmark results from the device to the build directory.
 android.enableAdditionalTestOutput=true


### PR DESCRIPTION
This should improve performance and is set to true for most other projects. It's not clear to me why it landed set to false back in #2489, but maybe things have changed in the last 3 years.