### PR TITLE
For #27117 - update copy in the menu from sign in to sync and save

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuLoginsAndPasswordRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuLoginsAndPasswordRobot.kt
@@ -110,5 +110,5 @@ private fun assertDefaultValueAutofillLogins(context: Context) = onView(
 private fun assertDefaultValueExceptions() = onView(ViewMatchers.withText("Exceptions"))
     .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
-private fun assertDefaultValueSyncLogins() = onView(ViewMatchers.withText("Sign in to Sync"))
+private fun assertDefaultValueSyncLogins() = onView(ViewMatchers.withText("Sync and save data"))
     .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuMainRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuMainRobot.kt
@@ -173,7 +173,7 @@ class ThreeDotMenuMainRobot {
 
         fun openSyncSignIn(interact: SyncSignInRobot.() -> Unit): SyncSignInRobot.Transition {
             threeDotMenuRecyclerView().perform(swipeDown())
-            mDevice.waitNotNull(Until.findObject(By.text("Sign in to sync")), waitingTime)
+            mDevice.waitNotNull(Until.findObject(By.text("Sync and save data")), waitingTime)
             signInToSyncButton().click()
 
             SyncSignInRobot().interact()
@@ -440,7 +440,7 @@ private fun bookmarksButton() = onView(allOf(withText(R.string.library_bookmarks
 private fun assertBookmarksButton() = bookmarksButton()
     .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
-private fun signInToSyncButton() = onView(withText("Sign in to sync"))
+private fun signInToSyncButton() = onView(withText("Sync and save data"))
 private fun assertSignInToSyncButton() = signInToSyncButton().check(matches(isDisplayed()))
 
 private fun helpButton() = onView(allOf(withText(R.string.browser_menu_help)))

--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/DefaultToolbarMenu.kt
@@ -352,7 +352,7 @@ open class DefaultToolbarMenu(
     private fun syncMenuItem(): BrowserMenuImageText? {
         val syncItemTitle =
             if (context.components.backgroundServices.accountManagerAvailableQueue.isReady()) {
-                accountManager.accountProfileEmail ?: context.getString(R.string.sync_menu_sign_in)
+                accountManager.accountProfileEmail ?: context.getString(R.string.sync_menu_sync_and_save_data)
             } else {
                 null
             }

--- a/app/src/main/java/org/mozilla/fenix/home/HomeMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeMenu.kt
@@ -100,7 +100,7 @@ class HomeMenu(
     private fun syncSignInMenuItem(): BrowserMenuImageText? {
         val syncItemTitle =
             if (context.components.backgroundServices.accountManagerAvailableQueue.isReady()) {
-                accountManager.accountProfileEmail ?: context.getString(R.string.sync_menu_sign_in)
+                accountManager.accountProfileEmail ?: context.getString(R.string.sync_menu_sync_and_save_data)
             } else {
                 null
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1043,9 +1043,11 @@
     <!-- Toast shown after copying link to clipboard -->
     <string name="toast_copy_link_to_clipboard">Copied to clipboard</string>
     <!-- An option from the three dot menu to into sync -->
-    <string name="sync_menu_sign_in">Sign in to sync</string>
+    <string name="sync_menu_sign_in" moz:removedIn="107" tools:ignore="UnusedResources">Sign in to sync</string>
     <!-- An option from the share dialog to sign into sync -->
     <string name="sync_sign_in">Sign in to Sync</string>
+     <!-- An option from the three dot menu to sync and save data -->
+    <string name="sync_menu_sync_and_save_data">Sync and save data</string>
     <!-- An option from the share dialog to send link to all other sync devices -->
     <string name="sync_send_to_all">Send to all devices</string>
     <!-- An option from the share dialog to reconnect to sync -->


### PR DESCRIPTION
This should line up with https://phabricator.services.mozilla.com/D159227 so they land around the same time for string consistency.

Screen shot of new copy change:
![Screen Shot 2022-10-13 at 9 23 21 AM](https://user-images.githubusercontent.com/436430/195691656-8e61e0b6-290a-4877-bea1-2179ab1a8909.png)



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
Fixes #27117