### PR TITLE
For #27746 - Move Top Sites text outside of backplating (backport #27711)

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/TopSitesTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/TopSitesTest.kt
@@ -9,6 +9,7 @@ import androidx.test.uiautomator.UiDevice
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.mozilla.fenix.R
@@ -235,6 +236,7 @@ class TopSitesTest {
 
     @SmokeTest
     @Test
+    @Ignore("Design was reverted: https://github.com/mozilla-mobile/fenix/issues/27714")
     fun verifySponsoredShortcutsListTest() {
         homeScreen {
             var sponsoredShortcutTitle = getSponsoredShortcutTitle(2)
@@ -253,6 +255,7 @@ class TopSitesTest {
     }
 
     @Test
+    @Ignore("Design was reverted: https://github.com/mozilla-mobile/fenix/issues/27714")
     fun openSponsoredShortcutTest() {
         var sponsoredShortcutTitle = ""
 
@@ -264,6 +267,7 @@ class TopSitesTest {
     }
 
     @Test
+    @Ignore("Design was reverted: https://github.com/mozilla-mobile/fenix/issues/27714")
     fun openSponsoredShortcutInPrivateBrowsingTest() {
         var sponsoredShortcutTitle = ""
 
@@ -276,6 +280,7 @@ class TopSitesTest {
     }
 
     @Test
+    @Ignore("Design was reverted: https://github.com/mozilla-mobile/fenix/issues/27714")
     fun verifySponsoredShortcutsSponsorsAndPrivacyOptionTest() {
         var sponsoredShortcutTitle = ""
 
@@ -288,6 +293,7 @@ class TopSitesTest {
     }
 
     @Test
+    @Ignore("Design was reverted: https://github.com/mozilla-mobile/fenix/issues/27714")
     fun verifySponsoredShortcutsSettingsOptionTest() {
         var sponsoredShortcutTitle = ""
 

--- a/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/sessioncontrol/SessionControlAdapter.kt
@@ -309,6 +309,7 @@ class SessionControlAdapter(
             TopPlaceholderViewHolder.LAYOUT_ID -> TopPlaceholderViewHolder(view)
             TopSitePagerViewHolder.LAYOUT_ID -> TopSitePagerViewHolder(
                 view = view,
+                appStore = components.appStore,
                 viewLifecycleOwner = viewLifecycleOwner,
                 interactor = interactor,
             )

--- a/app/src/main/java/org/mozilla/fenix/home/topsites/TopSitePagerViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/topsites/TopSitePagerViewHolder.kt
@@ -12,18 +12,20 @@ import androidx.viewpager2.widget.ViewPager2
 import mozilla.components.feature.top.sites.TopSite
 import org.mozilla.fenix.GleanMetrics.TopSites
 import org.mozilla.fenix.R
+import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.databinding.ComponentTopSitesPagerBinding
 import org.mozilla.fenix.home.sessioncontrol.AdapterItem
 import org.mozilla.fenix.home.sessioncontrol.TopSiteInteractor
 
 class TopSitePagerViewHolder(
     view: View,
+    appStore: AppStore,
     viewLifecycleOwner: LifecycleOwner,
     interactor: TopSiteInteractor,
 ) : RecyclerView.ViewHolder(view) {
 
     private val binding = ComponentTopSitesPagerBinding.bind(view)
-    private val topSitesPagerAdapter = TopSitesPagerAdapter(viewLifecycleOwner, interactor)
+    private val topSitesPagerAdapter = TopSitesPagerAdapter(appStore, viewLifecycleOwner, interactor)
     private val pageIndicator = binding.pageIndicator
     private var currentPage = 0
 

--- a/app/src/main/java/org/mozilla/fenix/home/topsites/TopSiteViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/topsites/TopSiteViewHolder.kt
@@ -9,17 +9,19 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.recyclerview.widget.RecyclerView
 import mozilla.components.feature.top.sites.TopSite
 import org.mozilla.fenix.R
+import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.databinding.ComponentTopSitesBinding
 import org.mozilla.fenix.home.sessioncontrol.TopSiteInteractor
 import org.mozilla.fenix.utils.AccessibilityGridLayoutManager
 
 class TopSiteViewHolder(
     view: View,
+    appStore: AppStore,
     viewLifecycleOwner: LifecycleOwner,
     interactor: TopSiteInteractor,
 ) : RecyclerView.ViewHolder(view) {
 
-    private val topSitesAdapter = TopSitesAdapter(viewLifecycleOwner, interactor)
+    private val topSitesAdapter = TopSitesAdapter(appStore, viewLifecycleOwner, interactor)
     val binding = ComponentTopSitesBinding.bind(view)
 
     init {

--- a/app/src/main/java/org/mozilla/fenix/home/topsites/TopSitesAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/topsites/TopSitesAdapter.kt
@@ -10,17 +10,19 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import mozilla.components.feature.top.sites.TopSite
+import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.home.sessioncontrol.TopSiteInteractor
 import org.mozilla.fenix.perf.StartupTimeline
 
 class TopSitesAdapter(
+    private val appStore: AppStore,
     private val viewLifecycleOwner: LifecycleOwner,
     private val interactor: TopSiteInteractor,
 ) : ListAdapter<TopSite, TopSiteItemViewHolder>(TopSitesDiffCallback) {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TopSiteItemViewHolder {
         val view = LayoutInflater.from(parent.context)
             .inflate(TopSiteItemViewHolder.LAYOUT_ID, parent, false)
-        return TopSiteItemViewHolder(view, viewLifecycleOwner, interactor)
+        return TopSiteItemViewHolder(view, appStore, viewLifecycleOwner, interactor)
     }
 
     override fun onBindViewHolder(holder: TopSiteItemViewHolder, position: Int) {

--- a/app/src/main/java/org/mozilla/fenix/home/topsites/TopSitesPagerAdapter.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/topsites/TopSitesPagerAdapter.kt
@@ -11,11 +11,13 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import mozilla.components.feature.top.sites.TopSite
+import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.home.sessioncontrol.AdapterItem.TopSitePagerPayload
 import org.mozilla.fenix.home.sessioncontrol.TopSiteInteractor
 import org.mozilla.fenix.home.topsites.TopSitePagerViewHolder.Companion.TOP_SITES_PER_PAGE
 
 class TopSitesPagerAdapter(
+    private val appStore: AppStore,
     private val viewLifecycleOwner: LifecycleOwner,
     private val interactor: TopSiteInteractor,
 ) : ListAdapter<List<TopSite>, TopSiteViewHolder>(TopSiteListDiffCallback) {
@@ -23,7 +25,7 @@ class TopSitesPagerAdapter(
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TopSiteViewHolder {
         val view = LayoutInflater.from(parent.context)
             .inflate(TopSiteViewHolder.LAYOUT_ID, parent, false)
-        return TopSiteViewHolder(view, viewLifecycleOwner, interactor)
+        return TopSiteViewHolder(view, appStore, viewLifecycleOwner, interactor)
     }
 
     override fun onBindViewHolder(

--- a/app/src/main/res/layout/top_site_item.xml
+++ b/app/src/main/res/layout/top_site_item.xml
@@ -2,75 +2,65 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<FrameLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/top_site_item"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_marginBottom="@dimen/top_sites_item_margin_bottom"
+    android:orientation="vertical"
     android:focusable="true">
 
     <com.google.android.material.card.MaterialCardView
-        style="@style/TopSite.Card">
+        android:id="@+id/favicon_card"
+        style="@style/TopSite.FaviconCard"
+        android:importantForAccessibility="noHideDescendants"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/top_site_item"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:orientation="vertical">
-
-            <com.google.android.material.imageview.ShapeableImageView
-                android:id="@+id/favicon_image"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintRight_toRightOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                style="@style/topSiteFavicon"
-                tools:src="@drawable/ic_pocket"/>
-
-            <LinearLayout
-                android:layout_width="wrap_content"
-                android:layout_height="0dp"
-                android:orientation="vertical"
-                android:gravity="bottom"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintRight_toRightOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/favicon_image"
-                app:layout_constraintBottom_toBottomOf="parent">
-
-                <TextView
-                    android:id="@+id/top_site_title"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center_horizontal"
-                    android:layout_marginTop="@dimen/top_sites_text_margin_top"
-                    android:drawablePadding="2dp"
-                    android:gravity="center"
-                    android:textAlignment="center"
-                    android:singleLine="true"
-                    android:textColor="@color/fx_mobile_text_color_primary"
-                    android:textSize="12sp"
-                    tools:ignore="RtlCompat,SmallSp"
-                    tools:text="Mozilla"/>
-
-                <TextView
-                    android:id="@+id/top_site_subtitle"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center_horizontal"
-                    android:gravity="center"
-                    android:textAlignment="center"
-                    android:singleLine="true"
-                    android:text="@string/top_sites_sponsored_label"
-                    android:textColor="@color/fx_mobile_text_color_secondary"
-                    android:textSize="11sp"
-                    android:visibility="gone"
-                    android:scrollbars="none"
-                    tools:ignore="RtlCompat,SmallSp"
-                    tools:visibility="visible"/>
-            </LinearLayout>
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
-
+        <com.google.android.material.imageview.ShapeableImageView
+            android:id="@+id/favicon_image"
+            style="@style/topSiteFavicon" />
     </com.google.android.material.card.MaterialCardView>
 
-</FrameLayout>
+    <TextView
+        android:id="@+id/top_site_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:maxWidth="84dp"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="@dimen/top_sites_text_margin_top"
+        android:drawablePadding="2dp"
+        android:gravity="center"
+        android:textAlignment="center"
+        android:singleLine="true"
+        android:textColor="@color/fx_mobile_text_color_primary"
+        android:textSize="12sp"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/favicon_card"
+        tools:ignore="RtlCompat,SmallSp"
+        tools:text="Mozilla"/>
+
+    <TextView
+        android:id="@+id/top_site_subtitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:maxWidth="84dp"
+        android:layout_gravity="center_horizontal"
+        android:gravity="center"
+        android:textAlignment="center"
+        android:singleLine="true"
+        android:text="@string/top_sites_sponsored_label"
+        android:textColor="@color/fx_mobile_text_color_secondary"
+        android:textSize="10sp"
+        android:visibility="invisible"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/top_site_title"
+        tools:ignore="RtlCompat,SmallSp"
+        tools:visibility="visible"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -174,6 +174,7 @@
     <dimen name="top_sites_favicon_corner_size">4dp</dimen>
 
     <dimen name="top_sites_card_size">60dp</dimen>
+    <dimen name="top_sites_card_margin_top">4dp</dimen>
     <dimen name="top_sites_card_padding">12dp</dimen>
     <dimen name="top_sites_card_elevation">6dp</dimen>
     <dimen name="top_sites_card_radius">8dp</dimen>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -167,16 +167,14 @@
     <dimen name="account_settings_device_name_min_height">48dp</dimen>
 
     <!-- Top sites  -->
-    <dimen name="top_sites_item_margin_top">4dp</dimen>
     <dimen name="top_sites_item_margin_bottom">12dp</dimen>
-    <dimen name="top_sites_text_margin_top">2dp</dimen>
+    <dimen name="top_sites_text_margin_top">6dp</dimen>
     <dimen name="top_sites_favicon_size">36dp</dimen>
     <dimen name="top_sites_favicon_elevation">0dp</dimen>
     <dimen name="top_sites_favicon_corner_size">4dp</dimen>
 
-    <dimen name="top_sites_card_height">84dp</dimen>
-    <dimen name="top_sites_card_width">72dp</dimen>
-    <dimen name="top_sites_card_padding">8dp</dimen>
+    <dimen name="top_sites_card_size">60dp</dimen>
+    <dimen name="top_sites_card_padding">12dp</dimen>
     <dimen name="top_sites_card_elevation">6dp</dimen>
     <dimen name="top_sites_card_radius">8dp</dimen>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -674,14 +674,10 @@
         <item name="behavior_halfExpandedRatio">0.001</item>
     </style>
 
-    <style name="TopSite.Card" parent="Mozac.Widgets.Favicon">
-        <item name="android:layout_width">@dimen/top_sites_card_width</item>
-        <item name="android:layout_height">@dimen/top_sites_card_height</item>
-        <item name="android:layout_marginTop">@dimen/top_sites_item_margin_top</item>
-        <item name="android:layout_marginBottom">@dimen/top_sites_item_margin_bottom</item>
-        <item name="android:layout_gravity">center_horizontal</item>
-        <item name="android:importantForAccessibility">noHideDescendants</item>
-        <item name="contentPadding">@dimen/top_sites_card_padding</item>
+    <style name="TopSite.FaviconCard" parent="Mozac.Widgets.Favicon">
+        <item name="android:layout_width">@dimen/top_sites_card_size</item>
+        <item name="android:layout_height">@dimen/top_sites_card_size</item>
+        <item name="android:padding">@dimen/top_sites_card_padding</item>
         <item name="cardBackgroundColor">?mozac_widget_favicon_background_color</item>
         <item name="cardCornerRadius">@dimen/top_sites_card_radius</item>
         <item name="cardElevation">@dimen/top_sites_card_elevation</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -677,6 +677,7 @@
     <style name="TopSite.FaviconCard" parent="Mozac.Widgets.Favicon">
         <item name="android:layout_width">@dimen/top_sites_card_size</item>
         <item name="android:layout_height">@dimen/top_sites_card_size</item>
+        <item name="android:layout_marginTop">@dimen/top_sites_card_margin_top</item>
         <item name="android:padding">@dimen/top_sites_card_padding</item>
         <item name="cardBackgroundColor">?mozac_widget_favicon_background_color</item>
         <item name="cardCornerRadius">@dimen/top_sites_card_radius</item>

--- a/app/src/test/java/org/mozilla/fenix/home/topsites/TopSiteItemViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/topsites/TopSiteItemViewHolderTest.kt
@@ -23,6 +23,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.fenix.GleanMetrics.Pings
 import org.mozilla.fenix.GleanMetrics.TopSites
+import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.databinding.TopSiteItemBinding
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
@@ -37,6 +38,7 @@ class TopSiteItemViewHolderTest {
     private lateinit var binding: TopSiteItemBinding
     private lateinit var interactor: TopSiteInteractor
     private lateinit var lifecycleOwner: LifecycleOwner
+    private lateinit var appStore: AppStore
 
     private val pocket = TopSite.Default(
         id = 1L,
@@ -50,13 +52,14 @@ class TopSiteItemViewHolderTest {
         binding = TopSiteItemBinding.inflate(LayoutInflater.from(testContext))
         interactor = mockk(relaxed = true)
         lifecycleOwner = mockk(relaxed = true)
+        appStore = mockk(relaxed = true)
 
         every { testContext.components.core.icons } returns BrowserIcons(testContext, mockk(relaxed = true))
     }
 
     @Test
     fun `calls interactor on click`() {
-        TopSiteItemViewHolder(binding.root, lifecycleOwner, interactor).bind(pocket, position = 0)
+        TopSiteItemViewHolder(binding.root, appStore, lifecycleOwner, interactor).bind(pocket, position = 0)
 
         binding.topSiteItem.performClick()
         verify { interactor.onSelectTopSite(pocket, position = 0) }
@@ -65,7 +68,7 @@ class TopSiteItemViewHolderTest {
     @Test
     fun `calls interactor on long click`() {
         every { testContext.components.analytics } returns mockk(relaxed = true)
-        TopSiteItemViewHolder(binding.root, lifecycleOwner, interactor).bind(pocket, position = 0)
+        TopSiteItemViewHolder(binding.root, appStore, lifecycleOwner, interactor).bind(pocket, position = 0)
 
         binding.topSiteItem.performLongClick()
         verify { interactor.onTopSiteMenuOpened() }
@@ -80,7 +83,7 @@ class TopSiteItemViewHolderTest {
             createdAt = 0,
         )
 
-        TopSiteItemViewHolder(binding.root, lifecycleOwner, interactor).bind(defaultTopSite, position = 0)
+        TopSiteItemViewHolder(binding.root, appStore, lifecycleOwner, interactor).bind(defaultTopSite, position = 0)
         val pinIndicator = binding.topSiteTitle.compoundDrawables[0]
 
         assertNotNull(pinIndicator)
@@ -95,7 +98,7 @@ class TopSiteItemViewHolderTest {
             createdAt = 0,
         )
 
-        TopSiteItemViewHolder(binding.root, lifecycleOwner, interactor).bind(pinnedTopSite, position = 0)
+        TopSiteItemViewHolder(binding.root, appStore, lifecycleOwner, interactor).bind(pinnedTopSite, position = 0)
         val pinIndicator = binding.topSiteTitle.compoundDrawables[0]
 
         assertNotNull(pinIndicator)
@@ -110,7 +113,7 @@ class TopSiteItemViewHolderTest {
             createdAt = 0,
         )
 
-        TopSiteItemViewHolder(binding.root, lifecycleOwner, interactor).bind(frecentTopSite, position = 0)
+        TopSiteItemViewHolder(binding.root, appStore, lifecycleOwner, interactor).bind(frecentTopSite, position = 0)
         val pinIndicator = binding.topSiteTitle.compoundDrawables[0]
 
         assertNull(pinIndicator)
@@ -144,7 +147,7 @@ class TopSiteItemViewHolderTest {
             topSiteImpressionSubmitted = true
         }
 
-        TopSiteItemViewHolder(binding.root, lifecycleOwner, interactor).submitTopSitesImpressionPing(topSite, position)
+        TopSiteItemViewHolder(binding.root, appStore, lifecycleOwner, interactor).submitTopSitesImpressionPing(topSite, position)
 
         assertNotNull(TopSites.contileImpression.testGetValue())
 

--- a/app/src/test/java/org/mozilla/fenix/home/topsites/TopSiteViewHolderTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/topsites/TopSiteViewHolderTest.kt
@@ -13,6 +13,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mozilla.fenix.components.AppStore
 import org.mozilla.fenix.databinding.ComponentTopSitesBinding
 import org.mozilla.fenix.helpers.FenixRobolectricTestRunner
 import org.mozilla.fenix.home.sessioncontrol.TopSiteInteractor
@@ -23,17 +24,19 @@ class TopSiteViewHolderTest {
     private lateinit var binding: ComponentTopSitesBinding
     private lateinit var lifecycleOwner: LifecycleOwner
     private lateinit var interactor: TopSiteInteractor
+    private lateinit var appStore: AppStore
 
     @Before
     fun setup() {
         binding = ComponentTopSitesBinding.inflate(LayoutInflater.from(testContext))
         interactor = mockk(relaxed = true)
         lifecycleOwner = mockk(relaxed = true)
+        appStore = mockk(relaxed = true)
     }
 
     @Test
     fun `binds list of top sites`() {
-        TopSiteViewHolder(binding.root, lifecycleOwner, interactor).bind(
+        TopSiteViewHolder(binding.root, appStore, lifecycleOwner, interactor).bind(
             listOf(
                 TopSite.Default(
                     id = 1L,

--- a/app/src/test/java/org/mozilla/fenix/home/topsites/TopSitesPagerAdapterTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/home/topsites/TopSitesPagerAdapterTest.kt
@@ -49,7 +49,7 @@ class TopSitesPagerAdapterTest {
 
     @Before
     fun setup() {
-        topSitesPagerAdapter = spyk(TopSitesPagerAdapter(mockk(), mockk()))
+        topSitesPagerAdapter = spyk(TopSitesPagerAdapter(mockk(), mockk(), mockk()))
     }
 
     @Test

--- a/app/src/test/java/org/mozilla/fenix/perf/StartupReportFullyDrawnTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/perf/StartupReportFullyDrawnTest.kt
@@ -53,7 +53,7 @@ class StartupReportFullyDrawnTest {
         holderItemView = spyk(binding.root)
         every { activity.findViewById<LinearLayout>(R.id.rootContainer) } returns rootContainer
         every { holderItemView.context } returns activity
-        holder = TopSiteItemViewHolder(holderItemView, mockk(), mockk())
+        holder = TopSiteItemViewHolder(holderItemView, mockk(), mockk(), mockk())
         every { rootContainer.viewTreeObserver } returns viewTreeObserver
         every { holderItemView.viewTreeObserver } returns viewTreeObserver
 


### PR DESCRIPTION
This fixes the conflict in https://github.com/mozilla-mobile/fenix/pull/27781

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
Fixes #27746