### PR TITLE
 For #27020 - Correct padding for wallpaper thumbnails 

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/wallpaper/WallpaperSettings.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/wallpaper/WallpaperSettings.kt
@@ -78,8 +78,8 @@ fun WallpaperSettings(
             .verticalScroll(rememberScrollState())
             .background(color = FirefoxTheme.colors.layer1)
             .padding(
-                end = 16.dp,
-                start = 16.dp,
+                end = 12.dp,
+                start = 12.dp,
                 top = 16.dp,
             ),
     ) {
@@ -90,7 +90,7 @@ fun WallpaperSettings(
                     onLearnMoreClick = onLearnMoreClick,
                 )
 
-                Spacer(modifier = Modifier.height(16.dp))
+                Spacer(modifier = Modifier.height(12.dp))
 
                 WallpaperThumbnails(
                     wallpapers = wallpapers,


### PR DESCRIPTION
Wallpaper thumbnails already surround themselves by a 4dp padding, hence the start and end padding should be reduced by 4dp at the top of hierarchy


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
Fixes #27020