### PR TITLE
Closes #26995: add sorting of wallpapers on wallpapers onboarding tool

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/onboarding/WallpaperOnboardingDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/onboarding/WallpaperOnboardingDialogFragment.kt
@@ -26,6 +26,7 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.settings.wallpaper.getWallpapersForOnboarding
 import org.mozilla.fenix.theme.FirefoxTheme
 import org.mozilla.fenix.wallpapers.Wallpaper
 import org.mozilla.fenix.wallpapers.WallpaperOnboarding
@@ -82,7 +83,7 @@ class WallpaperOnboardingDialogFragment : BottomSheetDialogFragment() {
         setContent {
             FirefoxTheme {
                 val wallpapers = appStore.observeAsComposableState { state ->
-                    state.wallpaperState.availableWallpapers.take(THUMBNAILS_SELECTION_COUNT)
+                    state.wallpaperState.availableWallpapers.getWallpapersForOnboarding()
                 }.value ?: listOf()
                 val currentWallpaper = appStore.observeAsComposableState { state ->
                     state.wallpaperState.currentWallpaper
@@ -127,6 +128,13 @@ class WallpaperOnboardingDialogFragment : BottomSheetDialogFragment() {
     }
 
     companion object {
+        // The number of wallpaper thumbnails to display.
         const val THUMBNAILS_SELECTION_COUNT = 6
+
+        // The desired amount of seasonal wallpapers inside of the selector.
+        const val SEASONAL_WALLPAPERS_COUNT = 3
+
+        // The desired amount of seasonal wallpapers inside of the selector.
+        const val CLASSIC_WALLPAPERS_COUNT = 2
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/settings/wallpaper/Extensions.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/wallpaper/Extensions.kt
@@ -4,24 +4,65 @@
 
 package org.mozilla.fenix.settings.wallpaper
 
+import org.mozilla.fenix.onboarding.WallpaperOnboardingDialogFragment.Companion.CLASSIC_WALLPAPERS_COUNT
+import org.mozilla.fenix.onboarding.WallpaperOnboardingDialogFragment.Companion.SEASONAL_WALLPAPERS_COUNT
+import org.mozilla.fenix.onboarding.WallpaperOnboardingDialogFragment.Companion.THUMBNAILS_SELECTION_COUNT
 import org.mozilla.fenix.wallpapers.Wallpaper
 
 /**
  * The extension function to group wallpapers according to their name.
  **/
-fun List<Wallpaper>.groupByDisplayableCollection(): Map<Wallpaper.Collection, List<Wallpaper>> = groupBy {
-    it.collection
-}.filter {
-    it.key.name != "default"
-}.map {
-    val wallpapers = it.value.filter { wallpaper ->
-        wallpaper.thumbnailFileState == Wallpaper.ImageFileState.Downloaded
+fun List<Wallpaper>.groupByDisplayableCollection(): Map<Wallpaper.Collection, List<Wallpaper>> =
+    groupBy {
+        it.collection
+    }.filter {
+        it.key.name != "default"
+    }.map {
+        val wallpapers = it.value.filter { wallpaper ->
+            wallpaper.thumbnailFileState == Wallpaper.ImageFileState.Downloaded
+        }
+        if (it.key.name == "classic-firefox") {
+            it.key to listOf(Wallpaper.Default) + wallpapers
+        } else {
+            it.key to wallpapers
+        }
+    }.toMap().takeIf {
+        it.isNotEmpty()
+    } ?: mapOf(Wallpaper.DefaultCollection to listOf(Wallpaper.Default))
+
+/**
+ * Returns a list of wallpapers to display in the wallpaper onboarding.
+ *
+ * The ideal scenario is to return a list of wallpaper in the following order: 1 default, 3 seasonal and
+ * 2 classic wallpapers, but in case where there are less than 3 seasonal wallpapers, the remaining
+ * wallpapers are filled by classic wallpapers. If we have less than 6 wallpapers, return all the available
+ * seasonal and classic wallpapers.
+ */
+fun List<Wallpaper>.getWallpapersForOnboarding(): List<Wallpaper> {
+    val result = mutableListOf(Wallpaper.Default)
+    val classicWallpapers = mutableListOf<Wallpaper>()
+    val seasonalWallpapers = mutableListOf<Wallpaper>()
+
+    for (wallpaper in this) {
+        if (wallpaper == Wallpaper.Default) continue
+
+        if (wallpaper.collection.name == "classic-firefox") {
+            classicWallpapers.add(wallpaper)
+        } else {
+            seasonalWallpapers.add(wallpaper)
+        }
     }
-    if (it.key.name == "classic-firefox") {
-        it.key to listOf(Wallpaper.Default) + wallpapers
+
+    if (seasonalWallpapers.size < SEASONAL_WALLPAPERS_COUNT) {
+        result.addAll(seasonalWallpapers)
+        result.addAll(classicWallpapers.take((THUMBNAILS_SELECTION_COUNT - 1) - seasonalWallpapers.size))
+    } else if (classicWallpapers.size < CLASSIC_WALLPAPERS_COUNT) {
+        result.addAll(seasonalWallpapers.take((THUMBNAILS_SELECTION_COUNT - 1) - classicWallpapers.size))
+        result.addAll(classicWallpapers)
     } else {
-        it.key to wallpapers
+        result.addAll(seasonalWallpapers.take(SEASONAL_WALLPAPERS_COUNT))
+        result.addAll(classicWallpapers.take(CLASSIC_WALLPAPERS_COUNT))
     }
-}.toMap().takeIf {
-    it.isNotEmpty()
-} ?: mapOf(Wallpaper.DefaultCollection to listOf(Wallpaper.Default))
+
+    return result
+}

--- a/app/src/test/java/org/mozilla/fenix/settings/wallpaper/ExtensionsTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/wallpaper/ExtensionsTest.kt
@@ -5,6 +5,7 @@
 package org.mozilla.fenix.settings.wallpaper
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mozilla.fenix.wallpapers.Wallpaper
 
@@ -52,6 +53,102 @@ class ExtensionsTest {
         assertEquals(2, result.size)
         assertEquals(listOf(Wallpaper.Default) + classicFirefoxWallpapers, result[classicCollection])
         assertEquals(downloadedSeasonalWallpapers, result[seasonalCollection])
+    }
+
+    @Test
+    fun `GIVEN two collections of appropriate size WHEN fetched for onboarding THEN result contains 3 seasonal and 2 classic`() {
+        val seasonalCollection = getSeasonalCollection("finally fall")
+        val seasonalWallpapers = (0..5).map { generateSeasonalWallpaperCollection("${seasonalCollection.name}$it", seasonalCollection.name) }
+        val classicFirefoxWallpapers = (0..5).map { generateClassicFirefoxWallpaper("firefox$it") }
+        val allWallpapers = listOf(Wallpaper.Default) + classicFirefoxWallpapers + seasonalWallpapers
+
+        val result = allWallpapers.getWallpapersForOnboarding()
+
+        assertEquals(3, result.count { it.collection.name == "finally fall" })
+        assertEquals(2, result.count { it.collection.name == classicCollection.name })
+        assertTrue(result.contains(Wallpaper.Default))
+    }
+
+    @Test
+    fun `GIVEN five collections of insufficient size WHEN fetched for onboarding THEN result contains 3 seasonal and 2 classic`() {
+        val seasonalCollectionA = getSeasonalCollection("finally winter")
+        val seasonalWallpapers = generateSeasonalWallpaperCollection("${seasonalCollectionA.name}$0", seasonalCollectionA.name)
+        val seasonalCollectionB = getSeasonalCollection("finally spring")
+        val seasonalWallpaperB = generateSeasonalWallpaperCollection("${seasonalCollectionB.name}$0", seasonalCollectionB.name)
+        val seasonalCollectionC = getSeasonalCollection("finally summer")
+        val seasonalWallpapersC = generateSeasonalWallpaperCollection("${seasonalCollectionC.name}$0", seasonalCollectionC.name)
+        val seasonalCollectionD = getSeasonalCollection("finally autumn")
+        val seasonalWallpaperD = generateSeasonalWallpaperCollection("${seasonalCollectionD.name}$0", seasonalCollectionD.name)
+        val seasonalCollectionE = getSeasonalCollection("finally vacation")
+        val seasonalWallpapersE = generateSeasonalWallpaperCollection("${seasonalCollectionE.name}$0", seasonalCollectionE.name)
+
+        val classicFirefoxWallpapers = (0..5).map { generateClassicFirefoxWallpaper("firefox$it") }
+        val allWallpapers = listOf(Wallpaper.Default) + classicFirefoxWallpapers + seasonalWallpapers +
+            seasonalWallpaperB + seasonalWallpapersC + seasonalWallpaperD + seasonalWallpapersE
+
+        val result = allWallpapers.getWallpapersForOnboarding()
+
+        assertEquals(3, result.count { it.collection.name != classicCollection.name && it != Wallpaper.Default })
+        assertEquals(2, result.count { it.collection.name == classicCollection.name })
+        assertTrue(result.contains(Wallpaper.Default))
+    }
+
+    @Test
+    fun `GIVEN seasonal collection of insufficient size WHEN grouped for onboarding THEN result contains all seasonal and the rest is classic`() {
+        val seasonalCollection = getSeasonalCollection("finally fall")
+        val seasonalWallpapers = generateSeasonalWallpaperCollection("${seasonalCollection.name}$0", seasonalCollection.name)
+        val classicFirefoxWallpapers = (0..5).map { generateClassicFirefoxWallpaper("firefox$it") }
+        val allWallpapers = listOf(Wallpaper.Default) + classicFirefoxWallpapers + seasonalWallpapers
+
+        val result = allWallpapers.getWallpapersForOnboarding()
+
+        assertEquals(1, result.count { it.collection.name == "finally fall" })
+        assertEquals(4, result.count { it.collection.name == classicCollection.name })
+        assertTrue(result.contains(Wallpaper.Default))
+    }
+
+    @Test
+    fun `GIVEN no seasonal collection WHEN grouped for onboarding THEN result contains all classic`() {
+        val classicFirefoxWallpapers = (0..5).map { generateClassicFirefoxWallpaper("firefox$it") }
+        val allWallpapers = listOf(Wallpaper.Default) + classicFirefoxWallpapers
+
+        val result = allWallpapers.getWallpapersForOnboarding()
+
+        assertEquals(5, result.count { it.collection.name == classicCollection.name })
+        assertTrue(result.contains(Wallpaper.Default))
+    }
+
+    @Test
+    fun `GIVEN insufficient items in classic collection WHEN grouped for onboarding THEN result contains all classic`() {
+        val classicFirefoxWallpapers = (0..2).map { generateClassicFirefoxWallpaper("firefox$it") }
+        val allWallpapers = listOf(Wallpaper.Default) + classicFirefoxWallpapers
+
+        val result = allWallpapers.getWallpapersForOnboarding()
+
+        assertEquals(3, result.count { it.collection.name == classicCollection.name })
+        assertTrue(result.contains(Wallpaper.Default))
+    }
+
+    @Test
+    fun `GIVEN no items in classic collection and some seasonal WHEN grouped for onboarding THEN result contains all seasonal`() {
+        val seasonalCollection = getSeasonalCollection("finally fall")
+        val seasonalWallpapers = (0..5).map { generateSeasonalWallpaperCollection("${seasonalCollection.name}$it", seasonalCollection.name) }
+        val allWallpapers = listOf(Wallpaper.Default) + seasonalWallpapers
+
+        val result = allWallpapers.getWallpapersForOnboarding()
+
+        assertEquals(5, result.count { it.collection.name == "finally fall" })
+        assertTrue(result.contains(Wallpaper.Default))
+    }
+
+    @Test
+    fun `GIVEN no items WHEN grouped for onboarding THEN result contains the default option`() {
+        val allWallpapers = listOf(Wallpaper.Default)
+
+        val result = allWallpapers.getWallpapersForOnboarding()
+
+        assertEquals(1, result.size)
+        assertTrue(result.contains(Wallpaper.Default))
     }
 
     private fun generateClassicFirefoxWallpaper(name: String) = Wallpaper(


### PR DESCRIPTION
Filtering of wallpapers for wallpaper onboarding tool.

We are given a list of wallpapers, that consists of classic and seasonal collections. They come from the server, so theoretically the numbers inside each group could be any. Wrote an extension function that has a goal to provide a sorted list, which under ideal conditions would have 3 seasonal wallpapers first and 2 classic after. 

Edge cases I could come up with are: when it's all classic, or all seasonal, or nothing at all, or 1 classic or 1 seasonal, or 5 seasonal and 1 classic, or 1 seasonal and 5 classic.

<img width="336" alt="image" src="https://user-images.githubusercontent.com/92760693/190319197-0cba800a-b093-46f8-ab3a-f51a14cb79d8.png">



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.











### GitHub Automation
Fixes #26995