### PR TITLE
For #27269: Use parentFile method over substring extraction

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/wallpapers/WallpaperDownloader.kt
+++ b/app/src/main/java/org/mozilla/fenix/wallpapers/WallpaperDownloader.kt
@@ -80,7 +80,7 @@ class WallpaperDownloader(
             if (!response.isSuccess) {
                 throw IllegalStateException()
             }
-            File(localFile.path.substringBeforeLast("/")).mkdirs()
+            localFile.parentFile?.mkdirs()
             response.body.useStream { input ->
                 input.copyTo(localFile.outputStream())
             }


### PR DESCRIPTION
This fixes gradle tests on Windows, where the file separator is "\\" and not "/".


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
Fixes #27269