### PR TITLE
For #27055: check whether applied wallpaper name is blank

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -945,7 +945,7 @@ class HomeFragment : Fragment() {
         when {
             !shouldEnableWallpaper() ||
                 (wallpaperName == lastAppliedWallpaperName && !orientationChange) -> return
-            wallpaperName == Wallpaper.defaultName -> {
+            Wallpaper.nameIsDefault(wallpaperName) -> {
                 binding.wallpaperImageView.isVisible = false
                 lastAppliedWallpaperName = wallpaperName
             }

--- a/app/src/main/java/org/mozilla/fenix/wallpapers/Wallpaper.kt
+++ b/app/src/main/java/org/mozilla/fenix/wallpapers/Wallpaper.kt
@@ -129,6 +129,14 @@ data class Wallpaper(
                 null
             }
         }
+
+        /**
+         * Check if a wallpaper name matches the default. Considers empty strings to be default
+         * since that likely means a wallpaper has never been set.
+         *
+         * @param name The name to check.
+         */
+        fun nameIsDefault(name: String): Boolean = name.isEmpty() || name == defaultName
     }
 
     /**

--- a/app/src/test/java/org/mozilla/fenix/wallpapers/WallpaperTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/wallpapers/WallpaperTest.kt
@@ -1,0 +1,28 @@
+package org.mozilla.fenix.wallpapers
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WallpaperTest {
+    @Test
+    fun `GIVEN blank wallpaper name WHEN checking whether is default THEN is default`() {
+        val result = Wallpaper.nameIsDefault("")
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `GIVEN the default wallpaper is set to be shown WHEN checking whether the current wallpaper should be default THEN return true`() {
+        val result = Wallpaper.nameIsDefault("default")
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `GIVEN a custom wallpaper is set to be shown WHEN checking whether the current wallpaper should be default THEN return false`() {
+        val result = Wallpaper.nameIsDefault("wally world")
+
+        assertFalse(result)
+    }
+}


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
Fixes #27055