### PR TITLE
Closes #27652: Fix A-C auto publish docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,9 +199,11 @@ raptorEnabled
 If you're making changes to these projects and want to test them in Fenix, auto-publication workflow is the fastest, most reliable
 way to do that.
 
-In `local.properties`, specify a relative path to your local `android-components` and/or `application-services` checkouts. E.g.:
-- `autoPublish.android-components.dir=../android-components`
+In `local.properties`, specify a relative path to your local `android-components` and/or `application-services` projects. E.g.:
+- `autoPublish.android-components.dir=../firefox-android/android-components`
 - `autoPublish.application-services.dir=../application-services`
+
+*Note that the Android Components project was already migrated to the new [firefox-android](https://github.com/mozilla-mobile/firefox-android) repository. Therefore, this auto publication workflow won't be neccessary for Android Components once Fenix is integrated in the new repository as well.*
 
 Once these flags are set, your Fenix builds will include any local modifications present in these projects.
 


### PR DESCRIPTION
Accounting for the A-C repo move.
Fixes #27652