### PR TITLE
For #9956 - Add Duplicate Tab functionality to FenixTabCountermenu

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarController.kt
@@ -161,6 +161,9 @@ class DefaultBrowserToolbarController(
                     BrowserFragmentDirections.actionGlobalHome(focusOnAddressBar = true),
                 )
             }
+            is TabCounterMenu.Item.DuplicateTab -> {
+                tabsUseCases.duplicateTab.invoke(selectNewTab = true)
+            }
         }
     }
 

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/FenixTabCounterMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/FenixTabCounterMenu.kt
@@ -31,6 +31,8 @@ class FenixTabCounterMenu(
             newTabItem,
             newPrivateTabItem,
             DividerMenuCandidate(),
+            duplicateTabItem,
+            DividerMenuCandidate(),
             closeTabItem,
         )
 

--- a/app/src/test/java/org/mozilla/fenix/components/toolbar/TabCounterMenuTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/toolbar/TabCounterMenuTest.kt
@@ -12,6 +12,7 @@ import mozilla.components.concept.menu.candidate.DividerMenuCandidate
 import mozilla.components.concept.menu.candidate.TextMenuCandidate
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.ui.tabcounter.TabCounterMenu
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -59,12 +60,20 @@ class TabCounterMenuTest {
     }
 
     @Test
-    fun `return two new tab items and a close button`() {
-        val (newTab, newPrivateTab, divider, closeTab) = menu.menuItems(ToolbarPosition.TOP)
+    fun `return two new tab items, a duplicate tab item, and a close button`() {
+        val expected = arrayOf(
+            menu.newTabItem,
+            menu.newPrivateTabItem,
+            DividerMenuCandidate(),
+            menu.duplicateTabItem,
+            DividerMenuCandidate(),
+            menu.closeTabItem,
+        )
+        val topItems = menu.menuItems(ToolbarPosition.TOP)
+        val bottomItems = menu.menuItems(ToolbarPosition.BOTTOM)
 
-        assertEquals("New tab", (newTab as TextMenuCandidate).text)
-        assertEquals("New private tab", (newPrivateTab as TextMenuCandidate).text)
-        assertEquals("Close tab", (closeTab as TextMenuCandidate).text)
-        assertEquals(DividerMenuCandidate(), divider)
+        assertArrayEquals(topItems.toTypedArray(), expected)
+        expected.reverse()
+        assertArrayEquals(bottomItems.toTypedArray(), expected)
     }
 }


### PR DESCRIPTION
This PR allows for holding on the tab counter icon and tapping Duplicate Tab to duplicate the current tab as shown below.

[Device-2022-09-24-233618-reencoded.webm](https://user-images.githubusercontent.com/13156601/192130850-9c636545-6948-4cc4-8f8a-8b31ba65af47.webm)

Note: seems that there's currently an unrelated bug where sometimes the title of the selected tab isn't shown, which shows up in the video.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
Fixes #9956