### PR TITLE
For #25029 and #26087 re-enable useAppWhileTabIsCrashedTest and privateBrowsingUseAppWhileTabIsCrashedTest UI tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/CrashReportingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/CrashReportingTest.kt
@@ -29,6 +29,7 @@ class CrashReportingTest {
             isPocketEnabled = false,
             isJumpBackInCFREnabled = false,
             isWallpaperOnboardingEnabled = false,
+            isTCPCFREnabled = false,
         ),
     ) { it.activity }
 
@@ -73,7 +74,6 @@ class CrashReportingTest {
         }
     }
 
-    @Ignore("Failing, see: https://github.com/mozilla-mobile/fenix/issues/25029")
     @SmokeTest
     @Test
     fun useAppWhileTabIsCrashedTest() {
@@ -106,7 +106,6 @@ class CrashReportingTest {
 
     @SmokeTest
     @Test
-    @Ignore("Failing after compose migration. See: https://github.com/mozilla-mobile/fenix/issues/26087")
     fun privateBrowsingUseAppWhileTabIsCrashedTest() {
         val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
         val secondWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 2)
@@ -120,7 +119,6 @@ class CrashReportingTest {
         }.openNewTab {
         }.submitQuery(secondWebPage.url.toString()) {
             waitForPageToLoad()
-            verifyPageContent("Page content: 2")
         }
 
         navigationToolbar {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -853,12 +853,22 @@ class BrowserRobot {
         }
 
         fun openTabDrawer(interact: TabDrawerRobot.() -> Unit): TabDrawerRobot.Transition {
-            mDevice.findObject(
-                UiSelector().descriptionContains("Tap to switch tabs."),
-            ).waitForExists(waitingTime)
+            mDevice.waitForObjects(
+                mDevice.findObject(
+                    UiSelector()
+                        .resourceId("$packageName:id/mozac_browser_toolbar_browser_actions"),
+                ),
+                waitingTime,
+            )
 
             tabsCounter().click()
-            mDevice.waitNotNull(Until.findObject(By.res("$packageName:id/tab_layout")))
+
+            mDevice.waitForObjects(
+                mDevice.findObject(
+                    UiSelector().resourceId("$packageName:id/new_tab_button"),
+                ),
+                waitingTime,
+            )
 
             TabDrawerRobot().interact()
             return TabDrawerRobot.Transition()
@@ -1034,7 +1044,8 @@ private fun assertMenuButton() {
         .check(matches(withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE)))
 }
 
-private fun tabsCounter() = mDevice.findObject(By.res("$packageName:id/counter_root"))
+private fun tabsCounter() =
+    mDevice.findObject(By.res("$packageName:id/mozac_browser_toolbar_browser_actions"))
 
 private fun mediaPlayerPlayButton() =
     mDevice.findObject(


### PR DESCRIPTION
For #25029 and #26087 re-enable `useAppWhileTabIsCrashedTest` and `privateBrowsingUseAppWhileTabIsCrashedTest` UI tests. ✅ successfully passed 100x on Firebase.

Also, ran 10x all the UI test affected by the `openTabDrawer` refactoring (26 UI tests), and successfully passed. ✅ 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
Fixes #25029
Fixes #26087