### PR TITLE
For #27307 - Use the correct warning button text and icon color for DestructiveButton

### DIFF
--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -60,7 +60,7 @@
     <!-- Warning text -->
     <color name="fx_mobile_text_color_warning">@color/photonRed20</color>
     <!-- Warning text on Secondary button -->
-    <color name="fx_mobile_text_color_warning_button" tools:ignore="UnusedResources">@color/photonRed70</color>
+    <color name="fx_mobile_text_color_warning_button">@color/photonRed70</color>
     <!-- Small heading, Text link -->
     <color name="fx_mobile_text_color_accent">@color/photonViolet20</color>
     <!-- Small heading, Text link -->
@@ -97,7 +97,7 @@
     <color name="fx_mobile_icon_color_button" tools:ignore="UnusedResources">@color/photonLightGrey05</color>
     <color name="fx_mobile_icon_color_warning" tools:ignore="UnusedResources">@color/photonRed20</color>
     <!-- Warning icon on Secondary button -->
-    <color name="fx_mobile_icon_color_warning_button" tools:ignore="UnusedResources">@color/photonRed70</color>
+    <color name="fx_mobile_icon_color_warning_button">@color/photonRed70</color>
     <color name="fx_mobile_icon_color_accent_violet">@color/photonViolet20</color>
     <color name="fx_mobile_icon_color_accent_blue">@color/photonBlue20</color>
     <color name="fx_mobile_icon_color_accent_pink">@color/photonPink20</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -60,7 +60,7 @@
     <!-- Warning text -->
     <color name="fx_mobile_text_color_warning">@color/photonRed70</color>
     <!-- Warning text on Secondary button -->
-    <color name="fx_mobile_text_color_warning_button" tools:ignore="UnusedResources">@color/photonRed70</color>
+    <color name="fx_mobile_text_color_warning_button">@color/photonRed70</color>
     <!-- Small heading, Text link -->
     <color name="fx_mobile_text_color_accent">@color/photonViolet70</color>
     <!-- Small heading, Text link -->
@@ -97,7 +97,7 @@
     <color name="fx_mobile_icon_color_button" tools:ignore="UnusedResources">@color/photonInk20</color>
     <color name="fx_mobile_icon_color_warning" tools:ignore="UnusedResources">@color/photonRed70</color>
     <!-- Warning icon on Secondary button -->
-    <color name="fx_mobile_icon_color_warning_button" tools:ignore="UnusedResources">@color/photonRed70</color>
+    <color name="fx_mobile_icon_color_warning_button">@color/photonRed70</color>
     <color name="fx_mobile_icon_color_accent_violet">@color/photonViolet60</color>
     <color name="fx_mobile_icon_color_accent_blue">@color/photonBlue60</color>
     <color name="fx_mobile_icon_color_accent_pink">@color/photonPink60</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -368,8 +368,8 @@
     </style>
 
     <style name="DestructiveButton" parent="NeutralButton">
-        <item name="iconTint">@color/fx_mobile_text_color_warning</item>
-        <item name="android:textColor">@color/fx_mobile_text_color_warning</item>
+        <item name="iconTint">@color/fx_mobile_icon_color_warning_button</item>
+        <item name="android:textColor">@color/fx_mobile_text_color_warning_button</item>
     </style>
 
     <style name="PositiveButton" parent="NeutralButton">


### PR DESCRIPTION
For reference, this is design system component for our warning buttons https://www.figma.com/file/ujdiReypSypu2GhRgzArea/Android-Components?node-id=1429%3A3084

| Old | New |
|----|-----|
|![194330100-e0a1f2cd-0bd8-4652-aa71-e408baf19daf](https://user-images.githubusercontent.com/1190888/194585244-bdc5e883-60bc-461a-8216-2423f1f9f03f.png)|<img width="465" alt="Screen Shot 2022-10-07 at 11 01 12 AM" src="https://user-images.githubusercontent.com/1190888/194585275-ee33d2c1-2255-473b-86bb-1ca387b4497d.png">|

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
Fixes #27307