### PR TITLE
Closes #26999: fix disapprearing wallpapers after going back to home screen

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -698,6 +698,7 @@ class HomeFragment : Fragment() {
         appBarLayout = null
         _binding = null
         bundleArgs.clear()
+        lastAppliedWallpaperName = Wallpaper.defaultName
     }
 
     override fun onStart() {


### PR DESCRIPTION
Debugging `HomeFragment` lead to the problem [here](https://searchfox.org/mozilla-mobile/source/fenix/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt#946).

Navigating back would keep the fragment instance and recreate the view, but because we kept track of `lastAppliedWallpaperName`, the `applyWallpaper` would return without applying any wallpaper.

Resetting the flag on the `onDestroyView` looks like a safe approach.


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
Fixes #26999