### PR TITLE
For #27381 - Unregister FXA observer to prevent memory leaks

### DIFF
--- a/app/src/test/java/org/mozilla/fenix/settings/SettingsFragmentTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/SettingsFragmentTest.kt
@@ -10,8 +10,10 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
+import io.mockk.verify
 import kotlinx.coroutines.test.advanceUntilIdle
 import mozilla.components.concept.fetch.Client
+import mozilla.components.service.fxa.manager.FxaAccountManager
 import mozilla.components.support.test.robolectric.testContext
 import mozilla.components.support.test.rule.MainCoroutineRule
 import mozilla.components.support.test.rule.runTestOnMain
@@ -175,6 +177,26 @@ class SettingsFragmentTest {
         settingsFragment.setupHttpsOnlyPreferences()
 
         assertEquals(summary, httpsOnlyPreference.summary)
+    }
+
+    @Test
+    fun `GIVEN an account observer WHEN the fragment is visible THEN register it for updates`() {
+        val accountManager: FxaAccountManager = mockk(relaxed = true)
+        every { testContext.components.backgroundServices.accountManager } returns accountManager
+
+        settingsFragment.onStart()
+
+        verify { accountManager.register(settingsFragment.accountObserver, settingsFragment, true) }
+    }
+
+    @Test
+    fun `GIVEN an account observer WHEN the fragment stops being visible THEN unregister it for updates`() {
+        val accountManager: FxaAccountManager = mockk(relaxed = true)
+        every { testContext.components.backgroundServices.accountManager } returns accountManager
+
+        settingsFragment.onStop()
+
+        verify { accountManager.unregister(settingsFragment.accountObserver) }
     }
 
     @After


### PR DESCRIPTION
Showing no leaks when navigating to and back from Settings:


https://user-images.githubusercontent.com/11428869/195334945-17a40e3f-72ed-4f00-b0b5-7a854c61ddf3.mp4



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
Fixes #27381