### PR TITLE
Use blank string instead of empty string for version name fallback in release variants.

### DIFF
--- a/buildSrc/src/main/java/Config.kt
+++ b/buildSrc/src/main/java/Config.kt
@@ -30,8 +30,8 @@ object Config {
         // Note: release builds must have the `versionName` set. However, the gradle ecosystem makes this hard to
         // ergonomically validate (sometimes IDEs default to a release variant and mysteriously fail due to the
         // validation, sometimes devs just need a release build and specifying project properties is annoying in IDEs),
-        // so instead we'll allow the `versionName` to silently default to an empty string.
-        return if (project.hasProperty("versionName")) project.property("versionName") as String else ""
+        // so instead we'll allow the `versionName` to silently default to a blank string.
+        return if (project.hasProperty("versionName")) project.property("versionName") as String else " "
     }
 
     @JvmStatic


### PR DESCRIPTION
App version name cannot be empty or null in SDK 33 PackageInfo.


When using the release build variant to build locally, without this change the app would crash with NPE when calling [Context.appVersionName](https://github.com/mozilla-mobile/firefox-android/blob/50292148bee8508d62b6fc0d80d98d6477e3e00a/android-components/components/support/ktx/src/main/java/mozilla/components/support/ktx/android/content/Context.kt#L49 ) that calls [versionName](https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/content/pm/PackageInfo.java#96) in `PackageInfo` .



### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [x] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [ ] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
