### PR TITLE
Update mergify queue conditions to account for update-nimbus-experime…

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,18 +3,7 @@ queue_rules:
     conditions:
       - or:
         - status-success=complete-pr
-        - and:
-          # For more context, see "Auto Merge" rules down below
-          - status-success=complete-push
-          - or:
-            - and:
-              - base~=^releases[_/].*
-              - or:
-                - head~=^automation/sync-strings-\d+
-                - head~=^relbot/fenix-\d+
-            - and:
-              - base=main
-              - head~=^relbot/AC-Nightly-.+
+        - status-success=complete-push
 pull_request_rules:
   - name: Resolve conflict
     conditions:


### PR DESCRIPTION
…nts PRs

The update-nimbus-experiments workflow creates PRs that don't schedule a `complete-pr` task (because the github-actions bot is untrusted), but in this case we have a `complete-push` task which is good enough.



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
