### PR TITLE
Close #27320: Include testing regex to Google Maven allowlist

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,7 @@ buildscript {
                     excludeGroupByRegex RepoMatching.androidx
                     excludeGroupByRegex RepoMatching.comGoogleAndroid
                     excludeGroupByRegex RepoMatching.comGoogleFirebase
+                    excludeGroupByRegex RepoMatching.comGoogleTesting
                     excludeGroupByRegex RepoMatching.comAndroid
                 }
             }
@@ -115,6 +116,7 @@ allprojects {
                     includeGroupByRegex RepoMatching.androidx
                     includeGroupByRegex RepoMatching.comGoogleAndroid
                     includeGroupByRegex RepoMatching.comGoogleFirebase
+                    includeGroupByRegex RepoMatching.comGoogleTesting
                     includeGroupByRegex RepoMatching.comAndroid
                 }
             }
@@ -134,6 +136,7 @@ allprojects {
                     excludeGroupByRegex RepoMatching.androidx
                     excludeGroupByRegex RepoMatching.comGoogleAndroid
                     excludeGroupByRegex RepoMatching.comGoogleFirebase
+                    excludeGroupByRegex RepoMatching.comGoogleTesting
                     excludeGroupByRegex RepoMatching.comAndroid
                 }
             }


### PR DESCRIPTION
When running UI tests locally, we found that the `android-device-provider-local` dependency is no longer available on mavenCentral. Our dependency repository uses various regex to allow only google dependencies to be fetched from Google Maven, but somehow these did not include the test ones everywhere.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
Fixes #27320