### PR TITLE
For #27392 fix flaky verifyAboutFirefoxPreview UI test

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/SettingsRobot.kt
@@ -44,6 +44,7 @@ import org.junit.Assert.assertTrue
 import org.mozilla.fenix.R
 import org.mozilla.fenix.helpers.Constants.LISTS_MAXSWIPES
 import org.mozilla.fenix.helpers.Constants.PackageName.GOOGLE_PLAY_SERVICES
+import org.mozilla.fenix.helpers.Constants.RETRY_COUNT
 import org.mozilla.fenix.helpers.TestAssetHelper.waitingTime
 import org.mozilla.fenix.helpers.TestHelper.appName
 import org.mozilla.fenix.helpers.TestHelper.getStringResource
@@ -575,7 +576,21 @@ private fun rateOnGooglePlayHeading(): UiObject {
 }
 
 private fun aboutFirefoxHeading(): UiObject {
-    settingsList().scrollToEnd(LISTS_MAXSWIPES)
+    for (i in 1..RETRY_COUNT) {
+        try {
+            settingsList().scrollToEnd(LISTS_MAXSWIPES)
+            assertTrue(
+                mDevice.findObject(UiSelector().text("About $appName"))
+                    .waitForExists(waitingTime),
+            )
+
+            break
+        } catch (e: AssertionError) {
+            if (i == RETRY_COUNT) {
+                throw e
+            }
+        }
+    }
     return mDevice.findObject(UiSelector().text("About $appName"))
 }
 


### PR DESCRIPTION
For #27392 fix flaky `verifyAboutFirefoxPreview` UI test ✅ successfully ran 100x on Firebase.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
Fixes #27392