### PR TITLE
For #26674: Update to androidX core 1.8.0

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/SwipeGestureLayout.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/SwipeGestureLayout.kt
@@ -106,8 +106,8 @@ class SwipeGestureLayout @JvmOverloads constructor(
         listeners.add(listener)
     }
 
-    override fun onInterceptTouchEvent(event: MotionEvent?): Boolean {
-        return when (event?.actionMasked) {
+    override fun onInterceptTouchEvent(event: MotionEvent): Boolean {
+        return when (event.actionMasked) {
             MotionEvent.ACTION_DOWN -> {
                 handledInitialScroll = false
                 gestureDetector.onTouchEvent(event)
@@ -117,8 +117,8 @@ class SwipeGestureLayout @JvmOverloads constructor(
         }
     }
 
-    override fun onTouchEvent(event: MotionEvent?): Boolean {
-        return when (event?.actionMasked) {
+    override fun onTouchEvent(event: MotionEvent): Boolean {
+        return when (event.actionMasked) {
             MotionEvent.ACTION_CANCEL, MotionEvent.ACTION_UP -> {
                 gestureDetector.onTouchEvent(event)
                 // If the active listener is not null here, then we haven't detected a fling

--- a/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionPanelView.kt
+++ b/app/src/main/java/org/mozilla/fenix/trackingprotection/TrackingProtectionPanelView.kt
@@ -297,7 +297,7 @@ class TrackingProtectionPanelView(
             view2,
             object : AccessibilityDelegateCompat() {
                 override fun onInitializeAccessibilityNodeInfo(
-                    host: View?,
+                    host: View,
                     info: AccessibilityNodeInfoCompat,
                 ) {
                     info.setTraversalAfter(view1)

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -34,7 +34,7 @@ object Versions {
     const val androidx_fragment = "1.3.4"
     const val androidx_navigation = "2.3.3"
     const val androidx_recyclerview = "1.2.1"
-    const val androidx_core = "1.3.2"
+    const val androidx_core = "1.8.0"
     const val androidx_paging = "3.1.1"
     const val androidx_transition = "1.4.0"
     const val androidx_work = "2.7.1"


### PR DESCRIPTION
androidx core < 1.8.0-alpha04 has a bug involving night mode that results in both status bar foreground and background to be white when in light mode on Android 11 only.

Note that due to transitive dependencies, the previous core version used was 1.7.0.

See: https://issuetracker.google.com/issues/180881870

Also fixes #26808.


See [here](https://user-images.githubusercontent.com/4487018/187073707-fc5a27f4-2169-4181-80c9-350dfe1fb9ed.png) for an example of the old behavior on Android 11. New behavior is what you would expect, as shown [here](https://user-images.githubusercontent.com/44677171/188307308-187a7085-241f-429a-bb53-03d09c663248.jpg).

Testing could be added after the PWA status bar issues are fixed. This PR fixes those issues only in light-mode, but a different solution is necessary for PWA dark mode.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
Fixes #26674
Fixes #26808