### PR TITLE
For#27753 - Update search engines immediately after changing language

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsSearchTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsSearchTest.kt
@@ -420,11 +420,7 @@ class SettingsSearchTest {
                 "Bing",
                 "Amazon.com",
                 "DuckDuckGo",
-                "eBay",
-                /* Disabled Arabic Wikipedia verification
-                   until https://github.com/mozilla-mobile/fenix/issues/12236 gets fixed
-                 "ويكيبيديا (ar)"
-                */
+                "ويكيبيديا (ar)",
             )
         }
     }

--- a/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
+++ b/app/src/main/java/org/mozilla/fenix/HomeActivity.kt
@@ -42,6 +42,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import mozilla.appservices.places.BookmarkRoot
 import mozilla.components.browser.state.action.ContentAction
+import mozilla.components.browser.state.action.SearchAction
 import mozilla.components.browser.state.search.SearchEngine
 import mozilla.components.browser.state.selector.getNormalOrPrivateTabs
 import mozilla.components.browser.state.state.SessionState
@@ -384,6 +385,11 @@ open class HomeActivity : LocaleAwareAppCompatActivity(), NavHostActivity {
             DefaultBrowserNotificationWorker.setDefaultBrowserNotificationIfNeeded(applicationContext)
             ReEngagementNotificationWorker.setReEngagementNotificationIfNeeded(applicationContext)
         }
+
+        // This was done in order to refresh search engines when app is running in background
+        // and the user changes the system language
+        // More details here: https://github.com/mozilla-mobile/fenix/pull/27793#discussion_r1029892536
+        components.core.store.dispatch(SearchAction.RefreshSearchEnginesAction)
     }
 
     override fun onStart() {

--- a/app/src/main/java/org/mozilla/fenix/settings/advanced/DefaultLocaleSettingsController.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/advanced/DefaultLocaleSettingsController.kt
@@ -6,6 +6,8 @@ package org.mozilla.fenix.settings.advanced
 
 import android.app.Activity
 import android.content.Context
+import mozilla.components.browser.state.action.SearchAction
+import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.support.locale.LocaleManager
 import mozilla.components.support.locale.LocaleUseCases
 import org.mozilla.fenix.nimbus.FxNimbus
@@ -20,6 +22,7 @@ interface LocaleSettingsController {
 class DefaultLocaleSettingsController(
     private val activity: Activity,
     private val localeSettingsStore: LocaleSettingsStore,
+    private val browserStore: BrowserStore,
     private val localeUseCase: LocaleUseCases,
 ) : LocaleSettingsController {
 
@@ -30,6 +33,7 @@ class DefaultLocaleSettingsController(
             return
         }
         localeSettingsStore.dispatch(LocaleSettingsAction.Select(locale))
+        browserStore.dispatch(SearchAction.RefreshSearchEnginesAction)
         LocaleManager.setNewLocale(activity, localeUseCase, locale)
         LocaleManager.updateBaseConfiguration(activity, locale)
 
@@ -44,6 +48,7 @@ class DefaultLocaleSettingsController(
             return
         }
         localeSettingsStore.dispatch(LocaleSettingsAction.Select(localeSettingsStore.state.localeList[0]))
+        browserStore.dispatch(SearchAction.RefreshSearchEnginesAction)
         LocaleManager.resetToSystemDefault(activity, localeUseCase)
         LocaleManager.updateBaseConfiguration(activity, localeSettingsStore.state.localeList[0])
 

--- a/app/src/main/java/org/mozilla/fenix/settings/advanced/LocaleSettingsFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/advanced/LocaleSettingsFragment.kt
@@ -58,6 +58,7 @@ class LocaleSettingsFragment : Fragment(), MenuProvider {
             controller = DefaultLocaleSettingsController(
                 activity = requireActivity(),
                 localeSettingsStore = localeSettingsStore,
+                browserStore = browserStore,
                 localeUseCase = localeUseCase,
             ),
         )

--- a/app/src/test/java/org/mozilla/fenix/settings/advanced/LocaleSettingsControllerTest.kt
+++ b/app/src/test/java/org/mozilla/fenix/settings/advanced/LocaleSettingsControllerTest.kt
@@ -14,6 +14,8 @@ import io.mockk.mockkStatic
 import io.mockk.spyk
 import io.mockk.verify
 import io.mockk.verifyAll
+import mozilla.components.browser.state.action.SearchAction
+import mozilla.components.browser.state.store.BrowserStore
 import mozilla.components.support.locale.LocaleManager
 import mozilla.components.support.locale.LocaleUseCases
 import org.junit.Before
@@ -24,6 +26,7 @@ class LocaleSettingsControllerTest {
 
     private val activity = mockk<Activity>(relaxed = true)
     private val localeSettingsStore: LocaleSettingsStore = mockk(relaxed = true)
+    private val browserStore: BrowserStore = mockk(relaxed = true)
     private val localeUseCases: LocaleUseCases = mockk(relaxed = true)
     private val mockState = LocaleSettingsState(mockk(), mockk(), mockk())
 
@@ -35,6 +38,7 @@ class LocaleSettingsControllerTest {
             DefaultLocaleSettingsController(
                 activity,
                 localeSettingsStore,
+                browserStore,
                 localeUseCases,
             ),
         )
@@ -53,6 +57,7 @@ class LocaleSettingsControllerTest {
 
         verifyAll(inverse = true) {
             localeSettingsStore.dispatch(LocaleSettingsAction.Select(selectedLocale))
+            browserStore.dispatch(SearchAction.RefreshSearchEnginesAction)
             LocaleManager.setNewLocale(activity, locale = selectedLocale)
             activity.recreate()
         }
@@ -77,6 +82,7 @@ class LocaleSettingsControllerTest {
         controller.handleLocaleSelected(selectedLocale)
 
         verify { localeSettingsStore.dispatch(LocaleSettingsAction.Select(selectedLocale)) }
+        verify { browserStore.dispatch(SearchAction.RefreshSearchEnginesAction) }
         verify { LocaleManager.setNewLocale(activity, localeUseCases, selectedLocale) }
         verify { activity.recreate() }
         verify { activity.overridePendingTransition(0, 0) }
@@ -101,6 +107,7 @@ class LocaleSettingsControllerTest {
         controller.handleLocaleSelected(selectedLocale)
 
         verify { localeSettingsStore.dispatch(LocaleSettingsAction.Select(selectedLocale)) }
+        verify { browserStore.dispatch(SearchAction.RefreshSearchEnginesAction) }
         verify { LocaleManager.setNewLocale(activity, localeUseCases, selectedLocale) }
         verify { activity.recreate() }
         verify { activity.overridePendingTransition(0, 0) }
@@ -120,6 +127,7 @@ class LocaleSettingsControllerTest {
 
         verifyAll(inverse = true) {
             localeSettingsStore.dispatch(LocaleSettingsAction.Select(selectedLocale))
+            browserStore.dispatch(SearchAction.RefreshSearchEnginesAction)
             LocaleManager.resetToSystemDefault(activity, localeUseCases)
             activity.recreate()
             with(controller) {
@@ -141,6 +149,7 @@ class LocaleSettingsControllerTest {
         controller.handleDefaultLocaleSelected()
 
         verify { localeSettingsStore.dispatch(LocaleSettingsAction.Select(selectedLocale)) }
+        verify { browserStore.dispatch(SearchAction.RefreshSearchEnginesAction) }
         verify { LocaleManager.resetToSystemDefault(activity, localeUseCases) }
         verify { activity.recreate() }
         verify { activity.overridePendingTransition(0, 0) }


### PR DESCRIPTION
Needs https://github.com/mozilla-mobile/firefox-android/pull/135

When changing language inside the application:

https://user-images.githubusercontent.com/32488956/201075839-de6249e4-01ef-44f7-bce2-796ba8abc7c3.mp4

When changing language from device settings:

https://user-images.githubusercontent.com/32488956/201076616-7b6b7d93-9b85-4e08-a227-80cf0d81ad9a.mp4


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.






### GitHub Automation
Fixes #27753