### PR TITLE
No issue: Fix for None key-pair in Flank client-details

### DIFF
--- a/automation/taskcluster/androidTest/ui-test.sh
+++ b/automation/taskcluster/androidTest/ui-test.sh
@@ -138,7 +138,7 @@ set -o pipefail && $JAVA_BIN -jar $FLANK_BIN android run \
 	--app=$APK_APP --test=$APK_TEST \
 	--local-result-dir="${RESULTS_DIR}" \
 	--project=$GOOGLE_PROJECT \
-	--client-details=commit=$MOBILE_BASE_REPOSITORY/commit/$MOBILE_HEAD_REV,pullRequest=$MOBILE_BASE_REPOSITORY/pull/$PULL_REQUEST_NUMBER \
+	--client-details=commit=${MOBILE_HEAD_REV:-None},pullRequest=${PULL_REQUEST_NUMBER:-None} \
 	| tee flank.log
 
 exitcode=$?


### PR DESCRIPTION
`PULL_REQUEST_NUMBER` can be empty on merges; simplifying, removing URL construction. None if empty. We can construct URLs elsewhere.