### PR TITLE
Closes #27021: add wallpaper onboarding downloading error snackbar

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/onboarding/WallpaperOnboardingDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/onboarding/WallpaperOnboardingDialogFragment.kt
@@ -15,6 +15,7 @@ import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import kotlinx.coroutines.launch
@@ -23,6 +24,7 @@ import mozilla.telemetry.glean.private.NoExtras
 import org.mozilla.fenix.GleanMetrics.Wallpapers
 import org.mozilla.fenix.NavGraphDirections
 import org.mozilla.fenix.R
+import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.requireComponents
 import org.mozilla.fenix.ext.settings
@@ -103,7 +105,7 @@ class WallpaperOnboardingDialogFragment : BottomSheetDialogFragment() {
                     onSelectWallpaper = {
                         coroutineScope.launch {
                             val result = wallpaperUseCases.selectWallpaper(it)
-                            onWallpaperSelected(it, result)
+                            onWallpaperSelected(it, result, this@WallpaperOnboardingDialogFragment.requireView())
                         }
                     },
                 )
@@ -114,15 +116,33 @@ class WallpaperOnboardingDialogFragment : BottomSheetDialogFragment() {
     private fun onWallpaperSelected(
         wallpaper: Wallpaper,
         result: Wallpaper.ImageFileState,
+        view: View,
     ) {
-        if (result == Wallpaper.ImageFileState.Downloaded) {
-            Wallpapers.wallpaperSelected.record(
-                Wallpapers.WallpaperSelectedExtra(
-                    name = wallpaper.name,
-                    source = "onboarding",
-                    themeCollection = wallpaper.collection.name,
-                ),
-            )
+        when (result) {
+            Wallpaper.ImageFileState.Downloaded -> {
+                Wallpapers.wallpaperSelected.record(
+                    Wallpapers.WallpaperSelectedExtra(
+                        name = wallpaper.name,
+                        source = "onboarding",
+                        themeCollection = wallpaper.collection.name,
+                    ),
+                )
+            }
+            Wallpaper.ImageFileState.Error -> {
+                FenixSnackbar.make(
+                    view = view,
+                    isDisplayedWithBrowserToolbar = false,
+                )
+                    .setText(view.context.getString(R.string.wallpaper_download_error_snackbar_message))
+                    .setAction(view.context.getString(R.string.wallpaper_download_error_snackbar_action)) {
+                        viewLifecycleOwner.lifecycleScope.launch {
+                            val retryResult = wallpaperUseCases.selectWallpaper(wallpaper)
+                            onWallpaperSelected(wallpaper, retryResult, view)
+                        }
+                    }
+                    .show()
+            }
+            else -> { /* noop */ }
         }
     }
 


### PR DESCRIPTION
Adding an error snack bar, in line with the wallpaper setting screen behavior.

[device-2022-09-15-110314.webm](https://user-images.githubusercontent.com/92760693/190477380-fd4f2a45-dfe0-47c0-bb8a-62712362a96a.webm)


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
Fixes #27021