### PR TITLE
For #26776 - Don't dim the window when the Jump back in CFR is shown

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/onboarding/JumpBackInCFRDialog.kt
+++ b/app/src/main/java/org/mozilla/fenix/onboarding/JumpBackInCFRDialog.kt
@@ -103,6 +103,7 @@ class JumpBackInCFRDialog(val recyclerView: RecyclerView) {
             attr.y = y - popupBinding.root.measuredHeight
             attributes = attr
             setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+            setDimAmount(0f)
         }
         return popup
     }


### PR DESCRIPTION
| Before        | After | 
| ------------- |:-------------:| 
|<img width="465" alt="Screen Shot 2022-09-01 at 7 04 04 PM" src="https://user-images.githubusercontent.com/1190888/188026923-958e3d81-6194-4c54-9081-139b1a6bb862.png">|<img width="465" alt="Screen Shot 2022-09-01 at 10 19 23 PM" src="https://user-images.githubusercontent.com/1190888/188044903-df091773-99e3-45fa-967a-fc9eb4e4533f.png">|

For reference, this is the current synced tabs CFR.

<img width="465" alt="Screen Shot 2022-09-01 at 10 19 04 PM" src="https://user-images.githubusercontent.com/1190888/188044984-6d206590-3067-429c-b223-968afd34e295.png">


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
Fixes #26776