### PR TITLE
For #27896 - Match share sheet header style with the rest

### DIFF
--- a/app/src/main/res/layout/share_to_account_devices.xml
+++ b/app/src/main/res/layout/share_to_account_devices.xml
@@ -11,16 +11,12 @@
 
     <TextView
         android:id="@+id/accountHeaderText"
+        style="@style/ShareHeaderTextStyle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
         android:layout_marginTop="12dp"
-        android:singleLine="true"
         android:text="@string/share_device_subheader"
-        android:textAllCaps="true"
-        android:textColor="?attr/textSecondary"
-        android:textSize="12sp"
-        android:textStyle="bold"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 


### PR DESCRIPTION
"Send to device" share sheet header is now styled to match the other headers.

https://user-images.githubusercontent.com/32488956/203053663-1b067741-f4bd-4391-bc04-7c6f47c57aab.mp4


### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [X] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
Fixes #27896