### PR TITLE
For #27691 - Replace 'Pocket' word in all strings with placeholder

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/pocket/PocketStoriesComposables.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/pocket/PocketStoriesComposables.kt
@@ -457,7 +457,10 @@ fun PoweredByPocketHeader(
 
             Column {
                 Text(
-                    text = stringResource(R.string.pocket_stories_feature_title),
+                    text = stringResource(
+                        R.string.pocket_stories_feature_title_2,
+                        LocalContext.current.getString(R.string.pocket_product_name),
+                    ),
                     color = textColor,
                     style = FirefoxTheme.typography.caption,
                 )

--- a/app/src/main/java/org/mozilla/fenix/settings/HomeSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/HomeSettingsFragment.kt
@@ -104,6 +104,10 @@ class HomeSettingsFragment : PreferenceFragmentCompat() {
         requirePreference<SwitchPreference>(R.string.pref_key_pocket_homescreen_recommendations).apply {
             isVisible = FeatureFlags.isPocketRecommendationsFeatureEnabled(context)
             isChecked = context.settings().showPocketRecommendationsFeature
+            summary = context.getString(
+                R.string.customize_toggle_pocket_summary,
+                context.getString(R.string.pocket_product_name),
+            )
             onPreferenceChangeListener = object : SharedPreferenceUpdater() {
                 override fun onPreferenceChange(preference: Preference, newValue: Any?): Boolean {
                     CustomizeHome.preferenceToggled.record(

--- a/app/src/main/res/values/static_strings.xml
+++ b/app/src/main/res/values/static_strings.xml
@@ -26,6 +26,8 @@
     <string name="components_abbreviation" translatable="false">AC</string>
     <!-- Application Services abbreviation used in AboutFragment -->
     <string name="app_services_abbreviation" translatable="false">AS</string>
+    <!-- Name for the Pocket product -->
+    <string name="pocket_product_name" translatable="false">Pocket</string>
 
     <!-- Secret Settings Strings -->
     <!-- Label for the secret settings preference -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -447,8 +447,8 @@
     <string name="customize_toggle_pocket" moz:RemovedIn="108" tools:ignore="UnusedResources">Pocket</string>
     <!-- Title for the customize home screen section with Pocket. -->
     <string name="customize_toggle_pocket_2">Thought-provoking stories</string>
-    <!-- Summary for the customize home screen section with Pocket. -->
-    <string name="customize_toggle_pocket_summary">Articles powered by Pocket</string>
+    <!-- Summary for the customize home screen section with Pocket. The first parameter is product name Pocket -->
+    <string name="customize_toggle_pocket_summary">Articles powered by %s</string>
     <!-- Title for the customize home screen section with sponsored Pocket stories. -->
     <string name="customize_toggle_pocket_sponsored">Sponsored stories</string>
     <!-- Title for the opening wallpaper settings screen -->
@@ -1867,7 +1867,9 @@
     <!-- Text of a button allowing users to access an external url for more Pocket recommendations. -->
     <string name="pocket_stories_placeholder_text">Discover more</string>
     <!-- Title of an app feature. Smaller than a heading.-->
-    <string name="pocket_stories_feature_title">Powered by Pocket.</string>
+    <string name="pocket_stories_feature_title" moz:removedIn="108" tools:ignore="UnusedResources">Powered by Pocket.</string>
+    <!-- Title of an app feature. Smaller than a heading. The first parameter is product name Pocket -->
+    <string name="pocket_stories_feature_title_2">Powered by %s.</string>
     <!-- Caption for describing a certain feature. The placeholder is for a clickable text (eg: Learn more) which will load an url in a new tab when clicked.  -->
     <string name="pocket_stories_feature_caption">Part of the Firefox family. %s</string>
     <!-- Clickable text for opening an external link for more information about Pocket. -->


### PR DESCRIPTION
Replaced 'Pocket' word with placeholder which is set at runtime.

https://user-images.githubusercontent.com/35462038/199793833-378fe038-52d0-42a0-b9b4-6e17d9c07a38.mp4

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
Fixes #27691