### PR TITLE
Bug 1791998 - Disable TCP popup when running performance tests.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/perf/Performance.kt
+++ b/app/src/main/java/org/mozilla/fenix/perf/Performance.kt
@@ -34,6 +34,7 @@ object Performance {
         disableOnboarding(context)
         disableTrackingProtectionPopups(context)
         disableFirstTimePWAPopup(context)
+        disableTCPPopup(context)
     }
 
     /**
@@ -84,5 +85,12 @@ object Performance {
      */
     private fun disableFirstTimePWAPopup(context: Context) {
         context.components.settings.userKnowsAboutPwas = true
+    }
+
+    /**
+     * Disables the TCP popup.
+     */
+    private fun disableTCPPopup(context: Context) {
+        context.components.settings.shouldShowTotalCookieProtectionCFR = false
     }
 }

--- a/taskcluster/ci/browsertime/kind.yml
+++ b/taskcluster/ci/browsertime/kind.yml
@@ -127,6 +127,7 @@ tasks:
 
     tp6m-hv:
         run-with-fission: True
+        run-on-tasks-for: [github-pull-request]
         page-load-tests:
             - google
             - [amazon-search, amazon-s]

--- a/taskcluster/ci/browsertime/kind.yml
+++ b/taskcluster/ci/browsertime/kind.yml
@@ -127,7 +127,6 @@ tasks:
 
     tp6m-hv:
         run-with-fission: True
-        run-on-tasks-for: [github-pull-request]
         page-load-tests:
             - google
             - [amazon-search, amazon-s]


### PR DESCRIPTION
This patch adds some code to disable the TCP popup when running performance tests on Fenix.