### PR TITLE
Close #26666: Use correct content scale when displaying recent tab thumbnail and icon

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/compose/ThumbnailCard.kt
+++ b/app/src/main/java/org/mozilla/fenix/compose/ThumbnailCard.kt
@@ -88,7 +88,7 @@ fun ThumbnailCard(
                             modifier = Modifier
                                 .size(36.dp)
                                 .clip(RoundedCornerShape(8.dp)),
-                            contentScale = ContentScale.Fit
+                            contentScale = contentScale
                         )
                     }
                 }

--- a/app/src/main/java/org/mozilla/fenix/home/recenttabs/view/RecentTabs.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recenttabs/view/RecentTabs.kt
@@ -126,7 +126,8 @@ private fun RecentTabItem(
                 tab = tab,
                 modifier = Modifier
                     .size(108.dp, 80.dp)
-                    .clip(RoundedCornerShape(8.dp))
+                    .clip(RoundedCornerShape(8.dp)),
+                contentScale = ContentScale.Crop,
             )
 
             Spacer(modifier = Modifier.width(16.dp))
@@ -214,7 +215,8 @@ fun RecentTabImage(
         else -> ThumbnailCard(
             url = tab.state.content.url,
             key = tab.state.id,
-            modifier = modifier
+            modifier = modifier,
+            contentScale = contentScale,
         )
     }
 }
@@ -305,7 +307,7 @@ private fun RecentTabIcon(
                         painter = icon.painter,
                         contentDescription = null,
                         modifier = modifier,
-                        contentScale = ContentScale.Fit
+                        contentScale = contentScale,
                     )
                 }
             }


### PR DESCRIPTION
This only fixes the case before the user opens the tab.  Once the tab is opened, we'll retrieve icon will use hero image.
To reproduce the problem.  Open apple.com and set to open on home when start.  Close Fenix and reopen.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
Fixes #26666