### PR TITLE
For #26444: Adapt home screen text to wallpaper selection.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/compose/SectionHeader.kt
+++ b/app/src/main/java/org/mozilla/fenix/compose/SectionHeader.kt
@@ -7,6 +7,7 @@ package org.mozilla.fenix.compose
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import org.mozilla.fenix.theme.FirefoxTheme
@@ -16,16 +17,18 @@ import org.mozilla.fenix.theme.FirefoxTheme
  *
  * @param text [String] to be styled as header and displayed.
  * @param modifier [Modifier] to be applied to the [Text].
+ * @param textColor [Color] to be applied to the [Text].
  */
 @Composable
 fun SectionHeader(
     text: String,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    textColor: Color = FirefoxTheme.colors.textPrimary,
 ) {
     Text(
         text = text,
         modifier = modifier,
-        color = FirefoxTheme.colors.textPrimary,
+        color = textColor,
         overflow = TextOverflow.Ellipsis,
         maxLines = 2,
         style = FirefoxTheme.typography.headline7

--- a/app/src/main/java/org/mozilla/fenix/compose/home/HomeSectionHeader.kt
+++ b/app/src/main/java/org/mozilla/fenix/compose/home/HomeSectionHeader.kt
@@ -40,7 +40,7 @@ import org.mozilla.fenix.wallpapers.Wallpaper
 @Composable
 fun HomeSectionHeader(
     headerText: String,
-    description: String,
+    description: String = "",
     onShowAllClick: (() -> Unit)? = null
 ) {
     if (inComposePreview) {
@@ -80,7 +80,7 @@ fun HomeSectionHeader(
 @Composable
 private fun HomeSectionHeaderContent(
     headerText: String,
-    description: String,
+    description: String = "",
     showAllTextColor: Color = FirefoxTheme.colors.textAccent,
     onShowAllClick: (() -> Unit)? = null,
 ) {

--- a/app/src/main/java/org/mozilla/fenix/compose/home/HomeSectionHeader.kt
+++ b/app/src/main/java/org/mozilla/fenix/compose/home/HomeSectionHeader.kt
@@ -53,16 +53,19 @@ fun HomeSectionHeader(
         val wallpaperState = components.appStore
             .observeAsComposableState { state -> state.wallpaperState }.value
 
+        val wallpaperAdaptedTextColor = wallpaperState?.currentWallpaper?.textColor?.let { Color(it) }
+
         val isWallpaperDefault =
             (wallpaperState?.currentWallpaper ?: Wallpaper.Default) == Wallpaper.Default
 
         HomeSectionHeaderContent(
             headerText = headerText,
+            textColor = wallpaperAdaptedTextColor ?: FirefoxTheme.colors.textPrimary,
             description = description,
             showAllTextColor = if (isWallpaperDefault) {
                 FirefoxTheme.colors.textAccent
             } else {
-                FirefoxTheme.colors.textPrimary
+                wallpaperAdaptedTextColor ?: FirefoxTheme.colors.textAccent
             },
             onShowAllClick = onShowAllClick,
         )
@@ -80,6 +83,7 @@ fun HomeSectionHeader(
 @Composable
 private fun HomeSectionHeaderContent(
     headerText: String,
+    textColor: Color = FirefoxTheme.colors.textPrimary,
     description: String = "",
     showAllTextColor: Color = FirefoxTheme.colors.textAccent,
     onShowAllClick: (() -> Unit)? = null,
@@ -89,6 +93,7 @@ private fun HomeSectionHeaderContent(
     ) {
         SectionHeader(
             text = headerText,
+            textColor = textColor,
             modifier = Modifier
                 .weight(1f)
                 .wrapContentHeight(align = Alignment.Top)

--- a/app/src/main/java/org/mozilla/fenix/compose/home/HomeSectionHeader.kt
+++ b/app/src/main/java/org/mozilla/fenix/compose/home/HomeSectionHeader.kt
@@ -41,7 +41,7 @@ import org.mozilla.fenix.wallpapers.Wallpaper
 fun HomeSectionHeader(
     headerText: String,
     description: String,
-    onShowAllClick: () -> Unit
+    onShowAllClick: (() -> Unit)? = null
 ) {
     if (inComposePreview) {
         HomeSectionHeaderContent(
@@ -82,7 +82,7 @@ private fun HomeSectionHeaderContent(
     headerText: String,
     description: String,
     showAllTextColor: Color = FirefoxTheme.colors.textAccent,
-    onShowAllClick: () -> Unit,
+    onShowAllClick: (() -> Unit)? = null,
 ) {
     Row(
         modifier = Modifier.fillMaxWidth(),
@@ -94,18 +94,20 @@ private fun HomeSectionHeaderContent(
                 .wrapContentHeight(align = Alignment.Top)
         )
 
-        ClickableText(
-            text = AnnotatedString(text = stringResource(id = R.string.recent_tabs_show_all)),
-            modifier = Modifier.padding(start = 16.dp)
-                .semantics {
-                    contentDescription = description
-                },
-            style = TextStyle(
-                color = showAllTextColor,
-                fontSize = 14.sp
-            ),
-            onClick = { onShowAllClick() }
-        )
+        onShowAllClick?.let {
+            ClickableText(
+                text = AnnotatedString(text = stringResource(id = R.string.recent_tabs_show_all)),
+                modifier = Modifier.padding(start = 16.dp)
+                    .semantics {
+                        contentDescription = description
+                    },
+                style = TextStyle(
+                    color = showAllTextColor,
+                    fontSize = 14.sp
+                ),
+                onClick = { onShowAllClick() }
+            )
+        }
     }
 }
 
@@ -116,7 +118,6 @@ private fun HomeSectionsHeaderPreview() {
         HomeSectionHeader(
             headerText = stringResource(R.string.recently_saved_title),
             description = stringResource(R.string.recently_saved_show_all_content_description_2),
-            onShowAllClick = {}
         )
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/home/pocket/PocketCategoriesViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/pocket/PocketCategoriesViewHolder.kt
@@ -9,9 +9,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.res.stringResource
@@ -23,7 +21,7 @@ import mozilla.components.lib.state.ext.observeAsComposableState
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.components
 import org.mozilla.fenix.compose.ComposeViewHolder
-import org.mozilla.fenix.compose.SectionHeader
+import org.mozilla.fenix.compose.home.HomeSectionHeader
 import org.mozilla.fenix.theme.FirefoxTheme
 import org.mozilla.fenix.theme.Theme
 
@@ -82,11 +80,8 @@ private fun PocketTopics(
     onCategoryClick: (PocketRecommendedStoriesCategory) -> Unit
 ) {
     Column {
-        SectionHeader(
-            text = stringResource(R.string.pocket_stories_categories_header),
-            modifier = Modifier
-                .fillMaxWidth()
-                .wrapContentHeight(align = Alignment.Top)
+        HomeSectionHeader(
+            headerText = stringResource(R.string.pocket_stories_categories_header),
         )
 
         Spacer(Modifier.height(16.dp))

--- a/app/src/main/java/org/mozilla/fenix/home/pocket/PocketRecommendationsHeaderViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/pocket/PocketRecommendationsHeaderViewHolder.kt
@@ -13,12 +13,15 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.LifecycleOwner
 import androidx.recyclerview.widget.RecyclerView
+import mozilla.components.lib.state.ext.observeAsComposableState
 import org.mozilla.fenix.R
+import org.mozilla.fenix.components.components
 import org.mozilla.fenix.compose.ComposeViewHolder
 import org.mozilla.fenix.theme.FirefoxTheme
 import org.mozilla.fenix.theme.Theme
@@ -42,12 +45,17 @@ class PocketRecommendationsHeaderViewHolder(
             composeView.resources.getDimensionPixelSize(R.dimen.home_item_horizontal_margin)
         composeView.setPadding(horizontalPadding, 0, horizontalPadding, 0)
 
+        val wallpaperState = components.appStore
+            .observeAsComposableState { state -> state.wallpaperState }.value
+        val wallpaperAdaptedTextColor = wallpaperState?.currentWallpaper?.textColor?.let { Color(it) }
+
         Column {
             Spacer(Modifier.height(24.dp))
 
             PoweredByPocketHeader(
                 onLearnMoreClicked = interactor::onLearnMoreClicked,
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier.fillMaxWidth(),
+                textColor = wallpaperAdaptedTextColor ?: FirefoxTheme.colors.textPrimary
             )
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/home/pocket/PocketStoriesComposables.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/pocket/PocketStoriesComposables.kt
@@ -378,11 +378,13 @@ fun PocketStoriesCategories(
  * @param onLearnMoreClicked Callback invoked when the user clicks the "Learn more" link.
  * Contains the full URL for where the user should be navigated to.
  * @param modifier [Modifier] to be applied to the layout.
+ * @param textColor [Color] to be applied to the text.
  */
 @Composable
 fun PoweredByPocketHeader(
     onLearnMoreClicked: (String) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    textColor: Color = FirefoxTheme.colors.textPrimary,
 ) {
     val link = stringResource(R.string.pocket_stories_feature_learn_more)
     val text = stringResource(R.string.pocket_stories_feature_caption, link)
@@ -411,14 +413,14 @@ fun PoweredByPocketHeader(
             Column {
                 Text(
                     text = stringResource(R.string.pocket_stories_feature_title),
-                    color = FirefoxTheme.colors.textPrimary,
+                    color = textColor,
                     fontSize = 12.sp,
                     lineHeight = 16.sp
                 )
 
                 ClickableSubstringLink(
                     text = text,
-                    textColor = FirefoxTheme.colors.textPrimary,
+                    textColor = textColor,
                     clickableStartIndex = linkStartIndex,
                     clickableEndIndex = linkEndIndex
                 ) {

--- a/app/src/main/java/org/mozilla/fenix/home/pocket/PocketStoriesComposables.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/pocket/PocketStoriesComposables.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -48,7 +47,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -211,7 +209,6 @@ fun PocketSponsoredStory(
 @Composable
 fun PocketStories(
     @PreviewParameter(PocketStoryProvider::class) stories: List<PocketStory>,
-    contentPadding: Dp,
     onStoryShown: (PocketStory, Pair<Int, Int>) -> Unit,
     onStoryClicked: (PocketStory, Pair<Int, Int>) -> Unit,
     onDiscoverMoreClicked: (String) -> Unit
@@ -224,7 +221,6 @@ fun PocketStories(
     val flingBehavior = EagerFlingBehavior(lazyRowState = listState)
 
     LazyRow(
-        contentPadding = PaddingValues(horizontal = contentPadding),
         state = listState,
         flingBehavior = flingBehavior,
         horizontalArrangement = Arrangement.spacedBy(8.dp)
@@ -441,7 +437,6 @@ private fun PocketStoriesComposablesPreview() {
             Column {
                 PocketStories(
                     stories = getFakePocketStories(8),
-                    contentPadding = 0.dp,
                     onStoryShown = { _, _ -> },
                     onStoryClicked = { _, _ -> },
                     onDiscoverMoreClicked = {}

--- a/app/src/main/java/org/mozilla/fenix/home/pocket/PocketStoriesViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/pocket/PocketStoriesViewHolder.kt
@@ -7,16 +7,12 @@ package org.mozilla.fenix.home.pocket
 import android.view.View
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -27,7 +23,7 @@ import mozilla.components.service.pocket.PocketStory.PocketRecommendedStory
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.components
 import org.mozilla.fenix.compose.ComposeViewHolder
-import org.mozilla.fenix.compose.SectionHeader
+import org.mozilla.fenix.compose.home.HomeSectionHeader
 import org.mozilla.fenix.theme.FirefoxTheme
 import org.mozilla.fenix.theme.Theme
 
@@ -44,14 +40,18 @@ class PocketStoriesViewHolder(
     private val interactor: PocketStoriesInteractor
 ) : ComposeViewHolder(composeView, viewLifecycleOwner) {
 
+    init {
+        val horizontalPadding =
+            composeView.resources.getDimensionPixelSize(R.dimen.home_item_horizontal_margin)
+        composeView.setPadding(horizontalPadding, 0, horizontalPadding, 0)
+    }
+
     companion object {
         val LAYOUT_ID = View.generateViewId()
     }
 
     @Composable
     override fun Content() {
-        val horizontalPadding = dimensionResource(R.dimen.home_item_horizontal_margin)
-
         val homeScreenReady = components.appStore
             .observeAsComposableState { state -> state.firstFrameDrawn }.value ?: false
 
@@ -79,19 +79,14 @@ class PocketStoriesViewHolder(
         }
 
         Column(modifier = Modifier.padding(top = 72.dp)) {
-            SectionHeader(
-                text = stringResource(R.string.pocket_stories_header_1),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = horizontalPadding)
-                    .wrapContentHeight(align = Alignment.Top)
+            HomeSectionHeader(
+                headerText = stringResource(R.string.pocket_stories_header_1),
             )
 
             Spacer(Modifier.height(16.dp))
 
             PocketStories(
                 stories ?: emptyList(),
-                horizontalPadding,
                 interactor::onStoryShown,
                 interactor::onStoryClicked,
                 interactor::onDiscoverMoreClicked
@@ -105,12 +100,8 @@ class PocketStoriesViewHolder(
 fun PocketStoriesViewHolderPreview() {
     FirefoxTheme(theme = Theme.getTheme()) {
         Column {
-            SectionHeader(
-                text = stringResource(R.string.pocket_stories_header_1),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp)
-                    .wrapContentHeight(align = Alignment.Top)
+            HomeSectionHeader(
+                headerText = stringResource(R.string.pocket_stories_header_1),
             )
 
             Spacer(Modifier.height(16.dp))
@@ -118,7 +109,6 @@ fun PocketStoriesViewHolderPreview() {
             @Suppress("MagicNumber")
             PocketStories(
                 stories = getFakePocketStories(8),
-                contentPadding = 0.dp,
                 onStoryShown = { _, _ -> },
                 onStoryClicked = { _, _ -> },
                 onDiscoverMoreClicked = {}

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/CollectionHeaderViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/CollectionHeaderViewHolder.kt
@@ -6,12 +6,9 @@ package org.mozilla.fenix.home.sessioncontrol.viewholders
 
 import android.view.View
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.res.stringResource
@@ -19,7 +16,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.LifecycleOwner
 import org.mozilla.fenix.R
 import org.mozilla.fenix.compose.ComposeViewHolder
-import org.mozilla.fenix.compose.SectionHeader
+import org.mozilla.fenix.compose.home.HomeSectionHeader
 
 /**
  * View holder for the "Collections" section header with the "Show all" button.
@@ -43,11 +40,8 @@ class CollectionHeaderViewHolder(
         Column {
             Spacer(Modifier.height(56.dp))
 
-            SectionHeader(
-                text = stringResource(R.string.collections_header),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .wrapContentHeight(align = Alignment.Top),
+            HomeSectionHeader(
+                headerText = stringResource(R.string.collections_header),
             )
 
             Spacer(Modifier.height(10.dp))


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.
















### GitHub Automation
Fixes #26444