### PR TITLE
Updating the code to work with application-services v95.0.0

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/browser/BaseBrowserFragment.kt
@@ -39,7 +39,7 @@ import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import mozilla.appservices.places.BookmarkRoot
-import mozilla.appservices.places.uniffi.PlacesException
+import mozilla.appservices.places.uniffi.PlacesApiException
 import mozilla.components.browser.state.action.ContentAction
 import mozilla.components.browser.state.selector.findCustomTab
 import mozilla.components.browser.state.selector.findCustomTabOrSelectedTab
@@ -1316,7 +1316,7 @@ abstract class BaseBrowserFragment :
                             .show()
                     }
                 }
-            } catch (e: PlacesException.UrlParseFailed) {
+            } catch (e: PlacesApiException.UrlParseFailed) {
                 withContext(Main) {
                     view?.let {
                         FenixSnackbar.make(

--- a/app/src/main/java/org/mozilla/fenix/components/bookmarks/BookmarksUseCase.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/bookmarks/BookmarksUseCase.kt
@@ -6,7 +6,7 @@ package org.mozilla.fenix.components.bookmarks
 
 import androidx.annotation.WorkerThread
 import mozilla.appservices.places.BookmarkRoot
-import mozilla.appservices.places.uniffi.PlacesException
+import mozilla.appservices.places.uniffi.PlacesApiException
 import mozilla.components.concept.storage.BookmarksStorage
 import mozilla.components.concept.storage.HistoryStorage
 import org.mozilla.fenix.home.recentbookmarks.RecentBookmark
@@ -42,7 +42,7 @@ class BookmarksUseCase(
                     )
                 }
                 canAdd
-            } catch (e: PlacesException.UrlParseFailed) {
+            } catch (e: PlacesApiException.UrlParseFailed) {
                 false
             }
         }

--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/edit/EditBookmarkFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/edit/EditBookmarkFragment.kt
@@ -29,7 +29,7 @@ import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.Dispatchers.Main
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import mozilla.appservices.places.uniffi.PlacesException
+import mozilla.appservices.places.uniffi.PlacesApiException
 import mozilla.components.concept.storage.BookmarkInfo
 import mozilla.components.concept.storage.BookmarkNode
 import mozilla.components.concept.storage.BookmarkNodeType
@@ -287,7 +287,7 @@ class EditBookmarkFragment : Fragment(R.layout.fragment_edit_bookmark), MenuProv
 
                     findNavController().popBackStack()
                 }
-            } catch (e: PlacesException.UrlParseFailed) {
+            } catch (e: PlacesApiException.UrlParseFailed) {
                 withContext(Main) {
                     binding.inputLayoutBookmarkUrl.error =
                         getString(R.string.bookmark_invalid_url_error)

--- a/app/src/main/java/org/mozilla/fenix/settings/logins/controller/SavedLoginsStorageController.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/controller/SavedLoginsStorageController.kt
@@ -17,7 +17,7 @@ import kotlinx.coroutines.withContext
 import mozilla.components.concept.storage.Login
 import mozilla.components.concept.storage.LoginEntry
 import mozilla.components.service.sync.logins.InvalidRecordException
-import mozilla.components.service.sync.logins.LoginsStorageException
+import mozilla.components.service.sync.logins.LoginsApiException
 import mozilla.components.service.sync.logins.NoSuchRecordException
 import mozilla.components.service.sync.logins.SyncableLoginsStorage
 import org.mozilla.fenix.R
@@ -90,7 +90,7 @@ open class SavedLoginsStorageController(
         try {
             val encryptedLogin = passwordsStorage.add(loginEntryToSave)
             syncAndUpdateList(passwordsStorage.decryptLogin(encryptedLogin))
-        } catch (loginException: LoginsStorageException) {
+        } catch (loginException: LoginsApiException) {
             Log.e(
                 "Add new login",
                 "Failed to add new login.",
@@ -140,7 +140,7 @@ open class SavedLoginsStorageController(
         try {
             val encryptedLogin = passwordsStorage.update(guid, loginEntryToSave)
             syncAndUpdateList(passwordsStorage.decryptLogin(encryptedLogin))
-        } catch (loginException: LoginsStorageException) {
+        } catch (loginException: LoginsApiException) {
             when (loginException) {
                 is NoSuchRecordException,
                 is InvalidRecordException,
@@ -194,7 +194,7 @@ open class SavedLoginsStorageController(
         val validEntry = if (entry.password.isNotEmpty()) entry else entry.copy(password = "password")
         var dupe = try {
             passwordsStorage.findLoginToUpdate(validEntry)?.mapToSavedLogin()
-        } catch (e: LoginsStorageException) {
+        } catch (e: LoginsApiException) {
             // If the entry was invalid, then consider it not a dupe
             null
         }

--- a/buildSrc/src/main/java/AndroidComponents.kt
+++ b/buildSrc/src/main/java/AndroidComponents.kt
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object AndroidComponents {
-    const val VERSION = "108.0.20221107190113"
+    const val VERSION = "108.0.20221108031613"
 }


### PR DESCRIPTION
This required updating the code to handle the new app-services error hierarchy.

This should be merged alongside https://github.com/mozilla-mobile/firefox-android/pull/80

No tests or screenshots because this doesn't change any behavior.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
