### PR TITLE
Issue #27759: Add link to storageMaintenance flag

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -123,7 +123,9 @@ object FeatureFlags {
     const val saveToPDF = true
 
     /**
-     * Enables storage maintenance feature
+     * Enables storage maintenance feature.
+     *
+     * Feature flag tracking: https://github.com/mozilla-mobile/fenix/issues/27759
      * */
     val storageMaintenanceFeature = Config.channel.isNightlyOrDebug
 }


### PR DESCRIPTION
Adding a link to the issue I filed to keep a list of blockers or discuss when we need to let this feature ride the trains.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.
Fixes #27759