### PR TITLE
For #27511: Remove duplicate padding update code

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/utils/Undo.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Undo.kt
@@ -6,13 +6,10 @@ package org.mozilla.fenix.utils
 
 import android.content.Context
 import android.view.View
-import androidx.appcompat.widget.ContentFrameLayout
-import androidx.core.view.updatePadding
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import org.mozilla.fenix.R
 import org.mozilla.fenix.components.FenixSnackbar
 import org.mozilla.fenix.ext.settings
 import java.util.concurrent.atomic.AtomicBoolean
@@ -66,7 +63,7 @@ fun CoroutineScope.allowUndo(
             .make(
                 view = view,
                 duration = FenixSnackbar.LENGTH_INDEFINITE,
-                isDisplayedWithBrowserToolbar = false,
+                isDisplayedWithBrowserToolbar = paddedForBottomToolbar,
             )
             .setText(message)
             .setAnchorView(anchorView)
@@ -80,27 +77,6 @@ fun CoroutineScope.allowUndo(
         elevation?.also {
             snackbar.view.elevation = it
         }
-
-        val shouldUseBottomToolbar = view.context.settings().shouldUseBottomToolbar
-        val toolbarHeight = view.resources.getDimensionPixelSize(R.dimen.browser_toolbar_height)
-        val dynamicToolbarEnabled = view.context.settings().isDynamicToolbarEnabled
-
-        snackbar.view.updatePadding(
-            bottom = if (
-                paddedForBottomToolbar &&
-                shouldUseBottomToolbar &&
-                // If the view passed in is a ContentFrameLayout, it does not matter
-                // if the user has a dynamicBottomToolbar or not, as the Android system
-                // can't intelligently position the snackbar on the upper most view.
-                // Ideally we should not pass ContentFrameLayout in, but it's the only
-                // way to display snackbars through a fragment transition.
-                (view is ContentFrameLayout || !dynamicToolbarEnabled)
-            ) {
-                toolbarHeight
-            } else {
-                0
-            },
-        )
 
         snackbar.show()
 


### PR DESCRIPTION
This padding update is already performed in `FenixSnackBar.make` when `isDisplayedWithBrowserToolbar` is true, and that variable has no other side-effects, so simply use that code.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
Fixes #27511