### PR TITLE
For #26690 - Dismiss search dialog when opening recent synced tab dropdown menu

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/recentsyncedtabs/controller/RecentSyncedTabController.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recentsyncedtabs/controller/RecentSyncedTabController.kt
@@ -26,6 +26,11 @@ interface RecentSyncedTabController {
     fun handleRecentSyncedTabClick(tab: RecentSyncedTab)
 
     /**
+     * @see [RecentSyncedTabInteractor.onRecentSyncedTabLongClick]
+     */
+    fun handleRecentSyncedTabLongClick()
+
+    /**
      * @see [RecentSyncedTabInteractor.onRecentSyncedTabClicked]
      */
     fun handleSyncedTabShowAllClicked()
@@ -64,6 +69,12 @@ class DefaultRecentSyncedTabController(
                 accessPoint = accessPoint,
             ),
         )
+    }
+
+    override fun handleRecentSyncedTabLongClick() {
+        if (navController.currentDestination?.id == R.id.searchDialogFragment) {
+            navController.navigateUp()
+        }
     }
 
     override fun handleRecentSyncedTabRemoved(tab: RecentSyncedTab) {

--- a/app/src/main/java/org/mozilla/fenix/home/recentsyncedtabs/interactor/RecentSyncedTabInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recentsyncedtabs/interactor/RecentSyncedTabInteractor.kt
@@ -18,6 +18,11 @@ interface RecentSyncedTabInteractor {
     fun onRecentSyncedTabClicked(tab: RecentSyncedTab)
 
     /**
+     * Called when opening the dropdown menu on a recent synced tab by long press.
+     */
+    fun onRecentSyncedTabLongClick()
+
+    /**
      * Opens the tabs tray to the synced tab page. Called when a user clicks on the "See all synced
      * tabs" button.
      */

--- a/app/src/main/java/org/mozilla/fenix/home/recentsyncedtabs/view/RecentSyncedTab.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recentsyncedtabs/view/RecentSyncedTab.kt
@@ -59,6 +59,7 @@ import org.mozilla.fenix.theme.Theme
  * @param onRecentSyncedTabClick Invoked when the user clicks on the recent synced tab.
  * @param onSeeAllSyncedTabsButtonClick Invoked when user clicks on the "See all" button in the synced tab card.
  * @param onRemoveSyncedTab Invoked when user clicks on the "Remove" dropdown menu option.
+ * @param onRecentSyncedTabLongClick Invoked when user long presses the recent synced tab.
  */
 @OptIn(ExperimentalFoundationApi::class)
 @Suppress("LongMethod")
@@ -68,6 +69,7 @@ fun RecentSyncedTab(
     onRecentSyncedTabClick: (RecentSyncedTab) -> Unit,
     onSeeAllSyncedTabsButtonClick: () -> Unit,
     onRemoveSyncedTab: (RecentSyncedTab) -> Unit,
+    onRecentSyncedTabLongClick: () -> Unit,
 ) {
     var isDropdownExpanded by remember { mutableStateOf(false) }
 
@@ -82,7 +84,10 @@ fun RecentSyncedTab(
             .height(180.dp)
             .combinedClickable(
                 onClick = { tab?.let { onRecentSyncedTabClick(tab) } },
-                onLongClick = { isDropdownExpanded = true },
+                onLongClick = {
+                    onRecentSyncedTabLongClick()
+                    isDropdownExpanded = true
+                },
             ),
         shape = RoundedCornerShape(8.dp),
         backgroundColor = FirefoxTheme.colors.layer2,
@@ -285,6 +290,7 @@ private fun LoadedRecentSyncedTab() {
             onRecentSyncedTabClick = {},
             onSeeAllSyncedTabsButtonClick = {},
             onRemoveSyncedTab = {},
+            onRecentSyncedTabLongClick = {},
         )
     }
 }
@@ -298,6 +304,7 @@ private fun LoadingRecentSyncedTab() {
             onRecentSyncedTabClick = {},
             onSeeAllSyncedTabsButtonClick = {},
             onRemoveSyncedTab = {},
+            onRecentSyncedTabLongClick = {},
         )
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/home/recentsyncedtabs/view/RecentSyncedTabViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recentsyncedtabs/view/RecentSyncedTabViewHolder.kt
@@ -56,6 +56,7 @@ class RecentSyncedTabViewHolder(
                 onRecentSyncedTabClick = recentSyncedTabInteractor::onRecentSyncedTabClicked,
                 onSeeAllSyncedTabsButtonClick = recentSyncedTabInteractor::onSyncedTabShowAllClicked,
                 onRemoveSyncedTab = recentSyncedTabInteractor::onRemovedRecentSyncedTab,
+                onRecentSyncedTabLongClick = recentSyncedTabInteractor::onRecentSyncedTabLongClick,
             )
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlInteractor.kt
@@ -388,6 +388,10 @@ class SessionControlInteractor(
         recentSyncedTabController.handleRecentSyncedTabClick(tab)
     }
 
+    override fun onRecentSyncedTabLongClick() {
+        recentSyncedTabController.handleRecentSyncedTabLongClick()
+    }
+
     override fun onSyncedTabShowAllClicked() {
         recentSyncedTabController.handleSyncedTabShowAllClicked()
     }

--- a/app/src/test/java/org/mozilla/fenix/home/recentsyncedtabs/controller/DefaultRecentSyncedTabControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/recentsyncedtabs/controller/DefaultRecentSyncedTabControllerTest.kt
@@ -151,6 +151,20 @@ class DefaultRecentSyncedTabControllerTest {
     }
 
     @Test
+    fun `GIVEN search dialog is displayed WHEN recent synced tab is long clicked THEN dismiss search dialog`() {
+        every { navController.navigateUp() } returns true
+        every { navController.currentDestination } returns mockk {
+            every { id } returns R.id.searchDialogFragment
+        }
+
+        controller.handleRecentSyncedTabLongClick()
+
+        verify {
+            navController.navigateUp()
+        }
+    }
+
+    @Test
     fun `WHEN synced tab clicked THEN metric counter labeled by device type is incremented`() {
         val url = "https://mozilla.org"
         val deviceType = DeviceType.DESKTOP


### PR DESCRIPTION
Added call to dismiss search dialog on long clicking the recent synced tabs. Allowing the user to interact with the `Remove` dropdown.

https://user-images.githubusercontent.com/35462038/188153391-b4ee767e-d6d3-477d-9132-cf59897ff212.mp4

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
Fixes #26690