### PR TITLE
Closes #26215: add telemetry events for wallpaper onboarding dialog

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -8095,7 +8095,7 @@ wallpapers:
   wallpaper_selected:
     type: event
     description: |
-      A wallpaper is selected from the settings screen.
+      A wallpaper is selected from the settings screen or onboarding dialog.
     extra_keys:
       name:
         description: The name of the selected wallpaper
@@ -8103,17 +8103,75 @@ wallpapers:
       theme_collection:
         description: The theme collection the selected wallpaper belongs to.
         type: string
+      source:
+        description: |
+          A string that tells us how the user selected the wallpaper.
+          Possible values are: `settings`, `onboarding`
+        type: string
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/23381
     data_reviews:
       - https://github.com/mozilla-mobile/fenix/pull/23382
+      - https://github.com/mozilla-mobile/fenix/pull/26893
     notification_emails:
       - android-probes@mozilla.com
     data_sensitivity:
       - interaction
-    expires: 114
+    expires: 116
     no_lint:
       - COMMON_PREFIX
+    metadata:
+      tags:
+        - Wallpapers
+  onboarding_opened:
+    type: event
+    description: |
+      The wallpaper onboarding dialog has been displayed.
+    bugs:
+      - https://github.com/mozilla-mobile/fenix/issues/26215
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/26893
+    notification_emails:
+      - android-probes@mozilla.com
+    data_sensitivity:
+      - interaction
+    expires: 116
+    metadata:
+      tags:
+        - Wallpapers
+  onboarding_closed:
+    type: event
+    description: |
+      The wallpaper onboarding dialog has been closed.
+    extra_keys:
+      is_selected:
+        description: Whether or not a wallpaper has been selected.
+        type: boolean
+    bugs:
+      - https://github.com/mozilla-mobile/fenix/issues/26215
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/26893
+    notification_emails:
+      - android-probes@mozilla.com
+    data_sensitivity:
+      - interaction
+    expires: 116
+    metadata:
+      tags:
+        - Wallpapers
+  onboarding_explore_more_click:
+    type: event
+    description: |
+      The wallpaper onboarding learn more button was clicked.
+    bugs:
+      - https://github.com/mozilla-mobile/fenix/issues/26215
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/26893
+    notification_emails:
+      - android-probes@mozilla.com
+    data_sensitivity:
+      - interaction
+    expires: 116
     metadata:
       tags:
         - Wallpapers

--- a/app/src/main/java/org/mozilla/fenix/settings/wallpaper/WallpaperSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/wallpaper/WallpaperSettingsFragment.kt
@@ -97,6 +97,14 @@ class WallpaperSettingsFragment : Fragment() {
                         findNavController().navigate(R.id.homeFragment)
                     }
                     .show()
+
+                Wallpapers.wallpaperSelected.record(
+                    Wallpapers.WallpaperSelectedExtra(
+                        name = wallpaper.name,
+                        source = "settings",
+                        themeCollection = wallpaper.collection.name,
+                    ),
+                )
             }
             Wallpaper.ImageFileState.Error -> {
                 FenixSnackbar.make(

--- a/app/src/main/java/org/mozilla/fenix/wallpapers/WallpapersUseCases.kt
+++ b/app/src/main/java/org/mozilla/fenix/wallpapers/WallpapersUseCases.kt
@@ -13,7 +13,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import mozilla.components.concept.fetch.Client
 import org.mozilla.fenix.FeatureFlags
-import org.mozilla.fenix.GleanMetrics.Wallpapers
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.components.appstate.AppAction
@@ -441,12 +440,6 @@ class WallpapersUseCases(
             settings.currentWallpaperTextColor = wallpaper.textColor ?: 0
             settings.currentWallpaperCardColor = wallpaper.cardColor ?: 0
             store.dispatch(AppAction.WallpaperAction.UpdateCurrentWallpaper(wallpaper))
-            Wallpapers.wallpaperSelected.record(
-                Wallpapers.WallpaperSelectedExtra(
-                    name = wallpaper.name,
-                    themeCollection = wallpaper.collection.name,
-                ),
-            )
             return Wallpaper.ImageFileState.Downloaded
         }
     }
@@ -482,12 +475,6 @@ class WallpapersUseCases(
         private fun selectWallpaper(wallpaper: Wallpaper) {
             settings.currentWallpaperName = wallpaper.name
             store.dispatch(AppAction.WallpaperAction.UpdateCurrentWallpaper(wallpaper))
-            Wallpapers.wallpaperSelected.record(
-                Wallpapers.WallpaperSelectedExtra(
-                    name = wallpaper.name,
-                    themeCollection = wallpaper.collection.name,
-                ),
-            )
         }
 
         private fun dispatchDownloadState(wallpaper: Wallpaper, downloadState: Wallpaper.ImageFileState) {

--- a/app/src/test/java/org/mozilla/fenix/wallpapers/WallpapersUseCasesTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/wallpapers/WallpapersUseCasesTest.kt
@@ -20,7 +20,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mozilla.fenix.GleanMetrics.Wallpapers
 import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.components.appstate.AppAction
 import org.mozilla.fenix.utils.Settings
@@ -514,7 +513,6 @@ class WallpapersUseCasesTest {
         appStore.waitUntilIdle()
         assertEquals(selectedWallpaper.name, slot.captured)
         assertEquals(selectedWallpaper, appStore.state.wallpaperState.currentWallpaper)
-        assertEquals(selectedWallpaper.name, Wallpapers.wallpaperSelected.testGetValue()?.first()?.extra?.get("name")!!)
         assertEquals(wallpaperFileState, Wallpaper.ImageFileState.Downloaded)
     }
 
@@ -537,7 +535,6 @@ class WallpapersUseCasesTest {
         appStore.waitUntilIdle()
         assertEquals(selectedWallpaper.name, slot.captured)
         assertEquals(selectedWallpaper, appStore.state.wallpaperState.currentWallpaper)
-        assertEquals(selectedWallpaper.name, Wallpapers.wallpaperSelected.testGetValue()?.first()?.extra?.get("name")!!)
         assertEquals(wallpaperFileState, Wallpaper.ImageFileState.Downloaded)
     }
 


### PR DESCRIPTION
Closes #26215

Adds wallpaper onboarding dialog telemetry events.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.













### GitHub Automation
Fixes #26215