### PR TITLE
For #26930: Upgrade kotlin to 1.7.10 and compose compiler to 1.3.0.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -449,7 +449,7 @@ configurations {
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
     kotlinOptions {
-        freeCompilerArgs += "-Xopt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"
+        freeCompilerArgs += "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -144,7 +144,7 @@ allprojects {
         kotlinOptions.jvmTarget = "1.8"
         kotlinOptions.allWarningsAsErrors = true
         kotlinOptions.freeCompilerArgs += [
-            "-Xopt-in=kotlin.RequiresOptIn", "-Xjvm-default=enable"
+            "-opt-in=kotlin.RequiresOptIn", "-Xjvm-default=all"
         ]
     }
 }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -6,7 +6,7 @@
 // FORCE REBUILD 2022-09-16
 
 object Versions {
-    const val kotlin = "1.6.10"
+    const val kotlin = "1.7.10"
     const val coroutines = "1.6.1"
 
     // These versions are linked: lint should be X+23.Y.Z of gradle_plugin version, according to:
@@ -21,7 +21,7 @@ object Versions {
     const val jna = "5.8.0"
 
     const val androidx_compose = "1.2.1"
-    const val androidx_compose_compiler = "1.1.1"
+    const val androidx_compose_compiler = "1.3.0"
     const val androidx_appcompat = "1.3.0"
     const val androidx_benchmark = "1.0.0"
     const val androidx_biometric = "1.1.0"


### PR DESCRIPTION
Replace deprecated Xopt-in with op-in.
Replace deprecated Xjvm-default=enable with Xjvm-default=all.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.







### GitHub Automation
Fixes #26930