### PR TITLE
For #26884 - Merge FeatureSettingsHelper with HomeActivityIntentTestRule

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/FeatureSettingsHelper.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/FeatureSettingsHelper.kt
@@ -4,72 +4,84 @@
 
 package org.mozilla.fenix.helpers
 
-import android.content.Context
 import androidx.test.platform.app.InstrumentationRegistry
 import org.mozilla.fenix.ext.settings
 
-class FeatureSettingsHelper {
-    private val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
-    private val settings = context.settings()
+/**
+ * Helper for querying the status and modifying various features and settings in the application.
+ */
+interface FeatureSettingsHelper {
+    /**
+     * Whether the onboarding for existing users should be shown or not.
+     * It should appear only once on the first visit to homescreen.
+     */
+    var isHomeOnboardingDialogEnabled: Boolean
 
-    // saving default values of feature flags
-    private var isPocketEnabled: Boolean = settings.showPocketRecommendationsFeature
-    private var isJumpBackInCFREnabled: Boolean = settings.shouldShowJumpBackInCFR
-    private var isRecentTabsFeatureEnabled: Boolean = settings.showRecentTabsFeature
-    private var isRecentlyVisitedFeatureEnabled: Boolean = settings.historyMetadataUIFeature
-    private var isUserKnowsAboutPwasTrue: Boolean = settings.userKnowsAboutPwas
-    private var isTCPCFREnabled: Boolean = settings.shouldShowTotalCookieProtectionCFR
-    private var isWallpaperOnboardingEnabled: Boolean = settings.showWallpaperOnboarding
+    /**
+     * Whether the Pocket stories feature is enabled or not.
+     */
+    var isPocketEnabled: Boolean
 
-    fun setPocketEnabled(enabled: Boolean) {
-        settings.showPocketRecommendationsFeature = enabled
-    }
+    /**
+     * Whether the "Jump back in" CFR should be shown or not.
+     * It should appear on the first visit to homescreen given that there is a tab opened.
+     */
+    var isJumpBackInCFREnabled: Boolean
 
-    fun setJumpBackCFREnabled(enabled: Boolean) {
-        settings.shouldShowJumpBackInCFR = enabled
-    }
+    /**
+     * Whether the onboarding dialog for choosing wallpapers should be shown or not.
+     */
+    var isWallpaperOnboardingEnabled: Boolean
 
-    fun setShowWallpaperOnboarding(enabled: Boolean) {
-        settings.showWallpaperOnboarding = enabled
-    }
+    /**
+     * Whether the "Jump back in" homescreen section is enabled or not.
+     * It shows the last visited tab on this device and on other synced devices.
+     */
+    var isRecentTabsFeatureEnabled: Boolean
 
-    fun setRecentTabsFeatureEnabled(enabled: Boolean) {
-        settings.showRecentTabsFeature = enabled
-    }
+    /**
+     * Whether the "Recently visited" homescreen section is enabled or not.
+     * It can show up to 9 history highlights and history groups.
+     */
+    var isRecentlyVisitedFeatureEnabled: Boolean
 
-    fun setRecentlyVisitedFeatureEnabled(enabled: Boolean) {
-        settings.historyMetadataUIFeature = enabled
-    }
+    /**
+     * Whether the onboarding dialog for PWAs should be shown or not.
+     * It can show the first time a website that can be installed as a PWA is accessed.
+     */
+    var isPWAsPromptEnabled: Boolean
 
-    fun setStrictETPEnabled() {
-        settings.setStrictETP()
-    }
-
-    fun disablePwaCFR(disable: Boolean) {
-        settings.userKnowsAboutPwas = disable
-    }
-
-    fun deleteSitePermissions(delete: Boolean) {
-        settings.deleteSitePermissions = delete
-    }
+    /**
+     * Whether the "Site permissions" option is checked in the "Delete browsing data" screen or not.
+     */
+    var isDeleteSitePermissionsEnabled: Boolean
 
     /**
      * Enable or disable showing the TCP CFR when accessing a webpage for the first time.
      */
-    fun setTCPCFREnabled(shouldShowCFR: Boolean) {
-        settings.shouldShowTotalCookieProtectionCFR = shouldShowCFR
-    }
+    var isTCPCFREnabled: Boolean
 
-    // Important:
-    // Use this after each test if you have modified these feature settings
-    // to make sure the app goes back to the default state
-    fun resetAllFeatureFlags() {
-        settings.showPocketRecommendationsFeature = isPocketEnabled
-        settings.shouldShowJumpBackInCFR = isJumpBackInCFREnabled
-        settings.showRecentTabsFeature = isRecentTabsFeatureEnabled
-        settings.historyMetadataUIFeature = isRecentlyVisitedFeatureEnabled
-        settings.userKnowsAboutPwas = isUserKnowsAboutPwasTrue
-        settings.shouldShowTotalCookieProtectionCFR = isTCPCFREnabled
-        settings.showWallpaperOnboarding = isWallpaperOnboardingEnabled
+    /**
+     * The current "Enhanced Tracking Protection" policy.
+     * @see ETPPolicy
+     */
+    var etpPolicy: ETPPolicy
+
+    fun applyFlagUpdates()
+
+    fun resetAllFeatureFlags()
+
+    companion object {
+        val settings = InstrumentationRegistry.getInstrumentation().targetContext.settings()
     }
+}
+
+/**
+ * All "Enhanced Tracking Protection" modes.
+ */
+enum class ETPPolicy {
+    STANDARD,
+    STRICT,
+    CUSTOM,
+    ;
 }

--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/FeatureSettingsHelperDelegate.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/FeatureSettingsHelperDelegate.kt
@@ -1,0 +1,159 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.helpers
+
+import org.mozilla.fenix.R
+import org.mozilla.fenix.ext.getPreferenceKey
+import org.mozilla.fenix.helpers.ETPPolicy.CUSTOM
+import org.mozilla.fenix.helpers.ETPPolicy.STANDARD
+import org.mozilla.fenix.helpers.ETPPolicy.STRICT
+import org.mozilla.fenix.helpers.FeatureSettingsHelper.Companion.settings
+import org.mozilla.fenix.helpers.TestHelper.appContext
+import org.mozilla.fenix.onboarding.FenixOnboarding
+import org.mozilla.fenix.utils.Settings
+
+/**
+ * Helper for querying the status and modifying various features and settings in the application.
+ */
+class FeatureSettingsHelperDelegate : FeatureSettingsHelper {
+    /**
+     * The current feature flags used inside the app before the tests start.
+     * These will be restored when the tests end.
+     */
+    private val initialFeatureFlags = FeatureFlags(
+        isHomeOnboardingDialogEnabled = settings.showHomeOnboardingDialog,
+        homeOnboardingDialogVersion = getHomeOnboardingVersion(),
+        isPocketEnabled = settings.showPocketRecommendationsFeature,
+        isJumpBackInCFREnabled = settings.shouldShowJumpBackInCFR,
+        isRecentTabsFeatureEnabled = settings.showRecentTabsFeature,
+        isRecentlyVisitedFeatureEnabled = settings.historyMetadataUIFeature,
+        isPWAsPromptEnabled = !settings.userKnowsAboutPwas,
+        isTCPCFREnabled = settings.shouldShowTotalCookieProtectionCFR,
+        isWallpaperOnboardingEnabled = settings.showWallpaperOnboarding,
+        isDeleteSitePermissionsEnabled = settings.deleteSitePermissions,
+        etpPolicy = getETPPolicy(settings),
+    )
+
+    /**
+     * The current feature flags updated in tests.
+     */
+    private var updatedFeatureFlags = initialFeatureFlags.copy()
+
+    override var isHomeOnboardingDialogEnabled: Boolean
+        get() = updatedFeatureFlags.isHomeOnboardingDialogEnabled &&
+            FenixOnboarding(appContext).userHasBeenOnboarded()
+        set(value) {
+            updatedFeatureFlags.isHomeOnboardingDialogEnabled = value
+            updatedFeatureFlags.homeOnboardingDialogVersion = when (value) {
+                true -> FenixOnboarding.CURRENT_ONBOARDING_VERSION
+                false -> 0
+            }
+        }
+    override var isPocketEnabled: Boolean by updatedFeatureFlags::isPocketEnabled
+    override var isJumpBackInCFREnabled: Boolean by updatedFeatureFlags::isJumpBackInCFREnabled
+    override var isWallpaperOnboardingEnabled: Boolean by updatedFeatureFlags::isWallpaperOnboardingEnabled
+    override var isRecentTabsFeatureEnabled: Boolean by updatedFeatureFlags::isRecentTabsFeatureEnabled
+    override var isRecentlyVisitedFeatureEnabled: Boolean by updatedFeatureFlags::isRecentlyVisitedFeatureEnabled
+    override var isPWAsPromptEnabled: Boolean by updatedFeatureFlags::isPWAsPromptEnabled
+    override var isTCPCFREnabled: Boolean by updatedFeatureFlags::isTCPCFREnabled
+    override var etpPolicy: ETPPolicy by updatedFeatureFlags::etpPolicy
+
+    override fun applyFlagUpdates() {
+        applyFeatureFlags(updatedFeatureFlags)
+    }
+
+    override fun resetAllFeatureFlags() {
+        applyFeatureFlags(initialFeatureFlags)
+    }
+    override var isDeleteSitePermissionsEnabled: Boolean by updatedFeatureFlags::isDeleteSitePermissionsEnabled
+
+    private fun applyFeatureFlags(featureFlags: FeatureFlags) {
+        settings.showHomeOnboardingDialog = featureFlags.isHomeOnboardingDialogEnabled
+        setHomeOnboardingVersion(featureFlags.homeOnboardingDialogVersion)
+        settings.showPocketRecommendationsFeature = featureFlags.isPocketEnabled
+        settings.shouldShowJumpBackInCFR = featureFlags.isJumpBackInCFREnabled
+        settings.showRecentTabsFeature = featureFlags.isRecentTabsFeatureEnabled
+        settings.historyMetadataUIFeature = featureFlags.isRecentlyVisitedFeatureEnabled
+        settings.userKnowsAboutPwas = !featureFlags.isPWAsPromptEnabled
+        settings.shouldShowTotalCookieProtectionCFR = featureFlags.isTCPCFREnabled
+        settings.showWallpaperOnboarding = featureFlags.isWallpaperOnboardingEnabled
+        settings.deleteSitePermissions = featureFlags.isDeleteSitePermissionsEnabled
+        setETPPolicy(featureFlags.etpPolicy)
+    }
+}
+
+private data class FeatureFlags(
+    var isHomeOnboardingDialogEnabled: Boolean,
+    var homeOnboardingDialogVersion: Int,
+    var isPocketEnabled: Boolean,
+    var isJumpBackInCFREnabled: Boolean,
+    var isRecentTabsFeatureEnabled: Boolean,
+    var isRecentlyVisitedFeatureEnabled: Boolean,
+    var isPWAsPromptEnabled: Boolean,
+    var isTCPCFREnabled: Boolean,
+    var isWallpaperOnboardingEnabled: Boolean,
+    var isDeleteSitePermissionsEnabled: Boolean,
+    var etpPolicy: ETPPolicy,
+)
+
+internal fun getETPPolicy(settings: Settings): ETPPolicy {
+    return when {
+        settings.useStrictTrackingProtection -> STRICT
+        settings.useCustomTrackingProtection -> CUSTOM
+        else -> STANDARD
+    }
+}
+
+private fun setETPPolicy(policy: ETPPolicy) {
+    when (policy) {
+        STRICT -> settings.setStrictETP()
+        // The following two cases update ETP in the same way "setStrictETP" does.
+        STANDARD -> {
+            settings.preferences.edit()
+                .putBoolean(
+                    appContext.getPreferenceKey(R.string.pref_key_tracking_protection_strict_default),
+                    false,
+                )
+                .putBoolean(
+                    appContext.getPreferenceKey(R.string.pref_key_tracking_protection_custom_option),
+                    false,
+                )
+                .putBoolean(
+                    appContext.getPreferenceKey(R.string.pref_key_tracking_protection_standard_option),
+                    true,
+                )
+                .commit()
+        }
+        CUSTOM -> {
+            settings.preferences.edit()
+                .putBoolean(
+                    appContext.getPreferenceKey(R.string.pref_key_tracking_protection_strict_default),
+                    false,
+                )
+                .putBoolean(
+                    appContext.getPreferenceKey(R.string.pref_key_tracking_protection_standard_option),
+                    true,
+                )
+                .putBoolean(
+                    appContext.getPreferenceKey(R.string.pref_key_tracking_protection_custom_option),
+                    true,
+                )
+                .commit()
+        }
+    }
+}
+
+private fun getHomeOnboardingVersion(): Int {
+    return FenixOnboarding(appContext)
+        .preferences
+        .getInt(FenixOnboarding.LAST_VERSION_ONBOARDING_KEY, 0)
+}
+
+private fun setHomeOnboardingVersion(version: Int) {
+    FenixOnboarding(appContext)
+        .preferences.edit()
+        .putInt(FenixOnboarding.LAST_VERSION_ONBOARDING_KEY, version)
+        .commit()
+}

--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/HomeActivityTestRule.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/HomeActivityTestRule.kt
@@ -6,12 +6,12 @@
 
 package org.mozilla.fenix.helpers
 
-import android.app.Activity
 import android.view.ViewConfiguration.getLongPressTimeout
 import androidx.test.espresso.intent.rule.IntentsTestRule
 import androidx.test.rule.ActivityTestRule
 import androidx.test.uiautomator.UiSelector
 import org.mozilla.fenix.HomeActivity
+import org.mozilla.fenix.helpers.FeatureSettingsHelper.Companion.settings
 import org.mozilla.fenix.helpers.TestHelper.appContext
 import org.mozilla.fenix.helpers.TestHelper.mDevice
 import org.mozilla.fenix.onboarding.FenixOnboarding
@@ -27,33 +27,90 @@ class HomeActivityTestRule(
     initialTouchMode: Boolean = false,
     launchActivity: Boolean = true,
     private val skipOnboarding: Boolean = false,
-) :
-    ActivityTestRule<HomeActivity>(HomeActivity::class.java, initialTouchMode, launchActivity) {
+) : ActivityTestRule<HomeActivity>(HomeActivity::class.java, initialTouchMode, launchActivity),
+    FeatureSettingsHelper by FeatureSettingsHelperDelegate() {
+
+    // Using a secondary constructor allows us to easily delegate the settings to FeatureSettingsHelperDelegate.
+    // Otherwise if wanting to use the same names we would have to override these settings in the primary
+    // constructor and in that elide the FeatureSettingsHelperDelegate.
+    constructor(
+        initialTouchMode: Boolean = false,
+        launchActivity: Boolean = true,
+        skipOnboarding: Boolean = false,
+        isHomeOnboardingDialogEnabled: Boolean = settings.showHomeOnboardingDialog &&
+            FenixOnboarding(appContext).userHasBeenOnboarded(),
+        isPocketEnabled: Boolean = settings.showPocketRecommendationsFeature,
+        isJumpBackInCFREnabled: Boolean = settings.shouldShowJumpBackInCFR,
+        isRecentTabsFeatureEnabled: Boolean = settings.showRecentTabsFeature,
+        isRecentlyVisitedFeatureEnabled: Boolean = settings.historyMetadataUIFeature,
+        isPWAsPromptEnabled: Boolean = !settings.userKnowsAboutPwas,
+        isTCPCFREnabled: Boolean = settings.shouldShowTotalCookieProtectionCFR,
+        isWallpaperOnboardingEnabled: Boolean = settings.showWallpaperOnboarding,
+        isDeleteSitePermissionsEnabled: Boolean = settings.deleteSitePermissions,
+        etpPolicy: ETPPolicy = getETPPolicy(settings),
+    ) : this(initialTouchMode, launchActivity, skipOnboarding) {
+        this.isHomeOnboardingDialogEnabled = isHomeOnboardingDialogEnabled
+        this.isPocketEnabled = isPocketEnabled
+        this.isJumpBackInCFREnabled = isJumpBackInCFREnabled
+        this.isRecentTabsFeatureEnabled = isRecentTabsFeatureEnabled
+        this.isRecentlyVisitedFeatureEnabled = isRecentlyVisitedFeatureEnabled
+        this.isPWAsPromptEnabled = isPWAsPromptEnabled
+        this.isTCPCFREnabled = isTCPCFREnabled
+        this.isWallpaperOnboardingEnabled = isWallpaperOnboardingEnabled
+        this.isDeleteSitePermissionsEnabled = isDeleteSitePermissionsEnabled
+        this.etpPolicy = etpPolicy
+    }
 
     /**
-     * Helper for updating various app settings that could interfere with the tests.
-     * Tests that use [HomeActivityTestRule] are expected to rely on this [FeatureSettingsHelper]
-     * instead of instantiating their own.
-     *
-     * The main benefit this brings is better ordering of operations with the settings cleanup
-     * automatically happening just before the [Activity] under test finishes which may as opposed to
-     * cleanup happening earlier and modifying the app behavior.
+     * Update settings after the activity was created.
      */
-    val featureSettingsHelper = FeatureSettingsHelper()
+    fun applySettingsExceptions(settings: (FeatureSettingsHelper) -> Unit) {
+        FeatureSettingsHelperDelegate().also {
+            settings(it)
+            applyFlagUpdates()
+        }
+    }
 
     private val longTapUserPreference = getLongPressTimeout()
 
     override fun beforeActivityLaunched() {
         super.beforeActivityLaunched()
         setLongTapTimeout(3000)
+        applyFlagUpdates()
         if (skipOnboarding) { skipOnboardingBeforeLaunch() }
     }
 
     override fun afterActivityFinished() {
         super.afterActivityFinished()
         setLongTapTimeout(longTapUserPreference)
-        featureSettingsHelper.resetAllFeatureFlags()
+        resetAllFeatureFlags()
         closeNotificationShade()
+    }
+
+    companion object {
+        /**
+         * Create a new instance of [HomeActivityTestRule] which by default will disable specific
+         * app features that would otherwise negatively impact most tests.
+         *
+         * The disabled features are:
+         *  - the Jump back in CFR,
+         *  - the Total Cookie Protection CFR,
+         *  - the PWA prompt dialog,
+         *  - the wallpaper onboarding.
+         */
+        fun withDefaultSettingsOverrides(
+            initialTouchMode: Boolean = false,
+            launchActivity: Boolean = true,
+            skipOnboarding: Boolean = false,
+        ) = HomeActivityTestRule(
+            initialTouchMode = initialTouchMode,
+            launchActivity = launchActivity,
+            skipOnboarding = skipOnboarding,
+            isJumpBackInCFREnabled = false,
+            isPWAsPromptEnabled = false,
+            isTCPCFREnabled = false,
+            isWallpaperOnboardingEnabled = false,
+        )
     }
 }
 
@@ -65,17 +122,59 @@ class HomeActivityTestRule(
  * @param launchActivity See [IntentsTestRule]
  */
 
-class HomeActivityIntentTestRule(
+class HomeActivityIntentTestRule internal constructor(
     initialTouchMode: Boolean = false,
     launchActivity: Boolean = true,
     private val skipOnboarding: Boolean = false,
-) :
-    IntentsTestRule<HomeActivity>(HomeActivity::class.java, initialTouchMode, launchActivity) {
+) : IntentsTestRule<HomeActivity>(HomeActivity::class.java, initialTouchMode, launchActivity),
+    FeatureSettingsHelper by FeatureSettingsHelperDelegate() {
+    // Using a secondary constructor allows us to easily delegate the settings to FeatureSettingsHelperDelegate.
+    // Otherwise if wanting to use the same names we would have to override these settings in the primary
+    // constructor and in that elide the FeatureSettingsHelperDelegate.
+    constructor(
+        initialTouchMode: Boolean = false,
+        launchActivity: Boolean = true,
+        skipOnboarding: Boolean = false,
+        isHomeOnboardingDialogEnabled: Boolean = settings.showHomeOnboardingDialog &&
+            FenixOnboarding(appContext).userHasBeenOnboarded(),
+        isPocketEnabled: Boolean = settings.showPocketRecommendationsFeature,
+        isJumpBackInCFREnabled: Boolean = settings.shouldShowJumpBackInCFR,
+        isRecentTabsFeatureEnabled: Boolean = settings.showRecentTabsFeature,
+        isRecentlyVisitedFeatureEnabled: Boolean = settings.historyMetadataUIFeature,
+        isPWAsPromptEnabled: Boolean = !settings.userKnowsAboutPwas,
+        isTCPCFREnabled: Boolean = settings.shouldShowTotalCookieProtectionCFR,
+        isWallpaperOnboardingEnabled: Boolean = settings.showWallpaperOnboarding,
+        isDeleteSitePermissionsEnabled: Boolean = settings.deleteSitePermissions,
+        etpPolicy: ETPPolicy = getETPPolicy(settings),
+    ) : this(initialTouchMode, launchActivity, skipOnboarding) {
+        this.isHomeOnboardingDialogEnabled = isHomeOnboardingDialogEnabled
+        this.isPocketEnabled = isPocketEnabled
+        this.isJumpBackInCFREnabled = isJumpBackInCFREnabled
+        this.isRecentTabsFeatureEnabled = isRecentTabsFeatureEnabled
+        this.isRecentlyVisitedFeatureEnabled = isRecentlyVisitedFeatureEnabled
+        this.isPWAsPromptEnabled = isPWAsPromptEnabled
+        this.isTCPCFREnabled = isTCPCFREnabled
+        this.isWallpaperOnboardingEnabled = isWallpaperOnboardingEnabled
+        this.isDeleteSitePermissionsEnabled = isDeleteSitePermissionsEnabled
+        this.etpPolicy = etpPolicy
+    }
+
     private val longTapUserPreference = getLongPressTimeout()
+
+    /**
+     * Update settings after the activity was created.
+     */
+    fun applySettingsExceptions(settings: (FeatureSettingsHelper) -> Unit) {
+        FeatureSettingsHelperDelegate().apply {
+            settings(this)
+            applyFlagUpdates()
+        }
+    }
 
     override fun beforeActivityLaunched() {
         super.beforeActivityLaunched()
         setLongTapTimeout(3000)
+        applyFlagUpdates()
         if (skipOnboarding) { skipOnboardingBeforeLaunch() }
     }
 
@@ -83,6 +182,53 @@ class HomeActivityIntentTestRule(
         super.afterActivityFinished()
         setLongTapTimeout(longTapUserPreference)
         closeNotificationShade()
+        resetAllFeatureFlags()
+    }
+
+    /**
+     * Update the settings values from when this rule was first instantiated to account for any changes
+     * done while running the tests.
+     * Useful in the scenario about the activity being restarted which would otherwise set the initial
+     * settings and override any changes made in the meantime.
+     */
+    fun updateCachedSettings() {
+        isHomeOnboardingDialogEnabled =
+            settings.showHomeOnboardingDialog && FenixOnboarding(appContext).userHasBeenOnboarded()
+        isPocketEnabled = settings.showPocketRecommendationsFeature
+        isJumpBackInCFREnabled = settings.shouldShowJumpBackInCFR
+        isRecentTabsFeatureEnabled = settings.showRecentTabsFeature
+        isRecentlyVisitedFeatureEnabled = settings.historyMetadataUIFeature
+        isPWAsPromptEnabled = !settings.userKnowsAboutPwas
+        isTCPCFREnabled = settings.shouldShowTotalCookieProtectionCFR
+        isWallpaperOnboardingEnabled = settings.showWallpaperOnboarding
+        isDeleteSitePermissionsEnabled = settings.deleteSitePermissions
+        etpPolicy = getETPPolicy(settings)
+    }
+
+    companion object {
+        /**
+         * Create a new instance of [HomeActivityIntentTestRule] which by default will disable specific
+         * app features that would otherwise negatively impact most tests.
+         *
+         * The disabled features are:
+         *  - the Jump back in CFR,
+         *  - the Total Cookie Protection CFR,
+         *  - the PWA prompt dialog,
+         *  - the wallpaper onboarding.
+         */
+        fun withDefaultSettingsOverrides(
+            initialTouchMode: Boolean = false,
+            launchActivity: Boolean = true,
+            skipOnboarding: Boolean = false,
+        ) = HomeActivityIntentTestRule(
+            initialTouchMode = initialTouchMode,
+            launchActivity = launchActivity,
+            skipOnboarding = skipOnboarding,
+            isJumpBackInCFREnabled = false,
+            isPWAsPromptEnabled = false,
+            isTCPCFREnabled = false,
+            isWallpaperOnboardingEnabled = false,
+        )
     }
 }
 

--- a/app/src/androidTest/java/org/mozilla/fenix/helpers/TestHelper.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/helpers/TestHelper.kt
@@ -95,6 +95,7 @@ object TestHelper {
 
     fun restartApp(activity: HomeActivityIntentTestRule) {
         with(activity) {
+            updateCachedSettings()
             finishActivity()
             mDevice.waitForIdle()
             launchActivity(null)

--- a/app/src/androidTest/java/org/mozilla/fenix/perf/StartupExcessiveResourceUseTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/perf/StartupExcessiveResourceUseTest.kt
@@ -33,7 +33,7 @@ import org.mozilla.fenix.helpers.HomeActivityTestRule
  *
  * Say no to main thread IO! 🙅
  */
-private const val EXPECTED_SUPPRESSION_COUNT = 17
+private const val EXPECTED_SUPPRESSION_COUNT = 19
 
 /**
  * The number of times we call the `runBlocking` coroutine method on the main thread during this

--- a/app/src/androidTest/java/org/mozilla/fenix/screenshots/MenuScreenShotTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/screenshots/MenuScreenShotTest.kt
@@ -43,8 +43,7 @@ class MenuScreenShotTest : ScreenshotTest() {
     val localeTestRule = LocaleTestRule()
 
     @get:Rule
-    var mActivityTestRule = HomeActivityTestRule()
-    private val featureSettingsHelper = mActivityTestRule.featureSettingsHelper
+    var mActivityTestRule = HomeActivityTestRule.withDefaultSettingsOverrides()
 
     @Before
     fun setUp() {
@@ -53,8 +52,6 @@ class MenuScreenShotTest : ScreenshotTest() {
             dispatcher = AndroidAssetDispatcher()
             start()
         }
-
-        featureSettingsHelper.setTCPCFREnabled(false)
     }
 
     @After

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
@@ -47,8 +47,7 @@ class BookmarksTest {
     }
 
     @get:Rule
-    val activityTestRule = HomeActivityTestRule()
-    private val featureSettingsHelper = activityTestRule.featureSettingsHelper
+    val activityTestRule = HomeActivityTestRule.withDefaultSettingsOverrides()
 
     @Rule
     @JvmField
@@ -61,8 +60,6 @@ class BookmarksTest {
             dispatcher = AndroidAssetDispatcher()
             start()
         }
-        featureSettingsHelper.setJumpBackCFREnabled(false)
-        featureSettingsHelper.setTCPCFREnabled(false)
     }
 
     @After

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/BrowsingErrorPagesTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/BrowsingErrorPagesTest.kt
@@ -5,7 +5,6 @@
 package org.mozilla.fenix.ui
 
 import androidx.core.net.toUri
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.R
@@ -26,19 +25,11 @@ class BrowsingErrorPagesTest {
     private val harmfulSiteWarning = getStringResource(R.string.mozac_browser_errorpages_safe_harmful_uri_title)
 
     @get: Rule
-    val mActivityTestRule = HomeActivityTestRule()
-    private val featureSettingsHelper = mActivityTestRule.featureSettingsHelper
+    val mActivityTestRule = HomeActivityTestRule.withDefaultSettingsOverrides()
 
     @Rule
     @JvmField
     val retryTestRule = RetryTestRule(3)
-
-    @Before
-    fun setUp() {
-        // disabling the jump-back-in pop-up that interferes with the tests.
-        featureSettingsHelper.setJumpBackCFREnabled(false)
-        featureSettingsHelper.setTCPCFREnabled(false)
-    }
 
     @SmokeTest
     @Test

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/CollectionTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/CollectionTest.kt
@@ -15,7 +15,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
-import org.mozilla.fenix.helpers.FeatureSettingsHelper
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper.getGenericAsset
 import org.mozilla.fenix.ui.robots.browserScreen
@@ -35,23 +34,21 @@ class CollectionTest {
     private val firstCollectionName = "testcollection_1"
     private val secondCollectionName = "testcollection_2"
     private val collectionName = "First Collection"
-    private val featureSettingsHelper = FeatureSettingsHelper()
 
     @get:Rule
     val composeTestRule = AndroidComposeTestRule(
-        HomeActivityIntentTestRule(),
-        { it.activity },
-    )
+        // disabling these features to have better visibility of Collections,
+        // and to avoid multiple matches on tab items
+        HomeActivityIntentTestRule(
+            isPocketEnabled = false,
+            isJumpBackInCFREnabled = false,
+            isRecentTabsFeatureEnabled = false,
+            isRecentlyVisitedFeatureEnabled = false,
+        ),
+    ) { it.activity }
 
     @Before
     fun setUp() {
-        // disabling these features to have better visibility of Collections,
-        // and to avoid multiple matches on tab items
-        featureSettingsHelper.setRecentTabsFeatureEnabled(false)
-        featureSettingsHelper.setPocketEnabled(false)
-        featureSettingsHelper.setJumpBackCFREnabled(false)
-        featureSettingsHelper.setRecentlyVisitedFeatureEnabled(false)
-
         mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
         mockWebServer = MockWebServer().apply {
             dispatcher = AndroidAssetDispatcher()
@@ -62,9 +59,6 @@ class CollectionTest {
     @After
     fun tearDown() {
         mockWebServer.shutdown()
-
-        // resetting modified features enabled setting to default
-        featureSettingsHelper.resetAllFeatureFlags()
     }
 
     @SmokeTest

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/ContextMenusTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/ContextMenusTest.kt
@@ -14,7 +14,6 @@ import org.junit.Test
 import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
-import org.mozilla.fenix.helpers.FeatureSettingsHelper
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.RetryTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
@@ -41,13 +40,11 @@ class ContextMenusTest {
     private lateinit var mockWebServer: MockWebServer
 
     @get:Rule
-    val activityIntentTestRule = HomeActivityIntentTestRule()
+    val activityIntentTestRule = HomeActivityIntentTestRule.withDefaultSettingsOverrides()
 
     @Rule
     @JvmField
     val retryTestRule = RetryTestRule(3)
-
-    private val featureSettingsHelper = FeatureSettingsHelper()
 
     @Before
     fun setUp() {
@@ -57,14 +54,11 @@ class ContextMenusTest {
             dispatcher = AndroidAssetDispatcher()
             start()
         }
-
-        featureSettingsHelper.setTCPCFREnabled(false)
     }
 
     @After
     fun tearDown() {
         mockWebServer.shutdown()
-        featureSettingsHelper.resetAllFeatureFlags()
     }
 
     @SmokeTest

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/CrashReportingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/CrashReportingTest.kt
@@ -12,7 +12,6 @@ import org.junit.Test
 import org.mozilla.fenix.R
 import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
-import org.mozilla.fenix.helpers.FeatureSettingsHelper
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.helpers.TestHelper.getStringResource
@@ -22,21 +21,19 @@ import org.mozilla.fenix.ui.robots.navigationToolbar
 class CrashReportingTest {
     private lateinit var mDevice: UiDevice
     private lateinit var mockWebServer: MockWebServer
-    private val featureSettingsHelper = FeatureSettingsHelper()
     private val tabCrashMessage = getStringResource(R.string.tab_crash_title_2)
 
     @get:Rule
     val activityTestRule = AndroidComposeTestRule(
-        HomeActivityIntentTestRule(),
-        { it.activity },
-    )
+        HomeActivityIntentTestRule(
+            isPocketEnabled = false,
+            isJumpBackInCFREnabled = false,
+            isWallpaperOnboardingEnabled = false,
+        ),
+    ) { it.activity }
 
     @Before
     fun setUp() {
-        featureSettingsHelper.setJumpBackCFREnabled(false)
-        featureSettingsHelper.setPocketEnabled(false)
-        featureSettingsHelper.setShowWallpaperOnboarding(false)
-
         mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
         mockWebServer = MockWebServer().apply {
             dispatcher = AndroidAssetDispatcher()
@@ -47,7 +44,6 @@ class CrashReportingTest {
     @After
     fun tearDown() {
         mockWebServer.shutdown()
-        featureSettingsHelper.resetAllFeatureFlags()
     }
 
     @Test

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/CustomTabsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/CustomTabsTest.kt
@@ -14,7 +14,7 @@ import org.junit.Test
 import org.mozilla.fenix.IntentReceiverActivity
 import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
-import org.mozilla.fenix.helpers.FeatureSettingsHelper
+import org.mozilla.fenix.helpers.FeatureSettingsHelperDelegate
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.helpers.TestHelper.createCustomTabIntent
@@ -47,7 +47,7 @@ class CustomTabsTest {
         false,
     )
 
-    private val featureSettingsHelper = FeatureSettingsHelper()
+    private val featureSettingsHelper = FeatureSettingsHelperDelegate()
 
     @Before
     fun setUp() {
@@ -57,7 +57,9 @@ class CustomTabsTest {
             start()
         }
 
-        featureSettingsHelper.setTCPCFREnabled(false)
+        featureSettingsHelper.apply {
+            isTCPCFREnabled = false
+        }.applyFlagUpdates()
     }
 
     @After

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/DownloadFileTypesTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/DownloadFileTypesTest.kt
@@ -5,14 +5,11 @@
 package org.mozilla.fenix.ui
 
 import androidx.core.net.toUri
-import org.junit.After
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import org.mozilla.fenix.customannotations.SmokeTest
-import org.mozilla.fenix.helpers.FeatureSettingsHelper
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.ui.robots.navigationToolbar
 
@@ -27,10 +24,9 @@ class DownloadFileTypesTest(fileName: String) {
     /* Remote test page managed by Mozilla Mobile QA team at https://github.com/mozilla-mobile/testapp */
     private val downloadTestPage = "https://storage.googleapis.com/mobile_test_assets/test_app/downloads.html"
     private var downloadFile: String = fileName
-    private val featureSettingsHelper = FeatureSettingsHelper()
 
     @get:Rule
-    val activityTestRule = HomeActivityIntentTestRule()
+    val activityTestRule = HomeActivityIntentTestRule.withDefaultSettingsOverrides()
 
     companion object {
         // Creating test data. The test will take each file name as a parameter and run it individually.
@@ -46,21 +42,6 @@ class DownloadFileTypesTest(fileName: String) {
             "CSVfile.csv",
             "XMLfile.xml",
         )
-    }
-
-    @Before
-    fun setUp() {
-        // disabling the jump-back-in pop-up that interferes with the tests.
-        featureSettingsHelper.setJumpBackCFREnabled(false)
-        // disable the TCP CFR that appears when loading webpages and interferes with the tests.
-        featureSettingsHelper.setTCPCFREnabled(false)
-        // disabling the PWA CFR on 3rd visit
-        featureSettingsHelper.disablePwaCFR(true)
-    }
-
-    @After
-    fun tearDown() {
-        featureSettingsHelper.resetAllFeatureFlags()
     }
 
     @SmokeTest

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/DownloadTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/DownloadTest.kt
@@ -16,7 +16,6 @@ import org.junit.rules.TestRule
 import org.junit.rules.TestWatcher
 import org.junit.runner.Description
 import org.mozilla.fenix.customannotations.SmokeTest
-import org.mozilla.fenix.helpers.FeatureSettingsHelper
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.TestHelper.deleteDownloadFromStorage
 import org.mozilla.fenix.ui.robots.browserScreen
@@ -34,14 +33,13 @@ import org.mozilla.fenix.ui.robots.notificationShade
  **/
 class DownloadTest {
     private lateinit var mDevice: UiDevice
-    private val featureSettingsHelper = FeatureSettingsHelper()
 
     /* Remote test page managed by Mozilla Mobile QA team at https://github.com/mozilla-mobile/testapp */
     private val downloadTestPage = "https://storage.googleapis.com/mobile_test_assets/test_app/downloads.html"
     private var downloadFile: String = ""
 
     @get:Rule
-    val activityTestRule = HomeActivityIntentTestRule()
+    val activityTestRule = HomeActivityIntentTestRule.withDefaultSettingsOverrides()
 
     // Making sure to grant storage access for this test running on API 28
     @get: Rule
@@ -62,12 +60,6 @@ class DownloadTest {
     @Before
     fun setUp() {
         mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-        // disabling the jump-back-in pop-up that interferes with the tests.
-        featureSettingsHelper.setJumpBackCFREnabled(false)
-        // disable the TCP CFR that appears when loading webpages and interferes with the tests.
-        featureSettingsHelper.setTCPCFREnabled(false)
-        // disabling the PWA CFR on 3rd visit
-        featureSettingsHelper.disablePwaCFR(true)
         // clear all existing notifications
         notificationShade {
             mDevice.openNotification()
@@ -77,7 +69,6 @@ class DownloadTest {
 
     @After
     fun tearDown() {
-        featureSettingsHelper.resetAllFeatureFlags()
         notificationShade {
             cancelAllShownNotifications()
         }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/HistoryTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/HistoryTest.kt
@@ -39,8 +39,7 @@ class HistoryTest {
     private lateinit var mDevice: UiDevice
 
     @get:Rule
-    val activityTestRule = HomeActivityTestRule()
-    private val featureSettingsHelper = activityTestRule.featureSettingsHelper
+    val activityTestRule = HomeActivityTestRule.withDefaultSettingsOverrides()
 
     @Before
     fun setUp() {
@@ -52,8 +51,6 @@ class HistoryTest {
             dispatcher = AndroidAssetDispatcher()
             start()
         }
-
-        featureSettingsHelper.setTCPCFREnabled(false)
     }
 
     @After

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
@@ -36,8 +36,7 @@ class HomeScreenTest {
     private lateinit var mockWebServer: MockWebServer
 
     @get:Rule
-    val activityTestRule = HomeActivityTestRule()
-    private val featureSettingsHelper = activityTestRule.featureSettingsHelper
+    val activityTestRule = HomeActivityTestRule.withDefaultSettingsOverrides()
 
     @Rule
     @JvmField
@@ -51,8 +50,6 @@ class HomeScreenTest {
             dispatcher = AndroidAssetDispatcher()
             start()
         }
-
-        featureSettingsHelper.setTCPCFREnabled(false)
     }
 
     @After
@@ -147,8 +144,10 @@ class HomeScreenTest {
 
     @Test
     fun dismissOnboardingUsingHelpTest() {
-        featureSettingsHelper.setJumpBackCFREnabled(false)
-        featureSettingsHelper.setShowWallpaperOnboarding(false)
+        activityTestRule.applySettingsExceptions {
+            it.isJumpBackInCFREnabled = false
+            it.isWallpaperOnboardingEnabled = false
+        }
 
         homeScreen {
             verifyWelcomeHeader()
@@ -175,8 +174,10 @@ class HomeScreenTest {
 
     @Test
     fun verifyPocketHomepageStoriesTest() {
-        featureSettingsHelper.setRecentTabsFeatureEnabled(false)
-        featureSettingsHelper.setRecentlyVisitedFeatureEnabled(false)
+        activityTestRule.applySettingsExceptions {
+            it.isRecentTabsFeatureEnabled = false
+            it.isRecentlyVisitedFeatureEnabled = false
+        }
 
         homeScreen {
         }.dismissOnboarding()
@@ -196,8 +197,6 @@ class HomeScreenTest {
     @Test
     fun verifyCustomizeHomepageTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-        featureSettingsHelper.setJumpBackCFREnabled(false)
-        featureSettingsHelper.setShowWallpaperOnboarding(false)
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(defaultWebPage.url) {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/MediaNotificationTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/MediaNotificationTest.kt
@@ -15,7 +15,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
-import org.mozilla.fenix.helpers.FeatureSettingsHelper
 import org.mozilla.fenix.helpers.HomeActivityTestRule
 import org.mozilla.fenix.helpers.RetryTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
@@ -35,10 +34,9 @@ class MediaNotificationTest {
 
     private lateinit var mockWebServer: MockWebServer
     private lateinit var mDevice: UiDevice
-    val featureSettingsHelper = FeatureSettingsHelper()
 
     @get:Rule
-    val activityTestRule = HomeActivityTestRule()
+    val activityTestRule = HomeActivityTestRule.withDefaultSettingsOverrides()
     private lateinit var browserStore: BrowserStore
 
     @Rule
@@ -56,7 +54,6 @@ class MediaNotificationTest {
             dispatcher = AndroidAssetDispatcher()
             start()
         }
-        featureSettingsHelper.setTCPCFREnabled(false)
     }
 
     @After

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/NavigationToolbarTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/NavigationToolbarTest.kt
@@ -34,8 +34,7 @@ class NavigationToolbarTest {
 
     /* ktlint-disable no-blank-line-before-rbrace */ // This imposes unreadable grouping.
     @get:Rule
-    val activityTestRule = HomeActivityTestRule()
-    private val featureSettingsHelper = activityTestRule.featureSettingsHelper
+    val activityTestRule = HomeActivityTestRule.withDefaultSettingsOverrides()
 
     @Before
     fun setUp() {
@@ -44,9 +43,6 @@ class NavigationToolbarTest {
             dispatcher = AndroidAssetDispatcher()
             start()
         }
-        featureSettingsHelper.setJumpBackCFREnabled(false)
-        featureSettingsHelper.setTCPCFREnabled(false)
-        featureSettingsHelper.disablePwaCFR(true)
     }
 
     @After

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/NoNetworkAccessStartupTests.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/NoNetworkAccessStartupTests.kt
@@ -6,7 +6,6 @@ package org.mozilla.fenix.ui
 
 import androidx.core.net.toUri
 import org.junit.After
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.R
@@ -26,14 +25,7 @@ import org.mozilla.fenix.ui.robots.navigationToolbar
 class NoNetworkAccessStartupTests {
 
     @get:Rule
-    val activityTestRule = HomeActivityTestRule(launchActivity = false)
-    private val featureSettingsHelper = activityTestRule.featureSettingsHelper
-
-    @Before
-    fun setUp() {
-        featureSettingsHelper.setTCPCFREnabled(false)
-        featureSettingsHelper.setShowWallpaperOnboarding(false)
-    }
+    val activityTestRule = HomeActivityTestRule.withDefaultSettingsOverrides(launchActivity = false)
 
     @After
     fun tearDown() {
@@ -60,7 +52,6 @@ class NoNetworkAccessStartupTests {
     // Based on STR from https://github.com/mozilla-mobile/fenix/issues/16886
     @Test
     fun networkInterruptedFromBrowserToHomeTest() {
-        featureSettingsHelper.setJumpBackCFREnabled(false)
         val url = "example.com"
 
         activityTestRule.launchActivity(null)

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/PwaTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/PwaTest.kt
@@ -1,14 +1,11 @@
 package org.mozilla.fenix.ui
 
 import androidx.core.net.toUri
-import org.junit.After
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.helpers.Constants.PackageName.GMAIL_APP
 import org.mozilla.fenix.helpers.Constants.PackageName.PHONE_APP
-import org.mozilla.fenix.helpers.FeatureSettingsHelper
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.TestHelper.assertNativeAppOpens
 import org.mozilla.fenix.ui.robots.customTabScreen
@@ -16,8 +13,6 @@ import org.mozilla.fenix.ui.robots.navigationToolbar
 import org.mozilla.fenix.ui.robots.pwaScreen
 
 class PwaTest {
-    private val featureSettingsHelper = FeatureSettingsHelper()
-
     /* Updated externalLinks.html to v2.0,
        changed the hypertext reference to mozilla-mobile.github.io/testapp/downloads for "External link"
      */
@@ -27,18 +22,7 @@ class PwaTest {
     private val shortcutTitle = "TEST_APP"
 
     @get:Rule
-    val activityTestRule = HomeActivityIntentTestRule()
-
-    @Before
-    fun setUp() {
-        featureSettingsHelper.disablePwaCFR(true)
-        featureSettingsHelper.setTCPCFREnabled(false)
-    }
-
-    @After
-    fun tearDown() {
-        featureSettingsHelper.resetAllFeatureFlags()
-    }
+    val activityTestRule = HomeActivityIntentTestRule.withDefaultSettingsOverrides()
 
     @SmokeTest
     @Test

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/ReaderViewTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/ReaderViewTest.kt
@@ -37,7 +37,7 @@ class ReaderViewTest {
     private val estimatedReadingTime = "1 - 2 minutes"
 
     @get:Rule
-    val activityIntentTestRule = HomeActivityIntentTestRule()
+    val activityIntentTestRule = HomeActivityIntentTestRule.withDefaultSettingsOverrides()
 
     @Rule
     @JvmField

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SearchTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SearchTest.kt
@@ -49,10 +49,13 @@ class SearchTest {
 
     @get:Rule
     val activityTestRule = AndroidComposeTestRule(
-        HomeActivityTestRule(),
-        { it.activity },
-    )
-    private val featureSettingsHelper = activityTestRule.activityRule.featureSettingsHelper
+        HomeActivityTestRule(
+            isPocketEnabled = false,
+            isJumpBackInCFREnabled = false,
+            isTCPCFREnabled = false,
+            isWallpaperOnboardingEnabled = false,
+        ),
+    ) { it.activity }
 
     @Before
     fun setUp() {
@@ -60,10 +63,6 @@ class SearchTest {
             dispatcher = SearchDispatcher()
             start()
         }
-        featureSettingsHelper.setJumpBackCFREnabled(false)
-        featureSettingsHelper.setTCPCFREnabled(false)
-        featureSettingsHelper.setPocketEnabled(false)
-        featureSettingsHelper.setShowWallpaperOnboarding(false)
     }
 
     @After

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAboutTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAboutTest.kt
@@ -13,7 +13,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
-import org.mozilla.fenix.helpers.FeatureSettingsHelper
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.RetryTestRule
 import org.mozilla.fenix.helpers.TestHelper.mDevice
@@ -30,7 +29,6 @@ class SettingsAboutTest {
 
     private lateinit var mDevice: UiDevice
     private lateinit var mockWebServer: MockWebServer
-    private val featureSettingsHelper = FeatureSettingsHelper()
 
     @get:Rule
     val activityIntentTestRule = HomeActivityIntentTestRule()
@@ -51,7 +49,6 @@ class SettingsAboutTest {
     @After
     fun tearDown() {
         mockWebServer.shutdown()
-        featureSettingsHelper.resetAllFeatureFlags()
     }
 
     // Walks through settings menu and sub-menus to ensure all items are present
@@ -71,7 +68,9 @@ class SettingsAboutTest {
     // ABOUT
     @Test
     fun verifyRateOnGooglePlayRedirect() {
-        featureSettingsHelper.setTCPCFREnabled(false)
+        activityIntentTestRule.applySettingsExceptions {
+            it.isTCPCFREnabled = false
+        }
 
         homeScreen {
         }.openThreeDotMenu {
@@ -86,8 +85,10 @@ class SettingsAboutTest {
 
     @Test
     fun verifyAboutFirefoxPreview() {
-        featureSettingsHelper.setJumpBackCFREnabled(false)
-        featureSettingsHelper.setTCPCFREnabled(false)
+        activityIntentTestRule.applySettingsExceptions {
+            it.isJumpBackInCFREnabled = false
+            it.isTCPCFREnabled = false
+        }
         homeScreen {
         }.openThreeDotMenu {
         }.openSettings {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAddonsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAddonsTest.kt
@@ -14,7 +14,6 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.ext.settings
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
-import org.mozilla.fenix.helpers.FeatureSettingsHelper
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.RecyclerViewIdlingResource
 import org.mozilla.fenix.helpers.TestAssetHelper.getEnhancedTrackingProtectionAsset
@@ -31,10 +30,9 @@ import org.mozilla.fenix.ui.robots.navigationToolbar
  */
 class SettingsAddonsTest {
     private lateinit var mockWebServer: MockWebServer
-    private val featureSettingsHelper = FeatureSettingsHelper()
 
     @get:Rule
-    val activityTestRule = HomeActivityIntentTestRule()
+    val activityTestRule = HomeActivityIntentTestRule.withDefaultSettingsOverrides()
 
     @Before
     fun setUp() {
@@ -42,15 +40,11 @@ class SettingsAddonsTest {
             dispatcher = AndroidAssetDispatcher()
             start()
         }
-
-        featureSettingsHelper.setTCPCFREnabled(false)
     }
 
     @After
     fun tearDown() {
         mockWebServer.shutdown()
-
-        featureSettingsHelper.resetAllFeatureFlags()
     }
 
     // Walks through settings add-ons menu to ensure all items are present

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAdvancedTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAdvancedTest.kt
@@ -13,7 +13,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
-import org.mozilla.fenix.helpers.FeatureSettingsHelper
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.helpers.TestHelper
@@ -30,10 +29,12 @@ class SettingsAdvancedTest {
 
     private lateinit var mDevice: UiDevice
     private lateinit var mockWebServer: MockWebServer
-    private val featureSettingsHelper = FeatureSettingsHelper()
 
     @get:Rule
-    val activityIntentTestRule = HomeActivityIntentTestRule()
+    val activityIntentTestRule = HomeActivityIntentTestRule(
+        isPocketEnabled = false,
+        isTCPCFREnabled = false,
+    )
 
     @Before
     fun setUp() {
@@ -42,15 +43,11 @@ class SettingsAdvancedTest {
             dispatcher = AndroidAssetDispatcher()
             start()
         }
-        featureSettingsHelper.setPocketEnabled(false)
-        featureSettingsHelper.setTCPCFREnabled(false)
     }
 
     @After
     fun tearDown() {
         mockWebServer.shutdown()
-
-        featureSettingsHelper.resetAllFeatureFlags()
     }
 
     // Walks through settings menu and sub-menus to ensure all items are present

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsBasicsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsBasicsTest.kt
@@ -15,7 +15,6 @@ import org.mozilla.fenix.FenixApplication
 import org.mozilla.fenix.R
 import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
-import org.mozilla.fenix.helpers.FeatureSettingsHelper
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.RecyclerViewIdlingResource
 import org.mozilla.fenix.helpers.TestAssetHelper
@@ -23,8 +22,8 @@ import org.mozilla.fenix.helpers.TestAssetHelper.getLoremIpsumAsset
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTimeLong
 import org.mozilla.fenix.helpers.TestHelper.getStringResource
 import org.mozilla.fenix.helpers.TestHelper.mDevice
-import org.mozilla.fenix.helpers.TestHelper.runWithSystemLocaleChanged
 import org.mozilla.fenix.helpers.TestHelper.registerAndCleanupIdlingResources
+import org.mozilla.fenix.helpers.TestHelper.runWithSystemLocaleChanged
 import org.mozilla.fenix.ui.SettingsBasicsTest.CreditCard.MOCK_CREDIT_CARD_NUMBER
 import org.mozilla.fenix.ui.SettingsBasicsTest.CreditCard.MOCK_EXPIRATION_MONTH
 import org.mozilla.fenix.ui.SettingsBasicsTest.CreditCard.MOCK_EXPIRATION_YEAR
@@ -47,7 +46,6 @@ import java.util.Locale
 class SettingsBasicsTest {
     /* ktlint-disable no-blank-line-before-rbrace */ // This imposes unreadable grouping.
     private lateinit var mockWebServer: MockWebServer
-    private val featureSettingsHelper = FeatureSettingsHelper()
 
     object CreditCard {
         const val MOCK_CREDIT_CARD_NUMBER = "5555555555554444"
@@ -58,7 +56,7 @@ class SettingsBasicsTest {
     }
 
     @get:Rule
-    val activityIntentTestRule = HomeActivityIntentTestRule()
+    val activityIntentTestRule = HomeActivityIntentTestRule.withDefaultSettingsOverrides()
 
     @Before
     fun setUp() {
@@ -66,18 +64,11 @@ class SettingsBasicsTest {
             dispatcher = AndroidAssetDispatcher()
             start()
         }
-
-        featureSettingsHelper.setJumpBackCFREnabled(false)
-        featureSettingsHelper.setTCPCFREnabled(false)
-        featureSettingsHelper.setShowWallpaperOnboarding(false)
     }
 
     @After
     fun tearDown() {
         mockWebServer.shutdown()
-
-        // resetting modified features enabled setting to default
-        featureSettingsHelper.resetAllFeatureFlags()
     }
 
     private fun getUiTheme(): Boolean {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsHomepageTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsHomepageTest.kt
@@ -12,7 +12,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
-import org.mozilla.fenix.helpers.FeatureSettingsHelper
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.RetryTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper.getGenericAsset
@@ -27,10 +26,9 @@ import org.mozilla.fenix.ui.robots.navigationToolbar
  */
 class SettingsHomepageTest {
     private lateinit var mockWebServer: MockWebServer
-    private val featureSettingsHelper = FeatureSettingsHelper()
 
     @get:Rule
-    val activityIntentTestRule = HomeActivityIntentTestRule(skipOnboarding = true)
+    val activityIntentTestRule = HomeActivityIntentTestRule.withDefaultSettingsOverrides(skipOnboarding = true)
 
     @Rule
     @JvmField
@@ -42,17 +40,11 @@ class SettingsHomepageTest {
             dispatcher = AndroidAssetDispatcher()
             start()
         }
-        featureSettingsHelper.setJumpBackCFREnabled(false)
-        featureSettingsHelper.setTCPCFREnabled(false)
-        featureSettingsHelper.setShowWallpaperOnboarding(false)
     }
 
     @After
     fun tearDown() {
         mockWebServer.shutdown()
-
-        // resetting modified features enabled setting to default
-        featureSettingsHelper.resetAllFeatureFlags()
     }
 
     @Test
@@ -90,7 +82,9 @@ class SettingsHomepageTest {
 
     @Test
     fun verifyRecentlyVisitedOptionTest() {
-        featureSettingsHelper.setRecentTabsFeatureEnabled(false)
+        activityIntentTestRule.applySettingsExceptions {
+            it.isRecentTabsFeatureEnabled = false
+        }
         val genericURL = getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {
@@ -107,8 +101,10 @@ class SettingsHomepageTest {
 
     @Test
     fun verifyPocketOptionTest() {
-        featureSettingsHelper.setRecentTabsFeatureEnabled(false)
-        featureSettingsHelper.setRecentlyVisitedFeatureEnabled(false)
+        activityIntentTestRule.applySettingsExceptions {
+            it.isRecentTabsFeatureEnabled = false
+            it.isRecentlyVisitedFeatureEnabled = false
+        }
         val genericURL = getGenericAsset(mockWebServer, 1)
 
         navigationToolbar {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsPrivacyTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsPrivacyTest.kt
@@ -18,7 +18,6 @@ import org.junit.Test
 import org.mozilla.fenix.R
 import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
-import org.mozilla.fenix.helpers.FeatureSettingsHelper
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.helpers.TestAssetHelper.getStorageTestAsset
@@ -47,10 +46,9 @@ class SettingsPrivacyTest {
     private lateinit var mDevice: UiDevice
     private lateinit var mockWebServer: MockWebServer
     private val pageShortcutName = generateRandomString(5)
-    private val featureSettingsHelper = FeatureSettingsHelper()
 
     @get:Rule
-    val activityTestRule = HomeActivityIntentTestRule(skipOnboarding = true)
+    val activityTestRule = HomeActivityIntentTestRule.withDefaultSettingsOverrides(skipOnboarding = true)
 
     @Before
     fun setUp() {
@@ -59,11 +57,6 @@ class SettingsPrivacyTest {
             dispatcher = AndroidAssetDispatcher()
             start()
         }
-
-        featureSettingsHelper.setJumpBackCFREnabled(false)
-        featureSettingsHelper.setTCPCFREnabled(false)
-        featureSettingsHelper.setShowWallpaperOnboarding(false)
-        featureSettingsHelper.disablePwaCFR(true)
 
         if (Build.VERSION.SDK_INT == Build.VERSION_CODES.R) {
             val autofillManager: AutofillManager =
@@ -75,7 +68,6 @@ class SettingsPrivacyTest {
     @After
     fun tearDown() {
         mockWebServer.shutdown()
-        featureSettingsHelper.resetAllFeatureFlags()
     }
 
     // Walks through settings privacy menu and sub-menus to ensure all items are present

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsSearchTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsSearchTest.kt
@@ -9,7 +9,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
-import org.mozilla.fenix.helpers.FeatureSettingsHelper
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.SearchDispatcher
 import org.mozilla.fenix.helpers.TestAssetHelper.getGenericAsset
@@ -20,11 +19,10 @@ import org.mozilla.fenix.ui.robots.navigationToolbar
 class SettingsSearchTest {
     private lateinit var mockWebServer: MockWebServer
     private lateinit var searchMockServer: MockWebServer
-    private val featureSettingsHelper = FeatureSettingsHelper()
 
     @get:Rule
     val activityTestRule = AndroidComposeTestRule(
-        HomeActivityIntentTestRule(),
+        HomeActivityIntentTestRule.withDefaultSettingsOverrides(),
     ) { it.activity }
 
     @Before
@@ -33,17 +31,11 @@ class SettingsSearchTest {
             dispatcher = AndroidAssetDispatcher()
             start()
         }
-        featureSettingsHelper.setJumpBackCFREnabled(false)
-        featureSettingsHelper.setShowWallpaperOnboarding(false)
-        featureSettingsHelper.setTCPCFREnabled(false)
     }
 
     @After
     fun tearDown() {
         mockWebServer.shutdown()
-
-        // resetting modified features enabled setting to default
-        featureSettingsHelper.resetAllFeatureFlags()
     }
 
     @Test

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SitePermissionsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SitePermissionsTest.kt
@@ -8,10 +8,11 @@ import android.Manifest
 import android.content.Context
 import android.hardware.camera2.CameraManager
 import android.media.AudioManager
+import android.os.Build
 import androidx.core.net.toUri
+import androidx.test.filters.SdkSuppress
 import androidx.test.rule.GrantPermissionRule
 import org.junit.Assume.assumeTrue
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.customannotations.SmokeTest
@@ -34,8 +35,12 @@ class SitePermissionsTest {
     private val micManager = appContext.getSystemService(Context.AUDIO_SERVICE) as AudioManager
 
     @get:Rule
-    val activityTestRule = HomeActivityTestRule()
-    private val featureSettingsHelper = activityTestRule.featureSettingsHelper
+    val activityTestRule = HomeActivityTestRule(
+        isJumpBackInCFREnabled = false,
+        isPWAsPromptEnabled = false,
+        isTCPCFREnabled = false,
+        isDeleteSitePermissionsEnabled = true,
+    )
 
     @get:Rule
     val grantPermissionRule: GrantPermissionRule = GrantPermissionRule.grant(
@@ -50,15 +55,7 @@ class SitePermissionsTest {
     @get: Rule
     val retryTestRule = RetryTestRule(3)
 
-    @Before
-    fun setUp() {
-        // disabling the new homepage pop-up that interferes with the tests.
-        featureSettingsHelper.setJumpBackCFREnabled(false)
-        featureSettingsHelper.setTCPCFREnabled(false)
-        featureSettingsHelper.deleteSitePermissions(true)
-        featureSettingsHelper.disablePwaCFR(true)
-    }
-
+    @SdkSuppress(maxSdkVersion = Build.VERSION_CODES.P, codeName = "P")
     @SmokeTest
     @Test
     fun audioVideoPermissionChoiceOnEachRequestTest() {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -26,7 +26,7 @@ import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.Constants.PackageName.YOUTUBE_APP
-import org.mozilla.fenix.helpers.FeatureSettingsHelper
+import org.mozilla.fenix.helpers.FeatureSettingsHelperDelegate
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.RecyclerViewIdlingResource
 import org.mozilla.fenix.helpers.RetryTestRule
@@ -62,7 +62,7 @@ class SmokeTest {
     private lateinit var mockWebServer: MockWebServer
     private val customMenuItem = "TestMenuItem"
     private lateinit var browserStore: BrowserStore
-    private val featureSettingsHelper = FeatureSettingsHelper()
+    private val featureSettingsHelper = FeatureSettingsHelperDelegate()
 
     @get:Rule(order = 0)
     val activityTestRule = AndroidComposeTestRule(
@@ -88,9 +88,11 @@ class SmokeTest {
         browserStore = activityTestRule.activity.components.core.store
 
         // disabling the new homepage pop-up that interferes with the tests.
-        featureSettingsHelper.setJumpBackCFREnabled(false)
-        featureSettingsHelper.setTCPCFREnabled(false)
-        featureSettingsHelper.setShowWallpaperOnboarding(false)
+        featureSettingsHelper.apply {
+            isJumpBackInCFREnabled = false
+            isTCPCFREnabled = false
+            isWallpaperOnboardingEnabled = false
+        }.applyFlagUpdates()
 
         mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
         mockWebServer = MockWebServer().apply {
@@ -673,7 +675,6 @@ class SmokeTest {
     // caution when making changes to it, so they don't block the builds
     @Test
     fun noHistoryInPrivateBrowsingTest() {
-        FeatureSettingsHelper().setTCPCFREnabled(false)
         val website = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 
         homeScreen {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -879,7 +879,6 @@ class SmokeTest {
         mDevice.pressBack()
     }
 
-    @Ignore("Failing: https://github.com/mozilla-mobile/fenix/issues/26884")
     @Test
     fun copyTextTest() {
         val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
@@ -899,7 +898,6 @@ class SmokeTest {
         }
     }
 
-    @Ignore("Failing: https://github.com/mozilla-mobile/fenix/issues/26884")
     @Test
     fun selectAllAndCopyTextTest() {
         val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/StrictEnhancedTrackingProtectionTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/StrictEnhancedTrackingProtectionTest.kt
@@ -11,6 +11,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
+import org.mozilla.fenix.helpers.ETPPolicy
 import org.mozilla.fenix.helpers.HomeActivityTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
 import org.mozilla.fenix.ui.robots.enhancedTrackingProtection
@@ -35,8 +36,12 @@ class StrictEnhancedTrackingProtectionTest {
     private lateinit var mockWebServer: MockWebServer
 
     @get:Rule
-    val activityTestRule = HomeActivityTestRule()
-    private val featureSettingsHelper = activityTestRule.featureSettingsHelper
+    val activityTestRule = HomeActivityTestRule(
+        isJumpBackInCFREnabled = false,
+        isTCPCFREnabled = false,
+        isWallpaperOnboardingEnabled = false,
+        etpPolicy = ETPPolicy.STRICT,
+    )
 
     @Before
     fun setUp() {
@@ -44,10 +49,6 @@ class StrictEnhancedTrackingProtectionTest {
             dispatcher = AndroidAssetDispatcher()
             start()
         }
-        featureSettingsHelper.setStrictETPEnabled()
-        featureSettingsHelper.setJumpBackCFREnabled(false)
-        featureSettingsHelper.setTCPCFREnabled(false)
-        featureSettingsHelper.setShowWallpaperOnboarding(false)
     }
 
     @After

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
@@ -45,8 +45,7 @@ class TabbedBrowsingTest {
 
     /* ktlint-disable no-blank-line-before-rbrace */ // This imposes unreadable grouping.
     @get:Rule
-    val activityTestRule = HomeActivityTestRule()
-    private val featureSettingsHelper = activityTestRule.featureSettingsHelper
+    val activityTestRule = HomeActivityTestRule.withDefaultSettingsOverrides()
 
     @Rule
     @JvmField
@@ -54,11 +53,6 @@ class TabbedBrowsingTest {
 
     @Before
     fun setUp() {
-        // disabling the new homepage pop-up that interferes with the tests.
-        featureSettingsHelper.setJumpBackCFREnabled(false)
-        featureSettingsHelper.setTCPCFREnabled(false)
-        featureSettingsHelper.setShowWallpaperOnboarding(false)
-
         mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
         mockWebServer = MockWebServer().apply {
             dispatcher = AndroidAssetDispatcher()
@@ -182,8 +176,10 @@ class TabbedBrowsingTest {
     @Test
     fun verifyUndoSnackBarTest() {
         // disabling these features because they interfere with the snackbar visibility
-        featureSettingsHelper.setPocketEnabled(false)
-        featureSettingsHelper.setRecentTabsFeatureEnabled(false)
+        activityTestRule.applySettingsExceptions {
+            it.isPocketEnabled = false
+            it.isRecentTabsFeatureEnabled = false
+        }
 
         val genericURL = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/ThreeDotMenuMainTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/ThreeDotMenuMainTest.kt
@@ -10,7 +10,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
-import org.mozilla.fenix.helpers.FeatureSettingsHelper
 import org.mozilla.fenix.helpers.HomeActivityTestRule
 import org.mozilla.fenix.ui.robots.homeScreen
 
@@ -23,15 +22,12 @@ class ThreeDotMenuMainTest {
     /* ktlint-disable no-blank-line-before-rbrace */ // This imposes unreadable grouping.
 
     private lateinit var mockWebServer: MockWebServer
-    val featureSettingsHelper = FeatureSettingsHelper()
 
     @get:Rule
-    val activityTestRule = HomeActivityTestRule()
+    val activityTestRule = HomeActivityTestRule.withDefaultSettingsOverrides()
 
     @Before
     fun setUp() {
-        featureSettingsHelper.setJumpBackCFREnabled(false)
-        featureSettingsHelper.setTCPCFREnabled(false)
         mockWebServer = MockWebServer().apply {
             dispatcher = AndroidAssetDispatcher()
             start()

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/TopSitesTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/TopSitesTest.kt
@@ -14,7 +14,6 @@ import org.junit.Test
 import org.mozilla.fenix.R
 import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
-import org.mozilla.fenix.helpers.FeatureSettingsHelper
 import org.mozilla.fenix.helpers.HomeActivityIntentTestRule
 import org.mozilla.fenix.helpers.RetryTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper.getGenericAsset
@@ -36,10 +35,9 @@ import org.mozilla.fenix.ui.robots.navigationToolbar
 class TopSitesTest {
     private lateinit var mDevice: UiDevice
     private lateinit var mockWebServer: MockWebServer
-    private val featureSettingsHelper = FeatureSettingsHelper()
 
     @get:Rule
-    val activityIntentTestRule = HomeActivityIntentTestRule(skipOnboarding = true)
+    val activityIntentTestRule = HomeActivityIntentTestRule.withDefaultSettingsOverrides(skipOnboarding = true)
 
     @get:Rule
     val retryTestRule = RetryTestRule(3)
@@ -51,16 +49,11 @@ class TopSitesTest {
             dispatcher = AndroidAssetDispatcher()
             start()
         }
-
-        featureSettingsHelper.setJumpBackCFREnabled(false)
-        featureSettingsHelper.setTCPCFREnabled(false)
-        featureSettingsHelper.setShowWallpaperOnboarding(false)
     }
 
     @After
     fun tearDown() {
         mockWebServer.shutdown()
-        featureSettingsHelper.resetAllFeatureFlags()
     }
 
     @SmokeTest


### PR DESCRIPTION
https://github.com/mozilla-mobile/fenix/pull/27012 would come to solve the issues seen by Aaron in https://github.com/mozilla-mobile/fenix/issues/26884#issuecomment-1247459000 by also ensuring the settings flags are restored when `HomeActivityIntentTestRule` finishes.

But in that PR other tests are failing seemingly because they use [restartApp](https://github.com/mozilla-mobile/fenix/blob/400a2a60d1cfa8e9c0fead7f7586927c0e025ea1/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsHomepageTest.kt#L175) 
which restarts the current activity
which will reset the settings
which would mean that in the newly restarted activity the previous settings to disable CFRs are not applying anymore.

Talked with @sv-ohorvath  and @AndiAJ about merging the `FeatureSettingsHelper` functionality with `HomeActivityIntentTestRule` to allow this rule to re-apply the updated settings.

This is a test for how would that work.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

















### GitHub Automation
Fixes #26884