### PR TITLE
For #26444: Adapt home screen text to wallpaper selection.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/compose/MessageCard.kt
+++ b/app/src/main/java/org/mozilla/fenix/compose/MessageCard.kt
@@ -72,7 +72,7 @@ fun MessageCard(
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                 ) {
-                    SectionHeader(
+                    SimpleHeader(
                         text = title,
                         modifier = Modifier
                             .weight(1f)

--- a/app/src/main/java/org/mozilla/fenix/compose/SectionHeader.kt
+++ b/app/src/main/java/org/mozilla/fenix/compose/SectionHeader.kt
@@ -7,8 +7,12 @@ package org.mozilla.fenix.compose
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import mozilla.components.lib.state.ext.observeAsComposableState
+import org.mozilla.fenix.components.AppStore
+import org.mozilla.fenix.components.components
 import org.mozilla.fenix.theme.FirefoxTheme
 
 /**
@@ -20,12 +24,18 @@ import org.mozilla.fenix.theme.FirefoxTheme
 @Composable
 fun SectionHeader(
     text: String,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    appStore: AppStore = components.appStore
 ) {
+    val wallpaperState = appStore
+        .observeAsComposableState { state -> state.wallpaperState }.value
+
+    val wallpaperAdaptedTextColor = wallpaperState?.currentWallpaper?.textColor?.let { Color(it) }
+
     Text(
         text = text,
         modifier = modifier,
-        color = FirefoxTheme.colors.textPrimary,
+        color = wallpaperAdaptedTextColor ?: FirefoxTheme.colors.textPrimary,
         overflow = TextOverflow.Ellipsis,
         maxLines = 2,
         style = FirefoxTheme.typography.headline7
@@ -35,5 +45,7 @@ fun SectionHeader(
 @Composable
 @Preview
 private fun HeadingTextPreview() {
-    SectionHeader(text = "Section title")
+    FirefoxTheme {
+        SectionHeader(text = "Section title", appStore = AppStore())
+    }
 }

--- a/app/src/main/java/org/mozilla/fenix/compose/SectionHeader.kt
+++ b/app/src/main/java/org/mozilla/fenix/compose/SectionHeader.kt
@@ -9,7 +9,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import mozilla.components.lib.state.ext.observeAsComposableState
 import org.mozilla.fenix.components.AppStore
@@ -36,13 +35,10 @@ fun SectionHeader(
 
     val wallpaperAdaptedTextColor = wallpaperState?.currentWallpaper?.textColor?.let { Color(it) }
 
-    Text(
+    SimpleHeader(
         text = text,
         modifier = modifier,
         color = wallpaperAdaptedTextColor ?: FirefoxTheme.colors.textPrimary,
-        overflow = TextOverflow.Ellipsis,
-        maxLines = 2,
-        style = FirefoxTheme.typography.headline7
     )
 }
 

--- a/app/src/main/java/org/mozilla/fenix/compose/SectionHeader.kt
+++ b/app/src/main/java/org/mozilla/fenix/compose/SectionHeader.kt
@@ -8,12 +8,16 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import mozilla.components.lib.state.ext.observeAsComposableState
 import org.mozilla.fenix.components.AppStore
+import org.mozilla.fenix.components.appstate.AppState
 import org.mozilla.fenix.components.components
 import org.mozilla.fenix.theme.FirefoxTheme
+import org.mozilla.fenix.wallpapers.Wallpaper
+import org.mozilla.fenix.wallpapers.WallpaperState
 
 /**
  * Default layout for the header of a screen section.
@@ -43,9 +47,34 @@ fun SectionHeader(
 }
 
 @Composable
-@Preview
-private fun HeadingTextPreview() {
+@Preview("with default wallpaper")
+private fun DefaultWallpaperHeadingTextPreview() {
     FirefoxTheme {
         SectionHeader(text = "Section title", appStore = AppStore())
     }
+}
+
+@Composable
+@Preview("with custom wallpaper", showBackground = true, backgroundColor = 0xffffff)
+private fun CustomWallpaperHeadingTextPreview() {
+    FirefoxTheme {
+        SectionHeader(text = "Section title", appStore = provideCustomWallpaperAppStore())
+    }
+}
+
+private fun provideCustomWallpaperAppStore(): AppStore {
+    return AppStore(
+        AppState(
+            wallpaperState = WallpaperState(
+                Wallpaper(
+                    "custom",
+                    Wallpaper.DefaultCollection.copy(name = "custom collection"),
+                    @Suppress("MagicNumber") // a color is not a magic number.
+                    Color(0xFFBB86FC).toArgb().toLong(),
+                    0
+                ),
+                emptyList()
+            )
+        )
+    )
 }

--- a/app/src/main/java/org/mozilla/fenix/compose/SimpleHeader.kt
+++ b/app/src/main/java/org/mozilla/fenix/compose/SimpleHeader.kt
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.compose
+
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import org.mozilla.fenix.theme.FirefoxTheme
+
+/**
+ * Default header for Cards, Dialogs, Banners, and Homepage.
+ * It enforces usage of headline7 typography.
+ */
+@Composable
+fun SimpleHeader(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = FirefoxTheme.colors.textPrimary
+) {
+    Text(
+        text = text,
+        modifier = modifier,
+        color = color,
+        overflow = TextOverflow.Ellipsis,
+        maxLines = 2,
+        style = FirefoxTheme.typography.headline7
+    )
+}
+
+@Composable
+@Preview
+private fun SimpleHeaderPreview() {
+    FirefoxTheme {
+        SimpleHeader(text = "Header title")
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/compose/home/HomeSectionHeader.kt
+++ b/app/src/main/java/org/mozilla/fenix/compose/home/HomeSectionHeader.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import mozilla.components.lib.state.ext.observeAsComposableState
 import org.mozilla.fenix.R
+import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.components.components
 import org.mozilla.fenix.compose.SectionHeader
 import org.mozilla.fenix.compose.inComposePreview
@@ -41,16 +42,18 @@ import org.mozilla.fenix.wallpapers.Wallpaper
 fun HomeSectionHeader(
     headerText: String,
     description: String,
+    appStore: AppStore = components.appStore,
     onShowAllClick: () -> Unit
 ) {
     if (inComposePreview) {
         HomeSectionHeaderContent(
             headerText = headerText,
             description = description,
-            onShowAllClick = onShowAllClick
+            onShowAllClick = onShowAllClick,
+            appStore = appStore
         )
     } else {
-        val wallpaperState = components.appStore
+        val wallpaperState = appStore
             .observeAsComposableState { state -> state.wallpaperState }.value
 
         val isWallpaperDefault =
@@ -64,6 +67,7 @@ fun HomeSectionHeader(
             } else {
                 FirefoxTheme.colors.textPrimary
             },
+            appStore = appStore,
             onShowAllClick = onShowAllClick,
         )
     }
@@ -82,6 +86,7 @@ private fun HomeSectionHeaderContent(
     headerText: String,
     description: String,
     showAllTextColor: Color = FirefoxTheme.colors.textAccent,
+    appStore: AppStore,
     onShowAllClick: () -> Unit,
 ) {
     Row(
@@ -94,6 +99,11 @@ private fun HomeSectionHeaderContent(
                 .wrapContentHeight(align = Alignment.Top)
         )
 
+        val wallpaperState = appStore
+            .observeAsComposableState { state -> state.wallpaperState }.value
+
+        val wallpaperAdaptedTextColor = wallpaperState?.currentWallpaper?.textColor?.let { Color(it) }
+
         ClickableText(
             text = AnnotatedString(text = stringResource(id = R.string.recent_tabs_show_all)),
             modifier = Modifier.padding(start = 16.dp)
@@ -101,7 +111,7 @@ private fun HomeSectionHeaderContent(
                     contentDescription = description
                 },
             style = TextStyle(
-                color = showAllTextColor,
+                color = wallpaperAdaptedTextColor ?: showAllTextColor,
                 fontSize = 14.sp
             ),
             onClick = { onShowAllClick() }
@@ -116,6 +126,7 @@ private fun HomeSectionsHeaderPreview() {
         HomeSectionHeader(
             headerText = stringResource(R.string.recently_saved_title),
             description = stringResource(R.string.recently_saved_show_all_content_description_2),
+            appStore = AppStore(),
             onShowAllClick = {}
         )
     }

--- a/app/src/main/java/org/mozilla/fenix/home/pocket/PocketStoriesComposables.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/pocket/PocketStoriesComposables.kt
@@ -53,12 +53,15 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.delay
+import mozilla.components.lib.state.ext.observeAsComposableState
 import mozilla.components.service.pocket.PocketStory
 import mozilla.components.service.pocket.PocketStory.PocketRecommendedStory
 import mozilla.components.service.pocket.PocketStory.PocketSponsoredStory
 import mozilla.components.service.pocket.PocketStory.PocketSponsoredStoryCaps
 import mozilla.components.service.pocket.PocketStory.PocketSponsoredStoryShim
 import org.mozilla.fenix.R
+import org.mozilla.fenix.components.AppStore
+import org.mozilla.fenix.components.components
 import org.mozilla.fenix.compose.ClickableSubstringLink
 import org.mozilla.fenix.compose.EagerFlingBehavior
 import org.mozilla.fenix.compose.ListItemTabLarge
@@ -396,12 +399,18 @@ fun PocketStoriesCategories(
 @Composable
 fun PoweredByPocketHeader(
     onLearnMoreClicked: (String) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    appStore: AppStore = components.appStore,
 ) {
     val link = stringResource(R.string.pocket_stories_feature_learn_more)
     val text = stringResource(R.string.pocket_stories_feature_caption, link)
     val linkStartIndex = text.indexOf(link)
     val linkEndIndex = linkStartIndex + link.length
+
+    val wallpaperState = appStore
+        .observeAsComposableState { state -> state.wallpaperState }.value
+
+    val wallpaperAdaptedTextColor = wallpaperState?.currentWallpaper?.textColor?.let { Color(it) }
 
     Column(
         modifier = modifier,
@@ -425,14 +434,14 @@ fun PoweredByPocketHeader(
             Column {
                 Text(
                     text = stringResource(R.string.pocket_stories_feature_title),
-                    color = FirefoxTheme.colors.textPrimary,
+                    color = wallpaperAdaptedTextColor ?: FirefoxTheme.colors.textPrimary,
                     fontSize = 12.sp,
                     lineHeight = 16.sp
                 )
 
                 ClickableSubstringLink(
                     text = text,
-                    textColor = FirefoxTheme.colors.textPrimary,
+                    textColor = wallpaperAdaptedTextColor ?: FirefoxTheme.colors.textPrimary,
                     clickableStartIndex = linkStartIndex,
                     clickableEndIndex = linkEndIndex
                 ) {
@@ -468,6 +477,7 @@ private fun PocketStoriesComposablesPreview() {
                 Spacer(Modifier.height(10.dp))
 
                 PoweredByPocketHeader(
+                    appStore = AppStore(),
                     onLearnMoreClicked = {}
                 )
             }


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





















### GitHub Automation
Fixes #26444