### PR TITLE
Closes #26945: adds telemetry for learn more link on wallpaper settings

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -8175,6 +8175,29 @@ wallpapers:
     metadata:
       tags:
         - Wallpapers
+  learn_more_link_click:
+    type: event
+    description: |
+      The learn more link for a wallpaper collection has been clicked.
+    extra_keys:
+      collection_name:
+        description: The name of the wallpaper collection the link leads to.
+        type: string
+      url:
+        description: The URL associated with the wallpaper collection.
+        type: string
+    bugs:
+      - https://github:com/mozilla-mobile/fenix/issues/26945
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/26990
+    notification_emails:
+      - android-probes@mozilla.com
+    data_sensitivity:
+      - interaction
+    expires: 116
+    metadata:
+      tags:
+        - Wallpapers
 
 recently_visited_homepage:
   history_highlight_opened:

--- a/app/src/main/java/org/mozilla/fenix/settings/wallpaper/WallpaperSettings.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/wallpaper/WallpaperSettings.kt
@@ -59,6 +59,7 @@ import org.mozilla.fenix.wallpapers.Wallpaper
  * @param loadWallpaperResource Callback to handle loading a wallpaper bitmap. Only optional in the default case.
  * @param onSelectWallpaper Callback for when a new wallpaper is selected.
  * @param onLearnMoreClick Callback for when the learn more action is clicked from the group description.
+ * Parameters are the URL that is clicked and the name of the collection.
  */
 @SuppressLint("UnusedMaterialScaffoldPaddingParameter")
 @Composable
@@ -69,7 +70,7 @@ fun WallpaperSettings(
     loadWallpaperResource: suspend (Wallpaper) -> Bitmap?,
     selectedWallpaper: Wallpaper,
     onSelectWallpaper: (Wallpaper) -> Unit,
-    onLearnMoreClick: (String) -> Unit,
+    onLearnMoreClick: (String, String) -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -109,7 +110,7 @@ fun WallpaperSettings(
 @Composable
 private fun WallpaperGroupHeading(
     collection: Wallpaper.Collection,
-    onLearnMoreClick: (String) -> Unit,
+    onLearnMoreClick: (String, String) -> Unit,
 ) {
     // Since the last new collection of wallpapers was tied directly to an MR release,
     // it was decided that we should use string resources for these titles
@@ -153,7 +154,7 @@ private fun WallpaperGroupHeading(
                     clickableStartIndex = linkStartIndex,
                     clickableEndIndex = linkEndIndex,
                 ) {
-                    onLearnMoreClick(collection.learnMoreUrl)
+                    onLearnMoreClick(collection.learnMoreUrl, collection.name)
                 }
             }
         }
@@ -302,7 +303,7 @@ private fun WallpaperThumbnailsPreview() {
             wallpaperGroups = mapOf(Wallpaper.DefaultCollection to listOf(Wallpaper.Default)),
             selectedWallpaper = Wallpaper.Default,
             onSelectWallpaper = {},
-            onLearnMoreClick = {},
+            onLearnMoreClick = { _, _ -> },
         )
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/settings/wallpaper/WallpaperSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/wallpaper/WallpaperSettingsFragment.kt
@@ -68,11 +68,17 @@ class WallpaperSettingsFragment : Fragment() {
                                 onWallpaperSelected(it, result, this@apply)
                             }
                         },
-                        onLearnMoreClick = { url ->
+                        onLearnMoreClick = { url, collectionName ->
                             (activity as HomeActivity).openToBrowserAndLoad(
                                 searchTermOrURL = url,
                                 newTab = true,
                                 from = BrowserDirection.FromWallpaper,
+                            )
+                            Wallpapers.learnMoreLinkClick.record(
+                                Wallpapers.LearnMoreLinkClickExtra(
+                                    url = url,
+                                    collectionName = collectionName,
+                                ),
                             )
                         },
                     )


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.







### GitHub Automation
Fixes #26945