### PR TITLE
For #27338: Make ETP and HTTPS-Only summaries more specific 

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
@@ -561,8 +561,10 @@ class SettingsFragment : PreferenceFragmentCompat() {
     internal fun setupHttpsOnlyPreferences() {
         val httpsOnlyPreference =
             requirePreference<Preference>(R.string.pref_key_https_only_settings)
-        httpsOnlyPreference.summary = context?.let {
-            if (it.settings().shouldUseHttpsOnly) {
+        httpsOnlyPreference.summary = context?.settings()?.let {
+            if (it.shouldUseHttpsOnlyInPrivateTabsOnly) {
+                getString(R.string.preferences_https_only_in_private_tabs)
+            } else if (it.shouldUseHttpsOnly) {
                 getString(R.string.preferences_https_only_on)
             } else {
                 getString(R.string.preferences_https_only_off)

--- a/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SettingsFragment.kt
@@ -194,14 +194,6 @@ class SettingsFragment : PreferenceFragmentCompat() {
     private fun update(shouldUpdateAccountUIState: Boolean) {
         val settings = requireContext().settings()
 
-        val trackingProtectionPreference =
-            requirePreference<Preference>(R.string.pref_key_tracking_protection_settings)
-        trackingProtectionPreference.summary = if (settings.shouldUseTrackingProtection) {
-            getString(R.string.tracking_protection_on)
-        } else {
-            getString(R.string.tracking_protection_off)
-        }
-
         val aboutPreference = requirePreference<Preference>(R.string.pref_key_about)
         val appName = getString(R.string.app_name)
         aboutPreference.title = getString(R.string.preferences_about, appName)
@@ -224,6 +216,8 @@ class SettingsFragment : PreferenceFragmentCompat() {
         } else {
             getString(R.string.preferences_credit_cards)
         }
+
+        setupTrackingProtectionPreference()
 
         setupPreferences()
 
@@ -572,6 +566,24 @@ class SettingsFragment : PreferenceFragmentCompat() {
                 getString(R.string.preferences_https_only_on)
             } else {
                 getString(R.string.preferences_https_only_off)
+            }
+        }
+    }
+
+    @VisibleForTesting
+    internal fun setupTrackingProtectionPreference() {
+        val trackingProtectionPreference =
+            requirePreference<Preference>(R.string.pref_key_tracking_protection_settings)
+
+        trackingProtectionPreference.summary = context?.settings()?.let {
+            if (!it.shouldUseTrackingProtection) {
+                getString(R.string.tracking_protection_off)
+            } else if (it.useStrictTrackingProtection) {
+                getString(R.string.preference_enhanced_tracking_protection_strict)
+            } else if (it.useCustomTrackingProtection) {
+                getString(R.string.preference_enhanced_tracking_protection_custom)
+            } else {
+                getString(R.string.tracking_protection_on)
             }
         }
     }

--- a/app/src/test/java/org/mozilla/fenix/settings/SettingsFragmentTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/SettingsFragmentTest.kt
@@ -149,14 +149,12 @@ class SettingsFragmentTest {
         assertFalse(preferenceAmoCollectionOverride.isVisible)
     }
 
-    @Test
-    fun `GIVEN the HttpsOnly is enabled THEN set the appropriate preference summary`() {
+    private fun testHttpsOnlySummary(summary: String) {
         val httpsOnlyPreference = settingsFragment.findPreference<Preference>(
             settingsFragment.getPreferenceKey(R.string.pref_key_https_only_settings),
         )!!
-        every { testContext.settings().shouldUseHttpsOnly } returns true
+
         assertTrue(httpsOnlyPreference.summary.isNullOrEmpty())
-        val summary = testContext.getString(R.string.preferences_https_only_on)
 
         settingsFragment.setupHttpsOnlyPreferences()
 
@@ -164,17 +162,82 @@ class SettingsFragmentTest {
     }
 
     @Test
+    fun `GIVEN the HttpsOnly is enabled THEN set the appropriate preference summary`() {
+        every { testContext.settings().shouldUseHttpsOnly } returns true
+        every { testContext.settings().shouldUseHttpsOnlyInPrivateTabsOnly } returns false
+        testHttpsOnlySummary(
+            summary = testContext.getString(R.string.preferences_https_only_on),
+        )
+    }
+
+    @Test
     fun `GIVEN the HttpsOnly is disabled THEN set the appropriate preference summary`() {
-        val httpsOnlyPreference = settingsFragment.findPreference<Preference>(
-            settingsFragment.getPreferenceKey(R.string.pref_key_https_only_settings),
-        )!!
         every { testContext.settings().shouldUseHttpsOnly } returns false
-        assertTrue(httpsOnlyPreference.summary.isNullOrEmpty())
-        val summary = testContext.getString(R.string.preferences_https_only_off)
+        every { testContext.settings().shouldUseHttpsOnlyInPrivateTabsOnly } returns false
+        testHttpsOnlySummary(
+            summary = testContext.getString(R.string.preferences_https_only_off),
+        )
+    }
 
-        settingsFragment.setupHttpsOnlyPreferences()
+    @Test
+    fun `GIVEN the HttpsOnly is enabled in private tabs only THEN set the appropriate preference summary`() {
+        every { testContext.settings().shouldUseHttpsOnly } returns true
+        every { testContext.settings().shouldUseHttpsOnlyInPrivateTabsOnly } returns true
+        testHttpsOnlySummary(
+            summary = testContext.getString(R.string.preferences_https_only_in_private_tabs),
+        )
+    }
 
-        assertEquals(summary, httpsOnlyPreference.summary)
+    private fun testTrackingProtectionSummary(summary: String) {
+        val trackingProtectionPreference = settingsFragment.findPreference<Preference>(
+            settingsFragment.getPreferenceKey(R.string.pref_key_tracking_protection_settings),
+        )!!
+
+        assertTrue(trackingProtectionPreference.summary.isNullOrEmpty())
+
+        settingsFragment.setupTrackingProtectionPreference()
+
+        assertEquals(summary, trackingProtectionPreference.summary)
+    }
+
+    @Test
+    fun `GIVEN TrackingProtection is enabled THEN set the appropriate preference summary`() {
+        every { testContext.settings().shouldUseTrackingProtection } returns true
+        every { testContext.settings().useStrictTrackingProtection } returns false
+        every { testContext.settings().useCustomTrackingProtection } returns false
+        testTrackingProtectionSummary(
+            summary = testContext.getString(R.string.tracking_protection_on),
+        )
+    }
+
+    @Test
+    fun `GIVEN TrackingProtection is disabled THEN set the appropriate preference summary`() {
+        every { testContext.settings().shouldUseTrackingProtection } returns false
+        every { testContext.settings().useStrictTrackingProtection } returns false
+        every { testContext.settings().useCustomTrackingProtection } returns false
+        testTrackingProtectionSummary(
+            summary = testContext.getString(R.string.tracking_protection_off),
+        )
+    }
+
+    @Test
+    fun `GIVEN strict TrackingProtection is enabled THEN set the appropriate preference summary`() {
+        every { testContext.settings().shouldUseTrackingProtection } returns true
+        every { testContext.settings().useStrictTrackingProtection } returns true
+        every { testContext.settings().useCustomTrackingProtection } returns false
+        testTrackingProtectionSummary(
+            summary = testContext.getString(R.string.preference_enhanced_tracking_protection_strict),
+        )
+    }
+
+    @Test
+    fun `GIVEN custom TrackingProtection is enabled THEN set the appropriate preference summary`() {
+        every { testContext.settings().shouldUseTrackingProtection } returns true
+        every { testContext.settings().useStrictTrackingProtection } returns false
+        every { testContext.settings().useCustomTrackingProtection } returns true
+        testTrackingProtectionSummary(
+            summary = testContext.getString(R.string.preference_enhanced_tracking_protection_custom),
+        )
     }
 
     @After


### PR DESCRIPTION
This does so without adding any new strings. `preferences_https_only_in_private_tabs` is a bit long in some languages, so perhaps that warrants a new string?

https://user-images.githubusercontent.com/13156601/194689943-564e6ae1-7f99-4c75-8fdc-f20b15b46ca2.mp4


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
Fixes #27338