### PR TITLE
For #27704: Disable search group tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SearchTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SearchTest.kt
@@ -160,6 +160,7 @@ class SearchTest {
         }
     }
 
+    @Ignore("Test run timing out: https://github.com/mozilla-mobile/fenix/issues/27704")
     @SmokeTest
     @Test
     fun searchGroupShowsInRecentlyVisitedTest() {
@@ -194,6 +195,7 @@ class SearchTest {
         }
     }
 
+    @Ignore("Test run timing out: https://github.com/mozilla-mobile/fenix/issues/27704")
     @Test
     fun verifySearchGroupHistoryWithNoDuplicatesTest() {
         val firstPageUrl = getGenericAsset(searchMockServer, 1).url
@@ -275,6 +277,7 @@ class SearchTest {
         }
     }
 
+    @Ignore("Test run timing out: https://github.com/mozilla-mobile/fenix/issues/27704")
     @SmokeTest
     @Test
     fun noSearchGroupFromPrivateBrowsingTest() {
@@ -313,6 +316,7 @@ class SearchTest {
         }
     }
 
+    @Ignore("Test run timing out: https://github.com/mozilla-mobile/fenix/issues/27704")
     @SmokeTest
     @Test
     fun deleteItemsFromSearchGroupHistoryTest() {
@@ -361,6 +365,7 @@ class SearchTest {
         }
     }
 
+    @Ignore("Test run timing out: https://github.com/mozilla-mobile/fenix/issues/27704")
     @Test
     fun deleteSearchGroupFromHistoryTest() {
         queryString = "test search"
@@ -407,6 +412,7 @@ class SearchTest {
         }
     }
 
+    @Ignore("Test run timing out: https://github.com/mozilla-mobile/fenix/issues/27704")
     @Test
     fun reopenTabsFromSearchGroupTest() {
         val firstPageUrl = getGenericAsset(searchMockServer, 1).url
@@ -460,6 +466,7 @@ class SearchTest {
         }
     }
 
+    @Ignore("Test run timing out: https://github.com/mozilla-mobile/fenix/issues/27704")
     @Test
     fun sharePageFromASearchGroupTest() {
         val firstPageUrl = getGenericAsset(searchMockServer, 1).url


### PR DESCRIPTION
The test runs are timing out, due to some unknown issue they are stuck and take up to 30 minutes: https://github.com/mozilla-mobile/fenix/issues/27704. Disabling until we can figure out the cause.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.


### GitHub Automation
