### PR TITLE
For #19888: Add option to close orphan tabs on back action

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -1209,7 +1209,7 @@ abstract class BaseBrowserFragment :
                 true
             } else {
                 val hasParentSession = session is TabSessionState && session.parentId != null
-                if (hasParentSession) {
+                if (hasParentSession || requireContext().settings().closeOrphanTabOnBack) {
                     requireComponents.useCases.tabsUseCases.removeTab(session.id, selectParentIfExists = true)
                 }
                 // We want to return to home if this session didn't have a parent session to select.

--- a/app/src/main/java/org/mozilla/fenix/settings/TabsSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/TabsSettingsFragment.kt
@@ -28,6 +28,7 @@ class TabsSettingsFragment : PreferenceFragmentCompat() {
     private lateinit var radioOneDay: RadioButtonPreference
     private lateinit var radioOneWeek: RadioButtonPreference
     private lateinit var radioOneMonth: RadioButtonPreference
+    private lateinit var closeOrphanTabOnBack: SwitchPreference
     private lateinit var inactiveTabsCategory: PreferenceCategory
     private lateinit var inactiveTabs: SwitchPreference
 
@@ -60,6 +61,10 @@ class TabsSettingsFragment : PreferenceFragmentCompat() {
         radioOneMonth = requirePreference(R.string.pref_key_close_tabs_after_one_month)
         radioOneWeek = requirePreference(R.string.pref_key_close_tabs_after_one_week)
         radioOneDay = requirePreference(R.string.pref_key_close_tabs_after_one_day)
+
+        closeOrphanTabOnBack = requirePreference<SwitchPreference>(R.string.pref_key_close_orphan_tab_on_back).also {
+            it.onPreferenceChangeListener = SharedPreferenceUpdater()
+        }
 
         inactiveTabs = requirePreference<SwitchPreference>(R.string.pref_key_inactive_tabs).also {
             it.isChecked = requireContext().settings().inactiveTabsAreEnabled

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -357,6 +357,14 @@ class Settings(private val appContext: Context) : PreferencesHolder {
         default = true,
     )
 
+    /**
+     * Indicates if invoking a back action should close a tab with no history or parent.
+     */
+    var closeOrphanTabOnBack by booleanPreference(
+        appContext.getPreferenceKey(R.string.pref_key_close_orphan_tab_on_back),
+        default = false,
+    )
+
     var manuallyCloseTabs by booleanPreference(
         appContext.getPreferenceKey(R.string.pref_key_close_tabs_manually),
         default = true,

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -275,6 +275,7 @@
     <string name="pref_key_tab_view_grid" translatable="false">pref_key_tab_view_grid</string>
     <string name="pref_key_tabs" translatable="false">pref_key_tabs</string>
     <string name="pref_key_home" translatable="false">pref_key_home</string>
+    <string name="pref_key_close_orphan_tab_on_back" translatable="false">pref_key_close_orphan_tab_on_back</string>
     <string name="pref_key_close_tabs_manually" translatable="false">pref_key_close_tabs_manually</string>
     <string name="pref_key_close_tabs_after_one_day" translatable="false">pref_key_close_tabs_after_one_day</string>
     <string name="pref_key_close_tabs_after_one_week" translatable="false">pref_key_close_tabs_after_one_week</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -644,7 +644,7 @@
     <string name="tab_view_list">List</string>
     <!-- Option for a grid tab view -->
     <string name="tab_view_grid">Grid</string>
-    <!-- Title of preference that allows a user to auto close tabs after a specified amount of time -->
+    <!-- Title of preference category for the close behavior of tabs -->
     <string name="preferences_close_tabs">Close tabs</string>
     <!-- Option for auto closing tabs that will never auto close tabs, always allows user to manually close tabs -->
     <string name="close_tabs_manually">Never</string>
@@ -656,6 +656,8 @@
     <string name="close_tabs_after_one_month">After one month</string>
     <!-- Title of preference that allows a user to specify the auto-close settings for open tabs -->
     <string name="preference_auto_close_tabs" tools:ignore="UnusedResources">Auto-close open tabs</string>
+    <!-- Option for closing the current tab with no history or parent on a back action -->
+    <string name="preference_close_orphan_tab_on_back">Back action closes tab with no history or parent</string>
 
     <!-- Opening screen -->
     <!-- Title of a preference that allows a user to choose what screen to show after opening the app -->

--- a/app/src/main/res/xml/tabs_preferences.xml
+++ b/app/src/main/res/xml/tabs_preferences.xml
@@ -44,6 +44,11 @@
             android:defaultValue="false"
             android:key="@string/pref_key_close_tabs_after_one_month"
             android:title="@string/close_tabs_after_one_month" />
+
+        <androidx.preference.SwitchPreference
+            android:defaultValue="false"
+            android:key="@string/pref_key_close_orphan_tab_on_back"
+            android:title="@string/preference_close_orphan_tab_on_back" />
     </androidx.preference.PreferenceCategory>
 
     <androidx.preference.PreferenceCategory


### PR DESCRIPTION
I'm not sure where the best place to put a test is at the moment. (Base)BrowserFragment tests don't seem to test the onBackPressed behavior...

EDIT: #27477 adds tests for removeSessionIfNeeded that I could use for this if necessary.

I believe this also addresses #13775, but perhaps for that the behavior should be unconditional for shortcuts launched from the home screen?

https://user-images.githubusercontent.com/13156601/194676546-0775803c-54a6-4a30-afa4-2206612b1243.mp4


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
Fixes #19888