### PR TITLE
For #26511: Parallelize work for setting the wallpaper

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -213,6 +213,7 @@ class HomeFragment : Fragment() {
         if (shouldEnableWallpaper()) {
             wallpapersObserver = WallpapersObserver(
                 appStore = components.appStore,
+                settings = requireContext().settings(),
                 wallpapersUseCases = components.useCases.wallpaperUseCases,
                 wallpaperImageView = binding.wallpaperImageView,
             ).also {
@@ -412,7 +413,6 @@ class HomeFragment : Fragment() {
         getMenuButton()?.dismissMenu()
 
         if (shouldEnableWallpaper()) {
-            // Setting the wallpaper is a potentially expensive operation - can take 100ms.
             // Running this on the Main thread helps to ensure that the just updated configuration
             // will be used when the wallpaper is scaled to match.
             // Otherwise the portrait wallpaper may remain shown on landscape,
@@ -756,6 +756,12 @@ class HomeFragment : Fragment() {
 
         lifecycleScope.launch(IO) {
             requireComponents.reviewPromptController.promptReview(requireActivity())
+        }
+
+        if (shouldEnableWallpaper()) {
+            runBlockingIncrement {
+                wallpapersObserver?.applyCurrentWallpaper()
+            }
         }
     }
 

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -115,6 +115,7 @@ import org.mozilla.fenix.tabstray.TabsTrayAccessPoint
 import org.mozilla.fenix.utils.Settings.Companion.TOP_SITES_PROVIDER_MAX_THRESHOLD
 import org.mozilla.fenix.utils.ToolbarPopupWindow
 import org.mozilla.fenix.utils.allowUndo
+import org.mozilla.fenix.wallpapers.WallpaperManager
 import java.lang.ref.WeakReference
 import kotlin.math.min
 
@@ -412,7 +413,8 @@ class HomeFragment : Fragment() {
 
         getMenuButton()?.dismissMenu()
 
-        if (shouldEnableWallpaper()) {
+        val isDefaultTheCurrentWallpaper = WallpaperManager.isDefaultTheCurrentWallpaper(requireContext().settings())
+        if (shouldEnableWallpaper() && !isDefaultTheCurrentWallpaper) {
             // Running this on the Main thread helps to ensure that the just updated configuration
             // will be used when the wallpaper is scaled to match.
             // Otherwise the portrait wallpaper may remain shown on landscape,
@@ -758,7 +760,8 @@ class HomeFragment : Fragment() {
             requireComponents.reviewPromptController.promptReview(requireActivity())
         }
 
-        if (shouldEnableWallpaper()) {
+        val isDefaultTheCurrentWallpaper = WallpaperManager.isDefaultTheCurrentWallpaper(requireContext().settings())
+        if (shouldEnableWallpaper() && !isDefaultTheCurrentWallpaper) {
             runBlockingIncrement {
                 wallpapersObserver?.applyCurrentWallpaper()
             }

--- a/app/src/main/java/org/mozilla/fenix/home/WallpapersObserver.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/WallpapersObserver.kt
@@ -4,21 +4,27 @@
 
 package org.mozilla.fenix.home
 
+import android.graphics.Bitmap
 import android.widget.ImageView
 import androidx.annotation.VisibleForTesting
+import androidx.annotation.WorkerThread
 import androidx.core.view.isVisible
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import mozilla.components.lib.state.Store
 import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.components.appstate.AppAction
 import org.mozilla.fenix.components.appstate.AppState
 import org.mozilla.fenix.ext.scaleToBottomOfView
+import org.mozilla.fenix.utils.Settings
 import org.mozilla.fenix.wallpapers.Wallpaper
 import org.mozilla.fenix.wallpapers.WallpapersUseCases
 
@@ -28,18 +34,44 @@ import org.mozilla.fenix.wallpapers.WallpapersUseCases
  * when the [LifecycleOwner] is destroyed.
  *
  * @param appStore Holds the details abut the current wallpaper.
+ * @param settings Used for checking user's option for what wallpaper to use.
  * @param wallpapersUseCases Used for interacting with the wallpaper feature.
  * @param wallpaperImageView Serves as the target when applying wallpapers.
+ * @param backgroundWorkDispatcher Used for scheduling the wallpaper update when the state is updated
+ * with a new wallpaper.
  */
 class WallpapersObserver(
     private val appStore: AppStore,
+    private val settings: Settings,
     private val wallpapersUseCases: WallpapersUseCases,
     private val wallpaperImageView: ImageView,
+    backgroundWorkDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : DefaultLifecycleObserver {
     @VisibleForTesting
     internal var observeWallpapersStoreSubscription: Store.Subscription<AppState, AppAction>? = null
+
+    /**
+     * Coroutine scope for updating the wallpapers when an update is observed.
+     * Allows for easy cleanup when the client of this is destroyed.
+     */
     @VisibleForTesting
-    internal var wallpapersScope = CoroutineScope(Dispatchers.Main.immediate)
+    internal var wallpapersScope = CoroutineScope(backgroundWorkDispatcher)
+
+    /**
+     * Setting the wallpaper assumes two steps:
+     * - load - running on IO
+     * - set - running on Main
+     * This property caches the result of [loadWallpaper] to be later used by [applyCurrentWallpaper].
+     */
+    @Volatile
+    @VisibleForTesting
+    internal var currentWallpaperImage: Bitmap? = null
+
+    /**
+     * Listener for when the first observed wallpaper is loaded and available to be set.
+     */
+    @VisibleForTesting
+    internal val isWallpaperLoaded = CompletableDeferred<Unit>()
 
     init {
         observeWallpaperUpdates()
@@ -49,8 +81,20 @@ class WallpapersObserver(
      * Immediately apply the current wallpaper automatically adjusted to support
      * the current configuration - portrait or landscape.
      */
-    fun applyCurrentWallpaper() {
-        showWallpaper()
+    internal suspend fun applyCurrentWallpaper() {
+        isWallpaperLoaded.await()
+
+        withContext(Dispatchers.Main.immediate) {
+            with(currentWallpaperImage) {
+                when (this) {
+                    null -> wallpaperImageView.isVisible = false
+                    else -> {
+                        scaleToBottomOfView(wallpaperImageView)
+                        wallpaperImageView.isVisible = true
+                    }
+                }
+            }
+        }
     }
 
     override fun onDestroy(owner: LifecycleOwner) {
@@ -63,37 +107,42 @@ class WallpapersObserver(
         var lastObservedValue: Wallpaper? = null
         observeWallpapersStoreSubscription = appStore.observeManually { state ->
             val currentValue = state.wallpaperState.currentWallpaper
+
+            // Use the persisted wallpaper name to wait until a state update
+            // that contains the wallpaper that the user chose.
+            // Avoids setting the AppState default wallpaper if we know that another wallpaper is chosen.
+            if (currentValue.name != settings.currentWallpaperName) {
+                return@observeManually
+            }
+
             // Use the wallpaper name to differentiate between updates to properly support
             // the restored from settings wallpaper being the same as the one downloaded
             // case in which details like "collection" may be different.
+            // Avoids setting the same wallpaper twice.
             if (currentValue.name != lastObservedValue?.name) {
                 lastObservedValue = currentValue
 
-                showWallpaper(currentValue)
+                wallpapersScope.launch {
+                    loadWallpaper(currentValue)
+                    applyCurrentWallpaper()
+                }
             }
         }.also {
             it.resume()
         }
     }
 
+    /**
+     * Load the bitmap of [wallpaper] and cache it in [currentWallpaperImage].
+     */
+    @WorkerThread
     @VisibleForTesting
-    internal fun showWallpaper(wallpaper: Wallpaper = appStore.state.wallpaperState.currentWallpaper) {
-        wallpapersScope.launch {
-            when (wallpaper) {
-                // We only want to update the wallpaper when it's different from the default one
-                // as the default is applied already on xml by default.
-                Wallpaper.Default -> {
-                    wallpaperImageView.isVisible = false
-                }
-                else -> {
-                    val bitmap = wallpapersUseCases.loadBitmap(wallpaper)
-
-                    bitmap?.let {
-                        it.scaleToBottomOfView(wallpaperImageView)
-                        wallpaperImageView.isVisible = true
-                    }
-                }
-            }
+    internal suspend fun loadWallpaper(wallpaper: Wallpaper) {
+        currentWallpaperImage = when (wallpaper) {
+            Wallpaper.Default -> null
+            else -> wallpapersUseCases.loadBitmap(wallpaper)
         }
+
+        isWallpaperLoaded.complete(Unit)
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/home/WallpapersObserverTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/WallpapersObserverTest.kt
@@ -7,55 +7,115 @@ package org.mozilla.fenix.home
 import android.graphics.Bitmap
 import android.widget.ImageView
 import androidx.core.view.isVisible
-import io.mockk.Called
 import io.mockk.Runs
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.cancel
+import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.libstate.ext.waitUntilIdle
+import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.rule.runTestOnMain
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertTrue
-import org.junit.Ignore
+import org.junit.Assert.assertNull
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.components.appstate.AppAction.WallpaperAction.UpdateCurrentWallpaper
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+import org.mozilla.fenix.utils.Settings
 import org.mozilla.fenix.wallpapers.Wallpaper
 import org.mozilla.fenix.wallpapers.WallpapersUseCases
 
 @RunWith(FenixRobolectricTestRunner::class)
 class WallpapersObserverTest {
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
+
     @Test
     fun `WHEN the observer is created THEN start observing the store`() {
         val appStore: AppStore = mockk(relaxed = true) {
             every { observeManually(any()) } answers { mockk(relaxed = true) }
         }
 
-        val observer = WallpapersObserver(appStore, mockk(), mockk())
+        val observer = getObserver(appStore)
 
         assertNotNull(observer.observeWallpapersStoreSubscription)
     }
 
     @Test
-    fun `WHEN asked to apply the wallpaper THEN show it`() {
+    fun `GIVEN a certain wallpaper is chosen WHEN the state is updated with that wallpaper THEN load it it`() = runTestOnMain {
         val appStore = AppStore()
-        val observer = spyk(WallpapersObserver(appStore, mockk(), mockk())) {
-            every { showWallpaper(any()) } just Runs
+        val settings: Settings = mockk { every { currentWallpaperName } returns "Test" }
+        val wallpaper: Wallpaper = mockk { every { name } returns "Test" }
+        val observer = spyk(
+            getObserver(appStore, settings, mockk(relaxed = true), mockk(relaxed = true)),
+        )
+
+        // Ignore the call on the real instance and call again "observeWallpaperUpdates"
+        // on the spy to be able to verify the "showWallpaper" call in the spy.
+        observer.observeWallpaperUpdates()
+        appStore.dispatch(UpdateCurrentWallpaper(wallpaper)).joinBlocking()
+        appStore.waitUntilIdle()
+
+        coVerify { observer.loadWallpaper(any()) }
+        coVerify { observer.applyCurrentWallpaper() }
+    }
+
+    @Test
+    fun `GIVEN a certain wallpaper is chosen WHEN the state updated with another wallpaper THEN avoid loading it`() = runTestOnMain {
+        val appStore = AppStore()
+        val settings: Settings = mockk { every { currentWallpaperName } returns "Test" }
+        val otherWallpaper: Wallpaper = mockk { every { name } returns "Other" }
+        val observer = spyk(
+            getObserver(appStore, settings, mockk(relaxed = true), mockk(relaxed = true)),
+        )
+
+        // Ignore the call on the real instance and call again "observeWallpaperUpdates"
+        // on the spy to be able to verify the "showWallpaper" call in the spy.
+        observer.observeWallpaperUpdates()
+        appStore.dispatch(UpdateCurrentWallpaper(otherWallpaper)).joinBlocking()
+        appStore.waitUntilIdle()
+
+        coVerify(exactly = 0) { observer.loadWallpaper(any()) }
+        coVerify(exactly = 0) { observer.applyCurrentWallpaper() }
+    }
+
+    @Test
+    fun `GIVEN a wallpaper is SHOWN WHEN the wallpaper is updated to the current one THEN don't try showing the same wallpaper again`() {
+        val appStore = AppStore()
+        val settings: Settings = mockk { every { currentWallpaperName } returns "Test" }
+        val wallpaper: Wallpaper = mockk { every { name } returns "Test" }
+        val wallpapersUseCases: WallpapersUseCases = mockk { coEvery { loadBitmap(any()) } returns null }
+        val observer = spyk(getObserver(appStore, settings, wallpapersUseCases, mockk(relaxed = true))) {
+            coEvery { loadWallpaper(any()) } just Runs
+            coEvery { applyCurrentWallpaper() } just Runs
         }
 
-        observer.applyCurrentWallpaper()
+        // Ignore the call on the real instance and call again "observeWallpaperUpdates"
+        // on the spy to be able to verify the "showWallpaper" call in the spy.
+        observer.observeWallpaperUpdates()
+        appStore.dispatch(UpdateCurrentWallpaper(wallpaper)).joinBlocking()
+        appStore.waitUntilIdle()
+        coVerify(exactly = 1) { observer.loadWallpaper(any()) }
+        coVerify(exactly = 1) { observer.applyCurrentWallpaper() }
 
-        verify { observer.showWallpaper(any()) }
+        appStore.dispatch(UpdateCurrentWallpaper(wallpaper)).joinBlocking()
+        appStore.waitUntilIdle()
+        coVerify(exactly = 1) { observer.loadWallpaper(any()) }
+        coVerify(exactly = 1) { observer.applyCurrentWallpaper() }
     }
 
     @Test
     fun `GIVEN the store was observed for updates WHEN the lifecycle owner is destroyed THEN stop observing the store`() {
-        val observer = WallpapersObserver(mockk(relaxed = true), mockk(), mockk())
+        val observer = getObserver(mockk(relaxed = true))
         observer.observeWallpapersStoreSubscription = mockk(relaxed = true)
         observer.wallpapersScope = mockk {
             every { cancel() } just Runs
@@ -68,116 +128,65 @@ class WallpapersObserverTest {
     }
 
     @Test
-    fun `WHEN the wallpaper is updated THEN show the wallpaper`() {
-        val appStore = AppStore()
-        val observer = spyk(WallpapersObserver(appStore, mockk(relaxed = true), mockk(relaxed = true))) {
-            every { showWallpaper(any()) } just Runs
-        }
+    fun `GIVEN a wallpaper image is available WHEN asked to apply the current wallpaper THEN show set it to the wallpaper ImageView`() = runTestOnMain {
+        val imageView: ImageView = mockk(relaxed = true)
+        val observer = getObserver(wallpaperImageView = imageView)
+        val image: Bitmap = mockk()
+        observer.currentWallpaperImage = image
+        observer.isWallpaperLoaded.complete(Unit)
 
-        // Ignore the call on the real instance and call again "observeWallpaperUpdates"
-        // on the spy to be able to verify the "showWallpaper" call in the spy.
-        observer.observeWallpaperUpdates()
+        observer.applyCurrentWallpaper()
 
-        val newWallpaper: Wallpaper = mockk(relaxed = true)
-        appStore.dispatch(UpdateCurrentWallpaper(newWallpaper))
-        appStore.waitUntilIdle()
-        verify { observer.showWallpaper(newWallpaper) }
+        verify { imageView.setImageBitmap(image) }
+        verify { imageView.isVisible = true }
+    }
+
+    fun `GIVEN no wallpaper image is available WHEN asked to apply the current wallpaper THEN hide the wallpaper ImageView`() = runTestOnMain {
+        val imageView: ImageView = mockk()
+        val observer = getObserver(wallpaperImageView = imageView)
+        observer.isWallpaperLoaded.complete(Unit)
+
+        observer.applyCurrentWallpaper()
+
+        verify { imageView.isVisible = false }
+        verify(exactly = 0) { imageView.setImageBitmap(any()) }
     }
 
     @Test
-    @Ignore("Intermittent test: https://github.com/mozilla-mobile/fenix/issues/26760")
-    fun `WHEN the wallpaper is updated to a new one THEN show the wallpaper`() {
-        val appStore = AppStore()
-        val wallpapersUseCases: WallpapersUseCases = mockk {
-            coEvery { loadBitmap(any()) } returns null
-        }
-        val observer = spyk(WallpapersObserver(appStore, wallpapersUseCases, mockk(relaxed = true))) {
-            every { showWallpaper(any()) } just Runs
-        }
+    fun `GIVEN the default wallpaper WHEN asked to load it THEN cache that the current image is null`() = runTestOnMain {
+        val observer = getObserver()
+        observer.currentWallpaperImage = mockk()
 
-        // Ignore the call on the real instance and call again "observeWallpaperUpdates"
-        // on the spy to be able to verify the "showWallpaper" call in the spy.
-        observer.observeWallpaperUpdates()
-        verify { observer.showWallpaper(Wallpaper.Default) }
+        observer.loadWallpaper(Wallpaper.Default)
 
-        val wallpaper: Wallpaper = mockk(relaxed = true)
-        appStore.dispatch(UpdateCurrentWallpaper(wallpaper))
-        appStore.waitUntilIdle()
-        verify { observer.showWallpaper(wallpaper) }
+        assertNull(observer.currentWallpaperImage)
     }
 
     @Test
-    fun `WHEN the wallpaper is updated to the current one THEN don't try showing the same wallpaper again`() {
-        val appStore = AppStore()
-        val wallpapersUseCases: WallpapersUseCases = mockk {
-            coEvery { loadBitmap(any()) } returns null
-        }
-        val observer = spyk(WallpapersObserver(appStore, wallpapersUseCases, mockk(relaxed = true))) {
-            every { showWallpaper(any()) } just Runs
-        }
-        // Ignore the call on the real instance and call again "observeWallpaperUpdates"
-        // on the spy to be able to verify the "showWallpaper" call in the spy.
-        observer.observeWallpaperUpdates()
-
-        val wallpaper: Wallpaper = mockk(relaxed = true)
-        appStore.dispatch(UpdateCurrentWallpaper(wallpaper))
-        appStore.waitUntilIdle()
-        verify { observer.showWallpaper(wallpaper) }
-
-        appStore.dispatch(UpdateCurrentWallpaper(wallpaper))
-        appStore.waitUntilIdle()
-        verify(exactly = 1) { observer.showWallpaper(wallpaper) }
-    }
-
-    @Test
-    fun `GIVEN no wallpaper is provided WHEN asked to show the wallpaper THEN show the current one`() {
-        val wallpaper: Wallpaper = mockk()
-        val appStore: AppStore = mockk(relaxed = true) {
-            every { state.wallpaperState.currentWallpaper } returns wallpaper
-        }
-        val observer = spyk(WallpapersObserver(appStore, mockk(relaxed = true), mockk(relaxed = true)))
-
-        observer.showWallpaper()
-
-        verify { observer.showWallpaper(wallpaper) }
-    }
-
-    fun `GiVEN the current wallpaper is the default one WHEN showing it THEN hide the wallpaper view`() {
-        val wallpapersUseCases: WallpapersUseCases = mockk()
-        val wallpaperView: ImageView = mockk(relaxed = true)
-        val observer = WallpapersObserver(mockk(relaxed = true), wallpapersUseCases, wallpaperView)
-
-        observer.showWallpaper(Wallpaper.Default)
-
-        verify { wallpaperView.isVisible = false }
-        verify { wallpapersUseCases wasNot Called }
-    }
-
-    @Test
-    fun `GiVEN the current wallpaper is different than the default one WHEN showing it THEN load it's bitmap in the visible wallpaper view`() {
-        val wallpaper: Wallpaper = mockk()
+    fun `GIVEN a custom wallpaper WHEN asked to load it THEN cache it's bitmap`() = runTestOnMain {
         val bitmap: Bitmap = mockk()
-        val wallpapersUseCases: WallpapersUseCases = mockk {
-            coEvery { loadBitmap(any()) } returns bitmap
+        val wallpaper: Wallpaper = mockk()
+        val usecases: WallpapersUseCases = mockk {
+            coEvery { loadBitmap(wallpaper) } returns bitmap
         }
-        val wallpaperView: ImageView = mockk(relaxed = true)
-        val observer = WallpapersObserver(mockk(relaxed = true), wallpapersUseCases, wallpaperView)
+        val observer = getObserver(wallpapersUseCases = usecases)
 
-        observer.showWallpaper(wallpaper)
+        observer.loadWallpaper(wallpaper)
 
-        verify { wallpaperView.isVisible = true }
-        verify { wallpaperView.setImageBitmap(bitmap) }
+        assertEquals(bitmap, observer.currentWallpaperImage)
     }
 
-    @Test
-    fun `GIVEN the observer THEN use the main thread for showing the wallpaper`() {
-        val wallpapersUseCases: WallpapersUseCases = mockk()
-        val wallpaperView: ImageView = mockk(relaxed = true)
-
-        val observer = WallpapersObserver(mockk(relaxed = true), wallpapersUseCases, wallpaperView)
-
-        // Check that the context that would be used is Dispatchers.Main.immediate
-        // Unfortunately I could not also test that this is actually used when "showWallpaper" is called.
-        assertTrue(observer.wallpapersScope.toString().contains("Dispatchers.Main.immediate"))
-    }
+    private fun getObserver(
+        appStore: AppStore = mockk(relaxed = true),
+        settings: Settings = mockk(),
+        wallpapersUseCases: WallpapersUseCases = mockk(),
+        wallpaperImageView: ImageView = mockk(),
+        backgroundWorkDispatcher: CoroutineDispatcher = coroutinesTestRule.testDispatcher,
+    ) = WallpapersObserver(
+        appStore = appStore,
+        settings = settings,
+        wallpapersUseCases = wallpapersUseCases,
+        wallpaperImageView = wallpaperImageView,
+        backgroundWorkDispatcher = backgroundWorkDispatcher,
+    )
 }

--- a/ktlint-baseline.xml
+++ b/ktlint-baseline.xml
@@ -1628,48 +1628,6 @@
         <error line="222" column="83" source="trailing-comma-on-call-site" />
         <error line="223" column="14" source="trailing-comma-on-call-site" />
     </file>
-    <file name="app/src/main/java/org/mozilla/fenix/components/Core.kt">
-        <error line="109" column="34" source="trailing-comma-on-declaration-site" />
-        <error line="132" column="48" source="trailing-comma-on-call-site" />
-        <error line="134" column="66" source="trailing-comma-on-call-site" />
-        <error line="140" column="25" source="trailing-comma-on-call-site" />
-        <error line="171" column="25" source="trailing-comma-on-call-site" />
-        <error line="180" column="77" source="trailing-comma-on-call-site" />
-        <error line="242" column="57" source="trailing-comma-on-call-site" />
-        <error line="263" column="18" source="trailing-comma-on-call-site" />
-        <error line="274" column="48" source="trailing-comma-on-call-site" />
-        <error line="275" column="14" source="trailing-comma-on-call-site" />
-        <error line="287" column="26" source="argument-list-wrapping" />
-        <error line="287" column="34" source="argument-list-wrapping" />
-        <error line="287" column="41" source="argument-list-wrapping" />
-        <error line="288" column="55" source="argument-list-wrapping" />
-        <error line="288" column="89" source="trailing-comma-on-call-site" />
-        <error line="340" column="34" source="trailing-comma-on-call-site" />
-        <error line="370" column="23" source="trailing-comma-on-call-site" />
-        <error line="388" column="56" source="trailing-comma-on-call-site" />
-        <error line="389" column="14" source="trailing-comma-on-call-site" />
-        <error line="398" column="57" source="trailing-comma-on-call-site" />
-        <error line="407" column="53" source="trailing-comma-on-call-site" />
-        <error line="420" column="51" source="trailing-comma-on-call-site" />
-        <error line="421" column="26" source="trailing-comma-on-call-site" />
-        <error line="427" column="48" source="trailing-comma-on-call-site" />
-        <error line="428" column="26" source="trailing-comma-on-call-site" />
-        <error line="434" column="49" source="trailing-comma-on-call-site" />
-        <error line="435" column="26" source="trailing-comma-on-call-site" />
-        <error line="441" column="48" source="trailing-comma-on-call-site" />
-        <error line="442" column="26" source="trailing-comma-on-call-site" />
-        <error line="448" column="53" source="trailing-comma-on-call-site" />
-        <error line="449" column="26" source="trailing-comma-on-call-site" />
-        <error line="455" column="52" source="trailing-comma-on-call-site" />
-        <error line="456" column="26" source="trailing-comma-on-call-site" />
-        <error line="463" column="65" source="trailing-comma-on-call-site" />
-        <error line="464" column="30" source="trailing-comma-on-call-site" />
-        <error line="471" column="55" source="trailing-comma-on-call-site" />
-        <error line="472" column="26" source="trailing-comma-on-call-site" />
-        <error line="484" column="46" source="trailing-comma-on-call-site" />
-        <error line="504" column="61" source="trailing-comma-on-call-site" />
-        <error line="538" column="9" source="spacing-between-declarations-with-comments" />
-    </file>
     <file name="app/src/main/java/org/mozilla/fenix/components/FenixSnackbar.kt">
         <error line="30" column="21" source="trailing-comma-on-declaration-site" />
         <error line="45" column="39" source="trailing-comma-on-call-site" />
@@ -1729,13 +1687,6 @@
     <file name="app/src/main/java/org/mozilla/fenix/components/TabCollectionStorage.kt">
         <error line="31" column="68" source="trailing-comma-on-declaration-site" />
         <error line="113" column="48" source="trailing-comma-on-call-site" />
-    </file>
-    <file name="app/src/main/java/org/mozilla/fenix/components/TrackingProtectionPolicyFactory.kt">
-        <error line="20" column="37" source="trailing-comma-on-declaration-site" />
-        <error line="35" column="68" source="trailing-comma-on-declaration-site" />
-        <error line="62" column="59" source="trailing-comma-on-call-site" />
-        <error line="92" column="69" source="trailing-comma-on-call-site" />
-        <error line="128" column="38" source="trailing-comma-on-call-site" />
     </file>
     <file name="app/src/main/java/org/mozilla/fenix/components/UseCases.kt">
         <error line="75" column="28" source="trailing-comma-on-call-site" />
@@ -2575,59 +2526,59 @@
         <error line="136" column="33" source="trailing-comma-on-call-site" />
     </file>
     <file name="app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt">
-        <error line="124" column="5" source="spacing-between-declarations-with-annotations" />
-        <error line="166" column="5" source="spacing-between-declarations-with-annotations" />
-        <error line="196" column="60" source="argument-list-wrapping" />
-        <error line="196" column="79" source="argument-list-wrapping" />
-        <error line="204" column="36" source="trailing-comma-on-declaration-site" />
-        <error line="227" column="34" source="trailing-comma-on-call-site" />
-        <error line="243" column="87" source="trailing-comma-on-call-site" />
-        <error line="244" column="26" source="trailing-comma-on-call-site" />
-        <error line="258" column="36" source="trailing-comma-on-call-site" />
-        <error line="267" column="55" source="trailing-comma-on-call-site" />
-        <error line="270" column="49" source="trailing-comma-on-call-site" />
-        <error line="273" column="36" source="trailing-comma-on-call-site" />
-        <error line="281" column="51" source="trailing-comma-on-call-site" />
-        <error line="284" column="36" source="trailing-comma-on-call-site" />
-        <error line="299" column="40" source="trailing-comma-on-call-site" />
-        <error line="311" column="62" source="trailing-comma-on-call-site" />
-        <error line="314" column="36" source="trailing-comma-on-call-site" />
-        <error line="324" column="62" source="trailing-comma-on-call-site" />
-        <error line="327" column="36" source="trailing-comma-on-call-site" />
-        <error line="353" column="45" source="trailing-comma-on-call-site" />
-        <error line="384" column="14" source="trailing-comma-on-call-site" />
-        <error line="404" column="60" source="argument-list-wrapping" />
-        <error line="404" column="79" source="argument-list-wrapping" />
-        <error line="436" column="60" source="trailing-comma-on-call-site" />
-        <error line="447" column="18" source="trailing-comma-on-call-site" />
-        <error line="448" column="14" source="trailing-comma-on-call-site" />
-        <error line="477" column="63" source="trailing-comma-on-call-site" />
-        <error line="494" column="87" source="trailing-comma-on-call-site" />
-        <error line="547" column="36" source="trailing-comma-on-call-site" />
-        <error line="555" column="50" source="trailing-comma-on-call-site" />
-        <error line="602" column="60" source="argument-list-wrapping" />
-        <error line="602" column="79" source="argument-list-wrapping" />
-        <error line="667" column="44" source="trailing-comma-on-call-site" />
-        <error line="689" column="69" source="trailing-comma-on-call-site" />
-        <error line="693" column="44" source="trailing-comma-on-call-site" />
-        <error line="723" column="61" source="trailing-comma-on-call-site" />
-        <error line="733" column="74" source="trailing-comma-on-call-site" />
-        <error line="742" column="61" source="trailing-comma-on-call-site" />
-        <error line="781" column="30" source="trailing-comma-on-call-site" />
-        <error line="812" column="64" source="trailing-comma-on-call-site" />
-        <error line="813" column="22" source="trailing-comma-on-call-site" />
-        <error line="814" column="18" source="trailing-comma-on-call-site" />
-        <error line="833" column="92" source="trailing-comma-on-call-site" />
-        <error line="836" column="25" source="trailing-comma-on-call-site" />
-        <error line="856" column="56" source="argument-list-wrapping" />
-        <error line="856" column="59" source="argument-list-wrapping" />
-        <error line="856" column="73" source="argument-list-wrapping" />
-        <error line="856" column="99" source="trailing-comma-on-call-site" />
-        <error line="868" column="56" source="trailing-comma-on-call-site" />
-        <error line="869" column="18" source="trailing-comma-on-call-site" />
-        <error line="884" column="33" source="trailing-comma-on-call-site" />
-        <error line="911" column="54" source="trailing-comma-on-call-site" />
-        <error line="922" column="66" source="trailing-comma-on-call-site" />
+        <error line="125" column="5" source="spacing-between-declarations-with-annotations" />
+        <error line="167" column="5" source="spacing-between-declarations-with-annotations" />
+        <error line="197" column="60" source="argument-list-wrapping" />
+        <error line="197" column="79" source="argument-list-wrapping" />
+        <error line="205" column="36" source="trailing-comma-on-declaration-site" />
+        <error line="229" column="34" source="trailing-comma-on-call-site" />
+        <error line="245" column="87" source="trailing-comma-on-call-site" />
+        <error line="246" column="26" source="trailing-comma-on-call-site" />
+        <error line="260" column="36" source="trailing-comma-on-call-site" />
+        <error line="269" column="55" source="trailing-comma-on-call-site" />
+        <error line="272" column="49" source="trailing-comma-on-call-site" />
+        <error line="275" column="36" source="trailing-comma-on-call-site" />
+        <error line="283" column="51" source="trailing-comma-on-call-site" />
+        <error line="286" column="36" source="trailing-comma-on-call-site" />
+        <error line="301" column="40" source="trailing-comma-on-call-site" />
+        <error line="313" column="62" source="trailing-comma-on-call-site" />
+        <error line="316" column="36" source="trailing-comma-on-call-site" />
+        <error line="326" column="62" source="trailing-comma-on-call-site" />
+        <error line="329" column="36" source="trailing-comma-on-call-site" />
+        <error line="355" column="45" source="trailing-comma-on-call-site" />
+        <error line="386" column="14" source="trailing-comma-on-call-site" />
+        <error line="406" column="60" source="argument-list-wrapping" />
+        <error line="406" column="79" source="argument-list-wrapping" />
+        <error line="438" column="60" source="trailing-comma-on-call-site" />
+        <error line="449" column="18" source="trailing-comma-on-call-site" />
+        <error line="450" column="14" source="trailing-comma-on-call-site" />
+        <error line="479" column="63" source="trailing-comma-on-call-site" />
+        <error line="496" column="87" source="trailing-comma-on-call-site" />
+        <error line="549" column="36" source="trailing-comma-on-call-site" />
+        <error line="557" column="50" source="trailing-comma-on-call-site" />
+        <error line="604" column="60" source="argument-list-wrapping" />
+        <error line="604" column="79" source="argument-list-wrapping" />
+        <error line="669" column="44" source="trailing-comma-on-call-site" />
+        <error line="691" column="69" source="trailing-comma-on-call-site" />
+        <error line="695" column="44" source="trailing-comma-on-call-site" />
+        <error line="725" column="61" source="trailing-comma-on-call-site" />
+        <error line="735" column="74" source="trailing-comma-on-call-site" />
+        <error line="744" column="61" source="trailing-comma-on-call-site" />
+        <error line="790" column="30" source="trailing-comma-on-call-site" />
+        <error line="821" column="64" source="trailing-comma-on-call-site" />
+        <error line="822" column="22" source="trailing-comma-on-call-site" />
+        <error line="823" column="18" source="trailing-comma-on-call-site" />
+        <error line="842" column="92" source="trailing-comma-on-call-site" />
+        <error line="845" column="25" source="trailing-comma-on-call-site" />
+        <error line="865" column="56" source="argument-list-wrapping" />
+        <error line="865" column="59" source="argument-list-wrapping" />
+        <error line="865" column="73" source="argument-list-wrapping" />
+        <error line="865" column="99" source="trailing-comma-on-call-site" />
+        <error line="877" column="56" source="trailing-comma-on-call-site" />
+        <error line="878" column="18" source="trailing-comma-on-call-site" />
+        <error line="893" column="33" source="trailing-comma-on-call-site" />
+        <error line="920" column="54" source="trailing-comma-on-call-site" />
+        <error line="931" column="66" source="trailing-comma-on-call-site" />
     </file>
     <file name="app/src/main/java/org/mozilla/fenix/home/HomeMenu.kt">
         <error line="43" column="72" source="trailing-comma-on-declaration-site" />
@@ -2704,9 +2655,6 @@
     </file>
     <file name="app/src/main/java/org/mozilla/fenix/home/TopPlaceholderViewHolder.kt">
         <error line="16" column="15" source="trailing-comma-on-declaration-site" />
-    </file>
-    <file name="app/src/main/java/org/mozilla/fenix/home/WallpapersObserver.kt">
-        <error line="41" column="5" source="spacing-between-declarations-with-annotations" />
     </file>
     <file name="app/src/main/java/org/mozilla/fenix/home/blocklist/BlocklistHandler.kt">
         <error line="67" column="5" source="spacing-between-declarations-with-comments" />
@@ -3461,11 +3409,6 @@
         <error line="246" column="30" source="trailing-comma-on-call-site" />
         <error line="304" column="69" source="trailing-comma-on-call-site" />
         <error line="320" column="18" source="trailing-comma-on-call-site" />
-        <error line="341" column="48" source="trailing-comma-on-call-site" />
-        <error line="347" column="50" source="trailing-comma-on-call-site" />
-        <error line="354" column="39" source="trailing-comma-on-call-site" />
-        <error line="362" column="23" source="trailing-comma-on-call-site" />
-        <error line="374" column="57" source="trailing-comma-on-declaration-site" />
     </file>
     <file name="app/src/main/java/org/mozilla/fenix/library/history/HistoryFragmentStore.kt">
         <error line="70" column="47" source="trailing-comma-on-declaration-site" />
@@ -5438,152 +5381,6 @@
         <error line="20" column="26" source="trailing-comma-on-declaration-site" />
         <error line="28" column="83" source="trailing-comma-on-call-site" />
     </file>
-    <file name="app/src/main/java/org/mozilla/fenix/utils/Settings.kt">
-        <error line="91" column="9" source="spacing-between-declarations-with-comments" />
-        <error line="142" column="20" source="trailing-comma-on-call-site" />
-        <error line="147" column="21" source="trailing-comma-on-call-site" />
-        <error line="152" column="21" source="trailing-comma-on-call-site" />
-        <error line="160" column="24" source="trailing-comma-on-call-site" />
-        <error line="165" column="21" source="trailing-comma-on-call-site" />
-        <error line="170" column="21" source="trailing-comma-on-call-site" />
-        <error line="175" column="21" source="trailing-comma-on-call-site" />
-        <error line="180" column="21" source="trailing-comma-on-call-site" />
-        <error line="185" column="21" source="trailing-comma-on-call-site" />
-        <error line="190" column="41" source="trailing-comma-on-call-site" />
-        <error line="198" column="20" source="trailing-comma-on-call-site" />
-        <error line="206" column="20" source="trailing-comma-on-call-site" />
-        <error line="220" column="24" source="trailing-comma-on-call-site" />
-        <error line="225" column="24" source="trailing-comma-on-call-site" />
-        <error line="230" column="14" source="trailing-comma-on-call-site" />
-        <error line="235" column="21" source="trailing-comma-on-call-site" />
-        <error line="240" column="24" source="trailing-comma-on-call-site" />
-        <error line="245" column="24" source="trailing-comma-on-call-site" />
-        <error line="250" column="23" source="trailing-comma-on-call-site" />
-        <error line="257" column="21" source="trailing-comma-on-call-site" />
-        <error line="262" column="24" source="trailing-comma-on-call-site" />
-        <error line="267" column="23" source="trailing-comma-on-call-site" />
-        <error line="272" column="50" source="trailing-comma-on-call-site" />
-        <error line="277" column="23" source="trailing-comma-on-call-site" />
-        <error line="292" column="23" source="trailing-comma-on-call-site" />
-        <error line="297" column="24" source="trailing-comma-on-call-site" />
-        <error line="302" column="23" source="trailing-comma-on-call-site" />
-        <error line="307" column="21" source="trailing-comma-on-call-site" />
-        <error line="312" column="23" source="trailing-comma-on-call-site" />
-        <error line="317" column="23" source="trailing-comma-on-call-site" />
-        <error line="322" column="23" source="trailing-comma-on-call-site" />
-        <error line="327" column="23" source="trailing-comma-on-call-site" />
-        <error line="332" column="24" source="trailing-comma-on-call-site" />
-        <error line="337" column="23" source="trailing-comma-on-call-site" />
-        <error line="342" column="23" source="trailing-comma-on-call-site" />
-        <error line="347" column="24" source="trailing-comma-on-call-site" />
-        <error line="352" column="24" source="trailing-comma-on-call-site" />
-        <error line="357" column="24" source="trailing-comma-on-call-site" />
-        <error line="362" column="24" source="trailing-comma-on-call-site" />
-        <error line="367" column="24" source="trailing-comma-on-call-site" />
-        <error line="372" column="23" source="trailing-comma-on-call-site" />
-        <error line="382" column="36" source="trailing-comma-on-call-site" />
-        <error line="391" column="23" source="trailing-comma-on-call-site" />
-        <error line="399" column="24" source="trailing-comma-on-call-site" />
-        <error line="408" column="24" source="trailing-comma-on-call-site" />
-        <error line="429" column="48" source="trailing-comma-on-call-site" />
-        <error line="484" column="24" source="trailing-comma-on-call-site" />
-        <error line="489" column="24" source="trailing-comma-on-call-site" />
-        <error line="494" column="24" source="trailing-comma-on-call-site" />
-        <error line="499" column="23" source="trailing-comma-on-call-site" />
-        <error line="504" column="24" source="trailing-comma-on-call-site" />
-        <error line="509" column="23" source="trailing-comma-on-call-site" />
-        <error line="537" column="24" source="trailing-comma-on-call-site" />
-        <error line="546" column="24" source="trailing-comma-on-call-site" />
-        <error line="551" column="13" source="trailing-comma-on-call-site" />
-        <error line="556" column="14" source="trailing-comma-on-call-site" />
-        <error line="561" column="14" source="trailing-comma-on-call-site" />
-        <error line="568" column="17" source="trailing-comma-on-call-site" />
-        <error line="572" column="18" source="trailing-comma-on-call-site" />
-        <error line="584" column="13" source="trailing-comma-on-call-site" />
-        <error line="607" column="10" source="trailing-comma-on-call-site" />
-        <error line="612" column="13" source="trailing-comma-on-call-site" />
-        <error line="617" column="43" source="trailing-comma-on-call-site" />
-        <error line="622" column="13" source="trailing-comma-on-call-site" />
-        <error line="627" column="13" source="trailing-comma-on-call-site" />
-        <error line="632" column="13" source="trailing-comma-on-call-site" />
-        <error line="651" column="22" source="trailing-comma-on-call-site" />
-        <error line="666" column="44" source="trailing-comma-on-call-site" />
-        <error line="675" column="24" source="trailing-comma-on-call-site" />
-        <error line="680" column="23" source="trailing-comma-on-call-site" />
-        <error line="685" column="23" source="trailing-comma-on-call-site" />
-        <error line="690" column="23" source="trailing-comma-on-call-site" />
-        <error line="695" column="23" source="trailing-comma-on-call-site" />
-        <error line="700" column="23" source="trailing-comma-on-call-site" />
-        <error line="705" column="23" source="trailing-comma-on-call-site" />
-        <error line="711" column="72" source="trailing-comma-on-call-site" />
-        <error line="761" column="14" source="trailing-comma-on-call-site" />
-        <error line="766" column="13" source="trailing-comma-on-call-site" />
-        <error line="772" column="21" source="trailing-comma-on-call-site" />
-        <error line="778" column="21" source="trailing-comma-on-call-site" />
-        <error line="787" column="23" source="trailing-comma-on-call-site" />
-        <error line="792" column="23" source="trailing-comma-on-call-site" />
-        <error line="797" column="24" source="trailing-comma-on-call-site" />
-        <error line="802" column="24" source="trailing-comma-on-call-site" />
-        <error line="807" column="24" source="trailing-comma-on-call-site" />
-        <error line="815" column="21" source="trailing-comma-on-call-site" />
-        <error line="841" column="24" source="trailing-comma-on-call-site" />
-        <error line="846" column="23" source="trailing-comma-on-call-site" />
-        <error line="854" column="23" source="trailing-comma-on-call-site" />
-        <error line="859" column="23" source="trailing-comma-on-call-site" />
-        <error line="867" column="24" source="trailing-comma-on-call-site" />
-        <error line="893" column="46" source="trailing-comma-on-declaration-site" />
-        <error line="907" column="29" source="trailing-comma-on-declaration-site" />
-        <error line="925" column="57" source="trailing-comma-on-declaration-site" />
-        <error line="930" column="22" source="trailing-comma-on-declaration-site" />
-        <error line="943" column="49" source="trailing-comma-on-call-site" />
-        <error line="947" column="49" source="trailing-comma-on-call-site" />
-        <error line="951" column="110" source="trailing-comma-on-call-site" />
-        <error line="965" column="49" source="trailing-comma-on-call-site" />
-        <error line="975" column="23" source="trailing-comma-on-call-site" />
-        <error line="984" column="23" source="trailing-comma-on-call-site" />
-        <error line="993" column="23" source="trailing-comma-on-call-site" />
-        <error line="998" column="23" source="trailing-comma-on-call-site" />
-        <error line="1003" column="23" source="trailing-comma-on-call-site" />
-        <error line="1008" column="20" source="trailing-comma-on-call-site" />
-        <error line="1022" column="14" source="trailing-comma-on-call-site" />
-        <error line="1029" column="24" source="trailing-comma-on-call-site" />
-        <error line="1033" column="75" source="trailing-comma-on-call-site" />
-        <error line="1058" column="24" source="trailing-comma-on-call-site" />
-        <error line="1063" column="23" source="trailing-comma-on-call-site" />
-        <error line="1068" column="21" source="trailing-comma-on-call-site" />
-        <error line="1073" column="21" source="trailing-comma-on-call-site" />
-        <error line="1078" column="21" source="trailing-comma-on-call-site" />
-        <error line="1083" column="21" source="trailing-comma-on-call-site" />
-        <error line="1088" column="21" source="trailing-comma-on-call-site" />
-        <error line="1097" column="20" source="trailing-comma-on-call-site" />
-        <error line="1102" column="38" source="trailing-comma-on-call-site" />
-        <error line="1107" column="10" source="trailing-comma-on-call-site" />
-        <error line="1112" column="10" source="trailing-comma-on-call-site" />
-        <error line="1117" column="10" source="trailing-comma-on-call-site" />
-        <error line="1125" column="10" source="trailing-comma-on-call-site" />
-        <error line="1133" column="21" source="trailing-comma-on-call-site" />
-        <error line="1135" column="5" source="spacing-between-declarations-with-comments" />
-        <error line="1145" column="31" source="trailing-comma-on-call-site" />
-        <error line="1153" column="10" source="trailing-comma-on-call-site" />
-        <error line="1161" column="21" source="trailing-comma-on-call-site" />
-        <error line="1166" column="88" source="trailing-comma-on-call-site" />
-        <error line="1190" column="23" source="trailing-comma-on-call-site" />
-        <error line="1195" column="23" source="trailing-comma-on-call-site" />
-        <error line="1200" column="23" source="trailing-comma-on-call-site" />
-        <error line="1206" column="58" source="trailing-comma-on-call-site" />
-        <error line="1218" column="20" source="trailing-comma-on-call-site" />
-        <error line="1224" column="24" source="trailing-comma-on-call-site" />
-        <error line="1236" column="88" source="trailing-comma-on-call-site" />
-        <error line="1275" column="58" source="trailing-comma-on-call-site" />
-        <error line="1284" column="24" source="trailing-comma-on-call-site" />
-        <error line="1289" column="24" source="trailing-comma-on-call-site" />
-        <error line="1300" column="23" source="trailing-comma-on-call-site" />
-        <error line="1311" column="23" source="trailing-comma-on-call-site" />
-        <error line="1329" column="86" source="trailing-comma-on-call-site" />
-        <error line="1338" column="41" source="trailing-comma-on-call-site" />
-        <error line="1364" column="56" source="trailing-comma-on-call-site" />
-        <error line="1372" column="26" source="trailing-comma-on-call-site" />
-    </file>
     <file name="app/src/main/java/org/mozilla/fenix/utils/ToolbarPopupWindow.kt">
         <error line="35" column="36" source="trailing-comma-on-declaration-site" />
         <error line="50" column="17" source="trailing-comma-on-call-site" />
@@ -5969,83 +5766,6 @@
         <error line="140" column="19" source="trailing-comma-on-call-site" />
         <error line="157" column="46" source="trailing-comma-on-call-site" />
         <error line="163" column="30" source="trailing-comma-on-call-site" />
-    </file>
-    <file name="app/src/test/java/org/mozilla/fenix/components/TrackingProtectionPolicyFactoryTest.kt">
-        <error line="53" column="34" source="trailing-comma-on-call-site" />
-        <error line="75" column="34" source="trailing-comma-on-call-site" />
-        <error line="95" column="55" source="trailing-comma-on-call-site" />
-        <error line="100" column="34" source="trailing-comma-on-call-site" />
-        <error line="118" column="55" source="trailing-comma-on-call-site" />
-        <error line="124" column="44" source="trailing-comma-on-call-site" />
-        <error line="126" column="34" source="trailing-comma-on-call-site" />
-        <error line="146" column="48" source="argument-list-wrapping" />
-        <error line="147" column="46" source="trailing-comma-on-call-site" />
-        <error line="154" column="43" source="trailing-comma-on-call-site" />
-        <error line="165" column="48" source="argument-list-wrapping" />
-        <error line="166" column="46" source="trailing-comma-on-call-site" />
-        <error line="173" column="43" source="trailing-comma-on-call-site" />
-        <error line="182" column="55" source="trailing-comma-on-call-site" />
-        <error line="188" column="47" source="trailing-comma-on-call-site" />
-        <error line="190" column="34" source="trailing-comma-on-call-site" />
-        <error line="208" column="55" source="trailing-comma-on-call-site" />
-        <error line="214" column="50" source="trailing-comma-on-call-site" />
-        <error line="216" column="34" source="trailing-comma-on-call-site" />
-        <error line="234" column="55" source="trailing-comma-on-call-site" />
-        <error line="240" column="51" source="trailing-comma-on-call-site" />
-        <error line="242" column="34" source="trailing-comma-on-call-site" />
-        <error line="260" column="55" source="trailing-comma-on-call-site" />
-        <error line="266" column="59" source="trailing-comma-on-call-site" />
-        <error line="268" column="34" source="trailing-comma-on-call-site" />
-        <error line="284" column="55" source="trailing-comma-on-call-site" />
-        <error line="290" column="53" source="trailing-comma-on-call-site" />
-        <error line="292" column="34" source="trailing-comma-on-call-site" />
-        <error line="312" column="47" source="trailing-comma-on-call-site" />
-        <error line="314" column="38" source="trailing-comma-on-call-site" />
-        <error line="325" column="38" source="trailing-comma-on-call-site" />
-        <error line="329" column="38" source="trailing-comma-on-call-site" />
-        <error line="330" column="14" source="trailing-comma-on-call-site" />
-        <error line="361" column="34" source="trailing-comma-on-call-site" />
-        <error line="369" column="34" source="trailing-comma-on-call-site" />
-        <error line="380" column="51" source="trailing-comma-on-call-site" />
-        <error line="385" column="51" source="trailing-comma-on-call-site" />
-        <error line="390" column="51" source="trailing-comma-on-call-site" />
-        <error line="395" column="51" source="trailing-comma-on-call-site" />
-        <error line="400" column="51" source="trailing-comma-on-call-site" />
-        <error line="405" column="51" source="trailing-comma-on-call-site" />
-        <error line="406" column="14" source="trailing-comma-on-call-site" />
-        <error line="412" column="55" source="trailing-comma-on-call-site" />
-        <error line="417" column="55" source="trailing-comma-on-call-site" />
-        <error line="422" column="55" source="trailing-comma-on-call-site" />
-        <error line="427" column="55" source="trailing-comma-on-call-site" />
-        <error line="432" column="55" source="trailing-comma-on-call-site" />
-        <error line="437" column="55" source="trailing-comma-on-call-site" />
-        <error line="438" column="14" source="trailing-comma-on-call-site" />
-        <error line="444" column="38" source="trailing-comma-on-call-site" />
-        <error line="447" column="35" source="trailing-comma-on-call-site" />
-        <error line="458" column="38" source="trailing-comma-on-call-site" />
-        <error line="461" column="35" source="trailing-comma-on-call-site" />
-        <error line="476" column="69" source="trailing-comma-on-call-site" />
-        <error line="481" column="59" source="trailing-comma-on-call-site" />
-        <error line="489" column="42" source="trailing-comma-on-call-site" />
-        <error line="491" column="34" source="trailing-comma-on-call-site" />
-        <error line="502" column="55" source="trailing-comma-on-call-site" />
-        <error line="510" column="41" source="trailing-comma-on-call-site" />
-        <error line="512" column="34" source="trailing-comma-on-call-site" />
-        <error line="526" column="69" source="trailing-comma-on-call-site" />
-        <error line="531" column="56" source="trailing-comma-on-call-site" />
-        <error line="540" column="45" source="trailing-comma-on-call-site" />
-        <error line="542" column="34" source="trailing-comma-on-call-site" />
-        <error line="554" column="33" source="trailing-comma-on-call-site" />
-        <error line="559" column="34" source="trailing-comma-on-call-site" />
-        <error line="580" column="45" source="trailing-comma-on-call-site" />
-        <error line="582" column="34" source="trailing-comma-on-call-site" />
-        <error line="604" column="45" source="trailing-comma-on-call-site" />
-        <error line="606" column="34" source="trailing-comma-on-call-site" />
-        <error line="623" column="47" source="trailing-comma-on-declaration-site" />
-        <error line="639" column="46" source="trailing-comma-on-declaration-site" />
-        <error line="641" column="1" source="no-empty-first-line-in-method-block" />
-        <error line="654" column="30" source="trailing-comma-on-declaration-site" />
-        <error line="681" column="63" source="trailing-comma-on-call-site" />
     </file>
     <file name="app/src/test/java/org/mozilla/fenix/components/appstate/AppStoreReducerTest.kt">
         <error line="21" column="40" source="trailing-comma-on-call-site" />


### PR DESCRIPTION
Split loading the bitmap from storage and actually setting it in two operations
with one that can run in parallel with onCreateView for HomeFragment and one
that can be used serially on the main thread to actually set the wallpaper.

This seems like the best compromise to ensure that everytime the homescreen is
shown it will have the wallpaper set but does affect the performance - there is a
delay in showing HomeFrament to account for waiting for the wallpaper to be set.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.









### GitHub Automation
Fixes #26511