### PR TITLE
No issue: Remove deprecated gradle property

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,6 @@ org.gradle.parallel=true
 kotlin.code.style=official
 android.useAndroidX=true
 android.enableJetifier=false
-android.enableUnitTestBinaryResources=false
 
 # Enables copying of Jetpack Benchmark results from the device to the build directory.
 android.enableAdditionalTestOutput=true


### PR DESCRIPTION
This fixes the following build warning with no behavior change:

WARNING:The option 'android.enableUnitTestBinaryResources' is deprecated. The current default is 'false'.
It has been removed from the current version of the Android Gradle plugin. The raw resource for unit test functionality is removed.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
