### PR TITLE
Update hash to be ignored for ktlint update

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,3 @@
 # .git-blame-ignore-revs
-# Fix issues from ktlint baseline
-8dcb16b607f7efc8ba4f7c25b7ce4aa1320ac6a1
+# 26901: Fix issues from ktlint baseline
+ffcef5ff2e3f78b6972dd16551f3f653b7035ccc


### PR DESCRIPTION
The original commit was rebased before landing and the hash changed. Update it to the landed one. Also add a reference to the issue number.