### PR TITLE
Close #27023: Add capability to override telemetry URL using local properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,11 @@ If you wish to use a Nimbus server during local development, you can add a `http
 
 Testing experimental branches should be possible without a server.
 
+### Using custom Glean servers during local development
+If you wish to use a custom Glean server during local development, you can add a `https://` endpoint to the `local.properties` file.
+
+- `glean.custom.server.url`
+
 ### GeckoView
 Specify a relative path to your local `mozilla-central` checkout via `dependencySubstitutions.geckoviewTopsrcdir`,
 and optional a path to m-c object directory via `dependencySubstitutions.geckoviewTopobjdir`.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -366,6 +366,21 @@ android.applicationVariants.all { variant ->
     }
 
 // -------------------------------------------------------------------------------------------------
+// Glean: Read custom server URL from local.properties of a local file if it exists
+// -------------------------------------------------------------------------------------------------
+
+    print("Glean custom server URL: ")
+
+    if (gradle.hasProperty("localProperties.glean.custom.server.url")) {
+        def url=gradle.getProperty("localProperties.glean.custom.server.url")
+        buildConfigField 'String', 'GLEAN_CUSTOM_URL', url
+        println "(Added from local.properties file)"
+    } else {
+        buildConfigField 'String', 'GLEAN_CUSTOM_URL', 'null'
+        println("--")
+    }
+
+// -------------------------------------------------------------------------------------------------
 // BuildConfig: Set flag for official builds; similar to MOZILLA_OFFICIAL in mozilla-central.
 // -------------------------------------------------------------------------------------------------
 

--- a/app/src/main/java/org/mozilla/fenix/ext/Configuration.kt
+++ b/app/src/main/java/org/mozilla/fenix/ext/Configuration.kt
@@ -7,16 +7,21 @@ package org.mozilla.fenix.ext
 import android.content.Context
 import androidx.preference.PreferenceManager
 import mozilla.components.service.glean.config.Configuration
+import org.mozilla.fenix.BuildConfig
 import org.mozilla.fenix.R
 
 /**
  * Get custom Glean server URL if available.
  */
 fun getCustomGleanServerUrlIfAvailable(context: Context): String? {
-    return PreferenceManager.getDefaultSharedPreferences(context).getString(
-        context.getPreferenceKey(R.string.pref_key_custom_glean_server_url),
-        null,
-    )
+    return if (BuildConfig.GLEAN_CUSTOM_URL.isNullOrEmpty()) {
+        PreferenceManager.getDefaultSharedPreferences(context).getString(
+            context.getPreferenceKey(R.string.pref_key_custom_glean_server_url),
+            null,
+        )
+    } else {
+        BuildConfig.GLEAN_CUSTOM_URL
+    }
 }
 
 /**

--- a/app/src/main/java/org/mozilla/fenix/settings/SecretSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SecretSettingsFragment.kt
@@ -9,6 +9,7 @@ import androidx.preference.EditTextPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreference
+import org.mozilla.fenix.BuildConfig
 import org.mozilla.fenix.Config
 import org.mozilla.fenix.FeatureFlags
 import org.mozilla.fenix.R
@@ -58,7 +59,7 @@ class SecretSettingsFragment : PreferenceFragmentCompat() {
 
         // for performance reasons, this is only available in Nightly or Debug builds
         requirePreference<EditTextPreference>(R.string.pref_key_custom_glean_server_url).apply {
-            isVisible = Config.channel.isNightlyOrDebug
+            isVisible = Config.channel.isNightlyOrDebug && BuildConfig.GLEAN_CUSTOM_URL.isNullOrEmpty()
         }
     }
 }


### PR DESCRIPTION
### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.




### GitHub Automation
Fixes #27023