### PR TITLE
For #26910: Enable TCP for all modes

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/TrackingProtectionPolicyFactory.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/TrackingProtectionPolicyFactory.kt
@@ -5,8 +5,10 @@
 package org.mozilla.fenix.components
 
 import android.content.res.Resources
+import androidx.annotation.VisibleForTesting
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy
 import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicy.CookiePolicy
+import mozilla.components.concept.engine.EngineSession.TrackingProtectionPolicyForSessionTypes
 import org.mozilla.fenix.R
 import org.mozilla.fenix.utils.Settings
 
@@ -40,9 +42,9 @@ class TrackingProtectionPolicyFactory(
             }
 
         return when {
-            normalMode && privateMode -> trackingProtectionPolicy
-            normalMode && !privateMode -> trackingProtectionPolicy.forRegularSessionsOnly()
-            !normalMode && privateMode -> trackingProtectionPolicy.forPrivateSessionsOnly()
+            normalMode && privateMode -> trackingProtectionPolicy.applyTCPIfNeeded(settings)
+            normalMode && !privateMode -> trackingProtectionPolicy.applyTCPIfNeeded(settings).forRegularSessionsOnly()
+            !normalMode && privateMode -> trackingProtectionPolicy.applyTCPIfNeeded(settings).forPrivateSessionsOnly()
             else -> TrackingProtectionPolicy.none()
         }
     }
@@ -102,4 +104,21 @@ class TrackingProtectionPolicyFactory(
     private fun getCustomCookiePurgingPolicy(): Boolean {
         return settings.blockRedirectTrackersInCustomTrackingProtection
     }
+}
+
+@VisibleForTesting
+internal fun TrackingProtectionPolicyForSessionTypes.applyTCPIfNeeded(settings: Settings):
+    TrackingProtectionPolicyForSessionTypes {
+    val updatedCookiePolicy = if (settings.enabledTotalCookieProtection) {
+        CookiePolicy.ACCEPT_FIRST_PARTY_AND_ISOLATE_OTHERS
+    } else {
+        cookiePolicy
+    }
+
+    return TrackingProtectionPolicy.select(
+        trackingCategories = trackingCategories,
+        cookiePolicy = updatedCookiePolicy,
+        strictSocialTrackingProtection = strictSocialTrackingProtection,
+        cookiePurging = cookiePurging,
+    )
 }

--- a/app/src/main/java/org/mozilla/fenix/settings/CustomEtpCookiesOptionsDropDownListPreference.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/CustomEtpCookiesOptionsDropDownListPreference.kt
@@ -34,7 +34,7 @@ class CustomEtpCookiesOptionsDropDownListPreference @JvmOverloads constructor(
             )
 
             @Suppress("UNCHECKED_CAST")
-            if (context.settings().enabledTotalCookieProtectionSetting) {
+            if (context.settings().enabledTotalCookieProtection) {
                 // If the new "Total cookie protection" should be shown it must be first item.
                 entries = arrayOf(getString(R.string.preference_enhanced_tracking_protection_custom_cookies_5)) +
                     entries as Array<String>

--- a/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionBlockingFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionBlockingFragment.kt
@@ -30,7 +30,7 @@ class TrackingProtectionBlockingFragment :
         binding = FragmentTrackingProtectionBlockingBinding.bind(view)
 
         // Text for the updated "Total cookie protection" option should be updated as part of a staged rollout
-        if (requireContext().settings().enabledTotalCookieProtectionSetting) {
+        if (requireContext().settings().enabledTotalCookieProtection) {
             binding.categoryCookies.apply {
                 trackingProtectionCategoryTitle.text = getText(R.string.etp_cookies_title_2)
                 trackingProtectionCategoryItemDescription.text = getText(R.string.etp_cookies_description_2)

--- a/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionPanelView.kt
+++ b/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionPanelView.kt
@@ -129,7 +129,7 @@ class TrackingProtectionPanelView(
         binding.notBlockingHeader.isGone = bucketedTrackers.loadedIsEmpty()
         binding.blockingHeader.isGone = bucketedTrackers.blockedIsEmpty()
 
-        if (containerView.context.settings().enabledTotalCookieProtectionSetting) {
+        if (containerView.context.settings().enabledTotalCookieProtection) {
             binding.crossSiteTracking.text = containerView.context.getString(R.string.etp_cookies_title_2)
             binding.crossSiteTrackingLoaded.text = containerView.context.getString(R.string.etp_cookies_title_2)
         }
@@ -147,7 +147,7 @@ class TrackingProtectionPanelView(
         binding.detailsMode.visibility = View.VISIBLE
 
         if (category == CROSS_SITE_TRACKING_COOKIES &&
-            containerView.context.settings().enabledTotalCookieProtectionSetting
+            containerView.context.settings().enabledTotalCookieProtection
         ) {
             binding.categoryTitle.setText(R.string.etp_cookies_title_2)
             binding.categoryDescription.setText(R.string.etp_cookies_description_2)

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -586,7 +586,7 @@ class Settings(private val appContext: Context) : PreferencesHolder {
         true,
     )
 
-    val enabledTotalCookieProtectionSetting: Boolean
+    val enabledTotalCookieProtection: Boolean
         get() = mr2022Sections[Mr2022Section.TCP_FEATURE] == true
 
     /**
@@ -599,7 +599,7 @@ class Settings(private val appContext: Context) : PreferencesHolder {
 
     val blockCookiesSelectionInCustomTrackingProtection by stringPreference(
         key = appContext.getPreferenceKey(R.string.pref_key_tracking_protection_custom_cookies_select),
-        default = if (enabledTotalCookieProtectionSetting) {
+        default = if (enabledTotalCookieProtection) {
             appContext.getString(R.string.total_protection)
         } else {
             appContext.getString(R.string.social)

--- a/app/src/test/java/org/mozilla/fenix/components/TrackingProtectionPolicyFactoryTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/TrackingProtectionPolicyFactoryTest.kt
@@ -138,6 +138,46 @@ class TrackingProtectionPolicyFactoryTest {
     }
 
     @Test
+    fun `GIVEN TCP is enabled by nimbus WHEN applyTCPIfNeeded THEN cookie policy should be TCP`() {
+        val settings: Settings = mockk(relaxed = true)
+        every { settings.enabledTotalCookieProtection } returns true
+
+        val policies = arrayOf(
+            TrackingProtectionPolicy.strict(),
+            TrackingProtectionPolicy.recommended(),
+            TrackingProtectionPolicy.select(),
+        )
+
+        for (policy in policies) {
+            val adaptedPolicy = policy.applyTCPIfNeeded(settings)
+            assertEquals(
+                CookiePolicy.ACCEPT_FIRST_PARTY_AND_ISOLATE_OTHERS,
+                adaptedPolicy.cookiePolicy,
+            )
+        }
+    }
+
+    fun `GIVEN TCP is NOT enabled by nimbus WHEN applyTCPIfNeeded THEN reuse cookie policy`() {
+        val settings: Settings = mockk(relaxed = true)
+
+        every { settings.enabledTotalCookieProtection } returns false
+
+        val policies = arrayOf(
+            TrackingProtectionPolicy.strict(),
+            TrackingProtectionPolicy.recommended(),
+            TrackingProtectionPolicy.select(),
+        )
+
+        for (policy in policies) {
+            val adaptedPolicy = policy.applyTCPIfNeeded(settings)
+            assertEquals(
+                policy.cookiePolicy,
+                adaptedPolicy.cookiePolicy,
+            )
+        }
+    }
+
+    @Test
     fun `GIVEN custom policy WHEN cookie policy social THEN tracking policy should have cookie policy allow non-trackers`() {
         val expected = TrackingProtectionPolicy.select(
             cookiePolicy = TrackingProtectionPolicy.CookiePolicy.ACCEPT_NON_TRACKERS,
@@ -586,6 +626,7 @@ class TrackingProtectionPolicyFactoryTest {
         useCustom: Boolean = false,
         useTrackingProtection: Boolean = false,
     ): Settings = mockk {
+        every { enabledTotalCookieProtection } returns false
         every { useStrictTrackingProtection } returns useStrict
         every { useCustomTrackingProtection } returns useCustom
         every { shouldUseTrackingProtection } returns useTrackingProtection

--- a/app/src/test/java/org/mozilla/fenix/settings/CustomEtpCookiesOptionsDropDownListPreferenceTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/CustomEtpCookiesOptionsDropDownListPreferenceTest.kt
@@ -29,7 +29,7 @@ class CustomEtpCookiesOptionsDropDownListPreferenceTest {
 
         mockkStatic("org.mozilla.fenix.ext.ContextKt") {
             every { any<Context>().settings() } returns mockk {
-                every { enabledTotalCookieProtectionSetting } returns true
+                every { enabledTotalCookieProtection } returns true
             }
 
             val preference = CustomEtpCookiesOptionsDropDownListPreference(testContext)
@@ -44,7 +44,7 @@ class CustomEtpCookiesOptionsDropDownListPreferenceTest {
     fun `GIVEN total cookie protection is disabled WHEN using this preference THEN don't show the total cookie protection option`() {
         mockkStatic("org.mozilla.fenix.ext.ContextKt") {
             every { any<Context>().settings() } returns mockk {
-                every { enabledTotalCookieProtectionSetting } returns false
+                every { enabledTotalCookieProtection } returns false
             }
 
             val preference = CustomEtpCookiesOptionsDropDownListPreference(testContext)

--- a/app/src/test/java/org/mozilla/fenix/trackingprotection/TrackingProtectionBlockingFragmentTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/trackingprotection/TrackingProtectionBlockingFragmentTest.kt
@@ -28,7 +28,7 @@ class TrackingProtectionBlockingFragmentTest {
 
         mockkStatic("org.mozilla.fenix.ext.ContextKt") {
             every { any<Context>().settings() } returns mockk(relaxed = true) {
-                every { enabledTotalCookieProtectionSetting } returns true
+                every { enabledTotalCookieProtection } returns true
             }
 
             val fragment = createFragment()
@@ -46,7 +46,7 @@ class TrackingProtectionBlockingFragmentTest {
 
         mockkStatic("org.mozilla.fenix.ext.ContextKt") {
             every { any<Context>().settings() } returns mockk(relaxed = true) {
-                every { enabledTotalCookieProtectionSetting } returns false
+                every { enabledTotalCookieProtection } returns false
             }
 
             val fragment = createFragment()

--- a/app/src/test/java/org/mozilla/fenix/trackingprotection/TrackingProtectionPanelViewTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/trackingprotection/TrackingProtectionPanelViewTest.kt
@@ -74,7 +74,7 @@ class TrackingProtectionPanelViewTest {
     fun testNormalModeUiCookiesWithTotalCookieProtectionEnabled() {
         mockkStatic("org.mozilla.fenix.ext.ContextKt") {
             every { any<Context>().settings() } returns mockk {
-                every { enabledTotalCookieProtectionSetting } returns true
+                every { enabledTotalCookieProtection } returns true
             }
             val expectedTitle = testContext.getString(R.string.etp_cookies_title_2)
 
@@ -89,7 +89,7 @@ class TrackingProtectionPanelViewTest {
     fun testNormalModeUiCookiesWithTotalCookieProtectionDisabled() {
         mockkStatic("org.mozilla.fenix.ext.ContextKt") {
             every { any<Context>().settings() } returns mockk {
-                every { enabledTotalCookieProtectionSetting } returns false
+                every { enabledTotalCookieProtection } returns false
             }
             val expectedTitle = testContext.getString(R.string.etp_cookies_title)
 
@@ -130,7 +130,7 @@ class TrackingProtectionPanelViewTest {
     fun testPrivateModeUiCookiesWithTotalCookieProtectionEnabled() {
         mockkStatic("org.mozilla.fenix.ext.ContextKt") {
             every { any<Context>().settings() } returns mockk {
-                every { enabledTotalCookieProtectionSetting } returns true
+                every { enabledTotalCookieProtection } returns true
             }
             val expectedTitle = testContext.getString(R.string.etp_cookies_title_2)
             val expectedDescription = testContext.getString(R.string.etp_cookies_description_2)
@@ -153,7 +153,7 @@ class TrackingProtectionPanelViewTest {
     fun testPrivateModeUiCookiesWithTotalCookieProtectionDisabled() {
         mockkStatic("org.mozilla.fenix.ext.ContextKt") {
             every { any<Context>().settings() } returns mockk {
-                every { enabledTotalCookieProtectionSetting } returns false
+                every { enabledTotalCookieProtection } returns false
             }
             val expectedTitle = testContext.getString(R.string.etp_cookies_title)
             val expectedDescription = testContext.getString(R.string.etp_cookies_description)


### PR DESCRIPTION
Unify the TCP feature with the TCP setting allowing both to be controlled through the same Nimbus experiment.
Allow changing the default cookie policy to TCP based on the Nimbus experiment.

This mainly revert the first commit from https://github.com/mozilla-mobile/fenix/pull/26857.


https://user-images.githubusercontent.com/11428869/189679697-09b175ef-1c4e-4626-8ff2-78b39a18986a.mp4




### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
Fixes #26910