### PR TITLE
For #27133: Specify type when retrieving resValues.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -235,7 +235,7 @@ android.applicationVariants.all { variant ->
 // Generate version codes for builds
 // -------------------------------------------------------------------------------------------------
 
-    def isDebug = variant.buildType.resValues['IS_DEBUG']?.value ?: false
+    def isDebug = variant.buildType.resValues['bool/IS_DEBUG']?.value ?: false
     def useReleaseVersioning = variant.buildType.buildConfigFields['USE_RELEASE_VERSIONING']?.value ?: false
 
     println("----------------------------------------------")

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAboutTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsAboutTest.kt
@@ -10,7 +10,6 @@ import androidx.test.uiautomator.UiSelector
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
@@ -85,10 +84,10 @@ class SettingsAboutTest {
         }
     }
 
-    @Ignore("Failing, see: https://github.com/mozilla-mobile/fenix/issues/25355")
     @Test
     fun verifyAboutFirefoxPreview() {
         featureSettingsHelper.setJumpBackCFREnabled(false)
+        featureSettingsHelper.setTCPCFREnabled(false)
         homeScreen {
         }.openThreeDotMenu {
         }.openSettings {


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
Fixes #27133
Fixes #24978