### PR TITLE
Closes #26973: adjust wallpaper onboarding ui

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/wallpapers/WallpaperOnboarding.kt
+++ b/app/src/main/java/org/mozilla/fenix/wallpapers/WallpaperOnboarding.kt
@@ -55,10 +55,10 @@ fun WallpaperOnboarding(
 ) {
     Surface(
         color = FirefoxTheme.colors.layer2,
-        shape = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp),
+        shape = RoundedCornerShape(topStart = 8.dp, topEnd = 8.dp),
     ) {
         Column(
-            modifier = Modifier.padding(16.dp),
+            modifier = Modifier.padding(horizontal = 32.dp, vertical = 16.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Icon(
@@ -117,8 +117,6 @@ fun WallpaperOnboarding(
                     style = FirefoxTheme.typography.button,
                 )
             }
-
-            Spacer(modifier = Modifier.height(12.dp))
         }
     }
 }

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -566,7 +566,7 @@
     <style name="HomeOnboardingDialogStyle" parent="DialogStyleBase"/>
     <style name="WallpaperOnboardingDialogStyle" parent="DialogStyleBase">
         <item name="android:windowIsFloating">true</item>
-        <item name="android:backgroundDimAmount">0.02</item>
+        <item name="android:backgroundDimAmount">0.06</item>
     </style>
     <style name="CreateShortcutDialogButton" parent="Widget.MaterialComponents.Button.TextButton.Dialog">
         <item name="android:layout_width">wrap_content</item>


### PR DESCRIPTION
Adjusting wallpaper onboarding ui.

[device-2022-09-13-193226.webm](https://user-images.githubusercontent.com/92760693/190045458-3febfad2-d23b-465f-8d11-42e02fdc73bc.webm)

[device-2022-09-14-113053.webm](https://user-images.githubusercontent.com/92760693/190234359-5f06dfd4-d68e-4cdd-9fe0-c5c0e8367b07.webm)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.











### GitHub Automation
Fixes #26973