### PR TITLE
Issue #26286: adds UI test for the Language menu

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -209,6 +209,7 @@ class SmokeTest {
         }
     }
 
+    @Ignore("Failing, see: https://github.com/mozilla-mobile/fenix/issues/26711")
     @Test
     // Verifies the list of items in a tab's 3 dot menu
     fun verifyPageMainMenuItemsTest() {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -47,9 +47,6 @@ import org.mozilla.fenix.ui.robots.navigationToolbar
 import org.mozilla.fenix.ui.robots.notificationShade
 import org.mozilla.fenix.ui.robots.openEditURLView
 import org.mozilla.fenix.ui.robots.searchScreen
-import org.mozilla.fenix.ui.util.FRENCH_LANGUAGE_HEADER
-import org.mozilla.fenix.ui.util.FRENCH_SYSTEM_LOCALE_OPTION
-import org.mozilla.fenix.ui.util.ROMANIAN_LANGUAGE_HEADER
 import org.mozilla.fenix.ui.util.STRING_ONBOARDING_TRACKING_PROTECTION_HEADER
 
 /**
@@ -68,7 +65,6 @@ class SmokeTest {
     private var recentlyClosedTabsListIdlingResource: RecyclerViewIdlingResource? = null
     private var readerViewNotification: ViewVisibilityIdlingResource? = null
     private var bookmarksListIdlingResource: RecyclerViewIdlingResource? = null
-    private var localeListIdlingResource: RecyclerViewIdlingResource? = null
     private val customMenuItem = "TestMenuItem"
     private lateinit var browserStore: BrowserStore
     private val featureSettingsHelper = FeatureSettingsHelper()
@@ -127,10 +123,6 @@ class SmokeTest {
 
         if (readerViewNotification != null) {
             IdlingRegistry.getInstance().unregister(readerViewNotification)
-        }
-
-        if (localeListIdlingResource != null) {
-            IdlingRegistry.getInstance().unregister(localeListIdlingResource)
         }
 
         // resetting modified features enabled setting to default
@@ -950,28 +942,6 @@ class SmokeTest {
             longClickToolbar()
             clickPasteText()
             verifyPastedToolbarText("Page content: 1")
-        }
-    }
-
-    @Test
-    fun switchLanguageTest() {
-        homeScreen {
-        }.openThreeDotMenu {
-        }.openSettings {
-        }.openLanguageSubMenu {
-            localeListIdlingResource =
-                RecyclerViewIdlingResource(
-                    activityTestRule.activity.findViewById(R.id.locale_list),
-                    2
-                )
-            IdlingRegistry.getInstance().register(localeListIdlingResource)
-            selectLanguage("Romanian")
-            verifyLanguageHeaderIsTranslated(ROMANIAN_LANGUAGE_HEADER)
-            selectLanguage("Français")
-            verifyLanguageHeaderIsTranslated(FRENCH_LANGUAGE_HEADER)
-            selectLanguage(FRENCH_SYSTEM_LOCALE_OPTION)
-            verifyLanguageHeaderIsTranslated("Language")
-            IdlingRegistry.getInstance().unregister(localeListIdlingResource)
         }
     }
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
@@ -192,12 +192,15 @@ class SettingsRobot {
             return SettingsSubMenuAccessibilityRobot.Transition()
         }
 
-        fun openLanguageSubMenu(interact: SettingsSubMenuLanguageRobot.() -> Unit): SettingsSubMenuLanguageRobot.Transition {
+        fun openLanguageSubMenu(
+            localizedText: String = getStringResource(R.string.preferences_language),
+            interact: SettingsSubMenuLanguageRobot.() -> Unit
+        ): SettingsSubMenuLanguageRobot.Transition {
             onView(withId(R.id.recycler_view))
                 .perform(
                     RecyclerViewActions.actionOnItem<RecyclerView.ViewHolder>(
                         hasDescendant(
-                            withText(R.string.preferences_language)
+                            withText(localizedText)
                         ),
                         ViewActions.click()
                     )

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuLanguageRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuLanguageRobot.kt
@@ -7,13 +7,16 @@ package org.mozilla.fenix.ui.robots
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.uiautomator.UiScrollable
 import androidx.test.uiautomator.UiSelector
 import junit.framework.TestCase.assertTrue
 import org.hamcrest.CoreMatchers
+import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.TestHelper.mDevice
 import org.mozilla.fenix.helpers.TestHelper.packageName
+import org.mozilla.fenix.helpers.click
 
 class SettingsSubMenuLanguageRobot {
     fun selectLanguage(language: String) {
@@ -23,8 +26,44 @@ class SettingsSubMenuLanguageRobot {
             .click()
     }
 
+    fun selectLanguageSearchResult(languageName: String) {
+        language(languageName).waitForExists(waitingTime)
+        language(languageName).click()
+    }
+
     fun verifyLanguageHeaderIsTranslated(translation: String) =
         assertTrue(mDevice.findObject(UiSelector().text(translation)).waitForExists(waitingTime))
+
+    fun verifySelectedLanguage(language: String) {
+        languagesList.waitForExists(waitingTime)
+        assertTrue(
+            languagesList
+                .getChildByText(UiSelector().text(language), language, true)
+                .getFromParent(UiSelector().resourceId("$packageName:id/locale_selected_icon"))
+                .waitForExists(waitingTime)
+        )
+    }
+
+    fun openSearchBar() {
+        onView(withId(R.id.search)).click()
+    }
+
+    fun typeInSearchBar(text: String) {
+        searchBar.waitForExists(waitingTime)
+        searchBar.text = text
+    }
+
+    fun verifySearchResultsContains(languageName: String) {
+        assertTrue(language(languageName).waitForExists(waitingTime))
+    }
+
+    fun clearSearchBar() {
+        onView(withId(R.id.search_close_btn)).click()
+    }
+
+    fun verifyLanguageListIsDisplayed() {
+        assertTrue(languagesList.waitForExists(waitingTime))
+    }
 
     class Transition {
 
@@ -47,3 +86,8 @@ private val languagesList =
             .resourceId("$packageName:id/locale_list")
             .scrollable(true)
     )
+
+private fun language(name: String) = mDevice.findObject(UiSelector().text(name))
+
+private val searchBar =
+    mDevice.findObject(UiSelector().resourceId("$packageName:id/search_src_text"))

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuMainRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuMainRobot.kt
@@ -33,6 +33,7 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.Constants.RETRY_COUNT
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeLong
+import org.mozilla.fenix.helpers.TestHelper.getStringResource
 import org.mozilla.fenix.helpers.TestHelper.mDevice
 import org.mozilla.fenix.helpers.TestHelper.packageName
 import org.mozilla.fenix.helpers.click
@@ -145,13 +146,16 @@ class ThreeDotMenuMainRobot {
     }
 
     class Transition {
-        fun openSettings(interact: SettingsRobot.() -> Unit): SettingsRobot.Transition {
+        fun openSettings(
+            localizedText: String = getStringResource(R.string.browser_menu_settings),
+            interact: SettingsRobot.() -> Unit
+        ): SettingsRobot.Transition {
             // We require one swipe to display the full size 3-dot menu. On smaller devices
             // such as the Pixel 2, we require two swipes to display the "Settings" menu item
             // at the bottom. On larger devices, the second swipe is a no-op.
             threeDotMenuRecyclerView().perform(swipeUp())
             threeDotMenuRecyclerView().perform(swipeUp())
-            settingsButton().click()
+            settingsButton(localizedText).click()
 
             SettingsRobot().interact()
             return SettingsRobot.Transition()
@@ -405,7 +409,9 @@ private fun threeDotMenuRecyclerViewExists() {
     threeDotMenuRecyclerView().check(matches(isDisplayed()))
 }
 
-private fun settingsButton() = mDevice.findObject(UiSelector().text("Settings"))
+private fun settingsButton(localizedText: String = getStringResource(R.string.browser_menu_settings)) =
+    mDevice.findObject(UiSelector().text(localizedText))
+
 private fun assertSettingsButton() = assertTrue(settingsButton().waitForExists(waitingTime))
 
 private fun customizeHomeButton() =

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/util/Strings.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/util/Strings.kt
@@ -8,5 +8,6 @@ const val STRING_ONBOARDING_ACCOUNT_SIGN_IN_HEADER = "Sync Firefox between devic
 const val STRING_ONBOARDING_TRACKING_PROTECTION_HEADER = "Always-on privacy"
 const val STRING_ONBOARDING_TOOLBAR_PLACEMENT_HEADER = "Pick your toolbar placement"
 const val FRENCH_LANGUAGE_HEADER = "Langues"
-const val ROMANIAN_LANGUAGE_HEADER = "Limbă"
+const val FR_SETTINGS = "Paramètres"
 const val FRENCH_SYSTEM_LOCALE_OPTION = "Utiliser la langue de l’appareil"
+const val ROMANIAN_LANGUAGE_HEADER = "Limbă"


### PR DESCRIPTION
New UI tests coverage on the Language menu. 
frenchSystemLocaleTest will have to wait for https://github.com/mozilla-mobile/fenix/issues/26728 to be fixed before enabling.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
Fixes #26286
Fixes #26711