### PR TITLE
For #3709: Add save to PDF UI.

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -449,6 +449,22 @@ events:
     notification_emails:
       - android-probes@mozilla.com
     expires: 113
+  save_to_pdf_tapped:
+    type: event
+    description: |
+      A user tapped the save to pdf option in the share sheet.
+    bugs:
+      - https://github.com/mozilla-mobile/fenix/issues/3709
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/27257
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: 122
+    metadata:
+      tags:
+        - Sharing
 
 onboarding:
   syn_cfr_shown:

--- a/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -118,4 +118,9 @@ object FeatureFlags {
      * Enables the wallpaper v2 enhancements.
      */
     const val wallpaperV2Enabled = true
+
+    /**
+     * Enables the save to PDF feature.
+     */
+    val saveToPDF = Config.channel.isNightlyOrDebug
 }

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarMenuController.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarMenuController.kt
@@ -211,6 +211,7 @@ class DefaultBrowserToolbarMenuController(
             }
             is ToolbarMenu.Item.Share -> {
                 val directions = NavGraphDirections.actionGlobalShareFragment(
+                    sessionId = currentSession?.id,
                     data = arrayOf(
                         ShareData(
                             url = getProperUrl(currentSession),

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlController.kt
@@ -583,6 +583,7 @@ class DefaultSessionControlController(
 
     private fun showShareFragment(shareSubject: String, data: List<ShareData>) {
         val directions = HomeFragmentDirections.actionGlobalShareFragment(
+            sessionId = store.state.selectedTabId,
             shareSubject = shareSubject,
             data = data.toTypedArray(),
         )

--- a/app/src/main/java/org/mozilla/fenix/share/SaveToPDFInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/share/SaveToPDFInteractor.kt
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.share
+
+/**
+ * Callbacks for possible user interactions on the [SaveToPDFItem]
+ */
+interface SaveToPDFInteractor {
+    /**
+     * Generates a PDF from the given [tabId].
+     * @param tabId The ID of the tab to save as PDF.
+     */
+    fun onSaveToPDF(tabId: String?)
+}

--- a/app/src/main/java/org/mozilla/fenix/share/SaveToPDFItem.kt
+++ b/app/src/main/java/org/mozilla/fenix/share/SaveToPDFItem.kt
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.share
+
+import android.content.res.Configuration
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.Icon
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import org.mozilla.fenix.R
+import org.mozilla.fenix.theme.FirefoxTheme
+
+/**
+ * A save to PDF item.
+ *
+ *  @param onClick event handler when the save to PDF item is clicked.
+ */
+@Composable
+fun SaveToPDFItem(
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .height(56.dp)
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Spacer(Modifier.width(16.dp))
+
+        Icon(
+            painter = painterResource(R.drawable.ic_download),
+            contentDescription = stringResource(
+                R.string.content_description_close_button,
+            ),
+            tint = FirefoxTheme.colors.iconPrimary,
+        )
+
+        Spacer(Modifier.width(32.dp))
+
+        Text(
+            color = FirefoxTheme.colors.textPrimary,
+            text = stringResource(R.string.share_save_to_pdf),
+            style = FirefoxTheme.typography.subtitle1,
+        )
+    }
+}
+
+@Composable
+@Preview
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_NO)
+private fun SaveToPDFItemPreview() {
+    FirefoxTheme {
+        SaveToPDFItem {}
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/share/ShareController.kt
+++ b/app/src/main/java/org/mozilla/fenix/share/ShareController.kt
@@ -29,9 +29,11 @@ import mozilla.components.concept.engine.prompt.ShareData
 import mozilla.components.concept.sync.Device
 import mozilla.components.concept.sync.TabData
 import mozilla.components.feature.accounts.push.SendTabUseCases
+import mozilla.components.feature.session.SessionUseCases
 import mozilla.components.feature.share.RecentAppsStorage
 import mozilla.components.service.glean.private.NoExtras
 import mozilla.components.support.ktx.kotlin.isExtensionUrl
+import org.mozilla.fenix.GleanMetrics.Events
 import org.mozilla.fenix.GleanMetrics.SyncAccount
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.FenixSnackbar
@@ -47,6 +49,11 @@ interface ShareController {
     fun handleReauth()
     fun handleShareClosed()
     fun handleShareToApp(app: AppShareOption)
+
+    /**
+     * Handles when a save to PDF action was requested.
+     */
+    fun handleSaveToPDF(tabId: String?)
     fun handleAddNewDevice()
     fun handleShareToDevice(device: Device)
     fun handleShareToAllDevices(devices: List<Device>)
@@ -68,12 +75,13 @@ interface ShareController {
  * @param navController - [NavController] used for navigation.
  * @param dismiss - callback signalling sharing can be closed.
  */
-@Suppress("TooManyFunctions")
+@Suppress("TooManyFunctions", "LongParameterList")
 class DefaultShareController(
     private val context: Context,
     private val shareSubject: String?,
     private val shareData: List<ShareData>,
     private val sendTabUseCases: SendTabUseCases,
+    private val saveToPdfUseCase: SessionUseCases.SaveToPdfUseCase,
     private val snackbar: FenixSnackbar,
     private val navController: NavController,
     private val recentAppsStorage: RecentAppsStorage,
@@ -128,6 +136,12 @@ class DefaultShareController(
             }
         }
         dismiss(result)
+    }
+
+    override fun handleSaveToPDF(tabId: String?) {
+        Events.saveToPdfTapped.record(NoExtras())
+        handleShareClosed()
+        saveToPdfUseCase.invoke(tabId)
     }
 
     override fun handleAddNewDevice() {

--- a/app/src/main/java/org/mozilla/fenix/share/ShareFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/share/ShareFragment.kt
@@ -10,6 +10,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatDialogFragment
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.core.view.isVisible
 import androidx.fragment.app.clearFragmentResult
 import androidx.fragment.app.setFragmentResult
 import androidx.fragment.app.viewModels
@@ -22,11 +24,13 @@ import mozilla.components.browser.state.selector.findTabOrCustomTab
 import mozilla.components.concept.engine.prompt.PromptRequest
 import mozilla.components.feature.accounts.push.SendTabUseCases
 import mozilla.components.feature.share.RecentAppsStorage
+import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.databinding.FragmentShareBinding
 import org.mozilla.fenix.ext.getRootView
 import org.mozilla.fenix.ext.requireComponents
+import org.mozilla.fenix.theme.FirefoxTheme
 
 class ShareFragment : AppCompatDialogFragment() {
 
@@ -80,6 +84,7 @@ class ShareFragment : AppCompatDialogFragment() {
                 ),
                 navController = findNavController(),
                 sendTabUseCases = SendTabUseCases(accountManager),
+                saveToPdfUseCase = requireComponents.useCases.sessionUseCases.saveToPdf,
                 recentAppsStorage = RecentAppsStorage(requireContext()),
                 viewLifecycleScope = viewLifecycleOwner.lifecycleScope,
             ) { result ->
@@ -111,6 +116,20 @@ class ShareFragment : AppCompatDialogFragment() {
         }
         shareToAppsView = ShareToAppsView(binding.appsShareLayout, shareInteractor)
 
+        if (FeatureFlags.saveToPDF) {
+            binding.dividerLineAppsShareAndPdfSection.isVisible = true
+            binding.savePdf.apply {
+                isVisible = true
+                setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+                setContent {
+                    FirefoxTheme {
+                        SaveToPDFItem {
+                            shareInteractor.onSaveToPDF(tabId = args.sessionId)
+                        }
+                    }
+                }
+            }
+        }
         return binding.root
     }
 

--- a/app/src/main/java/org/mozilla/fenix/share/ShareInteractor.kt
+++ b/app/src/main/java/org/mozilla/fenix/share/ShareInteractor.kt
@@ -12,7 +12,7 @@ import org.mozilla.fenix.share.listadapters.AppShareOption
  */
 class ShareInteractor(
     private val controller: ShareController,
-) : ShareCloseInteractor, ShareToAccountDevicesInteractor, ShareToAppsInteractor {
+) : ShareCloseInteractor, ShareToAccountDevicesInteractor, ShareToAppsInteractor, SaveToPDFInteractor {
     override fun onReauth() {
         controller.handleReauth()
     }
@@ -39,5 +39,9 @@ class ShareInteractor(
 
     override fun onShareToApp(appToShareTo: AppShareOption) {
         controller.handleShareToApp(appToShareTo)
+    }
+
+    override fun onSaveToPDF(tabId: String?) {
+        controller.handleSaveToPDF(tabId)
     }
 }

--- a/app/src/main/res/layout/fragment_share.xml
+++ b/app/src/main/res/layout/fragment_share.xml
@@ -35,16 +35,16 @@
         app:layout_constraintBottom_toBottomOf="parent">
 
         <FrameLayout
-            android:id="@+id/appsShareLayout"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:layout_constraintBottom_toBottomOf="parent" />
-
-        <FrameLayout
             android:id="@+id/devicesShareLayout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:layout_constraintBottom_toTopOf="@id/divider_line" />
+
+        <FrameLayout
+            android:id="@+id/appsShareLayout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toBottomOf="@id/divider_line" />
 
         <View
             android:id="@+id/divider_line"
@@ -53,6 +53,23 @@
             android:layout_marginTop="8dp"
             android:background="?borderPrimary"
             app:layout_constraintBottom_toTopOf="@id/appsShareLayout" />
+
+        <View
+            android:id="@+id/divider_line_apps_share_and_pdf_section"
+            android:visibility="gone"
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_marginTop="8dp"
+            android:background="?borderPrimary"
+            app:layout_constraintTop_toBottomOf="@id/appsShareLayout" />
+
+        <androidx.compose.ui.platform.ComposeView
+            android:visibility="gone"
+            android:id="@+id/save_pdf"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/divider_line_apps_share_and_pdf_section" />
 
         <androidx.constraintlayout.widget.Group
             android:id="@+id/devicesShareGroup"

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -895,7 +895,7 @@
             app:destination="@id/addNewDeviceFragment" />
         <argument
             android:name="sessionId"
-            android:defaultValue="null"
+            android:defaultValue="@null"
             app:argType="string"
             app:nullable="true" />
         <argument

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1030,6 +1030,8 @@
     <!-- Content description (not visible, for screen readers etc.):
         "Share" button. Opens the share menu when pressed. -->
     <string name="share_button_content_description">Share</string>
+    <!-- Text for the Save to PDF feature in the share menu -->
+    <string name="share_save_to_pdf">Save as PDF</string>
     <!-- Sub-header in the dialog to share a link to another sync device -->
     <string name="share_device_subheader">Send to device</string>
     <!-- Sub-header in the dialog to share a link to an app from the full list -->

--- a/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarMenuControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/components/toolbar/DefaultBrowserToolbarMenuControllerTest.kt
@@ -623,6 +623,7 @@ class DefaultBrowserToolbarMenuControllerTest {
             navController.navigate(
                 directionsEq(
                     NavGraphDirections.actionGlobalShareFragment(
+                        sessionId = browserStore.state.selectedTabId,
                         data = arrayOf(ShareData(url = "https://mozilla.org", title = "Mozilla")),
                         showPage = true,
                     ),
@@ -656,6 +657,7 @@ class DefaultBrowserToolbarMenuControllerTest {
             navController.navigate(
                 directionsEq(
                     NavGraphDirections.actionGlobalShareFragment(
+                        sessionId = browserStore.state.selectedTabId,
                         data = arrayOf(ShareData(url = "https://mozilla.org", title = "Mozilla")),
                         showPage = true,
                     ),

--- a/app/src/test/java/org/mozilla/fenix/share/ShareInteractorTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/share/ShareInteractorTest.kt
@@ -68,4 +68,11 @@ class ShareInteractorTest {
 
         verify { controller.handleShareToApp(app) }
     }
+
+    @Test
+    fun `WHEN onSaveToPDF is call THEN call handleSaveToPDF`() {
+        interactor.onSaveToPDF("tabID")
+
+        verify { controller.handleSaveToPDF("tabID") }
+    }
 }


### PR DESCRIPTION
https://www.figma.com/file/4TFvx6UlVO127bubv1WZKZ/Print-to-PDF-%2F-Share-Sheet?node-id=438%3A19971

<img width="312" alt="image" src="https://user-images.githubusercontent.com/773158/193665703-feea3b7e-89a4-4d7d-94a2-56d3f3577f6f.png">

We still need to land https://bugzilla.mozilla.org/show_bug.cgi?id=1784554 for improving the long time when the PDF is requested.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.









### GitHub Automation
Fixes #3709