### PR TITLE
Close #25919: Move UpdateFirstFrameDrawn to RecyclerView.onLayoutCompleted

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -26,7 +26,6 @@ import androidx.constraintlayout.widget.ConstraintSet.PARENT_ID
 import androidx.constraintlayout.widget.ConstraintSet.TOP
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.content.ContextCompat
-import androidx.core.view.doOnPreDraw
 import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.Fragment
@@ -394,10 +393,6 @@ class HomeFragment : Fragment() {
         activity.themeManager.applyStatusBarTheme(activity)
 
         FxNimbus.features.homescreen.recordExposure()
-
-        binding.root.doOnPreDraw {
-            requireComponents.appStore.dispatch(AppAction.UpdateFirstFrameDrawn(drawn = true))
-        }
 
         // DO NOT MOVE ANYTHING BELOW THIS addMarker CALL!
         requireComponents.core.engine.profiler?.addMarker(

--- a/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/SessionControlViewTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/sessioncontrol/SessionControlViewTest.kt
@@ -217,7 +217,8 @@ class SessionControlViewTest {
             false,
             showRecentSyncedTab = false,
             historyMetadata,
-            pocketStories
+            pocketStories,
+            true
         )
 
         assertTrue(results[0] is AdapterItem.TopPlaceholderItem)
@@ -225,6 +226,25 @@ class SessionControlViewTest {
         assertTrue(results[2] is AdapterItem.PocketCategoriesItem)
         assertTrue(results[3] is AdapterItem.PocketRecommendationsFooterItem)
         assertTrue(results[4] is AdapterItem.CustomizeHomeButton)
+
+        // When the first frame has not yet drawn don't add pocket.
+        val results2 = normalModeAdapterItems(
+            settings,
+            topSites,
+            collections,
+            expandedCollections,
+            recentBookmarks,
+            false,
+            null,
+            false,
+            showRecentSyncedTab = false,
+            historyMetadata,
+            pocketStories,
+            false
+        )
+
+        assertTrue(results2[0] is AdapterItem.TopPlaceholderItem)
+        assertTrue(results2[1] is AdapterItem.BottomSpacer)
     }
 
     @Test


### PR DESCRIPTION
The longer investigation that led to this patch can be found 
here: https://github.com/mozilla-mobile/fenix/issues/25919#issuecomment-1226151432

As part of a preventitive measure for home page regression loading, we
fixed the UpdateFirstFrameDrawn call to happen after the first layout in
the main RecyclerView is completed. In addition, we also make pocket
aware of this flag so that it renders itself after the first layout.

This helps prioritize current & future features that are visible first
to render before those that are off screen.

Co-authored-by: Arturo Mejia

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
Fixes #25919