### PR TITLE
For #26605 - Clean up RecentTabViewHolder

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/recenttabs/view/RecentTabViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recenttabs/view/RecentTabViewHolder.kt
@@ -5,7 +5,6 @@
 package org.mozilla.fenix.home.recenttabs.view
 
 import android.view.View
-import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.res.stringResource
@@ -22,7 +21,6 @@ import org.mozilla.fenix.home.recenttabs.interactor.RecentTabInteractor
  * @param composeView [ComposeView] which will be populated with Jetpack Compose UI content.
  * @param recentTabInteractor [RecentTabInteractor] which will have delegated to all user recent
  * tab interactions.
- * @param recentSyncedTabInteractor [RecentSyncedTabInteractor] which will have delegated to all user
  * recent synced tab interactions.
  */
 class RecentTabViewHolder(
@@ -45,17 +43,15 @@ class RecentTabViewHolder(
     override fun Content() {
         val recentTabs = components.appStore.observeAsComposableState { state -> state.recentTabs }
 
-        Column {
-            RecentTabs(
-                recentTabs = recentTabs.value ?: emptyList(),
-                onRecentTabClick = { recentTabInteractor.onRecentTabClicked(it) },
-                menuItems = listOf(
-                    RecentTabMenuItem(
-                        title = stringResource(id = R.string.recent_tab_menu_item_remove),
-                        onClick = { tab -> recentTabInteractor.onRemoveRecentTab(tab) }
-                    )
+        RecentTabs(
+            recentTabs = recentTabs.value ?: emptyList(),
+            onRecentTabClick = { recentTabInteractor.onRecentTabClicked(it) },
+            menuItems = listOf(
+                RecentTabMenuItem(
+                    title = stringResource(id = R.string.recent_tab_menu_item_remove),
+                    onClick = { tab -> recentTabInteractor.onRemoveRecentTab(tab) }
                 )
             )
-        }
+        )
     }
 }


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
Fixes #26605