### PR TITLE
For #26756 - Don't show Jump Back In CFR if the synced tab CFR is shown

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlView.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlView.kt
@@ -218,14 +218,13 @@ class SessionControlView(
                     super.onLayoutCompleted(state)
 
                     if (!context.settings().showHomeOnboardingDialog) {
-                        JumpBackInCFRDialog(view).showIfNeeded()
-
-                        if (context.settings().showSyncCFR) {
+                        if (context.settings().shouldShowJumpBackInCFR) {
+                            JumpBackInCFRDialog(view).showIfNeeded()
+                        } else if (context.settings().showSyncCFR) {
                             SyncCFRPresenter(
                                 context = context,
                                 recyclerView = view,
                             ).showSyncCFR()
-                            context.settings().showSyncCFR = false
                         }
                     }
 

--- a/app/src/main/java/org/mozilla/fenix/onboarding/JumpBackInCFRDialog.kt
+++ b/app/src/main/java/org/mozilla/fenix/onboarding/JumpBackInCFRDialog.kt
@@ -14,6 +14,7 @@ import android.view.View
 import androidx.recyclerview.widget.RecyclerView
 import org.mozilla.fenix.databinding.OnboardingJumpBackInCfrBinding
 import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.home.recentsyncedtabs.view.RecentSyncedTabViewHolder
 import org.mozilla.fenix.home.recenttabs.view.RecentTabsHeaderViewHolder
 
 /**
@@ -48,14 +49,30 @@ class JumpBackInCFRDialog(val recyclerView: RecyclerView) {
         return null
     }
 
+    private fun hasSyncTabsView(): Boolean {
+        val count = recyclerView.adapter?.itemCount ?: return false
+
+        for (index in count downTo 0) {
+            val viewHolder = recyclerView.findViewHolderForAdapterPosition(index)
+            if (viewHolder is RecentSyncedTabViewHolder) {
+                return true
+            }
+        }
+
+        return false
+    }
+
     private fun createJumpCRF(anchor: View): Dialog? {
         val context: Context = recyclerView.context
-        if (!context.settings().showSyncCFR) {
+
+        if (context.settings().showSyncCFR && hasSyncTabsView()) {
             context.settings().shouldShowJumpBackInCFR = false
         }
+
         if (!context.settings().shouldShowJumpBackInCFR) {
             return null
         }
+
         val anchorPosition = IntArray(2)
         val popupBinding = OnboardingJumpBackInCfrBinding.inflate(LayoutInflater.from(context))
         val popup = Dialog(context)

--- a/app/src/main/java/org/mozilla/fenix/onboarding/SyncCFRPresenter.kt
+++ b/app/src/main/java/org/mozilla/fenix/onboarding/SyncCFRPresenter.kt
@@ -13,6 +13,7 @@ import org.mozilla.fenix.GleanMetrics.Onboarding
 import org.mozilla.fenix.R
 import org.mozilla.fenix.compose.cfr.CFRPopup
 import org.mozilla.fenix.compose.cfr.CFRPopupProperties
+import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.home.recentsyncedtabs.view.RecentSyncedTabViewHolder
 
 /**
@@ -21,10 +22,10 @@ import org.mozilla.fenix.home.recentsyncedtabs.view.RecentSyncedTabViewHolder
 private const val CFR_TO_ANCHOR_VERTICAL_PADDING = -16
 
 /**
- * Delegate for handling sync onboarding CFR.
+ * Delegate for handling synced tab onboarding CFR.
  *
- * @param [Context] used for various Android interactions.
- * @param [RecyclerView] will serve as anchor for the sync CFR.
+ * @param context [Context] used for various Android interactions.
+ * @param recyclerView [RecyclerView] will serve as anchor for the sync CFR.
  */
 class SyncCFRPresenter(
     private val context: Context,
@@ -34,7 +35,7 @@ class SyncCFRPresenter(
     private var syncCFR: CFRPopup? = null
 
     /**
-     * Check if [view] is available to show sync CFR.
+     * Find the synced view and if it is available, then show the synced tab CFR.
      */
     fun showSyncCFR() {
         findSyncTabsView()?.let {
@@ -51,12 +52,15 @@ class SyncCFRPresenter(
                         false -> Onboarding.syncCfrImplicitDismissal.record(NoExtras())
                     }
                 }
-            ) {
-            }.apply {
+            ).apply {
                 syncCFR = this
                 show()
-                Onboarding.synCfrShown.record(NoExtras())
             }
+
+            context.settings().showSyncCFR = false
+            context.settings().shouldShowJumpBackInCFR = false
+
+            Onboarding.synCfrShown.record(NoExtras())
         }
     }
 


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.










### GitHub Automation
Fixes #26756