### PR TITLE
For #26502: Add time group and private extras in history telemetry

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -3238,37 +3238,30 @@ history:
         type: boolean
         description: |
           True if the history item is synced from other devices otherwise false.
+      time_group:
+        type: string
+        description: |
+          What time group does the history item belongs to.
+          Possible values: [Today], [Yesterday], [ThisWeek], [ThisMonth],
+          [Older].
+      is_private:
+        type: boolean
+        description: |
+          True if the history item is opened in a private tab, otherwise false.
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/18178
+      - https://github.com/mozilla-mobile/fenix/issues/26502
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/18261
       - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
       - https://github.com/mozilla-mobile/fenix/pull/21038#issuecomment-906757301
       - https://github.com/mozilla-mobile/fenix/pull/26503#issuecomment-1219761407
+      - https://github.com/mozilla-mobile/fenix/pull/26863
     data_sensitivity:
       - interaction
     notification_emails:
       - android-probes@mozilla.com
-      - mavduevskiy@mozilla.com
-    expires: never
-    metadata:
-      tags:
-        - History
-  opened_item_in_new_tab:
-    type: event
-    description: |
-      A user opened a history item in a new tab
-    bugs:
-      - https://github.com/mozilla-mobile/fenix/issues/18178
-    data_reviews:
-      - https://github.com/mozilla-mobile/fenix/pull/18261
-      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
-      - https://github.com/mozilla-mobile/fenix/pull/21038#issuecomment-906757301
-    data_sensitivity:
-      - interaction
-    notification_emails:
-      - android-probes@mozilla.com
-      - erichards@mozilla.com
+      - royang@mozilla.com
     expires: never
     metadata:
       tags:
@@ -3280,25 +3273,6 @@ history:
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/18178
       - https://github.com/mozilla-mobile/fenix/issues/19923
-    data_reviews:
-      - https://github.com/mozilla-mobile/fenix/pull/18261
-      - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789
-      - https://github.com/mozilla-mobile/fenix/pull/21038#issuecomment-906757301
-    data_sensitivity:
-      - interaction
-    notification_emails:
-      - android-probes@mozilla.com
-      - erichards@mozilla.com
-    expires: never
-    metadata:
-      tags:
-        - History
-  opened_item_in_private_tab:
-    type: event
-    description: |
-      A user opened a history item in a private tab
-    bugs:
-      - https://github.com/mozilla-mobile/fenix/issues/18178
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/18261
       - https://github.com/mozilla-mobile/fenix/pull/19924#issuecomment-861423789

--- a/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/HistoryFragment.kt
@@ -333,25 +333,31 @@ class HistoryFragment : LibraryPageFragment<History>(), UserInteractionHandler {
     }
 
     private fun openItem(item: History.Regular) {
-        GleanHistory.openedItem.record(GleanHistory.OpenedItemExtra(item.isRemote))
+        GleanHistory.openedItem.record(
+            GleanHistory.OpenedItemExtra(
+                isRemote = item.isRemote,
+                timeGroup = item.historyTimeGroup.toString(),
+                isPrivate = (activity as HomeActivity).browsingModeManager.mode == BrowsingMode.Private,
+            ),
+        )
 
         (activity as HomeActivity).openToBrowserAndLoad(
             searchTermOrURL = item.url,
             newTab = true,
-            from = BrowserDirection.FromHistory
+            from = BrowserDirection.FromHistory,
         )
     }
 
     private fun displayDeleteTimeRange() {
         DeleteConfirmationDialogFragment(
-            historyInteractor = historyInteractor
+            historyInteractor = historyInteractor,
         ).show(childFragmentManager, null)
     }
 
     private fun share(data: List<ShareData>) {
         GleanHistory.shared.record(NoExtras())
         val directions = HistoryFragmentDirections.actionGlobalShareFragment(
-            data = data.toTypedArray()
+            data = data.toTypedArray(),
         )
         navigateToHistoryFragment(directions)
     }
@@ -359,7 +365,7 @@ class HistoryFragment : LibraryPageFragment<History>(), UserInteractionHandler {
     private fun navigateToHistoryFragment(directions: NavDirections) {
         findNavController().nav(
             R.id.historyFragment,
-            directions
+            directions,
         )
     }
 
@@ -371,7 +377,7 @@ class HistoryFragment : LibraryPageFragment<History>(), UserInteractionHandler {
     }
 
     internal class DeleteConfirmationDialogFragment(
-        private val historyInteractor: HistoryInteractor
+        private val historyInteractor: HistoryInteractor,
     ) : DialogFragment() {
         override fun onCreateDialog(savedInstanceState: Bundle?): Dialog =
             AlertDialog.Builder(requireContext()).apply {


### PR DESCRIPTION
Updating history telemetry to make sure we're sending the needed information.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.







### GitHub Automation
Fixes #26502