### PR TITLE
For #26956 - TCP CFR URL now points to correct SUMO page.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarCFRPresenter.kt
+++ b/app/src/main/java/org/mozilla/fenix/components/toolbar/BrowserToolbarCFRPresenter.kt
@@ -118,8 +118,7 @@ class BrowserToolbarCFRPresenter(
                 color = FirefoxTheme.colors.textOnColorPrimary,
                 modifier = Modifier.clickable {
                     context.components.useCases.tabsUseCases.selectOrAddTab.invoke(
-                        SupportUtils.getSumoURLForTopic(
-                            context,
+                        SupportUtils.getGenericSumoURLForTopic(
                             TOTAL_COOKIE_PROTECTION,
                         ),
                     )

--- a/app/src/main/java/org/mozilla/fenix/settings/SupportUtils.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/SupportUtils.kt
@@ -42,7 +42,7 @@ object SupportUtils {
         PRIVATE_BROWSING_MYTHS("common-myths-about-private-browsing"),
         YOUR_RIGHTS("your-rights"),
         TRACKING_PROTECTION("tracking-protection-firefox-android"),
-        TOTAL_COOKIE_PROTECTION("enhanced-tracking-protection-android"),
+        TOTAL_COOKIE_PROTECTION("enhanced-tracking-protection-firefox-android"),
         WHATS_NEW("whats-new-firefox-preview"),
         OPT_OUT_STUDIES("how-opt-out-studies-firefox-android"),
         SEND_TABS("send-tab-preview"),


### PR DESCRIPTION
The Total Cookie Protection CFR now redirects the user to the correct SUMO page.

Behavior now:

https://user-images.githubusercontent.com/32488956/201648173-961cef9b-ebe7-4ff3-87f9-599968e8c3f1.mp4


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
