### PR TITLE
For #26706 - Deduplication of Sponsored shortcuts from the homescreen Jump back in and Recently visited sections

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -5,6 +5,7 @@
 package org.mozilla.fenix
 
 import android.annotation.SuppressLint
+import android.net.Uri
 import android.os.Build
 import android.os.Build.VERSION.SDK_INT
 import android.os.StrictMode
@@ -44,7 +45,6 @@ import mozilla.components.service.fxa.manager.SyncEnginesStorage
 import mozilla.components.service.glean.Glean
 import mozilla.components.service.glean.config.Configuration
 import mozilla.components.service.glean.net.ConceptFetchHttpUploader
-import mozilla.components.support.rusterrors.initializeRustErrors
 import mozilla.components.support.base.facts.register
 import mozilla.components.support.base.log.Log
 import mozilla.components.support.base.log.logger.Logger
@@ -52,6 +52,7 @@ import mozilla.components.support.base.observer.Observable
 import mozilla.components.support.ktx.android.content.isMainProcess
 import mozilla.components.support.ktx.android.content.runOnlyInMainProcess
 import mozilla.components.support.locale.LocaleAwareApplication
+import mozilla.components.support.rusterrors.initializeRustErrors
 import mozilla.components.support.rusthttp.RustHttpConfig
 import mozilla.components.support.rustlog.RustLog
 import mozilla.components.support.utils.logElapsedTime
@@ -275,7 +276,10 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
                             totalSites = components.settings.topSitesMaxLimit,
                             frecencyConfig = TopSitesFrecencyConfig(
                                 FrecencyThresholdOption.SKIP_ONE_TIME_PAGES
-                            ) { !it.containsQueryParameters(components.settings.frecencyFilterQuery) },
+                            ) {
+                                !Uri.parse(it.url)
+                                    .containsQueryParameters(components.settings.frecencyFilterQuery)
+                            },
                             providerConfig = TopSitesProviderConfig(
                                 showProviderTopSites = components.settings.showContileFeature,
                                 maxThreshold = TOP_SITES_PROVIDER_MAX_THRESHOLD

--- a/app/src/main/java/org/mozilla/fenix/ext/AppState.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/AppState.kt
@@ -170,9 +170,9 @@ fun AppState.filterState(blocklistHandler: BlocklistHandler): AppState =
     with(blocklistHandler) {
         copy(
             recentBookmarks = recentBookmarks.filteredByBlocklist(),
-            recentTabs = recentTabs.filteredByBlocklist(),
-            recentHistory = recentHistory.filteredByBlocklist(),
-            recentSyncedTabState = recentSyncedTabState.filteredByBlocklist()
+            recentTabs = recentTabs.filteredByBlocklist().filterContile(),
+            recentHistory = recentHistory.filteredByBlocklist().filterContile(),
+            recentSyncedTabState = recentSyncedTabState.filteredByBlocklist().filterContile()
         )
     }
 

--- a/app/src/main/java/org/mozilla/fenix/ext/TopSite.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/TopSite.kt
@@ -4,7 +4,6 @@
 
 package org.mozilla.fenix.ext
 
-import android.net.Uri
 import mozilla.components.feature.top.sites.TopSite
 import org.mozilla.fenix.settings.SupportUtils
 
@@ -34,33 +33,5 @@ fun List<TopSite>.sort(): List<TopSite> {
         result.removeAt(defaultGoogleTopSiteIndex)
         result.add(0, this[defaultGoogleTopSiteIndex])
         result
-    }
-}
-
-/**
- * Returns true if the url contains any query parameters specified by the [searchParameters].
- *
- * @param searchParameters [String] of the following forms:
- * - "" (empty) - Don't search for any params
- * - "key" - Search param named "key" with any or no value
- * - "key=" - Search param named "key" with no value
- * - "key=value" - Search param named "key" with value "value"
- */
-fun TopSite.containsQueryParameters(searchParameters: String): Boolean {
-    if (searchParameters.isBlank()) {
-        return false
-    }
-    val params = searchParameters.split("=")
-    val uri = Uri.parse(url)
-    return when (params.size) {
-        1 -> {
-            uri.queryParameterNames.contains(params.first()) &&
-                uri.getQueryParameter(params.first()).isNullOrBlank()
-        }
-        2 -> {
-            uri.queryParameterNames.contains(params.first()) &&
-                uri.getQueryParameter(params.first()) == params.last()
-        }
-        else -> false
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/ext/Uri.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/Uri.kt
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.ext
+
+import android.net.Uri
+
+/**
+ * Returns true if the url contains any query parameters specified by the [searchParameters].
+ *
+ * @param searchParameters [String] of the following forms:
+ * - "" (empty) - Don't search for any params
+ * - "key" - Search param named "key" with any or no value
+ * - "key=" - Search param named "key" with no value
+ * - "key=value" - Search param named "key" with value "value"
+ */
+fun Uri.containsQueryParameters(searchParameters: String): Boolean {
+    if (searchParameters.isBlank()) {
+        return false
+    }
+    val params = searchParameters.split("=")
+    return when (params.size) {
+        1 -> {
+            this.queryParameterNames.contains(params.first()) &&
+                this.getQueryParameter(params.first()).isNullOrBlank()
+        }
+        2 -> {
+            this.queryParameterNames.contains(params.first()) &&
+                this.getQueryParameter(params.first()) == params.last()
+        }
+        else -> false
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -8,6 +8,7 @@ import android.annotation.SuppressLint
 import android.content.res.Configuration
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.ColorDrawable
+import android.net.Uri
 import android.os.Bundle
 import android.os.StrictMode
 import android.view.Gravity
@@ -420,7 +421,7 @@ class HomeFragment : Fragment() {
             totalSites = settings.topSitesMaxLimit,
             frecencyConfig = TopSitesFrecencyConfig(
                 FrecencyThresholdOption.SKIP_ONE_TIME_PAGES
-            ) { !it.containsQueryParameters(settings.frecencyFilterQuery) },
+            ) { !Uri.parse(it.url).containsQueryParameters(settings.frecencyFilterQuery) },
             providerConfig = TopSitesProviderConfig(
                 showProviderTopSites = settings.showContileFeature,
                 maxThreshold = TOP_SITES_PROVIDER_MAX_THRESHOLD,

--- a/app/src/main/java/org/mozilla/fenix/home/blocklist/BlocklistHandler.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/blocklist/BlocklistHandler.kt
@@ -4,8 +4,10 @@
 
 package org.mozilla.fenix.home.blocklist
 
+import android.net.Uri
 import androidx.annotation.VisibleForTesting
 import mozilla.components.support.ktx.kotlin.sha1
+import org.mozilla.fenix.ext.containsQueryParameters
 import org.mozilla.fenix.home.recentbookmarks.RecentBookmark
 import org.mozilla.fenix.home.recentsyncedtabs.RecentSyncedTabState
 import org.mozilla.fenix.home.recenttabs.RecentTab
@@ -16,6 +18,8 @@ import org.mozilla.fenix.utils.Settings
  * Class for interacting with the a blocklist stored in [settings].
  * The blocklist is a set of SHA1 hashed URLs, which are stripped
  * of protocols and common subdomains like "www" or "mobile".
+ *
+ * Also used for filtering the sponsored URLs.
  */
 class BlocklistHandler(private val settings: Settings) {
 
@@ -53,6 +57,14 @@ class BlocklistHandler(private val settings: Settings) {
         }
 
     /**
+     * Filter a list of recent tabs from sponsored urls.
+     */
+    @JvmName("filterContileRecentTab")
+    fun List<RecentTab>.filterContile(): List<RecentTab> = filterNot {
+        it is RecentTab.Tab &&
+            Uri.parse(it.state.content.url).containsQueryParameters(settings.frecencyFilterQuery)
+    }
+    /**
      * If the state is set to [RecentSyncedTabState.Success], filter the list of recently synced
      * tabs by the blocklist. If the filtered list of tabs is empty, change the state to
      * [RecentSyncedTabState.None]
@@ -75,6 +87,24 @@ class BlocklistHandler(private val settings: Settings) {
         }
 
     /**
+     * Filter a list of recently synced tabs of sponsored urls if the state is
+     * [RecentSyncedTabState.Success].
+     */
+    @JvmName("filterContileRecentSyncedTab")
+    fun RecentSyncedTabState.filterContile() = if (this is RecentSyncedTabState.Success) {
+        val filteredTabs = this.tabs.filterNot {
+            Uri.parse(it.url).containsQueryParameters(settings.frecencyFilterQuery)
+        }
+        if (filteredTabs.isEmpty()) {
+            RecentSyncedTabState.None
+        } else {
+            RecentSyncedTabState.Success(filteredTabs)
+        }
+    } else {
+        this
+    }
+
+    /**
      * Filter a list of recent history items by the blocklist. Requires this class to be contextually
      * in a scope.
      */
@@ -86,6 +116,15 @@ class BlocklistHandler(private val settings: Settings) {
                     blocklistContainsUrl(blocklist, it.url)
             }
         }
+
+    /**
+     * Filter a list of recently visited history items of sponsored urls.
+     */
+    @JvmName("filterContileRecentlyVisited")
+    fun List<RecentlyVisitedItem>.filterContile(): List<RecentlyVisitedItem> = filterNot {
+        it is RecentlyVisitedItem.RecentHistoryHighlight &&
+            Uri.parse(it.url).containsQueryParameters(settings.frecencyFilterQuery)
+    }
 
     private fun blocklistContainsUrl(blocklist: Set<String>, url: String): Boolean =
         blocklist.any { it == url.stripAndHash() }

--- a/app/src/main/java/org/mozilla/fenix/home/blocklist/BlocklistMiddleware.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/blocklist/BlocklistMiddleware.kt
@@ -41,14 +41,14 @@ class BlocklistMiddleware(
             is AppAction.Change -> {
                 action.copy(
                     recentBookmarks = action.recentBookmarks.filteredByBlocklist(),
-                    recentTabs = action.recentTabs.filteredByBlocklist(),
-                    recentHistory = action.recentHistory.filteredByBlocklist(),
-                    recentSyncedTabState = action.recentSyncedTabState.filteredByBlocklist()
+                    recentTabs = action.recentTabs.filteredByBlocklist().filterContile(),
+                    recentHistory = action.recentHistory.filteredByBlocklist().filterContile(),
+                    recentSyncedTabState = action.recentSyncedTabState.filteredByBlocklist().filterContile()
                 )
             }
             is AppAction.RecentTabsChange -> {
                 action.copy(
-                    recentTabs = action.recentTabs.filteredByBlocklist()
+                    recentTabs = action.recentTabs.filteredByBlocklist().filterContile()
                 )
             }
             is AppAction.RecentBookmarksChange -> {
@@ -57,11 +57,11 @@ class BlocklistMiddleware(
                 )
             }
             is AppAction.RecentHistoryChange -> {
-                action.copy(recentHistory = action.recentHistory.filteredByBlocklist())
+                action.copy(recentHistory = action.recentHistory.filteredByBlocklist().filterContile())
             }
             is AppAction.RecentSyncedTabStateChange -> {
                 action.copy(
-                    state = action.state.filteredByBlocklist()
+                    state = action.state.filteredByBlocklist().filterContile()
                 )
             }
             is AppAction.RemoveRecentTab -> {
@@ -97,14 +97,14 @@ class BlocklistMiddleware(
     private fun AppState.toActionFilteringAllState(blocklistHandler: BlocklistHandler) =
         with(blocklistHandler) {
             AppAction.Change(
-                recentTabs = recentTabs.filteredByBlocklist(),
+                recentTabs = recentTabs.filteredByBlocklist().filterContile(),
                 recentBookmarks = recentBookmarks.filteredByBlocklist(),
-                recentHistory = recentHistory.filteredByBlocklist(),
+                recentHistory = recentHistory.filteredByBlocklist().filterContile(),
                 topSites = topSites,
                 mode = mode,
                 collections = collections,
                 showCollectionPlaceholder = showCollectionPlaceholder,
-                recentSyncedTabState = recentSyncedTabState.filteredByBlocklist()
+                recentSyncedTabState = recentSyncedTabState.filteredByBlocklist().filterContile()
             )
         }
 }

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -1112,8 +1112,8 @@ class Settings(private val appContext: Context) : PreferencesHolder {
         default = ""
     )
     /**
-     *  URLs from the user's history that contain this search param will be hidden
-     * from the top sites. The value is a string with one of the following forms:
+     *  URLs from the user's history that contain this search param will be hidden.
+     *  The value is a string with one of the following forms:
      * - "" (empty) - Disable this feature
      * - "key" - Search param named "key" with any or no value
      * - "key=" - Search param named "key" with no value
@@ -1121,7 +1121,7 @@ class Settings(private val appContext: Context) : PreferencesHolder {
      */
     val frecencyFilterQuery by stringPreference(
         appContext.getPreferenceKey(R.string.pref_key_frecency_filter_query),
-        default = "mfadid=adm"
+        default = "mfadid=adm" // Parameter provided by adM
     )
 
     /**

--- a/app/src/test/java/org/mozilla/fenix/ext/TopSiteTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/ext/TopSiteTest.kt
@@ -6,8 +6,6 @@ package org.mozilla.fenix.ext
 
 import mozilla.components.feature.top.sites.TopSite
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
@@ -115,44 +113,5 @@ class TopSiteTest {
         )
 
         assertEquals(topSites.sort(), expected)
-    }
-
-    @Test
-    fun `WHEN containsQueryParameters is invoked THEN the result should be true only if the url contains the search parameters`() {
-        var searchParameters = ""
-        val querySite = TopSite.Frecent(
-            id = 1L,
-            title = "Search",
-            url = "test.com/?q=value",
-            createdAt = 0
-        )
-        val blankQuerySite = TopSite.Frecent(
-            id = 1L,
-            title = "BlankSearch",
-            url = "test.com/?q=",
-            createdAt = 0
-        )
-
-        assertFalse(defaultGoogleTopSite.containsQueryParameters(searchParameters))
-        assertFalse(querySite.containsQueryParameters(searchParameters))
-        assertFalse(blankQuerySite.containsQueryParameters(searchParameters))
-
-        searchParameters = "q"
-
-        assertFalse(defaultGoogleTopSite.containsQueryParameters(searchParameters))
-        assertFalse(querySite.containsQueryParameters(searchParameters))
-        assertTrue(blankQuerySite.containsQueryParameters(searchParameters))
-
-        searchParameters = "q="
-
-        assertFalse(defaultGoogleTopSite.containsQueryParameters(searchParameters))
-        assertFalse(querySite.containsQueryParameters(searchParameters))
-        assertTrue(blankQuerySite.containsQueryParameters(searchParameters))
-
-        searchParameters = "q=value"
-
-        assertFalse(defaultGoogleTopSite.containsQueryParameters(searchParameters))
-        assertTrue(querySite.containsQueryParameters(searchParameters))
-        assertFalse(blankQuerySite.containsQueryParameters(searchParameters))
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/ext/UriTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/ext/UriTest.kt
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.ext
+
+import android.net.Uri
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+import org.mozilla.fenix.settings.SupportUtils
+
+@RunWith(FenixRobolectricTestRunner::class)
+class UriTest {
+    @Test
+    fun `WHEN urlContainsQueryParameters is invoked THEN the result should be true only if the url contains the search parameters`() {
+        var searchParameters = ""
+        val googleSite = Uri.parse(SupportUtils.GOOGLE_URL)
+        val querySite = Uri.parse("test.com/?q=value")
+        val blankQuerySite = Uri.parse("test.com/?q=")
+
+        assertFalse(googleSite.containsQueryParameters(searchParameters))
+        assertFalse(querySite.containsQueryParameters(searchParameters))
+        assertFalse(blankQuerySite.containsQueryParameters(searchParameters))
+
+        searchParameters = "q"
+
+        assertFalse(googleSite.containsQueryParameters(searchParameters))
+        assertFalse(querySite.containsQueryParameters(searchParameters))
+        assertTrue(blankQuerySite.containsQueryParameters(searchParameters))
+
+        searchParameters = "q="
+
+        assertFalse(googleSite.containsQueryParameters(searchParameters))
+        assertFalse(querySite.containsQueryParameters(searchParameters))
+        assertTrue(blankQuerySite.containsQueryParameters(searchParameters))
+
+        searchParameters = "q=value"
+
+        assertFalse(googleSite.containsQueryParameters(searchParameters))
+        assertTrue(querySite.containsQueryParameters(searchParameters))
+        assertFalse(blankQuerySite.containsQueryParameters(searchParameters))
+    }
+}

--- a/app/src/test/java/org/mozilla/fenix/home/blocklist/BlocklistHandlerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/blocklist/BlocklistHandlerTest.kt
@@ -5,14 +5,20 @@ import io.mockk.mockk
 import io.mockk.slot
 import mozilla.components.browser.state.state.ContentState
 import mozilla.components.browser.state.state.TabSessionState
+import mozilla.components.concept.sync.DeviceType
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.home.recentbookmarks.RecentBookmark
+import org.mozilla.fenix.home.recentsyncedtabs.RecentSyncedTab
+import org.mozilla.fenix.home.recentsyncedtabs.RecentSyncedTabState
 import org.mozilla.fenix.home.recenttabs.RecentTab
 import org.mozilla.fenix.home.recentvisits.RecentlyVisitedItem
 import org.mozilla.fenix.utils.Settings
 
+@RunWith(FenixRobolectricTestRunner::class)
 class BlocklistHandlerTest {
     private val mockSettings: Settings = mockk()
 
@@ -113,6 +119,67 @@ class BlocklistHandlerTest {
 
         val filtered = with(blocklistHandler) {
             tabs.filteredByBlocklist()
+        }
+
+        assertEquals(listOf<String>(), filtered)
+    }
+
+    @Test
+    fun `GIVEN recently synced tab is a sponsored url WHEN the tabs are filtered THEN the sponsored url be filtered`() {
+        val blockedUrl = "test.com/?query=value"
+        val mockSessionState: TabSessionState = mockk()
+        val mockContent: ContentState = mockk()
+        val tabs = RecentSyncedTabState.Success(
+            listOf(
+                RecentSyncedTab(
+                    "",
+                    DeviceType.DESKTOP,
+                    "title",
+                    blockedUrl,
+                    null
+                )
+            )
+        )
+        every { mockSessionState.content } returns mockContent
+        every { mockContent.url } returns blockedUrl
+        every { mockSettings.frecencyFilterQuery } returns "query=value"
+
+        val filtered = with(blocklistHandler) {
+            tabs.filterContile()
+        }
+
+        assertEquals(RecentSyncedTabState.None, filtered)
+    }
+
+    @Test
+    fun `GIVEN recently visited item is a sponsored url WHEN the tabs are filtered THEN the sponsored url be filtered`() {
+        val blockedUrl = "test.com/?query=value"
+        val mockSessionState: TabSessionState = mockk()
+        val mockContent: ContentState = mockk()
+        val tabs = listOf(RecentlyVisitedItem.RecentHistoryHighlight("title", blockedUrl))
+        every { mockSessionState.content } returns mockContent
+        every { mockContent.url } returns blockedUrl
+        every { mockSettings.frecencyFilterQuery } returns "query=value"
+
+        val filtered = with(blocklistHandler) {
+            tabs.filterContile()
+        }
+
+        assertEquals(listOf<String>(), filtered)
+    }
+
+    @Test
+    fun `GIVEN recent tab is a sponsored url WHEN the tabs are filtered THEN the sponsored url be filtered`() {
+        val blockedUrl = "test.com/?query=value"
+        val mockSessionState: TabSessionState = mockk()
+        val mockContent: ContentState = mockk()
+        val tabs = listOf(RecentTab.Tab(mockSessionState))
+        every { mockSessionState.content } returns mockContent
+        every { mockContent.url } returns blockedUrl
+        every { mockSettings.frecencyFilterQuery } returns "query=value"
+
+        val filtered = with(blocklistHandler) {
+            tabs.filterContile()
         }
 
         assertEquals(listOf<String>(), filtered)

--- a/app/src/test/java/org/mozilla/fenix/home/blocklist/BlocklistMiddlewareTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/blocklist/BlocklistMiddlewareTest.kt
@@ -14,15 +14,18 @@ import mozilla.components.support.test.mock
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.components.appstate.AppAction
 import org.mozilla.fenix.components.appstate.AppState
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.home.recentbookmarks.RecentBookmark
 import org.mozilla.fenix.home.recentsyncedtabs.RecentSyncedTab
 import org.mozilla.fenix.home.recentsyncedtabs.RecentSyncedTabState
 import org.mozilla.fenix.home.recenttabs.RecentTab
 import org.mozilla.fenix.utils.Settings
 
+@RunWith(FenixRobolectricTestRunner::class)
 class BlocklistMiddlewareTest {
     private val mockSettings: Settings = mockk()
     private val blocklistHandler = BlocklistHandler(mockSettings)
@@ -178,6 +181,7 @@ class BlocklistMiddlewareTest {
             listOf(RecentTab.Tab(createTab(url = blockedUrl)), unblockedRecentTab)
 
         every { mockSettings.homescreenBlocklist } returns setOf(blockedUrl.stripAndHash())
+        every { mockSettings.frecencyFilterQuery } returns ""
         val middleware = BlocklistMiddleware(blocklistHandler)
         val store = AppStore(
             AppState(),
@@ -328,6 +332,7 @@ class BlocklistMiddlewareTest {
         )
 
         every { mockSettings.homescreenBlocklist } returns setOf(blockedHost.stripAndHash())
+        every { mockSettings.frecencyFilterQuery } returns ""
         val middleware = BlocklistMiddleware(blocklistHandler)
         val store = AppStore(
             AppState(),
@@ -435,6 +440,7 @@ class BlocklistMiddlewareTest {
         val updateSlot = slot<Set<String>>()
         every { mockSettings.homescreenBlocklist = capture(updateSlot) } returns Unit
         every { mockSettings.homescreenBlocklist } returns setOf(tabUrls[0].stripAndHash())
+        every { mockSettings.frecencyFilterQuery } returns ""
 
         store.dispatch(
             AppAction.RemoveRecentSyncedTab(


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
Fixes #26706