### PR TITLE
For #27128 - Fix accessibility for wallpaper settings "Learn more" heading

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/wallpaper/WallpaperSettings.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/wallpaper/WallpaperSettings.kt
@@ -40,7 +40,11 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsPropertyReceiver
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
@@ -126,7 +130,22 @@ private fun WallpaperGroupHeading(
             style = FirefoxTheme.typography.subtitle2,
         )
     } else {
-        Column {
+        val label = stringResource(id = R.string.a11y_action_label_wallpaper_collection_learn_more)
+        val headingSemantics: SemanticsPropertyReceiver.() -> Unit =
+            if (collection.learnMoreUrl.isNullOrEmpty()) {
+                {}
+            } else {
+                {
+                    role = Role.Button
+                    onClick(label = label) {
+                        onLearnMoreClick(collection.learnMoreUrl, collection.name)
+                        false
+                    }
+                }
+            }
+        Column(
+            modifier = Modifier.semantics(mergeDescendants = true, properties = headingSemantics),
+        ) {
             Text(
                 text = stringResource(R.string.wallpaper_limited_edition_title),
                 color = FirefoxTheme.colors.textSecondary,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1880,4 +1880,6 @@
     <string name="a11y_action_label_collapse">collapse</string>
     <!-- Action label for elements that can be expanded if interacting with them. Talkback will append this to say "Double tap to expand". -->
     <string name="a11y_action_label_expand">expand</string>
+    <!-- Action label for links to a website containing documentation about a wallpaper collection. Talkback will append this to say "Double tap to open link to learn more about this collection". -->
+    <string name="a11y_action_label_wallpaper_collection_learn_more">open link to learn more about this collection</string>
 </resources>


### PR DESCRIPTION
Fixes accessibility for heading of wallpaper groups which have a "Learn more" link.

https://user-images.githubusercontent.com/35462038/194313673-a4961c13-d81a-4603-8d6e-c2fbc11be384.mp4

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
Fixes #27128