### PR TITLE
For #26743: Update URL text styling.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/compose/ClickableSubstringLink.kt
+++ b/app/src/main/java/org/mozilla/fenix/compose/ClickableSubstringLink.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
 import org.mozilla.fenix.theme.FirefoxTheme
@@ -45,7 +46,10 @@ fun ClickableSubstringLink(
         )
 
         addStyle(
-            SpanStyle(color = FirefoxTheme.colors.textAccent),
+            SpanStyle(
+                color = textColor,
+                textDecoration = TextDecoration.Underline
+            ),
             start = clickableStartIndex,
             end = clickableEndIndex
         )


### PR DESCRIPTION
Replace colored text with underlined text as per UX design.

After patch:

<img src= https://user-images.githubusercontent.com/48995920/188934891-bea08327-bfe4-4f0d-8e60-8df7ccb430f8.png width =45%>

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
Fixes #26743