### PR TITLE
For #26286 new home screen UI tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
@@ -8,15 +8,20 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.Until
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.helpers.AndroidAssetDispatcher
+import org.mozilla.fenix.helpers.FeatureSettingsHelper
 import org.mozilla.fenix.helpers.HomeActivityTestRule
 import org.mozilla.fenix.helpers.RetryTestRule
+import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.ext.waitNotNull
 import org.mozilla.fenix.ui.robots.homeScreen
+import org.mozilla.fenix.ui.robots.navigationToolbar
 
 /**
  *  Tests for verifying the presence of home screen and first-run homescreen elements
@@ -29,6 +34,8 @@ class HomeScreenTest {
     /* ktlint-disable no-blank-line-before-rbrace */ // This imposes unreadable grouping.
 
     private lateinit var mDevice: UiDevice
+    private lateinit var mockWebServer: MockWebServer
+    private val featureSettingsHelper = FeatureSettingsHelper()
 
     @get:Rule
     val activityTestRule = HomeActivityTestRule()
@@ -40,6 +47,19 @@ class HomeScreenTest {
     @Before
     fun setUp() {
         mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+
+        mockWebServer = MockWebServer().apply {
+            dispatcher = AndroidAssetDispatcher()
+            start()
+        }
+
+        featureSettingsHelper.setTCPCFREnabled(false)
+    }
+
+    @After
+    fun tearDown() {
+        mockWebServer.shutdown()
+        featureSettingsHelper.resetAllFeatureFlags()
     }
 
     @Test
@@ -129,8 +149,8 @@ class HomeScreenTest {
 
     @Test
     fun dismissOnboardingUsingHelpTest() {
-        val settings = activityTestRule.activity.applicationContext.settings()
-        settings.shouldShowJumpBackInCFR = false
+        featureSettingsHelper.setJumpBackCFREnabled(false)
+
         homeScreen {
             verifyWelcomeHeader()
         }.openThreeDotMenu {
@@ -151,6 +171,49 @@ class HomeScreenTest {
             verifyKeyboardVisibility()
         }.dismissSearchBar {
             verifyWelcomeHeader()
+        }
+    }
+
+    @Test
+    fun verifyPocketHomepageStoriesTest() {
+        featureSettingsHelper.setRecentTabsFeatureEnabled(false)
+        featureSettingsHelper.setRecentlyVisitedFeatureEnabled(false)
+
+        homeScreen {
+        }.dismissOnboarding()
+
+        homeScreen {
+            verifyThoughtProvokingStories(true)
+            verifyStoriesByTopic(true)
+        }.openThreeDotMenu {
+        }.openCustomizeHome {
+            clickPocketButton()
+        }.goBack {
+            verifyThoughtProvokingStories(false)
+            verifyStoriesByTopic(false)
+        }
+    }
+
+    @Test
+    fun verifyCustomizeHomepageTest() {
+        val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+        featureSettingsHelper.setJumpBackCFREnabled(false)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(defaultWebPage.url) {
+        }.goToHomescreen {
+        }.openCustomizeHomepage {
+            clickJumpBackInButton()
+            clickRecentBookmarksButton()
+            clickRecentSearchesButton()
+            clickPocketButton()
+        }.goBack {
+            verifyCustomizeHomepageButton(false)
+        }.openThreeDotMenu {
+        }.openCustomizeHome {
+            clickJumpBackInButton()
+        }.goBack {
+            verifyCustomizeHomepageButton(true)
         }
     }
 }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
@@ -222,6 +222,74 @@ class HomeScreenRobot {
 
     fun clickFirefoxLogo() = homepageWordmark.click()
 
+    fun verifyThoughtProvokingStories(enabled: Boolean) {
+        if (enabled) {
+            scrollToElementByText(getStringResource(R.string.pocket_stories_header_1))
+            assertTrue(
+                mDevice.findObject(
+                    UiSelector()
+                        .textContains(
+                            getStringResource(R.string.pocket_stories_header_1)
+                        )
+                ).waitForExists(waitingTime)
+            )
+        } else {
+            homeScreenList().scrollToEnd(LISTS_MAXSWIPES)
+            assertFalse(
+                mDevice.findObject(
+                    UiSelector()
+                        .textContains(
+                            getStringResource(R.string.pocket_stories_header_1)
+                        )
+                ).waitForExists(waitingTime)
+            )
+        }
+    }
+
+    fun verifyStoriesByTopic(enabled: Boolean) {
+        if (enabled) {
+            scrollToElementByText(getStringResource(R.string.pocket_stories_categories_header))
+            assertTrue(
+                mDevice.findObject(
+                    UiSelector()
+                        .textContains(
+                            getStringResource(R.string.pocket_stories_categories_header)
+                        )
+                ).waitForExists(waitingTime)
+            )
+        } else {
+            homeScreenList().scrollToEnd(LISTS_MAXSWIPES)
+            assertFalse(
+                mDevice.findObject(
+                    UiSelector()
+                        .textContains(
+                            getStringResource(R.string.pocket_stories_categories_header)
+                        )
+                ).waitForExists(waitingTime)
+            )
+        }
+    }
+
+    fun verifyCustomizeHomepageButton(enabled: Boolean) {
+        if (enabled) {
+            scrollToElementByText(getStringResource(R.string.browser_menu_customize_home_1))
+            assertTrue(
+                mDevice.findObject(
+                    UiSelector()
+                        .textContains("Customize homepage")
+                ).waitForExists(waitingTime)
+            )
+        } else {
+            homeScreenList().scrollToEnd(LISTS_MAXSWIPES)
+            assertFalse(
+                mDevice.findObject(
+                    UiSelector()
+                        .textContains("Customize homepage")
+                ).waitForExists(waitingTime)
+            )
+        }
+    }
+
     class Transition {
 
         fun openTabDrawer(interact: TabDrawerRobot.() -> Unit): TabDrawerRobot.Transition {
@@ -415,6 +483,19 @@ class HomeScreenRobot {
 
             HistoryRobot().interact()
             return HistoryRobot.Transition()
+        }
+
+        fun openCustomizeHomepage(interact: SettingsSubMenuHomepageRobot.() -> Unit): SettingsSubMenuHomepageRobot.Transition {
+            homeScreenList().scrollToEnd(LISTS_MAXSWIPES)
+            mDevice.findObject(
+                UiSelector()
+                    .textContains(
+                        "Customize homepage"
+                    )
+            ).clickAndWaitForNewWindow(waitingTime)
+
+            SettingsSubMenuHomepageRobot().interact()
+            return SettingsSubMenuHomepageRobot.Transition()
         }
     }
 }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuHomepageRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuHomepageRobot.kt
@@ -48,6 +48,10 @@ class SettingsSubMenuHomepageRobot {
 
     fun clickRecentBookmarksButton() = recentBookmarksButton().click()
 
+    fun clickRecentSearchesButton() = recentSearchesButton().click()
+
+    fun clickPocketButton() = pocketButton().click()
+
     fun clickStartOnHomepageButton() = homepageButton().click()
 
     fun clickStartOnLastTabButton() = lastTabButton().click()


### PR DESCRIPTION
For #26286 new home screen UI tests

`verifyPocketFunctionalityTest` ✅ successfully passed 100x on Firebase
`verifyCustomizeHomepageButtonTest` ✅ successfully passed 100x on Firebase

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.










### GitHub Automation
Fixes #26286