### PR TITLE
For#27697 - Set unified search toolbar icon before the screen is visible

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/library/bookmarks/toolbar/ToolbarView.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/bookmarks/toolbar/ToolbarView.kt
@@ -81,6 +81,8 @@ class ToolbarView(
                 false
             }
 
+            setDefaultIcon()
+
             setOnEditListener(
                 object : mozilla.components.concept.toolbar.Toolbar.OnEditListener {
                     override fun onCancelEditing(): Boolean {
@@ -110,7 +112,9 @@ class ToolbarView(
             view.editMode()
             isInitialized = true
         }
+    }
 
+    private fun setDefaultIcon() {
         val bookmarkSearchIcon =
             AppCompatResources.getDrawable(context, R.drawable.ic_bookmarks_menu)
 

--- a/app/src/main/java/org/mozilla/fenix/library/history/toolbar/ToolbarView.kt
+++ b/app/src/main/java/org/mozilla/fenix/library/history/toolbar/ToolbarView.kt
@@ -81,6 +81,8 @@ class ToolbarView(
                 false
             }
 
+            setDefaultIcon()
+
             setOnEditListener(
                 object : mozilla.components.concept.toolbar.Toolbar.OnEditListener {
                     override fun onCancelEditing(): Boolean {
@@ -110,7 +112,9 @@ class ToolbarView(
             view.editMode()
             isInitialized = true
         }
+    }
 
+    private fun setDefaultIcon() {
         val historySearchIcon = AppCompatResources.getDrawable(context, R.drawable.ic_history)
 
         historySearchIcon?.let {

--- a/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/SearchDialogFragment.kt
@@ -47,6 +47,7 @@ import kotlinx.coroutines.launch
 import mozilla.components.browser.domains.autocomplete.ShippedDomainsProvider
 import mozilla.components.browser.state.search.SearchEngine
 import mozilla.components.browser.state.state.searchEngines
+import mozilla.components.browser.state.state.selectedOrDefaultSearchEngine
 import mozilla.components.browser.toolbar.BrowserToolbar
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.concept.menu.candidate.DrawableMenuIcon
@@ -758,6 +759,7 @@ class SearchDialogFragment : AppCompatDialogFragment(), UserInteractionHandler {
         toolbarView.view.addEditActionStart(
             SearchSelectorToolbarAction(
                 store = store,
+                defaultSearchEngine = requireComponents.core.store.state.search.selectedOrDefaultSearchEngine,
                 menu = searchSelectorMenu,
             ),
         )

--- a/app/src/main/java/org/mozilla/fenix/search/toolbar/SearchSelectorToolbarAction.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/toolbar/SearchSelectorToolbarAction.kt
@@ -36,6 +36,7 @@ import org.mozilla.fenix.search.SearchDialogFragmentStore
  */
 class SearchSelectorToolbarAction(
     private val store: SearchDialogFragmentStore,
+    private val defaultSearchEngine: SearchEngine?,
     private val menu: SearchSelectorMenu,
 ) : Toolbar.Action {
     private var updateIconJob: Job? = null
@@ -43,7 +44,17 @@ class SearchSelectorToolbarAction(
     override fun createView(parent: ViewGroup): View {
         val context = parent.context
 
+        // Only search engines with type APPLICATION (tabs, history, bookmarks) will have a valid icon at this time.
+        // For other search engines show the icon of the default search engine which should be shown in the selector.
+        val initialSearchEngine = store.state.searchEngineSource.searchEngine ?: defaultSearchEngine
         return SearchSelector(context).apply {
+            initialSearchEngine?.let {
+                this.setIcon(
+                    icon = initialSearchEngine.getScaledIcon(this.context),
+                    contentDescription = initialSearchEngine.name,
+                )
+            }
+
             setOnClickListener {
                 val orientation = if (context.settings().shouldUseBottomToolbar) {
                     Orientation.UP

--- a/app/src/test/java/org/mozilla/fenix/search/toolbar/SearchSelectorToolbarActionTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/search/toolbar/SearchSelectorToolbarActionTest.kt
@@ -48,7 +48,6 @@ import java.util.UUID
 @RunWith(FenixRobolectricTestRunner::class)
 class SearchSelectorToolbarActionTest {
 
-    @MockK(relaxed = true)
     private lateinit var store: SearchDialogFragmentStore
 
     @MockK(relaxed = true)
@@ -66,6 +65,7 @@ class SearchSelectorToolbarActionTest {
     @Before
     fun setup() {
         MockKAnnotations.init(this)
+        store = SearchDialogFragmentStore(testSearchFragmentState)
 
         every { testContext.settings() } returns settings
     }
@@ -75,6 +75,7 @@ class SearchSelectorToolbarActionTest {
         val action = spyk(
             SearchSelectorToolbarAction(
                 store = store,
+                defaultSearchEngine = null,
                 menu = menu,
             ),
         )
@@ -103,8 +104,7 @@ class SearchSelectorToolbarActionTest {
         mockkStatic("org.mozilla.fenix.search.toolbar.SearchSelectorToolbarActionKt") {
             val searchEngineIcon: BitmapDrawable = mockk(relaxed = true)
             every { any<SearchEngine>().getScaledIcon(any()) } returns searchEngineIcon
-            val store = SearchDialogFragmentStore(testSearchFragmentState)
-            val selector = SearchSelectorToolbarAction(store, mockk())
+            val selector = SearchSelectorToolbarAction(store, mockk(), mockk())
             val view = spyk(SearchSelector(testContext))
 
             selector.bind(view)
@@ -132,8 +132,7 @@ class SearchSelectorToolbarActionTest {
         mockkStatic("org.mozilla.fenix.search.toolbar.SearchSelectorToolbarActionKt") {
             val searchEngineIcon: BitmapDrawable = mockk(relaxed = true)
             every { any<SearchEngine>().getScaledIcon(any()) } returns searchEngineIcon
-            val store = SearchDialogFragmentStore(testSearchFragmentState)
-            val selector = SearchSelectorToolbarAction(store, mockk())
+            val selector = SearchSelectorToolbarAction(store, mockk(), mockk())
             val view = spyk(SearchSelector(testContext))
 
             selector.bind(view)
@@ -162,8 +161,7 @@ class SearchSelectorToolbarActionTest {
         mockkStatic("org.mozilla.fenix.search.toolbar.SearchSelectorToolbarActionKt") {
             val searchEngineIcon: BitmapDrawable = mockk(relaxed = true)
             every { any<SearchEngine>().getScaledIcon(any()) } returns searchEngineIcon
-            val store = SearchDialogFragmentStore(testSearchFragmentState)
-            val selector = SearchSelectorToolbarAction(store, mockk())
+            val selector = SearchSelectorToolbarAction(store, mockk(), mockk())
             val view = spyk(SearchSelector(testContext))
 
             // Test an initial change


### PR DESCRIPTION
Before Video:

https://user-images.githubusercontent.com/32488956/200375376-ab40c5f4-5124-48b5-98b6-a99640e96f35.mp4

After Video

https://user-images.githubusercontent.com/32488956/200375426-680b643d-7f8c-4dd5-8c23-4cbcd87e0ffe.mp4

As you can see in the video, the fix should work for the bookmarks and history toolbar as well.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
Fixes #27697