### PR TITLE
No issue: Refactor common undo tab close snackbar usage and add tests

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -140,7 +140,7 @@ import org.mozilla.fenix.perf.MarkersFragmentLifecycleCallbacks
 import org.mozilla.fenix.settings.SupportUtils
 import org.mozilla.fenix.settings.biometric.BiometricPromptFeature
 import org.mozilla.fenix.theme.ThemeManager
-import org.mozilla.fenix.utils.allowUndo
+import org.mozilla.fenix.utils.UndoCloseTabSnackBar
 import org.mozilla.fenix.wifi.SitePermissionsWifiIntegration
 import java.lang.ref.WeakReference
 import mozilla.components.feature.session.behavior.ToolbarPosition as MozacToolbarPosition
@@ -345,21 +345,11 @@ abstract class BaseBrowserFragment :
             onCloseTab = { closedSession ->
                 val closedTab = store.state.findTab(closedSession.id) ?: return@DefaultBrowserToolbarController
 
-                val snackbarMessage = if (closedTab.content.private) {
-                    requireContext().getString(R.string.snackbar_private_tab_closed)
-                } else {
-                    requireContext().getString(R.string.snackbar_tab_closed)
-                }
-
-                viewLifecycleOwner.lifecycleScope.allowUndo(
-                    binding.browserLayout,
-                    snackbarMessage,
-                    requireContext().getString(R.string.snackbar_deleted_undo),
-                    {
-                        requireComponents.useCases.tabsUseCases.undo.invoke()
-                    },
+                UndoCloseTabSnackBar.show(
+                    fragment = this,
+                    isPrivate = closedTab.content.private,
+                    view = binding.browserLayout,
                     paddedForBottomToolbar = true,
-                    operation = { },
                 )
             },
         )

--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -137,7 +137,8 @@ class HomeFragment : Fragment() {
 
     private val homeViewModel: HomeScreenViewModel by activityViewModels()
 
-    private val snackbarAnchorView: View?
+    @VisibleForTesting
+    internal val snackbarAnchorView: View?
         get() = when (requireContext().settings().toolbarPosition) {
             ToolbarPosition.BOTTOM -> binding.toolbarLayout
             ToolbarPosition.TOP -> null
@@ -155,7 +156,8 @@ class HomeFragment : Fragment() {
         }
     }
 
-    private val store: BrowserStore
+    @VisibleForTesting
+    internal val store: BrowserStore
         get() = requireComponents.core.store
 
     private val onboarding by lazy {
@@ -643,7 +645,8 @@ class HomeFragment : Fragment() {
         }
     }
 
-    private fun removeAllTabsAndShowSnackbar(sessionCode: String) {
+    @VisibleForTesting
+    internal fun removeAllTabsAndShowSnackbar(sessionCode: String) {
         val isPrivate = sessionCode == ALL_PRIVATE_TABS
         if (isPrivate) {
             requireComponents.useCases.tabsUseCases.removePrivateTabs()
@@ -659,7 +662,8 @@ class HomeFragment : Fragment() {
         )
     }
 
-    private fun removeTabAndShowSnackbar(sessionId: String) {
+    @VisibleForTesting
+    internal fun removeTabAndShowSnackbar(sessionId: String) {
         val tab = store.state.findTab(sessionId) ?: return
 
         requireComponents.useCases.tabsUseCases.removeTab(sessionId)

--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
@@ -18,7 +18,6 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.setFragmentResultListener
 import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.google.android.material.bottomsheet.BottomSheetBehavior
@@ -65,7 +64,7 @@ import org.mozilla.fenix.tabstray.ext.make
 import org.mozilla.fenix.tabstray.ext.showWithTheme
 import org.mozilla.fenix.tabstray.syncedtabs.SyncedTabsIntegration
 import org.mozilla.fenix.theme.ThemeManager
-import org.mozilla.fenix.utils.allowUndo
+import org.mozilla.fenix.utils.UndoCloseTabSnackBar
 import kotlin.math.max
 
 /**
@@ -464,27 +463,18 @@ class TabsTrayFragment : AppCompatDialogFragment() {
 
     @VisibleForTesting
     internal fun showUndoSnackbarForTab(isPrivate: Boolean) {
-        val snackbarMessage =
-            when (isPrivate) {
-                true -> getString(R.string.snackbar_private_tab_closed)
-                false -> getString(R.string.snackbar_tab_closed)
-            }
-
-        lifecycleScope.allowUndo(
-            requireView(),
-            snackbarMessage,
-            getString(R.string.snackbar_deleted_undo),
-            {
-                requireComponents.useCases.tabsUseCases.undo.invoke()
+        UndoCloseTabSnackBar.show(
+            fragment = this,
+            isPrivate = isPrivate,
+            onCancel = {
                 tabLayoutMediator.withFeature {
                     it.selectTabAtPosition(
                         if (isPrivate) Page.PrivateTabs.ordinal else Page.NormalTabs.ordinal,
                     )
                 }
             },
-            operation = { },
+            anchorView = fabButtonBinding.newTabButton.let { if (it.isVisible) it else null },
             elevation = ELEVATION,
-            anchorView = if (fabButtonBinding.newTabButton.isVisible) fabButtonBinding.newTabButton else null,
         )
     }
 

--- a/app/src/test/java/org/mozilla/fenix/utils/UndoTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/utils/UndoTest.kt
@@ -1,0 +1,144 @@
+package org.mozilla.fenix.utils
+
+import android.view.ViewGroup
+import androidx.annotation.StringRes
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.LifecycleCoroutineScope
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.verify
+import io.mockk.verifyOrder
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.runBlocking
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.fenix.R
+import org.mozilla.fenix.ext.components
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+
+@RunWith(FenixRobolectricTestRunner::class)
+class UndoTest {
+    private lateinit var fragment: Fragment
+    private lateinit var view: ViewGroup
+
+    @Before
+    fun setup() {
+        fragment = mockk(relaxed = true)
+        view = mockk(relaxed = true)
+    }
+
+    private fun testUndoCloseTabSnackBar(
+        isPrivate: Boolean,
+        multiple: Boolean,
+        @StringRes messageId: Int,
+    ) {
+        // setup lifecycle
+        mockkStatic(LifecycleOwner::lifecycleScope)
+        val lifecycleScope: LifecycleCoroutineScope = mockk(relaxed = true)
+        every { any<LifecycleOwner>().lifecycleScope } returns lifecycleScope
+
+        // setup allowUndo
+        mockkStatic(CoroutineScope::allowUndo)
+        every {
+            any<CoroutineScope>().allowUndo(
+                view = any(),
+                message = any(),
+                undoActionTitle = any(),
+                onCancel = captureLambda(),
+                operation = any(),
+                anchorView = any(),
+                elevation = any(),
+                paddedForBottomToolbar = any(),
+            )
+        } answers {
+            // simulate cancellation
+            runBlocking {
+                lambda<suspend () -> Unit>().captured.invoke()
+            }
+        }
+
+        // setup fragment and context
+        every { fragment.requireContext() } returns testContext // needed for getString()
+        every { testContext.components.useCases.tabsUseCases.undo.invoke() } just Runs
+
+        // setup show
+        val onCancel = mockk<() -> Unit>()
+        val anchorView: ViewGroup = mockk()
+        val elevation: Float = mockk(relaxed = true)
+        val paddedForBottomToolbar: Boolean = mockk(relaxed = true)
+        every { onCancel.invoke() } just Runs
+
+        UndoCloseTabSnackBar.show(
+            fragment = fragment,
+            isPrivate = isPrivate,
+            multiple = multiple,
+            onCancel = onCancel,
+            view = view,
+            anchorView = anchorView,
+            elevation = elevation,
+            paddedForBottomToolbar = paddedForBottomToolbar,
+        )
+
+        // verify that the correct allowUndo call is made, including the proper strings
+        verify {
+            lifecycleScope.allowUndo(
+                view = view,
+                message = testContext.getString(messageId),
+                undoActionTitle = testContext.getString(R.string.snackbar_deleted_undo),
+                onCancel = any(),
+                operation = any(),
+                anchorView = anchorView,
+                elevation = elevation,
+                paddedForBottomToolbar = paddedForBottomToolbar,
+            )
+        }
+        // verify that the following were called on cancellation
+        verifyOrder {
+            testContext.components.useCases.tabsUseCases.undo.invoke()
+            onCancel.invoke()
+        }
+    }
+
+    @Test
+    fun `GIVEN single normal tab closed WHEN UndoCloseTabSnackBar#show is called THEN appropriate allowUndo call is made`() {
+        testUndoCloseTabSnackBar(
+            isPrivate = false,
+            multiple = false,
+            messageId = R.string.snackbar_tab_closed,
+        )
+    }
+
+    @Test
+    fun `GIVEN single private tab closed WHEN UndoCloseTabSnackBar#show is called THEN appropriate allowUndo call is made`() {
+        testUndoCloseTabSnackBar(
+            isPrivate = true,
+            multiple = false,
+            messageId = R.string.snackbar_private_tab_closed,
+        )
+    }
+
+    @Test
+    fun `GIVEN multiple normal tabs closed WHEN UndoCloseTabSnackBar#show is called THEN appropriate allowUndo call is made`() {
+        testUndoCloseTabSnackBar(
+            isPrivate = false,
+            multiple = true,
+            messageId = R.string.snackbar_tabs_closed,
+        )
+    }
+
+    @Test
+    fun `GIVEN multiple private tabs closed WHEN UndoCloseTabSnackBar#show is called THEN appropriate allowUndo call is made`() {
+        testUndoCloseTabSnackBar(
+            isPrivate = true,
+            multiple = true,
+            messageId = R.string.snackbar_private_tabs_closed,
+        )
+    }
+}


### PR DESCRIPTION
No behaviour change (this is setup for a subsequent PR for new functionality).

This also adds some new `HomeFragment` tests for methods that use this
helper.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
