### PR TITLE
For #27538: Avoid extra processing of large text from clipboard

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/utils/ClipboardHandler.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/ClipboardHandler.kt
@@ -11,6 +11,7 @@ import android.os.Build
 import android.view.textclassifier.TextClassifier
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.getSystemService
+import mozilla.components.support.ktx.kotlin.MAX_URI_LENGTH
 import mozilla.components.support.utils.SafeUrl
 import mozilla.components.support.utils.WebURLFinder
 import org.mozilla.fenix.perf.Performance.logger
@@ -58,6 +59,10 @@ class ClipboardHandler(val context: Context) {
      */
     fun extractURL(): String? {
         return text?.let {
+            if (it.length > MAX_URI_LENGTH) {
+                return null
+            }
+
             val finder = WebURLFinder(it)
             finder.bestWebURL()
         }


### PR DESCRIPTION
This avoids extra processing of large text that is unlikely to be an URL.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
Fixes #27538