### PR TITLE
For #27667 - Update the commit sha in .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,5 +1,5 @@
 # .git-blame-ignore-revs
 # For #27667 - Remove import-ordering from the list of disabled ktlint rules (#27680)
-463fcd53b8db5a43b0be7bf1a4c4bbe8f2a163e0
+9654b4dfb122b54b04369fe80a2f9c95811478e8
 # For #26844: Fix ktlint issues and remove them from baseline. (#26901)
 ffcef5ff2e3f78b6972dd16551f3f653b7035ccc


### PR DESCRIPTION
Have to update the commit sha with https://github.com/mozilla-mobile/fenix/commit/9654b4dfb122b54b04369fe80a2f9c95811478e8 since the original commit sha got updated when it was landed via mergify. 
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
Fixes #27667