### PR TITLE
For #26286 new site security quick settings UI tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/NavigationToolbarTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/NavigationToolbarTest.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.fenix.ui
 
+import androidx.core.net.toUri
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import okhttp3.mockwebserver.MockWebServer
@@ -15,6 +16,7 @@ import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.FeatureSettingsHelper
 import org.mozilla.fenix.helpers.HomeActivityTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
+import org.mozilla.fenix.ui.robots.homeScreen
 import org.mozilla.fenix.ui.robots.navigationToolbar
 
 /**
@@ -45,6 +47,7 @@ class NavigationToolbarTest {
         }
         featureSettingsHelper.setJumpBackCFREnabled(false)
         featureSettingsHelper.setTCPCFREnabled(false)
+        featureSettingsHelper.disablePwaCFR(true)
     }
 
     @After
@@ -137,5 +140,45 @@ class NavigationToolbarTest {
             enterFindInPageQuery("3")
             verifyFindNextInPageResult("1/1")
         }.closeFindInPage { }
+    }
+
+    @Test
+    fun verifySecurePageSecuritySubMenuTest() {
+        val defaultWebPage = "https://mozilla-mobile.github.io/testapp/loginForm"
+        val defaultWebPageTitle = "Login_form"
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(defaultWebPage.toUri()) {
+        }.openSiteSecuritySheet {
+            verifyQuickActionSheet(defaultWebPage, true)
+            openSecureConnectionSubMenu(true)
+            verifySecureConnectionSubMenu(defaultWebPageTitle, defaultWebPage, true)
+        }
+    }
+
+    @Test
+    fun verifyInsecurePageSecuritySubMenuTest() {
+        val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(defaultWebPage.url) {
+        }.openSiteSecuritySheet {
+            verifyQuickActionSheet(defaultWebPage.url.toString(), false)
+            openSecureConnectionSubMenu(false)
+            verifySecureConnectionSubMenu(defaultWebPage.title, defaultWebPage.url.toString(), false)
+        }
+    }
+
+    @Test
+    fun verifyClearCookiesFromQuickSettingsTest() {
+        val helpPageUrl = "mozilla.org"
+
+        homeScreen {
+        }.openThreeDotMenu {
+        }.openHelp {
+        }.openSiteSecuritySheet {
+            clickQuickActionSheetClearSiteData()
+            verifyClearSiteDataPrompt(helpPageUrl)
+        }
     }
 }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -945,6 +945,14 @@ class BrowserRobot {
             SitePermissionsRobot().interact()
             return SitePermissionsRobot.Transition()
         }
+
+        fun openSiteSecuritySheet(interact: SiteSecurityRobot.() -> Unit): SiteSecurityRobot.Transition {
+            siteSecurityToolbarButton().waitForExists(waitingTime)
+            siteSecurityToolbarButton().clickAndWaitForNewWindow(waitingTime)
+
+            SiteSecurityRobot().interact()
+            return SiteSecurityRobot.Transition()
+        }
     }
 }
 
@@ -1029,6 +1037,9 @@ private fun creditCardSuggestion(creditCardNumber: String) =
             .resourceId("$packageName:id/credit_card_number")
             .textContains(creditCardNumber),
     )
+
+private fun siteSecurityToolbarButton() =
+    mDevice.findObject(UiSelector().resourceId("$packageName:id/mozac_browser_toolbar_security_indicator"))
 
 // Permissions test page elements & prompts
 // Test page used located at https://mozilla-mobile.github.io/testapp/permissions

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SiteSecurityRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SiteSecurityRobot.kt
@@ -1,0 +1,149 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+@file:Suppress("TooManyFunctions")
+
+package org.mozilla.fenix.ui.robots
+
+import androidx.test.uiautomator.UiSelector
+import mozilla.components.support.ktx.kotlin.tryGetHostFromUrl
+import org.junit.Assert.assertTrue
+import org.mozilla.fenix.R
+import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
+import org.mozilla.fenix.helpers.TestHelper.getStringResource
+import org.mozilla.fenix.helpers.TestHelper.mDevice
+import org.mozilla.fenix.helpers.TestHelper.packageName
+
+/**
+ * Implementation of Robot Pattern for Site Security UI.
+ */
+class SiteSecurityRobot {
+
+    fun verifyQuickActionSheet(url: String = "", isConnectionSecure: Boolean) = assertQuickActionSheet(url, isConnectionSecure)
+    fun openSecureConnectionSubMenu(isConnectionSecure: Boolean) =
+        quickActionSheetSecurityInfo(isConnectionSecure).clickAndWaitForNewWindow(waitingTime)
+    fun verifySecureConnectionSubMenu(pageTitle: String = "", url: String = "", isConnectionSecure: Boolean) =
+        assertSecureConnectionSubMenu(pageTitle, url, isConnectionSecure)
+    fun clickQuickActionSheetClearSiteData() = quickActionSheetClearSiteData().click()
+    fun verifyClearSiteDataPrompt(url: String) = assertClearSiteDataPrompt(url)
+
+    class Transition
+}
+
+private fun assertQuickActionSheet(url: String = "", isConnectionSecure: Boolean) {
+    quickActionSheet().waitForExists(waitingTime)
+    assertTrue(quickActionSheetUrl(url.tryGetHostFromUrl()).waitForExists(waitingTime))
+    assertTrue(quickActionSheetSecurityInfo(isConnectionSecure).waitForExists(waitingTime))
+    assertTrue(quickActionSheetTrackingProtectionSwitch().waitForExists(waitingTime))
+    assertTrue(quickActionSheetClearSiteData().waitForExists(waitingTime))
+}
+
+private fun assertSecureConnectionSubMenu(pageTitle: String = "", url: String = "", isConnectionSecure: Boolean) {
+    secureConnectionSubMenu().waitForExists(waitingTime)
+    assertTrue(secureConnectionSubMenuPageTitle(pageTitle).waitForExists(waitingTime))
+    assertTrue(secureConnectionSubMenuPageUrl(url).waitForExists(waitingTime))
+    assertTrue(secureConnectionSubMenuLockIcon().waitForExists(waitingTime))
+    assertTrue(secureConnectionSubMenuSecurityInfo(isConnectionSecure).waitForExists(waitingTime))
+    assertTrue(secureConnectionSubMenuCertificateInfo().waitForExists(waitingTime))
+}
+
+private fun assertClearSiteDataPrompt(url: String) {
+    assertTrue(clearSiteDataPrompt(url).waitForExists(waitingTime))
+    assertTrue(cancelClearSiteDataButton.waitForExists(waitingTime))
+    assertTrue(deleteSiteDataButton.waitForExists(waitingTime))
+}
+
+private fun quickActionSheet() =
+    mDevice.findObject(UiSelector().resourceId("$packageName:id/quick_action_sheet"))
+
+private fun quickActionSheetUrl(url: String) =
+    mDevice.findObject(
+        UiSelector()
+            .resourceId("$packageName:id/url")
+            .textContains(url),
+    )
+
+private fun quickActionSheetSecurityInfo(isConnectionSecure: Boolean) =
+    if (isConnectionSecure) {
+        mDevice.findObject(
+            UiSelector()
+                .resourceId("$packageName:id/securityInfo")
+                .textContains(getStringResource(R.string.quick_settings_sheet_secure_connection_2)),
+        )
+    } else {
+        mDevice.findObject(
+            UiSelector()
+                .resourceId("$packageName:id/securityInfo")
+                .textContains(getStringResource(R.string.quick_settings_sheet_insecure_connection_2)),
+        )
+    }
+
+private fun quickActionSheetTrackingProtectionSwitch() =
+    mDevice.findObject(
+        UiSelector()
+            .resourceId("$packageName:id/trackingProtectionSwitch"),
+    )
+
+private fun quickActionSheetClearSiteData() =
+    mDevice.findObject(
+        UiSelector()
+            .resourceId("$packageName:id/clearSiteData"),
+    )
+
+private fun secureConnectionSubMenu() =
+    mDevice.findObject(
+        UiSelector()
+            .resourceId("$packageName:id/design_bottom_sheet"),
+    )
+
+private fun secureConnectionSubMenuPageTitle(pageTitle: String) =
+    mDevice.findObject(
+        UiSelector()
+            .resourceId("$packageName:id/title")
+            .textContains(pageTitle),
+    )
+
+private fun secureConnectionSubMenuPageUrl(url: String) =
+    mDevice.findObject(
+        UiSelector()
+            .resourceId("$packageName:id/url")
+            .textContains(url),
+    )
+
+private fun secureConnectionSubMenuLockIcon() =
+    mDevice.findObject(
+        UiSelector()
+            .resourceId("$packageName:id/securityInfoIcon"),
+    )
+
+private fun secureConnectionSubMenuSecurityInfo(isConnectionSecure: Boolean) =
+    if (isConnectionSecure) {
+        mDevice.findObject(
+            UiSelector()
+                .resourceId("$packageName:id/securityInfo")
+                .textContains(getStringResource(R.string.quick_settings_sheet_secure_connection_2)),
+        )
+    } else {
+        mDevice.findObject(
+            UiSelector()
+                .resourceId("$packageName:id/securityInfo")
+                .textContains(getStringResource(R.string.quick_settings_sheet_insecure_connection_2)),
+        )
+    }
+
+private fun secureConnectionSubMenuCertificateInfo() =
+    mDevice.findObject(
+        UiSelector()
+            .resourceId("$packageName:id/securityInfo"),
+    )
+
+private fun clearSiteDataPrompt(url: String) =
+    mDevice.findObject(
+        UiSelector()
+            .resourceId("android:id/message")
+            .textContains(url),
+    )
+
+private val cancelClearSiteDataButton = mDevice.findObject(UiSelector().resourceId("android:id/button2"))
+private val deleteSiteDataButton = mDevice.findObject(UiSelector().resourceId("android:id/button1"))


### PR DESCRIPTION
For #26286 new site security quick settings UI tests

`verifySecurePageSecuritySubMenuTest` ✅ successfully passed 100x on Firebase
`verifyInsecurePageSecuritySubMenuTest` ✅ successfully passed 100x on Firebase
`verifyClearCookiesFromQuickSettingsTest` ✅ successfully passed 100x on Firebase

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
Fixes #26286