### PR TITLE
For #27405 - Clean up references to "Sing in to Sync" phrase

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/BookmarksTest.kt
@@ -101,7 +101,7 @@ class BookmarksTest {
                 verifyFolderTitle("Bookmarks Menu")
                 verifyFolderTitle("Bookmarks Toolbar")
                 verifyFolderTitle("Other Bookmarks")
-                verifySignInToSyncButton()
+                verifySyncSignInButton()
             }
         }.clickSingInToSyncButton {
             verifyTurnOnSyncToolbarTitle()

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BookmarksRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BookmarksRobot.kt
@@ -138,8 +138,8 @@ class BookmarksRobot {
         mDevice.waitNotNull(Until.findObject(By.text(childFolderName)), waitingTime)
     }
 
-    fun verifySignInToSyncButton() =
-        signInToSyncButton().check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
+    fun verifySyncSignInButton() =
+        syncSignInButton().check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 
     fun verifyDeleteFolderConfirmationMessage() = assertDeleteFolderConfirmationMessage()
 
@@ -244,7 +244,7 @@ class BookmarksRobot {
         }
 
         fun clickSingInToSyncButton(interact: SettingsTurnOnSyncRobot.() -> Unit): SettingsTurnOnSyncRobot.Transition {
-            signInToSyncButton().click()
+            syncSignInButton().click()
 
             SettingsTurnOnSyncRobot().interact()
             return SettingsTurnOnSyncRobot.Transition()
@@ -308,7 +308,7 @@ private fun saveBookmarkButton() = onView(withId(R.id.save_bookmark_button))
 
 private fun deleteInEditModeButton() = onView(withId(R.id.delete_bookmark_button))
 
-private fun signInToSyncButton() = onView(withId(R.id.bookmark_folders_sign_in))
+private fun syncSignInButton() = onView(withId(R.id.bookmark_folders_sign_in))
 
 private fun assertBookmarksView() {
     onView(

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuMainRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/ThreeDotMenuMainRobot.kt
@@ -50,7 +50,7 @@ class ThreeDotMenuMainRobot {
     fun verifyAddOnsButton() = assertAddOnsButton()
     fun verifyHistoryButton() = assertHistoryButton()
     fun verifyBookmarksButton() = assertBookmarksButton()
-    fun verifySyncSignInButton() = assertSignInToSyncButton()
+    fun verifySyncSignInButton() = assertSyncSignInButton()
     fun verifyHelpButton() = assertHelpButton()
     fun verifyThreeDotMenuExists() = threeDotMenuRecyclerViewExists()
     fun verifyForwardButton() = assertForwardButton()
@@ -77,7 +77,6 @@ class ThreeDotMenuMainRobot {
     fun verifyDesktopSite() = assertDesktopSite()
     fun verifyDownloadsButton() = assertDownloadsButton()
     fun verifyShareTabsOverlay() = assertShareTabsOverlay()
-    fun verifySignInToSyncButton() = assertSignInToSyncButton()
     fun verifyNewTabButton() = assertNormalBrowsingNewTabButton()
     fun verifyReportSiteIssueButton() = assertReportSiteIssueButton()
 
@@ -97,7 +96,7 @@ class ThreeDotMenuMainRobot {
         verifyHistoryButton()
         verifyDownloadsButton()
         verifyAddOnsButton()
-        verifySignInToSyncButton()
+        verifySyncSignInButton()
         threeDotMenuRecyclerView().perform(swipeUp())
         verifyFindInPageButton()
         verifyDesktopSite()
@@ -174,7 +173,7 @@ class ThreeDotMenuMainRobot {
         fun openSyncSignIn(interact: SyncSignInRobot.() -> Unit): SyncSignInRobot.Transition {
             threeDotMenuRecyclerView().perform(swipeDown())
             mDevice.waitNotNull(Until.findObject(By.text("Sync and save data")), waitingTime)
-            signInToSyncButton().click()
+            syncSignInButton().click()
 
             SyncSignInRobot().interact()
             return SyncSignInRobot.Transition()
@@ -440,8 +439,8 @@ private fun bookmarksButton() = onView(allOf(withText(R.string.library_bookmarks
 private fun assertBookmarksButton() = bookmarksButton()
     .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
-private fun signInToSyncButton() = onView(withText("Sync and save data"))
-private fun assertSignInToSyncButton() = signInToSyncButton().check(matches(isDisplayed()))
+private fun syncSignInButton() = onView(withText("Sync and save data"))
+private fun assertSyncSignInButton() = syncSignInButton().check(matches(isDisplayed()))
 
 private fun helpButton() = onView(allOf(withText(R.string.browser_menu_help)))
 private fun assertHelpButton() = helpButton()

--- a/app/src/main/java/org/mozilla/fenix/settings/SyncPreferenceView.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SyncPreferenceView.kt
@@ -26,8 +26,7 @@ import mozilla.components.service.fxa.manager.SyncEnginesStorage
  * @param syncEngine The sync engine that will be used for the sync status lookup.
  * @param loggedOffTitle Text label for the setting when user is not logged in.
  * @param loggedInTitle Text label for the setting when user is logged in.
- * @param onSignInToSyncClicked A callback executed when the [syncPreference] is clicked with a
- * preference status of "Sign in to Sync".
+ * @param onSyncSignInClicked A callback executed when the sync sign in [syncPreference] is clicked.
  * @param onReconnectClicked A callback executed when the [syncPreference] is clicked with a
  * preference status of "Reconnect".
  */
@@ -39,7 +38,7 @@ class SyncPreferenceView(
     private val syncEngine: SyncEngine,
     private val loggedOffTitle: String,
     private val loggedInTitle: String,
-    private val onSignInToSyncClicked: () -> Unit = {},
+    private val onSyncSignInClicked: () -> Unit = {},
     private val onReconnectClicked: () -> Unit = {},
 ) {
 
@@ -102,7 +101,7 @@ class SyncPreferenceView(
             title = loggedOffTitle
 
             setOnPreferenceChangeListener { _, _ ->
-                onSignInToSyncClicked()
+                onSyncSignInClicked()
                 false
             }
         }

--- a/app/src/main/java/org/mozilla/fenix/settings/autofill/AutofillSettingFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/autofill/AutofillSettingFragment.kt
@@ -162,7 +162,7 @@ class AutofillSettingFragment : BiometricPromptPreferenceFragment() {
                 .getString(R.string.preferences_credit_cards_sync_cards_across_devices),
             loggedInTitle = requireContext()
                 .getString(R.string.preferences_credit_cards_sync_cards),
-            onSignInToSyncClicked = {
+            onSyncSignInClicked = {
                 findNavController().navigate(
                     NavGraphDirections.actionGlobalTurnOnSync(),
                 )

--- a/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/SavedLoginsAuthFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/SavedLoginsAuthFragment.kt
@@ -146,7 +146,7 @@ class SavedLoginsAuthFragment : PreferenceFragmentCompat() {
                 .getString(R.string.preferences_passwords_sync_logins_across_devices),
             loggedInTitle = requireContext()
                 .getString(R.string.preferences_passwords_sync_logins),
-            onSignInToSyncClicked = {
+            onSyncSignInClicked = {
                 val directions =
                     SavedLoginsAuthFragmentDirections.actionSavedLoginsAuthFragmentToTurnOnSyncFragment()
                 findNavController().navigate(directions)

--- a/app/src/test/java/org/mozilla/fenix/settings/logins/SyncPreferenceViewTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/logins/SyncPreferenceViewTest.kt
@@ -182,7 +182,7 @@ class SyncPreferenceViewTest {
         syncEngine = SyncEngine.Passwords,
         loggedOffTitle = notLoggedInTitle,
         loggedInTitle = loggedInTitle,
-        onSignInToSyncClicked = {
+        onSyncSignInClicked = {
             val directions =
                 SavedLoginsAuthFragmentDirections.actionSavedLoginsAuthFragmentToTurnOnSyncFragment()
             navController.navigate(directions)


### PR DESCRIPTION
Removed references to "Sign in to Sync" phrase after it was changed to "Sync and save your data"

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
Fixes #27405