### PR TITLE
For #26520 - Color homepage cards via wallpaper card colors

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/pocket/PocketCategoriesViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/pocket/PocketCategoriesViewHolder.kt
@@ -5,12 +5,14 @@
 package org.mozilla.fenix.home.pocket
 
 import android.view.View
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -24,6 +26,7 @@ import org.mozilla.fenix.compose.ComposeViewHolder
 import org.mozilla.fenix.compose.home.HomeSectionHeader
 import org.mozilla.fenix.theme.FirefoxTheme
 import org.mozilla.fenix.theme.Theme
+import org.mozilla.fenix.wallpapers.WallpaperState
 
 internal const val POCKET_CATEGORIES_SELECTED_AT_A_TIME_COUNT = 8
 
@@ -55,12 +58,37 @@ class PocketCategoriesViewHolder(
         val categoriesSelections = components.appStore
             .observeAsComposableState { state -> state.pocketStoriesCategoriesSelections }.value
 
+        val wallpaperState = components.appStore
+            .observeAsComposableState { state -> state.wallpaperState }.value ?: WallpaperState.default
+
+        var selectedBackgroundColor: Color? = null
+        var unselectedBackgroundColor: Color? = null
+        var selectedTextColor: Color? = null
+        var unselectedTextColor: Color? = null
+        wallpaperState.composeRunIfWallpaperCardColorsAreAvailable { cardColorLight, cardColorDark ->
+            if (isSystemInDarkTheme()) {
+                selectedBackgroundColor = cardColorDark
+                unselectedBackgroundColor = cardColorLight
+                selectedTextColor = FirefoxTheme.colors.textActionPrimary
+                unselectedTextColor = FirefoxTheme.colors.textActionSecondary
+            } else {
+                selectedBackgroundColor = cardColorLight
+                unselectedBackgroundColor = cardColorDark
+                selectedTextColor = FirefoxTheme.colors.textActionSecondary
+                unselectedTextColor = FirefoxTheme.colors.textActionPrimary
+            }
+        }
+
         // See the detailed comment in PocketStoriesViewHolder for reasoning behind this change.
         if (!homeScreenReady) return
         Column {
             Spacer(Modifier.height(24.dp))
 
             PocketTopics(
+                selectedBackgroundColor = selectedBackgroundColor,
+                unselectedBackgroundColor = unselectedBackgroundColor,
+                selectedTextColor = selectedTextColor,
+                unselectedTextColor = unselectedTextColor,
                 categories = categories ?: emptyList(),
                 categoriesSelections = categoriesSelections ?: emptyList(),
                 onCategoryClick = interactor::onCategoryClicked,
@@ -75,6 +103,10 @@ class PocketCategoriesViewHolder(
 
 @Composable
 private fun PocketTopics(
+    selectedTextColor: Color? = null,
+    unselectedTextColor: Color? = null,
+    selectedBackgroundColor: Color? = null,
+    unselectedBackgroundColor: Color? = null,
     categories: List<PocketRecommendedStoriesCategory> = emptyList(),
     categoriesSelections: List<PocketRecommendedStoriesSelectedCategory> = emptyList(),
     onCategoryClick: (PocketRecommendedStoriesCategory) -> Unit,
@@ -89,6 +121,10 @@ private fun PocketTopics(
         PocketStoriesCategories(
             categories = categories,
             selections = categoriesSelections,
+            selectedTextColor = selectedTextColor,
+            unselectedTextColor = unselectedTextColor,
+            selectedBackgroundColor = selectedBackgroundColor,
+            unselectedBackgroundColor = unselectedBackgroundColor,
             onCategoryClick = onCategoryClick,
             modifier = Modifier
                 .fillMaxWidth(),

--- a/app/src/main/java/org/mozilla/fenix/home/pocket/PocketStoriesComposables.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/pocket/PocketStoriesComposables.kt
@@ -98,11 +98,13 @@ private val placeholderStory = PocketRecommendedStory("", "", "", "", "", 0, 0)
  * Displays a single [PocketRecommendedStory].
  *
  * @param story The [PocketRecommendedStory] to be displayed.
+ * @param backgroundColor The background [Color] of the story.
  * @param onStoryClick Callback for when the user taps on this story.
  */
 @Composable
 fun PocketStory(
     @PreviewParameter(PocketStoryProvider::class) story: PocketRecommendedStory,
+    backgroundColor: Color,
     onStoryClick: (PocketRecommendedStory) -> Unit,
 ) {
     val imageUrl = story.imageUrl.replace(
@@ -113,6 +115,7 @@ fun PocketStory(
     val isValidTimeToRead = story.timeToRead >= 0
     ListItemTabLarge(
         imageUrl = imageUrl,
+        backgroundColor = backgroundColor,
         onClick = { onStoryClick(story) },
         title = {
             Text(
@@ -151,11 +154,13 @@ fun PocketStory(
  * Displays a single [PocketSponsoredStory].
  *
  * @param story The [PocketSponsoredStory] to be displayed.
+ * @param backgroundColor The background [Color] of the story.
  * @param onStoryClick Callback for when the user taps on this story.
  */
 @Composable
 fun PocketSponsoredStory(
     story: PocketSponsoredStory,
+    backgroundColor: Color,
     onStoryClick: (PocketSponsoredStory) -> Unit,
 ) {
     val (imageWidth, imageHeight) = with(LocalDensity.current) {
@@ -168,6 +173,7 @@ fun PocketSponsoredStory(
 
     ListItemTabSurface(
         imageUrl = imageUrl,
+        backgroundColor = backgroundColor,
         onClick = { onStoryClick(story) },
     ) {
         Text(
@@ -208,14 +214,17 @@ fun PocketSponsoredStory(
  * @param stories The list of [PocketStory]ies to be displayed. Expect a list with 8 items.
  * @param contentPadding Dimension for padding the content after it has been clipped.
  * This space will be used for shadows and also content rendering when the list is scrolled.
+ * @param backgroundColor The background [Color] of each story.
  * @param onStoryShown Callback for when a certain story is visible to the user.
  * @param onStoryClicked Callback for when the user taps on a recommended story.
  * @param onDiscoverMoreClicked Callback for when the user taps an element which contains an
  */
+@Suppress("LongParameterList")
 @Composable
 fun PocketStories(
     @PreviewParameter(PocketStoryProvider::class) stories: List<PocketStory>,
     contentPadding: Dp,
+    backgroundColor: Color = FirefoxTheme.colors.layer2,
     onStoryShown: (PocketStory, Pair<Int, Int>) -> Unit,
     onStoryClicked: (PocketStory, Pair<Int, Int>) -> Unit,
     onDiscoverMoreClicked: (String) -> Unit,
@@ -241,7 +250,10 @@ fun PocketStories(
                             onDiscoverMoreClicked("https://getpocket.com/explore?$POCKET_FEATURE_UTM_KEY_VALUE")
                         }
                     } else if (story is PocketRecommendedStory) {
-                        PocketStory(story) {
+                        PocketStory(
+                            story = story,
+                            backgroundColor = backgroundColor,
+                        ) {
                             val uri = Uri.parse(story.url)
                                 .buildUpon()
                                 .appendQueryParameter(URI_PARAM_UTM_KEY, POCKET_STORIES_UTM_VALUE)
@@ -254,7 +266,10 @@ fun PocketStories(
                                 onStoryShown(story, rowIndex to columnIndex)
                             },
                         ) {
-                            PocketSponsoredStory(story) {
+                            PocketSponsoredStory(
+                                story = story,
+                                backgroundColor = backgroundColor,
+                            ) {
                                 onStoryClicked(story, rowIndex to columnIndex)
                             }
                         }
@@ -359,13 +374,22 @@ private fun Rect.getIntersectPercentage(realSize: IntSize, other: Rect): Float {
  *
  * @param categories The categories needed to be displayed.
  * @param selections List of categories currently selected.
+ * @param selectedTextColor Text [Color] when the category is selected.
+ * @param unselectedTextColor Text [Color] when the category is not selected.
+ * @param selectedBackgroundColor Background [Color] when the category is selected.
+ * @param unselectedBackgroundColor Background [Color] when the category is not selected.
  * @param onCategoryClick Callback for when the user taps a category.
  * @param modifier [Modifier] to be applied to the layout.
  */
+@Suppress("LongParameterList")
 @Composable
 fun PocketStoriesCategories(
     categories: List<PocketRecommendedStoriesCategory>,
     selections: List<PocketRecommendedStoriesSelectedCategory>,
+    selectedTextColor: Color? = null,
+    unselectedTextColor: Color? = null,
+    selectedBackgroundColor: Color? = null,
+    unselectedBackgroundColor: Color? = null,
     onCategoryClick: (PocketRecommendedStoriesCategory) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -375,7 +399,14 @@ fun PocketStoriesCategories(
             verticalItemsSpacing = 16.dp,
         ) {
             categories.filter { it.name != POCKET_STORIES_DEFAULT_CATEGORY_NAME }.forEach { category ->
-                SelectableChip(category.name, selections.map { it.name }.contains(category.name)) {
+                SelectableChip(
+                    text = category.name,
+                    isSelected = selections.map { it.name }.contains(category.name),
+                    selectedTextColor = selectedTextColor,
+                    unselectedTextColor = unselectedTextColor,
+                    selectedBackgroundColor = selectedBackgroundColor,
+                    unselectedBackgroundColor = unselectedBackgroundColor,
+                ) {
                     onCategoryClick(category)
                 }
             }

--- a/app/src/main/java/org/mozilla/fenix/home/pocket/PocketStoriesViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/pocket/PocketStoriesViewHolder.kt
@@ -23,12 +23,12 @@ import androidx.recyclerview.widget.RecyclerView
 import mozilla.components.lib.state.ext.observeAsComposableState
 import mozilla.components.service.pocket.PocketStory.PocketRecommendedStory
 import org.mozilla.fenix.R
-import org.mozilla.fenix.R.dimen
 import org.mozilla.fenix.components.components
 import org.mozilla.fenix.compose.ComposeViewHolder
 import org.mozilla.fenix.compose.home.HomeSectionHeader
 import org.mozilla.fenix.theme.FirefoxTheme
 import org.mozilla.fenix.theme.Theme
+import org.mozilla.fenix.wallpapers.WallpaperState
 
 /**
  * [RecyclerView.ViewHolder] for displaying the list of [PocketRecommendedStory]s from [AppStore].
@@ -49,13 +49,16 @@ class PocketStoriesViewHolder(
 
     @Composable
     override fun Content() {
-        val horizontalPadding = dimensionResource(dimen.home_item_horizontal_margin)
+        val horizontalPadding = dimensionResource(R.dimen.home_item_horizontal_margin)
 
         val homeScreenReady = components.appStore
             .observeAsComposableState { state -> state.firstFrameDrawn }.value ?: false
 
         val stories = components.appStore
             .observeAsComposableState { state -> state.pocketStories }.value
+
+        val wallpaperState = components.appStore
+            .observeAsComposableState { state -> state.wallpaperState }.value ?: WallpaperState.default
 
         /* This was originally done to address this perf issue:
          * https://github.com/mozilla-mobile/fenix/issues/25545 for details.
@@ -88,11 +91,12 @@ class PocketStoriesViewHolder(
             Spacer(Modifier.height(16.dp))
 
             PocketStories(
-                stories ?: emptyList(),
-                horizontalPadding,
-                interactor::onStoryShown,
-                interactor::onStoryClicked,
-                interactor::onDiscoverMoreClicked,
+                stories = stories ?: emptyList(),
+                contentPadding = horizontalPadding,
+                backgroundColor = wallpaperState.wallpaperCardColor,
+                onStoryShown = interactor::onStoryShown,
+                onStoryClicked = interactor::onStoryClicked,
+                onDiscoverMoreClicked = interactor::onDiscoverMoreClicked,
             )
         }
     }
@@ -113,6 +117,7 @@ fun PocketStoriesViewHolderPreview() {
             PocketStories(
                 stories = getFakePocketStories(8),
                 contentPadding = 0.dp,
+                backgroundColor = FirefoxTheme.colors.layer2,
                 onStoryShown = { _, _ -> },
                 onStoryClicked = { _, _ -> },
                 onDiscoverMoreClicked = {},

--- a/app/src/main/java/org/mozilla/fenix/home/recentbookmarks/view/RecentBookmarks.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recentbookmarks/view/RecentBookmarks.kt
@@ -36,6 +36,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -64,6 +65,7 @@ private val imageModifier = Modifier
  *
  * @param bookmarks List of [RecentBookmark]s to display.
  * @param menuItems List of [RecentBookmarksMenuItem] shown when long clicking a [RecentBookmarkItem]
+ * @param backgroundColor The background [Color] of each bookmark.
  * @param onRecentBookmarkClick Invoked when the user clicks on a recent bookmark.
  * @param onRecentBookmarkLongClick Invoked when the user long clicks on a recent bookmark.
  */
@@ -71,6 +73,7 @@ private val imageModifier = Modifier
 fun RecentBookmarks(
     bookmarks: List<RecentBookmark>,
     menuItems: List<RecentBookmarksMenuItem>,
+    backgroundColor: Color,
     onRecentBookmarkClick: (RecentBookmark) -> Unit = {},
     onRecentBookmarkLongClick: () -> Unit = {},
 ) {
@@ -82,6 +85,7 @@ fun RecentBookmarks(
             RecentBookmarkItem(
                 bookmark = bookmark,
                 menuItems = menuItems,
+                backgroundColor = backgroundColor,
                 onRecentBookmarkClick = onRecentBookmarkClick,
                 onRecentBookmarkLongClick = onRecentBookmarkLongClick,
             )
@@ -93,6 +97,8 @@ fun RecentBookmarks(
  * A recent bookmark item.
  *
  * @param bookmark The [RecentBookmark] to display.
+ * @param menuItems The list of [RecentBookmarksMenuItem] shown when long clicking on the recent bookmark item.
+ * @param backgroundColor The background [Color] of the recent bookmark item.
  * @param onRecentBookmarkClick Invoked when the user clicks on the recent bookmark item.
  * @param onRecentBookmarkLongClick Invoked when the user long clicks on the recent bookmark item.
  */
@@ -101,6 +107,7 @@ fun RecentBookmarks(
 private fun RecentBookmarkItem(
     bookmark: RecentBookmark,
     menuItems: List<RecentBookmarksMenuItem>,
+    backgroundColor: Color,
     onRecentBookmarkClick: (RecentBookmark) -> Unit = {},
     onRecentBookmarkLongClick: () -> Unit = {},
 ) {
@@ -118,7 +125,7 @@ private fun RecentBookmarkItem(
                 },
             ),
         shape = cardShape,
-        backgroundColor = FirefoxTheme.colors.layer2,
+        backgroundColor = backgroundColor,
         elevation = 6.dp,
     ) {
         Column(
@@ -277,6 +284,7 @@ private fun RecentBookmarksPreview() {
                 ),
             ),
             menuItems = listOf(),
+            backgroundColor = FirefoxTheme.colors.layer2,
         )
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/home/recentbookmarks/view/RecentBookmarksViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recentbookmarks/view/RecentBookmarksViewHolder.kt
@@ -15,6 +15,7 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.components.components
 import org.mozilla.fenix.compose.ComposeViewHolder
 import org.mozilla.fenix.home.recentbookmarks.interactor.RecentBookmarksInteractor
+import org.mozilla.fenix.wallpapers.WallpaperState
 import org.mozilla.fenix.GleanMetrics.RecentBookmarks as RecentBookmarksMetrics
 
 class RecentBookmarksViewHolder(
@@ -33,11 +34,13 @@ class RecentBookmarksViewHolder(
 
     @Composable
     override fun Content() {
-        val recentBookmarks = components.appStore
-            .observeAsComposableState { state -> state.recentBookmarks }
+        val recentBookmarks = components.appStore.observeAsComposableState { state -> state.recentBookmarks }
+        val wallpaperState = components.appStore
+            .observeAsComposableState { state -> state.wallpaperState }.value ?: WallpaperState.default
 
         RecentBookmarks(
             bookmarks = recentBookmarks.value ?: emptyList(),
+            backgroundColor = wallpaperState.wallpaperCardColor,
             onRecentBookmarkClick = interactor::onRecentBookmarkClicked,
             menuItems = listOf(
                 RecentBookmarksMenuItem(

--- a/app/src/main/java/org/mozilla/fenix/home/recentsyncedtabs/view/RecentSyncedTab.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recentsyncedtabs/view/RecentSyncedTab.kt
@@ -34,6 +34,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource
@@ -57,16 +58,22 @@ import org.mozilla.fenix.theme.Theme
  * A recent synced tab card.
  *
  * @param tab The [RecentSyncedTab] to display.
+ * @param backgroundColor The background [Color] of the item.
+ * @param buttonBackgroundColor The background [Color] of the item's button.
+ * @param buttonTextColor The [Color] of the button's text.
  * @param onRecentSyncedTabClick Invoked when the user clicks on the recent synced tab.
  * @param onSeeAllSyncedTabsButtonClick Invoked when user clicks on the "See all" button in the synced tab card.
  * @param onRemoveSyncedTab Invoked when user clicks on the "Remove" dropdown menu option.
  * @param onRecentSyncedTabLongClick Invoked when user long presses the recent synced tab.
  */
 @OptIn(ExperimentalFoundationApi::class)
-@Suppress("LongMethod")
+@Suppress("LongMethod", "LongParameterList")
 @Composable
 fun RecentSyncedTab(
     tab: RecentSyncedTab?,
+    backgroundColor: Color = FirefoxTheme.colors.layer2,
+    buttonBackgroundColor: Color = FirefoxTheme.colors.actionSecondary,
+    buttonTextColor: Color = FirefoxTheme.colors.textActionSecondary,
     onRecentSyncedTabClick: (RecentSyncedTab) -> Unit,
     onSeeAllSyncedTabsButtonClick: () -> Unit,
     onRemoveSyncedTab: (RecentSyncedTab) -> Unit,
@@ -91,7 +98,7 @@ fun RecentSyncedTab(
                 },
             ),
         shape = RoundedCornerShape(8.dp),
-        backgroundColor = FirefoxTheme.colors.layer2,
+        backgroundColor = backgroundColor,
         elevation = 6.dp,
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
@@ -178,12 +185,8 @@ fun RecentSyncedTab(
                 } else {
                     ""
                 },
-                textColor = FirefoxTheme.colors.textActionSecondary,
-                backgroundColor = if (tab == null) {
-                    FirefoxTheme.colors.layer3
-                } else {
-                    FirefoxTheme.colors.actionSecondary
-                },
+                textColor = buttonTextColor,
+                backgroundColor = buttonBackgroundColor,
                 tint = FirefoxTheme.colors.iconActionSecondary,
                 onClick = onSeeAllSyncedTabsButtonClick,
             )
@@ -302,6 +305,7 @@ private fun LoadingRecentSyncedTab() {
     FirefoxTheme(theme = Theme.getTheme()) {
         RecentSyncedTab(
             tab = null,
+            buttonBackgroundColor = FirefoxTheme.colors.layer3,
             onRecentSyncedTabClick = {},
             onSeeAllSyncedTabsButtonClick = {},
             onRemoveSyncedTab = {},

--- a/app/src/main/java/org/mozilla/fenix/home/recentsyncedtabs/view/RecentSyncedTabViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recentsyncedtabs/view/RecentSyncedTabViewHolder.kt
@@ -5,6 +5,7 @@
 package org.mozilla.fenix.home.recentsyncedtabs.view
 
 import android.view.View
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.ComposeView
 import androidx.lifecycle.LifecycleOwner
@@ -14,6 +15,9 @@ import org.mozilla.fenix.components.components
 import org.mozilla.fenix.compose.ComposeViewHolder
 import org.mozilla.fenix.home.recentsyncedtabs.RecentSyncedTabState
 import org.mozilla.fenix.home.recentsyncedtabs.interactor.RecentSyncedTabInteractor
+import org.mozilla.fenix.theme.FirefoxTheme
+import org.mozilla.fenix.wallpapers.Wallpaper
+import org.mozilla.fenix.wallpapers.WallpaperState
 
 /**
  * View holder for a recent synced tab item.
@@ -42,8 +46,11 @@ class RecentSyncedTabViewHolder(
 
     @Composable
     override fun Content() {
-        val recentSyncedTabState =
-            components.appStore.observeAsComposableState { state -> state.recentSyncedTabState }
+        val recentSyncedTabState = components.appStore.observeAsComposableState { state -> state.recentSyncedTabState }
+        val wallpaperState = components.appStore
+            .observeAsComposableState { state -> state.wallpaperState }.value ?: WallpaperState.default
+        val isWallpaperNotDefault = !Wallpaper.nameIsDefault(wallpaperState.currentWallpaper.name)
+
         recentSyncedTabState.value?.let {
             val syncedTab = when (it) {
                 RecentSyncedTabState.None,
@@ -51,8 +58,22 @@ class RecentSyncedTabViewHolder(
                 -> null
                 is RecentSyncedTabState.Success -> it.tabs.firstOrNull()
             }
+            val buttonBackgroundColor = when {
+                syncedTab != null && isWallpaperNotDefault -> FirefoxTheme.colors.layer1
+                syncedTab != null -> FirefoxTheme.colors.actionSecondary
+                else -> FirefoxTheme.colors.layer3
+            }
+            val buttonTextColor = when {
+                wallpaperState.currentWallpaper.cardColorDark != null &&
+                    isSystemInDarkTheme() -> FirefoxTheme.colors.textPrimary
+                else -> FirefoxTheme.colors.textActionSecondary
+            }
+
             RecentSyncedTab(
                 tab = syncedTab,
+                backgroundColor = wallpaperState.wallpaperCardColor,
+                buttonBackgroundColor = buttonBackgroundColor,
+                buttonTextColor = buttonTextColor,
                 onRecentSyncedTabClick = recentSyncedTabInteractor::onRecentSyncedTabClicked,
                 onSeeAllSyncedTabsButtonClick = recentSyncedTabInteractor::onSyncedTabShowAllClicked,
                 onRemoveSyncedTab = recentSyncedTabInteractor::onRemovedRecentSyncedTab,

--- a/app/src/main/java/org/mozilla/fenix/home/recenttabs/view/RecentTabViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recenttabs/view/RecentTabViewHolder.kt
@@ -14,6 +14,7 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.components.components
 import org.mozilla.fenix.compose.ComposeViewHolder
 import org.mozilla.fenix.home.recenttabs.interactor.RecentTabInteractor
+import org.mozilla.fenix.wallpapers.WallpaperState
 
 /**
  * View holder for a recent tab item.
@@ -42,9 +43,12 @@ class RecentTabViewHolder(
     @Composable
     override fun Content() {
         val recentTabs = components.appStore.observeAsComposableState { state -> state.recentTabs }
+        val wallpaperState = components.appStore
+            .observeAsComposableState { state -> state.wallpaperState }.value ?: WallpaperState.default
 
         RecentTabs(
             recentTabs = recentTabs.value ?: emptyList(),
+            backgroundColor = wallpaperState.wallpaperCardColor,
             onRecentTabClick = { recentTabInteractor.onRecentTabClicked(it) },
             onRecentTabLongClick = { recentTabInteractor.onRecentTabLongClicked() },
             menuItems = listOf(

--- a/app/src/main/java/org/mozilla/fenix/home/recenttabs/view/RecentTabs.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recenttabs/view/RecentTabs.kt
@@ -39,6 +39,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.layout.ContentScale
@@ -66,12 +67,14 @@ import org.mozilla.fenix.theme.FirefoxTheme
  *
  * @param recentTabs List of [RecentTab] to display.
  * @param menuItems List of [RecentTabMenuItem] shown long clicking a [RecentTab].
+ * @param backgroundColor The background [Color] of each item.
  * @param onRecentTabClick Invoked when the user clicks on a recent tab.
  */
 @Composable
 fun RecentTabs(
     recentTabs: List<RecentTab>,
     menuItems: List<RecentTabMenuItem>,
+    backgroundColor: Color = FirefoxTheme.colors.layer2,
     onRecentTabClick: (String) -> Unit = {},
     onRecentTabLongClick: () -> Unit = {},
 ) {
@@ -85,6 +88,7 @@ fun RecentTabs(
                     RecentTabItem(
                         tab = tab,
                         menuItems = menuItems,
+                        backgroundColor = backgroundColor,
                         onRecentTabClick = onRecentTabClick,
                         onRecentTabLongClick = onRecentTabLongClick,
                     )
@@ -98,6 +102,7 @@ fun RecentTabs(
  * A recent tab item.
  *
  * @param tab [RecentTab.Tab] that was recently viewed.
+ * @param backgroundColor The background [Color] of the item.
  * @param onRecentTabClick Invoked when the user clicks on a recent tab.
  */
 @OptIn(ExperimentalFoundationApi::class)
@@ -105,6 +110,7 @@ fun RecentTabs(
 private fun RecentTabItem(
     tab: RecentTab.Tab,
     menuItems: List<RecentTabMenuItem>,
+    backgroundColor: Color,
     onRecentTabClick: (String) -> Unit = {},
     onRecentTabLongClick: () -> Unit = {},
 ) {
@@ -123,7 +129,7 @@ private fun RecentTabItem(
                 },
             ),
         shape = RoundedCornerShape(8.dp),
-        backgroundColor = FirefoxTheme.colors.layer2,
+        backgroundColor = backgroundColor,
         elevation = 6.dp,
     ) {
         Row(

--- a/app/src/main/java/org/mozilla/fenix/home/recentvisits/view/RecentlyVisited.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recentvisits/view/RecentlyVisited.kt
@@ -39,6 +39,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -64,6 +65,7 @@ private const val VISITS_PER_COLUMN = 3
  *
  * @param recentVisits List of [RecentlyVisitedItem] to display.
  * @param menuItems List of [RecentVisitMenuItem] shown long clicking a [RecentlyVisitedItem].
+ * @param backgroundColor The background [Color] of each item.
  * @param onRecentVisitClick Invoked when the user clicks on a recent visit.
  * @param onRecentVisitLongClick Invoked when the user long clicks on a recent visit.
  */
@@ -71,13 +73,14 @@ private const val VISITS_PER_COLUMN = 3
 fun RecentlyVisited(
     recentVisits: List<RecentlyVisitedItem>,
     menuItems: List<RecentVisitMenuItem>,
+    backgroundColor: Color = FirefoxTheme.colors.layer2,
     onRecentVisitClick: (RecentlyVisitedItem, Int) -> Unit = { _, _ -> },
     onRecentVisitLongClick: () -> Unit = {},
 ) {
     Card(
         modifier = Modifier.fillMaxWidth(),
         shape = RoundedCornerShape(8.dp),
-        backgroundColor = FirefoxTheme.colors.layer2,
+        backgroundColor = backgroundColor,
         elevation = 6.dp,
     ) {
         val listState = rememberLazyListState()

--- a/app/src/main/java/org/mozilla/fenix/home/recentvisits/view/RecentlyVisitedViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recentvisits/view/RecentlyVisitedViewHolder.kt
@@ -20,6 +20,7 @@ import org.mozilla.fenix.home.recentvisits.RecentlyVisitedItem
 import org.mozilla.fenix.home.recentvisits.RecentlyVisitedItem.RecentHistoryGroup
 import org.mozilla.fenix.home.recentvisits.RecentlyVisitedItem.RecentHistoryHighlight
 import org.mozilla.fenix.home.recentvisits.interactor.RecentVisitsInteractor
+import org.mozilla.fenix.wallpapers.WallpaperState
 
 /**
  * View holder for [RecentlyVisitedItem]s.
@@ -43,6 +44,8 @@ class RecentlyVisitedViewHolder(
     override fun Content() {
         val recentVisits = components.appStore
             .observeAsComposableState { state -> state.recentHistory }
+        val wallpaperState = components.appStore
+            .observeAsComposableState { state -> state.wallpaperState }.value ?: WallpaperState.default
 
         RecentlyVisited(
             recentVisits = recentVisits.value ?: emptyList(),
@@ -59,6 +62,7 @@ class RecentlyVisitedViewHolder(
                     },
                 ),
             ),
+            backgroundColor = wallpaperState.wallpaperCardColor,
             onRecentVisitClick = { recentlyVisitedItem, pageNumber ->
                 when (recentlyVisitedItem) {
                     is RecentHistoryHighlight -> {

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlAdapter.kt
@@ -309,6 +309,7 @@ class SessionControlAdapter(
             TopPlaceholderViewHolder.LAYOUT_ID -> TopPlaceholderViewHolder(view)
             TopSitePagerViewHolder.LAYOUT_ID -> TopSitePagerViewHolder(
                 view = view,
+                store = components.appStore,
                 viewLifecycleOwner = viewLifecycleOwner,
                 interactor = interactor,
             )

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/CustomizeHomeButtonViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/CustomizeHomeButtonViewHolder.kt
@@ -5,19 +5,27 @@
 package org.mozilla.fenix.home.sessioncontrol.viewholders
 
 import android.view.View
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.LifecycleOwner
+import mozilla.components.lib.state.ext.observeAsComposableState
 import org.mozilla.fenix.R
+import org.mozilla.fenix.components.components
 import org.mozilla.fenix.compose.ComposeViewHolder
+import org.mozilla.fenix.compose.button.Button
 import org.mozilla.fenix.compose.button.TertiaryButton
 import org.mozilla.fenix.home.sessioncontrol.CustomizeHomeIteractor
+import org.mozilla.fenix.theme.FirefoxTheme
+import org.mozilla.fenix.wallpapers.Wallpaper
+import org.mozilla.fenix.wallpapers.WallpaperState
 
 class CustomizeHomeButtonViewHolder(
     composeView: ComposeView,
@@ -37,11 +45,31 @@ class CustomizeHomeButtonViewHolder(
 
     @Composable
     override fun Content() {
+        val wallpaperState = components.appStore
+            .observeAsComposableState { state -> state.wallpaperState }.value ?: WallpaperState.default
+        var buttonColor: Color = FirefoxTheme.colors.actionTertiary
+        val textColor: Color = FirefoxTheme.colors.textActionTertiary
+
+        wallpaperState.composeRunIfWallpaperCardColorsAreAvailable { cardColorLight, cardColorDark ->
+            buttonColor = if (isSystemInDarkTheme()) {
+                cardColorDark
+            } else {
+                cardColorLight
+            }
+        }
+
         Column {
             Spacer(modifier = Modifier.height(68.dp))
 
-            TertiaryButton(
+            /**
+             * This button will be stylized as a [TertiaryButton] when no wallpaper is selected.
+             * Otherwise, the background will use [Wallpaper.cardColorLight] or [Wallpaper.cardColorDark].
+             * */
+            Button(
                 text = stringResource(R.string.browser_menu_customize_home_1),
+                textColor = textColor,
+                backgroundColor = buttonColor,
+                tint = FirefoxTheme.colors.iconActionTertiary,
                 onClick = interactor::openCustomizeHomePage,
             )
         }

--- a/app/src/main/java/org/mozilla/fenix/home/topsites/TopSitePagerViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/topsites/TopSitePagerViewHolder.kt
@@ -12,18 +12,20 @@ import androidx.viewpager2.widget.ViewPager2
 import mozilla.components.feature.top.sites.TopSite
 import org.mozilla.fenix.GleanMetrics.TopSites
 import org.mozilla.fenix.R
+import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.databinding.ComponentTopSitesPagerBinding
 import org.mozilla.fenix.home.sessioncontrol.AdapterItem
 import org.mozilla.fenix.home.sessioncontrol.TopSiteInteractor
 
 class TopSitePagerViewHolder(
     view: View,
+    store: AppStore,
     viewLifecycleOwner: LifecycleOwner,
     interactor: TopSiteInteractor,
 ) : RecyclerView.ViewHolder(view) {
 
     private val binding = ComponentTopSitesPagerBinding.bind(view)
-    private val topSitesPagerAdapter = TopSitesPagerAdapter(viewLifecycleOwner, interactor)
+    private val topSitesPagerAdapter = TopSitesPagerAdapter(store, viewLifecycleOwner, interactor)
     private val pageIndicator = binding.pageIndicator
     private var currentPage = 0
 

--- a/app/src/main/java/org/mozilla/fenix/home/topsites/TopSiteViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/topsites/TopSiteViewHolder.kt
@@ -9,17 +9,19 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.recyclerview.widget.RecyclerView
 import mozilla.components.feature.top.sites.TopSite
 import org.mozilla.fenix.R
+import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.databinding.ComponentTopSitesBinding
 import org.mozilla.fenix.home.sessioncontrol.TopSiteInteractor
 import org.mozilla.fenix.utils.AccessibilityGridLayoutManager
 
 class TopSiteViewHolder(
     view: View,
+    store: AppStore,
     viewLifecycleOwner: LifecycleOwner,
     interactor: TopSiteInteractor,
 ) : RecyclerView.ViewHolder(view) {
 
-    private val topSitesAdapter = TopSitesAdapter(viewLifecycleOwner, interactor)
+    private val topSitesAdapter = TopSitesAdapter(store, viewLifecycleOwner, interactor)
     val binding = ComponentTopSitesBinding.bind(view)
 
     init {

--- a/app/src/main/java/org/mozilla/fenix/home/topsites/TopSitesAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/topsites/TopSitesAdapter.kt
@@ -10,17 +10,19 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import mozilla.components.feature.top.sites.TopSite
+import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.home.sessioncontrol.TopSiteInteractor
 import org.mozilla.fenix.perf.StartupTimeline
 
 class TopSitesAdapter(
+    private val store: AppStore,
     private val viewLifecycleOwner: LifecycleOwner,
     private val interactor: TopSiteInteractor,
 ) : ListAdapter<TopSite, TopSiteItemViewHolder>(TopSitesDiffCallback) {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TopSiteItemViewHolder {
         val view = LayoutInflater.from(parent.context)
             .inflate(TopSiteItemViewHolder.LAYOUT_ID, parent, false)
-        return TopSiteItemViewHolder(view, viewLifecycleOwner, interactor)
+        return TopSiteItemViewHolder(view, store, viewLifecycleOwner, interactor)
     }
 
     override fun onBindViewHolder(holder: TopSiteItemViewHolder, position: Int) {

--- a/app/src/main/java/org/mozilla/fenix/home/topsites/TopSitesPagerAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/topsites/TopSitesPagerAdapter.kt
@@ -11,11 +11,13 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import mozilla.components.feature.top.sites.TopSite
+import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.home.sessioncontrol.AdapterItem.TopSitePagerPayload
 import org.mozilla.fenix.home.sessioncontrol.TopSiteInteractor
 import org.mozilla.fenix.home.topsites.TopSitePagerViewHolder.Companion.TOP_SITES_PER_PAGE
 
 class TopSitesPagerAdapter(
+    private val store: AppStore,
     private val viewLifecycleOwner: LifecycleOwner,
     private val interactor: TopSiteInteractor,
 ) : ListAdapter<List<TopSite>, TopSiteViewHolder>(TopSiteListDiffCallback) {
@@ -23,7 +25,7 @@ class TopSitesPagerAdapter(
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TopSiteViewHolder {
         val view = LayoutInflater.from(parent.context)
             .inflate(TopSiteViewHolder.LAYOUT_ID, parent, false)
-        return TopSiteViewHolder(view, viewLifecycleOwner, interactor)
+        return TopSiteViewHolder(view, store, viewLifecycleOwner, interactor)
     }
 
     override fun onBindViewHolder(

--- a/app/src/main/java/org/mozilla/fenix/wallpapers/WallpaperState.kt
+++ b/app/src/main/java/org/mozilla/fenix/wallpapers/WallpaperState.kt
@@ -4,6 +4,11 @@
 
 package org.mozilla.fenix.wallpapers
 
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import org.mozilla.fenix.theme.FirefoxTheme
+
 /**
  * Represents all state related to the Wallpapers feature.
  *
@@ -19,5 +24,45 @@ data class WallpaperState(
             currentWallpaper = Wallpaper.Default,
             availableWallpapers = listOf(),
         )
+    }
+
+    /**
+     * Helper property used to obtain the [Color] to fill-in cards in front of a wallpaper.
+     *
+     * @return The appropriate light or dark wallpaper card [Color], if available, otherwise a default.
+     */
+    val wallpaperCardColor: Color
+        @Composable get() = when {
+            currentWallpaper.cardColorLight != null && currentWallpaper.cardColorDark != null -> {
+                if (isSystemInDarkTheme()) {
+                    Color(currentWallpaper.cardColorDark)
+                } else {
+                    Color(currentWallpaper.cardColorLight)
+                }
+            }
+            else -> FirefoxTheme.colors.layer2
+        }
+
+    /**
+     * Run the Composable [run] block only if the current wallpaper's card colors are available.
+     */
+    @Composable
+    fun composeRunIfWallpaperCardColorsAreAvailable(
+        run: @Composable (cardColorLight: Color, cardColorDark: Color) -> Unit,
+    ) {
+        if (currentWallpaper.cardColorLight != null && currentWallpaper.cardColorDark != null) {
+            run(Color(currentWallpaper.cardColorLight), Color(currentWallpaper.cardColorDark))
+        }
+    }
+
+    /**
+     * Run the [run] block only if the current wallpaper's card colors are available.
+     */
+    fun runIfWallpaperCardColorsAreAvailable(
+        run: (cardColorLight: Int, cardColorDark: Int) -> Unit,
+    ) {
+        if (currentWallpaper.cardColorLight != null && currentWallpaper.cardColorDark != null) {
+            run(currentWallpaper.cardColorLight.toInt(), currentWallpaper.cardColorDark.toInt())
+        }
     }
 }

--- a/app/src/main/res/layout/top_site_item.xml
+++ b/app/src/main/res/layout/top_site_item.xml
@@ -11,6 +11,7 @@
     android:focusable="true">
 
     <com.google.android.material.card.MaterialCardView
+        android:id="@+id/top_site_card"
         style="@style/TopSite.Card">
 
         <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -682,7 +682,6 @@
         <item name="android:layout_gravity">center_horizontal</item>
         <item name="android:importantForAccessibility">noHideDescendants</item>
         <item name="contentPadding">@dimen/top_sites_card_padding</item>
-        <item name="cardBackgroundColor">?mozac_widget_favicon_background_color</item>
         <item name="cardCornerRadius">@dimen/top_sites_card_radius</item>
         <item name="cardElevation">@dimen/top_sites_card_elevation</item>
     </style>

--- a/app/src/test/java/org/mozilla/fenix/home/topsites/TopSiteItemViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/topsites/TopSiteItemViewHolderTest.kt
@@ -23,6 +23,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.GleanMetrics.Pings
 import org.mozilla.fenix.GleanMetrics.TopSites
+import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.databinding.TopSiteItemBinding
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
@@ -37,6 +38,7 @@ class TopSiteItemViewHolderTest {
     private lateinit var binding: TopSiteItemBinding
     private lateinit var interactor: TopSiteInteractor
     private lateinit var lifecycleOwner: LifecycleOwner
+    private lateinit var store: AppStore
 
     private val pocket = TopSite.Default(
         id = 1L,
@@ -50,13 +52,14 @@ class TopSiteItemViewHolderTest {
         binding = TopSiteItemBinding.inflate(LayoutInflater.from(testContext))
         interactor = mockk(relaxed = true)
         lifecycleOwner = mockk(relaxed = true)
+        store = mockk(relaxed = true)
 
         every { testContext.components.core.icons } returns BrowserIcons(testContext, mockk(relaxed = true))
     }
 
     @Test
     fun `calls interactor on click`() {
-        TopSiteItemViewHolder(binding.root, lifecycleOwner, interactor).bind(pocket, position = 0)
+        TopSiteItemViewHolder(binding.root, store, lifecycleOwner, interactor).bind(pocket, position = 0)
 
         binding.root.performClick()
         verify { interactor.onSelectTopSite(pocket, position = 0) }
@@ -65,7 +68,7 @@ class TopSiteItemViewHolderTest {
     @Test
     fun `calls interactor on long click`() {
         every { testContext.components.analytics } returns mockk(relaxed = true)
-        TopSiteItemViewHolder(binding.root, lifecycleOwner, interactor).bind(pocket, position = 0)
+        TopSiteItemViewHolder(binding.root, store, lifecycleOwner, interactor).bind(pocket, position = 0)
 
         binding.root.performLongClick()
         verify { interactor.onTopSiteMenuOpened() }
@@ -80,7 +83,7 @@ class TopSiteItemViewHolderTest {
             createdAt = 0,
         )
 
-        TopSiteItemViewHolder(binding.root, lifecycleOwner, interactor).bind(defaultTopSite, position = 0)
+        TopSiteItemViewHolder(binding.root, store, lifecycleOwner, interactor).bind(defaultTopSite, position = 0)
         val pinIndicator = binding.topSiteTitle.compoundDrawables[0]
 
         assertNotNull(pinIndicator)
@@ -95,7 +98,7 @@ class TopSiteItemViewHolderTest {
             createdAt = 0,
         )
 
-        TopSiteItemViewHolder(binding.root, lifecycleOwner, interactor).bind(pinnedTopSite, position = 0)
+        TopSiteItemViewHolder(binding.root, store, lifecycleOwner, interactor).bind(pinnedTopSite, position = 0)
         val pinIndicator = binding.topSiteTitle.compoundDrawables[0]
 
         assertNotNull(pinIndicator)
@@ -110,7 +113,7 @@ class TopSiteItemViewHolderTest {
             createdAt = 0,
         )
 
-        TopSiteItemViewHolder(binding.root, lifecycleOwner, interactor).bind(frecentTopSite, position = 0)
+        TopSiteItemViewHolder(binding.root, store, lifecycleOwner, interactor).bind(frecentTopSite, position = 0)
         val pinIndicator = binding.topSiteTitle.compoundDrawables[0]
 
         assertNull(pinIndicator)
@@ -144,7 +147,7 @@ class TopSiteItemViewHolderTest {
             topSiteImpressionSubmitted = true
         }
 
-        TopSiteItemViewHolder(binding.root, lifecycleOwner, interactor).submitTopSitesImpressionPing(topSite, position)
+        TopSiteItemViewHolder(binding.root, store, lifecycleOwner, interactor).submitTopSitesImpressionPing(topSite, position)
 
         assertNotNull(TopSites.contileImpression.testGetValue())
 

--- a/app/src/test/java/org/mozilla/fenix/home/topsites/TopSiteViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/topsites/TopSiteViewHolderTest.kt
@@ -13,6 +13,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.databinding.ComponentTopSitesBinding
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.home.sessioncontrol.TopSiteInteractor
@@ -23,17 +24,19 @@ class TopSiteViewHolderTest {
     private lateinit var binding: ComponentTopSitesBinding
     private lateinit var lifecycleOwner: LifecycleOwner
     private lateinit var interactor: TopSiteInteractor
+    private lateinit var store: AppStore
 
     @Before
     fun setup() {
         binding = ComponentTopSitesBinding.inflate(LayoutInflater.from(testContext))
         interactor = mockk(relaxed = true)
         lifecycleOwner = mockk(relaxed = true)
+        store = mockk(relaxed = true)
     }
 
     @Test
     fun `binds list of top sites`() {
-        TopSiteViewHolder(binding.root, lifecycleOwner, interactor).bind(
+        TopSiteViewHolder(binding.root, store, lifecycleOwner, interactor).bind(
             listOf(
                 TopSite.Default(
                     id = 1L,

--- a/app/src/test/java/org/mozilla/fenix/home/topsites/TopSitesPagerAdapterTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/topsites/TopSitesPagerAdapterTest.kt
@@ -49,7 +49,7 @@ class TopSitesPagerAdapterTest {
 
     @Before
     fun setup() {
-        topSitesPagerAdapter = spyk(TopSitesPagerAdapter(mockk(), mockk()))
+        topSitesPagerAdapter = spyk(TopSitesPagerAdapter(mockk(), mockk(), mockk()))
     }
 
     @Test

--- a/app/src/test/java/org/mozilla/fenix/perf/StartupReportFullyDrawnTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/perf/StartupReportFullyDrawnTest.kt
@@ -53,7 +53,7 @@ class StartupReportFullyDrawnTest {
         holderItemView = spyk(binding.root)
         every { activity.findViewById<LinearLayout>(R.id.rootContainer) } returns rootContainer
         every { holderItemView.context } returns activity
-        holder = TopSiteItemViewHolder(holderItemView, mockk(), mockk())
+        holder = TopSiteItemViewHolder(holderItemView, mockk(), mockk(), mockk())
         every { rootContainer.viewTreeObserver } returns viewTreeObserver
         every { holderItemView.viewTreeObserver } returns viewTreeObserver
 


### PR DESCRIPTION
The backplating coloring is dependent on _both_ light and dark colors (as they're used as inverses for Pocket category selection), if one card color is unavailable, then the backplating will use the default/existing coloring.

See the root issue for the logic for non-card components.

Note: turning red will be covered in https://github.com/mozilla-mobile/fenix/issues/27331

### Default / no wallpaper
| Light | Dark |
|--|--|
| <img src="https://user-images.githubusercontent.com/87384386/195909333-6d149485-5563-4fe6-8b18-709290a55778.png" width=300/> | <img src="https://user-images.githubusercontent.com/87384386/195911969-ec866c12-6c2c-4266-ba43-5767a0d3032c.png" width=300/> |
| <img src="https://user-images.githubusercontent.com/87384386/195909562-9fff73b6-c4c1-419d-b278-e43e10e19be3.png" width=300/> | <img src="https://user-images.githubusercontent.com/87384386/195911990-64ad90ae-93a4-42ca-bef6-5d43ede8ba5c.png" width=300/> |

### Amethyst
| Light | Dark |
|--|--|
| <img src="https://user-images.githubusercontent.com/87384386/195909666-4137349c-9496-47c8-b64a-b8f7989492e4.png" width=300/> | <img src="https://user-images.githubusercontent.com/87384386/195912024-4b920b2a-951f-4aff-a186-0f28f6e55e18.png" width=300/> |
| <img src="https://user-images.githubusercontent.com/87384386/195909692-77d8dd12-e710-4855-8ee2-2636122e49a5.png" width=300/> | <img src="https://user-images.githubusercontent.com/87384386/195912044-1f669cde-8d48-4e80-b019-113967d56a6f.png" width=300/> |

### Cerulean
| Light | Dark |
|--|--|
| <img src="https://user-images.githubusercontent.com/87384386/195910074-432b130c-d0f9-4e04-8a6b-f44d578cdb88.png" width=300/> | <img src="https://user-images.githubusercontent.com/87384386/195912087-10bc158b-f8bc-4bd0-bde9-e84f817801e2.png" width=300/> |
| <img src="https://user-images.githubusercontent.com/87384386/195910106-af087ec0-118b-4b6c-98cb-d1adbebdc378.png" width=300/> | <img src="https://user-images.githubusercontent.com/87384386/195912106-e2523e1e-792d-40b9-876b-db9639fee61a.png" width=300/> |

### Sunrise
| Light | Dark |
|--|--|
| <img src="https://user-images.githubusercontent.com/87384386/195910144-5c013d63-9746-45f0-baf2-8608e91d8f63.png" width=300/> | <img src="https://user-images.githubusercontent.com/87384386/195912142-34d6e16d-25a0-46ef-93bf-7fd61953350a.png" width=300/> |
| <img src="https://user-images.githubusercontent.com/87384386/195910172-1e0eeae5-dc7a-4fd4-bfec-6b884ce27d6b.png" width=300/> | <img src="https://user-images.githubusercontent.com/87384386/195912163-baa3a3d8-95bb-41dc-aeb7-7028cff346a6.png" width=300/> |

### Beach Vibes
| Light | Dark |
|--|--|
| <img src="https://user-images.githubusercontent.com/87384386/195910223-f917a5fa-fe94-48d9-8687-753aae037e2a.png" width=300/> | <img src="https://user-images.githubusercontent.com/87384386/195912194-e14fa09d-160b-4e6b-a05f-183c4aaa1acb.png" width=300/> |
| <img src="https://user-images.githubusercontent.com/87384386/195910250-593a5888-8f83-4c4b-bae5-2d4bf932caef.png" width=300/> | <img src="https://user-images.githubusercontent.com/87384386/195912207-82e7976a-afa9-4524-ae0a-25ce6c388478.png" width=300/> |

### Twilight Hills
| Light | Dark |
|--|--|
| <img src="https://user-images.githubusercontent.com/87384386/195910298-87efe318-a802-47c1-9088-9fa597c95082.png" width=300/> | <img src="https://user-images.githubusercontent.com/87384386/195912240-c47f6110-15b8-4536-8ac5-99a3645c975f.png" width=300/> |
| <img src="https://user-images.githubusercontent.com/87384386/195910321-fb3f5f5c-7216-4265-9cb9-5ea3a55e3fbe.png" width=300/> | <img src="https://user-images.githubusercontent.com/87384386/195912264-c9623cd9-e1a7-4fd9-bc8c-923026af1be6.png" width=300/> |

### Activist
| Light | Dark |
|--|--|
| <img src="https://user-images.githubusercontent.com/87384386/195910384-c790877f-7c2f-45ed-8890-dcab5938779e.png" width=300/> | <img src="https://user-images.githubusercontent.com/87384386/195912300-d29aa560-8f0f-46da-9283-3ed087a4c3c1.png" width=300/> |
| <img src="https://user-images.githubusercontent.com/87384386/195910413-e3da76c5-4cfc-49f7-97c3-e5de687d0dd4.png" width=300/> | <img src="https://user-images.githubusercontent.com/87384386/195912325-b36a08b4-c5f6-40b7-ade3-372c65b42fec.png" width=300/> |

### Dreamer
| Light | Dark |
|--|--|
| <img src="https://user-images.githubusercontent.com/87384386/195910531-74c13700-82b6-475e-8851-46df2b19d05e.png" width=300/> | <img src="https://user-images.githubusercontent.com/87384386/195912359-91e179c3-fba8-49a9-9614-5d5246c674b8.png" width=300/> |
| <img src="https://user-images.githubusercontent.com/87384386/195910562-a73e43f8-7843-427b-93bd-a71180d51b23.png" width=300/> | <img src="https://user-images.githubusercontent.com/87384386/195912376-7936138f-2f31-44b2-ba23-2a6835b88005.png" width=300/> |

### Expressionist
| Light | Dark |
|--|--|
| <img src="https://user-images.githubusercontent.com/87384386/195910612-28b059c7-5a5f-401f-ae29-7972457480e4.png" width=300/> | <img src="https://user-images.githubusercontent.com/87384386/195912402-0caa0034-3747-40eb-9d0e-62273d606bee.png" width=300/> |
| <img src="https://user-images.githubusercontent.com/87384386/195910637-ebccaab3-a1dd-4e6e-9c90-f38aee794233.png" width=300/> | <img src="https://user-images.githubusercontent.com/87384386/195912421-61fbbc9e-cb41-4b1f-b8f9-dcbef572dd2c.png" width=300/> |

### Innovator
| Light | Dark |
|--|--|
| <img src="https://user-images.githubusercontent.com/87384386/195910685-0c93a7c5-acd7-4721-a2e8-60addb843c67.png" width=300/> | <img src="https://user-images.githubusercontent.com/87384386/195912468-316fb594-2fc1-4ad8-ae71-09ead277fce6.png" width=300/> |
| <img src="https://user-images.githubusercontent.com/87384386/195910719-1bfe87b3-9750-4935-9d5d-873db4964a2b.png" width=300/> | <img src="https://user-images.githubusercontent.com/87384386/195912480-a9f40856-7f7e-4430-a214-b1deb842c5e6.png" width=300/> |

### Playmaker
| Light | Dark |
|--|--|
| <img src="https://user-images.githubusercontent.com/87384386/195910773-c7290962-3fcb-4b61-9414-23ae2509166f.png" width=300/> | <img src="https://user-images.githubusercontent.com/87384386/195912525-b28e5725-a059-4f92-a675-75fcafbc77e6.png" width=300/> |
| <img src="https://user-images.githubusercontent.com/87384386/195910797-57070bf4-d001-4620-8cc5-573d0456a0e6.png" width=300/> | <img src="https://user-images.githubusercontent.com/87384386/195912554-816d4492-90b0-4c02-b77f-4cb2e3ce70c4.png" width=300/> |

### Visionary
| Light | Dark |
|--|--|
| <img src="https://user-images.githubusercontent.com/87384386/195910841-5d50c533-a16b-4494-ba69-65aa4785310d.png" width=300/> | <img src="https://user-images.githubusercontent.com/87384386/195912572-35e0880c-2541-4048-b8e6-cfedcf2d11cf.png" width=300/> |
| <img src="https://user-images.githubusercontent.com/87384386/195910870-0c967526-ce93-4c2f-b1ed-d86b403da800.png" width=300/> | <img src="https://user-images.githubusercontent.com/87384386/195912600-b801273c-f967-4a33-96d3-3f84245511e2.png" width=300/> |


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

















### GitHub Automation
Fixes #26520