### PR TITLE
Bug 1793823 - Disable perf tests running on P2.

### DIFF
--- a/taskcluster/ci/browsertime/kind.yml
+++ b/taskcluster/ci/browsertime/kind.yml
@@ -17,7 +17,6 @@ only-for-build-types:
 
 only-for-abis:
     - armeabi-v7a
-    - arm64-v8a
 
 task-defaults:
     attributes:
@@ -43,12 +42,10 @@ task-defaults:
         tier: 2
         platform:
             by-abi:
-                arm64-v8a: android-hw-p2-8-0-android-aarch64-shippable-qr/opt
                 armeabi-v7a: android-hw-a51-11-0-aarch64-shippable-qr/opt
     worker-type:
         by-abi:
             armeabi-v7a: t-bitbar-gw-perf-a51
-            arm64-v8a: t-bitbar-gw-perf-p2
     worker:
         max-run-time: 3600
         env:


### PR DESCRIPTION
This patch disables performance tests running on the P2.