### PR TITLE
For #27005 fix flaky updateSavedLoginTest UI test

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -64,20 +64,20 @@ class SmokeTest {
     private lateinit var browserStore: BrowserStore
     private val featureSettingsHelper = FeatureSettingsHelper()
 
-    @get:Rule
+    @get:Rule(order = 0)
     val activityTestRule = AndroidComposeTestRule(
         HomeActivityIntentTestRule(),
         { it.activity },
     )
 
-    @get: Rule
+    @get: Rule(order = 1)
     val intentReceiverActivityTestRule = ActivityTestRule(
         IntentReceiverActivity::class.java,
         true,
         false,
     )
 
-    @Rule
+    @Rule(order = 2)
     @JvmField
     val retryTestRule = RetryTestRule(3)
 


### PR DESCRIPTION
For #27005 fix flaky `updateSavedLoginTest` UI test ✅ successfully ran 100x on Firebase.

The error seems to be cause by compose.
Found [this workaround](https://issuetracker.google.com/issues/235383900#comment2) and seems to be working properly.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
Fixes #27005