### PR TITLE
For #27584 - Replace Button in RecentSyncedTab with SecondaryButton

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/compose/button/Button.kt
+++ b/app/src/main/java/org/mozilla/fenix/compose/button/Button.kt
@@ -102,19 +102,23 @@ fun PrimaryButton(
  * Secondary button.
  *
  * @param text The button text to be displayed.
+ * @param textColor [Color] to apply to the button text.
+ * @param backgroundColor The background [Color] of the button.
  * @param icon Optional [Painter] used to display an [Icon] before the button text.
  * @param onClick Invoked when the user clicks on the button.
  */
 @Composable
 fun SecondaryButton(
     text: String,
+    textColor: Color = FirefoxTheme.colors.textActionSecondary,
+    backgroundColor: Color = FirefoxTheme.colors.actionSecondary,
     icon: Painter? = null,
     onClick: () -> Unit,
 ) {
     Button(
         text = text,
-        textColor = FirefoxTheme.colors.textActionSecondary,
-        backgroundColor = FirefoxTheme.colors.actionSecondary,
+        textColor = textColor,
+        backgroundColor = backgroundColor,
         icon = icon,
         tint = FirefoxTheme.colors.iconActionSecondary,
         onClick = onClick,

--- a/app/src/main/java/org/mozilla/fenix/home/recentsyncedtabs/view/RecentSyncedTab.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/recentsyncedtabs/view/RecentSyncedTab.kt
@@ -48,7 +48,7 @@ import mozilla.components.support.ktx.kotlin.trimmed
 import org.mozilla.fenix.R
 import org.mozilla.fenix.compose.Image
 import org.mozilla.fenix.compose.ThumbnailCard
-import org.mozilla.fenix.compose.button.Button
+import org.mozilla.fenix.compose.button.SecondaryButton
 import org.mozilla.fenix.home.recentsyncedtabs.RecentSyncedTab
 import org.mozilla.fenix.home.recenttabs.RecentTab
 import org.mozilla.fenix.theme.FirefoxTheme
@@ -179,7 +179,7 @@ fun RecentSyncedTab(
 
             Spacer(modifier = Modifier.height(32.dp))
 
-            Button(
+            SecondaryButton(
                 text = if (tab != null) {
                     stringResource(R.string.recent_tabs_see_all_synced_tabs_button_text)
                 } else {
@@ -187,7 +187,6 @@ fun RecentSyncedTab(
                 },
                 textColor = buttonTextColor,
                 backgroundColor = buttonBackgroundColor,
-                tint = FirefoxTheme.colors.iconActionSecondary,
                 onClick = onSeeAllSyncedTabsButtonClick,
             )
         }


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
Fixes #27584