### PR TITLE
No issue: Refactor web page item clicks, long clicks, and setting text in UI tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/ContextMenusTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/ContextMenusTest.kt
@@ -72,7 +72,7 @@ class ContextMenusTest {
         navigationToolbar {
         }.enterURLAndEnterToBrowser(pageLinks.url) {
             mDevice.waitForIdle()
-            longClickMatchingText("Link 1")
+            longClickLink("Link 1")
             verifyLinkContextMenuItems(genericURL.url)
             clickContextOpenLinkInNewTab()
             verifySnackBarText("New tab opened")
@@ -96,7 +96,7 @@ class ContextMenusTest {
         navigationToolbar {
         }.enterURLAndEnterToBrowser(pageLinks.url) {
             mDevice.waitForIdle()
-            longClickMatchingText("Link 2")
+            longClickLink("Link 2")
             verifyLinkContextMenuItems(genericURL.url)
             clickContextOpenLinkInPrivateTab()
             verifySnackBarText("New private tab opened")
@@ -118,7 +118,7 @@ class ContextMenusTest {
         navigationToolbar {
         }.enterURLAndEnterToBrowser(pageLinks.url) {
             mDevice.waitForIdle()
-            longClickMatchingText("Link 3")
+            longClickLink("Link 3")
             verifyLinkContextMenuItems(genericURL.url)
             clickContextCopyLink()
             verifySnackBarText("Link copied to clipboard")
@@ -138,7 +138,7 @@ class ContextMenusTest {
         navigationToolbar {
         }.enterURLAndEnterToBrowser(pageLinks.url) {
             mDevice.waitForIdle()
-            longClickMatchingText("Link 1")
+            longClickLink("Link 1")
             verifyLinkContextMenuItems(genericURL.url)
             clickContextShareLink(genericURL.url) // verify share intent is matched with associated URL
         }
@@ -154,7 +154,7 @@ class ContextMenusTest {
         navigationToolbar {
         }.enterURLAndEnterToBrowser(pageLinks.url) {
             mDevice.waitForIdle()
-            longClickMatchingText("test_link_image")
+            longClickLink("test_link_image")
             verifyLinkImageContextMenuItems(imageResource.url)
             clickContextOpenImageNewTab()
             verifySnackBarText("New tab opened")
@@ -173,7 +173,7 @@ class ContextMenusTest {
         navigationToolbar {
         }.enterURLAndEnterToBrowser(pageLinks.url) {
             mDevice.waitForIdle()
-            longClickMatchingText("test_link_image")
+            longClickLink("test_link_image")
             verifyLinkImageContextMenuItems(imageResource.url)
             clickContextCopyImageLocation()
             verifySnackBarText("Link copied to clipboard")
@@ -193,7 +193,7 @@ class ContextMenusTest {
         navigationToolbar {
         }.enterURLAndEnterToBrowser(pageLinks.url) {
             mDevice.waitForIdle()
-            longClickMatchingText("test_link_image")
+            longClickLink("test_link_image")
             verifyLinkImageContextMenuItems(imageResource.url)
             clickContextSaveImage()
         }
@@ -218,13 +218,13 @@ class ContextMenusTest {
         navigationToolbar {
         }.enterURLAndEnterToBrowser(pageLinks.url) {
             mDevice.waitForIdle()
-            longClickMatchingText("Link 1")
+            longClickLink("Link 1")
             verifyLinkContextMenuItems(genericURL.url)
             dismissContentContextMenu(genericURL.url)
-            longClickMatchingText("test_link_image")
+            longClickLink("test_link_image")
             verifyLinkImageContextMenuItems(imageResource.url)
             dismissContentContextMenu(imageResource.url)
-            longClickMatchingText("test_no_link_image")
+            longClickLink("test_no_link_image")
             verifyNoLinkImageContextMenuItems(imageResource.url)
         }
     }
@@ -236,7 +236,7 @@ class ContextMenusTest {
 
         navigationToolbar {
         }.enterURLAndEnterToBrowser(genericURL.url) {
-            longClickMatchingText(genericURL.content)
+            longClickLink(genericURL.content)
         }.clickShareSelectedText {
             verifyAndroidShareLayout()
         }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SearchTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SearchTest.kt
@@ -186,9 +186,9 @@ class SearchTest {
         homeScreen {
         }.openSearch {
         }.submitQuery("test search") {
-            longClickMatchingText("Link 1")
+            longClickLink("Link 1")
             clickContextOpenLinkInNewTab()
-            longClickMatchingText("Link 2")
+            longClickLink("Link 2")
             clickContextOpenLinkInNewTab()
         }.goToHomescreen {
             verifyJumpBackInSectionIsDisplayed()
@@ -221,9 +221,9 @@ class SearchTest {
         homeScreen {
         }.openSearch {
         }.submitQuery("test search") {
-            longClickMatchingText("Link 1")
+            longClickLink("Link 1")
             clickContextOpenLinkInPrivateTab()
-            longClickMatchingText("Link 2")
+            longClickLink("Link 2")
             clickContextOpenLinkInPrivateTab()
         }.goToHomescreen {
             verifyCurrentSearchGroupIsDisplayed(false, "test search", 3)
@@ -254,9 +254,9 @@ class SearchTest {
         homeScreen {
         }.openSearch {
         }.submitQuery("test search") {
-            longClickMatchingText("Link 1")
+            longClickLink("Link 1")
             clickContextOpenLinkInPrivateTab()
-            longClickMatchingText("Link 2")
+            longClickLink("Link 2")
             clickContextOpenLinkInPrivateTab()
         }.openTabDrawer {
         }.openTab(firstPage) {
@@ -290,9 +290,9 @@ class SearchTest {
         homeScreen {
         }.openSearch {
         }.submitQuery("test search") {
-            longClickMatchingText("Link 1")
+            longClickLink("Link 1")
             clickContextOpenLinkInNewTab()
-            longClickMatchingText("Link 2")
+            longClickLink("Link 2")
             clickContextOpenLinkInNewTab()
         }.openTabDrawer {
         }.openTabFromGroup(firstPage) {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -347,116 +347,35 @@ class BrowserRobot {
     fun clickLinkMatchingText(expectedText: String) =
         clickPageObject(webPageItemContainingText(expectedText))
 
-    fun longClickMatchingText(expectedText: String) {
-        try {
-            mDevice.waitForWindowUpdate(packageName, waitingTime)
-            mDevice.findObject(UiSelector().resourceId("$packageName:id/engineView"))
-                .waitForExists(waitingTime)
-            mDevice.findObject(UiSelector().textContains(expectedText)).waitForExists(waitingTime)
-            val link = mDevice.findObject(By.textContains(expectedText))
-            link.click(LONG_CLICK_DURATION)
-        } catch (e: NullPointerException) {
-            println(e)
+    fun longClickLink(expectedText: String) =
+        longClickPageObject(webPageItemWithText(expectedText))
 
-            // Refresh the page in case the first long click didn't succeed
-            navigationToolbar {
-            }.openThreeDotMenu {
-            }.refreshPage {
-                mDevice.waitForIdle()
-            }
-
-            // Long click again the desired text
-            mDevice.waitForWindowUpdate(packageName, waitingTime)
-            mDevice.findObject(UiSelector().resourceId("$packageName:id/engineView"))
-                .waitForExists(waitingTime)
-            mDevice.findObject(UiSelector().textContains(expectedText)).waitForExists(waitingTime)
-            val link = mDevice.findObject(By.textContains(expectedText))
-            link.click(LONG_CLICK_DURATION)
-        }
-    }
+    fun longClickMatchingText(expectedText: String) =
+        longClickPageObject(webPageItemContainingText(expectedText))
 
     fun longClickAndCopyText(expectedText: String, selectAll: Boolean = false) {
-        try {
-            // Long click desired text
-            mDevice.waitForWindowUpdate(packageName, waitingTime)
-            mDevice.findObject(UiSelector().resourceId("$packageName:id/engineView"))
-                .waitForExists(waitingTime)
-            mDevice.findObject(UiSelector().textContains(expectedText)).waitForExists(waitingTime)
-            val link = mDevice.findObject(By.textContains(expectedText))
-            link.click(LONG_CLICK_DURATION)
+        longClickPageObject(webPageItemContainingText(expectedText))
 
-            // Click Select all from the text selection toolbar
-            if (selectAll) {
-                mDevice.findObject(UiSelector().textContains("Select all")).waitForExists(waitingTime)
-                val selectAllText = mDevice.findObject(By.textContains("Select all"))
-                selectAllText.click()
-            }
-
-            // Click Copy from the text selection toolbar
-            mDevice.findObject(UiSelector().textContains("Copy")).waitForExists(waitingTime)
-            val copyText = mDevice.findObject(By.textContains("Copy"))
-            copyText.click()
-        } catch (e: NullPointerException) {
-            println("Failed to long click desired text: ${e.localizedMessage}")
-
-            // Refresh the page in case the first long click didn't succeed
-            navigationToolbar {
-            }.openThreeDotMenu {
-            }.refreshPage {
-                mDevice.waitForIdle()
-            }
-
-            // Long click again the desired text
-            mDevice.waitForWindowUpdate(packageName, waitingTime)
-            mDevice.findObject(UiSelector().resourceId("$packageName:id/engineView"))
-                .waitForExists(waitingTime)
-            mDevice.findObject(UiSelector().textContains(expectedText)).waitForExists(waitingTime)
-            val link = mDevice.findObject(By.textContains(expectedText))
-            link.click(LONG_CLICK_DURATION)
-
-            // Click again Select all from the text selection toolbar
-            if (selectAll) {
-                mDevice.findObject(UiSelector().textContains("Select all")).waitForExists(waitingTime)
-                val selectAllText = mDevice.findObject(By.textContains("Select all"))
-                selectAllText.click()
-            }
-
-            // Click again Copy from the text selection toolbar
-            mDevice.findObject(UiSelector().textContains("Copy")).waitForExists(waitingTime)
-            val copyText = mDevice.findObject(By.textContains("Copy"))
-            copyText.click()
+        // Click Select all from the text selection toolbar
+        if (selectAll) {
+            mDevice.findObject(UiSelector().textContains("Select all")).waitForExists(waitingTime)
+            val selectAllText = mDevice.findObject(By.textContains("Select all"))
+            selectAllText.click()
         }
+
+        // Click Copy from the text selection toolbar
+        mDevice.findObject(UiSelector().textContains("Copy")).waitForExists(waitingTime)
+        val copyText = mDevice.findObject(By.textContains("Copy"))
+        copyText.click()
     }
 
     fun longClickAndSearchText(searchButton: String, expectedText: String) {
-        var currentTries = 0
-        while (currentTries++ < 3) {
-            try {
-                // Long click desired text
-                mDevice.waitForWindowUpdate(packageName, waitingTime)
-                mDevice.findObject(UiSelector().resourceId("$packageName:id/engineView"))
-                    .waitForExists(waitingTime)
-                mDevice.findObject(UiSelector().textContains(expectedText)).waitForExists(waitingTime)
-                val link = mDevice.findObject(By.textContains(expectedText))
-                link.click(LONG_CLICK_DURATION)
+        longClickPageObject(webPageItemContainingText(expectedText))
 
-                // Click search from the text selection toolbar
-                mDevice.findObject(UiSelector().textContains(searchButton)).waitForExists(waitingTime)
-                val searchText = mDevice.findObject(By.textContains(searchButton))
-                searchText.click()
-
-                break
-            } catch (e: NullPointerException) {
-                println("Failed to long click desired text: ${e.localizedMessage}")
-
-                // Refresh the page in case the first long click didn't succeed
-                navigationToolbar {
-                }.openThreeDotMenu {
-                }.refreshPage {
-                    mDevice.waitForIdle()
-                }
-            }
-        }
+        // Click search from the text selection toolbar
+        mDevice.findObject(UiSelector().textContains(searchButton)).waitForExists(waitingTime)
+        val searchText = mDevice.findObject(By.textContains(searchButton))
+        searchText.click()
     }
 
     fun snackBarButtonClick() {
@@ -980,6 +899,29 @@ private fun clickPageObject(webPageItem: UiObject) {
                 }.refreshPage {
                     progressBar.waitUntilGone(waitingTime)
                 }
+            }
+        }
+    }
+}
+
+fun longClickPageObject(webPageItem: UiObject) {
+    for (i in 1..RETRY_COUNT) {
+        try {
+            webPageItem.also {
+                it.waitForExists(waitingTime)
+                it.longClick()
+            }
+
+            break
+        } catch (e: UiObjectNotFoundException) {
+            if (i == RETRY_COUNT) {
+                throw e
+            } else {
+                browserScreen {
+                }.openThreeDotMenu {
+                }.refreshPage {
+                }
+                progressBar.waitUntilGone(waitingTime)
             }
         }
     }


### PR DESCRIPTION
No issue: Refactor web page item clicks, long clicks, and setting text in UI tests.

1. ✅ All affected UI tests passed 25x on Firebase
2. This refactoring will also fix the following intermittent UI tests: 
#27057 
#27040 
#27007

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
4. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
5. Click on the `build-debug` task.
6. Click on `View task in Taskcluster` in the new `DETAILS` section.
7. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
