### PR TITLE
Bug 1815638 : disable permission prompt pre checking

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/search/SearchDialogController.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchDialogController.kt
@@ -69,6 +69,7 @@ class SearchDialogController(
     private val navController: NavController,
     private val settings: Settings,
     private val dismissDialog: () -> Unit,
+    private val onPermissionDialogClosure: () -> Unit,
     private val clearToolbarFocus: () -> Unit,
     private val focusToolbar: () -> Unit,
     private val clearToolbar: () -> Unit,
@@ -296,7 +297,7 @@ class SearchDialogController(
             )
             setMessage(spannableText)
             setNegativeButton(R.string.camera_permissions_needed_negative_button_text) { _, _ ->
-                dismissDialog()
+                onPermissionDialogClosure()
             }
             setPositiveButton(R.string.camera_permissions_needed_positive_button_text) {
                     dialog: DialogInterface, _ ->
@@ -315,6 +316,9 @@ class SearchDialogController(
                 intent.data = uri
                 dialog.cancel()
                 activity.startActivity(intent)
+            }
+            setOnCancelListener { _ ->
+                onPermissionDialogClosure()
             }
             create()
         }

--- a/app/src/main/java/org/mozilla/fenix/settings/account/TurnOnSyncFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/account/TurnOnSyncFragment.kt
@@ -4,7 +4,6 @@
 
 package org.mozilla.fenix.settings.account
 
-import android.Manifest
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -18,12 +17,10 @@ import mozilla.components.concept.sync.AccountObserver
 import mozilla.components.concept.sync.AuthType
 import mozilla.components.concept.sync.OAuthAccount
 import mozilla.components.support.ktx.android.content.hasCamera
-import mozilla.components.support.ktx.android.content.isPermissionGranted
 import mozilla.components.support.ktx.android.view.hideKeyboard
 import mozilla.telemetry.glean.private.NoExtras
 import org.mozilla.fenix.Config
 import org.mozilla.fenix.GleanMetrics.SyncAuth
-import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.databinding.FragmentTurnOnSyncBinding
@@ -34,7 +31,6 @@ import org.mozilla.fenix.ext.showToolbar
 class TurnOnSyncFragment : Fragment(), AccountObserver {
 
     private val args by navArgs<TurnOnSyncFragmentArgs>()
-    private lateinit var interactor: DefaultSyncInteractor
 
     private var shouldLoginJustWithEmail = false
     private var pairWithEmailStarted = false
@@ -44,18 +40,8 @@ class TurnOnSyncFragment : Fragment(), AccountObserver {
     }
 
     private val paringClickListener = View.OnClickListener {
-        if (requireContext().settings().shouldShowCameraPermissionPrompt) {
-            navigateToPairFragment()
-        } else {
-            if (requireContext().isPermissionGranted(Manifest.permission.CAMERA)) {
-                navigateToPairFragment()
-            } else {
-                interactor.onCameraPermissionsNeeded()
-                view?.hideKeyboard()
-            }
-        }
+        navigateToPairFragment()
         view?.hideKeyboard()
-        requireContext().settings().setCameraPermissionNeededState = false
     }
 
     private var _binding: FragmentTurnOnSyncBinding? = null
@@ -125,10 +111,6 @@ class TurnOnSyncFragment : Fragment(), AccountObserver {
                 getString(R.string.sign_in_instructions)
             },
             HtmlCompat.FROM_HTML_MODE_LEGACY,
-        )
-
-        interactor = DefaultSyncInteractor(
-            DefaultSyncController(activity = activity as HomeActivity),
         )
 
         binding.createAccount.apply {

--- a/app/src/main/java/org/mozilla/fenix/utils/CameraPermissionHandler.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/CameraPermissionHandler.kt
@@ -1,0 +1,63 @@
+package org.mozilla.fenix.utils
+
+import android.Manifest
+import android.content.Context
+import androidx.activity.result.ActivityResultCallback
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.activity.result.contract.ActivityResultContracts
+import org.mozilla.fenix.ext.settings
+
+/**
+ * Helper to handle the logic around the camera permission
+ * The logic is to always prompt the user to grant the permission.
+ * But the permission can reach a state of Denied Forever (the user won't be prompted anymore)
+ *      - On android 11+: if the user deny twice the permission in a row
+ *      - On android <= 10 : if the user select the `Deny Forever` option
+ * We use a setting to memorize when we reach this state in order to display the permission dialog
+ */
+interface CameraPermissionHandler {
+
+    /**
+     *  Implementation should be provided by Fragment
+     */
+    fun <I, O> registerForActivityResult(
+        contract: ActivityResultContract<I, O>,
+        callback: ActivityResultCallback<O>,
+    ): ActivityResultLauncher<I>
+
+    /**
+     * Implementation should be provided by Fragment
+     */
+    fun requireContext(): Context
+
+    /**
+     * Implementation should be provided by Fragment
+     */
+    fun shouldShowRequestPermissionRationale(permission: String): Boolean
+
+    /**
+     * Create an `ActivityResultLauncher<String>` used to request the camera permission.
+     * Add the common logic around handling the result to track if we are denied forever.
+     * Callbacks allow to add custom logic.
+     */
+    fun registerCameraLauncher(
+        permissionGranted: () -> Unit,
+        permissionDenied: (forever: Boolean) -> Unit,
+    ): ActivityResultLauncher<String> {
+        return registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted: Boolean ->
+            if (!isGranted) {
+                val wasBlocked = requireContext().settings().shouldShowCameraPermissionDialog
+                requireContext().settings().setCameraPermissionDeniedForeverState =
+                    !shouldShowRequestPermissionRationale(
+                        Manifest.permission.CAMERA,
+                    )
+
+                permissionDenied(wasBlocked && requireContext().settings().shouldShowCameraPermissionDialog)
+            } else {
+                requireContext().settings().setCameraPermissionDeniedForeverState = false
+                permissionGranted()
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -1018,21 +1018,22 @@ class Settings(private val appContext: Context) : PreferencesHolder {
     )
 
     /**
-     * Used in [SearchDialogFragment.kt], [SearchFragment.kt] (deprecated), and [PairFragment.kt]
-     * to see if we need to check for camera permissions before using the QR code scanner.
+     * Used in [SearchDialogFragment.kt] and [TurnOnSyncFragment.kt]
+     * to see if we need to display the Camera permission dialog
+     * to ask the user to change permissions in settings
      */
-    var shouldShowCameraPermissionPrompt by booleanPreference(
-        appContext.getPreferenceKey(R.string.pref_key_camera_permissions_needed),
-        default = true,
+    var shouldShowCameraPermissionDialog by booleanPreference(
+        appContext.getPreferenceKey(R.string.pref_key_camera_permission_denied_forever),
+        default = false,
     )
 
     /**
      * Sets the state of permissions that have been checked, where [false] denotes already checked
      * and [true] denotes needing to check. See [shouldShowCameraPermissionPrompt].
      */
-    var setCameraPermissionNeededState by booleanPreference(
-        appContext.getPreferenceKey(R.string.pref_key_camera_permissions_needed),
-        default = true,
+    var setCameraPermissionDeniedForeverState by booleanPreference(
+        appContext.getPreferenceKey(R.string.pref_key_camera_permission_denied_forever),
+        default = false,
     )
 
     var shouldPromptToSaveLogins by booleanPreference(

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -287,7 +287,7 @@
     <string name="pref_key_start_on_home_after_four_hours" translatable="false">pref_key_start_on_home_after_four_hours</string>
     <string name="pref_key_start_on_home_always" translatable="false">pref_key_start_on_home_always</string>
     <string name="pref_key_start_on_home_never" translatable="false">pref_key_start_on_home_never</string>
-    <string name="pref_key_camera_permissions_needed" translatable="false">pref_key_camera_permissions_needed</string>
+    <string name="pref_key_camera_permission_denied_forever" translatable="false">pref_key_camera_permission_denied_forever</string>
     <string name="pref_key_inactive_tabs_category" translatable="false">pref_key_inactive_tabs_category</string>
     <string name="pref_key_inactive_tabs" translatable="false">pref_key_inactive_tabs</string>
 

--- a/app/src/test/java/org/mozilla/fenix/search/SearchDialogControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/search/SearchDialogControllerTest.kt
@@ -552,6 +552,7 @@ class SearchDialogControllerTest {
         focusToolbar: () -> Unit = { },
         clearToolbar: () -> Unit = { },
         dismissDialog: () -> Unit = { },
+        onPermissionDialogClosure: () -> Unit = { },
     ): SearchDialogController {
         return SearchDialogController(
             activity = activity,
@@ -561,6 +562,7 @@ class SearchDialogControllerTest {
             navController = navController,
             settings = settings,
             dismissDialog = dismissDialog,
+            onPermissionDialogClosure = onPermissionDialogClosure,
             clearToolbarFocus = clearToolbarFocus,
             focusToolbar = focusToolbar,
             clearToolbar = clearToolbar,


### PR DESCRIPTION
Change the camera logic to always prompt the user and only rely on a setting to memorize if we are in the `Denied Forever` state.

Note: logic could be implemented without storing a state but it would mean opening the permission dialog change when we reached the `Denied Forever` state just after the user refused to grant the permission (a bit obnoxious I believe).

Switched to using `ActivityResultLauncher` to request the permission as mentioned in (https://github.com/mozilla-mobile/fenix/issues/19920) since it made code factorization easier.

It could be made cleaner by modifying the `QrFeature` component to change the signature of the parameter `onNeedToRequestPermissions` and the function `onPermissionsResult`.

As a side effect of working on the same code it include logic from https://github.com/mozilla-mobile/fenix/pull/27062 and fix #26577 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.







### GitHub Automation
Fixes #27177