### PR TITLE
For #27815: Properly enforce http(s) protocol for new login hostname

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/AddLoginFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/logins/fragment/AddLoginFragment.kt
@@ -199,6 +199,13 @@ class AddLoginFragment : Fragment(R.layout.fragment_add_login), MenuProvider {
             },
         )
 
+        binding.hostnameText.setOnFocusChangeListener { _, hasFocus ->
+            val hostnameText = binding.hostnameText.editableText
+            if (!(hasFocus || hostnameContainsProtocol || hostnameText.isEmpty())) {
+                hostnameText.insert(0, "https://")
+            }
+        }
+
         binding.usernameText.addTextChangedListener(
             object : TextWatcher {
                 override fun afterTextChanged(u: Editable?) {

--- a/app/src/main/res/layout/fragment_add_login.xml
+++ b/app/src/main/res/layout/fragment_add_login.xml
@@ -42,8 +42,6 @@
         app:layout_constraintEnd_toEndOf="@id/hostnameHeaderText"
         app:layout_constraintStart_toStartOf="@id/hostnameHeaderText"
         app:layout_constraintTop_toBottomOf="@id/hostnameHeaderText"
-        app:helperTextEnabled="true"
-        app:helperText="@string/add_login_hostname_invalid_text_3"
         app:hintEnabled="false" >
 
         <com.google.android.material.textfield.TextInputEditText


### PR DESCRIPTION
This also auto-adds the https protocol if no protocol is present for feature parity with desktop Firefox.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
Fixes #27815