### PR TITLE
For #27245: hold to open tab history item in duplicated tab 

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/tabhistory/TabHistoryController.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabhistory/TabHistoryController.kt
@@ -6,14 +6,26 @@ package org.mozilla.fenix.tabhistory
 
 import androidx.navigation.NavController
 import mozilla.components.feature.session.SessionUseCases
+import mozilla.components.feature.tabs.TabsUseCases
+import mozilla.components.support.base.log.logger.Logger
 
 interface TabHistoryController {
+    /**
+     * Jump to a specific index in the tab's history.
+     */
     fun handleGoToHistoryItem(item: TabHistoryItem)
+
+    /**
+     * Jump to a specific index in the tab's history in a duplicated tab.
+     * [onSuccess] is called on success of the action.
+     */
+    fun handleGoToHistoryItemNewTab(item: TabHistoryItem, onSuccess: () -> Unit): Boolean
 }
 
 class DefaultTabHistoryController(
     private val navController: NavController,
     private val goToHistoryIndexUseCase: SessionUseCases.GoToHistoryIndexUseCase,
+    private val duplicateTabUseCase: TabsUseCases.DuplicateTabUseCase,
     private val customTabId: String? = null,
 ) : TabHistoryController {
 
@@ -24,6 +36,25 @@ class DefaultTabHistoryController(
             goToHistoryIndexUseCase.invoke(item.index, customTabId)
         } else {
             goToHistoryIndexUseCase.invoke(item.index)
+        }
+    }
+
+    override fun handleGoToHistoryItemNewTab(item: TabHistoryItem, onSuccess: () -> Unit): Boolean {
+        // Opening a new tab is not supported in custom tabs, so fallback to regular click event
+        if (customTabId != null) {
+            return false
+        }
+
+        val tabId = duplicateTabUseCase.invoke(selectNewTab = true)
+
+        return if (tabId != null) {
+            // onSuccess is called first as otherwise haptic feedback would not be performed
+            onSuccess.invoke()
+            handleGoToHistoryItem(item)
+            true
+        } else {
+            Logger.error("$this: could not access selected tab to duplicate.")
+            false
         }
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/tabhistory/TabHistoryDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabhistory/TabHistoryDialogFragment.kt
@@ -41,9 +41,12 @@ class TabHistoryDialogFragment : BottomSheetDialogFragment() {
 
         customTabSessionId = requireArguments().getString(EXTRA_SESSION_ID)
 
+        val useCases = requireComponents.useCases
+
         val controller = DefaultTabHistoryController(
             navController = findNavController(),
-            goToHistoryIndexUseCase = requireComponents.useCases.sessionUseCases.goToHistoryIndex,
+            goToHistoryIndexUseCase = useCases.sessionUseCases.goToHistoryIndex,
+            duplicateTabUseCase = useCases.tabsUseCases.duplicateTab,
             customTabId = customTabSessionId,
         )
         val tabHistoryView = TabHistoryView(

--- a/app/src/main/java/org/mozilla/fenix/tabhistory/TabHistoryInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabhistory/TabHistoryInteractor.kt
@@ -11,4 +11,8 @@ class TabHistoryInteractor(
     override fun goToHistoryItem(item: TabHistoryItem) {
         controller.handleGoToHistoryItem(item)
     }
+
+    override fun goToHistoryItemNewTab(item: TabHistoryItem, onSuccess: () -> Unit): Boolean {
+        return controller.handleGoToHistoryItemNewTab(item, onSuccess)
+    }
 }

--- a/app/src/main/java/org/mozilla/fenix/tabhistory/TabHistoryView.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabhistory/TabHistoryView.kt
@@ -17,6 +17,12 @@ interface TabHistoryViewInteractor {
      * Jump to a specific index in the tab's history.
      */
     fun goToHistoryItem(item: TabHistoryItem)
+
+    /**
+     * Jump to a specific index in the tab's history in a duplicated tab.
+     * [onSuccess] is called on success of the action.
+     */
+    fun goToHistoryItemNewTab(item: TabHistoryItem, onSuccess: () -> Unit): Boolean
 }
 
 class TabHistoryView(

--- a/app/src/main/java/org/mozilla/fenix/tabhistory/TabHistoryViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabhistory/TabHistoryViewHolder.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.fenix.tabhistory
 
+import android.view.HapticFeedbackConstants
 import androidx.recyclerview.widget.RecyclerView
 import mozilla.components.browser.icons.BrowserIcons
 import mozilla.components.support.ktx.android.content.getColorFromAttr
@@ -22,6 +23,13 @@ class TabHistoryViewHolder(
 
     init {
         view.setOnClickListener { interactor.goToHistoryItem(item) }
+
+        val performFeedback: () -> Unit = {
+            view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
+        }
+        view.setOnLongClickListener {
+            interactor.goToHistoryItemNewTab(item, performFeedback)
+        }
     }
 
     fun bind(item: TabHistoryItem) {

--- a/app/src/test/java/org/mozilla/fenix/tabhistory/TabHistoryControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabhistory/TabHistoryControllerTest.kt
@@ -5,11 +5,19 @@
 package org.mozilla.fenix.tabhistory
 
 import androidx.navigation.NavController
+import io.mockk.Called
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
+import io.mockk.verifyOrder
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.feature.session.SessionUseCases
+import mozilla.components.feature.tabs.TabsUseCases
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
@@ -17,14 +25,18 @@ class TabHistoryControllerTest {
 
     private lateinit var navController: NavController
     private lateinit var goToHistoryIndexUseCase: SessionUseCases.GoToHistoryIndexUseCase
+    private lateinit var duplicateTabUseCase: TabsUseCases.DuplicateTabUseCase
     private lateinit var currentItem: TabHistoryItem
     private lateinit var store: BrowserStore
 
     @Before
     fun setUp() {
         store = BrowserStore()
+        val tabsUseCases = TabsUseCases(store)
+        tabsUseCases.addTab("mozilla.org")
         navController = mockk(relaxed = true)
         goToHistoryIndexUseCase = spyk(SessionUseCases(store).goToHistoryIndex)
+        duplicateTabUseCase = spyk(tabsUseCases.duplicateTab)
         currentItem = TabHistoryItem(
             index = 0,
             title = "",
@@ -33,12 +45,18 @@ class TabHistoryControllerTest {
         )
     }
 
-    @Test
-    fun handleGoToHistoryIndexNormalBrowsing() {
-        val controller = DefaultTabHistoryController(
+    private fun createDefaultTabHistoryController(tabId: String?): DefaultTabHistoryController {
+        return DefaultTabHistoryController(
             navController = navController,
             goToHistoryIndexUseCase = goToHistoryIndexUseCase,
+            duplicateTabUseCase = duplicateTabUseCase,
+            customTabId = tabId,
         )
+    }
+
+    @Test
+    fun handleGoToHistoryIndexNormalBrowsing() {
+        val controller = createDefaultTabHistoryController(null)
 
         controller.handleGoToHistoryItem(currentItem)
         verify { navController.navigateUp() }
@@ -48,14 +66,42 @@ class TabHistoryControllerTest {
     @Test
     fun handleGoToHistoryIndexCustomTab() {
         val customTabId = "customTabId"
-        val customTabController = DefaultTabHistoryController(
-            navController = navController,
-            goToHistoryIndexUseCase = goToHistoryIndexUseCase,
-            customTabId = customTabId,
-        )
+        val customTabController = createDefaultTabHistoryController(customTabId)
 
         customTabController.handleGoToHistoryItem(currentItem)
         verify { navController.navigateUp() }
         verify { goToHistoryIndexUseCase.invoke(currentItem.index, customTabId) }
+    }
+
+    @Test
+    fun handleGoToHistoryIndexNewTabNormalBrowsing() {
+        val controller = createDefaultTabHistoryController(null)
+        val onSuccess = mockk<() -> Unit>()
+        every { onSuccess.invoke() } just Runs
+
+        val res = controller.handleGoToHistoryItemNewTab(currentItem, onSuccess)
+        assertTrue(res)
+        verifyOrder {
+            duplicateTabUseCase.invoke(true)
+            onSuccess.invoke()
+            navController.navigateUp()
+            goToHistoryIndexUseCase.invoke(currentItem.index)
+        }
+    }
+
+    @Test
+    fun handleGoToHistoryIndexNewTabCustomTab() {
+        val customTabId = "customTabId"
+        val controller = createDefaultTabHistoryController(customTabId)
+        val onSuccess = mockk<() -> Unit>()
+
+        val res = controller.handleGoToHistoryItemNewTab(currentItem, onSuccess)
+        assertFalse(res)
+        verify {
+            duplicateTabUseCase wasNot Called
+            onSuccess wasNot Called
+            navController wasNot Called
+            goToHistoryIndexUseCase wasNot Called
+        }
     }
 }

--- a/app/src/test/java/org/mozilla/fenix/tabhistory/TabHistoryControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabhistory/TabHistoryControllerTest.kt
@@ -16,6 +16,7 @@ import io.mockk.verifyOrder
 import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.feature.session.SessionUseCases
 import mozilla.components.feature.tabs.TabsUseCases
+import mozilla.components.support.test.libstate.ext.waitUntilIdle
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -26,14 +27,14 @@ class TabHistoryControllerTest {
     private lateinit var navController: NavController
     private lateinit var goToHistoryIndexUseCase: SessionUseCases.GoToHistoryIndexUseCase
     private lateinit var duplicateTabUseCase: TabsUseCases.DuplicateTabUseCase
+    private lateinit var tabsUseCases: TabsUseCases
     private lateinit var currentItem: TabHistoryItem
     private lateinit var store: BrowserStore
 
     @Before
     fun setUp() {
         store = BrowserStore()
-        val tabsUseCases = TabsUseCases(store)
-        tabsUseCases.addTab("mozilla.org")
+        tabsUseCases = TabsUseCases(store)
         navController = mockk(relaxed = true)
         goToHistoryIndexUseCase = spyk(SessionUseCases(store).goToHistoryIndex)
         duplicateTabUseCase = spyk(tabsUseCases.duplicateTab)
@@ -75,6 +76,8 @@ class TabHistoryControllerTest {
 
     @Test
     fun handleGoToHistoryIndexNewTabNormalBrowsing() {
+        tabsUseCases.addTab("mozilla.org").also { store.waitUntilIdle() }
+
         val controller = createDefaultTabHistoryController(null)
         val onSuccess = mockk<() -> Unit>()
         every { onSuccess.invoke() } just Runs

--- a/app/src/test/java/org/mozilla/fenix/tabhistory/TabHistoryInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/tabhistory/TabHistoryInteractorTest.kt
@@ -12,13 +12,20 @@ class TabHistoryInteractorTest {
 
     val controller: TabHistoryController = mockk(relaxed = true)
     val interactor = TabHistoryInteractor(controller)
+    val item: TabHistoryItem = mockk()
 
     @Test
     fun onGoToHistoryItem() {
-        val item: TabHistoryItem = mockk()
-
         interactor.goToHistoryItem(item)
 
         verify { controller.handleGoToHistoryItem(item) }
+    }
+
+    @Test
+    fun onGoToHistoryItemNewTab() {
+        val onSuccess = mockk<() -> Unit>()
+        interactor.goToHistoryItemNewTab(item, onSuccess)
+
+        verify { controller.handleGoToHistoryItemNewTab(item, onSuccess) }
     }
 }

--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -921,7 +921,6 @@
     <ID>UndocumentedPublicFunction:TabCollectionStorage.kt$TabCollectionStorage$suspend fun removeTabFromCollection(tabCollection: TabCollection, tab: Tab)</ID>
     <ID>UndocumentedPublicFunction:TabCollectionStorage.kt$TabCollectionStorage$suspend fun renameCollection(tabCollection: TabCollection, title: String)</ID>
     <ID>UndocumentedPublicFunction:TabCollectionStorage.kt$fun TabCollection.description(context: Context): String</ID>
-    <ID>UndocumentedPublicFunction:TabHistoryController.kt$TabHistoryController$fun handleGoToHistoryItem(item: TabHistoryItem)</ID>
     <ID>UndocumentedPublicFunction:TabHistoryView.kt$TabHistoryView$fun updateState(historyState: HistoryState)</ID>
     <ID>UndocumentedPublicFunction:TabHistoryViewHolder.kt$TabHistoryViewHolder$fun bind(item: TabHistoryItem)</ID>
     <ID>UndocumentedPublicFunction:TabLayout.kt$fun TabLayout.isNormalModeSelected(): Boolean</ID>


### PR DESCRIPTION
This offers feature parity with Desktop.

[Device-2022-10-02-114950-reencoded.webm](https://user-images.githubusercontent.com/13156601/193468913-8d668937-d3fe-4200-9c5a-6d4804c0d7e3.webm)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
Fixes #27245