### PR TITLE
For #27129 - Fix accessibility for default wallpaper thumbnail

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/wallpaper/WallpaperSettings.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/wallpaper/WallpaperSettings.kt
@@ -40,6 +40,8 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -257,6 +259,21 @@ private fun WallpaperThumbnailItem(
     // Completely avoid drawing the item if a bitmap cannot be loaded and is required
     if (bitmap == null && wallpaper != defaultWallpaper) return
 
+    val description = stringResource(
+        R.string.wallpapers_item_name_content_description,
+        wallpaper.name,
+    )
+
+    // For the default wallpaper to be accessible, we should set the content description for
+    // the Surface instead of the thumbnail image
+    val contentDescriptionModifier = if (bitmap == null) {
+        Modifier.semantics {
+            contentDescription = description
+        }
+    } else {
+        Modifier
+    }
+
     Surface(
         elevation = 4.dp,
         shape = thumbnailShape,
@@ -265,16 +282,14 @@ private fun WallpaperThumbnailItem(
             .fillMaxWidth()
             .aspectRatio(aspectRatio)
             .then(border)
-            .clickable { onSelect(wallpaper) },
+            .clickable { onSelect(wallpaper) }
+            .then(contentDescriptionModifier),
     ) {
         bitmap?.let {
             Image(
                 bitmap = it.asImageBitmap(),
                 contentScale = ContentScale.FillBounds,
-                contentDescription = stringResource(
-                    R.string.wallpapers_item_name_content_description,
-                    wallpaper.name,
-                ),
+                contentDescription = description,
                 modifier = Modifier.fillMaxSize(),
                 alpha = if (isLoading) loadingOpacity else 1.0f,
             )


### PR DESCRIPTION
When clicking on default wallpaper with Talkback on, we get "Wallpaper item: Default, double tap to activate" for both Wallpaper settings and onboarding.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
Fixes #27129