### PR TITLE
For #26911 - Allow users to enable re-supported Fennec extensions

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/Components.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Components.kt
@@ -7,10 +7,8 @@ package org.mozilla.fenix.components
 import android.annotation.SuppressLint
 import android.app.Application
 import android.content.Context
-import android.content.Intent
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
-import androidx.core.net.toUri
 import com.google.android.play.core.review.ReviewManagerFactory
 import mozilla.components.feature.addons.AddonManager
 import mozilla.components.feature.addons.amo.AddonCollectionProvider
@@ -22,7 +20,6 @@ import mozilla.components.support.base.worker.Frequency
 import org.mozilla.fenix.BuildConfig
 import org.mozilla.fenix.Config
 import org.mozilla.fenix.FeatureFlags
-import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.autofill.AutofillConfirmActivity
 import org.mozilla.fenix.autofill.AutofillSearchActivity
@@ -33,8 +30,8 @@ import org.mozilla.fenix.ext.asRecentTabs
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.filterState
 import org.mozilla.fenix.ext.settings
-import org.mozilla.fenix.gleanplumb.state.MessagingMiddleware
 import org.mozilla.fenix.ext.sort
+import org.mozilla.fenix.gleanplumb.state.MessagingMiddleware
 import org.mozilla.fenix.home.PocketUpdatesMiddleware
 import org.mozilla.fenix.home.blocklist.BlocklistHandler
 import org.mozilla.fenix.home.blocklist.BlocklistMiddleware
@@ -142,11 +139,6 @@ class Components(private val context: Context) {
         DefaultSupportedAddonsChecker(
             context,
             Frequency(12, TimeUnit.HOURS),
-            onNotificationClickIntent = Intent(context, HomeActivity::class.java).apply {
-                action = Intent.ACTION_VIEW
-                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-                data = "${BuildConfig.DEEP_LINK_SCHEME}://settings_addon_manager".toUri()
-            },
         )
     }
 

--- a/app/src/test/java/org/mozilla/fenix/addons/InstalledAddonDetailsFragmentTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/addons/InstalledAddonDetailsFragmentTest.kt
@@ -1,0 +1,65 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.addons
+
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.spyk
+import io.mockk.verify
+import mozilla.components.concept.engine.webextension.EnableSource
+import mozilla.components.feature.addons.Addon
+import mozilla.components.feature.addons.AddonManager
+import org.junit.Before
+import org.junit.Test
+
+class InstalledAddonDetailsFragmentTest {
+
+    private lateinit var fragment: InstalledAddonDetailsFragment
+    private val addonManager = mockk<AddonManager>()
+
+    @Before
+    fun setup() {
+        fragment = spyk(InstalledAddonDetailsFragment())
+    }
+
+    @Test
+    fun `GIVEN add-on is supported and not disabled WHEN enabling it THEN the add-on is requested by the user`() {
+        val addon = mockk<Addon>()
+        every { addon.isDisabledAsUnsupported() } returns false
+        every { addon.isSupported() } returns true
+        every { fragment.addon } returns addon
+        every { addonManager.enableAddon(any(), any(), any(), any()) } just Runs
+
+        fragment.enableAddon(addonManager, {}, {})
+
+        verify { addonManager.enableAddon(addon, EnableSource.USER, any(), any()) }
+    }
+
+    @Test
+    fun `GIVEN add-on is supported and disabled as previously unsupported WHEN enabling it THEN the add-on is requested by both the app and the user`() {
+        val addon = mockk<Addon>()
+        every { addon.isDisabledAsUnsupported() } returns true
+        every { addon.isSupported() } returns true
+        every { fragment.addon } returns addon
+        val capturedAddon = slot<Addon>()
+        val capturedOnSuccess = slot<(Addon) -> Unit>()
+        every {
+            addonManager.enableAddon(
+                capture(capturedAddon),
+                any(),
+                capture(capturedOnSuccess),
+                any(),
+            )
+        } answers { capturedOnSuccess.captured.invoke(capturedAddon.captured) }
+
+        fragment.enableAddon(addonManager, {}, {})
+
+        verify { addonManager.enableAddon(addon, EnableSource.APP_SUPPORT, any(), any()) }
+        verify { addonManager.enableAddon(capturedAddon.captured, EnableSource.USER, any(), any()) }
+    }
+}

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "108.0.20221031143305"
+    const val VERSION = "108.0.20221101143225"
 }


### PR DESCRIPTION
Allow users to enable old Fennec extensions when they are re-supported in Fenix.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.










### GitHub Automation
Fixes #26911