### PR TITLE
Disable cookie banner handling by default.

### DIFF
--- a/app/src/main/java/org/mozilla/fenix/settings/CookieBannersFragment.kt
+++ b/app/src/main/java/org/mozilla/fenix/settings/CookieBannersFragment.kt
@@ -37,7 +37,7 @@ class CookieBannersFragment : PreferenceFragmentCompat() {
     }
 
     private fun setupPreferences() {
-        requirePreference<SwitchPreference>(R.string.pref_key_cookie_banner).apply {
+        requirePreference<SwitchPreference>(R.string.pref_key_cookie_banner_v1).apply {
             onPreferenceChangeListener = object : SharedPreferenceUpdater() {
                 override fun onPreferenceChange(
                     preference: Preference,

--- a/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
+++ b/app/src/main/java/org/mozilla/fenix/utils/Settings.kt
@@ -538,7 +538,7 @@ class Settings(private val appContext: Context) : PreferencesHolder {
     )
 
     var shouldUseCookieBanner by lazyFeatureFlagPreference(
-        appContext.getPreferenceKey(R.string.pref_key_cookie_banner),
+        appContext.getPreferenceKey(R.string.pref_key_cookie_banner_v1),
         featureFlag = true,
         default = { cookieBannersSection[CookieBannersSection.FEATURE_SETTING_VALUE] == true },
     )

--- a/app/src/main/res/values/preference_keys.xml
+++ b/app/src/main/res/values/preference_keys.xml
@@ -149,7 +149,7 @@
 
     <!-- Cookie Banner Reduction Settings-->
     <string name="pref_key_cookie_banner_settings" translatable="false">pref_key_cookie_banner_settings</string>
-    <string name="pref_key_cookie_banner" translatable="false">pref_key_cookie_banner</string>
+    <string name="pref_key_cookie_banner_v1" translatable="false">pref_key_cookie_banner_v1</string>
 
     <!-- Tracking Protection Settings -->
     <string name="pref_key_etp_learn_more" translatable="false">pref_key_etp_learn_more</string>

--- a/app/src/main/res/xml/cookie_banner_preferences.xml
+++ b/app/src/main/res/xml/cookie_banner_preferences.xml
@@ -3,8 +3,8 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <androidx.preference.PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
     <SwitchPreference
-        android:defaultValue="true"
-        android:key="@string/pref_key_cookie_banner"
+        android:defaultValue="false"
+        android:key="@string/pref_key_cookie_banner_v1"
         android:summary="@string/reduce_cookie_banner_summary"
         android:title="@string/reduce_cookie_banner_option" />
 </androidx.preference.PreferenceScreen>

--- a/nimbus.fml.yaml
+++ b/nimbus.fml.yaml
@@ -223,14 +223,14 @@ features:
         value: {
           "sections-enabled": {
             "feature-ui": true,
-            "feature-setting-value": true,
+            "feature-setting-value": false,
           }
         }
       - channel: nightly
         value: {
           "sections-enabled": {
             "feature-ui": true,
-            "feature-setting-value": true,
+            "feature-setting-value": false,
           }
         }
   unified-search:


### PR DESCRIPTION
After chatting with product they stated the the cookie banner handling setting should be OFF by default.

### Pull Request checklist
<!-- Before submitting the PR, please address each item -->
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Screenshots**: This PR includes screenshots or GIFs of the changes made or an explanation of why it does not
- [ ] **Accessibility**: The code in this PR follows [accessibility best practices](https://github.com/mozilla-mobile/shared-docs/blob/master/android/accessibility_guide.md) or does not include any user facing features. In addition, it includes a screenshot of a successful [accessibility scan](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor&hl=en_US) to ensure no new defects are added to the product.

### QA
<!-- Before submitting the PR, please address each item -->
- [x] **QA Needed**

### To download an APK when reviewing a PR (after all CI tasks finished running):
1. Click on `Checks` at the top of the PR page.
2. Click on the `firefoxci-taskcluster` group on the left to expand all tasks.
3. Click on the `build-debug` task.
4. Click on `View task in Taskcluster` in the new `DETAILS` section.
5. The APK links should be on the right side of the screen, named for each CPU architecture.

### GitHub Automation
<!-- Do not add anything below this line -->

Used by GitHub Actions.
