### PR TITLE
For #27182 allow to paste non url

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/utils/ToolbarPopupWindow.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/ToolbarPopupWindow.kt
@@ -38,9 +38,9 @@ object ToolbarPopupWindow {
         val clipboard = context.components.clipboardHandler
         val clipboardUrl = clipboard.getUrl()
         val clipboardText = clipboard.text
-        if (!copyVisible && clipboardUrl == null) return
-
         val isCustomTabSession = customTabId != null
+
+        if (!copyVisible && (clipboardText == null || isCustomTabSession)) return
 
         val binding = BrowserToolbarPopupWindowBinding.inflate(LayoutInflater.from(context))
         val popupWindow = PopupWindow(
@@ -57,7 +57,6 @@ object ToolbarPopupWindow {
         popupWindow.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
 
         binding.copy.isVisible = copyVisible
-
         binding.paste.isVisible = clipboardText != null && !isCustomTabSession
         binding.pasteAndGo.isVisible = clipboardUrl != null && !isCustomTabSession
 


### PR DESCRIPTION
Check if the clipboard is non null instead of the `clipboardUrl` to allow to still paste.
Added the `isCustomTabSession` check since if `true` both option will be disabled. 


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
Fixes #27182