### PR TITLE
For #27478 fix for allowCookiesStorageAccessTest UI test

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/EnhancedTrackingProtectionTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/EnhancedTrackingProtectionTest.kt
@@ -230,6 +230,7 @@ class EnhancedTrackingProtectionTest {
         }
     }
 
+    @SmokeTest
     @Test
     fun blockCookiesStorageAccessTest() {
         // With Standard TrackingProtection settings
@@ -246,6 +247,7 @@ class EnhancedTrackingProtectionTest {
         }
     }
 
+    @SmokeTest
     @Test
     fun allowCookiesStorageAccessTest() {
         // With Standard TrackingProtection settings

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/BrowserRobot.kt
@@ -822,8 +822,7 @@ class BrowserRobot {
         }
 
         fun clickRequestStorageAccessButton(interact: SitePermissionsRobot.() -> Unit): SitePermissionsRobot.Transition {
-            mDevice.findObject(UiSelector().text("requestStorageAccess()")).waitForExists(waitingTime)
-            mDevice.findObject(UiSelector().text("requestStorageAccess()")).click()
+            clickPageObject(webPageItemContainingText("requestStorageAccess()"))
 
             SitePermissionsRobot().interact()
             return SitePermissionsRobot.Transition()


### PR DESCRIPTION
For #27478 fix for `allowCookiesStorageAccessTest` UI test ✅ successfully passed 100x on Firebase.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
Fixes #27478