### PR TITLE
Close #27795: Add metrics ping to see if user allows notifications

### DIFF
--- a/app/metrics.yaml
+++ b/app/metrics.yaml
@@ -211,6 +211,22 @@ events:
     notification_emails:
       - android-probes@mozilla.com
     expires: 122
+  marketing_notification_allowed:
+    type: boolean
+    description: |
+      True if marketing notifications are allowed, otherwise false.
+    bugs:
+      - https://github.com/mozilla-mobile/fenix/issues/27795
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/27797
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: 122
+    metadata:
+      tags:
+        - Notifications
   toolbar_menu_visible:
     type: event
     description: |
@@ -1752,6 +1768,24 @@ metrics:
     metadata:
       tags:
         - Wallpapers
+  notifications_allowed:
+    type: boolean
+    description: |
+      True if notifications are allowed, otherwise false.
+    send_in_pings:
+      - metrics
+    bugs:
+      - https://github.com/mozilla-mobile/fenix/issues/27795
+    data_reviews:
+      - https://github.com/mozilla-mobile/fenix/pull/27797
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - android-probes@mozilla.com
+    expires: 122
+    metadata:
+      tags:
+        - Notifications
 
 customize_home:
   most_visited_sites:

--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -14,6 +14,7 @@ import android.util.Log.INFO
 import androidx.annotation.CallSuper
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.getSystemService
 import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.work.Configuration.Builder
@@ -714,6 +715,15 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
                 Wallpaper.nameIsDefault(settings.currentWallpaperName)
 
             defaultWallpaper.set(isDefaultTheCurrentWallpaper)
+
+            @Suppress("TooGenericExceptionCaught")
+            try {
+                notificationsAllowed.set(
+                    NotificationManagerCompat.from(applicationContext).areNotificationsEnabled(),
+                )
+            } catch (e: Exception) {
+                Logger.warn("Failed to check if notifications are enabled", e)
+            }
         }
 
         with(AndroidAutofill) {

--- a/app/src/main/java/org/mozilla/fenix/onboarding/DefaultBrowserNotificationWorker.kt
+++ b/app/src/main/java/org/mozilla/fenix/onboarding/DefaultBrowserNotificationWorker.kt
@@ -22,6 +22,7 @@ import androidx.work.WorkerParameters
 import mozilla.components.service.glean.private.NoExtras
 import mozilla.components.support.base.ids.SharedIdsHelper
 import org.mozilla.fenix.GleanMetrics.Events
+import org.mozilla.fenix.GleanMetrics.Events.marketingNotificationAllowed
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.ext.settings
@@ -35,9 +36,9 @@ class DefaultBrowserNotificationWorker(
 ) : Worker(context, workerParameters) {
 
     override fun doWork(): Result {
-        ensureChannelExists()
+        val channelId = ensureChannelExists()
         NotificationManagerCompat.from(applicationContext)
-            .notify(NOTIFICATION_TAG, NOTIFICATION_ID, buildNotification())
+            .notify(NOTIFICATION_TAG, NOTIFICATION_ID, buildNotification(channelId))
         Events.defaultBrowserNotifShown.record(NoExtras())
 
         // default browser notification should only happen once
@@ -49,8 +50,7 @@ class DefaultBrowserNotificationWorker(
     /**
      * Build the default browser notification.
      */
-    private fun buildNotification(): Notification {
-        val channelId = ensureChannelExists()
+    private fun buildNotification(channelId: String): Notification {
         val intent = Intent(applicationContext, HomeActivity::class.java)
         intent.putExtra(INTENT_DEFAULT_BROWSER_NOTIFICATION, true)
 
@@ -87,6 +87,7 @@ class DefaultBrowserNotificationWorker(
      * Returns the channel id to be used for notifications.
      */
     private fun ensureChannelExists(): String {
+        var channelEnabled = true
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val notificationManager: NotificationManager =
                 applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
@@ -98,7 +99,20 @@ class DefaultBrowserNotificationWorker(
             )
 
             notificationManager.createNotificationChannel(channel)
+
+            val existingChannel = notificationManager.getNotificationChannel(NOTIFICATION_CHANNEL_ID)
+            channelEnabled =
+                existingChannel != null && existingChannel.importance != NotificationManager.IMPORTANCE_NONE
         }
+
+        @Suppress("TooGenericExceptionCaught")
+        val notificationsEnabled = try {
+            NotificationManagerCompat.from(applicationContext).areNotificationsEnabled()
+        } catch (e: Exception) {
+            false
+        }
+
+        marketingNotificationAllowed.set(notificationsEnabled && channelEnabled)
 
         return NOTIFICATION_CHANNEL_ID
     }


### PR DESCRIPTION
Tested with emulators on API 33, API 29 and API 25 to ensure that when notification/marketing channel is enabled/disabled, the probe reported values matching our expectations.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.










### GitHub Automation
Fixes #27795