### PR TITLE
For #27522 new delete one/all search engines UI tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsSearchTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsSearchTest.kt
@@ -343,4 +343,31 @@ class SettingsSearchTest {
             verifyDefaultSearchEngine("Bing")
         }
     }
+
+    // Expected for en-us defaults
+    @Test
+    fun deleteAllSearchEnginesTest() {
+        homeScreen {
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openSearchSubMenu {
+            deleteMultipleSearchEngines(
+                "Google",
+                "Bing",
+                "Amazon.com",
+                "DuckDuckGo",
+                "eBay",
+            )
+            verifyDefaultSearchEngine("Wikipedia")
+            verifyThreeDotButtonIsNotDisplayed("Wikipedia")
+            openAddSearchEngineMenu()
+            verifyAddSearchEngineListContains(
+                "Google",
+                "Bing",
+                "Amazon.com",
+                "DuckDuckGo",
+                "eBay",
+            )
+        }
+    }
 }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsSearchTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsSearchTest.kt
@@ -312,4 +312,19 @@ class SettingsSearchTest {
             verifyClipboardSuggestionsAreDisplayed(link, false)
         }
     }
+
+    // Expected for en-us defaults
+    @Test
+    fun undoDeleteSearchEngineTest() {
+        homeScreen {
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openSearchSubMenu {
+            verifyEngineListContains("Bing")
+            openEngineOverflowMenu("Bing")
+            clickDeleteSearchEngine()
+            clickUndoSnackBarButton()
+            verifyEngineListContains("Bing")
+        }
+    }
 }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsSearchTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsSearchTest.kt
@@ -327,4 +327,20 @@ class SettingsSearchTest {
             verifyEngineListContains("Bing")
         }
     }
+
+    // Expected for en-us defaults
+    @Test
+    fun deleteDefaultSearchEngineTest() {
+        homeScreen {
+        }.openThreeDotMenu {
+        }.openSettings {
+        }.openSearchSubMenu {
+            verifyEngineListContains("Google")
+            verifyDefaultSearchEngine("Google")
+            openEngineOverflowMenu("Google")
+            clickDeleteSearchEngine()
+            verifyEngineListDoesNotContain("Google")
+            verifyDefaultSearchEngine("Bing")
+        }
+    }
 }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuSearchRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuSearchRobot.kt
@@ -249,6 +249,17 @@ class SettingsSubMenuSearchRobot {
 
     fun clickEdit() = onView(withText("Edit")).click()
 
+    fun clickDeleteSearchEngine() =
+        mDevice.findObject(
+            UiSelector().textContains(getStringResource(R.string.search_engine_delete)),
+        ).click()
+
+    fun clickUndoSnackBarButton() =
+        mDevice.findObject(
+            UiSelector()
+                .resourceId("$packageName:id/snackbar_btn"),
+        ).click()
+
     fun saveEditSearchEngine() {
         onView(withId(R.id.save_button)).click()
         assertTrue(

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuSearchRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuSearchRobot.kt
@@ -24,6 +24,7 @@ import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiSelector
 import org.hamcrest.CoreMatchers
+import org.hamcrest.CoreMatchers.not
 import org.hamcrest.Matchers.allOf
 import org.hamcrest.Matchers.endsWith
 import org.junit.Assert.assertTrue
@@ -170,6 +171,10 @@ class SettingsSubMenuSearchRobot {
     fun verifyAddSearchEngineList() = assertAddSearchEngineList()
 
     fun verifyEngineListContains(searchEngineName: String) = assertEngineListContains(searchEngineName)
+
+    fun verifyEngineListDoesNotContain(searchEngineName: String) = assertEngineListDoesNotContain(searchEngineName)
+
+    fun verifyDefaultSearchEngine(searchEngineName: String) = assertDefaultSearchEngine(searchEngineName)
 
     fun saveNewSearchEngine() {
         addSearchEngineSaveButton().click()
@@ -348,6 +353,18 @@ private fun addSearchEngineSaveButton() = onView(withId(R.id.add_search_engine))
 
 private fun assertEngineListContains(searchEngineName: String) {
     onView(withId(R.id.search_engine_group)).check(matches(hasDescendant(withText(searchEngineName))))
+}
+
+private fun assertDefaultSearchEngine(searchEngineName: String) =
+    onView(
+        allOf(
+            withId(R.id.radio_button),
+            withParent(withChild(withText(searchEngineName))),
+        ),
+    ).check(matches(isChecked(true)))
+
+private fun assertEngineListDoesNotContain(searchEngineName: String) {
+    onView(withId(R.id.search_engine_group)).check(matches(not(hasDescendant(withText(searchEngineName)))))
 }
 
 private fun threeDotMenu(searchEngineName: String) =

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuSearchRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsSubMenuSearchRobot.kt
@@ -176,6 +176,14 @@ class SettingsSubMenuSearchRobot {
 
     fun verifyDefaultSearchEngine(searchEngineName: String) = assertDefaultSearchEngine(searchEngineName)
 
+    fun verifyThreeDotButtonIsNotDisplayed(searchEngineName: String) = assertThreeDotButtonIsNotDisplayed(searchEngineName)
+
+    fun verifyAddSearchEngineListContains(vararg searchEngines: String) {
+        for (searchEngine in searchEngines) {
+            assertEngineListContains(searchEngine)
+        }
+    }
+
     fun saveNewSearchEngine() {
         addSearchEngineSaveButton().click()
         assertTrue(
@@ -250,6 +258,13 @@ class SettingsSubMenuSearchRobot {
             UiSelector().resourceId("org.mozilla.fenix.debug:id/overflow_menu"),
         ).waitForExists(waitingTime)
         threeDotMenu(searchEngineName).click()
+    }
+
+    fun deleteMultipleSearchEngines(vararg searchEngines: String) {
+        for (searchEngine in searchEngines) {
+            openEngineOverflowMenu(searchEngine)
+            clickDeleteSearchEngine()
+        }
     }
 
     fun clickEdit() = onView(withText("Edit")).click()
@@ -366,6 +381,9 @@ private fun assertDefaultSearchEngine(searchEngineName: String) =
 private fun assertEngineListDoesNotContain(searchEngineName: String) {
     onView(withId(R.id.search_engine_group)).check(matches(not(hasDescendant(withText(searchEngineName)))))
 }
+
+private fun assertThreeDotButtonIsNotDisplayed(searchEngineName: String) =
+    threeDotMenu(searchEngineName).check(matches(not(isDisplayed())))
 
 private fun threeDotMenu(searchEngineName: String) =
     onView(


### PR DESCRIPTION
For #27522 new delete one/all search engines UI tests.
All 3 UI tests successfully passed 100x on Firebase. ✅ 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.








### GitHub Automation
Fixes #27522