### PR TITLE
For #26489 - Display synced tab pickup message only when recent synced tab view is available

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlView.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlView.kt
@@ -224,7 +224,6 @@ class SessionControlView(
                             context = context,
                             recyclerView = view,
                         ).showSyncCFR()
-                        context.settings().showSyncCFR = false
                     }
 
                     // We want some parts of the home screen UI to be rendered first if they are

--- a/app/src/main/java/org/mozilla/fenix/onboarding/SyncCFRPresenter.kt
+++ b/app/src/main/java/org/mozilla/fenix/onboarding/SyncCFRPresenter.kt
@@ -13,6 +13,7 @@ import org.mozilla.fenix.GleanMetrics.Onboarding
 import org.mozilla.fenix.R
 import org.mozilla.fenix.compose.cfr.CFRPopup
 import org.mozilla.fenix.compose.cfr.CFRPopupProperties
+import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.home.recentsyncedtabs.view.RecentSyncedTabViewHolder
 
 /**
@@ -57,6 +58,7 @@ class SyncCFRPresenter(
                 show()
                 Onboarding.synCfrShown.record(NoExtras())
             }
+            context.settings().showSyncCFR = false
         }
     }
 


### PR DESCRIPTION
For the users that prefer to sync in after the onboarding, we risk not showing the CFR when there will be a recent synced tab on the homescreen. This also impacts the Jump back in CFR based on the condition [here](https://github.com/mozilla-mobile/fenix/blob/21d3d0f8f0ebed7d592bef425236e195acb13e4c/app/src/main/java/org/mozilla/fenix/onboarding/JumpBackInCFRDialog.kt#L53).

We want to first check if there is a recent synced tab on the homescreen and then show the cfr and change the setting to avoid displaying the CFR multiple times.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
Fixes #26489