### PR TITLE
For #26401: Remove unused wallpaper metrics.

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -7844,6 +7844,8 @@ wallpapers:
     data_sensitivity:
       - interaction
     expires: 114
+    no_lint:
+      - COMMON_PREFIX
     metadata:
       tags:
         - Wallpapers
@@ -7867,50 +7869,8 @@ wallpapers:
     data_sensitivity:
       - interaction
     expires: 114
-    metadata:
-      tags:
-        - Wallpapers
-  wallpaper_switched:
-    type: event
-    description: |
-      The wallpaper was switched by using the homescreen toggle.
-    extra_keys:
-      name:
-        description: The name of the new wallpaper
-        type: string
-      theme_collection:
-        description: The theme collection the new wallpaper belongs to.
-        type: string
-    bugs:
-      - https://github.com/mozilla-mobile/fenix/issues/23381
-    data_reviews:
-      - https://github.com/mozilla-mobile/fenix/pull/23382
-    notification_emails:
-      - android-probes@mozilla.com
-    data_sensitivity:
-      - interaction
-    expires: 114
-    metadata:
-      tags:
-        - Wallpapers
-  change_wallpaper_logo_toggled:
-    type: event
-    description: |
-      A user has toggled the switch that controls the tap-logo-to-change-
-      wallpaper feature.
-    extra_keys:
-      checked:
-        description: Whether the switch is enabled or disabled.
-        type: boolean
-    bugs:
-      - https://github.com/mozilla-mobile/fenix/issues/23381
-    data_reviews:
-      - https://github.com/mozilla-mobile/fenix/pull/23382
-    notification_emails:
-      - android-probes@mozilla.com
-    data_sensitivity:
-      - interaction
-    expires: 114
+    no_lint:
+      - COMMON_PREFIX
     metadata:
       tags:
         - Wallpapers


### PR DESCRIPTION
Remove wallpaper_switched and change_wallpaper_logo_toggled.
Add lint ignore for common prefix in wallpaper metrics.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
Fixes #26401