### PR TITLE
For #26826 - Add tests tags to homescreen composables

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/pocket/PocketStoriesComposables.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/pocket/PocketStoriesComposables.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.graphics.Color
@@ -44,6 +45,8 @@ import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTag
+import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -101,6 +104,7 @@ private val placeholderStory = PocketRecommendedStory("", "", "", "", "", 0, 0)
  * @param backgroundColor The background [Color] of the story.
  * @param onStoryClick Callback for when the user taps on this story.
  */
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun PocketStory(
     @PreviewParameter(PocketStoryProvider::class) story: PocketRecommendedStory,
@@ -120,6 +124,10 @@ fun PocketStory(
         title = {
             Text(
                 text = story.title,
+                modifier = Modifier.semantics {
+                    testTagsAsResourceId = true
+                    testTag = "pocket.story.title"
+                },
                 color = FirefoxTheme.colors.textPrimary,
                 overflow = TextOverflow.Ellipsis,
                 maxLines = 2,
@@ -132,6 +140,10 @@ fun PocketStory(
             } else if (isValidPublisher) {
                 Text(
                     text = story.publisher,
+                    modifier = Modifier.semantics {
+                        testTagsAsResourceId = true
+                        testTag = "pocket.story.publisher"
+                    },
                     color = FirefoxTheme.colors.textSecondary,
                     overflow = TextOverflow.Ellipsis,
                     maxLines = 1,
@@ -140,6 +152,10 @@ fun PocketStory(
             } else if (isValidTimeToRead) {
                 Text(
                     text = "${story.timeToRead} min",
+                    modifier = Modifier.semantics {
+                        testTagsAsResourceId = true
+                        testTag = "pocket.story.timeToRead"
+                    },
                     color = FirefoxTheme.colors.textSecondary,
                     overflow = TextOverflow.Ellipsis,
                     maxLines = 1,
@@ -157,6 +173,7 @@ fun PocketStory(
  * @param backgroundColor The background [Color] of the story.
  * @param onStoryClick Callback for when the user taps on this story.
  */
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun PocketSponsoredStory(
     story: PocketSponsoredStory,
@@ -178,6 +195,10 @@ fun PocketSponsoredStory(
     ) {
         Text(
             text = story.title,
+            modifier = Modifier.semantics {
+                testTagsAsResourceId = true
+                testTag = "pocket.sponsoredStory.title"
+            },
             color = FirefoxTheme.colors.textPrimary,
             overflow = TextOverflow.Ellipsis,
             maxLines = 2,
@@ -188,6 +209,10 @@ fun PocketSponsoredStory(
 
         Text(
             text = stringResource(R.string.pocket_stories_sponsor_indication),
+            modifier = Modifier.semantics {
+                testTagsAsResourceId = true
+                testTag = "pocket.sponsoredStory.identifier"
+            },
             color = FirefoxTheme.colors.textSecondary,
             overflow = TextOverflow.Ellipsis,
             maxLines = 1,
@@ -198,6 +223,10 @@ fun PocketSponsoredStory(
 
         Text(
             text = story.sponsor,
+            modifier = Modifier.semantics {
+                testTagsAsResourceId = true
+                testTag = "pocket.sponsoredStory.sponsor"
+            },
             color = FirefoxTheme.colors.textSecondary,
             overflow = TextOverflow.Ellipsis,
             maxLines = 1,
@@ -219,6 +248,7 @@ fun PocketSponsoredStory(
  * @param onStoryClicked Callback for when the user taps on a recommended story.
  * @param onDiscoverMoreClicked Callback for when the user taps an element which contains an
  */
+@OptIn(ExperimentalComposeUiApi::class)
 @Suppress("LongParameterList")
 @Composable
 fun PocketStories(
@@ -237,6 +267,10 @@ fun PocketStories(
     val flingBehavior = EagerFlingBehavior(lazyRowState = listState)
 
     LazyRow(
+        modifier = Modifier.semantics {
+            testTagsAsResourceId = true
+            testTag = "pocket.stories"
+        },
         contentPadding = PaddingValues(horizontal = contentPadding),
         state = listState,
         flingBehavior = flingBehavior,
@@ -381,6 +415,7 @@ private fun Rect.getIntersectPercentage(realSize: IntSize, other: Rect): Float {
  * @param onCategoryClick Callback for when the user taps a category.
  * @param modifier [Modifier] to be applied to the layout.
  */
+@OptIn(ExperimentalComposeUiApi::class)
 @Suppress("LongParameterList")
 @Composable
 fun PocketStoriesCategories(
@@ -393,7 +428,12 @@ fun PocketStoriesCategories(
     onCategoryClick: (PocketRecommendedStoriesCategory) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Box(modifier = modifier) {
+    Box(
+        modifier = modifier.semantics {
+            testTagsAsResourceId = true
+            testTag = "pocket.categories"
+        },
+    ) {
         StaggeredHorizontalGrid(
             horizontalItemsSpacing = 16.dp,
             verticalItemsSpacing = 16.dp,
@@ -424,6 +464,7 @@ fun PocketStoriesCategories(
  * @param textColor [Color] to be applied to the text.
  * @param linkTextColor [Color] of the link text.
  */
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun PoweredByPocketHeader(
     onLearnMoreClicked: (String) -> Unit,
@@ -437,7 +478,10 @@ fun PoweredByPocketHeader(
     val linkEndIndex = linkStartIndex + link.length
 
     Column(
-        modifier = modifier,
+        modifier = modifier.semantics {
+            testTagsAsResourceId = true
+            testTag = "pocket.header"
+        },
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Row(
@@ -461,19 +505,32 @@ fun PoweredByPocketHeader(
                         R.string.pocket_stories_feature_title_2,
                         LocalContext.current.getString(R.string.pocket_product_name),
                     ),
+                    modifier = Modifier.semantics {
+                        testTagsAsResourceId = true
+                        testTag = "pocket.header.title"
+                    },
                     color = textColor,
                     style = FirefoxTheme.typography.caption,
                 )
 
-                ClickableSubstringLink(
-                    text = text,
-                    textColor = textColor,
-                    linkTextColor = linkTextColor,
-                    linkTextDecoration = TextDecoration.Underline,
-                    clickableStartIndex = linkStartIndex,
-                    clickableEndIndex = linkEndIndex,
+                Box(
+                    modifier = modifier.semantics {
+                        testTagsAsResourceId = true
+                        testTag = "pocket.header.subtitle"
+                    },
                 ) {
-                    onLearnMoreClicked("https://www.mozilla.org/en-US/firefox/pocket/?$POCKET_FEATURE_UTM_KEY_VALUE")
+                    ClickableSubstringLink(
+                        text = text,
+                        textColor = textColor,
+                        linkTextColor = linkTextColor,
+                        linkTextDecoration = TextDecoration.Underline,
+                        clickableStartIndex = linkStartIndex,
+                        clickableEndIndex = linkEndIndex,
+                    ) {
+                        onLearnMoreClicked(
+                            "https://www.mozilla.org/en-US/firefox/pocket/?$POCKET_FEATURE_UTM_KEY_VALUE",
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/org/mozilla/fenix/home/recentbookmarks/view/RecentBookmarks.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recentbookmarks/view/RecentBookmarks.kt
@@ -34,10 +34,14 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTag
+import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -69,6 +73,7 @@ private val imageModifier = Modifier
  * @param onRecentBookmarkClick Invoked when the user clicks on a recent bookmark.
  * @param onRecentBookmarkLongClick Invoked when the user long clicks on a recent bookmark.
  */
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun RecentBookmarks(
     bookmarks: List<RecentBookmark>,
@@ -78,6 +83,10 @@ fun RecentBookmarks(
     onRecentBookmarkLongClick: () -> Unit = {},
 ) {
     LazyRow(
+        modifier = Modifier.semantics {
+            testTagsAsResourceId = true
+            testTag = "recent.bookmarks"
+        },
         contentPadding = PaddingValues(horizontal = 16.dp),
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
@@ -102,7 +111,10 @@ fun RecentBookmarks(
  * @param onRecentBookmarkClick Invoked when the user clicks on the recent bookmark item.
  * @param onRecentBookmarkLongClick Invoked when the user long clicks on the recent bookmark item.
  */
-@OptIn(ExperimentalFoundationApi::class)
+@OptIn(
+    ExperimentalFoundationApi::class,
+    ExperimentalComposeUiApi::class,
+)
 @Composable
 private fun RecentBookmarkItem(
     bookmark: RecentBookmark,
@@ -139,6 +151,10 @@ private fun RecentBookmarkItem(
 
             Text(
                 text = bookmark.title ?: bookmark.url ?: "",
+                modifier = Modifier.semantics {
+                    testTagsAsResourceId = true
+                    testTag = "recent.bookmark.title"
+                },
                 color = FirefoxTheme.colors.textPrimary,
                 overflow = TextOverflow.Ellipsis,
                 maxLines = 1,
@@ -222,6 +238,7 @@ private fun PlaceholderBookmarkImage() {
  * @param recentBookmark The [RecentBookmark] for which this menu is shown.
  * @param onDismissRequest Called when the user chooses a menu option or requests to dismiss the menu.
  */
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun RecentBookmarksMenu(
     showMenu: Boolean,
@@ -233,7 +250,11 @@ private fun RecentBookmarksMenu(
         expanded = showMenu,
         onDismissRequest = { onDismissRequest() },
         modifier = Modifier
-            .background(color = FirefoxTheme.colors.layer2),
+            .background(color = FirefoxTheme.colors.layer2)
+            .semantics {
+                testTagsAsResourceId = true
+                testTag = "recent.bookmark.menu"
+            },
     ) {
         for (item in menuItems) {
             DropdownMenuItem(

--- a/app/src/main/java/org/mozilla/fenix/home/recenttabs/view/RecentTabs.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recenttabs/view/RecentTabs.kt
@@ -37,6 +37,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
@@ -44,6 +45,9 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTag
+import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -70,6 +74,7 @@ import org.mozilla.fenix.theme.FirefoxTheme
  * @param backgroundColor The background [Color] of each item.
  * @param onRecentTabClick Invoked when the user clicks on a recent tab.
  */
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun RecentTabs(
     recentTabs: List<RecentTab>,
@@ -79,7 +84,12 @@ fun RecentTabs(
     onRecentTabLongClick: () -> Unit = {},
 ) {
     Column(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .semantics {
+                testTagsAsResourceId = true
+                testTag = "recent.tabs"
+            },
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         recentTabs.forEach { tab ->
@@ -105,8 +115,12 @@ fun RecentTabs(
  * @param backgroundColor The background [Color] of the item.
  * @param onRecentTabClick Invoked when the user clicks on a recent tab.
  */
-@OptIn(ExperimentalFoundationApi::class)
+@OptIn(
+    ExperimentalFoundationApi::class,
+    ExperimentalComposeUiApi::class,
+)
 @Composable
+@Suppress("LongMethod")
 private fun RecentTabItem(
     tab: RecentTab.Tab,
     menuItems: List<RecentTabMenuItem>,
@@ -151,6 +165,10 @@ private fun RecentTabItem(
             ) {
                 Text(
                     text = tab.state.content.title.ifEmpty { tab.state.content.url.trimmed() },
+                    modifier = Modifier.semantics {
+                        testTagsAsResourceId = true
+                        testTag = "recent.tab.title"
+                    },
                     color = FirefoxTheme.colors.textPrimary,
                     fontSize = 14.sp,
                     maxLines = 2,
@@ -171,6 +189,10 @@ private fun RecentTabItem(
 
                     Text(
                         text = tab.state.content.url.trimmed(),
+                        modifier = Modifier.semantics {
+                            testTagsAsResourceId = true
+                            testTag = "recent.tab.url"
+                        },
                         color = FirefoxTheme.colors.textSecondary,
                         fontSize = 12.sp,
                         overflow = TextOverflow.Ellipsis,
@@ -232,6 +254,7 @@ fun RecentTabImage(
  * @param tab The [RecentTab.Tab] for which this menu is shown.
  * @param onDismissRequest Called when the user chooses a menu option or requests to dismiss the menu.
  */
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun RecentTabMenu(
     showMenu: Boolean,
@@ -247,7 +270,11 @@ private fun RecentTabMenu(
         expanded = showMenu,
         onDismissRequest = { onDismissRequest() },
         modifier = Modifier
-            .background(color = FirefoxTheme.colors.layer2),
+            .background(color = FirefoxTheme.colors.layer2)
+            .semantics {
+                testTagsAsResourceId = true
+                testTag = "recent.tab.menu"
+            },
     ) {
         for (item in menuItems) {
             DropdownMenuItem(

--- a/app/src/main/java/org/mozilla/fenix/home/recentvisits/view/RecentlyVisited.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recentvisits/view/RecentlyVisited.kt
@@ -37,11 +37,15 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTag
+import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -69,6 +73,7 @@ private const val VISITS_PER_COLUMN = 3
  * @param onRecentVisitClick Invoked when the user clicks on a recent visit.
  * @param onRecentVisitLongClick Invoked when the user long clicks on a recent visit.
  */
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun RecentlyVisited(
     recentVisits: List<RecentlyVisitedItem>,
@@ -87,6 +92,10 @@ fun RecentlyVisited(
         val flingBehavior = EagerFlingBehavior(lazyRowState = listState)
 
         LazyRow(
+            modifier = Modifier.semantics {
+                testTagsAsResourceId = true
+                testTag = "recent.visits"
+            },
             state = listState,
             contentPadding = PaddingValues(16.dp),
             horizontalArrangement = Arrangement.spacedBy(32.dp),
@@ -138,7 +147,10 @@ fun RecentlyVisited(
  * @param onRecentVisitClick Invoked when the user clicks on a recent visit.
  * @param onRecentVisitClick Invoked when the user long clicks on a recently visited group.
  */
-@OptIn(ExperimentalFoundationApi::class)
+@OptIn(
+    ExperimentalFoundationApi::class,
+    ExperimentalComposeUiApi::class,
+)
 @Suppress("LongParameterList")
 @Composable
 private fun RecentlyVisitedHistoryGroup(
@@ -161,7 +173,11 @@ private fun RecentlyVisitedHistoryGroup(
                     isMenuExpanded = true
                 },
             )
-            .size(268.dp, 56.dp),
+            .size(268.dp, 56.dp)
+            .semantics {
+                testTagsAsResourceId = true
+                testTag = "recent.visits.group"
+            },
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Image(
@@ -179,12 +195,21 @@ private fun RecentlyVisitedHistoryGroup(
                 text = recentVisit.title,
                 modifier = Modifier
                     .padding(top = 7.dp, bottom = 2.dp)
-                    .weight(1f),
+                    .weight(1f)
+                    .semantics {
+                        testTagsAsResourceId = true
+                        testTag = "recent.visits.group.title"
+                    },
             )
 
             RecentlyVisitedCaption(
                 count = recentVisit.historyMetadata.size,
-                modifier = Modifier.weight(1f),
+                modifier = Modifier
+                    .weight(1f)
+                    .semantics {
+                        testTagsAsResourceId = true
+                        testTag = "recent.visits.group.caption"
+                    },
             )
 
             if (showDividerLine) {
@@ -211,7 +236,10 @@ private fun RecentlyVisitedHistoryGroup(
  * @param onRecentVisitClick Invoked when the user clicks on a recent visit.
  * @param onRecentVisitLongClick Invoked when the user long clicks on a recent visit highlight.
  */
-@OptIn(ExperimentalFoundationApi::class)
+@OptIn(
+    ExperimentalFoundationApi::class,
+    ExperimentalComposeUiApi::class,
+)
 @Suppress("LongParameterList")
 @Composable
 private fun RecentlyVisitedHistoryHighlight(
@@ -234,7 +262,11 @@ private fun RecentlyVisitedHistoryHighlight(
                     isMenuExpanded = true
                 },
             )
-            .size(268.dp, 56.dp),
+            .size(268.dp, 56.dp)
+            .semantics {
+                testTagsAsResourceId = true
+                testTag = "recent.visits.highlight"
+            },
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Favicon(url = recentVisit.url, size = 24.dp)
@@ -244,7 +276,12 @@ private fun RecentlyVisitedHistoryHighlight(
         Box(modifier = Modifier.fillMaxSize()) {
             RecentlyVisitedTitle(
                 text = recentVisit.title.trimmed(),
-                modifier = Modifier.align(Alignment.CenterStart),
+                modifier = Modifier
+                    .align(Alignment.CenterStart)
+                    .semantics {
+                        testTagsAsResourceId = true
+                        testTag = "recent.visits.highlight.title"
+                    },
             )
 
             if (showDividerLine) {
@@ -322,6 +359,7 @@ private fun RecentlyVisitedCaption(
  * @param recentVisit The [RecentlyVisitedItem] for which this menu is shown.
  * @param onDismissRequest Called when the user chooses a menu option or requests to dismiss the menu.
  */
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun RecentlyVisitedMenu(
     showMenu: Boolean,
@@ -337,7 +375,11 @@ private fun RecentlyVisitedMenu(
         expanded = showMenu,
         onDismissRequest = { onDismissRequest() },
         modifier = Modifier
-            .background(color = FirefoxTheme.colors.layer2),
+            .background(color = FirefoxTheme.colors.layer2)
+            .semantics {
+                testTagsAsResourceId = true
+                testTag = "recent.visit.menu"
+            },
     ) {
         for (item in menuItems) {
             DropdownMenuItem(


### PR DESCRIPTION
Added `testTag`s for the homescreen composables (minus collections which have their tests disabled for now) and enabled using easily finding and using them in UIAutomator using `testTagsAsResourceId` as Google recommends in https://developer.android.com/jetpack/compose/testing.

Tested locally using both `onNodeWithTag(<testTag>)` and `By.res(<testTag>)` and saw both calls working as expected.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.








### GitHub Automation
Fixes #26826