### PR TITLE
For #1938: Add "OLED" Black Theme

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
+++ b/app/src/main/java/org/mozilla/fenix/FeatureFlags.kt
@@ -128,4 +128,9 @@ object FeatureFlags {
      * Feature flag tracking: https://github.com/mozilla-mobile/fenix/issues/27759
      * */
     val storageMaintenanceFeature = Config.channel.isNightlyOrDebug
+
+    /**
+     * Allows the user to enable an "OLED Black" theme
+     */
+    val blackTheme = Config.channel.isNightlyOrDebug
 }

--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -509,7 +509,7 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
                     AppCompatDelegate.MODE_NIGHT_NO,
                 )
             }
-            settings.shouldUseDarkTheme -> {
+            settings.shouldUseDarkTheme || settings.shouldUseBlackTheme -> {
                 AppCompatDelegate.setDefaultNightMode(
                     AppCompatDelegate.MODE_NIGHT_YES,
                 )

--- a/app/src/main/java/org/mozilla/fenix/components/Core.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/Core.kt
@@ -519,7 +519,7 @@ class Core(
             (context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) ==
                 Configuration.UI_MODE_NIGHT_YES
         return when {
-            context.settings().shouldUseDarkTheme -> PreferredColorScheme.Dark
+            context.settings().shouldUseDarkTheme || context.settings().shouldUseBlackTheme -> PreferredColorScheme.Dark
             context.settings().shouldUseLightTheme -> PreferredColorScheme.Light
             inDark -> PreferredColorScheme.Dark
             else -> PreferredColorScheme.Light

--- a/app/src/main/java/org/mozilla/fenix/home/topsites/TopSiteItemViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/topsites/TopSiteItemViewHolder.kt
@@ -39,6 +39,7 @@ import org.mozilla.fenix.ext.loadIntoView
 import org.mozilla.fenix.ext.name
 import org.mozilla.fenix.home.sessioncontrol.TopSiteInteractor
 import org.mozilla.fenix.settings.SupportUtils
+import org.mozilla.fenix.theme.ThemeManager
 import org.mozilla.fenix.utils.view.ViewHolder
 
 @SuppressLint("ClickableViewAccessibility")
@@ -87,7 +88,8 @@ class TopSiteItemViewHolder(
             flow.map { state -> state.wallpaperState }
                 .ifChanged()
                 .collect { currentState ->
-                    var backgroundColor = ContextCompat.getColor(view.context, R.color.fx_mobile_layer_color_2)
+                    val colorResourceId = ThemeManager.resolveAttribute(R.attr.layer2, view.context)
+                    var backgroundColor = ContextCompat.getColor(view.context, colorResourceId)
 
                     currentState.runIfWallpaperCardColorsAreAvailable { cardColorLight, cardColorDark ->
                         backgroundColor = if (view.context.isSystemInDarkTheme()) {

--- a/app/src/main/java/org/mozilla/fenix/settings/CustomizationFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/CustomizationFragment.kt
@@ -29,6 +29,7 @@ import org.mozilla.fenix.utils.view.addToRadioGroup
 class CustomizationFragment : PreferenceFragmentCompat() {
     private lateinit var radioLightTheme: RadioButtonPreference
     private lateinit var radioDarkTheme: RadioButtonPreference
+    private lateinit var radioBlackTheme: RadioButtonPreference
     private lateinit var radioAutoBatteryTheme: RadioButtonPreference
     private lateinit var radioFollowDeviceTheme: RadioButtonPreference
 
@@ -45,6 +46,7 @@ class CustomizationFragment : PreferenceFragmentCompat() {
 
     private fun setupPreferences() {
         bindFollowDeviceTheme()
+        bindBlackTheme()
         bindDarkTheme()
         bindLightTheme()
         bindAutoBatteryTheme()
@@ -57,6 +59,7 @@ class CustomizationFragment : PreferenceFragmentCompat() {
         addToRadioGroup(
             radioLightTheme,
             radioDarkTheme,
+            radioBlackTheme,
             if (SDK_INT >= Build.VERSION_CODES.P) {
                 radioFollowDeviceTheme
             } else {
@@ -93,6 +96,13 @@ class CustomizationFragment : PreferenceFragmentCompat() {
         }
     }
 
+    private fun bindBlackTheme() {
+        radioBlackTheme = requirePreference(R.string.pref_key_black_theme)
+        radioBlackTheme.onClickListener {
+            setNewTheme(AppCompatDelegate.MODE_NIGHT_YES)
+        }
+    }
+
     private fun bindFollowDeviceTheme() {
         radioFollowDeviceTheme = requirePreference(R.string.pref_key_follow_device_theme)
         if (SDK_INT >= Build.VERSION_CODES.P) {
@@ -103,8 +113,9 @@ class CustomizationFragment : PreferenceFragmentCompat() {
     }
 
     private fun setNewTheme(mode: Int) {
-        if (AppCompatDelegate.getDefaultNightMode() == mode) return
-        AppCompatDelegate.setDefaultNightMode(mode)
+        if (AppCompatDelegate.getDefaultNightMode() != mode) {
+            AppCompatDelegate.setDefaultNightMode(mode)
+        }
         activity?.recreate()
         with(requireComponents.core) {
             engine.settings.preferredColorScheme = getPreferredColorScheme()

--- a/app/src/main/java/org/mozilla/fenix/settings/CustomizationFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/CustomizationFragment.kt
@@ -101,6 +101,7 @@ class CustomizationFragment : PreferenceFragmentCompat() {
         radioBlackTheme.onClickListener {
             setNewTheme(AppCompatDelegate.MODE_NIGHT_YES)
         }
+        radioBlackTheme.isVisible = FeatureFlags.blackTheme
     }
 
     private fun bindFollowDeviceTheme() {

--- a/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/TabsTrayFragment.kt
@@ -116,7 +116,11 @@ class TabsTrayFragment : AppCompatDialogFragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setStyle(STYLE_NO_TITLE, R.style.TabTrayDialogStyle)
+        if (requireContext().settings().shouldUseBlackTheme) {
+            setStyle(STYLE_NO_TITLE, R.style.NormalBlackTheme_TabTrayDialogStyle)
+        } else {
+            setStyle(STYLE_NO_TITLE, R.style.TabTrayDialogStyle)
+        }
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?) =

--- a/app/src/main/java/org/mozilla/fenix/tabstray/browser/BrowserTabViewHolder.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/browser/BrowserTabViewHolder.kt
@@ -18,6 +18,7 @@ import org.mozilla.fenix.databinding.TabTrayGridItemBinding
 import org.mozilla.fenix.ext.increaseTapArea
 import org.mozilla.fenix.selection.SelectionHolder
 import org.mozilla.fenix.tabstray.TabsTrayStore
+import org.mozilla.fenix.theme.ThemeManager
 import kotlin.math.max
 
 sealed class BrowserTabViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
@@ -94,6 +95,9 @@ sealed class BrowserTabViewHolder(itemView: View) : RecyclerView.ViewHolder(item
         itemView: View,
         featureName: String,
     ) : AbstractBrowserTabViewHolder(itemView, imageLoader, store, selectionHolder, featureName) {
+
+        private val nonSelectedColorId = ThemeManager.resolveAttribute(R.attr.layer1, itemView.context)
+
         override val thumbnailSize: Int
             get() = max(
                 itemView.resources.getDimensionPixelSize(R.dimen.tab_tray_list_item_thumbnail_height),
@@ -104,7 +108,7 @@ sealed class BrowserTabViewHolder(itemView: View) : RecyclerView.ViewHolder(item
             val color = if (showAsSelected) {
                 R.color.fx_mobile_layer_color_accent_opaque
             } else {
-                R.color.fx_mobile_layer_color_1
+                nonSelectedColorId
             }
             itemView.setBackgroundColor(
                 ContextCompat.getColor(

--- a/app/src/main/java/org/mozilla/fenix/tabstray/browser/SelectionBannerBinding.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/browser/SelectionBannerBinding.kt
@@ -26,6 +26,7 @@ import org.mozilla.fenix.tabstray.TabsTrayState.Mode
 import org.mozilla.fenix.tabstray.TabsTrayState.Mode.Select
 import org.mozilla.fenix.tabstray.TabsTrayStore
 import org.mozilla.fenix.tabstray.ext.showWithTheme
+import org.mozilla.fenix.theme.ThemeManager
 
 /**
  * A binding that shows/hides the multi-select banner of the selected count of tabs.
@@ -56,6 +57,10 @@ class SelectionBannerBinding(
      */
     class VisibilityModifier(vararg val views: View)
 
+    private val nonSelectModeColorId = ThemeManager.resolveAttribute(
+        R.attr.layer1,
+        backgroundView.context,
+    )
     private var isPreviousModeSelect = false
 
     override fun start() {
@@ -120,7 +125,7 @@ class SelectionBannerBinding(
             val colorResource = if (isSelectMode) {
                 R.color.fx_mobile_layer_color_accent
             } else {
-                R.color.fx_mobile_layer_color_1
+                nonSelectModeColorId
             }
 
             val color = ContextCompat.getColor(backgroundView.context, colorResource)

--- a/app/src/main/java/org/mozilla/fenix/tabstray/ext/BrowserMenu.kt
+++ b/app/src/main/java/org/mozilla/fenix/tabstray/ext/BrowserMenu.kt
@@ -9,17 +9,16 @@ import androidx.cardview.widget.CardView
 import androidx.core.content.ContextCompat
 import mozilla.components.browser.menu.BrowserMenu
 import org.mozilla.fenix.R
+import org.mozilla.fenix.theme.ThemeManager
 
 /**
  * Invokes [BrowserMenu.show] and applies the default theme color background.
  */
 fun BrowserMenu.showWithTheme(view: View) {
     show(view).also { popupMenu ->
+        val color = ThemeManager.resolveAttribute(R.attr.layer2, view.context)
         (popupMenu.contentView as? CardView)?.setCardBackgroundColor(
-            ContextCompat.getColor(
-                view.context,
-                R.color.fx_mobile_layer_color_2,
-            ),
+            ContextCompat.getColor(view.context, color),
         )
     }
 }

--- a/app/src/main/java/org/mozilla/fenix/theme/FirefoxTheme.kt
+++ b/app/src/main/java/org/mozilla/fenix/theme/FirefoxTheme.kt
@@ -28,6 +28,7 @@ import org.mozilla.fenix.ext.settings
 enum class Theme {
     Light,
     Dark,
+    Black,
     Private,
     ;
 
@@ -48,7 +49,11 @@ enum class Theme {
             ) {
                 Private
             } else if (isSystemInDarkTheme()) {
-                Dark
+                if (LocalContext.current.settings().shouldUseBlackTheme) {
+                    Black
+                } else {
+                    Dark
+                }
             } else {
                 Light
             }
@@ -68,6 +73,7 @@ fun FirefoxTheme(
     val colors = when (theme) {
         Theme.Light -> lightColorPalette
         Theme.Dark -> darkColorPalette
+        Theme.Black -> blackColorPalette
         Theme.Private -> privateColorPalette
     }
 

--- a/app/src/main/java/org/mozilla/fenix/theme/FirefoxTheme.kt
+++ b/app/src/main/java/org/mozilla/fenix/theme/FirefoxTheme.kt
@@ -153,6 +153,17 @@ private val darkColorPalette = FirefoxColors(
     borderWarning = PhotonColors.Red40,
 )
 
+private val blackColorPalette = darkColorPalette.copy(
+    layer1 = PhotonColors.Black,
+    layer2 = PhotonColors.DarkGrey90,
+    layer3 = PhotonColors.DarkGrey80,
+    layer4Start = PhotonColors.Black, // maybe these 3?
+    layer4Center = PhotonColors.Black, // maybe these 3?
+    layer4End = PhotonColors.Black, // maybe these 3?
+    actionTertiary = PhotonColors.DarkGrey80,
+    borderPrimary = PhotonColors.DarkGrey70,
+)
+
 private val lightColorPalette = FirefoxColors(
     layer1 = PhotonColors.LightGrey10,
     layer2 = PhotonColors.White,

--- a/app/src/main/java/org/mozilla/fenix/theme/ThemeManager.kt
+++ b/app/src/main/java/org/mozilla/fenix/theme/ThemeManager.kt
@@ -23,9 +23,11 @@ import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
 import org.mozilla.fenix.customtabs.ExternalAppBrowserActivity
+import org.mozilla.fenix.ext.settings
 
 abstract class ThemeManager {
 
+    protected abstract val activity: Activity
     abstract var currentTheme: BrowsingMode
 
     /**
@@ -33,7 +35,11 @@ abstract class ThemeManager {
      */
     @get:StyleRes
     val currentThemeResource get() = when (currentTheme) {
-        BrowsingMode.Normal -> R.style.NormalTheme
+        BrowsingMode.Normal -> if (activity.settings().shouldUseBlackTheme) {
+            R.style.NormalBlackTheme
+        } else {
+            R.style.NormalTheme
+        }
         BrowsingMode.Private -> R.style.PrivateTheme
     }
 
@@ -117,7 +123,7 @@ abstract class ThemeManager {
 
 class DefaultThemeManager(
     currentTheme: BrowsingMode,
-    private val activity: Activity,
+    override val activity: Activity,
 ) : ThemeManager() {
     override var currentTheme: BrowsingMode = currentTheme
         set(value) {

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -511,6 +511,11 @@ class Settings(private val appContext: Context) : PreferencesHolder {
         default = false,
     )
 
+    var shouldUseBlackTheme by booleanPreference(
+        appContext.getPreferenceKey(R.string.pref_key_black_theme),
+        default = false,
+    )
+
     var shouldFollowDeviceTheme by booleanPreference(
         appContext.getPreferenceKey(R.string.pref_key_follow_device_theme),
         default = false,

--- a/app/src/main/res/drawable/home_bottom_bar_background.xml
+++ b/app/src/main/res/drawable/home_bottom_bar_background.xml
@@ -5,8 +5,8 @@
 
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
 <item>
-    <shape>
-        <solid android:color="@color/fx_mobile_layer_color_1" />
+    <shape>.
+        <solid android:color="?attr/layer1" />
     </shape>
 </item>
 <item android:bottom="-2dp" android:left="-2dp" android:right="-2dp">

--- a/app/src/main/res/drawable/home_bottom_bar_background_top.xml
+++ b/app/src/main/res/drawable/home_bottom_bar_background_top.xml
@@ -6,7 +6,7 @@
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
 <item>
     <shape>
-        <solid android:color="@color/fx_mobile_layer_color_1" />
+        <solid android:color="?attr/layer1" />
     </shape>
 </item>
 <item android:top="-2dp" android:left="-2dp" android:right="-2dp">

--- a/app/src/main/res/drawable/swipe_delete_background.xml
+++ b/app/src/main/res/drawable/swipe_delete_background.xml
@@ -4,5 +4,5 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
-    <solid android:color="@color/fx_mobile_layer_color_3" />
+    <solid android:color="?attr/layer3" />
 </shape>

--- a/app/src/main/res/layout/component_tabstray2.xml
+++ b/app/src/main/res/layout/component_tabstray2.xml
@@ -9,7 +9,7 @@
     style="@style/BottomSheetModal"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:backgroundTint="@color/fx_mobile_layer_color_1"
+    android:backgroundTint="?attr/layer1"
     app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior"
     tools:ignore="MozMultipleConstraintLayouts">
 
@@ -28,7 +28,7 @@
         android:id="@+id/info_banner"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@color/fx_mobile_layer_color_1"
+        android:background="?attr/layer1"
         android:visibility="gone"
         app:layout_constraintTop_toBottomOf="@+id/topBar" />
 
@@ -36,7 +36,7 @@
         android:id="@+id/topBar"
         android:layout_width="match_parent"
         android:layout_height="80dp"
-        android:background="@color/fx_mobile_layer_color_1"
+        android:background="?attr/layer1"
         android:importantForAccessibility="no"
         app:layout_constraintTop_toBottomOf="@+id/handle" />
 
@@ -77,7 +77,7 @@
         android:id="@+id/tab_layout"
         android:layout_width="0dp"
         android:layout_height="80dp"
-        android:background="@color/fx_mobile_layer_color_1"
+        android:background="?attr/layer1"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/handle"
         app:layout_constraintWidth_percent="0.5"

--- a/app/src/main/res/layout/tab_tray_grid_item.xml
+++ b/app/src/main/res/layout/tab_tray_grid_item.xml
@@ -25,7 +25,7 @@ A FrameLayout here is an efficient way of having a views stack while allowing:
         android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:importantForAccessibility="yes"
-        app:cardBackgroundColor="@color/fx_mobile_layer_color_2"
+        app:cardBackgroundColor="?attr/layer2"
         app:cardCornerRadius="@dimen/tab_tray_grid_item_border_radius"
         app:cardElevation="0dp"
         app:strokeColor="@color/fx_mobile_border_color_primary"

--- a/app/src/main/res/values-night-v23/styles.xml
+++ b/app/src/main/res/values-night-v23/styles.xml
@@ -14,6 +14,6 @@
         <item name="android:windowLightStatusBar">false</item>
 
         <!-- Style the navigation bar -->
-        <item name="android:navigationBarColor">@color/fx_mobile_layer_color_1</item>
+        <item name="android:navigationBarColor">?attr/layer1</item>
     </style>
 </resources>

--- a/app/src/main/res/values-v27/styles.xml
+++ b/app/src/main/res/values-v27/styles.xml
@@ -48,6 +48,6 @@
     <style name="TabTrayDialogStyle" parent="TabTrayDialogStyleBase">
         <item name="android:navigationBarDividerColor">@android:color/transparent</item>
         <item name="android:windowLightNavigationBar">@bool/theme_is_light</item>
-        <item name="android:navigationBarColor">@color/fx_mobile_layer_color_1</item>
+        <item name="android:navigationBarColor">?attr/layer1</item>
     </style>
 </resources>

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -130,6 +130,7 @@
     <!-- Theme Settings -->
     <string name="pref_key_light_theme" translatable="false">pref_key_light_theme</string>
     <string name="pref_key_dark_theme" translatable="false">pref_key_dark_theme</string>
+    <string name="pref_key_black_theme" translatable="false">pref_key_black_theme</string>
     <string name="pref_key_auto_battery_theme" translatable="false">pref_key_auto_battery_theme</string>
     <string name="pref_key_follow_device_theme" translatable="false">pref_key_follow_device_theme</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -586,6 +586,8 @@
     <string name="preference_light_theme">Light</string>
     <!-- Preference for using dark theme -->
     <string name="preference_dark_theme">Dark</string>
+    <!-- Preference for using black theme -->
+    <string name="preference_black_theme">Black</string>
     <!-- Preference for using using dark or light theme automatically set by battery -->
     <string name="preference_auto_battery_theme">Set by Battery Saver</string>
     <!-- Preference for using following device theme -->

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -12,7 +12,7 @@
         <item name="android:windowAnimationStyle">@style/WindowAnimationTransition</item>
         <item name="android:progressBarStyleHorizontal">@style/progressBarStyleHorizontal</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
-        <item name="android:windowBackground">@color/fx_mobile_layer_color_1</item>
+        <item name="android:windowBackground">?attr/layer1</item>
         <item name="android:colorEdgeEffect">@color/accent_normal_theme</item>
         <item name="android:colorAccent">@color/fx_mobile_text_color_primary</item>
         <item name="android:textColorPrimary">@color/state_list_text_color</item>
@@ -93,9 +93,9 @@
         <item name="neutral">@color/neutral_normal_theme</item>
         <item name="neutralFaded">@color/neutral_faded_normal_theme</item>
         <item name="accentUsedOnDarkBackground">@color/fx_mobile_text_color_accent</item>
-        <item name="toolbarStartGradient">@color/fx_mobile_layer_color_1</item>
-        <item name="toolbarCenterGradient">@color/fx_mobile_layer_color_1</item>
-        <item name="toolbarEndGradient">@color/fx_mobile_layer_color_1</item>
+        <item name="toolbarStartGradient">?attr/layer1</item>
+        <item name="toolbarCenterGradient">?attr/layer1</item>
+        <item name="toolbarEndGradient">?attr/layer1</item>
         <item name="fillLinkFromClipboard">@color/fill_link_from_clipboard_normal_theme</item>
         <item name="syncDisconnected">@color/sync_disconnected_icon_fill_normal_theme</item>
         <item name="syncDisconnectedBackground">@color/sync_disconnected_background_normal_theme</item>
@@ -114,14 +114,14 @@
         <!-- Shared widget colors -->
         <item name="mozac_primary_text_color">@color/fx_mobile_text_color_primary</item>
         <item name="mozac_caption_text_color">@color/fx_mobile_text_color_secondary</item>
-        <item name="mozac_widget_favicon_background_color">@color/fx_mobile_layer_color_2</item>
+        <item name="mozac_widget_favicon_background_color">?attr/layer2</item>
         <item name="mozac_widget_favicon_border_color">@color/fx_mobile_border_color_primary</item>
 
         <!-- Drawables -->
         <item name="fenixLogo">@drawable/ic_logo_wordmark_normal</item>
         <item name="fenixWordmarkText">@drawable/ic_wordmark_text_normal</item>
         <item name="fenixWordmarkLogo">@drawable/ic_wordmark_logo</item>
-        <item name="homeBackground">@color/fx_mobile_layer_color_1</item>
+        <item name="homeBackground">?attr/layer1</item>
         <item name="bottomBarBackground">@drawable/home_bottom_bar_background</item>
         <item name="bottomBarBackgroundTop">@drawable/home_bottom_bar_background_top</item>
         <item name="privateBrowsingButtonBackground">@android:color/transparent</item>
@@ -650,8 +650,11 @@
 
     <!-- Tab Tray does not present a private theme, so it needs to be separate from other bottom sheet styles -->
     <style name="TabTrayDialogStyleBase" parent="BottomSheetBase">
+        <item name="layer1">@color/fx_mobile_layer_color_1</item>
+        <item name="layer2">@color/fx_mobile_layer_color_2</item>
+        <item name="layer3">@color/fx_mobile_layer_color_3</item>
         <item name="bottomSheetStyle">@style/BottomSheetModal</item>
-        <item name="android:colorBackground">@color/fx_mobile_layer_color_1</item>
+        <item name="android:colorBackground">?attr/layer1</item>
     </style>
 
     <style name="TabTrayDialogStyle" parent="TabTrayDialogStyleBase" />

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -130,6 +130,14 @@
         <item name="tabCounterTintColor">?attr/textPrimary</item>
     </style>
 
+    <!-- A black theme derived from the normal activity theme -->
+    <style name="NormalBlackTheme" parent="NormalTheme">
+        <item name="android:windowBackground">@color/photonBlack</item>
+        <item name="layer1">@color/photonBlack</item>
+        <item name="layer2">@color/photonDarkGrey90</item>
+        <item name="layer3">@color/fx_mobile_layer_color_3</item>
+    </style>
+
     <!-- A theme derived from the normal activity theme, but to look and behave like a dialog -->
     <style name="DialogActivityTheme" parent="NormalTheme">
         <item name="android:windowElevation">16dp</item>
@@ -658,6 +666,12 @@
     </style>
 
     <style name="TabTrayDialogStyle" parent="TabTrayDialogStyleBase" />
+
+    <!-- Inherit some layers from NormalBlackTheme when in Black theme -->
+    <style name="NormalBlackTheme.TabTrayDialogStyle" parent="TabTrayDialogStyle">
+        <item name="layer1">@color/photonBlack</item>
+        <item name="layer2">@color/photonBlack</item>
+    </style>
 
     <!-- Stuff to make the bottom sheet with round top borders -->
     <style name="BottomSheetShapeAppearance" parent="ShapeAppearance.MaterialComponents.LargeComponent">

--- a/app/src/main/res/xml/customization_preferences.xml
+++ b/app/src/main/res/xml/customization_preferences.xml
@@ -20,6 +20,11 @@
 
         <org.mozilla.fenix.settings.RadioButtonPreference
             android:defaultValue="false"
+            android:key="@string/pref_key_black_theme"
+            android:title="@string/preference_black_theme" />
+
+        <org.mozilla.fenix.settings.RadioButtonPreference
+            android:defaultValue="false"
             android:key="@string/pref_key_auto_battery_theme"
             android:title="@string/preference_auto_battery_theme"
             app:isPreferenceVisible="@bool/underAPI28" />


### PR DESCRIPTION
This defines and adds a "pure black"/"true black"/"OLED black" theme to Fenix.

I understand that the UX input for a whole theme can be quite involved; however, the engineering/product side is more or less straightforward (as this PR demonstrates), so I would like to propose a path forward:

- Get engineering/product approval for the idea of such a theme and *how* it is implemented (this PR)
- Limit the theme availability to Nightly/Debug until UX approval for final theme design

The above would mean that interested Nightly users would be able to have the option for a good-but-imperfect OLED black theme while the sordid details are hashed out by the UX team (similar to incubating features like pull to refresh).
It would also mean that developers (such as myself) would be able to add pure black options to other parts of the stack (e.g. Reader Mode and GeckoView base background) which would rely on the settings added in this PR.

Other future work could involve customizing the themes that `Follow device theme` uses (i.e. let users switch between light/black or dark/black depending on system-wide OS theme).

Sample:

https://user-images.githubusercontent.com/13156601/201012362-b632db80-6af3-46a6-8cd3-94b293e80346.mp4




### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
Fixes #1938