### PR TITLE
Bug 1800700 - Add default search suggest header

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/home/HomeFragment.kt
@@ -1085,6 +1085,7 @@ class HomeFragment : Fragment() {
         const val AMAZON_SPONSORED_TITLE = "Amazon"
         const val AMAZON_SEARCH_ENGINE_NAME = "Amazon.com"
         const val EBAY_SPONSORED_TITLE = "eBay"
+        const val GOOGLE_SEARCH_ENGINE_NAME = "Google"
 
         // Elevation for undo toasts
         internal const val TOAST_ELEVATION = 80f

--- a/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarView.kt
+++ b/app/src/main/java/org/mozilla/fenix/search/awesomebar/AwesomeBarView.kt
@@ -4,12 +4,14 @@
 
 package org.mozilla.fenix.search.awesomebar
 
+import android.provider.Settings.Global.getString
 import androidx.appcompat.content.res.AppCompatResources.getDrawable
 import androidx.core.graphics.BlendModeColorFilterCompat.createBlendModeColorFilterCompat
 import androidx.core.graphics.BlendModeCompat.SRC_IN
 import androidx.core.graphics.drawable.toBitmap
 import mozilla.components.browser.state.search.SearchEngine
 import mozilla.components.browser.state.state.searchEngines
+import mozilla.components.browser.state.state.selectedOrDefaultSearchEngine
 import mozilla.components.concept.awesomebar.AwesomeBar
 import mozilla.components.concept.engine.EngineSession
 import mozilla.components.feature.awesomebar.provider.BookmarksStorageSuggestionProvider
@@ -28,10 +30,12 @@ import mozilla.components.support.ktx.android.content.getColorFromAttr
 import org.mozilla.fenix.HomeActivity
 import org.mozilla.fenix.R
 import org.mozilla.fenix.browser.browsingmode.BrowsingMode
+import org.mozilla.fenix.components.Components
 import org.mozilla.fenix.components.Core.Companion.METADATA_HISTORY_SUGGESTION_LIMIT
 import org.mozilla.fenix.components.Core.Companion.METADATA_SHORTCUT_SUGGESTION_LIMIT
 import org.mozilla.fenix.ext.components
 import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.home.HomeFragment
 import org.mozilla.fenix.search.SearchEngineSource
 import org.mozilla.fenix.search.SearchFragmentState
 
@@ -176,6 +180,7 @@ class AwesomeBarView(
                     BrowsingMode.Normal -> false
                     BrowsingMode.Private -> true
                 },
+                suggestionsHeader = getDefaultSearchEngineSuggestionsHeader(components),
             )
 
         defaultSearchActionProvider =
@@ -184,6 +189,7 @@ class AwesomeBarView(
                 searchUseCase = searchUseCase,
                 icon = searchBitmap,
                 showDescription = false,
+                suggestionsHeader = getDefaultSearchEngineSuggestionsHeader(components),
             )
 
         shortcutsEnginePickerProvider =
@@ -205,6 +211,24 @@ class AwesomeBarView(
             )
 
         searchSuggestionProviderMap = HashMap()
+    }
+
+    private fun getDefaultSearchEngineSuggestionsHeader(components: Components, activity: HomeActivity): String? {
+        var defaultSearchEngine = components.core.store.state.search.selectedOrDefaultSearchEngine?.name
+
+        if (!defaultSearchEngine.isNullOrEmpty()) {
+            defaultSearchEngine = when (defaultSearchEngine) {
+                HomeFragment.GOOGLE_SEARCH_ENGINE_NAME -> activity.getString(
+                    defaultSearchEngine,
+                    R.string.google_search_engine_suggestion_header,
+                )
+                else -> activity.getString(
+                    defaultSearchEngine,
+                    R.string.other_default_search_engine_suggestion_header,
+                )
+            }
+        }
+        return defaultSearchEngine
     }
 
     fun update(state: SearchFragmentState) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1810,6 +1810,14 @@
     <!-- Text for the snackbar to confirm auto-close is enabled for inactive tabs -->
     <string name="inactive_tabs_auto_close_message_snackbar">Auto-close enabled</string>
 
+    <!-- Awesome bar suggestions' headers -->
+    <!-- Title for firefox suggestion -->
+    <string name="firefox_suggest_header">Firefox Suggest</string>
+    <!-- Title for suggestions when Google is default search suggestion engine. The first parameter is Google search engine. -->
+    <string name="google_search_engine_suggestion_header">%s Search</string>
+    <!-- Title for suggestions when default search suggestion engine is anything other than Google. The first parameter is default search engine -->
+    <string name="other_default_search_engine_suggestion_header">%s search</string>
+
     <!-- Default browser experiment -->
     <string name="default_browser_experiment_card_text">Set links from websites, emails, and messages to open automatically in Firefox.</string>
 
@@ -1847,7 +1855,6 @@
     <string name="experiments_snackbar">Enable telemetry to send data.</string>
     <!-- Snackbar button text to navigate to telemetry settings.-->
     <string name="experiments_snackbar_button">Go to settings</string>
-    <string name="firefox_suggest_header">Firefox Suggest</string>
 
     <!-- Accessibility services actions labels. These will be appended to accessibility actions like "Double tap to.." but not by or applications but by services like Talkback. -->
     <!-- Action label for elements that can be collapsed if interacting with them. Talkback will append this to say "Double tap to collapse". -->


### PR DESCRIPTION
| | |
|----|----|
|<img width="432" alt="Screen Shot 2022-11-21 at 1 04 17 PM" src="https://user-images.githubusercontent.com/1190888/203128150-b9770599-3581-464d-b30a-49137f8c2648.png">|<img width="452" alt="Screen Shot 2022-11-21 at 1 03 11 PM" src="https://user-images.githubusercontent.com/1190888/203128181-1ce24971-779c-41e0-9b0b-16c7bd8d9512.png">|



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
