### PR TITLE
Bug 1810044 and 1810045 - Do not prematurely read clipboard content and allow to paste non url

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/utils/ClipboardHandler.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/ClipboardHandler.kt
@@ -101,10 +101,11 @@ class ClipboardHandler(val context: Context) {
         primaryClipDescription?.hasMimeType(MIME_TYPE_TEXT_URL) ?: false
 
     /**
+     * Returns whether or not the clipboard has any clip data.
      * Reads the clip data, be aware this is a sensitive API as from Android 12 and above,
      * accessing it will trigger a notification letting the user know the app has accessed the clipboard,
      * make sure when you call this API that users are completely aware that we are accessing the clipboard.
-     * See for more details https://github.com/mozilla-mobile/fenix/issues/22271.
+     * See https://github.com/mozilla-mobile/fenix/issues/22271 for more details.
      */
     private fun ClipboardManager.isPrimaryClipEmpty() = primaryClip?.itemCount == 0
 

--- a/app/src/main/java/org/mozilla/fenix/utils/ClipboardHandler.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/ClipboardHandler.kt
@@ -38,10 +38,7 @@ class ClipboardHandler(val context: Context) {
             if (clipboard.isPrimaryClipEmpty()) {
                 return null
             }
-            if (clipboard.isPrimaryClipPlainText() ||
-                clipboard.isPrimaryClipHtmlText() ||
-                clipboard.isPrimaryClipUrlText()
-            ) {
+            if (containsText()) {
                 return firstSafePrimaryClipItemText
             }
             return null
@@ -51,7 +48,6 @@ class ClipboardHandler(val context: Context) {
         }
 
     /**
-     * Returns a possible URL from the actual content of the clipboard, be aware this is a sensitive
      * API as from Android 12 and above, accessing it will trigger a notification letting the user
      * know the app has accessed the clipboard, make sure when you call this API that users are
      * completely aware that we are accessing the clipboard.
@@ -66,6 +62,15 @@ class ClipboardHandler(val context: Context) {
             val finder = WebURLFinder(it)
             finder.bestWebURL()
         }
+    }
+
+    /**
+     * We cannot rely on `isPrimaryClipEmpty()` since it triggers a clipboard access system notification.
+     */
+    fun containsText(): Boolean {
+        return clipboard.isPrimaryClipHtmlText() ||
+            clipboard.isPrimaryClipPlainText() ||
+            clipboard.isPrimaryClipUrlText()
     }
 
     @Suppress("MagicNumber")
@@ -94,6 +99,12 @@ class ClipboardHandler(val context: Context) {
     private fun ClipboardManager.isPrimaryClipUrlText() =
         primaryClipDescription?.hasMimeType(MIME_TYPE_TEXT_URL) ?: false
 
+    /**
+     * Reads the clip data, be aware this is a sensitive API as from Android 12 and above,
+     * accessing it will trigger a notification letting the user know the app has accessed the clipboard,
+     * make sure when you call this API that users are completely aware that we are accessing the clipboard.
+     * See for more details https://github.com/mozilla-mobile/fenix/issues/22271.
+     */
     private fun ClipboardManager.isPrimaryClipEmpty() = primaryClip?.itemCount == 0
 
     /**

--- a/app/src/main/java/org/mozilla/fenix/utils/ClipboardHandler.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/ClipboardHandler.kt
@@ -65,6 +65,7 @@ class ClipboardHandler(val context: Context) {
     }
 
     /**
+     * Returns whether or not the clipboard data contains text.
      * We cannot rely on `isPrimaryClipEmpty()` since it triggers a clipboard access system notification.
      */
     fun containsText(): Boolean {


### PR DESCRIPTION
In relation with #26564 dot not read the clipboard content to determine if we may have an url available to paste.

This is similar to what is done for the Clipboard suggestion of the url bar  
https://github.com/mozilla-mobile/fenix/blob/47b7336387f020607f95f43d25024d22e6e8c6f0/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt#L519 
And
 https://github.com/mozilla-mobile/fenix/blob/47b7336387f020607f95f43d25024d22e6e8c6f0/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt#L486


This logic was initially introduced in https://github.com/gexsi/user-agent-android/commit/ccc439e9c4119e4518e5bc63e948cd3ccb082310 but then reverted in https://github.com/mozilla-mobile/fenix/commit/5daa06f7dcd8b98fd98b4a7273f3093692c34209. To avoid NPE  switched to rely on `orEmpty()` and since the PopupWindow should almost always be short lived I believe it should be sufficient as even if the user trigger the `pasteAndGo` option with a non url it will just trigger an empty search.



Note on the use of `extractUrl()` for the `pasteAndGo` it was done to keep a similar handling to the clipboard suggestion :
https://github.com/mozilla-mobile/fenix/blob/47b7336387f020607f95f43d25024d22e6e8c6f0/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt#L366 

Additionally include the change for #27182, since it concerns the same component, which is to allow to paste plain text even when the urlbar is empty, the ability to paste when there is an url was added in https://github.com/mozilla-mobile/fenix/pull/24294.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
Fixes #26564
Fixes #27182