### PR TITLE
For #27469 - Update no collections button colors when a wallpaper is selected

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/NoCollectionsMessageViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/viewholders/NoCollectionsMessageViewHolder.kt
@@ -7,6 +7,7 @@ package org.mozilla.fenix.home.sessioncontrol.viewholders
 import android.view.View
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
+import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.lifecycle.LifecycleOwner
 import kotlinx.coroutines.flow.map
@@ -19,6 +20,7 @@ import org.mozilla.fenix.R
 import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.databinding.NoCollectionsMessageBinding
 import org.mozilla.fenix.ext.increaseTapArea
+import org.mozilla.fenix.ext.isSystemInDarkTheme
 import org.mozilla.fenix.home.sessioncontrol.CollectionInteractor
 import org.mozilla.fenix.utils.view.ViewHolder
 
@@ -58,9 +60,10 @@ class NoCollectionsMessageViewHolder(
         }
 
         appStore.flowScoped(viewLifecycleOwner) { flow ->
-            flow.map { state -> state.wallpaperState.currentWallpaper.textColor }
+            flow.map { state -> state.wallpaperState }
                 .ifChanged()
-                .collect { textColor ->
+                .collect { wallpaperState ->
+                    val textColor = wallpaperState.currentWallpaper.textColor
                     if (textColor == null) {
                         val context = view.context
                         binding.noCollectionsHeader.setTextColor(
@@ -78,6 +81,25 @@ class NoCollectionsMessageViewHolder(
                         binding.noCollectionsDescription.setTextColor(color)
                         binding.removeCollectionPlaceholder.setColorFilter(color)
                     }
+
+                    var buttonColor = ContextCompat.getColor(view.context, R.color.fx_mobile_action_color_primary)
+                    var buttonTextColor = ContextCompat.getColor(
+                        view.context,
+                        R.color.fx_mobile_text_color_action_primary,
+                    )
+                    wallpaperState.runIfWallpaperCardColorsAreAvailable { _, _ ->
+                        buttonColor = ContextCompat.getColor(view.context, R.color.fx_mobile_layer_color_1)
+
+                        if (!view.context.isSystemInDarkTheme()) {
+                            buttonTextColor = ContextCompat.getColor(
+                                view.context,
+                                R.color.fx_mobile_text_color_action_secondary,
+                            )
+                        }
+                    }
+
+                    binding.addTabsToCollectionsButton.setBackgroundColor(buttonColor)
+                    binding.addTabsToCollectionsButton.setTextColor(buttonTextColor)
                 }
         }
     }


### PR DESCRIPTION
| Light | Dark |
| -- | -- |
| <img src="https://user-images.githubusercontent.com/87384386/199619659-0df3970f-67a0-416d-8a86-2597af459041.png" width=300/> | <img src="https://user-images.githubusercontent.com/87384386/199619612-f8da36c4-7cec-4894-9c73-5e1b790da47f.png" width=300/> |

(Ignore the blue wallpaper with the red card colors. Pardon the pun, but it's a Turning Red herring 😉)

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
Fixes #27469