### PR TITLE
Close #26320: Make Nimbus first-startup comments clear in FenixApplication

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
+++ b/app/src/main/java/org/mozilla/fenix/FenixApplication.kt
@@ -131,16 +131,9 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
             return
         }
 
-        // We can initialize Nimbus before Glean because Glean will queue messages
-        // before it's initialized.
-        initializeNimbus()
-
-        // We need to always initialize Glean and do it early here.
-        initializeGlean()
-
+        // DO NOT ADD ANYTHING ABOVE HERE.
         setupInMainProcessOnly()
-
-        downloadWallpapers()
+        // DO NOT ADD ANYTHING UNDER HERE.
 
         // DO NOT MOVE ANYTHING BELOW THIS elapsedRealtimeNanos CALL.
         val stop = SystemClock.elapsedRealtimeNanos()
@@ -198,9 +191,20 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
 
     @CallSuper
     open fun setupInMainProcessOnly() {
+        // ⚠️ DO NOT ADD ANYTHING ABOVE THIS LINE.
+        // Especially references to the engine/BrowserStore which can alter the app initialization.
+        // See: https://github.com/mozilla-mobile/fenix/issues/26320
+        //
+        // We can initialize Nimbus before Glean because Glean will queue messages
+        // before it's initialized.
+        initializeNimbus()
+
         ProfilerMarkerFactProcessor.create { components.core.engine.profiler }.register()
 
         run {
+            // We need to always initialize Glean and do it early here.
+            initializeGlean()
+
             // Attention: Do not invoke any code from a-s in this scope.
             val megazordSetup = finishSetupMegazord()
 
@@ -246,6 +250,8 @@ open class FenixApplication : LocaleAwareApplication(), Provider {
         initVisualCompletenessQueueAndQueueTasks()
 
         ProcessLifecycleOwner.get().lifecycle.addObserver(TelemetryLifecycleObserver(components.core.store))
+
+        downloadWallpapers()
     }
 
     @OptIn(DelicateCoroutinesApi::class) // GlobalScope usage


### PR DESCRIPTION
Adding a bit of cleanup that makes it clear we don't want anyone to add things to the application onCreate before Nimbus. No logical changes; cleanup.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.



### GitHub Automation
Fixes #26320