### PR TITLE
For #27388 - Add optional background colors to SelectableChip

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/compose/SelectableChip.kt
+++ b/app/src/main/java/org/mozilla/fenix/compose/SelectableChip.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.capitalize
 import androidx.compose.ui.text.intl.Locale
@@ -32,12 +33,16 @@ import org.mozilla.fenix.theme.Theme
  *
  * @param text [String] displayed in this chip. Ideally should only be one word.
  * @param isSelected Whether this should be shown as selected.
+ * @param selectedBackgroundColor Optional background [Color] when the chip is selected.
+ * @param unselectedBackgroundColor Optional background [Color] when the chip is not selected.
  * @param onClick Callback for when the user taps this.
  */
 @Composable
 fun SelectableChip(
     text: String,
     isSelected: Boolean,
+    selectedBackgroundColor: Color? = null,
+    unselectedBackgroundColor: Color? = null,
     onClick: () -> Unit,
 ) {
     Box(
@@ -46,9 +51,9 @@ fun SelectableChip(
             .clip(MaterialTheme.shapes.small)
             .background(
                 color = if (isSelected) {
-                    FirefoxTheme.colors.actionPrimary
+                    selectedBackgroundColor ?: FirefoxTheme.colors.actionPrimary
                 } else {
-                    FirefoxTheme.colors.actionTertiary
+                    unselectedBackgroundColor ?: FirefoxTheme.colors.actionTertiary
                 },
             )
             .padding(horizontal = 16.dp, vertical = 10.dp),
@@ -67,7 +72,8 @@ fun SelectableChip(
 
 @Composable
 @Preview(uiMode = UI_MODE_NIGHT_YES)
-private fun SelectableChipDarkThemePreview() {
+@Preview(uiMode = UI_MODE_NIGHT_NO)
+private fun SelectableChipPreview() {
     FirefoxTheme(theme = Theme.getTheme()) {
         Row(
             modifier = Modifier
@@ -82,8 +88,9 @@ private fun SelectableChipDarkThemePreview() {
 }
 
 @Composable
+@Preview(uiMode = UI_MODE_NIGHT_YES)
 @Preview(uiMode = UI_MODE_NIGHT_NO)
-private fun SelectableChipLightThemePreview() {
+private fun SelectableChipWithBackgroundColorPreview() {
     FirefoxTheme(theme = Theme.getTheme()) {
         Row(
             modifier = Modifier
@@ -91,8 +98,8 @@ private fun SelectableChipLightThemePreview() {
                 .background(FirefoxTheme.colors.layer1),
             horizontalArrangement = Arrangement.SpaceEvenly,
         ) {
-            SelectableChip(text = "Chirp", isSelected = false) { }
-            SelectableChip(text = "Chirp", isSelected = true) { }
+            SelectableChip(text = "Chirp", isSelected = false, unselectedBackgroundColor = Color.Cyan) { }
+            SelectableChip(text = "Chirp", isSelected = true, selectedBackgroundColor = Color.Yellow) { }
         }
     }
 }


### PR DESCRIPTION
I opted for a nullable, optional parameter because of the use case with wallpapers. The wallpaper card colors are not assumed to be not-null, so rather than have the implementor of `SelectableChip` know about the default colors, I opted for a nullable optional parameter. The other solution would have been to somehow have a named parameter wrapped around an `if`, but I don't think that's possible with Kotlin.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
Fixes #27388