### PR TITLE
For #26286 improve full functional home screen section UI test coverage

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
@@ -278,6 +278,23 @@ class HomeScreenTest {
     }
 
     @Test
+    fun selectStoriesByTopicItemTest() {
+        activityTestRule.activityRule.applySettingsExceptions {
+            it.isRecentTabsFeatureEnabled = false
+            it.isRecentlyVisitedFeatureEnabled = false
+        }
+
+        homeScreen {
+        }.dismissOnboarding()
+
+        homeScreen {
+            verifyStoriesByTopicItemState(activityTestRule, false, 1)
+            clickStoriesByTopicItem(activityTestRule, 1)
+            verifyStoriesByTopicItemState(activityTestRule, true, 1)
+        }
+    }
+
+    @Test
     fun verifyCustomizeHomepageTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
@@ -295,6 +295,23 @@ class HomeScreenTest {
     }
 
     @Test
+    fun verifyPocketLearnMoreLinkTest() {
+        activityTestRule.activityRule.applySettingsExceptions {
+            it.isRecentTabsFeatureEnabled = false
+            it.isRecentlyVisitedFeatureEnabled = false
+        }
+
+        homeScreen {
+        }.dismissOnboarding()
+
+        homeScreen {
+            verifyPoweredByPocket(activityTestRule)
+        }.clickPocketLearnMoreLink(activityTestRule) {
+            verifyUrl("mozilla.org/en-US/firefox/pocket")
+        }
+    }
+
+    @Test
     fun verifyCustomizeHomepageTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
@@ -124,6 +124,38 @@ class HomeScreenTest {
     }
 
     @Test
+    fun verifyJumpBackInSectionTest() {
+        val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 4)
+        val secondWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(firstWebPage.url) {
+        }.goToHomescreen {
+            verifyJumpBackInSectionIsDisplayed()
+            verifyJumpBackInItemTitle(firstWebPage.title)
+            verifyJumpBackInItemWithUrl(firstWebPage.url.toString())
+            verifyJumpBackInShowAllButton()
+        }.clickJumpBackInShowAllButton {
+            verifyExistingOpenTabs(firstWebPage.title)
+        }.closeTabDrawer() {
+        }
+        homeScreen {
+        }.clickJumpBackInItemWithTitle(firstWebPage.title) {
+            verifyUrl(firstWebPage.url.toString())
+            clickLinkMatchingText("Link 1")
+        }.goToHomescreen {
+            verifyJumpBackInSectionIsDisplayed()
+            verifyJumpBackInItemTitle(secondWebPage.title)
+            verifyJumpBackInItemWithUrl(secondWebPage.url.toString())
+        }.openTabDrawer {
+            closeTab()
+        }
+        homeScreen {
+            verifyJumpBackInSectionIsNotDisplayed()
+        }
+    }
+
+    @Test
     fun dismissOnboardingUsingSettingsTest() {
         homeScreen {
             verifyWelcomeHeader()

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
@@ -35,6 +35,7 @@ class HomeScreenTest {
 
     private lateinit var mDevice: UiDevice
     private lateinit var mockWebServer: MockWebServer
+    private lateinit var firstPocketStoryPublisher: String
 
     @get:Rule(order = 0)
     val activityTestRule =
@@ -235,6 +236,25 @@ class HomeScreenTest {
         }.goBack {
             verifyThoughtProvokingStories(false)
             verifyStoriesByTopic(false)
+        }
+    }
+
+    @Test
+    fun openPocketStoryItemTest() {
+        activityTestRule.activityRule.applySettingsExceptions {
+            it.isRecentTabsFeatureEnabled = false
+            it.isRecentlyVisitedFeatureEnabled = false
+        }
+
+        homeScreen {
+        }.dismissOnboarding()
+
+        homeScreen {
+            verifyThoughtProvokingStories(true)
+            scrollToPocketProvokingStories()
+            firstPocketStoryPublisher = getProvokingStoryPublisher(1)
+        }.clickPocketStoryItem(firstPocketStoryPublisher, 1) {
+            verifyUrl(firstPocketStoryPublisher)
         }
     }
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.fenix.ui
 
+import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.By
 import androidx.test.uiautomator.UiDevice
@@ -35,10 +36,11 @@ class HomeScreenTest {
     private lateinit var mDevice: UiDevice
     private lateinit var mockWebServer: MockWebServer
 
-    @get:Rule
-    val activityTestRule = HomeActivityTestRule.withDefaultSettingsOverrides()
+    @get:Rule(order = 0)
+    val activityTestRule =
+        AndroidComposeTestRule(HomeActivityTestRule.withDefaultSettingsOverrides()) { it.activity }
 
-    @Rule
+    @Rule(order = 1)
     @JvmField
     val retryTestRule = RetryTestRule(3)
 
@@ -62,21 +64,26 @@ class HomeScreenTest {
         homeScreen { }.dismissOnboarding()
 
         homeScreen {
-            verifyHomeScreen()
-            verifyNavigationToolbar()
-            verifyHomePrivateBrowsingButton()
-            verifyHomeMenu()
             verifyHomeWordmark()
-            verifyTabButton()
-            verifyCollectionsHeader()
-            verifyHomeToolbar()
-            verifyHomeComponent()
-
-            // Verify Top Sites
-            verifyExistingTopSitesList()
+            verifyHomePrivateBrowsingButton()
             verifyExistingTopSitesTabs("Wikipedia")
             verifyExistingTopSitesTabs("Top Articles")
             verifyExistingTopSitesTabs("Google")
+            verifyCollectionsHeader()
+            verifyNoCollectionsText()
+            scrollToPocketProvokingStories()
+            swipePocketProvokingStories()
+            verifyPocketRecommendedStoriesItems(activityTestRule, 1, 3, 4, 5, 6, 7)
+            verifyPocketSponsoredStoriesItems(activityTestRule, 2, 8)
+            verifyDiscoverMoreStoriesButton(activityTestRule, 9)
+            verifyStoriesByTopicItems()
+            verifyPoweredByPocket(activityTestRule)
+            verifyCustomizeHomepageButton(true)
+            verifyNavigationToolbar()
+            verifyDefaultSearchEngine("Google")
+            verifyHomeMenuButton()
+            verifyTabButton()
+            verifyNoTabsOpened()
         }
     }
 
@@ -89,11 +96,11 @@ class HomeScreenTest {
             verifyHomeScreen()
             verifyNavigationToolbar()
             verifyHomePrivateBrowsingButton()
-            verifyHomeMenu()
+            verifyHomeMenuButton()
             verifyHomeWordmark()
             verifyTabButton()
             verifyPrivateSessionMessage()
-            verifyHomeToolbar()
+            verifyNavigationToolbar()
             verifyHomeComponent()
         }.openCommonMythsLink {
             verifyUrl("common-myths-about-private-browsing")
@@ -107,11 +114,11 @@ class HomeScreenTest {
             verifyHomeScreen()
             verifyNavigationToolbar()
             verifyHomePrivateBrowsingButton()
-            verifyHomeMenu()
+            verifyHomeMenuButton()
             verifyHomeWordmark()
             verifyTabButton()
             verifyPrivateSessionMessage()
-            verifyHomeToolbar()
+            verifyNavigationToolbar()
             verifyHomeComponent()
         }
     }
@@ -144,7 +151,7 @@ class HomeScreenTest {
 
     @Test
     fun dismissOnboardingUsingHelpTest() {
-        activityTestRule.applySettingsExceptions {
+        activityTestRule.activityRule.applySettingsExceptions {
             it.isJumpBackInCFREnabled = false
             it.isWallpaperOnboardingEnabled = false
         }
@@ -174,7 +181,7 @@ class HomeScreenTest {
 
     @Test
     fun verifyPocketHomepageStoriesTest() {
-        activityTestRule.applySettingsExceptions {
+        activityTestRule.activityRule.applySettingsExceptions {
             it.isRecentTabsFeatureEnabled = false
             it.isRecentlyVisitedFeatureEnabled = false
         }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
@@ -223,6 +223,11 @@ class HomeScreenTest {
 
         homeScreen {
             verifyThoughtProvokingStories(true)
+            scrollToPocketProvokingStories()
+            swipePocketProvokingStories()
+            verifyPocketRecommendedStoriesItems(activityTestRule, 1, 3, 4, 5, 6, 7)
+            verifyPocketSponsoredStoriesItems(activityTestRule, 2, 8)
+            verifyDiscoverMoreStoriesButton(activityTestRule, 9)
             verifyStoriesByTopic(true)
         }.openThreeDotMenu {
         }.openCustomizeHome {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/HomeScreenTest.kt
@@ -259,6 +259,25 @@ class HomeScreenTest {
     }
 
     @Test
+    fun openPocketDiscoverMoreTest() {
+        activityTestRule.activityRule.applySettingsExceptions {
+            it.isRecentTabsFeatureEnabled = false
+            it.isRecentlyVisitedFeatureEnabled = false
+        }
+
+        homeScreen {
+        }.dismissOnboarding()
+
+        homeScreen {
+            scrollToPocketProvokingStories()
+            swipePocketProvokingStories()
+            verifyDiscoverMoreStoriesButton(activityTestRule, 9)
+        }.clickPocketDiscoverMoreButton(activityTestRule, 9) {
+            verifyUrl("getpocket.com/explore")
+        }
+    }
+
+    @Test
     fun verifyCustomizeHomepageTest() {
         val defaultWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -115,7 +115,7 @@ class SmokeTest {
             verifyHomeScreen()
             verifyNavigationToolbar()
             verifyHomePrivateBrowsingButton()
-            verifyHomeMenu()
+            verifyHomeMenuButton()
             verifyHomeWordmark()
 
             verifyWelcomeHeader()

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/TabbedBrowsingTest.kt
@@ -354,7 +354,7 @@ class TabbedBrowsingTest {
             // dismiss search dialog
             homeScreen { }.pressBack()
             verifyPrivateSessionMessage()
-            verifyHomeToolbar()
+            verifyNavigationToolbar()
         }
         navigationToolbar {
         }.enterURLAndEnterToBrowser(defaultWebPage.url) {
@@ -365,7 +365,7 @@ class TabbedBrowsingTest {
             // dismiss search dialog
             homeScreen { }.pressBack()
             verifyHomeWordmark()
-            verifyHomeToolbar()
+            verifyNavigationToolbar()
         }
     }
 }

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
@@ -185,6 +185,9 @@ class HomeScreenRobot {
 
     fun verifyJumpBackInSectionIsDisplayed() = assertJumpBackInSectionIsDisplayed()
     fun verifyJumpBackInSectionIsNotDisplayed() = assertJumpBackInSectionIsNotDisplayed()
+    fun verifyJumpBackInItemTitle(itemTitle: String) = assertJumpBackInItemTitle(itemTitle)
+    fun verifyJumpBackInItemWithUrl(itemUrl: String) = assertJumpBackInItemWithUrl(itemUrl)
+    fun verifyJumpBackInShowAllButton() = assertJumpBackInShowAllButton()
     fun verifyRecentlyVisitedSectionIsDisplayed() = assertRecentlyVisitedSectionIsDisplayed()
     fun verifyRecentlyVisitedSectionIsNotDisplayed() = assertRecentlyVisitedSectionIsNotDisplayed()
     fun verifyRecentBookmarksSectionIsDisplayed() = assertRecentBookmarksSectionIsDisplayed()
@@ -627,6 +630,29 @@ class HomeScreenRobot {
             SettingsSubMenuHomepageRobot().interact()
             return SettingsSubMenuHomepageRobot.Transition()
         }
+
+        fun clickJumpBackInShowAllButton(interact: TabDrawerRobot.() -> Unit): TabDrawerRobot.Transition {
+            mDevice
+                .findObject(
+                    UiSelector()
+                        .textContains(getStringResource(R.string.recent_tabs_show_all)),
+                ).clickAndWaitForNewWindow(waitingTime)
+
+            TabDrawerRobot().interact()
+            return TabDrawerRobot.Transition()
+        }
+
+        fun clickJumpBackInItemWithTitle(itemTitle: String, interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
+            mDevice
+                .findObject(
+                    UiSelector()
+                        .resourceId("recent.tab.title")
+                        .textContains(itemTitle),
+                ).clickAndWaitForNewWindow(waitingTime)
+
+            BrowserRobot().interact()
+            return BrowserRobot.Transition()
+        }
     }
 }
 
@@ -942,6 +968,35 @@ private fun assertTopSiteContextMenuItems() {
 private fun assertJumpBackInSectionIsDisplayed() = assertTrue(jumpBackInSection().waitForExists(waitingTime))
 
 private fun assertJumpBackInSectionIsNotDisplayed() = assertFalse(jumpBackInSection().waitForExists(waitingTimeShort))
+
+private fun assertJumpBackInItemTitle(itemTitle: String) =
+    assertTrue(
+        mDevice
+            .findObject(
+                UiSelector()
+                    .resourceId("recent.tab.title")
+                    .textContains(itemTitle),
+            ).waitForExists(waitingTime),
+    )
+
+private fun assertJumpBackInItemWithUrl(itemUrl: String) =
+    assertTrue(
+        mDevice
+            .findObject(
+                UiSelector()
+                    .resourceId("recent.tab.url")
+                    .textContains(itemUrl),
+            ).waitForExists(waitingTime),
+    )
+
+private fun assertJumpBackInShowAllButton() =
+    assertTrue(
+        mDevice
+            .findObject(
+                UiSelector()
+                    .textContains(getStringResource(R.string.recent_tabs_show_all)),
+            ).waitForExists(waitingTime),
+    )
 
 private fun assertRecentlyVisitedSectionIsDisplayed() = assertTrue(recentlyVisitedSection().waitForExists(waitingTime))
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
@@ -8,9 +8,13 @@ package org.mozilla.fenix.ui.robots
 
 import android.graphics.Bitmap
 import android.widget.EditText
+import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.onChildAt
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.recyclerview.widget.RecyclerView
@@ -75,12 +79,11 @@ class HomeScreenRobot {
     fun verifyFocusedNavigationToolbar() = assertFocusedNavigationToolbar()
     fun verifyHomeScreen() = assertHomeScreen()
     fun verifyHomePrivateBrowsingButton() = assertHomePrivateBrowsingButton()
-    fun verifyHomeMenu() = assertHomeMenu()
+    fun verifyHomeMenuButton() = assertHomeMenuButton()
     fun verifyTabButton() = assertTabButton()
     fun verifyCollectionsHeader() = assertCollectionsHeader()
     fun verifyNoCollectionsText() = assertNoCollectionsText()
     fun verifyHomeWordmark() = assertHomeWordmark()
-    fun verifyHomeToolbar() = assertHomeToolbar()
     fun verifyHomeComponent() = assertHomeComponent()
     fun verifyDefaultSearchEngine(searchEngine: String) = verifySearchEngineIcon(searchEngine)
     fun verifyNoTabsOpened() = assertNoTabsOpened()
@@ -267,6 +270,39 @@ class HomeScreenRobot {
         }
     }
 
+    fun scrollToPocketProvokingStories() =
+        scrollToElementByText(getStringResource(R.string.pocket_stories_categories_header))
+
+    fun swipePocketProvokingStories() {
+        UiScrollable(UiSelector().resourceId("pocket.stories")).setAsHorizontalList()
+            .swipeLeft(3)
+    }
+
+    fun verifyPocketRecommendedStoriesItems(composeTestRule: ComposeTestRule, vararg positions: Int) {
+        composeTestRule.onNodeWithTag("pocket.stories").assertIsDisplayed()
+        positions.forEach {
+            composeTestRule.onNodeWithTag("pocket.stories")
+                .onChildAt(it - 1)
+                .assert(hasTestTag("pocket.recommended.story"))
+        }
+    }
+
+    fun verifyPocketSponsoredStoriesItems(composeTestRule: ComposeTestRule, vararg positions: Int) {
+        composeTestRule.onNodeWithTag("pocket.stories").assertIsDisplayed()
+        positions.forEach {
+            composeTestRule.onNodeWithTag("pocket.stories")
+                .onChildAt(it - 1)
+                .assert(hasTestTag("pocket.sponsored.story"))
+        }
+    }
+
+    fun verifyDiscoverMoreStoriesButton(composeTestRule: ComposeTestRule, position: Int) {
+        composeTestRule.onNodeWithTag("pocket.stories")
+            .assertIsDisplayed()
+            .onChildAt(position - 1)
+            .assert(hasTestTag("pocket.discover.more.story"))
+    }
+
     fun verifyStoriesByTopic(enabled: Boolean) {
         if (enabled) {
             scrollToElementByText(getStringResource(R.string.pocket_stories_categories_header))
@@ -289,6 +325,15 @@ class HomeScreenRobot {
                 ).waitForExists(waitingTime),
             )
         }
+    }
+
+    fun verifyStoriesByTopicItems() =
+        assertTrue(mDevice.findObject(UiSelector().resourceId("pocket.categories")).childCount > 1)
+
+    fun verifyPoweredByPocket(rule: ComposeTestRule) {
+        homeScreenList().scrollIntoView(mDevice.findObject(UiSelector().resourceId("pocket.header")))
+        rule.onNodeWithTag("pocket.header.title", true).assertIsDisplayed()
+        rule.onNodeWithTag("pocket.header.subtitle", true).assertIsDisplayed()
     }
 
     fun verifyCustomizeHomepageButton(enabled: Boolean) {
@@ -619,7 +664,7 @@ private fun assertHomeScreen() {
         .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 }
 
-private fun assertHomeMenu() = onView(ViewMatchers.withResourceName("menuButton"))
+private fun assertHomeMenuButton() = onView(ViewMatchers.withResourceName("menuButton"))
     .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
 private fun assertHomePrivateBrowsingButton() =
@@ -629,9 +674,6 @@ private fun assertHomePrivateBrowsingButton() =
 private val homepageWordmark = onView(ViewMatchers.withResourceName("wordmark"))
 private fun assertHomeWordmark() =
     homepageWordmark.check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-
-private fun assertHomeToolbar() = onView(ViewMatchers.withResourceName("toolbar"))
-    .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
 
 private fun assertTabButton() =
     onView(allOf(withId(R.id.tab_button), isDisplayed()))
@@ -668,9 +710,9 @@ private fun getSearchEngine(searchEngineName: String) =
     appContext.components.core.store.state.search.searchEngines.find { it.name == searchEngineName }
 
 private fun verifySearchEngineIcon(searchEngineName: String) {
-    val ddgSearchEngine = getSearchEngine(searchEngineName)
+    val defaultSearchEngine = getSearchEngine(searchEngineName)
         ?: throw AssertionError("No search engine with name $searchEngineName")
-    verifySearchEngineIcon(ddgSearchEngine.icon, ddgSearchEngine.name)
+    verifySearchEngineIcon(defaultSearchEngine.icon, defaultSearchEngine.name)
 }
 
 // First Run elements
@@ -948,6 +990,17 @@ private fun sponsoredShortcut(sponsoredShortcutTitle: String) =
             .res("$packageName:id/top_site_title")
             .textContains(sponsoredShortcutTitle),
     )
+
+private fun discoverMoreStoriesButton(position: Int) =
+    mDevice
+        .findObject(
+            UiSelector()
+                .resourceId("pocket.stories"),
+        ).getChild(
+            UiSelector()
+                .resourceId("pocket.discover.more.story")
+                .index(position - 1),
+        )
 
 val deleteFromHistory =
     onView(

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
@@ -711,6 +711,13 @@ class HomeScreenRobot {
             BrowserRobot().interact()
             return BrowserRobot.Transition()
         }
+
+        fun clickPocketLearnMoreLink(composeTestRule: ComposeTestRule, interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
+            composeTestRule.onNodeWithTag("pocket.header.subtitle", true).performClick()
+
+            BrowserRobot().interact()
+            return BrowserRobot.Transition()
+        }
     }
 }
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
@@ -10,6 +10,8 @@ import android.graphics.Bitmap
 import android.widget.EditText
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotSelected
+import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.ComposeTestRule
@@ -332,6 +334,21 @@ class HomeScreenRobot {
 
     fun verifyStoriesByTopicItems() =
         assertTrue(mDevice.findObject(UiSelector().resourceId("pocket.categories")).childCount > 1)
+
+    fun verifyStoriesByTopicItemState(composeTestRule: ComposeTestRule, isSelected: Boolean, position: Int) {
+        homeScreenList().scrollIntoView(mDevice.findObject(UiSelector().resourceId("pocket.header")))
+
+        if (isSelected) {
+            composeTestRule.onNodeWithTag("pocket.categories").assertIsDisplayed()
+            storyByTopicItem(composeTestRule, position).assertIsSelected()
+        } else {
+            composeTestRule.onNodeWithTag("pocket.categories").assertIsDisplayed()
+            storyByTopicItem(composeTestRule, position).assertIsNotSelected()
+        }
+    }
+
+    fun clickStoriesByTopicItem(composeTestRule: ComposeTestRule, position: Int) =
+        storyByTopicItem(composeTestRule, position).performClick()
 
     fun verifyPoweredByPocket(rule: ComposeTestRule) {
         homeScreenList().scrollIntoView(mDevice.findObject(UiSelector().resourceId("pocket.header")))
@@ -1086,6 +1103,9 @@ private fun sponsoredShortcut(sponsoredShortcutTitle: String) =
             .res("$packageName:id/top_site_title")
             .textContains(sponsoredShortcutTitle),
     )
+
+private fun storyByTopicItem(composeTestRule: ComposeTestRule, position: Int) =
+    composeTestRule.onNodeWithTag("pocket.categories").onChildAt(position - 1)
 
 val deleteFromHistory =
     onView(

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
@@ -382,6 +382,20 @@ class HomeScreenRobot {
         )
     }
 
+    fun getProvokingStoryPublisher(position: Int): String {
+        val publisher = mDevice.findObject(
+            UiSelector()
+                .className("android.view.View")
+                .index(position - 1),
+        ).getChild(
+            UiSelector()
+                .className("android.widget.TextView")
+                .index(1),
+        ).text
+
+        return publisher
+    }
+
     class Transition {
 
         fun openTabDrawer(interact: TabDrawerRobot.() -> Unit): TabDrawerRobot.Transition {
@@ -649,6 +663,22 @@ class HomeScreenRobot {
                         .resourceId("recent.tab.title")
                         .textContains(itemTitle),
                 ).clickAndWaitForNewWindow(waitingTime)
+
+            BrowserRobot().interact()
+            return BrowserRobot.Transition()
+        }
+
+        fun clickPocketStoryItem(publisher: String, position: Int, interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
+            mDevice.findObject(
+                UiSelector()
+                    .className("android.view.View")
+                    .index(position - 1),
+            ).getChild(
+                UiSelector()
+                    .className("android.widget.TextView")
+                    .index(1)
+                    .textContains(publisher),
+            ).clickAndWaitForNewWindow(waitingTime)
 
             BrowserRobot().interact()
             return BrowserRobot.Transition()

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/robots/HomeScreenRobot.kt
@@ -683,6 +683,17 @@ class HomeScreenRobot {
             BrowserRobot().interact()
             return BrowserRobot.Transition()
         }
+
+        fun clickPocketDiscoverMoreButton(composeTestRule: ComposeTestRule, position: Int, interact: BrowserRobot.() -> Unit): BrowserRobot.Transition {
+            composeTestRule.onNodeWithTag("pocket.stories")
+                .assertIsDisplayed()
+                .onChildAt(position - 1)
+                .assert(hasTestTag("pocket.discover.more.story"))
+                .performClick()
+
+            BrowserRobot().interact()
+            return BrowserRobot.Transition()
+        }
     }
 }
 
@@ -1075,17 +1086,6 @@ private fun sponsoredShortcut(sponsoredShortcutTitle: String) =
             .res("$packageName:id/top_site_title")
             .textContains(sponsoredShortcutTitle),
     )
-
-private fun discoverMoreStoriesButton(position: Int) =
-    mDevice
-        .findObject(
-            UiSelector()
-                .resourceId("pocket.stories"),
-        ).getChild(
-            UiSelector()
-                .resourceId("pocket.discover.more.story")
-                .index(position - 1),
-        )
 
 val deleteFromHistory =
     onView(


### PR DESCRIPTION
For #26286 improve full functional [home screen](https://testrail.stage.mozaws.net/index.php?/suites/view/3192&group_by=cases:section_id&group_id=31269&group_order=asc) section UI test coverage.

- Refactor `homeScreenItemsTest` UI test ✅ successfully passed 75x on Firebase

- New `verifyJumpBackInSectionTest` UI test ✅ successfully passed 75x on Firebase

- Improve coverage for `verifyPocketHomepageStoriesTest` UI test ✅ successfully passed 75x on Firebase

- New `openPocketStoryItemTest` UI test ✅ successfully passed 75x on Firebase

- New `openPocketDiscoverMoreTest` UI test ✅ successfully passed 75x on Firebase

- New `selectStoriesByTopicItemTest` UI test ✅ successfully passed 75x on Firebase

- New `verifyPocketLearnMoreLinkTest` UI test ✅ successfully passed 75x on Firebase

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

Fixes #26286