### PR TITLE
No issue: RTL nav bar UI tests

### DIFF
--- a/app/src/androidTest/java/org/mozilla/fenix/ui/NavigationToolbarTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/NavigationToolbarTest.kt
@@ -12,11 +12,14 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.mozilla.fenix.customannotations.SmokeTest
 import org.mozilla.fenix.helpers.AndroidAssetDispatcher
 import org.mozilla.fenix.helpers.HomeActivityTestRule
 import org.mozilla.fenix.helpers.TestAssetHelper
+import org.mozilla.fenix.helpers.TestHelper.runWithSystemLocaleChanged
 import org.mozilla.fenix.ui.robots.homeScreen
 import org.mozilla.fenix.ui.robots.navigationToolbar
+import java.util.Locale
 
 /**
  *  Tests for verifying basic functionality of browser navigation and page related interactions
@@ -92,6 +95,46 @@ class NavigationToolbarTest {
             verifyThreeDotMenuExists()
         }.goForward {
             verifyUrl(nextWebPage.url.toString())
+        }
+    }
+
+    // Swipes the nav bar left/right to switch between tabs
+    @SmokeTest
+    @Test
+    fun swipeToSwitchTabTest() {
+        val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+        val secondWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 2)
+
+        navigationToolbar {
+        }.enterURLAndEnterToBrowser(firstWebPage.url) {
+        }.openTabDrawer {
+        }.openNewTab {
+        }.submitQuery(secondWebPage.url.toString()) {
+            swipeNavBarRight(secondWebPage.url.toString())
+            verifyUrl(firstWebPage.url.toString())
+            swipeNavBarLeft(firstWebPage.url.toString())
+            verifyUrl(secondWebPage.url.toString())
+        }
+    }
+
+    // Because it requires changing system prefs, this test will run only on Debug builds
+    @Test
+    fun swipeToSwitchTabInRTLTest() {
+        val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
+        val secondWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 2)
+        val arabicLocale = Locale("ar", "AR")
+
+        runWithSystemLocaleChanged(arabicLocale, activityTestRule) {
+            navigationToolbar {
+            }.enterURLAndEnterToBrowser(firstWebPage.url) {
+            }.openTabDrawer {
+            }.openNewTab {
+            }.submitQuery(secondWebPage.url.toString()) {
+                swipeNavBarLeft(secondWebPage.url.toString())
+                verifyUrl(firstWebPage.url.toString())
+                swipeNavBarRight(firstWebPage.url.toString())
+                verifyUrl(secondWebPage.url.toString())
+            }
         }
     }
 

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsBasicsTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SettingsBasicsTest.kt
@@ -302,6 +302,7 @@ class SettingsBasicsTest {
         }
     }
 
+    // Because it requires changing system prefs, this test will run only on Debug builds
     @Ignore("Failing due to app translation bug, see: https://github.com/mozilla-mobile/fenix/issues/26729")
     @Test
     fun frenchSystemLocaleTest() {

--- a/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
+++ b/app/src/androidTest/java/org/mozilla/fenix/ui/SmokeTest.kt
@@ -421,24 +421,6 @@ class SmokeTest {
         }
     }
 
-    // Swipes the nav bar left/right to switch between tabs
-    @Test
-    fun swipeToSwitchTabTest() {
-        val firstWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 1)
-        val secondWebPage = TestAssetHelper.getGenericAsset(mockWebServer, 2)
-
-        navigationToolbar {
-        }.enterURLAndEnterToBrowser(firstWebPage.url) {
-        }.openTabDrawer {
-        }.openNewTab {
-        }.submitQuery(secondWebPage.url.toString()) {
-            swipeNavBarRight(secondWebPage.url.toString())
-            verifyUrl(firstWebPage.url.toString())
-            swipeNavBarLeft(firstWebPage.url.toString())
-            verifyUrl(secondWebPage.url.toString())
-        }
-    }
-
     // Saves a login, then changes it and verifies the update
     @Test
     fun updateSavedLoginTest() {


### PR DESCRIPTION
I wrote a test that needs an RTL language set on the device, and for that, I need to allow Config changes permissions for the app in any variant. 
If GrantPermission is not declared, we can't change the device language for some tests, like following the system default locale.

I found that Kate did this in the past here https://github.com/mozilla-mobile/fenix/pull/3562/files - but she has set that only for the debug version.

I would need to change that to work on other variants as well if we run our tests in Nightly/Beta/Release. I'm not sure that's ok to do in the main manifest file, so I need someone's informed advice & approval.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
