### PR TITLE
No issue: Adjust shard count in legacy/nightly/beta UI test jobs

### DIFF
--- a/automation/taskcluster/androidTest/flank-arm-beta.yml
+++ b/automation/taskcluster/androidTest/flank-arm-beta.yml
@@ -35,7 +35,7 @@ gcloud:
 
 flank:
   project: GOOGLE_PROJECT
-  max-test-shards: 1
+  max-test-shards: 2
   num-test-runs: 1
   output-style: compact
   full-junit-result: true

--- a/automation/taskcluster/androidTest/flank-arm-legacy-api-tests.yml
+++ b/automation/taskcluster/androidTest/flank-arm-legacy-api-tests.yml
@@ -41,7 +41,7 @@ gcloud:
 
 flank:
   project: GOOGLE_PROJECT
-  max-test-shards: -1
+  max-test-shards: 2
   num-test-runs: 1
   output-style: compact
   full-junit-result: true

--- a/automation/taskcluster/androidTest/flank-arm-start-test.yml
+++ b/automation/taskcluster/androidTest/flank-arm-start-test.yml
@@ -35,7 +35,7 @@ gcloud:
 
 flank:
   project: GOOGLE_PROJECT
-  max-test-shards: 1
+  max-test-shards: 2
   num-test-runs: 1
   output-style: compact
   full-junit-result: true

--- a/taskcluster/ci/ui-test/kind.yml
+++ b/taskcluster/ci/ui-test/kind.yml
@@ -132,7 +132,7 @@ tasks:
             signing-android-test: signing-android-test-beta
         run:
             commands:
-                - [automation/taskcluster/androidTest/ui-test.sh, arm-beta-tests, app.apk, android-test.apk, '1']
+                - [automation/taskcluster/androidTest/ui-test.sh, arm-beta-tests, app.apk, android-test.apk, '2']
         treeherder:
             symbol: beta(ui-test-arm-beta)
     arm-nightly:
@@ -145,7 +145,7 @@ tasks:
             signing-android-test: signing-android-test-nightly
         run:
             commands:
-                - [automation/taskcluster/androidTest/ui-test.sh, arm-start-test, app.apk, android-test.apk, '1']
+                - [automation/taskcluster/androidTest/ui-test.sh, arm-start-test, app.apk, android-test.apk, '2']
         treeherder:
             symbol: nightly(ui-test-arm-nightly)
     legacy-arm:
@@ -156,6 +156,6 @@ tasks:
         run-on-git-branches: [main]
         run:
             commands:
-                - [automation/taskcluster/androidTest/ui-test.sh, arm-legacy-api-tests, app.apk, android-test.apk, '1']
+                - [automation/taskcluster/androidTest/ui-test.sh, arm-legacy-api-tests, app.apk, android-test.apk, '2']
         treeherder:
             symbol: debug(legacy-arm)


### PR DESCRIPTION
Balance out shard count for legacy (~13 tests) and beta/nightly (~7) tests. Indirectly should fix reporting in Slack with the JUnitReport XML parsing for single vs multiple shards which is a mess 😵‍💫 