### PR TITLE
Set the Gradle max heap size to 7g

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx8g -Xms2g -XX:MaxMetaspaceSize=6g
+org.gradle.jvmargs=-Xmx7g -Xms2g -XX:MaxMetaspaceSize=6g
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects


### PR DESCRIPTION
Github Actions workers only have 7GB available, so the 8GB limit is causing crashes in that environment.