### PR TITLE
For #26784 refactor use of idling resources in UI tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/TestHelper.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/TestHelper.kt
@@ -24,6 +24,7 @@ import androidx.browser.customtabs.CustomTabsIntent
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.IdlingRegistry
+import androidx.test.espresso.IdlingResource
 import androidx.test.espresso.action.ViewActions.longClick
 import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.intent.Intents.intended
@@ -42,8 +43,6 @@ import androidx.test.uiautomator.UiObjectNotFoundException
 import androidx.test.uiautomator.UiScrollable
 import androidx.test.uiautomator.UiSelector
 import androidx.test.uiautomator.Until
-import java.util.Locale
-import java.util.regex.Pattern
 import junit.framework.AssertionFailedError
 import mozilla.components.browser.state.search.SearchEngine
 import mozilla.components.support.ktx.android.content.appName
@@ -64,6 +63,8 @@ import org.mozilla.fenix.helpers.idlingresource.NetworkConnectionIdlingResource
 import org.mozilla.fenix.ui.robots.BrowserRobot
 import org.mozilla.fenix.utils.IntentUtils
 import org.mozilla.gecko.util.ThreadUtils
+import java.util.Locale
+import java.util.regex.Pattern
 
 object TestHelper {
 
@@ -281,6 +282,29 @@ object TestHelper {
         mDevice.waitForIdle(waitingTimeShort)
 
         return activityManager.appTasks[0].taskInfo.topActivity!!.className == ExternalAppBrowserActivity::class.java.name
+    }
+
+    /**
+     * Run test with automatically registering idling resources and cleanup.
+     *
+     * @param idlingResources zero or more [IdlingResource] to be used when running [testBlock].
+     * @param testBlock test code to execute.
+     */
+    fun registerAndCleanupIdlingResources(
+        vararg idlingResources: IdlingResource,
+        testBlock: () -> Unit,
+    ) {
+        idlingResources.forEach {
+            IdlingRegistry.getInstance().register(it)
+        }
+
+        try {
+            testBlock()
+        } finally {
+            idlingResources.forEach {
+                IdlingRegistry.getInstance().unregister(it)
+            }
+        }
     }
 
     // exit from Menus to home screen or browser

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
@@ -5,7 +5,6 @@
 package org.mozilla.fenix.ui
 
 import androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu
-import androidx.test.espresso.IdlingRegistry
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import androidx.test.uiautomator.UiDevice
@@ -28,6 +27,7 @@ import org.mozilla.fenix.helpers.RetryTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.helpers.TestHelper
 import org.mozilla.fenix.helpers.TestHelper.longTapSelectItem
+import org.mozilla.fenix.helpers.TestHelper.registerAndCleanupIdlingResources
 import org.mozilla.fenix.ui.robots.bookmarksMenu
 import org.mozilla.fenix.ui.robots.browserScreen
 import org.mozilla.fenix.ui.robots.homeScreen
@@ -47,7 +47,6 @@ class BookmarksTest {
         var title: String = "Bookmark title"
         var url: String = "https://www.test.com"
     }
-    private var bookmarksListIdlingResource: RecyclerViewIdlingResource? = null
 
     @get:Rule
     val activityTestRule = HomeActivityTestRule()
@@ -77,10 +76,6 @@ class BookmarksTest {
             val bookmarks = bookmarksStorage?.getTree(BookmarkRoot.Mobile.id)?.children
             bookmarks?.forEach { bookmarksStorage.deleteNode(it.guid) }
         }
-
-        if (bookmarksListIdlingResource != null) {
-            IdlingRegistry.getInstance().unregister(bookmarksListIdlingResource!!)
-        }
     }
 
     @Test
@@ -88,17 +83,14 @@ class BookmarksTest {
         homeScreen {
         }.openThreeDotMenu {
         }.openBookmarks {
-            bookmarksListIdlingResource =
-                RecyclerViewIdlingResource(
-                    activityTestRule.activity.findViewById(R.id.bookmark_list),
-                    1,
-                )
-            IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
-
-            verifyBookmarksMenuView()
-            verifyAddFolderButton()
-            verifyCloseButton()
-            verifyBookmarkTitle("Desktop Bookmarks")
+            registerAndCleanupIdlingResources(
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 1),
+            ) {
+                verifyBookmarksMenuView()
+                verifyAddFolderButton()
+                verifyCloseButton()
+                verifyBookmarkTitle("Desktop Bookmarks")
+            }
         }
     }
 
@@ -107,15 +99,15 @@ class BookmarksTest {
         homeScreen {
         }.openThreeDotMenu {
         }.openBookmarks {
-            bookmarksListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 1)
-            IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
-
-            selectFolder("Desktop Bookmarks")
-            verifyFolderTitle("Bookmarks Menu")
-            verifyFolderTitle("Bookmarks Toolbar")
-            verifyFolderTitle("Other Bookmarks")
-            verifySignInToSyncButton()
+            registerAndCleanupIdlingResources(
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 1),
+            ) {
+                selectFolder("Desktop Bookmarks")
+                verifyFolderTitle("Bookmarks Menu")
+                verifyFolderTitle("Bookmarks Toolbar")
+                verifyFolderTitle("Other Bookmarks")
+                verifySignInToSyncButton()
+            }
         }.clickSingInToSyncButton {
             verifyTurnOnSyncToolbarTitle()
         }
@@ -142,12 +134,12 @@ class BookmarksTest {
             createBookmark(defaultWebPage.url)
         }.openThreeDotMenu {
         }.openBookmarks {
-            bookmarksListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 2)
-            IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
-
-            verifyBookmarkedURL(defaultWebPage.url.toString())
-            verifyBookmarkFavicon(defaultWebPage.url)
+            registerAndCleanupIdlingResources(
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 2),
+            ) {
+                verifyBookmarkedURL(defaultWebPage.url.toString())
+                verifyBookmarkFavicon(defaultWebPage.url)
+            }
         }
     }
 
@@ -156,16 +148,16 @@ class BookmarksTest {
         homeScreen {
         }.openThreeDotMenu {
         }.openBookmarks {
-            bookmarksListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 1)
-            IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
-
-            clickAddFolderButton()
-            verifyKeyboardVisible()
-            addNewFolderName(bookmarksFolderName)
-            saveNewFolder()
-            verifyFolderTitle(bookmarksFolderName)
-            verifyKeyboardHidden()
+            registerAndCleanupIdlingResources(
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 1),
+            ) {
+                clickAddFolderButton()
+                verifyKeyboardVisible()
+                addNewFolderName(bookmarksFolderName)
+                saveNewFolder()
+                verifyFolderTitle(bookmarksFolderName)
+                verifyKeyboardHidden()
+            }
         }
     }
 
@@ -191,9 +183,9 @@ class BookmarksTest {
             createBookmark(defaultWebPage.url)
         }.openThreeDotMenu {
         }.openBookmarks {
-            bookmarksListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 2)
-            IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
+            registerAndCleanupIdlingResources(
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 2),
+            ) {}
         }.openThreeDotMenu(defaultWebPage.url) {
         }.clickEdit {
             verifyEditBookmarksView()
@@ -217,9 +209,9 @@ class BookmarksTest {
             createBookmark(defaultWebPage.url)
         }.openThreeDotMenu {
         }.openBookmarks {
-            bookmarksListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 2)
-            IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
+            registerAndCleanupIdlingResources(
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 2),
+            ) {}
         }.openThreeDotMenu(defaultWebPage.url) {
         }.clickCopy {
             verifyCopySnackBarText()
@@ -243,9 +235,9 @@ class BookmarksTest {
             createBookmark(defaultWebPage.url)
         }.openThreeDotMenu {
         }.openBookmarks {
-            bookmarksListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 2)
-            IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
+            registerAndCleanupIdlingResources(
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 2),
+            ) {}
         }.openThreeDotMenu(defaultWebPage.url) {
         }.clickShare {
             verifyShareOverlay()
@@ -263,9 +255,9 @@ class BookmarksTest {
             createBookmark(defaultWebPage.url)
         }.openThreeDotMenu {
         }.openBookmarks {
-            bookmarksListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 2)
-            IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
+            registerAndCleanupIdlingResources(
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 2),
+            ) {}
         }.openThreeDotMenu(defaultWebPage.url) {
         }.clickOpenInNewTab {
             verifyTabTrayIsOpened()
@@ -281,9 +273,9 @@ class BookmarksTest {
             createBookmark(defaultWebPage.url)
         }.openThreeDotMenu {
         }.openBookmarks {
-            bookmarksListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 2)
-            IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
+            registerAndCleanupIdlingResources(
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 2),
+            ) {}
         }.openThreeDotMenu(defaultWebPage.url) {
         }.clickOpenInPrivateTab {
             verifyTabTrayIsOpened()
@@ -300,11 +292,10 @@ class BookmarksTest {
             createBookmark(defaultWebPage.url)
         }.openThreeDotMenu {
         }.openBookmarks {
-            bookmarksListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 2)
-            IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
+            registerAndCleanupIdlingResources(
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 2),
+            ) {}
         }.openThreeDotMenu(defaultWebPage.url) {
-            IdlingRegistry.getInstance().unregister(bookmarksListIdlingResource!!)
         }.clickDelete {
             verifyDeleteSnackBarText()
             verifyUndoDeleteSnackBarButton()
@@ -320,19 +311,19 @@ class BookmarksTest {
             createBookmark(defaultWebPage.url)
         }.openThreeDotMenu {
         }.openBookmarks {
-            bookmarksListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 2)
-            IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
+            registerAndCleanupIdlingResources(
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 2),
+            ) {}
         }.openThreeDotMenu(defaultWebPage.url) {
-            IdlingRegistry.getInstance().unregister(bookmarksListIdlingResource!!)
         }.clickDelete {
             verifyUndoDeleteSnackBarButton()
             clickUndoDeleteButton()
             verifySnackBarHidden()
-            bookmarksListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 2)
-            IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
-            verifyBookmarkedURL(defaultWebPage.url.toString())
+            registerAndCleanupIdlingResources(
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 2),
+            ) {
+                verifyBookmarkedURL(defaultWebPage.url.toString())
+            }
         }
     }
 
@@ -345,11 +336,11 @@ class BookmarksTest {
             createBookmark(defaultWebPage.url)
         }.openThreeDotMenu {
         }.openBookmarks {
-            bookmarksListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 2)
-            IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
-
-            longTapSelectItem(defaultWebPage.url)
+            registerAndCleanupIdlingResources(
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 2),
+            ) {
+                longTapSelectItem(defaultWebPage.url)
+            }
         }
 
         multipleSelectionToolbar {
@@ -379,12 +370,12 @@ class BookmarksTest {
         homeScreen {
         }.openThreeDotMenu {
         }.openBookmarks {
-            bookmarksListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 2)
-            IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
-
-            longTapSelectItem(defaultWebPage.url)
-            openActionBarOverflowOrOptionsMenu(activityTestRule.activity)
+            registerAndCleanupIdlingResources(
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 2),
+            ) {
+                longTapSelectItem(defaultWebPage.url)
+                openActionBarOverflowOrOptionsMenu(activityTestRule.activity)
+            }
         }
 
         multipleSelectionToolbar {
@@ -404,12 +395,12 @@ class BookmarksTest {
             createBookmark(defaultWebPage.url)
         }.openThreeDotMenu {
         }.openBookmarks {
-            bookmarksListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 2)
-            IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
-
-            longTapSelectItem(defaultWebPage.url)
-            openActionBarOverflowOrOptionsMenu(activityTestRule.activity)
+            registerAndCleanupIdlingResources(
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 2),
+            ) {
+                longTapSelectItem(defaultWebPage.url)
+                openActionBarOverflowOrOptionsMenu(activityTestRule.activity)
+            }
         }
 
         multipleSelectionToolbar {
@@ -430,13 +421,12 @@ class BookmarksTest {
             createBookmark(secondWebPage.url)
         }.openThreeDotMenu {
         }.openBookmarks {
-            bookmarksListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 3)
-            IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
-
-            longTapSelectItem(firstWebPage.url)
-            longTapSelectItem(secondWebPage.url)
-            IdlingRegistry.getInstance().unregister(bookmarksListIdlingResource!!)
+            registerAndCleanupIdlingResources(
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 3),
+            ) {
+                longTapSelectItem(firstWebPage.url)
+                longTapSelectItem(secondWebPage.url)
+            }
             openActionBarOverflowOrOptionsMenu(activityTestRule.activity)
         }
 
@@ -460,13 +450,12 @@ class BookmarksTest {
             createBookmark(secondWebPage.url)
         }.openThreeDotMenu {
         }.openBookmarks {
-            bookmarksListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 3)
-            IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
-
-            longTapSelectItem(firstWebPage.url)
-            longTapSelectItem(secondWebPage.url)
-            IdlingRegistry.getInstance().unregister(bookmarksListIdlingResource!!)
+            registerAndCleanupIdlingResources(
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 3),
+            ) {
+                longTapSelectItem(firstWebPage.url)
+                longTapSelectItem(secondWebPage.url)
+            }
             openActionBarOverflowOrOptionsMenu(activityTestRule.activity)
         }
 
@@ -490,11 +479,11 @@ class BookmarksTest {
             createBookmark(defaultWebPage.url)
         }.openThreeDotMenu {
         }.openBookmarks {
-            bookmarksListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 2)
-            IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
-
-            longTapSelectItem(defaultWebPage.url)
+            registerAndCleanupIdlingResources(
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 2),
+            ) {
+                longTapSelectItem(defaultWebPage.url)
+            }
         }
 
         multipleSelectionToolbar {
@@ -549,27 +538,19 @@ class BookmarksTest {
             createBookmark(defaultWebPage.url)
         }.openThreeDotMenu {
         }.openBookmarks {
-            bookmarksListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 2)
-            IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
-
-            createFolder(bookmarksFolderName)
-
-            IdlingRegistry.getInstance().unregister(bookmarksListIdlingResource!!)
-
+            registerAndCleanupIdlingResources(
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 2),
+            ) {
+                createFolder(bookmarksFolderName)
+            }
         }.openThreeDotMenu(defaultWebPage.title) {
         }.clickEdit {
             clickParentFolderSelector()
             selectFolder(bookmarksFolderName)
             navigateUp()
             saveEditBookmark()
-
-            IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
-
             selectFolder(bookmarksFolderName)
             verifyBookmarkedURL(defaultWebPage.url.toString())
-
-            IdlingRegistry.getInstance().unregister(bookmarksListIdlingResource!!)
         }
     }
 
@@ -601,12 +582,12 @@ class BookmarksTest {
         homeScreen {
         }.openThreeDotMenu {
         }.openBookmarks {
-            bookmarksListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list))
-            IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
-
-            longTapDesktopFolder("Desktop Bookmarks")
-            verifySelectDefaultFolderSnackBarText()
+            registerAndCleanupIdlingResources(
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list)),
+            ) {
+                longTapDesktopFolder("Desktop Bookmarks")
+                verifySelectDefaultFolderSnackBarText()
+            }
         }
     }
 
@@ -628,11 +609,10 @@ class BookmarksTest {
             createBookmark(defaultWebPage.url)
         }.openThreeDotMenu {
         }.openBookmarks {
-            bookmarksListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 2)
-            IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
+            registerAndCleanupIdlingResources(
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 2),
+            ) {}
         }.openThreeDotMenu(defaultWebPage.url) {
-            IdlingRegistry.getInstance().unregister(bookmarksListIdlingResource!!)
         }.clickEdit {
             clickDeleteInEditModeButton()
             cancelDeletion()
@@ -649,12 +629,12 @@ class BookmarksTest {
         browserScreen {
         }.openThreeDotMenu {
         }.openBookmarks {
-            bookmarksListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 1)
-            IdlingRegistry.getInstance().register(bookmarksListIdlingResource!!)
-            createFolder("My Folder")
-            verifyFolderTitle("My Folder")
-            IdlingRegistry.getInstance().unregister(bookmarksListIdlingResource!!)
+            registerAndCleanupIdlingResources(
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.bookmark_list), 1),
+            ) {
+                createFolder("My Folder")
+                verifyFolderTitle("My Folder")
+            }
         }.openThreeDotMenu("My Folder") {
         }.clickDelete {
             cancelFolderDeletion()

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/HistoryTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/HistoryTest.kt
@@ -6,7 +6,6 @@ package org.mozilla.fenix.ui
 
 import android.content.Context
 import androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu
-import androidx.test.espresso.IdlingRegistry
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import kotlinx.coroutines.runBlocking
@@ -25,6 +24,7 @@ import org.mozilla.fenix.helpers.HomeActivityTestRule
 import org.mozilla.fenix.helpers.RecyclerViewIdlingResource
 import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.helpers.TestHelper.longTapSelectItem
+import org.mozilla.fenix.helpers.TestHelper.registerAndCleanupIdlingResources
 import org.mozilla.fenix.ui.robots.historyMenu
 import org.mozilla.fenix.ui.robots.homeScreen
 import org.mozilla.fenix.ui.robots.multipleSelectionToolbar
@@ -38,8 +38,6 @@ class HistoryTest {
     /* ktlint-disable no-blank-line-before-rbrace */ // This imposes unreadable grouping.
     private lateinit var mockWebServer: MockWebServer
     private lateinit var mDevice: UiDevice
-    private var historyListIdlingResource: RecyclerViewIdlingResource? = null
-    private var recentlyClosedTabsListIdlingResource: RecyclerViewIdlingResource? = null
 
     @get:Rule
     val activityTestRule = HomeActivityTestRule()
@@ -69,14 +67,6 @@ class HistoryTest {
         runBlocking {
             historyStorage.deleteEverything()
         }
-
-        if (historyListIdlingResource != null) {
-            IdlingRegistry.getInstance().unregister(historyListIdlingResource!!)
-        }
-
-        if (recentlyClosedTabsListIdlingResource != null) {
-            IdlingRegistry.getInstance().unregister(recentlyClosedTabsListIdlingResource!!)
-        }
     }
 
     @Test
@@ -102,13 +92,14 @@ class HistoryTest {
         }.openThreeDotMenu {
         }.openHistory {
             verifyHistoryListExists()
-            historyListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.history_list), 1)
-            IdlingRegistry.getInstance().register(historyListIdlingResource!!)
-            verifyHistoryMenuView()
-            verifyVisitedTimeTitle()
-            verifyFirstTestPageTitle("Test_Page_1")
-            verifyTestPageUrl(firstWebPage.url)
+            registerAndCleanupIdlingResources(
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.history_list), 1),
+            ) {
+                verifyHistoryMenuView()
+                verifyVisitedTimeTitle()
+                verifyFirstTestPageTitle("Test_Page_1")
+                verifyTestPageUrl(firstWebPage.url)
+            }
         }
     }
 
@@ -122,11 +113,11 @@ class HistoryTest {
         }.openThreeDotMenu {
         }.openHistory {
             verifyHistoryListExists()
-            historyListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.history_list), 1)
-            IdlingRegistry.getInstance().register(historyListIdlingResource!!)
-            clickDeleteHistoryButton(firstWebPage.url.toString())
-            IdlingRegistry.getInstance().unregister(historyListIdlingResource!!)
+            registerAndCleanupIdlingResources(
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.history_list), 1),
+            ) {
+                clickDeleteHistoryButton(firstWebPage.url.toString())
+            }
             verifyDeleteSnackbarText("Deleted")
             verifyEmptyHistoryView()
         }
@@ -142,11 +133,11 @@ class HistoryTest {
         }.openThreeDotMenu {
         }.openHistory {
             verifyHistoryListExists()
-            historyListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.history_list), 1)
-            IdlingRegistry.getInstance().register(historyListIdlingResource!!)
-            clickDeleteHistoryButton(firstWebPage.url.toString())
-            IdlingRegistry.getInstance().unregister(historyListIdlingResource!!)
+            registerAndCleanupIdlingResources(
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.history_list), 1),
+            ) {
+                clickDeleteHistoryButton(firstWebPage.url.toString())
+            }
             verifyUndoDeleteSnackBarButton()
             clickUndoDeleteButton()
             verifyHistoryItemExists(true, firstWebPage.url.toString())
@@ -164,11 +155,12 @@ class HistoryTest {
         }.openThreeDotMenu {
         }.openHistory {
             verifyHistoryListExists()
-            historyListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.history_list), 1)
-            IdlingRegistry.getInstance().register(historyListIdlingResource!!)
-            clickDeleteAllHistoryButton()
-            IdlingRegistry.getInstance().unregister(historyListIdlingResource!!)
+            registerAndCleanupIdlingResources(
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.history_list), 1),
+            ) {
+                clickDeleteAllHistoryButton()
+
+            }
             verifyDeleteConfirmationMessage()
             selectEverythingOption()
             cancelDeleteHistory()
@@ -187,11 +179,11 @@ class HistoryTest {
         }.openThreeDotMenu {
         }.openHistory {
             verifyHistoryListExists()
-            historyListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.history_list), 1)
-            IdlingRegistry.getInstance().register(historyListIdlingResource!!)
-            clickDeleteAllHistoryButton()
-            IdlingRegistry.getInstance().unregister(historyListIdlingResource!!)
+            registerAndCleanupIdlingResources(
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.history_list), 1),
+            ) {
+                clickDeleteAllHistoryButton()
+            }
             verifyDeleteConfirmationMessage()
             selectEverythingOption()
             confirmDeleteAllHistory()
@@ -211,10 +203,11 @@ class HistoryTest {
         }.openThreeDotMenu {
         }.openHistory {
             verifyHistoryListExists()
-            historyListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.history_list), 1)
-            IdlingRegistry.getInstance().register(historyListIdlingResource!!)
-            longTapSelectItem(firstWebPage.url)
+            registerAndCleanupIdlingResources(
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.history_list), 1),
+            ) {
+                longTapSelectItem(firstWebPage.url)
+            }
         }
 
         multipleSelectionToolbar {
@@ -242,11 +235,12 @@ class HistoryTest {
         homeScreen { }.openThreeDotMenu {
         }.openHistory {
             verifyHistoryListExists()
-            historyListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.history_list), 1)
-            IdlingRegistry.getInstance().register(historyListIdlingResource!!)
-            longTapSelectItem(firstWebPage.url)
-            openActionBarOverflowOrOptionsMenu(activityTestRule.activity)
+            registerAndCleanupIdlingResources(
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.history_list), 1),
+            ) {
+                longTapSelectItem(firstWebPage.url)
+                openActionBarOverflowOrOptionsMenu(activityTestRule.activity)
+            }
         }
 
         multipleSelectionToolbar {
@@ -267,11 +261,12 @@ class HistoryTest {
         }.openThreeDotMenu {
         }.openHistory {
             verifyHistoryListExists()
-            historyListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.history_list), 1)
-            IdlingRegistry.getInstance().register(historyListIdlingResource!!)
-            longTapSelectItem(firstWebPage.url)
-            openActionBarOverflowOrOptionsMenu(activityTestRule.activity)
+            registerAndCleanupIdlingResources(
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.history_list), 1),
+            ) {
+                longTapSelectItem(firstWebPage.url)
+                openActionBarOverflowOrOptionsMenu(activityTestRule.activity)
+            }
         }
 
         multipleSelectionToolbar {
@@ -295,15 +290,15 @@ class HistoryTest {
         }.openThreeDotMenu {
         }.openHistory {
             verifyHistoryListExists()
-            historyListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.history_list), 2)
-            IdlingRegistry.getInstance().register(historyListIdlingResource!!)
-            verifyHistoryItemExists(true, firstWebPage.url.toString())
-            verifyHistoryItemExists(true, secondWebPage.url.toString())
-            longTapSelectItem(firstWebPage.url)
-            longTapSelectItem(secondWebPage.url)
-            openActionBarOverflowOrOptionsMenu(activityTestRule.activity)
-            IdlingRegistry.getInstance().unregister(historyListIdlingResource!!)
+            registerAndCleanupIdlingResources(
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.history_list), 2),
+            ) {
+                verifyHistoryItemExists(true, firstWebPage.url.toString())
+                verifyHistoryItemExists(true, secondWebPage.url.toString())
+                longTapSelectItem(firstWebPage.url)
+                longTapSelectItem(secondWebPage.url)
+                openActionBarOverflowOrOptionsMenu(activityTestRule.activity)
+            }
         }
 
         multipleSelectionToolbar {
@@ -325,10 +320,11 @@ class HistoryTest {
         }.openThreeDotMenu {
         }.openHistory {
             verifyHistoryListExists()
-            historyListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.history_list), 1)
-            IdlingRegistry.getInstance().register(historyListIdlingResource!!)
-            longTapSelectItem(firstWebPage.url)
+            registerAndCleanupIdlingResources(
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.history_list), 1),
+            ) {
+                longTapSelectItem(firstWebPage.url)
+            }
         }
 
         multipleSelectionToolbar {
@@ -355,11 +351,11 @@ class HistoryTest {
         }.openTabDrawer {
         }.openRecentlyClosedTabs {
             waitForListToExist()
-            recentlyClosedTabsListIdlingResource =
-                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.recently_closed_list), 1)
-            IdlingRegistry.getInstance().register(recentlyClosedTabsListIdlingResource!!)
-            verifyRecentlyClosedTabsMenuView()
-            IdlingRegistry.getInstance().unregister(recentlyClosedTabsListIdlingResource!!)
+            registerAndCleanupIdlingResources(
+                RecyclerViewIdlingResource(activityTestRule.activity.findViewById(R.id.recently_closed_list), 1),
+            ) {
+                verifyRecentlyClosedTabsMenuView()
+            }
             verifyRecentlyClosedTabsPageTitle("Test_Page_1")
             verifyRecentlyClosedTabsUrl(website.url)
         }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/ReaderViewTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/ReaderViewTest.kt
@@ -5,7 +5,6 @@
 package org.mozilla.fenix.ui
 
 import android.view.View
-import androidx.test.espresso.IdlingRegistry
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import okhttp3.mockwebserver.MockWebServer
@@ -18,6 +17,7 @@ import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.RetryTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
+import org.mozilla.fenix.helpers.TestHelper.registerAndCleanupIdlingResources
 import org.mozilla.fenix.helpers.ViewVisibilityIdlingResource
 import org.mozilla.fenix.ui.robots.browserScreen
 import org.mozilla.fenix.ui.robots.navigationToolbar
@@ -34,7 +34,6 @@ import org.mozilla.fenix.ui.robots.navigationToolbar
 class ReaderViewTest {
     private lateinit var mockWebServer: MockWebServer
     private lateinit var mDevice: UiDevice
-    private var readerViewNotification: ViewVisibilityIdlingResource? = null
     private val estimatedReadingTime = "1 - 2 minutes"
 
     @get:Rule
@@ -56,7 +55,6 @@ class ReaderViewTest {
     @After
     fun tearDown() {
         mockWebServer.shutdown()
-        IdlingRegistry.getInstance().unregister(readerViewNotification)
     }
 
     /**
@@ -75,12 +73,12 @@ class ReaderViewTest {
             mDevice.waitForIdle()
         }
 
-        readerViewNotification = ViewVisibilityIdlingResource(
-            activityIntentTestRule.activity.findViewById(R.id.mozac_browser_toolbar_page_actions),
-            View.VISIBLE,
-        )
-
-        IdlingRegistry.getInstance().register(readerViewNotification)
+        registerAndCleanupIdlingResources(
+            ViewVisibilityIdlingResource(
+                activityIntentTestRule.activity.findViewById(R.id.mozac_browser_toolbar_page_actions),
+                View.VISIBLE,
+            ),
+        ) {}
 
         navigationToolbar {
             verifyReaderViewDetected(true)
@@ -118,12 +116,12 @@ class ReaderViewTest {
             mDevice.waitForIdle()
         }
 
-        readerViewNotification = ViewVisibilityIdlingResource(
-            activityIntentTestRule.activity.findViewById(R.id.mozac_browser_toolbar_page_actions),
-            View.VISIBLE,
-        )
-
-        IdlingRegistry.getInstance().register(readerViewNotification)
+        registerAndCleanupIdlingResources(
+            ViewVisibilityIdlingResource(
+                activityIntentTestRule.activity.findViewById(R.id.mozac_browser_toolbar_page_actions),
+                View.VISIBLE,
+            ),
+        ) {}
 
         navigationToolbar {
             verifyReaderViewDetected(true)
@@ -156,12 +154,12 @@ class ReaderViewTest {
             mDevice.waitForIdle()
         }
 
-        readerViewNotification = ViewVisibilityIdlingResource(
-            activityIntentTestRule.activity.findViewById(R.id.mozac_browser_toolbar_page_actions),
-            View.VISIBLE,
-        )
-
-        IdlingRegistry.getInstance().register(readerViewNotification)
+        registerAndCleanupIdlingResources(
+            ViewVisibilityIdlingResource(
+                activityIntentTestRule.activity.findViewById(R.id.mozac_browser_toolbar_page_actions),
+                View.VISIBLE,
+            ),
+        ) {}
 
         navigationToolbar {
             verifyReaderViewDetected(true)
@@ -196,12 +194,12 @@ class ReaderViewTest {
             mDevice.waitForIdle()
         }
 
-        readerViewNotification = ViewVisibilityIdlingResource(
-            activityIntentTestRule.activity.findViewById(R.id.mozac_browser_toolbar_page_actions),
-            View.VISIBLE,
-        )
-
-        IdlingRegistry.getInstance().register(readerViewNotification)
+        registerAndCleanupIdlingResources(
+            ViewVisibilityIdlingResource(
+                activityIntentTestRule.activity.findViewById(R.id.mozac_browser_toolbar_page_actions),
+                View.VISIBLE,
+            ),
+        ) {}
 
         navigationToolbar {
             verifyReaderViewDetected(true)
@@ -242,12 +240,12 @@ class ReaderViewTest {
             mDevice.waitForIdle()
         }
 
-        readerViewNotification = ViewVisibilityIdlingResource(
-            activityIntentTestRule.activity.findViewById(R.id.mozac_browser_toolbar_page_actions),
-            View.VISIBLE,
-        )
-
-        IdlingRegistry.getInstance().register(readerViewNotification)
+        registerAndCleanupIdlingResources(
+            ViewVisibilityIdlingResource(
+                activityIntentTestRule.activity.findViewById(R.id.mozac_browser_toolbar_page_actions),
+                View.VISIBLE,
+            ),
+        ) {}
 
         navigationToolbar {
             verifyReaderViewDetected(true)

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsBasicsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsBasicsTest.kt
@@ -5,9 +5,6 @@
 package org.mozilla.fenix.ui
 
 import android.content.res.Configuration
-import androidx.test.espresso.IdlingRegistry
-import java.time.LocalDate
-import java.util.Locale
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
@@ -24,9 +21,10 @@ import org.mozilla.fenix.helpers.RecyclerViewIdlingResource
 import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.helpers.TestAssetHelper.getLoremIpsumAsset
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeLong
-import org.mozilla.fenix.helpers.TestHelper.runWithSystemLocaleChanged
 import org.mozilla.fenix.helpers.TestHelper.getStringResource
 import org.mozilla.fenix.helpers.TestHelper.mDevice
+import org.mozilla.fenix.helpers.TestHelper.runWithSystemLocaleChanged
+import org.mozilla.fenix.helpers.TestHelper.registerAndCleanupIdlingResources
 import org.mozilla.fenix.ui.SettingsBasicsTest.CreditCard.MOCK_CREDIT_CARD_NUMBER
 import org.mozilla.fenix.ui.SettingsBasicsTest.CreditCard.MOCK_EXPIRATION_MONTH
 import org.mozilla.fenix.ui.SettingsBasicsTest.CreditCard.MOCK_EXPIRATION_YEAR
@@ -39,6 +37,8 @@ import org.mozilla.fenix.ui.util.FRENCH_LANGUAGE_HEADER
 import org.mozilla.fenix.ui.util.FRENCH_SYSTEM_LOCALE_OPTION
 import org.mozilla.fenix.ui.util.FR_SETTINGS
 import org.mozilla.fenix.ui.util.ROMANIAN_LANGUAGE_HEADER
+import java.time.LocalDate
+import java.util.Locale
 
 /**
  *  Tests for verifying the General section of the Settings menu
@@ -48,7 +48,6 @@ class SettingsBasicsTest {
     /* ktlint-disable no-blank-line-before-rbrace */ // This imposes unreadable grouping.
     private lateinit var mockWebServer: MockWebServer
     private val featureSettingsHelper = FeatureSettingsHelper()
-    private var localeListIdlingResource: RecyclerViewIdlingResource? = null
 
     object CreditCard {
         const val MOCK_CREDIT_CARD_NUMBER = "5555555555554444"
@@ -79,10 +78,6 @@ class SettingsBasicsTest {
 
         // resetting modified features enabled setting to default
         featureSettingsHelper.resetAllFeatureFlags()
-
-        if (localeListIdlingResource != null) {
-            IdlingRegistry.getInstance().unregister(localeListIdlingResource)
-        }
     }
 
     private fun getUiTheme(): Boolean {
@@ -279,19 +274,19 @@ class SettingsBasicsTest {
         }.openThreeDotMenu {
         }.openSettings {
         }.openLanguageSubMenu {
-            localeListIdlingResource =
+            registerAndCleanupIdlingResources(
                 RecyclerViewIdlingResource(
                     activityIntentTestRule.activity.findViewById(R.id.locale_list),
                     2,
-                )
-            IdlingRegistry.getInstance().register(localeListIdlingResource)
-            selectLanguage("Romanian")
-            verifyLanguageHeaderIsTranslated(ROMANIAN_LANGUAGE_HEADER)
-            selectLanguage("Français")
-            verifyLanguageHeaderIsTranslated(FRENCH_LANGUAGE_HEADER)
-            selectLanguage(FRENCH_SYSTEM_LOCALE_OPTION)
-            verifyLanguageHeaderIsTranslated(enLanguageHeaderText)
-            IdlingRegistry.getInstance().unregister(localeListIdlingResource)
+                ),
+            ) {
+                selectLanguage("Romanian")
+                verifyLanguageHeaderIsTranslated(ROMANIAN_LANGUAGE_HEADER)
+                selectLanguage("Français")
+                verifyLanguageHeaderIsTranslated(FRENCH_LANGUAGE_HEADER)
+                selectLanguage(FRENCH_SYSTEM_LOCALE_OPTION)
+                verifyLanguageHeaderIsTranslated(enLanguageHeaderText)
+            }
         }
     }
 


### PR DESCRIPTION
For #26784 refactor use of idling resources in UI tests.

Ran all effected UI tests 20x on Firebase and successfully passed. ✅ 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
Fixes #26784