### PR TITLE
For #24544 - Have Talkback use "expand" and "collapse" actions for collections

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/collections/Collection.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/collections/Collection.kt
@@ -35,6 +35,7 @@ import mozilla.components.browser.state.state.recover.RecoverableTab
 import mozilla.components.concept.engine.Engine
 import mozilla.components.feature.tab.collections.Tab
 import mozilla.components.feature.tab.collections.TabCollection
+import org.mozilla.fenix.R
 import org.mozilla.fenix.R.drawable
 import org.mozilla.fenix.R.string
 import org.mozilla.fenix.compose.list.ExpandableListHeader
@@ -64,7 +65,7 @@ private val expandedCollectionShape = RoundedCornerShape(topStart = 8.dp, topEnd
  * @param onCollectionMenuOpened Invoked when the user clicks to open a menu for the collection.
  */
 @Composable
-@Suppress("LongParameterList")
+@Suppress("LongParameterList", "LongMethod")
 fun Collection(
     collection: TabCollection,
     expanded: Boolean,
@@ -79,7 +80,14 @@ fun Collection(
     Card(
         modifier = Modifier
             .semantics(mergeDescendants = true) {}
-            .clickable { onToggleCollectionExpanded(collection, !isExpanded) }
+            .clickable(
+                onClickLabel = if (isExpanded) {
+                    stringResource(R.string.a11y_action_label_collapse)
+                } else {
+                    stringResource(R.string.a11y_action_label_expand)
+                },
+                onClick = { onToggleCollectionExpanded(collection, !isExpanded) },
+            )
             .height(48.dp),
         shape = if (isExpanded) expandedCollectionShape else collapsedCollectionShape,
         backgroundColor = FirefoxTheme.colors.layer2,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1870,4 +1870,10 @@
     <!-- Snackbar button text to navigate to telemetry settings.-->
     <string name="experiments_snackbar_button">Go to settings</string>
     <string name="firefox_suggest_header">Firefox Suggest</string>
+
+    <!-- Accessibility services actions labels. These will be appended to accessibility actions like "Double tap to.." but not by or applications but by services like Talkback. -->
+    <!-- Action label for elements that can be collapsed if interacting with them. Talkback will append this to say "Double tap to collapse". -->
+    <string name="a11y_action_label_collapse">collapse</string>
+    <!-- Action label for elements that can be expanded if interacting with them. Talkback will append this to say "Double tap to expand". -->
+    <string name="a11y_action_label_expand">expand</string>
 </resources>


### PR DESCRIPTION

https://user-images.githubusercontent.com/11428869/193286973-d3e31357-6b07-4a39-9583-9ba3a0662d69.mp4

Focus jumping to the private browsing button is a pre-existent issue that seems to affect all other homescreen items, opened https://github.com/mozilla-mobile/fenix/issues/27230 for it.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
Fixes #24544