### PR TITLE
For #27746 - Move Top Sites text outside of backplating

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/TopSitesTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/TopSitesTest.kt
@@ -9,6 +9,7 @@ import androidx.test.uiautomator.UiDevice
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.R
@@ -235,6 +236,7 @@ class TopSitesTest {
 
     @SmokeTest
     @Test
+    @Ignore("Design was reverted: https://github.com/mozilla-mobile/fenix/issues/27714")
     fun verifySponsoredShortcutsListTest() {
         homeScreen {
             var sponsoredShortcutTitle = getSponsoredShortcutTitle(2)
@@ -253,6 +255,7 @@ class TopSitesTest {
     }
 
     @Test
+    @Ignore("Design was reverted: https://github.com/mozilla-mobile/fenix/issues/27714")
     fun openSponsoredShortcutTest() {
         var sponsoredShortcutTitle = ""
 
@@ -264,6 +267,7 @@ class TopSitesTest {
     }
 
     @Test
+    @Ignore("Design was reverted: https://github.com/mozilla-mobile/fenix/issues/27714")
     fun openSponsoredShortcutInPrivateBrowsingTest() {
         var sponsoredShortcutTitle = ""
 
@@ -276,6 +280,7 @@ class TopSitesTest {
     }
 
     @Test
+    @Ignore("Design was reverted: https://github.com/mozilla-mobile/fenix/issues/27714")
     fun verifySponsoredShortcutsSponsorsAndPrivacyOptionTest() {
         var sponsoredShortcutTitle = ""
 
@@ -288,6 +293,7 @@ class TopSitesTest {
     }
 
     @Test
+    @Ignore("Design was reverted: https://github.com/mozilla-mobile/fenix/issues/27714")
     fun verifySponsoredShortcutsSettingsOptionTest() {
         var sponsoredShortcutTitle = ""
 

--- a/app/src/main/java/org/mozilla/fenix/home/topsites/TopSiteItemViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/topsites/TopSiteItemViewHolder.kt
@@ -5,13 +5,17 @@
 package org.mozilla.fenix.home.topsites
 
 import android.annotation.SuppressLint
+import android.content.res.ColorStateList
 import android.view.MotionEvent
 import android.view.View
 import android.widget.PopupWindow
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.content.res.AppCompatResources.getDrawable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
+import androidx.core.widget.TextViewCompat
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.Dispatchers.IO
@@ -21,6 +25,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import mozilla.components.feature.top.sites.TopSite
 import mozilla.components.lib.state.ext.flowScoped
+import mozilla.components.support.ktx.android.content.getColorFromAttr
 import mozilla.components.support.ktx.kotlinx.coroutines.flow.ifChanged
 import org.mozilla.fenix.GleanMetrics.Pings
 import org.mozilla.fenix.GleanMetrics.TopSites
@@ -92,7 +97,24 @@ class TopSiteItemViewHolder(
                         }
                     }
 
-                    binding.topSiteCard.setCardBackgroundColor(backgroundColor)
+                    binding.faviconCard.setCardBackgroundColor(backgroundColor)
+
+                    val textColor = currentState.currentWallpaper.textColor
+                    if (textColor != null) {
+                        val color = Color(textColor).toArgb()
+                        val colorList = ColorStateList.valueOf(color)
+                        binding.topSiteTitle.setTextColor(color)
+                        binding.topSiteSubtitle.setTextColor(color)
+                        TextViewCompat.setCompoundDrawableTintList(binding.topSiteTitle, colorList)
+                    } else {
+                        binding.topSiteTitle.setTextColor(
+                            view.context.getColorFromAttr(R.attr.textPrimary),
+                        )
+                        binding.topSiteSubtitle.setTextColor(
+                            view.context.getColorFromAttr(R.attr.textSecondary),
+                        )
+                        TextViewCompat.setCompoundDrawableTintList(binding.topSiteTitle, null)
+                    }
                 }
         }
     }

--- a/app/src/main/res/layout/top_site_item.xml
+++ b/app/src/main/res/layout/top_site_item.xml
@@ -2,76 +2,65 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<FrameLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/top_site_item"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_marginBottom="@dimen/top_sites_item_margin_bottom"
+    android:orientation="vertical"
     android:focusable="true">
 
     <com.google.android.material.card.MaterialCardView
-        android:id="@+id/top_site_card"
-        style="@style/TopSite.Card">
+        android:id="@+id/favicon_card"
+        style="@style/TopSite.FaviconCard"
+        android:importantForAccessibility="noHideDescendants"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/top_site_item"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:orientation="vertical">
-
-            <com.google.android.material.imageview.ShapeableImageView
-                android:id="@+id/favicon_image"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintRight_toRightOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                style="@style/topSiteFavicon"
-                tools:src="@drawable/ic_pocket"/>
-
-            <LinearLayout
-                android:layout_width="wrap_content"
-                android:layout_height="0dp"
-                android:orientation="vertical"
-                android:gravity="bottom"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintRight_toRightOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/favicon_image"
-                app:layout_constraintBottom_toBottomOf="parent">
-
-                <TextView
-                    android:id="@+id/top_site_title"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center_horizontal"
-                    android:layout_marginTop="@dimen/top_sites_text_margin_top"
-                    android:drawablePadding="2dp"
-                    android:gravity="center"
-                    android:textAlignment="center"
-                    android:singleLine="true"
-                    android:textColor="@color/fx_mobile_text_color_primary"
-                    android:textSize="12sp"
-                    tools:ignore="RtlCompat,SmallSp"
-                    tools:text="Mozilla"/>
-
-                <TextView
-                    android:id="@+id/top_site_subtitle"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center_horizontal"
-                    android:gravity="center"
-                    android:textAlignment="center"
-                    android:singleLine="true"
-                    android:text="@string/top_sites_sponsored_label"
-                    android:textColor="@color/fx_mobile_text_color_secondary"
-                    android:textSize="11sp"
-                    android:visibility="gone"
-                    android:scrollbars="none"
-                    tools:ignore="RtlCompat,SmallSp"
-                    tools:visibility="visible"/>
-            </LinearLayout>
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
-
+        <com.google.android.material.imageview.ShapeableImageView
+            android:id="@+id/favicon_image"
+            style="@style/topSiteFavicon" />
     </com.google.android.material.card.MaterialCardView>
 
-</FrameLayout>
+    <TextView
+        android:id="@+id/top_site_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:maxWidth="84dp"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="@dimen/top_sites_text_margin_top"
+        android:drawablePadding="2dp"
+        android:gravity="center"
+        android:textAlignment="center"
+        android:singleLine="true"
+        android:textColor="@color/fx_mobile_text_color_primary"
+        android:textSize="12sp"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/favicon_card"
+        tools:ignore="RtlCompat,SmallSp"
+        tools:text="Mozilla"/>
+
+    <TextView
+        android:id="@+id/top_site_subtitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:maxWidth="84dp"
+        android:layout_gravity="center_horizontal"
+        android:gravity="center"
+        android:textAlignment="center"
+        android:singleLine="true"
+        android:text="@string/top_sites_sponsored_label"
+        android:textColor="@color/fx_mobile_text_color_secondary"
+        android:textSize="10sp"
+        android:visibility="invisible"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/top_site_title"
+        tools:ignore="RtlCompat,SmallSp"
+        tools:visibility="visible"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -174,6 +174,7 @@
     <dimen name="top_sites_favicon_corner_size">4dp</dimen>
 
     <dimen name="top_sites_card_size">60dp</dimen>
+    <dimen name="top_sites_card_margin_top">4dp</dimen>
     <dimen name="top_sites_card_padding">12dp</dimen>
     <dimen name="top_sites_card_elevation">6dp</dimen>
     <dimen name="top_sites_card_radius">8dp</dimen>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -167,16 +167,14 @@
     <dimen name="account_settings_device_name_min_height">48dp</dimen>
 
     <!-- Top sites  -->
-    <dimen name="top_sites_item_margin_top">4dp</dimen>
     <dimen name="top_sites_item_margin_bottom">12dp</dimen>
-    <dimen name="top_sites_text_margin_top">2dp</dimen>
+    <dimen name="top_sites_text_margin_top">6dp</dimen>
     <dimen name="top_sites_favicon_size">36dp</dimen>
     <dimen name="top_sites_favicon_elevation">0dp</dimen>
     <dimen name="top_sites_favicon_corner_size">4dp</dimen>
 
-    <dimen name="top_sites_card_height">84dp</dimen>
-    <dimen name="top_sites_card_width">72dp</dimen>
-    <dimen name="top_sites_card_padding">8dp</dimen>
+    <dimen name="top_sites_card_size">60dp</dimen>
+    <dimen name="top_sites_card_padding">12dp</dimen>
     <dimen name="top_sites_card_elevation">6dp</dimen>
     <dimen name="top_sites_card_radius">8dp</dimen>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -674,14 +674,11 @@
         <item name="behavior_halfExpandedRatio">0.001</item>
     </style>
 
-    <style name="TopSite.Card" parent="Mozac.Widgets.Favicon">
-        <item name="android:layout_width">@dimen/top_sites_card_width</item>
-        <item name="android:layout_height">@dimen/top_sites_card_height</item>
-        <item name="android:layout_marginTop">@dimen/top_sites_item_margin_top</item>
-        <item name="android:layout_marginBottom">@dimen/top_sites_item_margin_bottom</item>
-        <item name="android:layout_gravity">center_horizontal</item>
-        <item name="android:importantForAccessibility">noHideDescendants</item>
-        <item name="contentPadding">@dimen/top_sites_card_padding</item>
+    <style name="TopSite.FaviconCard" parent="Mozac.Widgets.Favicon">
+        <item name="android:layout_width">@dimen/top_sites_card_size</item>
+        <item name="android:layout_height">@dimen/top_sites_card_size</item>
+        <item name="android:padding">@dimen/top_sites_card_padding</item>
+        <item name="cardBackgroundColor">?mozac_widget_favicon_background_color</item>
         <item name="cardCornerRadius">@dimen/top_sites_card_radius</item>
         <item name="cardElevation">@dimen/top_sites_card_elevation</item>
     </style>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -677,6 +677,7 @@
     <style name="TopSite.FaviconCard" parent="Mozac.Widgets.Favicon">
         <item name="android:layout_width">@dimen/top_sites_card_size</item>
         <item name="android:layout_height">@dimen/top_sites_card_size</item>
+        <item name="android:layout_marginTop">@dimen/top_sites_card_margin_top</item>
         <item name="android:padding">@dimen/top_sites_card_padding</item>
         <item name="cardBackgroundColor">?mozac_widget_favicon_background_color</item>
         <item name="cardCornerRadius">@dimen/top_sites_card_radius</item>


### PR DESCRIPTION
| Light | Dark |
| -- | -- | 
| <img src="https://user-images.githubusercontent.com/87384386/200399708-31aa3ea6-34c9-4a4e-86e5-784261ae1aa2.png" width=300/> | <img src="https://user-images.githubusercontent.com/87384386/200399809-127aba28-2351-418a-b33d-9fb6ce8d459c.png" width=300/>

| No wallpaper selected |
| -- | 
| <img src="https://user-images.githubusercontent.com/87384386/200399441-20a544e2-a481-4bfb-903b-d68ad3b3e4a9.png" width=300/>


**Changelog**
- Initial commit
    - The text has been moved outside of the backplating
    - The title/sponsor name is colored to the wallpaper text color
    - The pin is colored to the wallpaper text color
    - The “Sponsored” subtitle is colored to the wallpaper text color with an alpha of 0.66
- Removed transparency from "Sponsored"
- Rebased with `main` so the builds include the latest backplating changes.
- Split the commits: one for the layout revert, and one for any design changes
- Added ignores for UI tests that fail as a result of the reversion.
- Added a 4dp margin to the favicon card so the shadow fully renders. (screenshots updated)
- Created an issue and added issue number to commits and PR.
- PR feedback review
    - Re organized some of the text color setting.
    - Added back in `focusable` to root `View`

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.





### GitHub Automation
Fixes #27746