### PR TITLE
For #27468 - Backplate homepage MessageCard

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/MessageCardViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/onboarding/MessageCardViewHolder.kt
@@ -5,17 +5,24 @@
 package org.mozilla.fenix.home.sessioncontrol.viewholders.onboarding
 
 import android.view.View
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.ComposeView
 import androidx.lifecycle.LifecycleOwner
+import mozilla.components.lib.state.ext.observeAsComposableState
 import org.mozilla.fenix.R
+import org.mozilla.fenix.components.components
 import org.mozilla.fenix.compose.ComposeViewHolder
 import org.mozilla.fenix.compose.MessageCard
+import org.mozilla.fenix.compose.MessageCardColors
 import org.mozilla.fenix.gleanplumb.Message
 import org.mozilla.fenix.home.sessioncontrol.SessionControlInteractor
+import org.mozilla.fenix.theme.FirefoxTheme
+import org.mozilla.fenix.wallpapers.Wallpaper
+import org.mozilla.fenix.wallpapers.WallpaperState
 
 /**
  * View holder for the Nimbus Message Card.
@@ -47,11 +54,31 @@ class MessageCardViewHolder(
     @Composable
     override fun Content() {
         val message by remember { mutableStateOf(messageGlobal) }
+        val wallpaperState = components.appStore
+            .observeAsComposableState { state -> state.wallpaperState }.value ?: WallpaperState.default
+        val isWallpaperNotDefault = !Wallpaper.nameIsDefault(wallpaperState.currentWallpaper.name)
+
+        var (_, _, _, _, buttonColor, buttonTextColor) = MessageCardColors.buildMessageCardColors()
+
+        if (isWallpaperNotDefault) {
+            buttonColor = FirefoxTheme.colors.layer1
+
+            if (!isSystemInDarkTheme()) {
+                buttonTextColor = FirefoxTheme.colors.textActionSecondary
+            }
+        }
+
+        val messageCardColors = MessageCardColors.buildMessageCardColors(
+            backgroundColor = wallpaperState.wallpaperCardColor,
+            buttonColor = buttonColor,
+            buttonTextColor = buttonTextColor,
+        )
 
         MessageCard(
             messageText = message.data.text,
             titleText = message.data.title,
             buttonText = message.data.buttonLabel,
+            messageColors = messageCardColors,
             onClick = { interactor.onMessageClicked(message) },
             onCloseButtonClick = { interactor.onMessageClosedClicked(message) },
         )


### PR DESCRIPTION
| Light | Dark |
| -- | -- |
| <img src="https://user-images.githubusercontent.com/87384386/199616296-991e493d-c430-49a3-b2fd-ff0f1e63bb93.png" width = 300/> | <img src="https://user-images.githubusercontent.com/87384386/199616351-99f8321e-9dc1-4154-a721-b82320df3f45.png" width=300/> |

In essence, this section is styled the same as the recent synced tab (Jump back in)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
Fixes #27468