### PR TITLE
For #26093: Use `ic_menu` instead of `ic_close`

### DIFF
--- a/app/src/main/res/layout/library_site_item.xml
+++ b/app/src/main/res/layout/library_site_item.xml
@@ -80,7 +80,7 @@
             android:layout_height="wrap_content"
             android:background="?android:attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/content_description_menu"
-            app:srcCompat="@drawable/ic_close"
+            app:srcCompat="@drawable/ic_menu"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent"


### PR DESCRIPTION
This PR is for #26093 
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.
Screenshots of the fix:
![photo_2022-08-30_12-12-57](https://user-images.githubusercontent.com/58442255/187347652-bbb15647-d60b-4c93-9244-c8d1009adcba.jpg)
![photo_2022-08-30_12-12-56](https://user-images.githubusercontent.com/58442255/187347661-3c3fe231-443f-472e-9240-0543622c25fc.jpg)

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
Fixes #26093