### PR TITLE
CI For #16162: Simplify site addresses in saved logins view

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/logins/view/LoginsListViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/view/LoginsListViewHolder.kt
@@ -9,6 +9,7 @@ import androidx.core.view.isVisible
 import org.mozilla.fenix.databinding.LoginsItemBinding
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.loadIntoView
+import org.mozilla.fenix.ext.simplifiedUrl
 import org.mozilla.fenix.settings.logins.SavedLogin
 import org.mozilla.fenix.settings.logins.interactor.SavedLoginsInteractor
 import org.mozilla.fenix.utils.view.ViewHolder
@@ -29,7 +30,7 @@ class LoginsListViewHolder(
             timeLastUsed = item.timeLastUsed,
         )
         val binding = LoginsItemBinding.bind(view)
-        binding.webAddressView.text = item.origin
+        binding.webAddressView.text = item.origin.simplifiedUrl()
         binding.usernameView.isVisible = item.username.isNotEmpty()
         binding.usernameView.text = item.username
 

--- a/app/src/test/java/org/mozilla/fenix/settings/logins/LoginsListViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/logins/LoginsListViewHolderTest.kt
@@ -25,7 +25,7 @@ class LoginsListViewHolderTest {
 
     private val baseLogin = SavedLogin(
         guid = "abcd",
-        origin = "mozilla.org",
+        origin = "https://www.mozilla.org",
         username = "admin",
         password = "password",
         timeLastUsed = 100L,
@@ -33,20 +33,21 @@ class LoginsListViewHolderTest {
 
     private lateinit var interactor: SavedLoginsInteractor
     private lateinit var binding: LoginsItemBinding
+    private lateinit var holder: LoginsListViewHolder
 
     @Before
     fun setup() {
         binding = LoginsItemBinding.inflate(LayoutInflater.from(testContext))
         interactor = mockk(relaxed = true)
+        holder = LoginsListViewHolder(
+            binding.root,
+            interactor,
+        )
         every { testContext.components.core.icons } returns BrowserIcons(testContext, mockk(relaxed = true))
     }
 
     @Test
     fun `bind url and username`() {
-        val holder = LoginsListViewHolder(
-            binding.root,
-            interactor,
-        )
         holder.bind(baseLogin)
 
         assertEquals("mozilla.org", binding.webAddressView.text)
@@ -54,11 +55,18 @@ class LoginsListViewHolderTest {
     }
 
     @Test
+    fun `GIVEN url has a mobile prefix WHEN url is binded THEN mobile prefix is stripped`() {
+        holder.bind(baseLogin.copy(origin = "https://m.mozilla.org"))
+
+        assertEquals("mozilla.org", binding.webAddressView.text)
+
+        holder.bind(baseLogin.copy(origin = "https://mobile.mozilla.org"))
+
+        assertEquals("mozilla.org", binding.webAddressView.text)
+    }
+
+    @Test
     fun `call interactor on click`() {
-        val holder = LoginsListViewHolder(
-            binding.root,
-            interactor,
-        )
         holder.bind(baseLogin)
 
         binding.root.performClick()


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
Fixes #16162