### PR TITLE
 For #27671 - Search metrics will now be sent in baseline ping

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -6198,6 +6198,7 @@ browser.search:
     expires: never
     no_lint:
       - BASELINE_PING
+
 addons:
   open_addons_in_settings:
     type: event

--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -1315,6 +1315,7 @@ metrics:
       `other` option for the source but it should never enter on this case.
     send_in_pings:
       - metrics
+      - baseline
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/1158
       - https://github.com/mozilla-mobile/fenix/issues/6556
@@ -1333,6 +1334,8 @@ metrics:
       - android-probes@mozilla.com
       - kbrosnan@mozilla.com
     expires: never
+    no_lint:
+      - BASELINE_PING
     metadata:
       tags:
         - Search
@@ -2364,6 +2367,7 @@ search.default_engine:
       value will be "custom"
     send_in_pings:
       - metrics
+      - baseline
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/800
     data_reviews:
@@ -2380,6 +2384,8 @@ search.default_engine:
       - android-probes@mozilla.com
       - kbrosnan@mozilla.com
     expires: never
+    no_lint:
+      - BASELINE_PING
   name:
     type: string
     lifetime: application
@@ -2390,6 +2396,7 @@ search.default_engine:
       value will be "custom"
     send_in_pings:
       - metrics
+      - baseline
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/800
     data_reviews:
@@ -2406,6 +2413,8 @@ search.default_engine:
       - android-probes@mozilla.com
       - kbrosnan@mozilla.com
     expires: never
+    no_lint:
+      - BASELINE_PING
   search_url:
     type: url
     lifetime: application
@@ -6125,6 +6134,7 @@ browser.search:
       The key format is `<provider-name>`.
     send_in_pings:
       - metrics
+      - baseline
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/6558
     data_reviews:
@@ -6139,6 +6149,8 @@ browser.search:
       - android-probes@mozilla.com
       - kbrosnan@mozilla.com
     expires: never
+    no_lint:
+      - BASELINE_PING
   ad_clicks:
     type: labeled_counter
     description: |
@@ -6146,6 +6158,7 @@ browser.search:
       The key format is `<provider-name>`.
     send_in_pings:
       - metrics
+      - baseline
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/6558
     data_reviews:
@@ -6160,12 +6173,15 @@ browser.search:
       - android-probes@mozilla.com
       - kbrosnan@mozilla.com
     expires: never
+    no_lint:
+      - BASELINE_PING
   in_content:
     type: labeled_counter
     description: |
       Records the type of interaction a user has on SERP pages.
     send_in_pings:
       - metrics
+      - baseline
     bugs:
       - https://github.com/mozilla-mobile/fenix/issues/6557
     data_reviews:
@@ -6180,7 +6196,8 @@ browser.search:
       - android-probes@mozilla.com
       - kbrosnan@mozilla.com
     expires: never
-
+    no_lint:
+      - BASELINE_PING
 addons:
   open_addons_in_settings:
     type: event


### PR DESCRIPTION

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

Tests: this counter is already sent in metrics & is covered by existing tests
Screenshots: no visible changes
Accessibility: does not impact any user facing feature

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
