### PR TITLE
For #25814 - Hide "Show search engines" toggle from search settings when unified search is enabled

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/search/SearchDialogController.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchDialogController.kt
@@ -144,7 +144,8 @@ class SearchDialogController(
         fragmentStore.dispatch(SearchFragmentAction.UpdateQuery(text))
         fragmentStore.dispatch(
             SearchFragmentAction.ShowSearchShortcutEnginePicker(
-                (textMatchesCurrentUrl || textMatchesCurrentSearch || text.isEmpty()) &&
+                !settings.showUnifiedSearchFeature &&
+                    (textMatchesCurrentUrl || textMatchesCurrentSearch || text.isEmpty()) &&
                     settings.shouldShowSearchShortcuts,
             ),
         )

--- a/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt
@@ -296,7 +296,12 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
             flow.map { state -> state.search }
                 .ifChanged()
                 .collect { search ->
-                    store.dispatch(SearchFragmentAction.UpdateSearchState(search))
+                    store.dispatch(
+                        SearchFragmentAction.UpdateSearchState(
+                            search,
+                            showUnifiedSearchFeature,
+                        ),
+                    )
 
                     updateSearchSelectorMenu(search.searchEngines)
                 }

--- a/app/src/main/java/org/mozilla/fenix/search/SearchFragmentStore.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchFragmentStore.kt
@@ -212,8 +212,9 @@ sealed class SearchFragmentAction : Action {
 
     /**
      * Updates the local `SearchFragmentState` from the global `SearchState` in `BrowserStore`.
+     * If the unified search is enabled, then search shortcuts should not be shown.
      */
-    data class UpdateSearchState(val search: SearchState) : SearchFragmentAction()
+    data class UpdateSearchState(val search: SearchState, val isUnifiedSearchEnabled: Boolean) : SearchFragmentAction()
 }
 
 /**
@@ -304,7 +305,8 @@ private fun searchStateReducer(state: SearchFragmentState, action: SearchFragmen
             state.copy(
                 defaultEngine = action.search.selectedOrDefaultSearchEngine,
                 areShortcutsAvailable = action.search.searchEngines.size > 1,
-                showSearchShortcuts = state.url.isEmpty() &&
+                showSearchShortcuts = !action.isUnifiedSearchEnabled &&
+                    state.url.isEmpty() &&
                     state.showSearchShortcutsSetting &&
                     action.search.searchEngines.size > 1,
                 searchEngineSource = when (state.searchEngineSource) {

--- a/app/src/main/java/org/mozilla/fenix/settings/search/SearchEngineFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/search/SearchEngineFragment.kt
@@ -50,6 +50,7 @@ class SearchEngineFragment : PreferenceFragmentCompat() {
         val showSearchShortcuts =
             requirePreference<SwitchPreference>(R.string.pref_key_show_search_engine_shortcuts).apply {
                 isChecked = context.settings().shouldShowSearchShortcuts
+                isVisible = !context.settings().showUnifiedSearchFeature
             }
 
         val showHistorySuggestions =

--- a/app/src/test/java/org/mozilla/fenix/search/SearchDialogControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/search/SearchDialogControllerTest.kt
@@ -272,6 +272,29 @@ class SearchDialogControllerTest {
     }
 
     @Test
+    fun `GIVEN show search shortcuts setting is enabled AND unified search is enabled WHEN query is empty THEN do not show search shortcuts`() {
+        val text = ""
+        every { settings.shouldShowSearchShortcuts } returns true
+        every { settings.showUnifiedSearchFeature } returns true
+
+        createController().handleTextChanged(text)
+
+        verify { store.dispatch(SearchFragmentAction.ShowSearchShortcutEnginePicker(false)) }
+    }
+
+    @Test
+    fun `GIVEN show search shortcuts setting is enabled AND unified search is enabled WHEN query is url THEN do not show search shortcuts`() {
+        val text = "mozilla.org"
+        every { store.state.url } returns "mozilla.org"
+        every { settings.shouldShowSearchShortcuts } returns true
+        every { settings.showUnifiedSearchFeature } returns true
+
+        createController().handleTextChanged(text)
+
+        verify { store.dispatch(SearchFragmentAction.ShowSearchShortcutEnginePicker(false)) }
+    }
+
+    @Test
     fun `do not show search shortcuts when setting enabled AND query non-empty`() {
         val text = "mozilla"
 

--- a/app/src/test/java/org/mozilla/fenix/search/SearchFragmentStoreTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/search/SearchFragmentStoreTest.kt
@@ -268,7 +268,7 @@ class SearchFragmentStoreTest {
 
         store.dispatch(
             SearchFragmentAction.UpdateSearchState(
-                SearchState(
+                search = SearchState(
                     region = RegionState("US", "US"),
                     regionSearchEngines = listOf(
                         SearchEngine("engine-a", "Engine A", mockk(), type = SearchEngine.Type.BUNDLED),
@@ -293,6 +293,7 @@ class SearchFragmentStoreTest {
                     userSelectedSearchEngineId = null,
                     userSelectedSearchEngineName = null,
                 ),
+                isUnifiedSearchEnabled = false,
             ),
         )
 
@@ -327,7 +328,7 @@ class SearchFragmentStoreTest {
 
         store.dispatch(
             SearchFragmentAction.UpdateSearchState(
-                SearchState(
+                search = SearchState(
                     region = RegionState("US", "US"),
                     regionSearchEngines = listOf(
                         SearchEngine("engine-a", "Engine A", mockk(), type = SearchEngine.Type.BUNDLED),
@@ -352,6 +353,7 @@ class SearchFragmentStoreTest {
                     userSelectedSearchEngineId = null,
                     userSelectedSearchEngineName = null,
                 ),
+                isUnifiedSearchEnabled = false,
             ),
         )
 
@@ -366,6 +368,43 @@ class SearchFragmentStoreTest {
         assertTrue(store.state.searchEngineSource is SearchEngineSource.Default)
         assertNotNull(store.state.searchEngineSource.searchEngine)
         assertEquals("Engine B", store.state.searchEngineSource.searchEngine!!.name)
+    }
+
+    @Test
+    fun `GIVEN unified search is enabled WHEN updating the SearchFragmentState from SearchState THEN disable search shortcuts`() {
+        val store = SearchFragmentStore(
+            emptyDefaultState(
+                searchEngineSource = SearchEngineSource.None,
+                areShortcutsAvailable = false,
+                defaultEngine = null,
+                showSearchShortcutsSetting = false,
+            ),
+        )
+
+        assertFalse(store.state.showSearchShortcuts)
+
+        store.dispatch(
+            SearchFragmentAction.UpdateSearchState(
+                search = SearchState(
+                    region = RegionState("US", "US"),
+                    regionSearchEngines = listOf(
+                        SearchEngine("engine-a", "Engine A", mockk(), type = SearchEngine.Type.BUNDLED),
+                        SearchEngine("engine-b", "Engine B", mockk(), type = SearchEngine.Type.BUNDLED),
+                    ),
+                    customSearchEngines = listOf(),
+                    additionalSearchEngines = listOf(),
+                    additionalAvailableSearchEngines = listOf(),
+                    hiddenSearchEngines = listOf(),
+                    regionDefaultSearchEngineId = "engine-b",
+                    userSelectedSearchEngineId = null,
+                    userSelectedSearchEngineName = null,
+                ),
+                isUnifiedSearchEnabled = true,
+            ),
+        )
+        store.waitUntilIdle()
+
+        assertFalse(store.state.showSearchShortcuts)
     }
 
     private fun emptyDefaultState(


### PR DESCRIPTION
Hide "Show search engines" toggle from search settings when unified search is enabled
This PR also prevents showing search engine shortcuts after unified search is enabled.

https://user-images.githubusercontent.com/35462038/198674514-b7ede986-ffc5-4c65-bb97-b936ea73fc6f.mp4

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.







### GitHub Automation
Fixes #25814