### PR TITLE
For #27635 - New telemetry for Save to PDF failures

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -468,6 +468,23 @@ events:
     metadata:
       tags:
         - Sharing
+  save_to_pdf_failure:
+    type: event
+    description: |
+      A user tapped the save pdf but an error ocurred
+      and the process failed.
+    bugs:
+      - https://github.com/mozilla-mobile/fenix/issues/27635
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/27661#issuecomment-1300505370
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: 122
+    metadata:
+      tags:
+        - Sharing
 
 onboarding:
   syn_cfr_shown:

--- a/app/src/main/java/org/mozilla/fenix/share/SaveToPDFMiddleware.kt
+++ b/app/src/main/java/org/mozilla/fenix/share/SaveToPDFMiddleware.kt
@@ -17,7 +17,10 @@ import mozilla.components.browser.state.state.BrowserState
 import mozilla.components.lib.state.Action
 import mozilla.components.lib.state.Middleware
 import mozilla.components.lib.state.MiddlewareContext
+import mozilla.telemetry.glean.private.NoExtras
+import org.mozilla.fenix.GleanMetrics.Events
 import org.mozilla.fenix.R
+import org.mozilla.gecko.util.ThreadUtils
 
 /**
  * [BrowserAction] middleware reacting in response to Save to PDF related [Action]s.
@@ -37,7 +40,10 @@ class SaveToPDFMiddleware(
             // See https://github.com/mozilla-mobile/fenix/issues/27649 for more details,
             // why a Toast is used here.
             GlobalScope.launch(Dispatchers.Main) {
-                Toast.makeText(context, R.string.unable_to_save_to_pdf_error, LENGTH_LONG).show()
+                ThreadUtils.runOnUiThread {
+                    Toast.makeText(context, R.string.unable_to_save_to_pdf_error, LENGTH_LONG).show()
+                }
+                Events.saveToPdfFailure.record(NoExtras())
             }
         } else {
             next(action)

--- a/app/src/test/java/org/mozilla/fenix/share/SaveToPDFMiddlewareTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/share/SaveToPDFMiddlewareTest.kt
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.share
+
+import mozilla.components.browser.state.action.EngineAction
+import mozilla.components.browser.state.store.BrowserStore
+import mozilla.components.service.glean.testing.GleanTestRule
+import mozilla.components.support.test.libstate.ext.waitUntilIdle
+import mozilla.components.support.test.robolectric.testContext
+import mozilla.components.support.test.rule.MainCoroutineRule
+import mozilla.components.support.test.rule.runTestOnMain
+import org.junit.Assert.assertNotNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.fenix.GleanMetrics.Events
+import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
+
+@RunWith(FenixRobolectricTestRunner::class)
+class SaveToPDFMiddlewareTest {
+
+    @get:Rule
+    val gleanTestRule = GleanTestRule(testContext)
+
+    @get:Rule
+    val mainCoroutineTestRule = MainCoroutineRule()
+
+    @Test
+    fun `GIVEN a save to pdf request WHEN it fails THEN telemetry is sent`() = runTestOnMain {
+        val middleware = SaveToPDFMiddleware(testContext)
+        val browserStore = BrowserStore(middleware = listOf(middleware))
+
+        browserStore.dispatch(EngineAction.SaveToPdfExceptionAction("14", RuntimeException("reader save to pdf failed")))
+        browserStore.waitUntilIdle()
+        testScheduler.advanceUntilIdle()
+
+        assertNotNull(Events.saveToPdfFailure.testGetValue())
+    }
+}


### PR DESCRIPTION

Checking in logcat I see: 
```
"events": [
{
    "timestamp": 0,
    "category": "nimbus_health",
    "name": "sdk_unavailable_for_feature",
    "extra": {
    "feature_id": "mr2022"
}
},
{
    "timestamp": 3690,
    "category": "events",
    "name": "save_to_pdf_failure"
},
```

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
Fixes #27635