### PR TITLE
For #26159: Add option for user to hide history (frecent) top sites

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -274,7 +274,11 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
                         components.core.topSitesStorage.getTopSites(
                             totalSites = components.settings.topSitesMaxLimit,
                             frecencyConfig = TopSitesFrecencyConfig(
-                                FrecencyThresholdOption.SKIP_ONE_TIME_PAGES
+                                frecencyTresholdOption = if (components.settings.showHistoryShortcuts) {
+                                    FrecencyThresholdOption.SKIP_ONE_TIME_PAGES
+                                } else {
+                                    null
+                                },
                             ) { !it.containsQueryParameters(components.settings.frecencyFilterQuery) },
                             providerConfig = TopSitesProviderConfig(
                                 showProviderTopSites = components.settings.showContileFeature,

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -419,7 +419,11 @@ class HomeFragment : Fragment() {
         return TopSitesConfig(
             totalSites = settings.topSitesMaxLimit,
             frecencyConfig = TopSitesFrecencyConfig(
-                FrecencyThresholdOption.SKIP_ONE_TIME_PAGES
+                frecencyTresholdOption = if (settings.showHistoryShortcuts) {
+                    FrecencyThresholdOption.SKIP_ONE_TIME_PAGES
+                } else {
+                    null
+                },
             ) { !it.containsQueryParameters(settings.frecencyFilterQuery) },
             providerConfig = TopSitesProviderConfig(
                 showProviderTopSites = settings.showContileFeature,

--- a/app/src/main/java/org/mozilla/fenix/settings/HomeSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/HomeSettingsFragment.kt
@@ -67,6 +67,22 @@ class HomeSettingsFragment : PreferenceFragmentCompat() {
             }
         }
 
+        requirePreference<CheckBoxPreference>(R.string.pref_key_enable_history_shortcuts).apply {
+            isChecked = context.settings().showHistoryShortcuts
+            onPreferenceChangeListener = object : SharedPreferenceUpdater() {
+                override fun onPreferenceChange(preference: Preference, newValue: Any?): Boolean {
+                    CustomizeHome.preferenceToggled.record(
+                        CustomizeHome.PreferenceToggledExtra(
+                            newValue as Boolean,
+                            "history_shortcuts"
+                        )
+                    )
+
+                    return super.onPreferenceChange(preference, newValue)
+                }
+            }
+        }
+
         requirePreference<SwitchPreference>(R.string.pref_key_recent_tabs).apply {
             isVisible = FeatureFlags.showRecentTabsFeature
             isChecked = context.settings().showRecentTabsFeature

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -1328,6 +1328,14 @@ class Settings(private val appContext: Context) : PreferencesHolder {
     )
 
     /**
+     * Indicates if the history shortcuts should be visible.
+     */
+    var showHistoryShortcuts by booleanPreference(
+        key = appContext.getPreferenceKey(R.string.pref_key_enable_history_shortcuts),
+        default = true,
+    )
+
+    /**
      * Indicates if the Task Continuity enhancements are enabled.
      */
     var enableTaskContinuityEnhancements by featureFlagPreference(

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -215,6 +215,8 @@
     <string name="pref_key_show_top_sites" translatable="false">pref_key_show_top_sites</string>
     <!-- Whether or not the sponsored shortcuts are shown along with the top recent sites shortcuts -->
     <string name="pref_key_enable_contile" translatable="false">pref_key_enable_contile</string>
+    <!-- Whether or not the history shortcuts are shown along with the top recent sites shortcuts -->
+    <string name="pref_key_enable_history_shortcuts" translatable="false">pref_key_enable_history_shortcuts</string>
     <!-- Whether or not the Task Continuity enhancements are shown -->
     <string name="pref_key_enable_task_continuity" translatable="false">pref_key_enable_task_continuity</string>
     <!-- Query containing the search parameters to be hidden from the top frecent sites  -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -418,6 +418,8 @@
     <string name="customize_wallpapers">Wallpapers</string>
     <!-- Title for the customize home screen section with sponsored shortcuts. -->
     <string name="customize_toggle_contile">Sponsored shortcuts</string>
+    <!-- Title for the customize home screen section with history shortcuts. -->
+    <string name="customize_toggle_history_shortcuts">History shortcuts</string>
 
     <!-- Wallpapers -->
     <!-- Content description for various wallpapers. The first parameter is the name of the wallpaper -->

--- a/app/src/main/res/xml/home_preferences.xml
+++ b/app/src/main/res/xml/home_preferences.xml
@@ -15,6 +15,12 @@
         android:key="@string/pref_key_enable_contile"
         android:title="@string/customize_toggle_contile" />
 
+    <androidx.preference.CheckBoxPreference
+        android:dependency="@string/pref_key_show_top_sites"
+        android:layout="@layout/checkbox_left_sub_preference"
+        android:key="@string/pref_key_enable_history_shortcuts"
+        android:title="@string/customize_toggle_history_shortcuts" />
+
     <androidx.preference.SwitchPreference
         android:key="@string/pref_key_recent_tabs"
         android:title="@string/customize_toggle_jump_back_in"

--- a/app/src/test/java/org/mozilla/fenix/home/HomeFragmentTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/HomeFragmentTest.kt
@@ -17,6 +17,7 @@ import mozilla.components.feature.top.sites.TopSite
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -54,10 +55,23 @@ class HomeFragmentTest {
     @Test
     fun `WHEN getTopSitesConfig is called THEN it returns TopSitesConfig with non-null frecencyConfig`() {
         every { settings.topSitesMaxLimit } returns 10
+        every { settings.showHistoryShortcuts } returns true
 
         val topSitesConfig = homeFragment.getTopSitesConfig()
 
         assertNotNull(topSitesConfig.frecencyConfig)
+        assertNotNull(topSitesConfig.frecencyConfig?.frecencyTresholdOption)
+    }
+
+    @Test
+    fun `WHEN getTopSitesConfig is called with history shortcuts disabled THEN it returns TopSitesConfig with null frecencyTresholdOption`() {
+        every { settings.topSitesMaxLimit } returns 10
+        every { settings.showHistoryShortcuts } returns false
+
+        val topSitesConfig = homeFragment.getTopSitesConfig()
+
+        assertNotNull(topSitesConfig.frecencyConfig)
+        assertNull(topSitesConfig.frecencyConfig?.frecencyTresholdOption)
     }
 
     @Test


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
Fixes #26159