### PR TITLE
Update Google Play Review dependency to 2.0.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -590,7 +590,9 @@ dependencies {
 
     implementation Deps.google_ads_id // Required for the Google Advertising ID
 
-    implementation Deps.google_play_store // Required for in-app reviews
+    // Required for in-app reviews
+    implementation Deps.google_play_review
+    implementation Deps.google_play_review_ktx
 
     androidTestImplementation Deps.uiautomator
     androidTestImplementation "tools.fastlane:screengrab:2.0.0"

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -57,7 +57,7 @@ object Versions {
 
     const val google_ads_id_version = "16.0.0"
 
-    const val google_play_store_version = "1.8.0"
+    const val google_play_review_version = "2.0.0"
 
     const val protobuf = "3.21.6" // keep in sync with the version used in AS.
 }
@@ -260,7 +260,8 @@ object Deps {
     const val google_ads_id = "com.google.android.gms:play-services-ads-identifier:${Versions.google_ads_id_version}"
 
     // Required for in-app reviews
-    const val google_play_store = "com.google.android.play:core:${Versions.google_play_store_version}"
+    const val google_play_review = "com.google.android.play:review:${Versions.google_play_review_version}"
+    const val google_play_review_ktx = "com.google.android.play:review-ktx:${Versions.google_play_review_version}"
 
     const val detektApi = "io.gitlab.arturbosch.detekt:detekt-api:${Versions.detekt}"
     const val detektTest = "io.gitlab.arturbosch.detekt:detekt-test:${Versions.detekt}"


### PR DESCRIPTION
Changelog:
https://developer.android.com/reference/com/google/android/play/core/release-notes

Additionally, the Google Play Core library was split into multiple separate libraries for each feature now, so change all references to the new Google Play Review component. AFAICT, nothing changed between 1.10.3 and 2.0.0 other than the split.
https://developer.android.com/reference/com/google/android/play/core/release-notes-in_app_reviews