### PR TITLE
For #25811 - Add header to unified search engine menu

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt
@@ -730,9 +730,9 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
                 ) {
                     interactor.onMenuItemTapped(SearchSelectorMenu.Item.SearchEngine(it))
                 }
-            } + searchSelectorMenu.menuItems()
+            }
 
-        searchSelectorMenu.menuController.submitList(searchEngineList)
+        searchSelectorMenu.menuController.submitList(searchSelectorMenu.menuItems(searchEngineList))
         toolbarView.view.invalidateActions()
     }
 

--- a/app/src/main/java/org/mozilla/fenix/search/toolbar/SearchSelectorMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/toolbar/SearchSelectorMenu.kt
@@ -5,12 +5,13 @@
 package org.mozilla.fenix.search.toolbar
 
 import android.content.Context
-import androidx.annotation.VisibleForTesting
 import androidx.appcompat.content.res.AppCompatResources
 import mozilla.components.browser.menu2.BrowserMenuController
 import mozilla.components.browser.state.search.SearchEngine
 import mozilla.components.concept.menu.MenuController
+import mozilla.components.concept.menu.candidate.DecorativeTextMenuCandidate
 import mozilla.components.concept.menu.candidate.DrawableMenuIcon
+import mozilla.components.concept.menu.candidate.MenuCandidate
 import mozilla.components.concept.menu.candidate.TextMenuCandidate
 import mozilla.components.support.ktx.android.content.getColorFromAttr
 import org.mozilla.fenix.R
@@ -47,21 +48,22 @@ class SearchSelectorMenu(
 
     val menuController: MenuController by lazy { BrowserMenuController() }
 
-    @VisibleForTesting
-    internal fun menuItems(): List<TextMenuCandidate> {
-        return listOf(
-            TextMenuCandidate(
-                text = context.getString(R.string.search_settings_menu_item),
-                start = DrawableMenuIcon(
-                    drawable = AppCompatResources.getDrawable(
-                        context,
-                        R.drawable.mozac_ic_settings,
-                    ),
-                    tint = context.getColorFromAttr(R.attr.textPrimary),
-                ),
-            ) {
-                interactor.onMenuItemTapped(Item.SearchSettings)
-            },
+    internal fun menuItems(searchEngines: List<MenuCandidate>): List<MenuCandidate> {
+        val headerCandidate = DecorativeTextMenuCandidate(
+            text = context.getString(R.string.search_header_menu_item),
         )
+        val settingsCandidate = TextMenuCandidate(
+            text = context.getString(R.string.search_settings_menu_item),
+            start = DrawableMenuIcon(
+                drawable = AppCompatResources.getDrawable(
+                    context,
+                    R.drawable.mozac_ic_settings,
+                ),
+                tint = context.getColorFromAttr(R.attr.textPrimary),
+            ),
+        ) {
+            interactor.onMenuItemTapped(Item.SearchSettings)
+        }
+        return listOf(headerCandidate) + searchEngines + listOf(settingsCandidate)
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -239,6 +239,8 @@
     <string name="search_engine_suggestions_description">Search directly from the address bar</string>
     <!-- Menu option in the search selector menu to open the search settings -->
     <string name="search_settings_menu_item">Search settings</string>
+    <!-- Header text for the search selector menu -->
+    <string name="search_header_menu_item">This time search:</string>
 
     <!-- Home onboarding -->
     <!-- Onboarding home screen dialog title text. The first parameter is the name of the application.-->

--- a/app/src/test/java/org/mozilla/fenix/search/toolbar/SearchSelectorMenuTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/search/toolbar/SearchSelectorMenuTest.kt
@@ -1,0 +1,47 @@
+package org.mozilla.fenix.search.toolbar
+
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import mozilla.components.concept.menu.candidate.DecorativeTextMenuCandidate
+import mozilla.components.concept.menu.candidate.TextMenuCandidate
+import mozilla.components.support.test.robolectric.testContext
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.fenix.R
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+
+@RunWith(FenixRobolectricTestRunner::class)
+class SearchSelectorMenuTest {
+
+    private lateinit var menu: SearchSelectorMenu
+    private val interactor = mockk<ToolbarInteractor>()
+
+    @Before
+    fun setup() {
+        menu = SearchSelectorMenu(testContext, interactor)
+    }
+
+    @Test
+    fun `WHEN building the menu items THEN the header is the first item AND the search settings is the last item`() {
+        every { interactor.onMenuItemTapped(any()) } just Runs
+
+        val items = menu.menuItems(listOf())
+        val lastItem = (items.last() as TextMenuCandidate)
+        lastItem.onClick()
+
+        assertEquals(
+            testContext.getString(R.string.search_header_menu_item),
+            (items.first() as DecorativeTextMenuCandidate).text,
+        )
+        assertEquals(
+            testContext.getString(R.string.search_settings_menu_item),
+            lastItem.text,
+        )
+        verify { interactor.onMenuItemTapped(SearchSelectorMenu.Item.SearchSettings) }
+    }
+}


### PR DESCRIPTION
Added header with "This time search:" text to the unified search engine menu.

![Screenshot_20221031_141809](https://user-images.githubusercontent.com/35462038/199006254-110fffa2-6e2a-4226-a886-bb45f1a8313f.png)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
Fixes #25811