### PR TITLE
Close #27023: Add capability to override telemetry URL

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/ext/Configuration.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/Configuration.kt
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.ext
+
+import android.content.Context
+import androidx.preference.PreferenceManager
+import mozilla.components.service.glean.config.Configuration
+import org.mozilla.fenix.R
+
+/**
+ * Get custom Glean server URL if available.
+ */
+fun getCustomGleanServerUrlIfAvailable(context: Context): String? {
+    return PreferenceManager.getDefaultSharedPreferences(context).getString(
+        context.getPreferenceKey(R.string.pref_key_custom_glean_server_url),
+        null,
+    )
+}
+
+/**
+ * Applies the custom Glean server URL to the Configuration if available.
+ */
+fun Configuration.setCustomEndpointIfAvailable(serverEndpoint: String?): Configuration {
+    if (!serverEndpoint.isNullOrEmpty()) {
+        return copy(serverEndpoint = serverEndpoint)
+    }
+
+    return this
+}

--- a/app/src/main/java/org/mozilla/fenix/settings/SecretSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SecretSettingsFragment.kt
@@ -5,9 +5,11 @@
 package org.mozilla.fenix.settings
 
 import android.os.Bundle
+import androidx.preference.EditTextPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreference
+import org.mozilla.fenix.Config
 import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.components
@@ -52,6 +54,11 @@ class SecretSettingsFragment : PreferenceFragmentCompat() {
             isVisible = FeatureFlags.unifiedSearchFeature
             isChecked = context.settings().showUnifiedSearchFeature
             onPreferenceChangeListener = SharedPreferenceUpdater()
+        }
+
+        // for performance reasons, this is only available in Nightly or Debug builds
+        requirePreference<EditTextPreference>(R.string.pref_key_custom_glean_server_url).apply {
+            isVisible = Config.channel.isNightlyOrDebug
         }
     }
 }

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -306,4 +306,5 @@
     <string name="pref_key_nimbus_use_preview" translatable="false">pref_key_nimbus_use_preview</string>
     <string name="pref_key_history_metadata_feature" translatable="false">pref_key_history_metadata_feature</string>
     <string name="pref_key_show_unified_search" translatable="false">pref_key_show_unified_search</string>
+    <string name="pref_key_custom_glean_server_url" translatable="false">pref_key_custom_glean_server_url</string>
 </resources>

--- a/app/src/main/res/values/static_strings.xml
+++ b/app/src/main/res/values/static_strings.xml
@@ -44,6 +44,8 @@
     <string name="preferences_debug_settings_task_continuity" translatable="false">Enable Task Continuity</string>
     <!-- Label for enabling the Unified Search feature -->
     <string name="preferences_debug_settings_unified_search" translatable="false">Enable Unified Search (requires restart)</string>
+    <!-- Label for custom Glean server URL -->
+    <string name="preferences_debug_settings_custom_glean_server_url" translatable="false">Custom Glean server URL (requires restart)</string>
     <!-- Title of preference for sync debugging (only shown in the when the secret debug menu is enabled) -->
     <string name="preferences_sync_debug">Sync Debug</string>
     <!-- Preference to override the Push server -->

--- a/app/src/main/res/xml/secret_settings_preferences.xml
+++ b/app/src/main/res/xml/secret_settings_preferences.xml
@@ -25,4 +25,10 @@
         android:key="@string/pref_key_show_unified_search"
         android:title="@string/preferences_debug_settings_unified_search"
         app:iconSpaceReserved="false" />
+    <EditTextPreference
+        android:key="@string/pref_key_custom_glean_server_url"
+        android:title="@string/preferences_debug_settings_custom_glean_server_url"
+        android:inputType="textUri"
+        app:useSimpleSummaryProvider="true"
+        app:iconSpaceReserved="false" />
 </PreferenceScreen>

--- a/app/src/test/java/org/mozilla/fenix/ext/ConfigurationKtTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/ext/ConfigurationKtTest.kt
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.ext
+
+import io.mockk.mockk
+import mozilla.components.service.glean.config.Configuration
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class ConfigurationKtTest {
+    @Test
+    fun `GIVEN server endpoint is null THEN return the same configuration`() {
+        val configuration = Configuration(httpClient = mockk())
+
+        assertEquals(configuration, configuration.setCustomEndpointIfAvailable(null))
+    }
+
+    @Test
+    fun `GIVEN server endpoint is not empty THEN make a copy of configuration with server endpoint`() {
+        val configuration = Configuration(httpClient = mockk())
+
+        assertNotEquals(configuration, configuration.setCustomEndpointIfAvailable("test"))
+    }
+
+    @Test
+    fun `GIVEN server endpoint is empty THEN return the same configuration`() {
+        val configuration = Configuration(httpClient = mockk())
+
+        assertEquals(configuration, configuration.setCustomEndpointIfAvailable(""))
+    }
+}


### PR DESCRIPTION
Tested with help from @jrbenny35.  I have confirmed that it works with a local [ping server](https://github.com/mozilla/experimenter/tree/main/app/tests/integration/nimbus/utils/ping_server).

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.








### GitHub Automation
Fixes #27023