### PR TITLE
For #27095 - Download light/dark wallpaper card colors

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -201,14 +201,6 @@ class Settings(private val appContext: Context) : PreferencesHolder {
     )
 
     /**
-     * A cache of the background color to use on cards overlaying the current wallpaper.
-     */
-    var currentWallpaperCardColor by longPreference(
-        appContext.getPreferenceKey(R.string.pref_key_current_wallpaper_card_color),
-        default = 0,
-    )
-
-    /**
      * Indicates if the current legacy wallpaper should be migrated.
      */
     var shouldMigrateLegacyWallpaper by booleanPreference(

--- a/app/src/main/java/org/mozilla/fenix/wallpapers/LegacyWallpaperFileManager.kt
+++ b/app/src/main/java/org/mozilla/fenix/wallpapers/LegacyWallpaperFileManager.kt
@@ -37,7 +37,8 @@ class LegacyWallpaperFileManager(
                 name = name,
                 collection = Wallpaper.DefaultCollection,
                 textColor = null,
-                cardColor = null,
+                cardColorLight = null,
+                cardColorDark = null,
                 thumbnailFileState = Wallpaper.ImageFileState.Unavailable,
                 assetsFileState = Wallpaper.ImageFileState.Downloaded,
             )

--- a/app/src/main/java/org/mozilla/fenix/wallpapers/Wallpaper.kt
+++ b/app/src/main/java/org/mozilla/fenix/wallpapers/Wallpaper.kt
@@ -14,13 +14,17 @@ import java.util.Date
  * @property collection The name of the collection the wallpaper belongs to.
  * is not restricted.
  * @property textColor The 8 digit hex code color that should be used for text overlaying the wallpaper.
- * @property cardColor The 8 digit hex code color that should be used for cards overlaying the wallpaper.
+ * @property cardColorLight The 8 digit hex code color that should be used for cards overlaying the wallpaper
+ * when the user's theme is set to Light.
+ * @property cardColorDark The 8 digit hex code color that should be used for cards overlaying the wallpaper
+ * when the user's theme is set to Dark.
  */
 data class Wallpaper(
     val name: String,
     val collection: Collection,
     val textColor: Long?,
-    val cardColor: Long?,
+    val cardColorLight: Long?,
+    val cardColorDark: Long?,
     val thumbnailFileState: ImageFileState,
     val assetsFileState: ImageFileState,
 ) {
@@ -84,7 +88,8 @@ data class Wallpaper(
             name = defaultName,
             collection = DefaultCollection,
             textColor = null,
-            cardColor = null,
+            cardColorLight = null,
+            cardColorDark = null,
             thumbnailFileState = ImageFileState.Downloaded,
             assetsFileState = ImageFileState.Downloaded,
         )
@@ -115,12 +120,12 @@ data class Wallpaper(
         fun getCurrentWallpaperFromSettings(settings: Settings): Wallpaper? {
             val name = settings.currentWallpaperName
             val textColor = settings.currentWallpaperTextColor
-            val cardColor = settings.currentWallpaperCardColor
-            return if (name.isNotEmpty() && textColor != 0L && cardColor != 0L) {
+            return if (name.isNotEmpty() && textColor != 0L) {
                 Wallpaper(
                     name = name,
                     textColor = textColor,
-                    cardColor = cardColor,
+                    cardColorLight = null,
+                    cardColorDark = null,
                     collection = DefaultCollection,
                     thumbnailFileState = ImageFileState.Downloaded,
                     assetsFileState = ImageFileState.Downloaded,

--- a/app/src/main/java/org/mozilla/fenix/wallpapers/WallpaperFileManager.kt
+++ b/app/src/main/java/org/mozilla/fenix/wallpapers/WallpaperFileManager.kt
@@ -36,7 +36,8 @@ class WallpaperFileManager(
                 name = name,
                 collection = Wallpaper.DefaultCollection,
                 textColor = null,
-                cardColor = null,
+                cardColorLight = null,
+                cardColorDark = null,
                 thumbnailFileState = Wallpaper.ImageFileState.Downloaded,
                 assetsFileState = Wallpaper.ImageFileState.Downloaded,
             )

--- a/app/src/main/java/org/mozilla/fenix/wallpapers/WallpaperMetadataFetcher.kt
+++ b/app/src/main/java/org/mozilla/fenix/wallpapers/WallpaperMetadataFetcher.kt
@@ -81,7 +81,8 @@ class WallpaperMetadataFetcher(
                 Wallpaper(
                     name = getString("id"),
                     textColor = getArgbValueAsLong("text-color"),
-                    cardColor = getArgbValueAsLong("card-color"),
+                    cardColorLight = getArgbValueAsLong("card-color-light"),
+                    cardColorDark = getArgbValueAsLong("card-color-dark"),
                     collection = collection,
                     thumbnailFileState = Wallpaper.ImageFileState.Unavailable,
                     assetsFileState = Wallpaper.ImageFileState.Unavailable,

--- a/app/src/main/java/org/mozilla/fenix/wallpapers/WallpapersUseCases.kt
+++ b/app/src/main/java/org/mozilla/fenix/wallpapers/WallpapersUseCases.kt
@@ -185,7 +185,8 @@ class WallpapersUseCases(
                     name = Wallpaper.amethystName,
                     collection = firefoxClassicCollection,
                     textColor = null,
-                    cardColor = null,
+                    cardColorLight = null,
+                    cardColorDark = null,
                     thumbnailFileState = Wallpaper.ImageFileState.Unavailable,
                     assetsFileState = Wallpaper.ImageFileState.Downloaded,
                 ),
@@ -193,7 +194,8 @@ class WallpapersUseCases(
                     name = Wallpaper.ceruleanName,
                     collection = firefoxClassicCollection,
                     textColor = null,
-                    cardColor = null,
+                    cardColorLight = null,
+                    cardColorDark = null,
                     thumbnailFileState = Wallpaper.ImageFileState.Unavailable,
                     assetsFileState = Wallpaper.ImageFileState.Downloaded,
                 ),
@@ -201,7 +203,8 @@ class WallpapersUseCases(
                     name = Wallpaper.sunriseName,
                     collection = firefoxClassicCollection,
                     textColor = null,
-                    cardColor = null,
+                    cardColorLight = null,
+                    cardColorDark = null,
                     thumbnailFileState = Wallpaper.ImageFileState.Unavailable,
                     assetsFileState = Wallpaper.ImageFileState.Downloaded,
                 ),
@@ -211,7 +214,8 @@ class WallpapersUseCases(
                     name = Wallpaper.twilightHillsName,
                     collection = firefoxClassicCollection,
                     textColor = null,
-                    cardColor = null,
+                    cardColorLight = null,
+                    cardColorDark = null,
                     thumbnailFileState = Wallpaper.ImageFileState.Unavailable,
                     assetsFileState = Wallpaper.ImageFileState.Downloaded,
                 ),
@@ -219,7 +223,8 @@ class WallpapersUseCases(
                     name = Wallpaper.beachVibeName,
                     collection = firefoxClassicCollection,
                     textColor = null,
-                    cardColor = null,
+                    cardColorLight = null,
+                    cardColorDark = null,
                     thumbnailFileState = Wallpaper.ImageFileState.Unavailable,
                     assetsFileState = Wallpaper.ImageFileState.Downloaded,
                 ),
@@ -454,7 +459,6 @@ class WallpapersUseCases(
         override suspend fun invoke(wallpaper: Wallpaper): Wallpaper.ImageFileState {
             settings.currentWallpaperName = wallpaper.name
             settings.currentWallpaperTextColor = wallpaper.textColor ?: 0
-            settings.currentWallpaperCardColor = wallpaper.cardColor ?: 0
             store.dispatch(AppAction.WallpaperAction.UpdateCurrentWallpaper(wallpaper))
             return Wallpaper.ImageFileState.Downloaded
         }

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -205,7 +205,6 @@
     <string name="pref_key_wallpapers" translatable="false">pref_key_wallpapers</string>
     <string name="pref_key_current_wallpaper" translatable="false">pref_key_current_wallpaper</string>
     <string name="pref_key_current_wallpaper_text_color" translatable="false">pref_key_current_wallpaper_text_color</string>
-    <string name="pref_key_current_wallpaper_card_color" translatable="false">pref_key_current_wallpaper_card_color</string>
     <string name="pref_key_wallpapers_onboarding" translatable="false">pref_key_wallpapers_onboarding</string>
     <string name="pref_key_should_migrate_wallpaper" translatable="false">pref_key_should_migrate_wallpaper</string>
 

--- a/app/src/test/java/org/mozilla/fenix/home/DefaultSessionControlControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/DefaultSessionControlControllerTest.kt
@@ -1357,7 +1357,8 @@ class DefaultSessionControlControllerTest {
             learnMoreUrl = null,
         ),
         textColor = null,
-        cardColor = null,
+        cardColorLight = null,
+        cardColorDark = null,
         thumbnailFileState = thumbnailFileState,
         assetsFileState = Wallpaper.ImageFileState.Unavailable,
     )

--- a/app/src/test/java/org/mozilla/fenix/settings/wallpaper/ExtensionsTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/wallpaper/ExtensionsTest.kt
@@ -172,7 +172,8 @@ class ExtensionsTest {
     private fun generateClassicFirefoxWallpaper(name: String) = Wallpaper(
         name = name,
         textColor = 0L,
-        cardColor = 0L,
+        cardColorLight = 0L,
+        cardColorDark = 0L,
         thumbnailFileState = Wallpaper.ImageFileState.Downloaded,
         assetsFileState = Wallpaper.ImageFileState.Downloaded,
         collection = classicCollection,
@@ -195,7 +196,8 @@ class ExtensionsTest {
     ) = Wallpaper(
         name = wallpaperName,
         textColor = 0L,
-        cardColor = 0L,
+        cardColorLight = 0L,
+        cardColorDark = 0L,
         thumbnailFileState = thumbnailState,
         assetsFileState = Wallpaper.ImageFileState.Downloaded,
         collection = getSeasonalCollection(collectionName),

--- a/app/src/test/java/org/mozilla/fenix/wallpapers/LegacyWallpaperFileManagerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/wallpapers/LegacyWallpaperFileManagerTest.kt
@@ -97,7 +97,8 @@ class LegacyWallpaperFileManagerTest {
     private fun generateWallpaper(name: String) = Wallpaper(
         name = name,
         textColor = null,
-        cardColor = null,
+        cardColorLight = null,
+        cardColorDark = null,
         thumbnailFileState = Wallpaper.ImageFileState.Unavailable,
         assetsFileState = Wallpaper.ImageFileState.Downloaded,
         collection = Wallpaper.Collection(

--- a/app/src/test/java/org/mozilla/fenix/wallpapers/WallpaperDownloaderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/wallpapers/WallpaperDownloaderTest.kt
@@ -128,7 +128,8 @@ class WallpaperDownloaderTest {
         name = name,
         collection = wallpaperCollection,
         textColor = null,
-        cardColor = null,
+        cardColorLight = null,
+        cardColorDark = null,
         thumbnailFileState = Wallpaper.ImageFileState.Unavailable,
         assetsFileState = Wallpaper.ImageFileState.Unavailable,
     )

--- a/app/src/test/java/org/mozilla/fenix/wallpapers/WallpaperFileManagerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/wallpapers/WallpaperFileManagerTest.kt
@@ -154,7 +154,8 @@ class WallpaperFileManagerTest {
     private fun generateWallpaper(name: String) = Wallpaper(
         name = name,
         textColor = null,
-        cardColor = null,
+        cardColorLight = null,
+        cardColorDark = null,
         thumbnailFileState = Wallpaper.ImageFileState.Downloaded,
         assetsFileState = Wallpaper.ImageFileState.Downloaded,
         collection = Wallpaper.DefaultCollection,

--- a/app/src/test/java/org/mozilla/fenix/wallpapers/WallpaperMetadataFetcherTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/wallpapers/WallpaperMetadataFetcherTest.kt
@@ -52,12 +52,14 @@ class WallpaperMetadataFetcherTest {
                             {
                                 "id": "beach-vibes",
                                 "text-color": "FBFBFE",
-                                "card-color": "15141A"
+                                "card-color-light": "FFFFFF",
+                                "card-color-dark": "000000"
                             },
                             {
                                 "id": "sunrise",
                                 "text-color": "15141A",
-                                "card-color": "FBFBFE"
+                                "card-color-light": "FFFFFF",
+                                "card-color-dark": "000000"
                             }
                         ]
                     }
@@ -70,11 +72,13 @@ class WallpaperMetadataFetcherTest {
 
         with(wallpapers[0]) {
             assertEquals(0xFFFBFBFE, textColor)
-            assertEquals(0xFF15141A, cardColor)
+            assertEquals(0xFFFFFFFF, cardColorLight)
+            assertEquals(0xFF000000, cardColorDark)
         }
         with(wallpapers[1]) {
             assertEquals(0xFF15141A, textColor)
-            assertEquals(0xFFFBFBFE, cardColor)
+            assertEquals(0xFFFFFFFF, cardColorLight)
+            assertEquals(0xFF000000, cardColorDark)
         }
     }
 
@@ -91,12 +95,14 @@ class WallpaperMetadataFetcherTest {
                         "wallpapers": [
                             {
                                 "text-color": "FBFBFE",
-                                "card-color": "15141A"
+                                "card-color-light": "FFFFFF",
+                                "card-color-dark": "000000"
                             },
                             {
                                 "id": "sunrise",
                                 "text-color": "15141A",
-                                "card-color": "FBFBFE"
+                                "card-color-light": "FFFFFF",
+                                "card-color-dark": "000000"
                             }
                         ]
                     }
@@ -123,12 +129,14 @@ class WallpaperMetadataFetcherTest {
                         "wallpapers": [
                             {
                                 "id": "beach-vibes",
-                                "card-color": "15141A"
+                                "card-color-light": "FFFFFF",
+                                "card-color-dark": "000000"
                             },
                             {
                                 "id": "sunrise",
                                 "text-color": "15141A",
-                                "card-color": "FBFBFE"
+                                "card-color-light": "FFFFFF",
+                                "card-color-dark": "000000"
                             }
                         ]
                     }
@@ -160,7 +168,8 @@ class WallpaperMetadataFetcherTest {
                             {
                                 "id": "sunrise",
                                 "text-color": "15141A",
-                                "card-color": "FBFBFE"
+                                "card-color-light": "FFFFFF",
+                                "card-color-dark": "000000"
                             }
                         ]
                     }
@@ -189,12 +198,14 @@ class WallpaperMetadataFetcherTest {
                             {
                                 "id": "beach-vibes",
                                 "text-color": "FBFBFE",
-                                "card-color": "15141A"
+                                "card-color-light": "FFFFFF",
+                                "card-color-dark": "000000"
                             },
                             {
                                 "id": "sunrise",
                                 "text-color": "15141A",
-                                "card-color": "FBFBFE"
+                                "card-color-light": "FFFFFF",
+                                "card-color-dark": "000000"
                             }
                         ]
                     }
@@ -239,12 +250,14 @@ class WallpaperMetadataFetcherTest {
                             {
                                 "id": "beach-vibes",
                                 "text-color": "FBFBFE",
-                                "card-color": "15141A"
+                                "card-color-light": "FFFFFF",
+                                "card-color-dark": "000000"
                             },
                             {
                                 "id": "sunrise",
                                 "text-color": "15141A",
-                                "card-color": "FBFBFE"
+                                "card-color-light": "FFFFFF",
+                                "card-color-dark": "000000"
                             }
                         ]
                     }
@@ -280,12 +293,14 @@ class WallpaperMetadataFetcherTest {
                             {
                                 "id": "beach-vibes",
                                 "text-color": "FBFBFE",
-                                "card-color": "15141A"
+                                "card-color-light": "FFFFFF",
+                                "card-color-dark": "000000"
                             },
                             {
                                 "id": "sunrise",
                                 "text-color": "15141A",
-                                "card-color": "FBFBFE"
+                                "card-color-light": "FFFFFF",
+                                "card-color-dark": "000000"
                             }
                         ]
                     }
@@ -323,12 +338,14 @@ class WallpaperMetadataFetcherTest {
                             {
                                 "id": "beach-vibes",
                                 "text-color": "FBFBFE",
-                                "card-color": "15141A"
+                                "card-color-light": "FFFFFF",
+                                "card-color-dark": "000000"
                             },
                             {
                                 "id": "sunrise",
                                 "text-color": "15141A",
-                                "card-color": "FBFBFE"
+                                "card-color-light": "FFFFFF",
+                                "card-color-dark": "000000"
                             }
                         ]
                     }
@@ -364,12 +381,14 @@ class WallpaperMetadataFetcherTest {
                             {
                                 "id": "beach-vibes",
                                 "text-color": "FBFBFE",
-                                "card-color": "15141A"
+                                "card-color-light": "FFFFFF",
+                                "card-color-dark": "000000"
                             },
                             {
                                 "id": "sunrise",
                                 "text-color": "15141A",
-                                "card-color": "FBFBFE"
+                                "card-color-light": "FFFFFF",
+                                "card-color-dark": "000000"
                             }
                         ]
                     }

--- a/app/src/test/java/org/mozilla/fenix/wallpapers/WallpapersUseCasesTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/wallpapers/WallpapersUseCasesTest.kt
@@ -41,8 +41,6 @@ class WallpapersUseCasesTest {
     private val mockSettings = mockk<Settings> {
         every { currentWallpaperTextColor } returns 0L
         every { currentWallpaperTextColor = any() } just Runs
-        every { currentWallpaperCardColor } returns 0L
-        every { currentWallpaperCardColor = any() } just Runs
         every { shouldMigrateLegacyWallpaper } returns false
         every { shouldMigrateLegacyWallpaper = any() } just Runs
     }
@@ -525,7 +523,6 @@ class WallpapersUseCasesTest {
 
         verify { mockSettings.currentWallpaperName = selectedWallpaper.name }
         verify { mockSettings.currentWallpaperTextColor = selectedWallpaper.textColor!! }
-        verify { mockSettings.currentWallpaperCardColor = selectedWallpaper.cardColor!! }
         assertEquals(selectedWallpaper, appStore.state.wallpaperState.currentWallpaper)
         assertEquals(wallpaperFileState, Wallpaper.ImageFileState.Downloaded)
     }
@@ -677,7 +674,8 @@ class WallpapersUseCasesTest {
                     learnMoreUrl = null,
                 ),
                 textColor = Random.nextLong(),
-                cardColor = Random.nextLong(),
+                cardColorLight = Random.nextLong(),
+                cardColorDark = Random.nextLong(),
                 thumbnailFileState = Wallpaper.ImageFileState.Unavailable,
                 assetsFileState = Wallpaper.ImageFileState.Unavailable,
             )
@@ -694,7 +692,8 @@ class WallpapersUseCasesTest {
                     learnMoreUrl = null,
                 ),
                 textColor = Random.nextLong(),
-                cardColor = Random.nextLong(),
+                cardColorLight = Random.nextLong(),
+                cardColorDark = Random.nextLong(),
                 thumbnailFileState = Wallpaper.ImageFileState.Unavailable,
                 assetsFileState = Wallpaper.ImageFileState.Unavailable,
             )


### PR DESCRIPTION
`card-color-light` and `card-color-dark` have been added to the metadata for wallpapers, making `card-color` defunct. The migration code for `card-color` was removed since that color is not needed and should not be used for any logic going forward.

Two follow-ups have been filed to specifically handle expired wallpapers:
- https://github.com/mozilla-mobile/fenix/issues/27330
- https://github.com/mozilla-mobile/fenix/issues/27331

The light/dark card colors will be integrated into the UI in:
- https://github.com/mozilla-mobile/fenix/issues/26520

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
Fixes #27095