### PR TITLE
For #27366 - Revert "For #26644 - Apply the new theme earlier to the private browsing button

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -39,7 +39,6 @@ import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.LinearSmoothScroller
 import androidx.recyclerview.widget.RecyclerView.SmoothScroller
-import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat
 import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.snackbar.Snackbar
@@ -994,22 +993,7 @@ class HomeFragment : Fragment() {
         }
 
         binding.wordmarkText.imageTintList = tintColor
-
-        // Need to preemptively apply the new theme to the private browsing button drawable
-        // See https://github.com/mozilla-mobile/fenix/issues/26644#issuecomment-1254961616
-        (activity as? HomeActivity)?.themeManager?.let { themeManager ->
-            with(binding.privateBrowsingButton) {
-                val drawable = VectorDrawableCompat.create(
-                    resources,
-                    R.drawable.private_browsing_button,
-                    resources.newTheme().apply {
-                        applyStyle(themeManager.currentThemeResource, true)
-                    },
-                )
-                setImageDrawable(drawable)
-                imageTintList = tintColor
-            }
-        }
+        binding.privateBrowsingButton.imageTintList = tintColor
     }
 
     private fun observeWallpaperUpdates() {


### PR DESCRIPTION
This reverts commit c7c5682104264ad1396fd0dc2852c0b9f9224b82 given that the severity of the new issue is much higher and the button is to be refactored soon in https://github.com/mozilla-mobile/fenix/pull/27262.

Fixing the general issue with the theme taking a visibly long time to be applied - https://github.com/mozilla-mobile/fenix/issues/27120 would fix the issue with the private browsing button too.

This will probably have to be uplifted since the issue also happens in the current Beta.

Testing on an Android 6 emulator:

[PrivateBrowsingButtonOnAndroid6.webm](https://user-images.githubusercontent.com/11428869/195098104-f435c822-b06d-493d-ad8f-8418a545d574.webm)



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
Fixes #27366
Fixes #26644