### PR TITLE
For #26511 - Wait until the wallpaper is available to show HomeFragment

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -218,7 +218,6 @@ class HomeFragment : Fragment() {
         if (shouldEnableWallpaper()) {
             wallpapersObserver = WallpapersObserver(
                 appStore = components.appStore,
-                settings = requireContext().settings(),
                 wallpapersUseCases = components.useCases.wallpaperUseCases,
                 wallpaperImageView = binding.wallpaperImageView,
             ).also {

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -115,6 +115,7 @@ import org.mozilla.fenix.tabstray.TabsTrayAccessPoint
 import org.mozilla.fenix.utils.Settings.Companion.TOP_SITES_PROVIDER_MAX_THRESHOLD
 import org.mozilla.fenix.utils.ToolbarPopupWindow
 import org.mozilla.fenix.utils.allowUndo
+import org.mozilla.fenix.wallpapers.WallpaperManager
 import java.lang.ref.WeakReference
 import kotlin.math.min
 
@@ -418,7 +419,8 @@ class HomeFragment : Fragment() {
 
         getMenuButton()?.dismissMenu()
 
-        if (shouldEnableWallpaper()) {
+        val isDefaultTheCurrentWallpaper = WallpaperManager.isDefaultTheCurrentWallpaper(requireContext().settings())
+        if (shouldEnableWallpaper() && !isDefaultTheCurrentWallpaper) {
             // Running this on the Main thread helps to ensure that the just updated configuration
             // will be used when the wallpaper is scaled to match.
             // Otherwise the portrait wallpaper may remain shown on landscape,
@@ -766,7 +768,8 @@ class HomeFragment : Fragment() {
             requireComponents.reviewPromptController.promptReview(requireActivity())
         }
 
-        if (shouldEnableWallpaper()) {
+        val isDefaultTheCurrentWallpaper = WallpaperManager.isDefaultTheCurrentWallpaper(requireContext().settings())
+        if (shouldEnableWallpaper() && !isDefaultTheCurrentWallpaper) {
             runBlockingIncrement {
                 wallpapersObserver?.applyCurrentWallpaper()
             }

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -217,6 +217,7 @@ class HomeFragment : Fragment() {
         if (shouldEnableWallpaper()) {
             wallpapersObserver = WallpapersObserver(
                 appStore = components.appStore,
+                settings = requireContext().settings(),
                 wallpapersUseCases = components.useCases.wallpaperUseCases,
                 wallpaperImageView = binding.wallpaperImageView,
             ).also {
@@ -418,7 +419,6 @@ class HomeFragment : Fragment() {
         getMenuButton()?.dismissMenu()
 
         if (shouldEnableWallpaper()) {
-            // Setting the wallpaper is a potentially expensive operation - can take 100ms.
             // Running this on the Main thread helps to ensure that the just updated configuration
             // will be used when the wallpaper is scaled to match.
             // Otherwise the portrait wallpaper may remain shown on landscape,
@@ -764,6 +764,12 @@ class HomeFragment : Fragment() {
 
         lifecycleScope.launch(IO) {
             requireComponents.reviewPromptController.promptReview(requireActivity())
+        }
+
+        if (shouldEnableWallpaper()) {
+            runBlockingIncrement {
+                wallpapersObserver?.applyCurrentWallpaper()
+            }
         }
     }
 

--- a/app/src/main/java/org/mozilla/fenix/home/WallpapersObserver.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/WallpapersObserver.kt
@@ -4,21 +4,27 @@
 
 package org.mozilla.fenix.home
 
+import android.graphics.Bitmap
 import android.widget.ImageView
 import androidx.annotation.VisibleForTesting
+import androidx.annotation.WorkerThread
 import androidx.core.view.isVisible
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import mozilla.components.lib.state.Store
 import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.components.appstate.AppAction
 import org.mozilla.fenix.components.appstate.AppState
 import org.mozilla.fenix.ext.scaleToBottomOfView
+import org.mozilla.fenix.utils.Settings
 import org.mozilla.fenix.wallpapers.Wallpaper
 import org.mozilla.fenix.wallpapers.WallpapersUseCases
 
@@ -28,19 +34,44 @@ import org.mozilla.fenix.wallpapers.WallpapersUseCases
  * when the [LifecycleOwner] is destroyed.
  *
  * @param appStore Holds the details abut the current wallpaper.
+ * @param settings Used for checking user's option for what wallpaper to use.
  * @param wallpapersUseCases Used for interacting with the wallpaper feature.
  * @param wallpaperImageView Serves as the target when applying wallpapers.
+ * @param backgroundWorkDispatcher Used for scheduling the wallpaper update when the state is updated
+ * with a new wallpaper.
  */
 class WallpapersObserver(
     private val appStore: AppStore,
+    private val settings: Settings,
     private val wallpapersUseCases: WallpapersUseCases,
     private val wallpaperImageView: ImageView,
+    backgroundWorkDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : DefaultLifecycleObserver {
     @VisibleForTesting
     internal var observeWallpapersStoreSubscription: Store.Subscription<AppState, AppAction>? = null
 
+    /**
+     * Coroutine scope for updating the wallpapers when an update is observed.
+     * Allows for easy cleanup when the client of this is destroyed.
+     */
     @VisibleForTesting
-    internal var wallpapersScope = CoroutineScope(Dispatchers.Main.immediate)
+    internal var wallpapersScope = CoroutineScope(backgroundWorkDispatcher)
+
+    /**
+     * Setting the wallpaper assumes two steps:
+     * - load - running on IO
+     * - set - running on Main
+     * This property caches the result of [loadWallpaper] to be later used by [applyCurrentWallpaper].
+     */
+    @Volatile
+    @VisibleForTesting
+    internal var currentWallpaperImage: Bitmap? = null
+
+    /**
+     * Listener for when the first observed wallpaper is loaded and available to be set.
+     */
+    @VisibleForTesting
+    internal val isWallpaperLoaded = CompletableDeferred<Unit>()
 
     init {
         observeWallpaperUpdates()
@@ -50,8 +81,20 @@ class WallpapersObserver(
      * Immediately apply the current wallpaper automatically adjusted to support
      * the current configuration - portrait or landscape.
      */
-    fun applyCurrentWallpaper() {
-        showWallpaper()
+    internal suspend fun applyCurrentWallpaper() {
+        isWallpaperLoaded.await()
+
+        withContext(Dispatchers.Main.immediate) {
+            with(currentWallpaperImage) {
+                when (this) {
+                    null -> wallpaperImageView.isVisible = false
+                    else -> {
+                        scaleToBottomOfView(wallpaperImageView)
+                        wallpaperImageView.isVisible = true
+                    }
+                }
+            }
+        }
     }
 
     override fun onDestroy(owner: LifecycleOwner) {
@@ -64,37 +107,42 @@ class WallpapersObserver(
         var lastObservedValue: Wallpaper? = null
         observeWallpapersStoreSubscription = appStore.observeManually { state ->
             val currentValue = state.wallpaperState.currentWallpaper
+
+            // Use the persisted wallpaper name to wait until a state update
+            // that contains the wallpaper that the user chose.
+            // Avoids setting the AppState default wallpaper if we know that another wallpaper is chosen.
+            if (currentValue.name != settings.currentWallpaperName) {
+                return@observeManually
+            }
+
             // Use the wallpaper name to differentiate between updates to properly support
             // the restored from settings wallpaper being the same as the one downloaded
             // case in which details like "collection" may be different.
+            // Avoids setting the same wallpaper twice.
             if (currentValue.name != lastObservedValue?.name) {
                 lastObservedValue = currentValue
 
-                showWallpaper(currentValue)
+                wallpapersScope.launch {
+                    loadWallpaper(currentValue)
+                    applyCurrentWallpaper()
+                }
             }
         }.also {
             it.resume()
         }
     }
 
+    /**
+     * Load the bitmap of [wallpaper] and cache it in [currentWallpaperImage].
+     */
+    @WorkerThread
     @VisibleForTesting
-    internal fun showWallpaper(wallpaper: Wallpaper = appStore.state.wallpaperState.currentWallpaper) {
-        wallpapersScope.launch {
-            when (wallpaper) {
-                // We only want to update the wallpaper when it's different from the default one
-                // as the default is applied already on xml by default.
-                Wallpaper.Default -> {
-                    wallpaperImageView.isVisible = false
-                }
-                else -> {
-                    val bitmap = wallpapersUseCases.loadBitmap(wallpaper)
-
-                    bitmap?.let {
-                        it.scaleToBottomOfView(wallpaperImageView)
-                        wallpaperImageView.isVisible = true
-                    }
-                }
-            }
+    internal suspend fun loadWallpaper(wallpaper: Wallpaper) {
+        currentWallpaperImage = when (wallpaper) {
+            Wallpaper.Default -> null
+            else -> wallpapersUseCases.loadBitmap(wallpaper)
         }
+
+        isWallpaperLoaded.complete(Unit)
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/home/WallpapersObserver.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/WallpapersObserver.kt
@@ -24,7 +24,6 @@ import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.components.appstate.AppAction
 import org.mozilla.fenix.components.appstate.AppState
 import org.mozilla.fenix.ext.scaleToBottomOfView
-import org.mozilla.fenix.utils.Settings
 import org.mozilla.fenix.wallpapers.Wallpaper
 import org.mozilla.fenix.wallpapers.WallpapersUseCases
 
@@ -34,7 +33,6 @@ import org.mozilla.fenix.wallpapers.WallpapersUseCases
  * when the [LifecycleOwner] is destroyed.
  *
  * @param appStore Holds the details abut the current wallpaper.
- * @param settings Used for checking user's option for what wallpaper to use.
  * @param wallpapersUseCases Used for interacting with the wallpaper feature.
  * @param wallpaperImageView Serves as the target when applying wallpapers.
  * @param backgroundWorkDispatcher Used for scheduling the wallpaper update when the state is updated
@@ -42,7 +40,6 @@ import org.mozilla.fenix.wallpapers.WallpapersUseCases
  */
 class WallpapersObserver(
     private val appStore: AppStore,
-    private val settings: Settings,
     private val wallpapersUseCases: WallpapersUseCases,
     private val wallpaperImageView: ImageView,
     backgroundWorkDispatcher: CoroutineDispatcher = Dispatchers.IO,
@@ -106,14 +103,7 @@ class WallpapersObserver(
     internal fun observeWallpaperUpdates() {
         var lastObservedValue: Wallpaper? = null
         observeWallpapersStoreSubscription = appStore.observeManually { state ->
-            val currentValue = state.wallpaperState.currentWallpaper
-
-            // Use the persisted wallpaper name to wait until a state update
-            // that contains the wallpaper that the user chose.
-            // Avoids setting the AppState default wallpaper if we know that another wallpaper is chosen.
-            if (currentValue.name != settings.currentWallpaperName) {
-                return@observeManually
-            }
+            val currentValue = state.wallpaperState.currentWallpaper ?: return@observeManually
 
             // Use the wallpaper name to differentiate between updates to properly support
             // the restored from settings wallpaper being the same as the one downloaded

--- a/app/src/main/java/org/mozilla/fenix/wallpapers/WallpaperManager.kt
+++ b/app/src/main/java/org/mozilla/fenix/wallpapers/WallpaperManager.kt
@@ -18,7 +18,7 @@ class WallpaperManager(
     val logger = Logger("WallpaperManager")
 
     val wallpapers get() = appStore.state.wallpaperState.availableWallpapers
-    val currentWallpaper: Wallpaper get() = appStore.state.wallpaperState.currentWallpaper
+    val currentWallpaper: Wallpaper? get() = appStore.state.wallpaperState.currentWallpaper
 
     companion object {
         /**

--- a/app/src/main/java/org/mozilla/fenix/wallpapers/WallpaperState.kt
+++ b/app/src/main/java/org/mozilla/fenix/wallpapers/WallpaperState.kt
@@ -7,16 +7,16 @@ package org.mozilla.fenix.wallpapers
 /**
  * Represents all state related to the Wallpapers feature.
  *
- * @property currentWallpaper The currently selected [Wallpaper].
+ * @property currentWallpaper The currently selected [Wallpaper]. `null` if selection is not yet known.
  * @property availableWallpapers The full list of wallpapers that can be selected.
  */
 data class WallpaperState(
-    val currentWallpaper: Wallpaper,
+    val currentWallpaper: Wallpaper?,
     val availableWallpapers: List<Wallpaper>,
 ) {
     companion object {
         val default = WallpaperState(
-            currentWallpaper = Wallpaper.Default,
+            currentWallpaper = null,
             availableWallpapers = listOf(),
         )
     }

--- a/app/src/test/java/org/mozilla/fenix/home/WallpapersObserverTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/WallpapersObserverTest.kt
@@ -7,55 +7,115 @@ package org.mozilla.fenix.home
 import android.graphics.Bitmap
 import android.widget.ImageView
 import androidx.core.view.isVisible
-import io.mockk.Called
 import io.mockk.Runs
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.cancel
+import mozilla.components.support.test.ext.joinBlocking
 import mozilla.components.support.test.libstate.ext.waitUntilIdle
+import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.rule.runTestOnMain
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertTrue
-import org.junit.Ignore
+import org.junit.Assert.assertNull
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.components.appstate.AppAction.WallpaperAction.UpdateCurrentWallpaper
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+import org.mozilla.fenix.utils.Settings
 import org.mozilla.fenix.wallpapers.Wallpaper
 import org.mozilla.fenix.wallpapers.WallpapersUseCases
 
 @RunWith(FenixRobolectricTestRunner::class)
 class WallpapersObserverTest {
+    @get:Rule
+    val coroutinesTestRule = MainCoroutineRule()
+
     @Test
     fun `WHEN the observer is created THEN start observing the store`() {
         val appStore: AppStore = mockk(relaxed = true) {
             every { observeManually(any()) } answers { mockk(relaxed = true) }
         }
 
-        val observer = WallpapersObserver(appStore, mockk(), mockk())
+        val observer = getObserver(appStore)
 
         assertNotNull(observer.observeWallpapersStoreSubscription)
     }
 
     @Test
-    fun `WHEN asked to apply the wallpaper THEN show it`() {
+    fun `GIVEN a certain wallpaper is chosen WHEN the state is updated with that wallpaper THEN load it it`() = runTestOnMain {
         val appStore = AppStore()
-        val observer = spyk(WallpapersObserver(appStore, mockk(), mockk())) {
-            every { showWallpaper(any()) } just Runs
+        val settings: Settings = mockk { every { currentWallpaperName } returns "Test" }
+        val wallpaper: Wallpaper = mockk { every { name } returns "Test" }
+        val observer = spyk(
+            getObserver(appStore, settings, mockk(relaxed = true), mockk(relaxed = true)),
+        )
+
+        // Ignore the call on the real instance and call again "observeWallpaperUpdates"
+        // on the spy to be able to verify the "showWallpaper" call in the spy.
+        observer.observeWallpaperUpdates()
+        appStore.dispatch(UpdateCurrentWallpaper(wallpaper)).joinBlocking()
+        appStore.waitUntilIdle()
+
+        coVerify { observer.loadWallpaper(any()) }
+        coVerify { observer.applyCurrentWallpaper() }
+    }
+
+    @Test
+    fun `GIVEN a certain wallpaper is chosen WHEN the state updated with another wallpaper THEN avoid loading it`() = runTestOnMain {
+        val appStore = AppStore()
+        val settings: Settings = mockk { every { currentWallpaperName } returns "Test" }
+        val otherWallpaper: Wallpaper = mockk { every { name } returns "Other" }
+        val observer = spyk(
+            getObserver(appStore, settings, mockk(relaxed = true), mockk(relaxed = true)),
+        )
+
+        // Ignore the call on the real instance and call again "observeWallpaperUpdates"
+        // on the spy to be able to verify the "showWallpaper" call in the spy.
+        observer.observeWallpaperUpdates()
+        appStore.dispatch(UpdateCurrentWallpaper(otherWallpaper)).joinBlocking()
+        appStore.waitUntilIdle()
+
+        coVerify(exactly = 0) { observer.loadWallpaper(any()) }
+        coVerify(exactly = 0) { observer.applyCurrentWallpaper() }
+    }
+
+    @Test
+    fun `GIVEN a wallpaper is SHOWN WHEN the wallpaper is updated to the current one THEN don't try showing the same wallpaper again`() {
+        val appStore = AppStore()
+        val settings: Settings = mockk { every { currentWallpaperName } returns "Test" }
+        val wallpaper: Wallpaper = mockk { every { name } returns "Test" }
+        val wallpapersUseCases: WallpapersUseCases = mockk { coEvery { loadBitmap(any()) } returns null }
+        val observer = spyk(getObserver(appStore, settings, wallpapersUseCases, mockk(relaxed = true))) {
+            coEvery { loadWallpaper(any()) } just Runs
+            coEvery { applyCurrentWallpaper() } just Runs
         }
 
-        observer.applyCurrentWallpaper()
+        // Ignore the call on the real instance and call again "observeWallpaperUpdates"
+        // on the spy to be able to verify the "showWallpaper" call in the spy.
+        observer.observeWallpaperUpdates()
+        appStore.dispatch(UpdateCurrentWallpaper(wallpaper)).joinBlocking()
+        appStore.waitUntilIdle()
+        coVerify(exactly = 1) { observer.loadWallpaper(any()) }
+        coVerify(exactly = 1) { observer.applyCurrentWallpaper() }
 
-        verify { observer.showWallpaper(any()) }
+        appStore.dispatch(UpdateCurrentWallpaper(wallpaper)).joinBlocking()
+        appStore.waitUntilIdle()
+        coVerify(exactly = 1) { observer.loadWallpaper(any()) }
+        coVerify(exactly = 1) { observer.applyCurrentWallpaper() }
     }
 
     @Test
     fun `GIVEN the store was observed for updates WHEN the lifecycle owner is destroyed THEN stop observing the store`() {
-        val observer = WallpapersObserver(mockk(relaxed = true), mockk(), mockk())
+        val observer = getObserver(mockk(relaxed = true))
         observer.observeWallpapersStoreSubscription = mockk(relaxed = true)
         observer.wallpapersScope = mockk {
             every { cancel() } just Runs
@@ -68,116 +128,65 @@ class WallpapersObserverTest {
     }
 
     @Test
-    fun `WHEN the wallpaper is updated THEN show the wallpaper`() {
-        val appStore = AppStore()
-        val observer = spyk(WallpapersObserver(appStore, mockk(relaxed = true), mockk(relaxed = true))) {
-            every { showWallpaper(any()) } just Runs
-        }
+    fun `GIVEN a wallpaper image is available WHEN asked to apply the current wallpaper THEN show set it to the wallpaper ImageView`() = runTestOnMain {
+        val imageView: ImageView = mockk(relaxed = true)
+        val observer = getObserver(wallpaperImageView = imageView)
+        val image: Bitmap = mockk()
+        observer.currentWallpaperImage = image
+        observer.isWallpaperLoaded.complete(Unit)
 
-        // Ignore the call on the real instance and call again "observeWallpaperUpdates"
-        // on the spy to be able to verify the "showWallpaper" call in the spy.
-        observer.observeWallpaperUpdates()
+        observer.applyCurrentWallpaper()
 
-        val newWallpaper: Wallpaper = mockk(relaxed = true)
-        appStore.dispatch(UpdateCurrentWallpaper(newWallpaper))
-        appStore.waitUntilIdle()
-        verify { observer.showWallpaper(newWallpaper) }
+        verify { imageView.setImageBitmap(image) }
+        verify { imageView.isVisible = true }
+    }
+
+    fun `GIVEN no wallpaper image is available WHEN asked to apply the current wallpaper THEN hide the wallpaper ImageView`() = runTestOnMain {
+        val imageView: ImageView = mockk()
+        val observer = getObserver(wallpaperImageView = imageView)
+        observer.isWallpaperLoaded.complete(Unit)
+
+        observer.applyCurrentWallpaper()
+
+        verify { imageView.isVisible = false }
+        verify(exactly = 0) { imageView.setImageBitmap(any()) }
     }
 
     @Test
-    @Ignore("Intermittent test: https://github.com/mozilla-mobile/fenix/issues/26760")
-    fun `WHEN the wallpaper is updated to a new one THEN show the wallpaper`() {
-        val appStore = AppStore()
-        val wallpapersUseCases: WallpapersUseCases = mockk {
-            coEvery { loadBitmap(any()) } returns null
-        }
-        val observer = spyk(WallpapersObserver(appStore, wallpapersUseCases, mockk(relaxed = true))) {
-            every { showWallpaper(any()) } just Runs
-        }
+    fun `GIVEN the default wallpaper WHEN asked to load it THEN cache that the current image is null`() = runTestOnMain {
+        val observer = getObserver()
+        observer.currentWallpaperImage = mockk()
 
-        // Ignore the call on the real instance and call again "observeWallpaperUpdates"
-        // on the spy to be able to verify the "showWallpaper" call in the spy.
-        observer.observeWallpaperUpdates()
-        verify { observer.showWallpaper(Wallpaper.Default) }
+        observer.loadWallpaper(Wallpaper.Default)
 
-        val wallpaper: Wallpaper = mockk(relaxed = true)
-        appStore.dispatch(UpdateCurrentWallpaper(wallpaper))
-        appStore.waitUntilIdle()
-        verify { observer.showWallpaper(wallpaper) }
+        assertNull(observer.currentWallpaperImage)
     }
 
     @Test
-    fun `WHEN the wallpaper is updated to the current one THEN don't try showing the same wallpaper again`() {
-        val appStore = AppStore()
-        val wallpapersUseCases: WallpapersUseCases = mockk {
-            coEvery { loadBitmap(any()) } returns null
-        }
-        val observer = spyk(WallpapersObserver(appStore, wallpapersUseCases, mockk(relaxed = true))) {
-            every { showWallpaper(any()) } just Runs
-        }
-        // Ignore the call on the real instance and call again "observeWallpaperUpdates"
-        // on the spy to be able to verify the "showWallpaper" call in the spy.
-        observer.observeWallpaperUpdates()
-
-        val wallpaper: Wallpaper = mockk(relaxed = true)
-        appStore.dispatch(UpdateCurrentWallpaper(wallpaper))
-        appStore.waitUntilIdle()
-        verify { observer.showWallpaper(wallpaper) }
-
-        appStore.dispatch(UpdateCurrentWallpaper(wallpaper))
-        appStore.waitUntilIdle()
-        verify(exactly = 1) { observer.showWallpaper(wallpaper) }
-    }
-
-    @Test
-    fun `GIVEN no wallpaper is provided WHEN asked to show the wallpaper THEN show the current one`() {
-        val wallpaper: Wallpaper = mockk()
-        val appStore: AppStore = mockk(relaxed = true) {
-            every { state.wallpaperState.currentWallpaper } returns wallpaper
-        }
-        val observer = spyk(WallpapersObserver(appStore, mockk(relaxed = true), mockk(relaxed = true)))
-
-        observer.showWallpaper()
-
-        verify { observer.showWallpaper(wallpaper) }
-    }
-
-    fun `GiVEN the current wallpaper is the default one WHEN showing it THEN hide the wallpaper view`() {
-        val wallpapersUseCases: WallpapersUseCases = mockk()
-        val wallpaperView: ImageView = mockk(relaxed = true)
-        val observer = WallpapersObserver(mockk(relaxed = true), wallpapersUseCases, wallpaperView)
-
-        observer.showWallpaper(Wallpaper.Default)
-
-        verify { wallpaperView.isVisible = false }
-        verify { wallpapersUseCases wasNot Called }
-    }
-
-    @Test
-    fun `GiVEN the current wallpaper is different than the default one WHEN showing it THEN load it's bitmap in the visible wallpaper view`() {
-        val wallpaper: Wallpaper = mockk()
+    fun `GIVEN a custom wallpaper WHEN asked to load it THEN cache it's bitmap`() = runTestOnMain {
         val bitmap: Bitmap = mockk()
-        val wallpapersUseCases: WallpapersUseCases = mockk {
-            coEvery { loadBitmap(any()) } returns bitmap
+        val wallpaper: Wallpaper = mockk()
+        val usecases: WallpapersUseCases = mockk {
+            coEvery { loadBitmap(wallpaper) } returns bitmap
         }
-        val wallpaperView: ImageView = mockk(relaxed = true)
-        val observer = WallpapersObserver(mockk(relaxed = true), wallpapersUseCases, wallpaperView)
+        val observer = getObserver(wallpapersUseCases = usecases)
 
-        observer.showWallpaper(wallpaper)
+        observer.loadWallpaper(wallpaper)
 
-        verify { wallpaperView.isVisible = true }
-        verify { wallpaperView.setImageBitmap(bitmap) }
+        assertEquals(bitmap, observer.currentWallpaperImage)
     }
 
-    @Test
-    fun `GIVEN the observer THEN use the main thread for showing the wallpaper`() {
-        val wallpapersUseCases: WallpapersUseCases = mockk()
-        val wallpaperView: ImageView = mockk(relaxed = true)
-
-        val observer = WallpapersObserver(mockk(relaxed = true), wallpapersUseCases, wallpaperView)
-
-        // Check that the context that would be used is Dispatchers.Main.immediate
-        // Unfortunately I could not also test that this is actually used when "showWallpaper" is called.
-        assertTrue(observer.wallpapersScope.toString().contains("Dispatchers.Main.immediate"))
-    }
+    private fun getObserver(
+        appStore: AppStore = mockk(relaxed = true),
+        settings: Settings = mockk(),
+        wallpapersUseCases: WallpapersUseCases = mockk(),
+        wallpaperImageView: ImageView = mockk(),
+        backgroundWorkDispatcher: CoroutineDispatcher = coroutinesTestRule.testDispatcher,
+    ) = WallpapersObserver(
+        appStore = appStore,
+        settings = settings,
+        wallpapersUseCases = wallpapersUseCases,
+        wallpaperImageView = wallpaperImageView,
+        backgroundWorkDispatcher = backgroundWorkDispatcher,
+    )
 }


### PR DESCRIPTION
This continues the work from https://github.com/mozilla-mobile/fenix/pull/26794
and refactors the check for the wallpaper chosen by the user to only a check
that a wallpaper is set in `AppState`.

Result:


https://user-images.githubusercontent.com/11428869/189669752-2d207e96-797b-4585-883b-0d22afd70aa1.mp4



&nbsp;

----

##### 3rd commit would help with the issue from https://github.com/mozilla-mobile/fenix/issues/26914:
Previously we were waiting until the AppState is updated with the wallpaper
previously chosen by the user (option persisted in SharedPreferences).
It is possible though that the previously chosen wallpaper has expired (or for
other reasons it is unavailable) in which case the AppState will be updated
with the default wallpaper while in SharedPreferences we still keep the name of
unavailable wallpapers.

---

##### 4th commit would help avoid an issue with multiple layout change listeners for the wallpaper image

In the scenario of setting the wallpaper from both the observer and the
fragment there would be two layout listeners set for scaling the bitmap with
only the first being used immediately and the second being left to observe
future changes as when the keyboard is shown moment at which it would trigger
an unexpected wallpaper scaling.
By avoiding the apply the wallpaper from the observer and only applying it from
HomeFragment there will be only one layout change listener and so the above
issue will also be avoided.


https://user-images.githubusercontent.com/11428869/189669124-ee332076-75ae-49ea-bac3-55e4bbeeb34a.mp4






### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
Fixes #26511