### PR TITLE
Close #7227: Re-enable storage maintenance call.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -121,4 +121,9 @@ object FeatureFlags {
      * Enables the save to PDF feature.
      */
     const val saveToPDF = true
+
+    /**
+     * Enables storage maintenance feature
+     * */
+    val storageMaintenanceFeature = Config.channel.isNightlyOrDebug
 }

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -1035,11 +1035,6 @@ class Settings(private val appContext: Context) : PreferencesHolder {
         default = true,
     )
 
-    var lastPlacesStorageMaintenance by longPreference(
-        appContext.getPreferenceKey(R.string.pref_key_last_maintenance),
-        default = 0,
-    )
-
     fun addSearchWidgetInstalled(count: Int) {
         val key = appContext.getPreferenceKey(R.string.pref_key_search_widget_installed)
         val newValue = preferences.getInt(key, 0) + count

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -38,7 +38,6 @@
     <string name="pref_key_addons" translatable="false">pref_key_addons</string>
     <string name="pref_key_override_amo_user" translatable="false">pref_key_override_amo_user</string>
     <string name="pref_key_override_amo_collection" translatable="false">pref_key_override_amo_collection</string>
-    <string name="pref_key_last_maintenance" translatable="false">pref_key_last_maintenance</string>
     <string name="pref_key_help" translatable="false">pref_key_help</string>
     <string name="pref_key_rate" translatable="false">pref_key_rate</string>
     <string name="pref_key_about" translatable="false">pref_key_about</string>


### PR DESCRIPTION
Re-enable storage maintenance call by introducing WorkManager worker on A-C side and consuming it from Fenix. The work request is periodic and the repeat interval is 24h. It requires the device to be idle and not to have low battery. This feature is available only for Nightly for now.

Please take a look at [this PR](https://github.com/mozilla-mobile/firefox-android/pull/59) for the related A-C changes.

_**Note:** WorkManager does not ensure that the Worker will run exactly at the same time after the period delay passes, so the periodic waiting times may change while testing because of the work request constraints and OS operations. In addition, one of the work request's constraints is setRequiresDeviceIdle(true) and it is hard to meet immediately. Tried forcing the idle mode but could not trigger the worker right away. (My guess is the retry time intervals that are bound to BackoffPolicy which is, by default, EXPONENTIAL. Though, it is not quite clear from the docs whether OS retries the work request to run right after the constraints are met or it aligns with the BackoffPolicy.) I suspect that if the user is using the device actively, meeting the same 24h execution window for the work request is going be very hard._ 

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
Fixes #7227