### PR TITLE
mergify: allow complete-push check as an alternative to complete-pr i…

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -77,7 +77,9 @@ pull_request_rules:
         rebase_fallback: none
   - name: Needs landing - Rebase
     conditions:
-      - check-success=complete-pr
+      - or:
+        - check-success=complete-pr
+        - check-success=complete-push
       - label=pr:needs-landing
       - "#approved-reviews-by>=1"
       - -draft
@@ -90,7 +92,9 @@ pull_request_rules:
         rebase_fallback: none
   - name: Needs landing - Squash
     conditions:
-      - check-success=complete-pr
+      - or:
+        - check-success=complete-pr
+        - check-success=complete-push
       - label=pr:needs-landing-squashed
       - "#approved-reviews-by>=1"
       - -draft


### PR DESCRIPTION
…n queue conditions

PRs created by github actions don't get a pull-request taskcluster graph scheduled (because that is only done for PRs created by collaborators). However, if the PR is created in the main fenix repo, typically because it comes from one of our internal github workflows, then we get a push graph, which is sufficient to run the required checks.

This change lets mergify consider a green `complete-push` task as sufficient to queue a PR (in addition to all the other conditions, e.g. wrt review), which will allow PRs created by the
update-nimbus-experiments workflow to be queued by mergify instead of having to be merged by a repo admin.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
