### PR TITLE
For #26286 new sponsored shortcut UI tests and other refactoring work

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/TopSitesTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/TopSitesTest.kt
@@ -9,7 +9,6 @@ import androidx.test.uiautomator.UiDevice
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.R
@@ -242,23 +241,69 @@ class TopSitesTest {
         }
     }
 
-    @Ignore("Failing after updates to Top Sites UI. See: https://github.com/mozilla-mobile/fenix/issues/26698")
     @SmokeTest
     @Test
     fun verifySponsoredShortcutsListTest() {
         homeScreen {
+            var sponsoredShortcutTitle = getSponsoredShortcutTitle(2)
+            var sponsoredShortcutTitle2 = getSponsoredShortcutTitle(3)
+
+            verifyExistingSponsoredTopSitesTabs(sponsoredShortcutTitle, 2)
+            verifyExistingSponsoredTopSitesTabs(sponsoredShortcutTitle2, 3)
         }.openThreeDotMenu {
         }.openCustomizeHome {
             verifySponsoredShortcutsCheckBox(true)
-        }.goBack {
-            verifyExistingSponsoredTopSitesTabs(2)
-            verifyExistingSponsoredTopSitesTabs(3)
-        }.openThreeDotMenu {
-        }.openCustomizeHome {
             clickSponsoredShortcuts()
             verifySponsoredShortcutsCheckBox(false)
         }.goBack {
             verifyNotExistingSponsoredTopSitesList()
+        }
+    }
+
+    @Test
+    fun openSponsoredShortcutTest() {
+        var sponsoredShortcutTitle = ""
+
+        homeScreen {
+            sponsoredShortcutTitle = getSponsoredShortcutTitle(2)
+        }.openSponsoredShortcut(sponsoredShortcutTitle) {
+            verifyUrl(sponsoredShortcutTitle)
+        }
+    }
+
+    @Test
+    fun openSponsoredShortcutInPrivateBrowsingTest() {
+        var sponsoredShortcutTitle = ""
+
+        homeScreen {
+            sponsoredShortcutTitle = getSponsoredShortcutTitle(2)
+        }.openContextMenuOnSponsoredShortcut(sponsoredShortcutTitle) {
+        }.openTopSiteInPrivateTab {
+            verifyUrl(sponsoredShortcutTitle)
+        }
+    }
+
+    @Test
+    fun verifySponsoredShortcutsSponsorsAndPrivacyOptionTest() {
+        var sponsoredShortcutTitle = ""
+
+        homeScreen {
+            sponsoredShortcutTitle = getSponsoredShortcutTitle(2)
+        }.openContextMenuOnSponsoredShortcut(sponsoredShortcutTitle) {
+        }.clickSponsorsAndPrivacyButton {
+            verifyUrl("support.mozilla.org/en-US/kb/sponsor-privacy")
+        }
+    }
+
+    @Test
+    fun verifySponsoredShortcutsSettingsOptionTest() {
+        var sponsoredShortcutTitle = ""
+
+        homeScreen {
+            sponsoredShortcutTitle = getSponsoredShortcutTitle(2)
+        }.openContextMenuOnSponsoredShortcut(sponsoredShortcutTitle) {
+        }.clickSponsoredShortcutsSettingsButton {
+            verifyHomePageView()
         }
     }
 }


### PR DESCRIPTION
For #26286 new sponsored shortcut UI tests and other refactoring work.

`verifySponsoredShortcutsListTest` ✅ successfully passed 100x on Firebase
`openSponsoredShortcutTest` ✅ successfully passed 100x on Firebase
`openSponsoredShortcutInPrivateBrowsingTest` ✅ successfully passed 100x on Firebase
`verifySponsoredShortcutsSponsorsAndPrivacyOptionTest` ✅ successfully passed 100x on Firebase
`verifySponsoredShortcutsSettingsOptionTest` ✅ successfully passed 100x on Firebase

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.










### GitHub Automation
Fixes #26286