### PR TITLE
For #26790 - Dismiss search dialog when interacting with popups from homescreen 

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/recentbookmarks/controller/RecentBookmarksController.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recentbookmarks/controller/RecentBookmarksController.kt
@@ -40,6 +40,11 @@ interface RecentBookmarksController {
      * @see [RecentBookmarksInteractor.onRecentBookmarkRemoved]
      */
     fun handleBookmarkRemoved(bookmark: RecentBookmark)
+
+    /**
+     * @see [RecentBookmarksInteractor.onRecentBookmarkLongClicked]
+     */
+    fun handleBookmarkLongClicked()
 }
 
 /**
@@ -72,6 +77,10 @@ class DefaultRecentBookmarksController(
 
     override fun handleBookmarkRemoved(bookmark: RecentBookmark) {
         appStore.dispatch(AppAction.RemoveRecentBookmark(bookmark))
+    }
+
+    override fun handleBookmarkLongClicked() {
+        dismissSearchDialogIfDisplayed()
     }
 
     @VisibleForTesting(otherwise = PRIVATE)

--- a/app/src/main/java/org/mozilla/fenix/home/recentbookmarks/interactor/RecentBookmarksInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recentbookmarks/interactor/RecentBookmarksInteractor.kt
@@ -33,4 +33,9 @@ interface RecentBookmarksInteractor {
      * @param bookmark The bookmark that has been removed.
      */
     fun onRecentBookmarkRemoved(bookmark: RecentBookmark)
+
+    /**
+     * Called when the user long clicks a recent bookmark.
+     */
+    fun onRecentBookmarkLongClicked()
 }

--- a/app/src/main/java/org/mozilla/fenix/home/recentbookmarks/view/RecentBookmarks.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recentbookmarks/view/RecentBookmarks.kt
@@ -65,12 +65,14 @@ private val imageModifier = Modifier
  * @param bookmarks List of [RecentBookmark]s to display.
  * @param menuItems List of [RecentBookmarksMenuItem] shown when long clicking a [RecentBookmarkItem]
  * @param onRecentBookmarkClick Invoked when the user clicks on a recent bookmark.
+ * @param onRecentBookmarkLongClick Invoked when the user long clicks on a recent bookmark.
  */
 @Composable
 fun RecentBookmarks(
     bookmarks: List<RecentBookmark>,
     menuItems: List<RecentBookmarksMenuItem>,
     onRecentBookmarkClick: (RecentBookmark) -> Unit = {},
+    onRecentBookmarkLongClick: () -> Unit = {},
 ) {
     LazyRow(
         contentPadding = PaddingValues(horizontal = 16.dp),
@@ -81,6 +83,7 @@ fun RecentBookmarks(
                 bookmark = bookmark,
                 menuItems = menuItems,
                 onRecentBookmarkClick = onRecentBookmarkClick,
+                onRecentBookmarkLongClick = onRecentBookmarkLongClick,
             )
         }
     }
@@ -91,6 +94,7 @@ fun RecentBookmarks(
  *
  * @param bookmark The [RecentBookmark] to display.
  * @param onRecentBookmarkClick Invoked when the user clicks on the recent bookmark item.
+ * @param onRecentBookmarkLongClick Invoked when the user long clicks on the recent bookmark item.
  */
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -98,6 +102,7 @@ private fun RecentBookmarkItem(
     bookmark: RecentBookmark,
     menuItems: List<RecentBookmarksMenuItem>,
     onRecentBookmarkClick: (RecentBookmark) -> Unit = {},
+    onRecentBookmarkLongClick: () -> Unit = {},
 ) {
     var isMenuExpanded by remember { mutableStateOf(false) }
 
@@ -107,7 +112,10 @@ private fun RecentBookmarkItem(
             .combinedClickable(
                 enabled = true,
                 onClick = { onRecentBookmarkClick(bookmark) },
-                onLongClick = { isMenuExpanded = true },
+                onLongClick = {
+                    onRecentBookmarkLongClick()
+                    isMenuExpanded = true
+                },
             ),
         shape = cardShape,
         backgroundColor = FirefoxTheme.colors.layer2,

--- a/app/src/main/java/org/mozilla/fenix/home/recentbookmarks/view/RecentBookmarksViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recentbookmarks/view/RecentBookmarksViewHolder.kt
@@ -45,6 +45,7 @@ class RecentBookmarksViewHolder(
                     onClick = { bookmark -> interactor.onRecentBookmarkRemoved(bookmark) },
                 ),
             ),
+            onRecentBookmarkLongClick = interactor::onRecentBookmarkLongClicked,
         )
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/home/recenttabs/controller/RecentTabController.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recenttabs/controller/RecentTabController.kt
@@ -30,6 +30,11 @@ interface RecentTabController {
     fun handleRecentTabClicked(tabId: String)
 
     /**
+     * @see [RecentTabInteractor.onRecentTabLongClicked]
+     */
+    fun handleRecentTabLongClicked()
+
+    /**
      * @see [RecentTabInteractor.onRecentTabShowAllClicked]
      */
     fun handleRecentTabShowAllClicked()
@@ -62,6 +67,10 @@ class DefaultRecentTabsController(
 
         selectTabUseCase.invoke(tabId)
         navController.navigate(R.id.browserFragment)
+    }
+
+    override fun handleRecentTabLongClicked() {
+        dismissSearchDialogIfDisplayed()
     }
 
     override fun handleRecentTabShowAllClicked() {

--- a/app/src/main/java/org/mozilla/fenix/home/recenttabs/interactor/RecentTabInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recenttabs/interactor/RecentTabInteractor.kt
@@ -18,6 +18,11 @@ interface RecentTabInteractor {
     fun onRecentTabClicked(tabId: String)
 
     /**
+     * Called when the user long clicks on a recent tab.
+     */
+    fun onRecentTabLongClicked()
+
+    /**
      * Show the tabs tray. Called when a user clicks on the "Show all" button besides the recent
      * tabs.
      */

--- a/app/src/main/java/org/mozilla/fenix/home/recenttabs/view/RecentTabViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recenttabs/view/RecentTabViewHolder.kt
@@ -46,6 +46,7 @@ class RecentTabViewHolder(
         RecentTabs(
             recentTabs = recentTabs.value ?: emptyList(),
             onRecentTabClick = { recentTabInteractor.onRecentTabClicked(it) },
+            onRecentTabLongClick = { recentTabInteractor.onRecentTabLongClicked() },
             menuItems = listOf(
                 RecentTabMenuItem(
                     title = stringResource(id = R.string.recent_tab_menu_item_remove),

--- a/app/src/main/java/org/mozilla/fenix/home/recenttabs/view/RecentTabs.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recenttabs/view/RecentTabs.kt
@@ -72,6 +72,7 @@ fun RecentTabs(
     recentTabs: List<RecentTab>,
     menuItems: List<RecentTabMenuItem>,
     onRecentTabClick: (String) -> Unit = {},
+    onRecentTabLongClick: () -> Unit = {},
 ) {
     Column(
         modifier = Modifier.fillMaxWidth(),
@@ -84,6 +85,7 @@ fun RecentTabs(
                         tab = tab,
                         menuItems = menuItems,
                         onRecentTabClick = onRecentTabClick,
+                        onRecentTabLongClick = onRecentTabLongClick,
                     )
                 }
             }
@@ -103,6 +105,7 @@ private fun RecentTabItem(
     tab: RecentTab.Tab,
     menuItems: List<RecentTabMenuItem>,
     onRecentTabClick: (String) -> Unit = {},
+    onRecentTabLongClick: () -> Unit = {},
 ) {
     var isMenuExpanded by remember { mutableStateOf(false) }
 
@@ -113,7 +116,10 @@ private fun RecentTabItem(
             .combinedClickable(
                 enabled = true,
                 onClick = { onRecentTabClick(tab.state.id) },
-                onLongClick = { isMenuExpanded = true },
+                onLongClick = {
+                    onRecentTabLongClick()
+                    isMenuExpanded = true
+                },
             ),
         shape = RoundedCornerShape(8.dp),
         backgroundColor = FirefoxTheme.colors.layer2,

--- a/app/src/main/java/org/mozilla/fenix/home/recentvisits/controller/RecentVisitsController.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recentvisits/controller/RecentVisitsController.kt
@@ -60,6 +60,11 @@ interface RecentVisitsController {
      * @param highlightUrl Url of the [RecentHistoryHighlight] to remove.
      */
     fun handleRemoveRecentHistoryHighlight(highlightUrl: String)
+
+    /**
+     * Callback for when the user long clicks on a recent visit.
+     */
+    fun handleRecentVisitLongClicked()
 }
 
 /**
@@ -138,6 +143,13 @@ class DefaultRecentVisitsController(
         scope.launch {
             storage.deleteHistoryMetadataForUrl(highlightUrl)
         }
+    }
+
+    /**
+     * Dismiss the search dialog if displayed.
+     */
+    override fun handleRecentVisitLongClicked() {
+        dismissSearchDialogIfDisplayed()
     }
 
     @VisibleForTesting(otherwise = PRIVATE)

--- a/app/src/main/java/org/mozilla/fenix/home/recentvisits/interactor/RecentVisitsInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recentvisits/interactor/RecentVisitsInteractor.kt
@@ -44,4 +44,9 @@ interface RecentVisitsInteractor {
      * @param highlightUrl [RecentHistoryHighlight.url] of the item to remove.
      */
     fun onRemoveRecentHistoryHighlight(highlightUrl: String)
+
+    /**
+     * Called when opening the dropdown menu on a recent visit by long press.
+     */
+    fun onRecentVisitLongClicked()
 }

--- a/app/src/main/java/org/mozilla/fenix/home/recentvisits/view/RecentlyVisited.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recentvisits/view/RecentlyVisited.kt
@@ -64,12 +64,14 @@ private const val VISITS_PER_COLUMN = 3
  * @param recentVisits List of [RecentlyVisitedItem] to display.
  * @param menuItems List of [RecentVisitMenuItem] shown long clicking a [RecentlyVisitedItem].
  * @param onRecentVisitClick Invoked when the user clicks on a recent visit.
+ * @param onRecentVisitLongClick Invoked when the user long clicks on a recent visit.
  */
 @Composable
 fun RecentlyVisited(
     recentVisits: List<RecentlyVisitedItem>,
     menuItems: List<RecentVisitMenuItem>,
     onRecentVisitClick: (RecentlyVisitedItem, Int) -> Unit = { _, _ -> },
+    onRecentVisitLongClick: () -> Unit = {},
 ) {
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -102,6 +104,7 @@ fun RecentlyVisited(
                                 onRecentVisitClick = {
                                     onRecentVisitClick(it, pageIndex + 1)
                                 },
+                                onRecentVisitLongClick = { onRecentVisitLongClick() },
                             )
                             is RecentHistoryGroup -> RecentlyVisitedHistoryGroup(
                                 recentVisit = recentVisit,
@@ -111,6 +114,7 @@ fun RecentlyVisited(
                                 onRecentVisitClick = {
                                     onRecentVisitClick(it, pageIndex + 1)
                                 },
+                                onRecentVisitLongClick = { onRecentVisitLongClick() },
                             )
                         }
                     }
@@ -128,8 +132,10 @@ fun RecentlyVisited(
  * @param clickableEnabled Whether click actions should be invoked or not.
  * @param showDividerLine Whether to show a divider line at the bottom.
  * @param onRecentVisitClick Invoked when the user clicks on a recent visit.
+ * @param onRecentVisitClick Invoked when the user long clicks on a recently visited group.
  */
 @OptIn(ExperimentalFoundationApi::class)
+@Suppress("LongParameterList")
 @Composable
 private fun RecentlyVisitedHistoryGroup(
     recentVisit: RecentHistoryGroup,
@@ -137,6 +143,7 @@ private fun RecentlyVisitedHistoryGroup(
     clickableEnabled: Boolean,
     showDividerLine: Boolean,
     onRecentVisitClick: (RecentHistoryGroup) -> Unit = { _ -> },
+    onRecentVisitLongClick: () -> Unit = {},
 ) {
     var isMenuExpanded by remember { mutableStateOf(false) }
 
@@ -145,7 +152,10 @@ private fun RecentlyVisitedHistoryGroup(
             .combinedClickable(
                 enabled = clickableEnabled,
                 onClick = { onRecentVisitClick(recentVisit) },
-                onLongClick = { isMenuExpanded = true },
+                onLongClick = {
+                    onRecentVisitLongClick()
+                    isMenuExpanded = true
+                },
             )
             .size(268.dp, 56.dp),
         verticalAlignment = Alignment.CenterVertically,
@@ -195,8 +205,10 @@ private fun RecentlyVisitedHistoryGroup(
  * @param clickableEnabled Whether click actions should be invoked or not.
  * @param showDividerLine Whether to show a divider line at the bottom.
  * @param onRecentVisitClick Invoked when the user clicks on a recent visit.
+ * @param onRecentVisitLongClick Invoked when the user long clicks on a recent visit highlight.
  */
 @OptIn(ExperimentalFoundationApi::class)
+@Suppress("LongParameterList")
 @Composable
 private fun RecentlyVisitedHistoryHighlight(
     recentVisit: RecentHistoryHighlight,
@@ -204,6 +216,7 @@ private fun RecentlyVisitedHistoryHighlight(
     clickableEnabled: Boolean,
     showDividerLine: Boolean,
     onRecentVisitClick: (RecentHistoryHighlight) -> Unit = { _ -> },
+    onRecentVisitLongClick: () -> Unit = {},
 ) {
     var isMenuExpanded by remember { mutableStateOf(false) }
 
@@ -212,7 +225,10 @@ private fun RecentlyVisitedHistoryHighlight(
             .combinedClickable(
                 enabled = clickableEnabled,
                 onClick = { onRecentVisitClick(recentVisit) },
-                onLongClick = { isMenuExpanded = true },
+                onLongClick = {
+                    onRecentVisitLongClick()
+                    isMenuExpanded = true
+                },
             )
             .size(268.dp, 56.dp),
         verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/org/mozilla/fenix/home/recentvisits/view/RecentlyVisitedViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recentvisits/view/RecentlyVisitedViewHolder.kt
@@ -76,6 +76,7 @@ class RecentlyVisitedViewHolder(
                     }
                 }
             },
+            onRecentVisitLongClick = { interactor.onRecentVisitLongClicked() },
         )
     }
 

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlInteractor.kt
@@ -412,6 +412,10 @@ class SessionControlInteractor(
         recentBookmarksController.handleBookmarkRemoved(bookmark)
     }
 
+    override fun onRecentBookmarkLongClicked() {
+        recentBookmarksController.handleBookmarkLongClicked()
+    }
+
     override fun onHistoryShowAllClicked() {
         recentVisitsController.handleHistoryShowAllClicked()
     }

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlInteractor.kt
@@ -380,6 +380,10 @@ class SessionControlInteractor(
         recentTabController.handleRecentTabShowAllClicked()
     }
 
+    override fun onRecentTabLongClicked() {
+        recentTabController.handleRecentTabLongClicked()
+    }
+
     override fun onRemoveRecentTab(tab: RecentTab.Tab) {
         recentTabController.handleRecentTabRemoved(tab)
     }

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlInteractor.kt
@@ -434,6 +434,10 @@ class SessionControlInteractor(
         recentVisitsController.handleRemoveRecentHistoryHighlight(highlightUrl)
     }
 
+    override fun onRecentVisitLongClicked() {
+        recentVisitsController.handleRecentVisitLongClicked()
+    }
+
     override fun openCustomizeHomePage() {
         controller.handleCustomizeHomeTapped()
     }

--- a/app/src/test/java/org/mozilla/fenix/home/SessionControlInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/SessionControlInteractorTest.kt
@@ -198,6 +198,12 @@ class SessionControlInteractorTest {
     }
 
     @Test
+    fun `WHEN a recent bookmark is long clicked THEN the long click is handled`() {
+        interactor.onRecentBookmarkLongClicked()
+        verify { recentBookmarksController.handleBookmarkLongClicked() }
+    }
+
+    @Test
     fun `WHEN tapping on the customize home button THEN openCustomizeHomePage`() {
         interactor.openCustomizeHomePage()
         verify { controller.handleCustomizeHomeTapped() }

--- a/app/src/test/java/org/mozilla/fenix/home/SessionControlInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/SessionControlInteractorTest.kt
@@ -163,6 +163,12 @@ class SessionControlInteractorTest {
     }
 
     @Test
+    fun onRecentTabLongClicked() {
+        interactor.onRecentTabLongClicked()
+        verify { recentTabController.handleRecentTabLongClicked() }
+    }
+
+    @Test
     fun onRecentTabShowAllClicked() {
         interactor.onRecentTabShowAllClicked()
         verify { recentTabController.handleRecentTabShowAllClicked() }

--- a/app/src/test/java/org/mozilla/fenix/home/recentbookmarks/DefaultRecentBookmarksControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/recentbookmarks/DefaultRecentBookmarksControllerTest.kt
@@ -132,4 +132,18 @@ class DefaultRecentBookmarksControllerTest {
         }
         assertNotNull(RecentBookmarks.showAllBookmarks.testGetValue())
     }
+
+    @Test
+    fun `GIVEN search dialog is displayed WHEN recent bookmark is long clicked THEN dismiss search dialog`() {
+        every { navController.currentDestination } returns mockk {
+            every { id } returns R.id.searchDialogFragment
+        }
+
+        controller.handleBookmarkLongClicked()
+
+        verify {
+            controller.dismissSearchDialogIfDisplayed()
+            navController.navigateUp()
+        }
+    }
 }

--- a/app/src/test/java/org/mozilla/fenix/home/recenttabs/controller/RecentTabControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/recenttabs/controller/RecentTabControllerTest.kt
@@ -163,4 +163,19 @@ class RecentTabControllerTest {
 
         assertNotNull(RecentTabs.showAllClicked.testGetValue())
     }
+
+    @Test
+    fun `GIVEN search dialog is displayed WHEN long clicking a recent tab THEN search dialog is dismissed`() {
+        every { navController.currentDestination } returns mockk {
+            every { id } returns R.id.searchDialogFragment
+        }
+        every { navController.navigateUp() } returns true
+
+        controller.handleRecentTabLongClicked()
+
+        verify {
+            controller.dismissSearchDialogIfDisplayed()
+            navController.navigateUp()
+        }
+    }
 }

--- a/app/src/test/java/org/mozilla/fenix/home/recentvisits/controller/RecentVisitsControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/recentvisits/controller/RecentVisitsControllerTest.kt
@@ -181,4 +181,18 @@ class RecentVisitsControllerTest {
             }
         }
     }
+
+    @Test
+    fun `WHEN long clicking a recent visit THEN search dialog should be dismissed `() = runTestOnMain {
+        every { navController.currentDestination } returns mockk {
+            every { id } returns R.id.searchDialogFragment
+        }
+
+        controller.handleRecentVisitLongClicked()
+
+        verify {
+            controller.dismissSearchDialogIfDisplayed()
+            navController.navigateUp()
+        }
+    }
 }

--- a/app/src/test/java/org/mozilla/fenix/home/recentvisits/interactor/RecentVisitsInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/recentvisits/interactor/RecentVisitsInteractorTest.kt
@@ -120,4 +120,11 @@ class RecentVisitsInteractorTest {
 
         verify { recentVisitsController.handleRemoveRecentHistoryHighlight("url") }
     }
+
+    @Test
+    fun onRecentVisitLongClicked() {
+        interactor.onRecentVisitLongClicked()
+
+        verify { recentVisitsController.handleRecentVisitLongClicked() }
+    }
 }


### PR DESCRIPTION
Dismiss search dialog when the user interacts with the homescreen by long clicking recent tabs, recent saved bookmarks and recent visits.

https://user-images.githubusercontent.com/35462038/188628254-5a79989c-546b-4346-954d-28d3eaba093c.mp4

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
Fixes #26790