### PR TITLE
For #27289: standardize coroutine usage in WallpaperFileManager

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/wallpapers/WallpaperFileManager.kt
+++ b/app/src/main/java/org/mozilla/fenix/wallpapers/WallpaperFileManager.kt
@@ -21,16 +21,15 @@ import java.io.File
  */
 class WallpaperFileManager(
     private val storageRootDirectory: File,
-    coroutineDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val coroutineDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
-    private val scope = CoroutineScope(coroutineDispatcher)
     private val wallpapersDirectory = File(storageRootDirectory, "wallpapers")
 
     /**
      * Lookup all the files for a wallpaper name. This lookup will fail if there are not
      * files for each of a portrait and landscape orientation as well as a thumbnail.
      */
-    suspend fun lookupExpiredWallpaper(name: String): Wallpaper? = withContext(Dispatchers.IO) {
+    suspend fun lookupExpiredWallpaper(name: String): Wallpaper? = withContext(coroutineDispatcher) {
         if (allAssetsExist(name)) {
             Wallpaper(
                 name = name,
@@ -53,8 +52,8 @@ class WallpaperFileManager(
     /**
      * Remove all wallpapers that are not the [currentWallpaper] or in [availableWallpapers].
      */
-    suspend fun clean(currentWallpaper: Wallpaper, availableWallpapers: List<Wallpaper>) = withContext(Dispatchers.IO) {
-        scope.launch {
+    fun clean(currentWallpaper: Wallpaper, availableWallpapers: List<Wallpaper>) {
+        CoroutineScope(coroutineDispatcher).launch {
             val wallpapersToKeep = (listOf(currentWallpaper) + availableWallpapers).map { it.name }
             wallpapersDirectory.listFiles()?.forEach { file ->
                 if (file.isDirectory && !wallpapersToKeep.contains(file.name)) {
@@ -67,7 +66,7 @@ class WallpaperFileManager(
     /**
      * Checks whether all the assets for a wallpaper exist on the file system.
      */
-    suspend fun wallpaperImagesExist(wallpaper: Wallpaper): Boolean = withContext(Dispatchers.IO) {
-        return@withContext allAssetsExist(wallpaper.name)
+    suspend fun wallpaperImagesExist(wallpaper: Wallpaper): Boolean = withContext(coroutineDispatcher) {
+        allAssetsExist(wallpaper.name)
     }
 }


### PR DESCRIPTION
scope variable inlined as in only one place it is used, class injected dispatcher is used in all withcontext to use differnt dispatchers in different scenarios, clean function suspend keyword removed, as there no requirement to know its result, unnecessary return removed



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
Fixes #27289