### PR TITLE
Closes #26971: fix wallpaper onboarding display condition

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
@@ -56,7 +56,7 @@ import org.mozilla.fenix.gleanplumb.MessageController
 import org.mozilla.fenix.home.HomeFragment
 import org.mozilla.fenix.home.HomeFragmentDirections
 import org.mozilla.fenix.home.Mode
-import org.mozilla.fenix.onboarding.WallpaperOnboardingDialogFragment
+import org.mozilla.fenix.onboarding.WallpaperOnboardingDialogFragment.Companion.THUMBNAILS_SELECTION_COUNT
 import org.mozilla.fenix.settings.SupportUtils
 import org.mozilla.fenix.settings.SupportUtils.SumoTopic.PRIVATE_BROWSING_MYTHS
 import org.mozilla.fenix.utils.Settings
@@ -510,16 +510,19 @@ class DefaultSessionControlController(
     }
 
     override fun handleShowWallpapersOnboardingDialog(state: WallpaperState): Boolean {
-        if (state.availableWallpapers.all { it.thumbnailFileState == Wallpaper.ImageFileState.Downloaded } &&
-            state.availableWallpapers.size >= WallpaperOnboardingDialogFragment.THUMBNAILS_COUNT
-        ) {
-            navController.nav(
-                R.id.homeFragment,
-                HomeFragmentDirections.actionGlobalWallpaperOnboardingDialog(),
-            )
-            return true
+        return state.availableWallpapers.filter { wallpaper ->
+            wallpaper.thumbnailFileState == Wallpaper.ImageFileState.Downloaded
+        }.size.let { downloadedCount ->
+            // We only display the dialog if enough thumbnails have been downloaded for it.
+            downloadedCount >= THUMBNAILS_SELECTION_COUNT
+        }.also { showOnboarding ->
+            if (showOnboarding) {
+                navController.nav(
+                    R.id.homeFragment,
+                    HomeFragmentDirections.actionGlobalWallpaperOnboardingDialog(),
+                )
+            }
         }
-        return false
     }
 
     override fun handleReadPrivacyNoticeClicked() {

--- a/app/src/main/java/org/mozilla/fenix/onboarding/WallpaperOnboardingDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/onboarding/WallpaperOnboardingDialogFragment.kt
@@ -82,7 +82,7 @@ class WallpaperOnboardingDialogFragment : BottomSheetDialogFragment() {
         setContent {
             FirefoxTheme {
                 val wallpapers = appStore.observeAsComposableState { state ->
-                    state.wallpaperState.availableWallpapers.take(THUMBNAILS_COUNT)
+                    state.wallpaperState.availableWallpapers.take(THUMBNAILS_SELECTION_COUNT)
                 }.value ?: listOf()
                 val currentWallpaper = appStore.observeAsComposableState { state ->
                     state.wallpaperState.currentWallpaper
@@ -127,6 +127,6 @@ class WallpaperOnboardingDialogFragment : BottomSheetDialogFragment() {
     }
 
     companion object {
-        const val THUMBNAILS_COUNT = 6
+        const val THUMBNAILS_SELECTION_COUNT = 6
     }
 }


### PR DESCRIPTION
Closes #26971

Currently one of the thumbnails can not be loaded, and it breaks showing the wallpaper onboarding condition.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.










### GitHub Automation
Fixes #26971